### PR TITLE
chore(schema): mark provider API keys as secret in .env.schema.json

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -54,19 +54,23 @@
     },
     "TARGET_API_KEY": {
       "type": "string",
-      "description": "API key for Privacy Shield upstream target (set to LITELLM_KEY in lemonade mode)"
+      "description": "API key for Privacy Shield upstream target (set to LITELLM_KEY in lemonade mode)",
+      "secret": true
     },
     "ANTHROPIC_API_KEY": {
       "type": "string",
-      "description": "Anthropic API key (cloud/hybrid modes)"
+      "description": "Anthropic API key (cloud/hybrid modes)",
+      "secret": true
     },
     "OPENAI_API_KEY": {
       "type": "string",
-      "description": "OpenAI API key (cloud/hybrid modes)"
+      "description": "OpenAI API key (cloud/hybrid modes)",
+      "secret": true
     },
     "TOGETHER_API_KEY": {
       "type": "string",
-      "description": "Together AI API key (optional)"
+      "description": "Together AI API key (optional)",
+      "secret": true
     },
     "WEBUI_SECRET": {
       "type": "string",
@@ -407,7 +411,8 @@
     },
     "LIVEKIT_API_KEY": {
       "type": "string",
-      "description": "LiveKit API key"
+      "description": "LiveKit API key",
+      "secret": true
     },
     "LIVEKIT_API_SECRET": {
       "type": "string",

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -309,3 +309,32 @@ def test_render_env_preserves_extras_with_empty_values():
     rendered = _render_env_from_values(values)
     assert "TENSOR_SPLIT=" in rendered
     assert "GPU_UUID=GPU-abc123" in rendered
+
+
+# --- Production schema secret-flag coverage ---
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "TARGET_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "TOGETHER_API_KEY",
+        "LIVEKIT_API_KEY",
+    ],
+)
+def test_production_schema_marks_provider_api_keys_secret(key):
+    """Credential API keys in the production schema must carry ``secret: true``.
+
+    Regression guard: without the explicit flag, masking in both
+    ``dream config show`` and ``GET /api/settings/env`` falls back to a
+    name-pattern match. The schema should be the authoritative source.
+    """
+    import pathlib
+
+    schema_path = pathlib.Path(__file__).resolve().parents[4] / ".env.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    entry = schema["properties"].get(key)
+    assert entry is not None, f"schema missing entry for {key}"
+    assert entry.get("secret") is True, f"{key} must have 'secret': true in .env.schema.json"


### PR DESCRIPTION
## What
Flip `"secret": true` on five provider API-key entries in `dream-server/.env.schema.json`:
- `TARGET_API_KEY`
- `ANTHROPIC_API_KEY`
- `OPENAI_API_KEY`
- `TOGETHER_API_KEY`
- `LIVEKIT_API_KEY`

Adds a parametric pytest locking the flag in as a regression guard.

## Why
These keys were already being masked in `dream config show` (inline grep on `key=`) and in the dashboard-api `GET /api/settings/env` response (via `_is_secret_field` regex fallback on `API_KEY`). The schema is the intended authoritative source, and relying on name-pattern coincidence is fragile — any future rename that breaks the pattern would silently stop masking.

No runtime behavior change: both the schema-authoritative path and the regex fallback produce the same masked output today. This just routes through the primary path.

## How
- Added `"secret": true` as the third property on each of the five entries, matching the style of neighbors like `LIVEKIT_API_SECRET` and `OPENCLAW_TOKEN`.
- Added a parametric pytest (`test_production_schema_marks_provider_api_keys_secret`) that loads the **production** schema (not a fixture) and asserts the flag on each of the five keys. Uses `pathlib.Path(__file__).resolve().parents[4]` for cross-platform path resolution.

## Testing
- [x] `jq . dream-server/.env.schema.json` — parses cleanly
- [x] `python3 -m pytest extensions/services/dashboard-api/tests/test_settings_env.py -v` — **16/16 pass** (11 pre-existing + 5 new parametric)
- [x] `make lint` — clean
- [x] Pre-commit hooks (gitleaks / private-key / large-file) — clean
- [x] Manual macOS: `dream config show` continues to mask these 5 keys (unchanged behavior)

## Platform Impact
- **macOS**: no runtime change (schema consumed identically)
- **Linux**: no runtime change
- **Windows (WSL2)**: no runtime change

Schema is read by the dashboard-api container and `validate-env.sh` (jq) identically on all three platforms.