### PR TITLE
fix(dream-cli): color-escape + table-separator + NO_COLOR spec

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -61,6 +61,14 @@ error() { echo -e "${RED}✗${NC} $1"; exit 1; }
 log_warn() { echo -e "${YELLOW}⚠${NC} $1"; }
 log_error() { echo -e "${RED}✗${NC} $1" >&2; }
 
+# Print a separator of repeated characters filling the given width.
+# Usage: hr <width> [<char=─>]
+hr() {
+    local w="${1:-10}" c="${2:-─}" out=''
+    printf -v out '%*s' "$w" ''
+    printf '%s' "${out// /$c}"
+}
+
 # Update or add a key=value in .env
 _env_set() {
     local key="$1" val="$2" file="$INSTALL_DIR/.env"
@@ -1664,7 +1672,7 @@ cmd_list() {
     active_flags=$(get_compose_flags)
     echo -e "${BLUE}━━━ Available Services ━━━${NC}"
     printf "%-20s %-12s %-10s\n" "SERVICE" "CATEGORY" "STATUS"
-    printf "%-20s %-12s %-10s\n" "───────" "────────" "──────"
+    printf "%-20s %-12s %-10s\n" "$(hr 20)" "$(hr 12)" "$(hr 10)"
     for sid in "${SERVICE_IDS[@]}"; do
         local cat="${SERVICE_CATEGORIES[$sid]}"
         local cf="${SERVICE_COMPOSE[$sid]}"
@@ -3100,9 +3108,10 @@ _template_list() {
         return 0
     fi
 
-    local found=0
-    printf "${CYAN}%-20s %-30s %-6s %s${NC}\n" "ID" "NAME" "TIER" "SERVICES"
-    printf "%-20s %-30s %-6s %s\n" "----" "----" "----" "--------"
+    # First pass: collect template rows and compute max ID width so the
+    # column fits IDs like "personal-knowledge-base" (23) without overflow.
+    local -a rows=()
+    local max_id_len=2  # at minimum, wide enough for the "ID" header
 
     for f in "$templates_dir"/*.yaml "$templates_dir"/*.yml; do
         [[ -f "$f" ]] || continue
@@ -3123,14 +3132,29 @@ if tid:
 PYEOF
         ) || continue
         [[ -z "$info" ]] && continue
-        IFS=$'\t' read -r tid tname ttier tsvcs <<< "$info"
-        printf "%-20s %-30s %-6s %s\n" "$tid" "$tname" "$ttier" "$tsvcs"
-        found=1
+        rows+=("$info")
+        local this_id="${info%%$'\t'*}"
+        (( ${#this_id} > max_id_len )) && max_id_len=${#this_id}
     done
 
-    if [[ "$found" -eq 0 ]]; then
+    if [[ ${#rows[@]} -eq 0 ]]; then
         log "No templates found."
+        return 0
     fi
+
+    # Second pass: emit header, full-width separator, and rows using the
+    # dynamic ID column width. `hr` produces separators that span each
+    # column exactly, replacing the old hard-coded "----" dashes that
+    # left visible gaps under %-Ns padding.
+    printf "${CYAN}%-*s %-30s %-6s %s${NC}\n" "$max_id_len" "ID" "NAME" "TIER" "SERVICES"
+    printf "%-*s %-30s %-6s %s\n" \
+        "$max_id_len" "$(hr "$max_id_len")" "$(hr 30)" "$(hr 6)" "$(hr 8)"
+
+    local row tid tname ttier tsvcs
+    for row in "${rows[@]}"; do
+        IFS=$'\t' read -r tid tname ttier tsvcs <<< "$row"
+        printf "%-*s %-30s %-6s %s\n" "$max_id_len" "$tid" "$tname" "$ttier" "$tsvcs"
+    done
 }
 
 _template_preview() {

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -35,7 +35,11 @@ fi
 # at assignment time. Single-quoted strings store the backslash literally,
 # which breaks unquoted heredocs (cmd_help) that never re-interpret escapes.
 # Guard on TTY + NO_COLOR so redirected / piped output stays clean.
-if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+# Per no-color.org, NO_COLOR disables colors when it is present (set to any
+# value, including empty), so we check set-ness with ${NO_COLOR+x} — which
+# expands to "x" whenever NO_COLOR is set and to "" only when truly unset —
+# rather than ${NO_COLOR:-} which would treat NO_COLOR="" as unset.
+if [[ -t 1 ]] && [[ -z "${NO_COLOR+x}" ]]; then
     RED=$'\033[0;31m'
     GREEN=$'\033[0;32m'
     YELLOW=$'\033[1;33m'
@@ -1841,7 +1845,7 @@ META
             fi
 
             printf "  %-20s %-22s %-10s\n" "NAME" "CREATED" "BACKEND"
-            printf "  %-20s %-22s %-10s\n" "────" "───────" "───────"
+            printf "  %-20s %-22s %-10s\n" "$(hr 20)" "$(hr 22)" "$(hr 10)"
             for dir in "$PRESETS_DIR"/*/; do
                 [[ -d "$dir" ]] || continue
                 local pname

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -31,13 +31,25 @@ if [[ -f "$INSTALL_DIR/.env" ]]; then
     [[ -n "${_v:-}" ]] && VERSION="$_v"
 fi
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m'
+# Colors — use ANSI-C quoting ($'\033') so the variables hold real ESC bytes
+# at assignment time. Single-quoted strings store the backslash literally,
+# which breaks unquoted heredocs (cmd_help) that never re-interpret escapes.
+# Guard on TTY + NO_COLOR so redirected / piped output stays clean.
+if [[ -t 1 ]] && [[ -z "${NO_COLOR:-}" ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    BLUE=$'\033[0;34m'
+    CYAN=$'\033[0;36m'
+    NC=$'\033[0m'
+else
+    RED=''
+    GREEN=''
+    YELLOW=''
+    BLUE=''
+    CYAN=''
+    NC=''
+fi
 
 #=============================================================================
 # Helpers


### PR DESCRIPTION
## What

Three visual-polish fixes for `dream-cli`:

1. ANSI-C quoting (`$'\033[...'`) for color variables + `TTY && NO_COLOR`-guarded color emission, so color codes don't leak as literal escape text into non-ANSI-processing contexts (notably `cmd_help`'s heredoc, and piped/redirected output).
2. Table separators rendered at correct column widths via a new `hr <width>` helper using `printf -v` + parameter expansion.
3. `NO_COLOR` check uses `${NO_COLOR+x}` per [no-color.org spec](https://no-color.org/) (empty-string variable counts as "set"); `cmd_preset list` adopts the same separator helper for consistency.

## Why

`dream help` was printing literal `\033[0;34mDream Server CLI...` to terminals because single-quoted color vars held the escape string, not the ESC byte, and heredocs don't process `\033`. Short separator dashes made `dream list`, `dream template list`, and `dream preset list` headers appear broken on wider terminals.

## How

Three commits, each self-contained with full rationale:

- `d52cb120` — `$'\033[0;31m'`-style ANSI-C quoting + TTY+NO_COLOR guard block.
- `7c407c0a` — `hr()` helper using `printf -v` + `${var// /<char>}` parameter expansion; dynamic-width `_template_list`.
- `9cba4879` — spec-strict NO_COLOR check (`${NO_COLOR+x}`) + `cmd_preset list` separator.

## Testing

- `dream help`, `dream list`, `dream template list`, `dream preset list` render cleanly on macOS Terminal.app and iTerm2.
- `dream help > file.txt` emits zero escape codes (TTY-guard working as intended).
- Operator's integration-branch test battery: green.

## Platform Impact

- **macOS:** fix verified on Terminal.app and iTerm2.
- **Linux:** same fix applies (Bash 4+ features everywhere).
- **Windows terminal / WSL2:** same — covers all three reproducers from the underlying fork tracking.

No GNU-only tools used (no `sed -i`, `grep -P`, or `date -d`).
