### PR TITLE
fix(macos): install-time polish — DIM constant, busybox pin, healthcheck rewrite

### DIFF
--- a/dream-server/installers/macos/docker-compose.macos.yml
+++ b/dream-server/installers/macos/docker-compose.macos.yml
@@ -6,7 +6,7 @@
 
 services:
   llama-server:
-    image: busybox:latest   # Placeholder -- container never runs (replicas: 0)
+    image: busybox:1.36.1   # Placeholder -- container never runs (replicas: 0)
     deploy:
       replicas: 0    # Disabled -- running natively on macOS host via Metal
 
@@ -15,7 +15,7 @@ services:
   # lightweight container bridges the gap.  open-webui waits on its
   # healthcheck before starting.
   llama-server-ready:
-    image: busybox:latest
+    image: busybox:1.36.1
     container_name: dream-llama-ready
     restart: unless-stopped
     extra_hosts:

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1053,31 +1053,48 @@ fi
 
 # Health check loop
 ai "Running health checks..."
-MAX_ATTEMPTS=30
+MAX_ATTEMPTS=90   # 90 * 2s = 180s -- covers base compose start_period (60s) + image pull
 ALL_HEALTHY=true
 
-# Parallel arrays (Bash 3.2 compatible -- no associative arrays)
+# Parallel arrays (Bash 3.2 compatible -- no associative arrays).
+# HEALTH_CONTAINERS holds the Docker container name when a service runs in
+# Docker; an empty string means the service is host-native (llama-server
+# runs natively on macOS via Metal; OpenCode is a LaunchAgent). Docker
+# services wait on `docker inspect ... .State.Health.Status == healthy`;
+# host-native services fall back to an HTTP probe on 127.0.0.1.
 HEALTH_NAMES=("LLM (llama-server)" "Chat UI (Open WebUI)")
