### PR TITLE
fix(host-agent): start extension sidecars during install

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1148,7 +1148,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                 _write_progress(service_id, "starting", "Starting container...")
                 _precreate_data_dirs(service_id)
                 start_result = subprocess.run(
-                    ["docker", "compose"] + flags + ["up", "-d", "--no-deps", service_id],
+                    ["docker", "compose"] + flags + ["up", "-d", service_id],
                     cwd=str(INSTALL_DIR), capture_output=True, text=True,
                     timeout=SUBPROCESS_TIMEOUT_START,
                 )

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -284,6 +284,43 @@ class TestInstallHookEnvAllowlist:
         )
 
 
+# --- Install "up -d" must not use --no-deps (regression) ---
+#
+# _handle_install previously passed --no-deps to `docker compose up -d`, which
+# prevented an extension's private sidecar services (declared in its own
+# compose fragment) from starting — including cross-extension depends_on
+# relationships like perplexica -> searxng. The fix removes --no-deps from
+# the install path only; docker_compose_recreate (used for core-service
+# force-recreate after a model swap) intentionally keeps --no-deps.
+
+
+class TestInstallStartCommandNoDeps:
+
+    def _install_source(self):
+        import inspect
+        return inspect.getsource(_mod.AgentHandler._handle_install)
+
+    def _recreate_source(self):
+        import inspect
+        return inspect.getsource(_mod.docker_compose_recreate)
+
+    def test_install_up_command_does_not_pass_no_deps(self):
+        src = self._install_source()
+        assert '"--no-deps"' not in src and "'--no-deps'" not in src, (
+            "_handle_install must not pass --no-deps to `docker compose up -d`; "
+            "extensions with private sidecars or cross-extension depends_on "
+            "need compose to bring dependencies up."
+        )
+
+    def test_docker_compose_recreate_still_uses_no_deps(self):
+        src = self._recreate_source()
+        assert '"--no-deps"' in src or "'--no-deps'" in src, (
+            "docker_compose_recreate must keep --no-deps; "
+            "core-service recreation (e.g. after a model swap) is intentionally "
+            "scoped to the named services only."
+        )
+
+
 # --- _handle_env_update ---
 
 


### PR DESCRIPTION
## What
Remove `--no-deps` from the `docker compose up -d` call inside `_handle_install()` so that extension sidecar services and cross-extension `depends_on` targets start correctly when an extension is installed.

## Why
`_handle_install()` called `docker compose up -d --no-deps <service>`, which tells Compose to bring up only the named service and skip everything it depends on. Extensions that declare private sidecar containers in their own compose fragment (e.g. a paperless extension shipping its own postgres and redis) had those sidecars silently ignored. Cross-extension `depends_on` relationships (e.g. perplexica → searxng) were also skipped, leaving services in a broken state after install.

## How
One-character change: drop `"--no-deps"` from the `subprocess.run` argv in `_handle_install()` (line 1151 of `bin/dream-host-agent.py`). `docker_compose_recreate()` — used for core-service force-recreate after a model swap — retains `--no-deps` intentionally; that call site is unchanged.

## Testing
- 40/40 tests pass in `dashboard-api/tests/test_host_agent.py`
- New `TestInstallStartCommandNoDeps` regression test uses `inspect.getsource` (file's existing pattern) to lock the argv shape for both paths:
  - `test_install_up_command_does_not_pass_no_deps` — asserts `--no-deps` absent from `_handle_install`
  - `test_docker_compose_recreate_still_uses_no_deps` — asserts `--no-deps` present in `docker_compose_recreate`
- No behaviour change for single-service extensions (they have no deps to start)

## Platform Impact
- **macOS / Linux / Windows-WSL2**: identical — the host agent is a platform-agnostic Python daemon; this code path runs on all platforms.

## Known Considerations
Follow-up candidate: the subprocess argv in `_run_install` could be extracted into module-level helpers to enable direct argv-mock tests rather than source inspection. Good candidate for a standalone refactor PR if the pattern spreads.
