### PR TITLE
fix(dashboard-api): async hygiene in routers/extensions.py

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -475,6 +475,18 @@ _AGENT_TIMEOUT = 300  # seconds — image pulls can take several minutes on firs
 _AGENT_LOG_TIMEOUT = 30  # seconds — log fetches should be fast
 
 
+def _fetch_agent_logs(url: str, headers: dict, data: bytes, timeout: int) -> str:
+    """Blocking POST to host agent that returns the response body as text.
+
+    Extracted so async handlers can offload the urllib call via
+    ``asyncio.to_thread``. urllib.error.HTTPError / URLError raised inside
+    propagate back to the caller and are handled there.
+    """
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode()
+
+
 def _call_agent(action: str, service_id: str) -> bool:
     """Call host agent to start/stop a service. Returns True on success."""
     url = f"{AGENT_URL}/v1/extension/{action}"
@@ -487,8 +499,11 @@ def _call_agent(action: str, service_id: str) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=_AGENT_TIMEOUT) as resp:
             return resp.status == 200
-    except Exception:
-        logger.warning("Host agent unreachable at %s — fallback to restart_required", AGENT_URL)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as exc:
+        logger.warning(
+            "Host agent unreachable at %s — fallback to restart_required: %s",
+            AGENT_URL, exc,
+        )
         return False
 
 
@@ -503,9 +518,10 @@ def _call_agent_invalidate_compose_cache() -> None:
                 logger.warning(
                     "compose-flags cache invalidation returned HTTP %d", resp.status,
                 )
-    except Exception:
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as exc:
         logger.warning(
-            "Host agent unreachable for compose-flags invalidation at %s", AGENT_URL,
+            "Host agent unreachable for compose-flags invalidation at %s: %s",
+            AGENT_URL, exc,
         )
 
 
@@ -583,8 +599,10 @@ def _call_agent_compose_rename(action: str, service_id: str) -> bool:
     try:
         with urllib.request.urlopen(req, timeout=_AGENT_LOG_TIMEOUT) as resp:
             return resp.status == 200
-    except Exception:
-        logger.warning("Host agent unreachable for compose rename at %s", AGENT_URL)
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as exc:
+        logger.warning(
+            "Host agent unreachable for compose rename at %s: %s", AGENT_URL, exc,
+        )
         return False
 
 
@@ -603,7 +621,7 @@ def _check_agent_health() -> bool:
         req = urllib.request.Request(f"{AGENT_URL}/health")
         with urllib.request.urlopen(req, timeout=3) as resp:
             available = resp.status == 200
-    except Exception:
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
         available = False
     with _agent_cache_lock:
         _agent_cache.update(available=available, checked_at=time.monotonic())
@@ -645,7 +663,16 @@ async def extensions_catalog(
     api_key: str = Depends(verify_api_key),
 ):
     """Get the extensions catalog with computed status."""
-    asyncio.get_running_loop().run_in_executor(None, _cleanup_stale_progress)
+    _cleanup_future = asyncio.get_running_loop().run_in_executor(
+        None, _cleanup_stale_progress,
+    )
+
+    def _log_cleanup_error(f: asyncio.Future) -> None:
+        exc = f.exception()
+        if exc is not None:
+            logger.error("stale-progress cleanup failed: %s", exc, exc_info=exc)
+
+    _cleanup_future.add_done_callback(_log_cleanup_error)
 
     from helpers import get_cached_services, get_all_services
 
