### PR TITLE
refactor(windows): trim dead fields from New-DreamEnv return hash

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -165,7 +165,7 @@ Write-DreamBanner
 #  Phase 03 → $enableVoice, $enableWorkflows, $enableRag, $enableOpenClaw, $openClawConfig
 #  Phase 04 → $requirementsMet
 #  Phase 05 → $dockerComposeCmd
-#  Phase 06 → $envResult (EnvPath, SearxngSecret, OpenclawToken, DreamAgentKey)
+#  Phase 06 → $envResult (SearxngSecret, OpenclawToken)
 #  Phase 07 → (no output -- tools installed to $env:USERPROFILE)
 
 . (Join-Path $PhasesDir "01-preflight.ps1")

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -165,7 +165,7 @@ Write-DreamBanner
 #  Phase 03 → $enableVoice, $enableWorkflows, $enableRag, $enableOpenClaw, $openClawConfig
 #  Phase 04 → $requirementsMet
 #  Phase 05 → $dockerComposeCmd
-#  Phase 06 → $envResult (EnvPath, SearxngSecret, OpenclawToken, DashboardKey)
+#  Phase 06 → $envResult (SearxngSecret, OpenclawToken)
 #  Phase 07 → (no output -- tools installed to $env:USERPROFILE)
 
 . (Join-Path $PhasesDir "01-preflight.ps1")

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -356,10 +356,8 @@ LANGFUSE_INIT_USER_PASSWORD=$langfuseInitUserPassword
     }
 
     return @{
-        EnvPath        = $envPath
         SearxngSecret  = $searxngSecret
         OpenclawToken  = $openclawToken
-        DreamAgentKey  = $dreamAgentKey
     }
 }
 

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -354,10 +354,8 @@ LANGFUSE_INIT_USER_PASSWORD=$langfuseInitUserPassword
     }
 
     return @{
-        EnvPath        = $envPath
         SearxngSecret  = $searxngSecret
         OpenclawToken  = $openclawToken
-        DashboardKey   = $dashboardApiKey
     }
 }
 

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -16,7 +16,7 @@
 #   $openClawConfig            -- from phase 03
 #
 # Writes:
-#   $envResult  -- hashtable: EnvPath, SearxngSecret, OpenclawToken, DreamAgentKey
+#   $envResult  -- hashtable: SearxngSecret, OpenclawToken
 #
 # Modder notes:
 #   Add new directories to $_dirs array below.
@@ -38,10 +38,8 @@ if ($dryRun) {
     }
     # Signal to later phases: no envResult in dry-run mode
     $envResult = @{
-        EnvPath       = Join-Path $installDir ".env"
         SearxngSecret = "(dry-run-placeholder)"
         OpenclawToken = "(dry-run-placeholder)"
-        DreamAgentKey = "(dry-run-placeholder)"
     }
     return
 }

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -16,7 +16,7 @@
 #   $openClawConfig            -- from phase 03
 #
 # Writes:
-#   $envResult  -- hashtable: EnvPath, SearxngSecret, OpenclawToken, DashboardKey
+#   $envResult  -- hashtable: SearxngSecret, OpenclawToken
 #
 # Modder notes:
 #   Add new directories to $_dirs array below.
@@ -38,10 +38,8 @@ if ($dryRun) {
     }
     # Signal to later phases: no envResult in dry-run mode
     $envResult = @{
-        EnvPath       = Join-Path $installDir ".env"
         SearxngSecret = "(dry-run-placeholder)"
         OpenclawToken = "(dry-run-placeholder)"
-        DashboardKey  = "(dry-run-placeholder)"
     }
     return
 }

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -10,7 +10,7 @@
 #   $dryRun, $cloudMode         -- from orchestrator context
 #   $installDir                 -- from orchestrator context
 #   $tierConfig                 -- from phase 02 (LlmModel, MaxContext, GgufFile)
-#   $envResult                  -- from phase 06 (OpenclawToken, DreamAgentKey)
+#   $envResult                  -- from phase 06 (OpenclawToken)
 #   $script:OPENCODE_*          -- from lib/constants.ps1
 #
 # Writes:

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -10,7 +10,7 @@
 #   $dryRun, $cloudMode         -- from orchestrator context
 #   $installDir                 -- from orchestrator context
 #   $tierConfig                 -- from phase 02 (LlmModel, MaxContext, GgufFile)
-#   $envResult                  -- from phase 06 (OpenclawToken, DashboardKey)
+#   $envResult                  -- from phase 06 (OpenclawToken)
 #   $script:OPENCODE_*          -- from lib/constants.ps1
 #
 # Writes:

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -10,7 +10,6 @@
 #   $dryRun, $cloudMode         -- from orchestrator context
 #   $installDir                 -- from orchestrator context
 #   $tierConfig                 -- from phase 02 (LlmModel, MaxContext, GgufFile)
-#   $envResult                  -- from phase 06 (OpenclawToken)
 #   $script:OPENCODE_*          -- from lib/constants.ps1
 #
 # Writes:


