### PR TITLE
fix(dream-cli): pre-validate 'dream shell' service + Docker daemon preflight

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1079,12 +1079,37 @@ cmd_shell() {
     check_install
     cd "$INSTALL_DIR"
 
-    local service="${1:-$(sr_resolve llm)}"
+    # Resolve aliases (e.g. "llm" -> "llama-server"); sr_resolve calls sr_load.
+    local service
+    service=$(sr_resolve "${1:-llm}")
+
+    # Validate against registry before doing anything.
+    local _found=false
+    for _sid in "${SERVICE_IDS[@]}"; do
+        if [[ "$_sid" == "$service" ]]; then
+            _found=true
+            break
+        fi
+    done
+    if ! $_found; then
+        error "Unknown service: $service"
+    fi
+
     local container
     container=$(sr_container "$service")
 
+    # Confirm the container is running before trying to exec.
+    if ! docker ps --format '{{.Names}}' | grep -qx "$container"; then
+        error "Container $container is not running. Start it with: dream start $service"
+    fi
+
     log "Opening shell in $container..."
-    docker exec -it "$container" /bin/bash || docker exec -it "$container" /bin/sh
+    # Distinguish "no bash binary" from "exec failed" by probing first.
+    if docker exec "$container" test -x /bin/bash >/dev/null 2>&1; then
+        docker exec -it "$container" /bin/bash
+    else
+        docker exec -it "$container" /bin/sh
+    fi
 }
 
 cmd_config() {

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1079,7 +1079,10 @@ cmd_shell() {
     check_install
     cd "$INSTALL_DIR"
 
-    # Resolve aliases (e.g. "llm" -> "llama-server"); sr_resolve calls sr_load.
+    # Load the service registry so SERVICE_IDS is populated in our shell.
+    sr_load
+
+    # Resolve aliases (e.g. "llm" -> "llama-server").
     local service
     service=$(sr_resolve "${1:-llm}")
 
@@ -1098,8 +1101,24 @@ cmd_shell() {
     local container
     container=$(sr_container "$service")
 
+    # Distinguish "daemon down" from "container stopped" — the container-running
+    # check below uses `docker ps`, which also exits non-zero when the daemon
+    # is unreachable. Without this preflight a user whose Docker is stopped
+    # sees "Container X is not running" and tries `dream start`, which also
+    # fails, creating a confusing loop. The explicit check lets the error
+    # reflect the actual cause.
+    #
+    # `docker info` can hang for 20+ seconds when Docker Desktop is mid-boot
+    # (socket exists, daemon not yet accepting RPCs). `timeout` isn't stock
+    # macOS, but `perl alarm` is (perl ships with macOS ≥ 10.5 and every
+    # Linux/WSL2 distro we target). `alarm` is inherited across `exec`, so
+    # the docker process receives SIGALRM after 3s if it hasn't returned.
+    if ! perl -e 'alarm 3; exec "docker", "info"' >/dev/null 2>&1; then
+        error "Docker is not running (or not responding within 3s). Start Docker Desktop / dockerd and retry."
+    fi
+
     # Confirm the container is running before trying to exec.
-    if ! docker ps --format '{{.Names}}' | grep -qx "$container"; then
+    if ! docker ps 2>/dev/null --format '{{.Names}}' | grep -qx "$container"; then
         error "Container $container is not running. Start it with: dream start $service"
     fi
 


### PR DESCRIPTION
## What

Three improvements to `dream shell <service>`:

1. **Pre-validate the service ID against the registry** before any Docker call, so `dream shell bogus-service` fails fast with "Unknown service" instead of emitting mismatched Docker errors.
2. **Docker daemon preflight** — distinguish "daemon down" from "container stopped" so the error message reflects the actual cause. Uses `perl -e 'alarm 3; exec "docker", "info"'` for a portable 3-second timeout (`timeout` isn't on stock macOS).
3. **Probe for `/bin/bash`** via `docker exec <c> test -x /bin/bash` before choosing the shell, so the `/bin/sh` fallback only fires on images that genuinely lack bash (instead of firing on any exec failure).

## Why

The original code printed an optimistic "Opening shell..." log, then Docker emitted "No such container" twice — once for `/bin/bash` and once for the fallback — before exiting. Misleading UX. The existing container-running check (`docker ps`) also returns non-zero when the daemon itself is down, so users whose Docker Desktop wasn't running saw "Container X is not running" and tried `dream start` (which also failed), creating a confusing loop.

`docker info` can hang for 20+ seconds when Docker Desktop is mid-boot (socket exists, daemon not yet accepting RPCs); the `perl alarm` wrapper gives a portable 3-second timeout.

## How

Two commits:

- `14c3d869` — service ID validation, container-running check, `/bin/bash` probe before fallback.
- `ca08b830` — call `sr_load` directly in `cmd_shell` so `SERVICE_IDS` is populated in the outer shell (the previous revision relied on a subshell `$(...)` populating the array, which was lost on return). Adds the Docker daemon preflight with `perl alarm`.

## Testing

- Sandbox: `perl -e 'alarm 3; exec "docker", "info"'` returns rc=0 on a healthy daemon, rc=142 on a 10s sleep with 3s alarm.
- `dream shell bogus-service` → "Unknown service: bogus-service" (previously Docker errors).
- `dream shell llama-server` with Docker stopped → "Docker is not running (or not responding within 3s)" (previously "Container X is not running").
- Round-1 review: Critique Guardian approved. Round-2 adversarial audit: verified.

## Platform Impact

- **macOS / Linux / Windows (WSL2):** identical CLI path. `perl alarm` semantics identical across platforms (perl ships with macOS ≥ 10.5 and every supported Linux/WSL2 distro). No BSD/GNU userland differences.