@@ -752,12 +779,14 @@ async def extensions_catalog(
     except OSError:
         lib_available = False
 
+    agent_available = await asyncio.to_thread(_check_agent_health)
+
     return {
         "extensions": extensions,
         "summary": summary,
         "gpu_backend": GPU_BACKEND,
         "library_available": lib_available,
-        "agent_available": _check_agent_health(),
+        "agent_available": agent_available,
     }
 
 
@@ -863,10 +892,11 @@ async def extension_logs(
         "Authorization": f"Bearer {DREAM_AGENT_KEY}",
     }
     data = json.dumps({"service_id": service_id, "tail": 100}).encode()
-    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
-        with urllib.request.urlopen(req, timeout=_AGENT_LOG_TIMEOUT) as resp:
-            return json.loads(resp.read().decode())
+        body = await asyncio.to_thread(
+            _fetch_agent_logs, url, headers, data, _AGENT_LOG_TIMEOUT,
+        )
+        return json.loads(body)
     except urllib.error.HTTPError as exc:
         try:
             err_body = json.loads(exc.read().decode())

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -2278,3 +2278,63 @@ class TestAssertNotCoreAllowsBuiltins:
         with pytest.raises(HTTPException) as exc_info:
             _assert_not_core(service_id)
         assert exc_info.value.status_code == 403
+
+
+class TestCallAgentErrorNarrowing:
+    """_call_agent swallows network errors but not programmer errors."""
+
+    def test_call_agent_returns_false_on_urlerror(self, monkeypatch, caplog):
+        """Network failures produce (False, warning) — callers rely on this."""
+        import logging
+        import urllib.error
+        from routers import extensions as ext_module
+
+        def _raise(*_args, **_kwargs):
+            raise urllib.error.URLError("timeout")
+
+        monkeypatch.setattr(ext_module.urllib.request, "urlopen", _raise)
+        with caplog.at_level(logging.WARNING, logger="routers.extensions"):
+            result = ext_module._call_agent("start", "svc-x")
+
+        assert result is False
+        assert any("Host agent unreachable" in r.message for r in caplog.records)
+
+    def test_call_agent_reraises_non_network_errors(self, monkeypatch):
+        """Programmer errors (e.g. AttributeError) must not be swallowed."""
+        from routers import extensions as ext_module
+
+        def _raise(*_args, **_kwargs):
+            raise AttributeError("boom")
+
+        monkeypatch.setattr(ext_module.urllib.request, "urlopen", _raise)
+        with pytest.raises(AttributeError):
+            ext_module._call_agent("start", "svc-x")
+
+    def test_catalog_logs_when_cleanup_future_fails(
+        self, test_client, monkeypatch, tmp_path, caplog,
+    ):
+        """Stale-progress cleanup failures are logged, not lost to fire-and-forget."""
+        import logging
+
+        catalog = [_make_catalog_ext("test-svc", "Test Service")]
+        _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
+
+        def _boom():
+            raise RuntimeError("cleanup exploded")
+
+        monkeypatch.setattr(
+            "routers.extensions._cleanup_stale_progress", _boom,
+        )
+
+        with caplog.at_level(logging.ERROR, logger="routers.extensions"):
+            with patch("helpers.get_all_services", new_callable=AsyncMock,
+                       return_value=[]):
+                resp = test_client.get(
+                    "/api/extensions/catalog",
+                    headers=test_client.auth_headers,
+                )
+
+        assert resp.status_code == 200
+        assert any(
+            "stale-progress cleanup failed" in r.message for r in caplog.records
+        )


### PR DESCRIPTION
## What
Fixes three async-hygiene defects in `routers/extensions.py`: blocking urllib calls on the event-loop thread, over-broad `except Exception` catches that swallow programmer errors, and a fire-and-forget executor future that silently discards cleanup failures.

## Why
- `extension_logs` and `extensions_catalog` called `urllib.urlopen` directly on the async event loop. The Console modal polls every 2 s with a 30 s agent timeout, so a single slow host-agent response could block the entire dashboard-api event loop for up to 30 s.
- `_call_agent`, `_call_agent_invalidate_compose_cache`, and `_call_agent_compose_rename` caught `except Exception`, meaning `AttributeError`, `TypeError`, and other programmer bugs were silently swallowed and logged as "host agent unreachable" — masking real bugs.
- `_cleanup_stale_progress` was dispatched via `run_in_executor(None, ...)` with the returned Future immediately discarded, so any unhandled exception inside the cleanup only produced an opaque "Future exception was never retrieved" warning in stderr with no context.

## How
- Extracted `_fetch_agent_logs(url, headers, data, timeout) -> str` — a plain synchronous function that can be safely offloaded via `asyncio.to_thread`.
- `extension_logs`: replaced inline `urllib.urlopen` block with `await asyncio.to_thread(_fetch_agent_logs, ...)`, matching the existing `asyncio.to_thread` pattern already used in `main.py`'s `api_settings_env_save`.
- `extensions_catalog`: replaced direct `_check_agent_health()` call with `await asyncio.to_thread(_check_agent_health)`.
- `_call_agent`, `_call_agent_invalidate_compose_cache`, `_call_agent_compose_rename`, `_check_agent_health`: narrowed `except Exception` → `except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError)`. Non-network exceptions now propagate with a full stack trace instead of a misleading warning.
- `extensions_catalog`: retained the `run_in_executor` Future in `_cleanup_future` and attached `_log_cleanup_error` as a `done_callback` to log any exception at ERROR level with full context.

## Testing
- **Automated:** pytest 140/140 pass (137 pre-existing + 3 new); ruff clean.
- **New tests (`tests/test_extensions.py`):**
  - `test_call_agent_returns_false_on_urlerror` — network errors return `False` and log a warning.
  - `test_call_agent_reraises_non_network_errors` — `AttributeError` propagates (behaviour change from old broad catch).
  - `test_catalog_logs_when_cleanup_future_fails` — cleanup RuntimeError is logged at ERROR level, catalog endpoint still returns 200.
- **Manual:** Start dashboard-api with a non-responsive host agent; verify `/api/extensions/catalog` and `/api/extensions/{id}/logs` return promptly without blocking other requests.

## Platform Impact
- **macOS:** Affected — dashboard-api runs in Docker on all platforms; async event-loop fix is platform-neutral.
- **Linux:** Affected — same fix applies to NVIDIA/AMD deployments.
- **Windows (WSL2):** Affected — same.

## Known Considerations
Non-blocking follow-ups:
1. Add symmetric tests for `_call_agent_invalidate_compose_cache` and `_call_agent_compose_rename` (the other two narrowed helpers).
2. Hoist `_log_cleanup_error` out of the `extensions_catalog` function body to module level for reuse.
3. Audit remaining `except Exception:` blocks in `main.py`.
