### PR TITLE
fix(installer): pre-mark setup wizard complete on successful install

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1150,6 +1150,22 @@ else
     ai_warn "Perplexica auto-config skipped -- complete setup at http://localhost:3004"
 fi
 
+# ── Pre-mark setup wizard complete ──
+# The dashboard-api reads ${INSTALL_DIR}/data/config/setup-complete.json
+# (mounted at /data/config/setup-complete.json inside the container) to
+# decide first_run state. Writing this here prevents the wizard from
+# reappearing on every visit after a fresh install. Non-fatal.
+_setup_config_dir="${INSTALL_DIR}/data/config"
+_setup_complete_file="${_setup_config_dir}/setup-complete.json"
+_completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+if mkdir -p "${_setup_config_dir}" 2>/dev/null \
+    && printf '{"completed_at": "%s", "version": "1.0.0"}\n' "${_completed_at}" > "${_setup_complete_file}" 2>/dev/null \
+    && chmod 644 "${_setup_complete_file}" 2>/dev/null; then
+    ai_ok "Setup wizard pre-marked complete"
+else
+    ai_warn "Could not write ${_setup_complete_file} (non-fatal)"
+fi
+
 # ── Success card ──
 if ! $ALL_HEALTHY; then
     echo ""

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -47,6 +47,24 @@ fi
 # Show the cinematic success card
 show_success_card "http://localhost:3000" "http://localhost:3001" "$LOCAL_IP"
 
+# Mark the setup wizard as already completed for fresh installs. The
+# dashboard-api reads this file (container path /data/config/setup-complete.json,
+# mounted from ${INSTALL_DIR}/data) to decide first_run state; without it the
+# wizard reappears on every visit after a fresh install. Non-fatal — if the
+# write fails, the wizard simply shows once.
+if ! $DRY_RUN; then
+    _setup_config_dir="${INSTALL_DIR}/data/config"
+    _setup_complete_file="${_setup_config_dir}/setup-complete.json"
+    _completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    if mkdir -p "${_setup_config_dir}" 2>/dev/null \
+        && printf '{"completed_at": "%s", "version": "1.0.0"}\n' "${_completed_at}" > "${_setup_complete_file}" 2>/dev/null \
+        && chmod 644 "${_setup_complete_file}" 2>/dev/null; then
+        log "Setup wizard pre-marked complete at ${_setup_complete_file}"
+    else
+        ai_warn "Could not write ${_setup_complete_file} (non-fatal)"
+    fi
+fi
+
 # Check background tasks before showing additional info
 if [[ -f "$SCRIPT_DIR/installers/lib/background-tasks.sh" ]]; then
     . "$SCRIPT_DIR/installers/lib/background-tasks.sh"

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -877,6 +877,23 @@ if ($allHealthy) {
     Write-SuccessCard
 }
 
