### PR TITLE
fix(scripts): SIGPIPE-safe first-line selection in 5 scripts

### DIFF
--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -155,7 +155,7 @@ read_env_value() {
     local env_file="$1"
     local key="$2"
     [[ -f "$env_file" ]] || { echo ""; return 0; }
-    grep -E "^${key}=" "$env_file" 2>/dev/null | head -n 1 | cut -d'=' -f2- | tr -d '\r' || true
+    grep -E "^${key}=" "$env_file" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r' || true
 }
 
 upsert_env_value() {

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -36,7 +36,7 @@ read_env_value() {
     local env_path="$1"
     local key="$2"
     [[ -f "$env_path" ]] || { echo ""; return 0; }
-    grep -E "^${key}=" "$env_path" 2>/dev/null | head -n 1 | cut -d'=' -f2- | tr -d '\r' || true
+    grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r' || true
 }
 
 # Read SearXNG secret_key from an existing settings.yml file.
@@ -48,7 +48,7 @@ read_searxng_secret() {
     [[ -f "$settings_path" ]] || { echo ""; return 0; }
     # Expected line format: secret_key: "...."
     grep -E '^[[:space:]]*secret_key:[[:space:]]*"' "$settings_path" 2>/dev/null \
-        | head -n 1 \
+        | sed -n '1p' \
         | sed -E 's/^[[:space:]]*secret_key:[[:space:]]*"([^"]+)".*$/\1/' \
         | tr -d '\r' || true
 }

--- a/dream-server/scripts/check-offline-models.sh
+++ b/dream-server/scripts/check-offline-models.sh
@@ -24,7 +24,7 @@ MISSING=()
 
 # Check LLM model (GGUF)
 if ls data/models/*.gguf &>/dev/null; then
-    MODEL_FILE=$(ls -1 data/models/*.gguf | head -1)
+    MODEL_FILE=$(ls -1 data/models/*.gguf | sed -n '1p')
     echo -e "${GREEN}✓${NC} LLM model: $(basename "$MODEL_FILE")"
 else
     echo -e "${RED}✗${NC} LLM model (GGUF) - MISSING"

--- a/dream-server/scripts/dream-preflight.sh
+++ b/dream-server/scripts/dream-preflight.sh
@@ -84,7 +84,7 @@ fi
 # Check GPU if available
 echo -n "GPU availability... "
 if docker exec "$LLM_CONTAINER" nvidia-smi >/dev/null 2>&1; then
-    GPU_MEM=$(docker exec "$LLM_CONTAINER" nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')
+    GPU_MEM=$(docker exec "$LLM_CONTAINER" nvidia-smi --query-gpu=memory.free --format=csv,noheader,nounits 2>/dev/null | sed -n '1p' | tr -d ' ')
     echo -e "${GREEN}✓ detected (${GPU_MEM}MB free)${NC}"
 else
     echo -e "${YELLOW}⚠ not detected (CPU mode)${NC}"

--- a/dream-server/scripts/pre-download.sh
+++ b/dream-server/scripts/pre-download.sh
@@ -109,7 +109,7 @@ check_dependencies() {
 
 detect_vram_gb() {
     if command -v nvidia-smi &>/dev/null; then
-        nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | head -1 | awk '{print int($1/1024)}'
+        nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null | sed -n '1p' | awk '{print int($1/1024)}'
     else
         echo "0"
     fi


### PR DESCRIPTION
## What
Replace `| head -1 |` / `| head -n 1 |` with `| sed -n '1p' |` in five scripts to eliminate SIGPIPE termination under `set -euo pipefail`.

## Why
`head -1` closes its stdin after consuming one line. When the upstream pipeline stage produces multiple lines (multi-GPU nvidia-smi output, multiple GGUFs, duplicate .env keys), the resulting SIGPIPE (exit 141) propagates back through the pipeline and — because all five files run under `set -euo pipefail` — aborts the script entirely. The three distinct trigger conditions are:

- **Multi-GPU NVIDIA host**: `nvidia-smi --query-gpu=...` emits one line per GPU. `pre-download.sh` (VRAM detection) and `dream-preflight.sh` (GPU probe) both abort on the SIGPIPE.
- **Multiple GGUFs present**: `ls -1 data/models/*.gguf` on a host with 2+ downloaded models causes `check-offline-models.sh` to abort before reporting status.
- **Duplicate key in `.env`**: `grep` returns multiple matches; `read_env_value` (dream-macos.sh + env-generator.sh) and `read_searxng_secret` (env-generator.sh) silently return empty strings — the `|| true` guard prevents script abort but leaves the variable empty/truncated.

## How
Six targeted substitutions across 5 files:

| File | Line | Change |
|------|------|--------|
| `dream-server/scripts/pre-download.sh` | 112 | `head -1` → `sed -n '1p'` |
| `dream-server/scripts/dream-preflight.sh` | 87 | `head -1` → `sed -n '1p'` |
| `dream-server/scripts/check-offline-models.sh` | 27 | `head -1` → `sed -n '1p'` |
| `dream-server/installers/macos/dream-macos.sh` | 158 | `head -n 1` → `sed -n '1p'` |
| `dream-server/installers/macos/lib/env-generator.sh` | 39 | `head -n 1` → `sed -n '1p'` |
| `dream-server/installers/macos/lib/env-generator.sh` | 51 | `head -n 1` → `sed -n '1p'` |

`sed -n '1p'` consumes the full stdin stream before exiting, so the upstream producer never receives SIGPIPE. It is identical in behaviour on BSD sed (macOS) and GNU sed (Linux).

## Testing
- Automated: `bash -n` syntax check passes on all 5 files. ShellCheck: no new warnings introduced.
- Manual (Linux NVIDIA multi-GPU): Run `dream-server/scripts/pre-download.sh` and `dream-server/scripts/dream-preflight.sh` on a host with 2+ GPUs — both should complete without SIGPIPE exit 141.
- Manual (macOS, multiple GGUFs): Place 2+ `.gguf` files in `data/models/` and run `dream-server/scripts/check-offline-models.sh` — should enumerate correctly.
- Manual (macOS, duplicate .env key): Add a duplicate key to `.env` and run through the macOS installer `read_env_value` path — should return the first value, not empty.

## Platform Impact
- **macOS**: Affected — `dream-macos.sh` and `env-generator.sh` fixes apply here only.
- **Linux (NVIDIA)**: Affected — `pre-download.sh` and `dream-preflight.sh` fixes apply to multi-GPU NVIDIA hosts.
- **Linux (AMD/CPU)**: `check-offline-models.sh` fix applies to any platform with 2+ GGUFs.
- **Windows (WSL2)**: Not directly affected — these scripts run on the Linux / macOS side. WSL2 inherits Linux behaviour if any of these scripts are invoked there.

## Known Considerations
None — mechanical substitutions only; no logic changes.
