### PR TITLE
fix(windows): generate DREAM_AGENT_KEY in installer env-generator.ps1

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -165,7 +165,7 @@ Write-DreamBanner
 #  Phase 03 → $enableVoice, $enableWorkflows, $enableRag, $enableOpenClaw, $openClawConfig
 #  Phase 04 → $requirementsMet
 #  Phase 05 → $dockerComposeCmd
-#  Phase 06 → $envResult (EnvPath, SearxngSecret, OpenclawToken, DashboardKey)
+#  Phase 06 → $envResult (EnvPath, SearxngSecret, OpenclawToken, DreamAgentKey)
 #  Phase 07 → (no output -- tools installed to $env:USERPROFILE)
 
 . (Join-Path $PhasesDir "01-preflight.ps1")

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -134,6 +134,7 @@ function New-DreamEnv {
     $livekitSecret   = Get-EnvOrNew "LIVEKIT_API_SECRET" (New-SecureBase64 -Bytes 32)
     $livekitApiKey   = Get-EnvOrNew "LIVEKIT_API_KEY"    (New-SecureHex -Bytes 16)
     $dashboardApiKey = Get-EnvOrNew "DASHBOARD_API_KEY"  (New-SecureHex -Bytes 32)
+    $dreamAgentKey   = Get-EnvOrNew "DREAM_AGENT_KEY"    (New-SecureHex -Bytes 32)
     $openclawToken   = Get-EnvOrNew "OPENCLAW_TOKEN"     (New-SecureHex -Bytes 24)
     $searxngSecret   = Get-EnvOrNew "SEARXNG_SECRET"     (New-SecureHex -Bytes 32)
     $difySecretKey    = Get-EnvOrNew "DIFY_SECRET_KEY"           (New-SecureHex -Bytes 32)
@@ -285,6 +286,7 @@ SEARXNG_PORT=8888
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=$webuiSecret
 DASHBOARD_API_KEY=$dashboardApiKey
+DREAM_AGENT_KEY=$dreamAgentKey
 N8N_USER=admin@dreamserver.local
 N8N_PASS=$n8nPass
 LITELLM_KEY=$litellmKey
@@ -357,7 +359,7 @@ LANGFUSE_INIT_USER_PASSWORD=$langfuseInitUserPassword
         EnvPath        = $envPath
         SearxngSecret  = $searxngSecret
         OpenclawToken  = $openclawToken
-        DashboardKey   = $dashboardApiKey
+        DreamAgentKey  = $dreamAgentKey
     }
 }
 

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -16,7 +16,7 @@
 #   $openClawConfig            -- from phase 03
 #
 # Writes:
-#   $envResult  -- hashtable: EnvPath, SearxngSecret, OpenclawToken, DashboardKey
+#   $envResult  -- hashtable: EnvPath, SearxngSecret, OpenclawToken, DreamAgentKey
 #
 # Modder notes:
 #   Add new directories to $_dirs array below.
@@ -41,7 +41,7 @@ if ($dryRun) {
         EnvPath       = Join-Path $installDir ".env"
         SearxngSecret = "(dry-run-placeholder)"
         OpenclawToken = "(dry-run-placeholder)"
-        DashboardKey  = "(dry-run-placeholder)"
+        DreamAgentKey = "(dry-run-placeholder)"
     }
     return
 }

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -10,7 +10,7 @@
 #   $dryRun, $cloudMode         -- from orchestrator context
 #   $installDir                 -- from orchestrator context
 #   $tierConfig                 -- from phase 02 (LlmModel, MaxContext, GgufFile)
-#   $envResult                  -- from phase 06 (OpenclawToken, DashboardKey)
+#   $envResult                  -- from phase 06 (OpenclawToken, DreamAgentKey)
 #   $script:OPENCODE_*          -- from lib/constants.ps1
 #
 # Writes:


### PR DESCRIPTION
## What

Windows installer now generates a dedicated `DREAM_AGENT_KEY` via `[System.Security.Cryptography.RandomNumberGenerator]`, writes it to `.env`, and exposes it via the `$envResult` hashtable. Removes the vestigial `DashboardKey` field from the return hashtable (zero readers anywhere in the installer).

## Why

Host agent and dashboard-api were sharing a fallback secret on Windows because `DREAM_AGENT_KEY` wasn't being generated there. The macOS installer (`env-generator.sh`) and Linux installer (`06-directories.sh`) both generate both keys independently. Windows was the only platform with this gap.

Separately, `$envResult.DashboardKey` had zero readers across all Windows installer phases (verified via grep) but was still documented in three header comments as part of the return shape — code hygiene gap.

## How

Single commit `b0b10641`. Generates `$dreamAgentKey` via CSPRNG, writes the `DREAM_AGENT_KEY=...` heredoc block alongside `DASHBOARD_API_KEY`, returns the key in `$envResult`. Updates three header comments (`install-windows.ps1:168`, `phases/06-directories.ps1:19`, `phases/07-devtools.ps1:13`) and one dry-run placeholder (`phases/06-directories.ps1:44`) to reflect the new field set: `{EnvPath, SearxngSecret, OpenclawToken, DreamAgentKey}`.

`$dashboardApiKey` continues to be generated at line 136 and written to `.env` as `DASHBOARD_API_KEY=...` for runtime use; only the in-memory hashtable surface changes.

## Testing

- PowerShell syntax validation via CI's `.github/workflows/lint-powershell.yml` (PSScriptAnalyzer).
- Repo-wide grep confirms no orphan references to `DashboardKey` after the change.
- Round-1 review: Critique Guardian approved. Round-2 adversarial audit by analysis team: security-critical path verified (CSPRNG entropy, preservation across reinstall, schema registration, Windows ACL).

## Known Considerations

The new `DreamAgentKey` field in the return hashtable has zero current readers; it's a forward-compat affordance for future phases that may consume it. A broader cleanup of the entire `$envResult` return pattern (3 of 4 fields currently unread) is tracked as a separate follow-up issue on the fork.

## Platform Impact

- **Windows:** defense-in-depth — host agent and dashboard-api now use distinct secrets.
- **macOS / Linux:** no-op. Their installers already generate the key via different code paths.
