### PR TITLE
fix(dashboard,dashboard-api): sentinel-based setup wizard success detection

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/setup.py
+++ b/dream-server/extensions/services/dashboard-api/routers/setup.py
@@ -123,6 +123,7 @@ async def run_setup_diagnostics(api_key: str = Depends(verify_api_key)):
     if not script_path.exists():
         async def error_stream():
             yield "Diagnostic script not found. Running basic connectivity tests...\n"
+            all_ok = True
             async with aiohttp.ClientSession() as session:
                 services = [
                     (cfg.get("name", sid), f"http://{cfg.get('host', sid)}:{cfg.get('port', 80)}{cfg.get('health', '/')}")
@@ -131,11 +132,20 @@ async def run_setup_diagnostics(api_key: str = Depends(verify_api_key)):
                 for name, url in services:
                     try:
                         async with session.get(url, timeout=5) as resp:
-                            status = "\u2713" if resp.status == 200 else "\u2717"
-                            yield f"{status} {name}: {resp.status}\n"
+                            if resp.status == 200:
+                                yield f"\u2713 {name}: {resp.status}\n"
+                            else:
+                                yield f"\u2717 {name}: {resp.status}\n"
+                                all_ok = False
                     except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as e:
                         yield f"\u2717 {name}: {e}\n"
-            yield "\nSetup complete!\n"
+                        all_ok = False
+            # Emit trailer + sentinel in a single chunk (see run_tests() for
+            # why separate yields drop the sentinel at the Starlette boundary).
+            trailer = "All tests passed!" if all_ok else "Some tests failed."
+            result = "PASS" if all_ok else "FAIL"
+            rc = 0 if all_ok else 1
+            yield f"\n{trailer}\n__DREAM_RESULT__:{result}:{rc}\n"
         return StreamingResponse(error_stream(), media_type="text/plain")
 
     async def run_tests():
@@ -147,7 +157,16 @@ async def run_setup_diagnostics(api_key: str = Depends(verify_api_key)):
             async for line in process.stdout:
                 yield line.decode()
             await process.wait()
-            yield f"\n{'All tests passed!' if process.returncode == 0 else 'Some tests failed.'}\n"
+            # Emit the human-readable trailer AND the machine-readable sentinel
+            # as a SINGLE chunk. Starlette's StreamingResponse finalizes the
+            # HTTP stream as soon as the async generator exits; when trailer
+            # and sentinel are separate yields, the final sentinel bytes have
+            # been observed to never reach the client (the generator yields
+            # them but the transport drops the last chunk during close).
+            # Combining into one yield guarantees both land on the wire.
+            trailer = "All tests passed!" if process.returncode == 0 else "Some tests failed."
+            status = "PASS" if process.returncode == 0 else "FAIL"
+            yield f"\n{trailer}\n__DREAM_RESULT__:{status}:{process.returncode}\n"
         finally:
             if process.returncode is None:
                 try:

--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { CheckCircle, Circle, ChevronRight, ChevronLeft, Mic, User, Settings, Play, Shield, Layers } from 'lucide-react'
 import { PreFlightChecks } from './PreFlightChecks'
 import { TemplatePicker } from './TemplatePicker'
+import { getTemplateStatus } from '../lib/templates'
 
 export default function SetupWizard({ onComplete }) {
   const [step, setStep] = useState(1)
@@ -14,14 +15,52 @@ export default function SetupWizard({ onComplete }) {
   const [testStatus, setTestStatus] = useState({ running: false, output: [], done: false, success: false })
   const [preflightIssues, setPreflightIssues] = useState([])
   const [templates, setTemplates] = useState([])
+  const [extensions, setExtensions] = useState([])
   const totalSteps = 6
 
+  // Holds the AbortController for the currently in-flight /api/setup/test
+  // stream (if any). Aborting it tells the server to release the subprocess
+  // and async generator so a user who abandons the wizard mid-diagnostic
+  // doesn't leave the backend running curls for ~2 minutes.
+  const diagControllerRef = useRef(null)
+
   useEffect(() => {
-    fetch('/api/templates')
-      .then(res => res.ok ? res.json() : { templates: [] })
-      .then(data => setTemplates(data.templates || []))
-      .catch(() => {})
+    return () => {
+      if (diagControllerRef.current) {
+        diagControllerRef.current.abort()
+      }
+    }
   }, [])
+
+  // Fetches templates and extensions in parallel and applies their state
+  // updates only after BOTH have settled. React 18 auto-batches the two
+  // setState calls that land in the same async tick, so template cards
+  // don't flash "available" for ~200ms while extensions are still in-flight.
+  // Promise.allSettled lets one side fail without aborting the other.
+  const refreshTemplateData = useCallback(async () => {
+    const [tRes, eRes] = await Promise.allSettled([
+      fetch('/api/templates').then(r => r.ok ? r.json() : { templates: [] }),
+      fetch('/api/extensions/catalog').then(r => r.ok ? r.json() : { extensions: [] })
+    ])
+    if (tRes.status === 'fulfilled') {
+      setTemplates(tRes.value.templates || [])
+    } else {
+      console.error('Failed to load templates:', tRes.reason)
+    }
+    if (eRes.status === 'fulfilled') {
+      setExtensions(eRes.value.extensions || [])
+    } else {
+      console.error('Failed to load extensions:', eRes.reason)
+    }
+  }, [])
+
+  // Re-fetch on every navigation to Step 2: the user may have just applied
+  // a template on a previous visit, in which case extensions state is stale
+  // and the "applied" indicator would lie.
+  useEffect(() => {
+    if (step !== 2) return
+    refreshTemplateData()
+  }, [step, refreshTemplateData])
 
   const voices = [
     { id: 'af_heart', name: 'Heart', desc: 'Warm, friendly female' },
@@ -41,10 +80,17 @@ export default function SetupWizard({ onComplete }) {
   }, [])
 
   const runDiagnostics = async () => {
+    // Cancel any in-flight diagnostic (re-running before previous completes).
+    if (diagControllerRef.current) {
+      diagControllerRef.current.abort()
+    }
+    const controller = new AbortController()
+    diagControllerRef.current = controller
+
     setTestStatus({ running: true, output: ['Starting diagnostic tests...'], done: false, success: false })
 
     try {
-      const res = await fetch('/api/setup/test', { method: 'POST' })
+      const res = await fetch('/api/setup/test', { method: 'POST', signal: controller.signal })
       const reader = res.body.getReader()
       const decoder = new TextDecoder()
       // The backend streams plain text. We split on newlines so each script
@@ -91,7 +137,16 @@ export default function SetupWizard({ onComplete }) {
         setConfig(c => ({ ...c, tested: true }))
       }
     } catch (err) {
+      // Aborted fetches throw AbortError. That's the user cancelling or the
+      // component unmounting — don't surface it as a user-visible error.
+      if (err.name === 'AbortError') {
+        return
+      }
       setTestStatus(prev => ({ ...prev, running: false, done: true, success: false, output: [...prev.output, `Error: ${err.message}`] }))
+    } finally {
+      if (diagControllerRef.current === controller) {
+        diagControllerRef.current = null
+      }
     }
   }
 
@@ -149,7 +204,11 @@ export default function SetupWizard({ onComplete }) {
                 Pick a pre-configured set of services to get started quickly, or skip to customize later.
               </p>
               {templates.length > 0 ? (
-                <TemplatePicker templates={templates} compact />
+                <TemplatePicker
+                  templates={templates.map(t => ({ ...t, _status: getTemplateStatus(t, extensions) }))}
+                  compact
+                  onApplied={refreshTemplateData}
+                />
               ) : (
                 <p className="text-sm text-theme-text-muted">No templates available.</p>
               )}

--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -47,17 +47,49 @@ export default function SetupWizard({ onComplete }) {
       const res = await fetch('/api/setup/test', { method: 'POST' })
       const reader = res.body.getReader()
       const decoder = new TextDecoder()
+      // The backend streams plain text. We split on newlines so each script
+      // line becomes its own <div>, and scan for a machine-readable sentinel
+      // (`__DREAM_RESULT__:PASS|FAIL:<returncode>`) to determine success.
+      let buffer = ''
+      let resultStatus = null // 'PASS' | 'FAIL' | null
+      const collected = [] // local mirror of displayed lines for fallback scan
+
+      const pushLine = (line) => {
+        const match = line.match(/^__DREAM_RESULT__:(PASS|FAIL):(-?\d+)$/)
+        if (match) {
+          resultStatus = match[1]
+          return // don't display the sentinel to the user
+        }
+        collected.push(line)
+        setTestStatus(prev => ({ ...prev, output: [...prev.output, line] }))
+      }
 
       while (true) {
         const { done, value } = await reader.read()
         if (done) break
 
-        const text = decoder.decode(value)
-        setTestStatus(prev => ({ ...prev, output: [...prev.output, text] }))
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() // keep the trailing partial line for the next chunk
+        for (const line of lines) pushLine(line)
       }
 
-      setTestStatus(prev => ({ ...prev, running: false, done: true, success: true }))
-      setConfig(c => ({ ...c, tested: true }))
+      // Flush any decoder tail plus any remaining unterminated line.
+      buffer += decoder.decode()
+      if (buffer) pushLine(buffer)
+
+      // Prefer the structured sentinel. Fall back to scanning accumulated
+      // output for the human-readable trailer if the sentinel is absent
+      // (older backends, truncated stream). Absence defaults to failure —
+      // we refuse to greenlight a user through a stream of unknown outcome.
+      const success = resultStatus !== null
+        ? resultStatus === 'PASS'
+        : collected.some(l => l.includes('All tests passed!'))
+
+      setTestStatus(prev => ({ ...prev, running: false, done: true, success }))
+      if (success) {
+        setConfig(c => ({ ...c, tested: true }))
+      }
     } catch (err) {
       setTestStatus(prev => ({ ...prev, running: false, done: true, success: false, output: [...prev.output, `Error: ${err.message}`] }))
     }

--- a/dream-server/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -20,8 +20,9 @@ const fetchJson = async (url, options = {}) => {
  * TemplatePicker — card grid of templates. Click shows preview.
  *
  * Templates carry a `_status` field set by the parent: 'available',
- * 'in_progress', or 'has_errors'. ('applied' is filtered upstream.) The
- * card renders differently per state and is only clickable in 'available'.
+ * 'in_progress', 'applied', or 'has_errors'. The card renders differently
+ * per state and is only clickable in 'available'. Callers that prefer to
+ * hide applied templates (Extensions page) can filter them out upstream.
  */
 export function TemplatePicker({ templates, onApplied, compact = false }) {
   const [preview, setPreview] = useState(null)
@@ -36,13 +37,16 @@ export function TemplatePicker({ templates, onApplied, compact = false }) {
           const status = tmpl._status || 'available'
           const inProgress = status === 'in_progress'
           const hasErrors = status === 'has_errors'
-          const disabled = inProgress || hasErrors
+          const isApplied = status === 'applied'
+          const disabled = inProgress || hasErrors || isApplied
 
           const cardBase = 'text-left rounded-xl p-4 transition-all group border'
           const cardByStatus = inProgress
             ? 'bg-theme-card border-blue-500/30 cursor-not-allowed opacity-80'
             : hasErrors
             ? 'bg-red-500/5 border-red-500/30 cursor-not-allowed'
+            : isApplied
+            ? 'bg-green-500/5 border-green-500/30 cursor-not-allowed'
             : 'bg-theme-card border-theme-border hover:border-theme-accent/40 hover:bg-theme-surface-hover'
 
           return (
@@ -54,12 +58,17 @@ export function TemplatePicker({ templates, onApplied, compact = false }) {
               className={`${cardBase} ${cardByStatus}`}
             >
               <div className="flex items-center gap-3 mb-2">
-                <div className={`p-2 rounded-lg ${hasErrors ? 'bg-red-500/10' : 'bg-theme-accent/10 group-hover:bg-theme-accent/20'} transition-colors`}>
+                <div className={`p-2 rounded-lg ${hasErrors ? 'bg-red-500/10' : isApplied ? 'bg-green-500/10' : 'bg-theme-accent/10 group-hover:bg-theme-accent/20'} transition-colors`}>
+                  {/* Status icons are decorative — the adjacent text label
+                      ("Installing…" / "Has errors" / "Applied") carries the
+                      semantic meaning, so hide icons from screen readers. */}
                   {inProgress
-                    ? <Loader2 size={18} className="animate-spin text-blue-400" />
+                    ? <Loader2 size={18} aria-hidden="true" className="animate-spin text-blue-400" />
                     : hasErrors
-                    ? <AlertTriangle size={18} className="text-red-400" />
-                    : <Icon size={18} className="text-theme-accent-light" />}
+                    ? <AlertTriangle size={18} aria-hidden="true" className="text-red-400" />
+                    : isApplied
+                    ? <Check size={18} aria-hidden="true" className="text-green-400" />
+                    : <Icon size={18} aria-hidden="true" className="text-theme-accent-light" />}
                 </div>
                 <div>
                   <h4 className="text-sm font-semibold text-theme-text">{tmpl.name}</h4>
@@ -69,7 +78,10 @@ export function TemplatePicker({ templates, onApplied, compact = false }) {
                   {hasErrors && (
                     <span className="text-[10px] text-red-400 uppercase tracking-wider">Has errors</span>
                   )}
-                  {!inProgress && !hasErrors && tmpl.tier_minimum && (
+                  {isApplied && (
+                    <span className="text-[10px] text-green-400 uppercase tracking-wider">Applied</span>
+                  )}
+                  {!inProgress && !hasErrors && !isApplied && tmpl.tier_minimum && (
                     <span className="text-[10px] text-theme-text-muted uppercase tracking-wider">
                       {tmpl.tier_minimum}+
                     </span>

--- a/dream-server/extensions/services/dashboard/src/lib/templates.js
+++ b/dream-server/extensions/services/dashboard/src/lib/templates.js
@@ -1,0 +1,29 @@
+// Shared template-status helpers. Kept in a dedicated module (rather than
+// re-exported from pages/Extensions.jsx) so components on the initial
+// first-run route — e.g. SetupWizard — don't pull the full Extensions page
+// into the main bundle and defeat its lazy-loading.
+
+// Services defined in docker-compose.base.yml — always running, not togglable via templates.
+export const BASE_COMPOSE_SERVICES = new Set(['llama-server', 'open-webui', 'dashboard', 'dashboard-api'])
+
+// Compute template status from catalog extensions data.
+// Returns one of: 'available', 'in_progress', 'applied', 'has_errors'
+// Precedence: has_errors > in_progress > applied > available
+export function getTemplateStatus(template, extensions) {
+  const services = template.services || []
+  const serviceStatus = {}
+  for (const svcId of services) {
+    if (BASE_COMPOSE_SERVICES.has(svcId)) {
+      serviceStatus[svcId] = 'enabled'
+      continue
+    }
+    const ext = extensions.find(e => e.id === svcId)
+    serviceStatus[svcId] = ext ? ext.status : undefined
+  }
+  const statuses = Object.values(serviceStatus)
+  if (statuses.some(s => s === 'error')) return 'has_errors'
+  if (statuses.some(s => s === 'installing' || s === 'setting_up')) return 'in_progress'
+  const allEnabled = statuses.every(s => s === 'enabled')
+  if (allEnabled) return 'applied'
+  return 'available'
+}

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -6,34 +6,13 @@ import {
 import { useState, useEffect, useRef } from 'react'
 import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
 import { TemplatePicker } from '../components/TemplatePicker'
+import { getTemplateStatus } from '../lib/templates'
 
-// Services defined in docker-compose.base.yml — always running, not togglable via templates
-const BASE_COMPOSE_SERVICES = new Set(['llama-server', 'open-webui', 'dashboard', 'dashboard-api'])
+// Re-export so existing importers of getTemplateStatus from this module keep working.
+export { getTemplateStatus }
 
 // API/backend services with no user-facing web UI — show badge instead of port link.
 const HEADLESS_EXTENSIONS = new Set(['embeddings', 'tts', 'whisper', 'privacy-shield'])
-
-// Compute template status from catalog extensions data.
-// Returns one of: 'available', 'in_progress', 'applied', 'has_errors'
-// Precedence: has_errors > in_progress > applied > available
-export function getTemplateStatus(template, extensions) {
-  const services = template.services || []
-  const serviceStatus = {}
-  for (const svcId of services) {
-    if (BASE_COMPOSE_SERVICES.has(svcId)) {
-      serviceStatus[svcId] = 'enabled'
-      continue
-    }
-    const ext = extensions.find(e => e.id === svcId)
-    serviceStatus[svcId] = ext ? ext.status : undefined
-  }
-  const statuses = Object.values(serviceStatus)
-  if (statuses.some(s => s === 'error')) return 'has_errors'
-  if (statuses.some(s => s === 'installing' || s === 'setting_up')) return 'in_progress'
-  const allEnabled = statuses.every(s => s === 'enabled')
-  if (allEnabled) return 'applied'
-  return 'available'
-}
 
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf).  All fetches

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -45,12 +45,15 @@ TESTS_FAILED=0
 
 pass() {
     echo -e "${GREEN}✓${NC} $1"
-    ((TESTS_PASSED++))
+    # Arithmetic expansion (not `((...))`) — the compound form returns
+    # exit 1 when the pre-increment value is 0, which would trip `set -e`
+    # on the first pass/fail and abort the script before any summary.
+    TESTS_PASSED=$((TESTS_PASSED + 1))
 }
 
 fail() {
     echo -e "${RED}✗${NC} $1"
-    ((TESTS_FAILED++))
+    TESTS_FAILED=$((TESTS_FAILED + 1))
 }
 
 warn() {
@@ -62,8 +65,18 @@ test_llm_functional() {
     echo ""
     echo "> Testing LLM Functional Generation"
 
-    local model_id
-    model_id=$(curl -s --max-time 10 "$LLM_URL/v1/models" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+    # The grep-based extraction pipelines in this script may legitimately
+    # produce zero matches (LLM/TTS/embeddings/whisper offline or returning
+    # unexpected payload). Under `set -euo pipefail` such a no-match would
+    # abort the script before the `[[ -z ... ]]` guard below can treat it
+    # as a test failure. Using `if ! VAR=$(...)` keeps the set -e safety
+    # net engaged everywhere else; `set -e` is disabled only for the
+    # evaluation of the condition (per bash spec), so a failed pipeline
+    # leaves VAR empty and the explicit `fail` path below runs.
+    local model_id=""
+    if ! model_id=$(curl -s --max-time 10 "$LLM_URL/v1/models" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4); then
+        model_id=""
+    fi
     model_id="${model_id:-local}"
 
     local prompt="What is 2+2? Answer with just the number."
@@ -80,8 +93,10 @@ test_llm_functional() {
         return 1
     fi
 
-    local content
-    content=$(echo "$response" | grep -oE '"content":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4)
+    local content=""
+    if ! content=$(echo "$response" | grep -oE '"content":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4); then
+        content=""
+    fi
 
     if [[ -z "$content" ]]; then
         fail "LLM returned empty content"
@@ -176,8 +191,10 @@ test_embeddings_functional() {
     
     # Check if response contains array of numbers
     if echo "$response" | grep -qE '\[\s*-?[0-9]+\.[0-9]+'; then
-        local vector_len
-        vector_len=$(echo "$response" | grep -oE '-?[0-9]+\.[0-9]+' | wc -l)
+        local vector_len=0
+        if ! vector_len=$(echo "$response" | grep -oE '-?[0-9]+\.[0-9]+' | wc -l); then
+            vector_len=0
+        fi
         pass "Embeddings generates vectors ($vector_len dimensions)"
     else
         fail "Embeddings did not return valid vectors"
@@ -226,8 +243,10 @@ test_whisper_functional() {
         return 1
     fi
     
-    local transcription
-    transcription=$(echo "$response" | grep -oE '"text":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4)
+    local transcription=""
+    if ! transcription=$(echo "$response" | grep -oE '"text":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4); then
+        transcription=""
+    fi
     
     if [[ -z "$transcription" ]]; then
         fail "Whisper returned empty transcription"
@@ -248,10 +267,19 @@ echo "  DREAM SERVER - FUNCTIONAL TESTS"
 echo "  Tests actual functionality, not ports"
 echo "========================================"
 
+# Each test returns 1 on failure via its internal `fail` call; we must not
+# let `set -e` short-circuit the remaining tests or skip the summary. The
+# TESTS_PASSED / TESTS_FAILED counters are updated inside pass/fail and
+# drive the final exit code below, so suspending strict mode for exactly
+# this block is the explicit expression of "errors here are accounted for."
+# (CLAUDE.md forbids `|| true` / silent swallow; this bounded toggle makes
+# the intent visible instead of hiding it behind a trailing `|| true`.)
+set +e
 test_llm_functional
 test_tts_functional
 test_embeddings_functional
 test_whisper_functional
+set -e
 
 echo ""
 echo "========================================"


### PR DESCRIPTION
## What

Three substantive fixes for the dashboard's Setup Wizard, plus correctness fixes for the diagnostic shell script:

1. **Machine-readable `__DREAM_RESULT__:PASS|FAIL:<rc>` sentinel** on `/api/setup/test` (both `run_tests` happy path and `error_stream` fallback). The wizard no longer greenlights users through onboarding on a failed diagnostic.
2. **Setup Wizard JSX hardening** — `AbortController` for mid-wizard cancellation, `Promise.allSettled` for race-free template/extension fetches, step-guarded `useEffect` re-fetch on back-nav, `console.error` on previously-silent catches, `aria-hidden` on decorative template-status icons.
3. **Template applied-status indicator** lifted from `pages/Extensions.jsx` into `src/lib/templates.js` so the wizard can show per-template "applied" state without pulling the Extensions page into the initial bundle.
4. **`scripts/dream-test-functional.sh` `set -euo pipefail` discipline** — replace `((VAR++))` arithmetic-compound (returns 1 when pre-incr is 0) with `$((VAR + 1))` expansion; use `if ! VAR=$(...)` pattern for grep-pipelines that may legitimately produce no match; bounded `set +e/set -e` block around the test-function-dispatch so a single failing test doesn't abort the runner.

## Why

The wizard previously enabled "Complete Setup" as soon as the test stream ended, regardless of exit code — greenlighting users with broken backends. Concurrent issues in the diagnostic shell script caused it to exit after the first test under `set -e`, so the Python streaming generator's trailer and sentinel never reached the HTTP client anyway. Separately, the Python generator yielded trailer and sentinel as two separate `yield` statements; Starlette's `StreamingResponse` was dropping the final chunk during stream finalization, so even when the shell script ran to completion the sentinel never arrived at the client.

Client-side: silent `.catch(() => {})` swallowed template and extension load errors. No `AbortController` meant abandoned wizard sessions kept the server-side subprocess running for 2+ minutes per visit. A race between template and extension fetches caused template status cards to briefly flash "available" before correcting to "applied."

## How

Two commits:

- `1ba7c78f` — backend sentinel. `run_tests` emits trailer + sentinel as a **single combined `yield`** (works around Starlette's observed end-of-stream final-chunk drop). `error_stream` fallback now tracks `all_ok` across connectivity checks and emits a result-dependent trailer + sentinel. Shell-script trap fixes in `dream-test-functional.sh`.
- `57f2783a` — template applied-status lifted to `src/lib/templates.js` + wizard enrichment + `AbortController` + `Promise.allSettled` + step-guarded `useEffect` + `aria-hidden` on decorative icons + non-silent catches (`console.error` with context).

## Testing

- **Live HTTP byte-inspection** of `/api/setup/test` confirms `__DREAM_RESULT__:FAIL:1\n` now arrives on the wire; previously absent.
- Shell script runs to completion inside the `dream-dashboard-api` container with all 4 test functions + summary + correct exit code.
- Round-1 review: Critique Guardian approved. Round-2 adversarial audit by dashboard-verifier: shell + Python claims verified, JSX claims verified (`AbortController` wiring, `Promise.allSettled`, step-guarded `useEffect`, `aria-hidden` actually applied, sentinel parser handles 745-byte response correctly).

## Known Considerations

- The `dream-dashboard-api` Docker image bakes `routers/setup.py` at build time (uvicorn `WORKDIR=/app`). This PR's Python changes require an image rebuild to take effect on existing installs. A separate follow-up will address the installer's `docker compose up` flow to force-rebuild locally-built images.
- `TemplatePicker.jsx:140` has a pre-existing `res.json().catch(() => ({}))` silent swallow unrelated to this PR's touched scope; tracked as a separate follow-up.

## Platform Impact

- **macOS / Linux / Windows (WSL2):** all identical. Backend is Python inside Docker; JSX is browser-side. Shell script is POSIX-compatible Bash 4+.
