### PR TITLE
fix(resolver): skip compose.local.yaml on Apple Silicon to avoid llama-server deadlock

### DIFF
--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -190,8 +190,13 @@ if ext_dir.exists():
             if gpu_overlay.exists():
                 resolved.append(str(gpu_overlay.relative_to(script_dir)))
             
-            # Mode-specific overlay — depends_on for local/hybrid mode only
-            if dream_mode in ("local", "hybrid", "lemonade"):
+            # Mode-specific overlay — depends_on for local/hybrid mode only.
+            # Skip on Apple Silicon: macOS runs llama-server natively on the host
+            # (Docker service has replicas: 0), so `depends_on: llama-server:
+            # service_healthy` inside compose.local.yaml overlays can never be
+            # satisfied and deadlocks the stack. The real LLM-ready gate on macOS
+            # is the `llama-server-ready` sidecar defined in the macOS overlay.
+            if dream_mode in ("local", "hybrid", "lemonade") and gpu_backend != "apple":
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))


### PR DESCRIPTION
## What
`scripts/resolve-compose-stack.sh` was unconditionally including extension
`compose.local.yaml` overlays whenever `DREAM_MODE` was `local`, `hybrid`,
or `lemonade` — even when `gpu_backend` was `apple`. On macOS, those
overlays deadlock the stack.

## Why
Extension `compose.local.yaml` overlays declare
`depends_on: llama-server: condition: service_healthy`. On macOS the
`llama-server` Docker service has `replicas: 0` because the real
llama-server runs natively on the host via LaunchAgent. That dependency
therefore can never be satisfied and deadlocks every service that
declares it whenever the resolver regenerates `.compose-flags` (i.e.
any `dream enable` / `dream disable` / `dream restart`).

The correct macOS LLM-ready gate is the `llama-server-ready` sidecar in
`installers/macos/docker-compose.macos.yml`.

## How
Add `and gpu_backend != "apple"` to the existing
`dream_mode in ("local", "hybrid", "lemonade")` guard. Linux and Windows
NVIDIA/AMD paths unchanged — still pick up all 7 `compose.local.yaml`
files. macOS now correctly emits 0.

## Testing
- `bash -n` and Python heredoc `ast.parse` pass.
- Behavior matrix verified locally:
  | backend | mode | count | expected |
  | --- | --- | --- | --- |
  | apple | local / hybrid / lemonade | 0 | 0 |
  | nvidia | local | 7 | 7 |
  | amd | local | 7 | 7 |
- `make lint` and `make test` pass.

## Platform Impact
- macOS Apple Silicon: deadlock fixed.
- Linux NVIDIA/AMD/CPU/Intel/ARC: unchanged (still pick up all 7 overlays).
- Windows WSL2: unchanged.

## Known follow-up
The macOS installer currently builds `.compose-flags` inline (in
`installers/macos/install-macos.sh`) rather than delegating to the
resolver. That second half of the original audit finding was split off
to a separate PR because delegating without first mirroring Linux's
feature-flag `.disabled` renames would regress `--minimal` macOS
installs. It is tracked separately as a follow-up.