### PR TITLE
refactor(dream-cli): guard .env grep pipelines against pipefail kill on missing keys

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -251,7 +251,7 @@ _check_version_compat() {
 
     # 1. Installed version
     _COMPAT_INSTALLED_VER=$(grep '^DREAM_VERSION=' "$INSTALL_DIR/.env" 2>/dev/null \
-        | head -1 | cut -d= -f2 | tr -d '[:space:]')
+        | sed -n '1p' | cut -d= -f2 | tr -d '[:space:]' || true)
     # Fall back to .version file (written by dream-update.sh / PR #349 convention)
     if [[ -z "$_COMPAT_INSTALLED_VER" && -f "$INSTALL_DIR/.version" ]]; then
         _COMPAT_INSTALLED_VER=$(jq -r '.version // empty' "$INSTALL_DIR/.version" 2>/dev/null \
@@ -833,7 +833,7 @@ cmd_dry_run() {
     local cur_ver="0.0.0"
     if [[ -f "$INSTALL_DIR/.env" ]]; then
         local _v
-        _v=$(grep '^DREAM_VERSION=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+        _v=$(grep '^DREAM_VERSION=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)
         [[ -n "$_v" ]] && cur_ver="$_v"
     fi
     if [[ "$cur_ver" == "0.0.0" && -f "$INSTALL_DIR/.version" ]]; then
@@ -846,7 +846,7 @@ cmd_dry_run() {
     local api_json=""
     local dashboard_port="${DASHBOARD_PORT:-3002}"
     local api_key=""
-    api_key=$(grep '^DASHBOARD_API_KEY=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+    api_key=$(grep '^DASHBOARD_API_KEY=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)
     if [[ -n "$api_key" ]]; then
         api_json=$(curl -sf --max-time 5 \
             -H "X-API-Key: ${api_key}" \
@@ -935,7 +935,7 @@ cmd_dry_run() {
     local key
     for key in "${model_keys[@]}"; do
         local val
-        val=$(grep "^${key}=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+        val=$(grep "^${key}=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)
         printf "  %-16s %s\n" "${key}:" "${val:-(not set)}"
     done
     echo ""
@@ -950,7 +950,7 @@ cmd_dry_run() {
     else
         for key in "${update_keys[@]}"; do
             local val
-            val=$(grep "^${key}=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]')
+            val=$(grep "^${key}=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)
             printf "  %-16s %s\n" "${key}:" "${val:-(not set)}"
         done
     fi
@@ -1431,7 +1431,7 @@ cmd_enable() {
         local current_backend="${GPU_BACKEND:-nvidia}"
         if [[ -f "$INSTALL_DIR/.env" ]]; then
             local env_backend
-            env_backend=$(grep "^GPU_BACKEND=" "$INSTALL_DIR/.env" | cut -d= -f2 | tr -d '"')
+            env_backend=$(grep "^GPU_BACKEND=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || true)
             if [[ -n "$env_backend" ]]; then
                 current_backend="$env_backend"
             else
@@ -1778,7 +1778,7 @@ META
             if [[ -f "$preset_dir/env" ]]; then
                 cp "$preset_dir/env" "$INSTALL_DIR/.env"
                 local restored_mode
-                restored_mode=$(grep "^DREAM_MODE=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2)
+                restored_mode=$(grep "^DREAM_MODE=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 || true)
                 success "Restored .env (mode: ${restored_mode:-local})"
             fi
 


### PR DESCRIPTION
## What
Seven `grep "^KEY=" .env | cut | tr` pipelines in `dream-cli` would
exit 1 when the key is absent. Under `set -eo pipefail` those
pipelines would kill the script before the downstream defensive
checks (`[[ -n ... ]]`, `${var:-(not set)}`) can handle the
empty-on-miss case the surrounding code was written for.

## Why
The surrounding code treats missing keys as benign (empty string,
"not set" default, fallthrough to defaults). That contract held
pre-pipefail because a grep miss yielded an empty pipeline output
with exit 0. Post-pipefail, a grep miss propagates exit 1, and
because these pipelines are assigned with bare `VAR=$(...)` (not
`local VAR=$(...)`, which would mask the exit status), `set -e`
kills the script mid-flow.

## How
Appended `|| true` to each of the seven pipelines:

| line | function                | key read             |
| ---- | ----------------------- | -------------------- |
| 254  | `_check_version_compat` | `DREAM_VERSION`      |
| 836  | `cmd_dry_run`           | `DREAM_VERSION`      |
| 849  | `cmd_dry_run`           | `DASHBOARD_API_KEY`  |
| 938  | `cmd_dry_run` loop      | model-related keys   |
| 953  | `cmd_dry_run` loop (2)  | model-related keys   |
| 1434 | `cmd_enable`            | `GPU_BACKEND`        |
| 1781 | `cmd_preset`            | `DREAM_MODE`         |

Line 254 additionally swaps `| head -1` for `| sed -n '1p'` —
SIGPIPE-safe under pipefail, portable across BSD and GNU sed.

Line 1434 additionally picks up a missing `2>/dev/null` for
consistency with the other six sites.

Six other `grep "^KEY="` pipelines in the file (around lines 2082,
2084–2086, 2163–2164) use the single-line `local VAR=$(...)` form,
which masks the pipeline exit status (a `local` command always
exits 0 regardless of RHS) — those sites are already safe and are
intentionally out of scope.

## Testing
- `bash -n` passes.
- `shellcheck` diff against base: zero new warnings.
- Behavior confirmed under `set -eo pipefail`:
  - `grep '^NOPE=' file | cut -d= -f2 | tr -d '[:space:]' || true` → `rc=0`, empty value (missing key).
  - `grep '^FOO=' file  | cut -d= -f2 | tr -d '[:space:]' || true` → `rc=0`, value returned (present key).
- `sed -n '1p'` works identically on BSD (macOS) and GNU (Linux)
  sed; no platform hazard.

## Merge order (important)
This refactor is **preventive** on upstream/main today: `dream-cli`
is on `set -e` only, so a grep miss in any of these pipelines is
silently absorbed. It becomes load-bearing the moment #998
(`fix/dream-cli-pipefail-exit-codes`, enables `set -o pipefail`)
merges — without this fix in place, `dream update`, `dream
rollback`, `dream enable`, `dream preset`, and `dream dry-run` can
abort mid-flow on installs that predate (or manually-edited-out) a
given .env key.

**Recommended ordering:** merge this PR in the same batch as
#998, or land this first. If #998 merges alone, users on upstream
hit the regression immediately.

## Platform Impact
- macOS / Linux / Windows WSL2: POSIX `grep`, `cut`, `tr`, `sed -n '1p'` all behave identically. Zero platform risk.


---

## 📋 Chain status (operator's reminder — apr-25)

This PR is the **head of a `dream-cli` strict-mode chain**:

```
#1008 (this) ──READY──▶ #998 ──DRAFT─▶ #1002 ──DRAFT
                              └──────▶ #1018 ──DRAFT
```

**After this PR merges, the next operator step is:**
1. Promote #998 from DRAFT → ready (`gh pr ready 998`).
2. Maintainer merges #998.
3. Operator rebases #1002 onto post-#998 main (shared hunks drop out automatically) → promote #1002.
4. Operator does the same for #1018 (after its other 4 deps land — #994, #1003, #1016, plus #998 itself).

#998 / #1002 / #1018 are kept in DRAFT as a mechanical safeguard so they cannot merge before this one.
