### PR TITLE
fix(resolver): dedupe override.yml; apply gpu_backends filter to user-extensions

### DIFF
--- a/dream-server/installers/lib/compose-select.sh
+++ b/dream-server/installers/lib/compose-select.sh
@@ -102,12 +102,5 @@ resolve_compose_config() {
         log "Including docker-compose.tier0.yml (Tier 0 memory limits)"
     fi
 
-    # Auto-include docker-compose.override.yml if present (standard Docker convention).
-    # This lets modders add services without editing core compose files.
-    if [[ -f "$SCRIPT_DIR/docker-compose.override.yml" ]]; then
-        COMPOSE_FLAGS="$COMPOSE_FLAGS -f docker-compose.override.yml"
-        log "Including docker-compose.override.yml (user overrides)"
-    fi
-
     log "Compose selection: $COMPOSE_FLAGS"
 }

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -224,9 +224,55 @@ if ext_dir.exists():
 user_ext_dir = script_dir / "data" / "user-extensions"
 if user_ext_dir.exists():
     try:
+        import yaml
+        yaml_available = True
+    except ImportError:
+        yaml_available = False
+
+    try:
         for service_dir in sorted(user_ext_dir.iterdir()):
             if not service_dir.is_dir():
                 continue
+            # Find manifest
+            manifest_path = None
+            for name in ("manifest.yaml", "manifest.yml", "manifest.json"):
+                candidate = service_dir / name
+                if candidate.exists():
+                    manifest_path = candidate
+                    break
+            if not manifest_path:
+                continue
+            try:
+                with open(manifest_path) as f:
+                    if manifest_path.suffix == ".json":
+                        manifest = json.load(f)
+                    elif yaml_available:
+                        manifest = yaml.safe_load(f)
+                    else:
+                        continue  # skip YAML manifests when PyYAML unavailable
+                if manifest.get("schema_version") != "dream.services.v1":
+                    continue
+                service = manifest.get("service", {})
+                # same gpu_backends filter as built-in loop
+                backends = service.get("gpu_backends", ["amd", "nvidia"])
+                if gpu_backend not in backends and "all" not in backends and "none" not in backends:
+                    continue
+            except Exception as e:
+                yaml_error = yaml_available and hasattr(yaml, 'YAMLError') and isinstance(e, yaml.YAMLError)
+                json_error = isinstance(e, json.JSONDecodeError)
+                structure_error = isinstance(e, (KeyError, TypeError))
+
+                if yaml_error or json_error or structure_error:
+                    print(f"ERROR: Failed to parse manifest for {service_dir.name}: {e}", file=sys.stderr)
+                    print(f"  Manifest path: {manifest_path}", file=sys.stderr)
+                    print(f"  This service will be skipped. Fix the manifest or disable the service.", file=sys.stderr)
+                    if skip_broken:
+                        continue
+                    else:
+                        sys.exit(1)
+                else:
+                    raise
+
             compose_path = service_dir / "compose.yaml"
             if compose_path.exists():
                 resolved.append(str(compose_path.relative_to(script_dir)))


### PR DESCRIPTION
## What
Two resolver fixes bundled:
1. Stop appending `docker-compose.override.yml` twice to `COMPOSE_FLAGS`.
2. Apply the same `gpu_backends` filter to user-installed extensions that built-in extensions already receive.

## Why
**Defect 1:** `installers/lib/compose-select.sh` called the resolver (which appends `docker-compose.override.yml` internally) and then appended it again at the bash layer. Docker merges the file twice — idempotent for scalars but a foot-gun for anchors / `extends:` / list-merge semantics.

**Defect 2:** `scripts/resolve-compose-stack.sh` read the manifest and filtered by `gpu_backends` for built-in extensions but included every `data/user-extensions/*/compose.yaml` unconditionally. A user-library extension declaring `gpu_backends: [nvidia]` would be merged on AMD/Apple and fail at container start — or worse, block any `depends_on` chain.

## How
- **compose-select.sh:** delete the now-redundant `if [[ -f ... override.yml ]]` block after `load_env_from_output`.
- **resolve-compose-stack.sh (inline Python):** mirror the built-in loop's filter verbatim into the user-extension loop. Same manifest lookup order (`.yaml` -> `.yml` -> `.json`), same `schema_version == "dream.services.v1"` gate, same `gpu_backends` default `["amd","nvidia"]`, same `"all"`/`"none"` sentinels, same narrow yaml/json/structure exception dispatch honouring `skip_broken`.

The intentional scope limit: user-extension loop still hardcodes `compose.yaml` and does not apply `compose.local.yaml` / `compose.multigpu.yaml` overlays — those gaps pre-dated this PR and are left for a separate follow-up to keep blast radius small.

## Testing
- `bash -n`, `shellcheck` (zero net-new warnings), `python3 -m py_compile` on the extracted heredoc — all pass.
- `make lint` — passes.
- `tests/test-tier-map.sh` — 82/0.
- Functional:
  - Override dedup: old code emits 2x `override.yml`, new code emits 1x.
  - `gpu_backends: [nvidia]` user-ext filtered out on AMD, included on NVIDIA.
  - `gpu_backends: [all]` included on every backend.
  - Missing manifest -> skipped (matches built-in).

## Review
Critique Guardian APPROVED (no required changes).

## Platform Impact
- **macOS / Linux / Windows (WSL2):** user-ext filter is pure Python using `pathlib`; no BSD/GNU divergence. compose-select.sh change is Linux-installer-only (matches file's scope).
