### PR TITLE
fix(ci): add OPENCLAW_TOKEN placeholder to .env.example

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -38,6 +38,9 @@ SEARXNG_SECRET=CHANGEME
 # OpenCode web UI password (generate: openssl rand -base64 16)
 OPENCODE_SERVER_PASSWORD=CHANGEME
 
+# OpenClaw gateway token (generate: openssl rand -hex 32)
+OPENCLAW_TOKEN=CHANGEME
+
 # ═══════════════════════════════════════════════════════════════════
 # Network Binding
 # ═══════════════════════════════════════════════════════════════════

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -38,7 +38,7 @@ SEARXNG_SECRET=CHANGEME
 # OpenCode web UI password (generate: openssl rand -base64 16)
 OPENCODE_SERVER_PASSWORD=CHANGEME
 
-# OpenClaw gateway token (generate: openssl rand -hex 32)
+# OpenClaw gateway token (generate: openssl rand -hex 24)
 OPENCLAW_TOKEN=CHANGEME
 
 # ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## What

Add `OPENCLAW_TOKEN` placeholder to `.env.example` and align its documented byte count with what the installers actually generate (24 bytes / 192 bits, not the previously-documented 32).

## Why

Integration-smoke CI fails on upstream `main` because `openclaw/compose.yaml` requires `OPENCLAW_TOKEN` via strict `${VAR:?msg}` interpolation but the variable isn't listed in `.env.example`. Separately, the documented byte count in `.env.example`'s comment didn't match installer output (`installers/phases/06-directories.sh` and `installers/windows/lib/env-generator.ps1` both use 24 bytes, consistent with other 192-bit tokens).

## How

Two commits:

- `ca2ded8f` — add `CHANGEME` placeholder with generate command, matching the convention used for `WEBUI_SECRET` and `SEARXNG_SECRET`.
- `001f5d07` — correct the documented byte count to match installer output.

## Testing

- `docker compose config --env-file .env.example` passes locally on macOS.
- Integration-smoke CI job (currently broken on upstream `main`) will unblock on merge.
- Operator's end-to-end test battery on the 23APRdevelopments integration branch: green.

## Known Considerations

Security-irrelevant change: 24 bytes = 192 bits, well above any reasonable secret-strength floor. This is documentation hygiene, not a security fix.

## Platform Impact

- **macOS:** fixes local `docker compose config` validation.
- **Linux:** fixes integration-smoke CI job.
- **Windows / WSL2:** same behavior as Linux; no platform branching.
