### PR TITLE
fix(embeddings): raise healthcheck start_period from 120s to 600s

### DIFF
--- a/dream-server/extensions/services/embeddings/compose.yaml
+++ b/dream-server/extensions/services/embeddings/compose.yaml
@@ -25,7 +25,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 120s
+      start_period: 600s
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## What
Raise `start_period` on the `embeddings` extension healthcheck from `120s` to `600s`.

## Why
The Hugging Face TEI image downloads its model at first start. On slow connections a ~115 MB model (default `BAAI/bge-base-en-v1.5`) can exceed the existing 120s + 5x30s = 270s total grace window, making the container flip `unhealthy` while the download is still progressing, followed by restart-loop confusion on the dashboard.

## How
One-line edit to `dream-server/extensions/services/embeddings/compose.yaml:28`.

`start_period` is a grace window — Docker ignores failed checks inside it and flips to healthy on the first successful probe — so raising it does not slow down warm starts and does not mask true crash-loops (`restart: unless-stopped` still triggers on non-zero exit).

## Testing
- `docker compose config` parses the modified file cleanly.
- `scripts/validate-compose-stack.sh` passes (2 services, exit 0).
- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML valid.
- `pre-commit` (gitleaks, private-key, large-file) passes.
- No env vars added, `.env.schema.json` untouched.

## Review
Critique Guardian APPROVED (no required changes).

## Platform Impact
- **macOS:** identical behavior (Docker Desktop); healthcheck semantics are engine-level, platform-neutral.
- **Linux:** identical behavior.
- **Windows (WSL2):** identical behavior.