### PR DESCRIPTION
## ✅ Rebased on current `main` 2026-04-28 (post-#996)

Original PR trimmed the dead `EnvPath` + `DashboardKey` fields from `New-DreamEnv`'s return hash. After #996 merged (which renamed `DashboardKey` → `DreamAgentKey` while adding a `DREAM_AGENT_KEY=...` line to the `.env` heredoc), `$envResult.DreamAgentKey` is also dead surface (zero readers anywhere in the tree — host agent reads `DREAM_AGENT_KEY` from `.env` directly via Docker env-file injection, not from the PowerShell return value).

Per the audit ask and this PR's own merge-order coordination clause, I dropped `DreamAgentKey` along with `EnvPath` on rebase. The return hash now contains exactly the 2 fields with live readers: `SearxngSecret` + `OpenclawToken`.

## What
Reduces the `$envResult` hashtable returned by `New-DreamEnv` from four fields (`EnvPath`, `SearxngSecret`, `OpenclawToken`, `DreamAgentKey` — was `DashboardKey` pre-#996) to the two that are actually consumed (`SearxngSecret`, `OpenclawToken`). Updates header comments and the dry-run stub to match.

Files touched:
- `dream-server/installers/windows/lib/env-generator.ps1` — return block
- `dream-server/installers/windows/install-windows.ps1` — header comment
- `dream-server/installers/windows/phases/06-directories.ps1` — header comment + dry-run stub
- `dream-server/installers/windows/phases/07-devtools.ps1` — header comment (additional commit `414c41ec` drops the misleading `$envResult` reference entirely; phase 07 doesn't actually read from the hash)

## Why
Pure code hygiene. A full grep of `installers/windows/` confirms `$envResult.EnvPath`, `$envResult.DashboardKey` (pre-#996), and `$envResult.DreamAgentKey` (post-#996) are never accessed. These fields were stale API surface that drifted past what any caller needs; the headers pointed consumers at properties that would silently return `$null` if accessed.

`DASHBOARD_API_KEY` and `DREAM_AGENT_KEY` themselves are unaffected — `$dashboardApiKey` and `$dreamAgentKey` are still generated via `Get-EnvOrNew "<KEY>"` and written to `.env` through the heredoc (lines 287 + 289 of `env-generator.ps1`). Only their unused return-hash surface was dropped.

## How
- Return block: remove `EnvPath` and `DreamAgentKey` lines (the latter introduced by #996); keep `SearxngSecret` and `OpenclawToken` with existing alignment.
- Dry-run stub in phase 06: trim to the same 2 fields so real/dry-run shapes remain symmetric.
- Header comments in `install-windows.ps1`, `phases/06-directories.ps1`, and `phases/07-devtools.ps1`: updated to advertise only the fields the function actually emits. Phase 07's `Reads:` block additionally drops the entire `$envResult` line — phase 07 reads only `$dryRun`, `$cloudMode`, `$installDir`, `$tierConfig`, `$script:OPENCODE_*`.

## Testing
- [x] Grep coverage: `git grep '$envResult\.' dream-server/installers/windows/` → exactly `.SearxngSecret` and `.OpenclawToken`. Zero references to `.EnvPath`, `.DashboardKey`, or `.DreamAgentKey` anywhere.
- [x] Pre-commit (gitleaks / private-key / large-file) — clean.
- [ ] **PSScriptAnalyzer could not be run on the macOS dev host** — maintainer should run `Invoke-ScriptAnalyzer -Path dream-server/installers/windows/ -Recurse` on Windows before merge. CI gate `lint-powershell.yml` covers this on push.

### Manual Windows test checklist (WSL2 + Docker Desktop + PowerShell 7+)
1. `pwsh -NoProfile -ExecutionPolicy Bypass -File install-windows.ps1 -DryRun` — phase 06 prints dry-run messages; no `MissingProperty` errors; `$envResult` populated with 2 fields.
2. Fresh install `pwsh -NoProfile -ExecutionPolicy Bypass -File install-windows.ps1` — `.env` contains non-empty values for `DASHBOARD_API_KEY`, `DREAM_AGENT_KEY`, `SEARXNG_SECRET`, `OPENCLAW_TOKEN`; `config/searxng/settings.yml` and `config/openclaw/openclaw.json` have the generated secrets.
3. Re-install over existing `.env` — `DASHBOARD_API_KEY` and `DREAM_AGENT_KEY` preserved byte-for-byte (Get-EnvOrNew path).
4. `Invoke-ScriptAnalyzer -Path dream-server/installers/windows/ -Recurse` — no new warnings against the four modified files.

## Platform Impact
- **Windows** (only platform touched): no runtime behavior change. Callers that read `$envResult.SearxngSecret` / `.OpenclawToken` still work. Zero references to the removed `.EnvPath` / `.DashboardKey` / `.DreamAgentKey` exist anywhere in the tree.
- **Linux**: N/A — no files in `installers/linux/` or Linux-reachable paths touched.
- **macOS**: N/A — no files in `installers/macos/` or macOS-reachable paths touched.