-HEALTH_URLS=("http://localhost:8080/health" "http://localhost:3000")
-$ENABLE_VOICE && HEALTH_NAMES+=("Whisper (STT)") && HEALTH_URLS+=("http://localhost:9000/health")
-$ENABLE_WORKFLOWS && HEALTH_NAMES+=("n8n (Workflows)") && HEALTH_URLS+=("http://localhost:5678/healthz")
-[[ -x "$OPENCODE_BIN" ]] && HEALTH_NAMES+=("OpenCode (IDE)") && HEALTH_URLS+=("http://localhost:${OPENCODE_PORT}")
+HEALTH_URLS=("http://127.0.0.1:8080/health" "http://127.0.0.1:3000")
+HEALTH_CONTAINERS=("" "dream-webui")
+$ENABLE_VOICE && HEALTH_NAMES+=("Whisper (STT)") && HEALTH_URLS+=("http://127.0.0.1:9000/health") && HEALTH_CONTAINERS+=("dream-whisper")
+$ENABLE_WORKFLOWS && HEALTH_NAMES+=("n8n (Workflows)") && HEALTH_URLS+=("http://127.0.0.1:5678/healthz") && HEALTH_CONTAINERS+=("dream-n8n")
+[[ -x "$OPENCODE_BIN" ]] && HEALTH_NAMES+=("OpenCode (IDE)") && HEALTH_URLS+=("http://127.0.0.1:${OPENCODE_PORT}") && HEALTH_CONTAINERS+=("")
 
 for ((idx=0; idx<${#HEALTH_NAMES[@]}; idx++)); do
     NAME="${HEALTH_NAMES[$idx]}"
     URL="${HEALTH_URLS[$idx]}"
+    CONTAINER="${HEALTH_CONTAINERS[$idx]}"
     HEALTHY=false
 
     for ((attempt=1; attempt<=MAX_ATTEMPTS; attempt++)); do
-        HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
-        if [[ "$HTTP_CODE" -ge 200 ]] && [[ "$HTTP_CODE" -lt 400 ]]; then
-            HEALTHY=true
-            break
-        fi
-        # 401/403 means service is responding (auth-protected) -- treat as healthy
-        if [[ "$HTTP_CODE" == "401" ]] || [[ "$HTTP_CODE" == "403" ]]; then
-            HEALTHY=true
-            break
+        if [[ -n "$CONTAINER" ]]; then
+            # Docker service -- wait for the container healthcheck to report healthy.
+            STATUS=$(docker inspect --format '{{.State.Health.Status}}' "$CONTAINER" 2>/dev/null || echo "missing")
+            if [[ "$STATUS" == "healthy" ]]; then
+                HEALTHY=true
+                break
+            fi
+        else
+            # Host-native service -- poll HTTP on 127.0.0.1.
+            HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
+            if [[ "$HTTP_CODE" -ge 200 ]] && [[ "$HTTP_CODE" -lt 400 ]]; then
+                HEALTHY=true
+                break
+            fi
+            # 401/403 means service is responding (auth-protected) -- treat as healthy
+            if [[ "$HTTP_CODE" == "401" ]] || [[ "$HTTP_CODE" == "403" ]]; then
+                HEALTHY=true
+                break
+            fi
         fi
         if (( attempt <= 3 || attempt % 5 == 0 )); then
             ai "  Waiting for ${NAME}... (${attempt}/${MAX_ATTEMPTS})"

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -79,6 +79,7 @@ BGRN='\033[1;32m'        # Bright green -- emphasis, success, headings
 DGRN='\033[2;32m'        # Dim green -- secondary text, lore
 AMB='\033[0;33m'         # Amber -- warnings, ETA labels
 WHT='\033[1;37m'         # White -- key URLs
+DIM='\033[2;37m'         # Dim white -- subdued hints, lore
 NC='\033[0m'             # Reset
 CURSOR='█'               # Block cursor for typing
 


### PR DESCRIPTION
## What
Three macOS-only install-time defects, each in a distinct file.

## Why / How

### 1. `DIM` color variable missing from macOS constants
`installers/macos/lib/ui.sh:180` referenced `\${DIM}` in the final
summary banner, but the macOS `lib/constants.sh` did not define it
(the shared `installers/lib/constants.sh` defines it at line 52, but
the macOS installer does not source that file). Under `set -u` the
installer crashed at the very last line — a scary UX on an install
that otherwise succeeded. Added `DIM='\033[2;37m'` to the macOS
constants, matching the shared palette.

### 2. `busybox:latest` pinned
`installers/macos/docker-compose.macos.yml` used `busybox:latest` for
both the `replicas: 0` placeholder and the active
`llama-server-ready` sidecar. The active sidecar runs a `wget`
polling loop that depends on busybox applet semantics — `:latest` is
a reproducibility risk. Pinned both references to `busybox:1.36.1`,
matching the explicit-pin pattern used elsewhere in the compose tree.

### 3. Phase-6 healthcheck loop rewrite
The installer's own HTTP poll (`MAX_ATTEMPTS=30`, 60s total) often
emitted false `not responding after 30 attempts` warnings on cold
first installs because image pull + first-run DB migrations + Docker
Desktop container startup can exceed 60s.

Replaced with `docker inspect --format '{{.State.Health.Status}}'`
for Docker services (`dream-webui`, `dream-whisper`, `dream-n8n`)
so the container's own healthcheck drives the gate. Host-native
services (llama-server, OpenCode) keep the HTTP fallback.

Also in this commit:
- `MAX_ATTEMPTS=90` (180s total) comfortably accommodates Open
  WebUI's `start_period: 60s` + image pull time.
- All `HEALTH_URLS` entries changed from `localhost` to `127.0.0.1`
  per project convention (avoids IPv6 `::1` resolution quirks).
- Error semantics preserved — still a `warn` + `ALL_HEALTHY=false`
  on timeout, no `exit` (forgiving happy-path behavior retained).

## Testing
- `bash -n` passes on all three files.
- `shellcheck` diff against base: zero new warnings.
- `docker manifest inspect busybox:1.36.1` confirms pullability.
- Busybox 1.36.x includes the `wget` applets the sidecar needs.

## Platform Impact
- macOS Apple Silicon: all three defects fixed.
- Linux / Windows: zero touch — files are under `installers/macos/`
  only.

## Manual test for reviewers
On macOS Apple Silicon:
1. Fresh `install-macos.sh --force` → no `DIM: unbound variable`
   crash at the final summary banner; no false
   `Chat UI (Open WebUI): not responding after 30 attempts`.
2. `docker inspect dream-llama-ready | jq -r '.[0].Config.Image'`
   → `busybox:1.36.1`.