### PR TITLE
fix(compose): image-gen default off on non-GPU platforms + dreamforge network convention

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -70,6 +70,7 @@ services:
   open-webui:
     environment:
       - OPENAI_API_KEY=no-key
+      - ENABLE_IMAGE_GENERATION=${ENABLE_IMAGE_GENERATION:-true}
 
   dashboard-api:
     environment:

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -82,7 +82,7 @@ services:
       ENABLE_SEARCH_QUERY_GENERATION: "true"
       WEB_SEARCH_RESULT_COUNT: "5"
       # ── ComfyUI Image Generation (SDXL Lightning 4-step) ──
-      ENABLE_IMAGE_GENERATION: "${ENABLE_IMAGE_GENERATION:-true}"
+      ENABLE_IMAGE_GENERATION: "${ENABLE_IMAGE_GENERATION:-false}"
       IMAGE_GENERATION_ENGINE: "comfyui"
       COMFYUI_BASE_URL: "http://comfyui:8188"
       IMAGE_SIZE: "1024x1024"

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -82,6 +82,10 @@ services:
       ENABLE_SEARCH_QUERY_GENERATION: "true"
       WEB_SEARCH_RESULT_COUNT: "5"
       # ── ComfyUI Image Generation (SDXL Lightning 4-step) ──
+      # Default OFF in base: ComfyUI ships only on GPU backends (amd/nvidia per
+      # comfyui/manifest.yaml). The amd and nvidia overlays re-assert this as
+      # ${...:-true} so image-gen is on for GPU users by default. CPU/Apple
+      # users would otherwise hit a missing-engine error from Open WebUI.
       ENABLE_IMAGE_GENERATION: "${ENABLE_IMAGE_GENERATION:-false}"
       IMAGE_GENERATION_ENGINE: "comfyui"
       COMFYUI_BASE_URL: "http://comfyui:8188"

--- a/dream-server/docker-compose.nvidia.yml
+++ b/dream-server/docker-compose.nvidia.yml
@@ -29,3 +29,4 @@ services:
   open-webui:
     environment:
       AUDIO_STT_MODEL: "deepdml/faster-whisper-large-v3-turbo-ct2"
+      ENABLE_IMAGE_GENERATION: "${ENABLE_IMAGE_GENERATION:-true}"

--- a/dream-server/extensions/services/dreamforge/compose.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.yaml
@@ -54,9 +54,3 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
-    networks:
-      - dream-network
-
-networks:
-  dream-network:
-    external: true


### PR DESCRIPTION
## What
Two small independent compose defects.

### 1. `ENABLE_IMAGE_GENERATION` default
`docker-compose.base.yml` defaulted `ENABLE_IMAGE_GENERATION` to
`true`. ComfyUI's manifest restricts it to `gpu_backends: [amd,
nvidia]`, so the image-gen backend cannot run on macOS Apple
Silicon, Linux CPU-only, Linux Intel/ARC, or Windows AMD. On those
platforms Open WebUI happily showed the image-gen UI, but clicking
it produced a connection error to `comfyui:8188`.

Flipped the base default to `false`. NVIDIA and AMD overlays now
add `ENABLE_IMAGE_GENERATION` to the `open-webui` environment
using env substitution (`\${ENABLE_IMAGE_GENERATION:-true}`) so the
existing user opt-out path remains intact:

- `installers/phases/06-directories.sh` writes
  `ENABLE_IMAGE_GENERATION=false` to `.env` when `ENABLE_COMFYUI=false`
  (i.e. `--no-comfyui` or Tier 0/1 auto-disable). Env-substitution
  means that \`.env\` value wins over the overlay default → button
  correctly hidden.
- The dashboard settings toggle (dashboard-api
  `_OPEN_WEBUI_APPLY_KEYS`) continues to work at runtime by writing
  `.env`.
- Git-clone-and-docker-compose-up path (no installer, no `.env`)
  still gets `true` on NVIDIA/AMD via the overlay default.

### 2. dreamforge network convention
`extensions/services/dreamforge/compose.yaml` declared a top-level
`networks: dream-network: external: true` block and added
`networks: - dream-network` to the service. Base compose renames the
default network to `dream-network` via
`networks: default: name: dream-network`, so at runtime the merge
produced a single network and everything worked.

However: standalone `docker compose -f dreamforge/compose.yaml
config` failed (`network dream-network declared as external, but
could not be found`), and the pattern diverged from the convention
used by all 16 other extensions (none declare networks).

Removed both the top-level `networks:` block and the service-level
`networks:` reference. Dreamforge now implicitly joins the project
default network — identical runtime reachability, matching
convention.

## Testing
- `docker compose config --quiet` passes for: base alone, base +
  nvidia, base + amd, base + dreamforge (merged).
- Standalone `docker compose -f dreamforge/compose.yaml config` now
  exits 0 (previously failed).
- Env substitution verified on both overlays:
  - NVIDIA / AMD, env unset → `ENABLE_IMAGE_GENERATION: "true"` ✓
  - NVIDIA / AMD, env=false → `ENABLE_IMAGE_GENERATION: "false"` ✓

## Platform Impact
- macOS Apple Silicon: image-gen UI now hidden (button no longer
  errors).
- Linux NVIDIA / AMD default install: unchanged — UI visible,
  ComfyUI available.
- Linux NVIDIA / AMD with `--no-comfyui`: UI now correctly hidden
  (previously would have shown a broken button).
- Linux CPU-only / Intel / ARC: UI hidden (was the primary goal of
  the base flip; matches ComfyUI manifest scope).
- Windows AMD: UI hidden (correct — the Windows installer does not
  load ComfyUI's AMD overlay).
- Windows NVIDIA: unchanged (UI visible, ComfyUI available).

## Scope note
An initially-related healthcheck concern on
\`extensions/services/perplexica/compose.yaml\` was dropped from
this PR pending runtime reproduction — the original report cited
\"Next.js 16\" as root cause, which does not exist as a version,
and the 127.0.0.1 probe was already the intended convention after
an earlier PR. Tracked as a separate follow-up.