+# ── Pre-mark setup wizard complete ────────────────────────────────────────────
+# The dashboard-api reads ${INSTALL_DIR}/data/config/setup-complete.json
+# (mounted at /data/config/setup-complete.json inside the container) to decide
+# first_run state. Writing this here prevents the wizard from reappearing on
+# every visit after a fresh install. Non-fatal.
+try {
+    $setupConfigDir = Join-Path $installDir "data\config"
+    $setupCompleteFile = Join-Path $setupConfigDir "setup-complete.json"
+    New-Item -Path $setupConfigDir -ItemType Directory -Force | Out-Null
+    $completedAt = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $payload = @{ completed_at = $completedAt; version = "1.0.0" } | ConvertTo-Json -Compress
+    Set-Content -Path $setupCompleteFile -Value $payload -Encoding UTF8
+    Write-AISuccess "Setup wizard pre-marked complete"
+} catch {
+    Write-AIWarn "Could not write setup-complete.json (non-fatal): $_"
+}
+
 # ── Summary JSON (for CI / automation) ───────────────────────────────────────
 if ($SummaryJsonPath) {
     $summary = @{

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -67,4 +67,16 @@ if grep -q 'cdn.jsdelivr.net/npm/chart.js\|cdn.jsdelivr.net/npm/chartjs-adapter-
   exit 1
 fi
 
+echo "[contract] installers pre-mark setup wizard complete"
+# All three installers must write data/config/setup-complete.json at install time
+# so the dashboard wizard doesn't reappear on every visit after a fresh install.
+# dashboard-api reads this file (container path /data/config/setup-complete.json,
+# mounted from ${INSTALL_DIR}/data) to decide first_run state.
+grep -q 'data/config/setup-complete.json' installers/phases/13-summary.sh \
+  || { echo "[FAIL] Linux phase 13 does not write data/config/setup-complete.json"; exit 1; }
+grep -q 'data/config/setup-complete.json' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer does not write data/config/setup-complete.json"; exit 1; }
+grep -q 'data\\\\config\\\\setup-complete.json\|setup-complete.json' installers/windows/install-windows.ps1 \
+  || { echo "[FAIL] Windows installer does not write setup-complete.json"; exit 1; }
+
 echo "[PASS] installer contracts"


### PR DESCRIPTION
## What
All three installers now write `setup-complete.json` after a successful install, so the setup wizard does not reappear on first dashboard load.

## Why
`routers/setup.py::setup_status` returns `first_run=true` whenever `${SETUP_CONFIG_DIR}/setup-complete.json` is absent. The file was only ever written by `POST /api/setup/complete` — the final step of the wizard UI. A user who installed normally but never clicked through all six wizard steps saw the overlay on every page load indefinitely.

## How
Write the marker from all three installers immediately after the success card is displayed and services are confirmed up:

- **Linux** (`installers/phases/13-summary.sh`): added inside the `if ! $DRY_RUN` block after `show_success_card`. Uses `date -u +%Y-%m-%dT%H:%M:%SZ` (BSD/GNU-safe).
- **macOS** (`installers/macos/install-macos.sh`): added in Phase 6 between `configure_perplexica` and `show_success_card`, past the dry-run exit at L1051. Uses BSD-safe `date -u +"%Y-%m-%dT%H:%M:%SZ"`.
- **Windows** (`installers/windows/install-windows.ps1`): added after `Write-SuccessCard`, wrapped in `try/catch`. Uses `Join-Path`, `New-Item -Force`, `ConvertTo-Json -Compress`, `Set-Content -Encoding UTF8`.
- **Contract test** (`tests/contracts/test-installer-contracts.sh`): static-grep assertion that all three installers emit the write.

Payload matches what `POST /api/setup/complete` writes:
```json
{"completed_at":"<ISO-8601 UTC>","version":"1.0.0"}
```

Host path: `${INSTALL_DIR}/data/config/setup-complete.json`
Container path: `/data/config/setup-complete.json` (via `./data:/data` bind mount in `docker-compose.base.yml`).

Failure to write the marker is non-fatal — logged as a warning; the worst outcome is the wizard reappearing.

## Testing
- **Automated:** `bash -n` clean on Linux and macOS installer files; shellcheck shows no new warnings (reductions only); contract test passes (`tests/contracts/test-installer-contracts.sh`).
- **Manual (Linux):** Run installer to completion → open dashboard → confirm setup wizard does **not** appear → verify `${INSTALL_DIR}/data/config/setup-complete.json` exists with correct JSON.
- **Manual (macOS):** Same as Linux, using `install-macos.sh`.
- **Manual (Windows/WSL2):** Run `install-windows.ps1` to completion → same dashboard check → verify file at `${INSTALL_DIR}/data/config/setup-complete.json`.

## Platform Impact
- **macOS:** Affected — `install-macos.sh` Phase 6 writes the marker using BSD-safe `date -u` syntax.
- **Linux:** Affected — `installers/phases/13-summary.sh` writes the marker in the `if ! $DRY_RUN` block.
- **Windows (WSL2):** Affected — `install-windows.ps1` writes the marker via PowerShell `Set-Content -Encoding UTF8`.

## Known Considerations
- The contract test uses static grep — a future refactor that moves the write call into a helper function without updating the grep pattern would cause a false negative. Runtime verification should be added if the write is ever abstracted.
- On Windows, `Set-Content -Encoding UTF8` under PowerShell 5.1 writes a UTF-8 BOM. This is moot for this use case because `routers/setup.py` only calls `.exists()` on the file path — the file content is not parsed on the read path. PowerShell 7+ writes BOM-free UTF-8 by default.
- PowerShell syntax was not locally validated (pwsh unavailable on macOS dev machine); CI `lint-powershell.yml` is the gate.
