### PR TITLE
fix(host-agent): install flow — built-in hooks, bind-mount anchor, post-up state verify

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
@@ -167,7 +168,9 @@ def resolve_compose_flags() -> list:
 
 def _precreate_data_dirs(service_id: str):
     """Pre-create data directories for an extension with correct ownership."""
-    ext_dir = USER_EXTENSIONS_DIR / service_id
+    ext_dir = _find_ext_dir(service_id)
+    if ext_dir is None:
+        return
     compose_path = ext_dir / "compose.yaml"
     if not compose_path.exists():
         return
@@ -200,10 +203,14 @@ def _precreate_data_dirs(service_id: str):
             continue
         for vol in volumes:
             vol_str = str(vol).split(":")[0]
-            if vol_str.startswith("./data/") or vol_str.startswith("data/"):
-                dir_path = (INSTALL_DIR / vol_str.lstrip("./")).resolve()
+            # Accept any relative bind-mount source (e.g. "./data/state",
+            # "./upload", "config/stuff"). Skip named volumes (no "/") and
+            # absolute paths ("/etc/..."). Compose resolves relative paths
+            # against the compose file's directory, so anchor on ext_dir.
+            if vol_str and not vol_str.startswith("/") and "/" in vol_str:
+                dir_path = (ext_dir / vol_str.lstrip("./")).resolve()
                 try:
-                    dir_path.relative_to(INSTALL_DIR.resolve())
+                    dir_path.relative_to(ext_dir.resolve())
                 except ValueError:
                     logger.warning("Skipping out-of-tree volume path in %s: %s", service_id, vol_str)
                     continue
@@ -1100,10 +1107,15 @@ class AgentHandler(BaseHTTPRequestHandler):
             try:
                 flags = resolve_compose_flags()
 
+                ext_dir = _find_ext_dir(service_id)
+                if ext_dir is None:
+                    _write_progress(service_id, "error", "Installation failed",
+                                    error=f"Extension directory not found for {service_id}")
+                    return
+
                 # Step 1: Setup hook (if requested)
                 if run_setup_hook:
                     _write_progress(service_id, "setup_hook", "Running setup...")
-                    ext_dir = USER_EXTENSIONS_DIR / service_id
                     hook_path = _resolve_hook(ext_dir, "post_install")
                     if hook_path:
                         # Minimal allowlist env — mirror _execute_hook (L856-866)
@@ -1155,6 +1167,43 @@ class AgentHandler(BaseHTTPRequestHandler):
                 if start_result.returncode != 0:
                     _write_progress(service_id, "error", "Installation failed",
                                     error=start_result.stderr[:500])
+                    return
+
+                # Poll for running state; compose `up -d` returns 0 even for
+                # Created/Exited/Restarting containers, so a 0 exit is not
+                # conclusive proof the service actually started.
+                install_manifest = _read_manifest(ext_dir)
+                install_service_def = install_manifest.get("service", {}) if install_manifest else {}
+                if not isinstance(install_service_def, dict):
+                    install_service_def = {}
+                container_name = install_service_def.get("container_name") or f"dream-{service_id}"
+
+                deadline = time.monotonic() + 15
+                state: str | None = None
+                state_error = ""
+                while time.monotonic() < deadline:
+                    try:
+                        inspect_result = subprocess.run(
+                            ["docker", "inspect", "--format",
+                             "{{.State.Status}}|{{.State.Error}}", container_name],
+                            capture_output=True, text=True, timeout=5,
+                        )
+                    except subprocess.TimeoutExpired:
+                        inspect_result = None
+                    if inspect_result is not None and inspect_result.returncode == 0:
+                        parts = inspect_result.stdout.strip().split("|", 1)
+                        state = parts[0] if parts else ""
+                        state_error = parts[1] if len(parts) > 1 else ""
+                        if state == "running":
+                            break
+                    time.sleep(1)
+
+                if state != "running":
+                    msg = f"Container did not reach running state within 15s (state={state or 'unknown'})"
+                    if state_error:
+                        msg += f": {state_error}"
+                    _write_progress(service_id, "error", "Installation failed",
+                                    error=msg)
                     return
 
                 # Step 4: Success

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1180,7 +1180,11 @@ class AgentHandler(BaseHTTPRequestHandler):
                     install_service_def = {}
                 container_name = install_service_def.get("container_name") or f"dream-{service_id}"
 
-                deadline = time.monotonic() + 15
+                # Per-extension startup deadline; manifests with heavy init
+                # (postgres, clickhouse, JVM-based services) can override the
+                # 15s default via service.startup_timeout.
+                startup_timeout = install_service_def.get("startup_timeout", 15)
+                deadline = time.monotonic() + startup_timeout
                 state: str | None = None
                 state_error = ""
                 while time.monotonic() < deadline:
@@ -1201,7 +1205,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     time.sleep(1)
 
                 if state != "running":
-                    msg = f"Container did not reach running state within 15s (state={state or 'unknown'})"
+                    msg = f"Container did not reach running state within {startup_timeout}s (state={state or 'unknown'})"
                     if state_error:
                         msg += f": {state_error}"
                     _write_progress(service_id, "error", "Installation failed",

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1252,7 +1252,11 @@ class AgentHandler(BaseHTTPRequestHandler):
                     install_service_def = {}
                 container_name = install_service_def.get("container_name") or f"dream-{service_id}"
 
-                deadline = time.monotonic() + 15
+                # Per-extension startup deadline; manifests with heavy init
+                # (postgres, clickhouse, JVM-based services) can override the
+                # 15s default via service.startup_timeout.
+                startup_timeout = install_service_def.get("startup_timeout", 15)
+                deadline = time.monotonic() + startup_timeout
                 state: str | None = None
                 state_error = ""
                 while time.monotonic() < deadline:
@@ -1273,7 +1277,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     time.sleep(1)
 
                 if state != "running":
-                    msg = f"Container did not reach running state within 15s (state={state or 'unknown'})"
+                    msg = f"Container did not reach running state within {startup_timeout}s (state={state or 'unknown'})"
                     if state_error:
                         msg += f": {state_error}"
                     _write_progress(service_id, "error", "Installation failed",

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -205,12 +205,14 @@ def _precreate_data_dirs(service_id: str):
             vol_str = str(vol).split(":")[0]
             # Accept any relative bind-mount source (e.g. "./data/state",
             # "./upload", "config/stuff"). Skip named volumes (no "/") and
-            # absolute paths ("/etc/..."). Compose resolves relative paths
-            # against the compose file's directory, so anchor on ext_dir.
+            # absolute paths ("/etc/..."). Docker Compose v2 resolves relative
+            # bind paths against the project directory (the first -f file's
+            # parent = INSTALL_DIR), not the individual fragment's directory,
+            # so anchor on INSTALL_DIR to match where Compose actually mounts.
             if vol_str and not vol_str.startswith("/") and "/" in vol_str:
-                dir_path = (ext_dir / vol_str.lstrip("./")).resolve()
+                dir_path = (INSTALL_DIR / vol_str.lstrip("./")).resolve()
                 try:
-                    dir_path.relative_to(ext_dir.resolve())
+                    dir_path.relative_to(INSTALL_DIR.resolve())
                 except ValueError:
                     logger.warning("Skipping out-of-tree volume path in %s: %s", service_id, vol_str)
                     continue

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
@@ -226,7 +227,9 @@ def _fs_type(path: Path) -> str | None:
 
 def _precreate_data_dirs(service_id: str):
     """Pre-create data directories for an extension with correct ownership."""
-    ext_dir = USER_EXTENSIONS_DIR / service_id
+    ext_dir = _find_ext_dir(service_id)
+    if ext_dir is None:
+        return
     compose_path = ext_dir / "compose.yaml"
     if not compose_path.exists():
         return
@@ -259,10 +262,14 @@ def _precreate_data_dirs(service_id: str):
             continue
         for vol in volumes:
             vol_str = str(vol).split(":")[0]
-            if vol_str.startswith("./data/") or vol_str.startswith("data/"):
-                dir_path = (INSTALL_DIR / vol_str.lstrip("./")).resolve()
+            # Accept any relative bind-mount source (e.g. "./data/state",
+            # "./upload", "config/stuff"). Skip named volumes (no "/") and
+            # absolute paths ("/etc/..."). Compose resolves relative paths
+            # against the compose file's directory, so anchor on ext_dir.
+            if vol_str and not vol_str.startswith("/") and "/" in vol_str:
+                dir_path = (ext_dir / vol_str.lstrip("./")).resolve()
                 try:
-                    dir_path.relative_to(INSTALL_DIR.resolve())
+                    dir_path.relative_to(ext_dir.resolve())
                 except ValueError:
                     logger.warning("Skipping out-of-tree volume path in %s: %s", service_id, vol_str)
                     continue
@@ -1172,10 +1179,15 @@ class AgentHandler(BaseHTTPRequestHandler):
             try:
                 flags = resolve_compose_flags()
 
+                ext_dir = _find_ext_dir(service_id)
+                if ext_dir is None:
+                    _write_progress(service_id, "error", "Installation failed",
+                                    error=f"Extension directory not found for {service_id}")
+                    return
+
                 # Step 1: Setup hook (if requested)
                 if run_setup_hook:
                     _write_progress(service_id, "setup_hook", "Running setup...")
-                    ext_dir = USER_EXTENSIONS_DIR / service_id
                     hook_path = _resolve_hook(ext_dir, "post_install")
                     if hook_path:
                         # Minimal allowlist env — mirror _execute_hook (L856-866)
@@ -1227,6 +1239,43 @@ class AgentHandler(BaseHTTPRequestHandler):
                 if start_result.returncode != 0:
                     _write_progress(service_id, "error", "Installation failed",
                                     error=start_result.stderr[:500])
+                    return
+
+                # Poll for running state; compose `up -d` returns 0 even for
+                # Created/Exited/Restarting containers, so a 0 exit is not
+                # conclusive proof the service actually started.
+                install_manifest = _read_manifest(ext_dir)
+                install_service_def = install_manifest.get("service", {}) if install_manifest else {}
+                if not isinstance(install_service_def, dict):
+                    install_service_def = {}
+                container_name = install_service_def.get("container_name") or f"dream-{service_id}"
+
+                deadline = time.monotonic() + 15
+                state: str | None = None
+                state_error = ""
+                while time.monotonic() < deadline:
+                    try:
+                        inspect_result = subprocess.run(
+                            ["docker", "inspect", "--format",
+                             "{{.State.Status}}|{{.State.Error}}", container_name],
+                            capture_output=True, text=True, timeout=5,
+                        )
+                    except subprocess.TimeoutExpired:
+                        inspect_result = None
+                    if inspect_result is not None and inspect_result.returncode == 0:
+                        parts = inspect_result.stdout.strip().split("|", 1)
+                        state = parts[0] if parts else ""
+                        state_error = parts[1] if len(parts) > 1 else ""
+                        if state == "running":
+                            break
+                    time.sleep(1)
+
+                if state != "running":
+                    msg = f"Container did not reach running state within 15s (state={state or 'unknown'})"
+                    if state_error:
+                        msg += f": {state_error}"
+                    _write_progress(service_id, "error", "Installation failed",
+                                    error=msg)
                     return
 
                 # Step 4: Success

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1252,37 +1252,46 @@ class AgentHandler(BaseHTTPRequestHandler):
                     install_service_def = {}
                 container_name = install_service_def.get("container_name") or f"dream-{service_id}"
 
-                # Per-extension startup deadline; manifests with heavy init
-                # (postgres, clickhouse, JVM-based services) can override the
-                # 15s default via service.startup_timeout.
-                startup_timeout = install_service_def.get("startup_timeout", 15)
-                deadline = time.monotonic() + startup_timeout
-                state: str | None = None
-                state_error = ""
-                while time.monotonic() < deadline:
-                    try:
-                        inspect_result = subprocess.run(
-                            ["docker", "inspect", "--format",
-                             "{{.State.Status}}|{{.State.Error}}", container_name],
-                            capture_output=True, text=True, timeout=5,
-                        )
-                    except subprocess.TimeoutExpired:
-                        inspect_result = None
-                    if inspect_result is not None and inspect_result.returncode == 0:
-                        parts = inspect_result.stdout.strip().split("|", 1)
-                        state = parts[0] if parts else ""
-                        state_error = parts[1] if len(parts) > 1 else ""
-                        if state == "running":
-                            break
-                    time.sleep(1)
+                # Manifest-driven opt-out for one-shot / setup-only extensions
+                # whose containers intentionally exit (init containers,
+                # extensions whose value is purely the setup_hook). Setting
+                # `service.startup_check: false` skips the running-state poll
+                # — compose up's clean exit is taken as success. Default is
+                # True so existing long-running services are unchanged.
+                startup_check = install_service_def.get("startup_check", True)
 
-                if state != "running":
-                    msg = f"Container did not reach running state within {startup_timeout}s (state={state or 'unknown'})"
-                    if state_error:
-                        msg += f": {state_error}"
-                    _write_progress(service_id, "error", "Installation failed",
-                                    error=msg)
-                    return
+                if startup_check:
+                    # Per-extension startup deadline; manifests with heavy init
+                    # (postgres, clickhouse, JVM-based services) can override the
+                    # 15s default via service.startup_timeout.
+                    startup_timeout = install_service_def.get("startup_timeout", 15)
+                    deadline = time.monotonic() + startup_timeout
+                    state: str | None = None
+                    state_error = ""
+                    while time.monotonic() < deadline:
+                        try:
+                            inspect_result = subprocess.run(
+                                ["docker", "inspect", "--format",
+                                 "{{.State.Status}}|{{.State.Error}}", container_name],
+                                capture_output=True, text=True, timeout=5,
+                            )
+                        except subprocess.TimeoutExpired:
+                            inspect_result = None
+                        if inspect_result is not None and inspect_result.returncode == 0:
+                            parts = inspect_result.stdout.strip().split("|", 1)
+                            state = parts[0] if parts else ""
+                            state_error = parts[1] if len(parts) > 1 else ""
+                            if state == "running":
+                                break
+                        time.sleep(1)
+
+                    if state != "running":
+                        msg = f"Container did not reach running state within {startup_timeout}s (state={state or 'unknown'})"
+                        if state_error:
+                            msg += f": {state_error}"
+                        _write_progress(service_id, "error", "Installation failed",
+                                        error=msg)
+                        return
 
                 # Step 4: Success
                 _write_progress(service_id, "started", "Service started")

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1243,9 +1243,14 @@ class AgentHandler(BaseHTTPRequestHandler):
                                     error=start_result.stderr[:500])
                     return
 
-                # Poll for running state; compose `up -d` returns 0 even for
-                # Created/Exited/Restarting containers, so a 0 exit is not
-                # conclusive proof the service actually started.
+                # By default, poll for running state: compose `up -d`
+                # returns 0 even for Created/Exited/Restarting containers,
+                # so a 0 exit is NOT conclusive proof the service actually
+                # started. Extensions whose containers intentionally exit
+                # after init (one-shot setup containers, extensions whose
+                # value is purely the setup_hook) can opt out via the
+                # manifest's `service.startup_check: false`, in which
+                # case compose's 0 exit is taken as success.
                 install_manifest = _read_manifest(ext_dir)
                 install_service_def = install_manifest.get("service", {}) if install_manifest else {}
                 if not isinstance(install_service_def, dict):

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -264,12 +264,14 @@ def _precreate_data_dirs(service_id: str):
             vol_str = str(vol).split(":")[0]
             # Accept any relative bind-mount source (e.g. "./data/state",
             # "./upload", "config/stuff"). Skip named volumes (no "/") and
-            # absolute paths ("/etc/..."). Compose resolves relative paths
-            # against the compose file's directory, so anchor on ext_dir.
+            # absolute paths ("/etc/..."). Docker Compose v2 resolves relative
+            # bind paths against the project directory (the first -f file's
+            # parent = INSTALL_DIR), not the individual fragment's directory,
+            # so anchor on INSTALL_DIR to match where Compose actually mounts.
             if vol_str and not vol_str.startswith("/") and "/" in vol_str:
-                dir_path = (ext_dir / vol_str.lstrip("./")).resolve()
+                dir_path = (INSTALL_DIR / vol_str.lstrip("./")).resolve()
                 try:
-                    dir_path.relative_to(ext_dir.resolve())
+                    dir_path.relative_to(INSTALL_DIR.resolve())
                 except ValueError:
                     logger.warning("Skipping out-of-tree volume path in %s: %s", service_id, vol_str)
                     continue

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -527,3 +527,126 @@ class TestHandleModelDownloadCancel:
         assert handler.parse_response()["status"] == "cancelling"
         assert _mod._model_download_cancel.is_set() is True
         assert proc.killed is True
+
+
+# --- _precreate_data_dirs + install flow (PR 2A regressions) ---
+#
+# Defect 1/2: _run_install and _precreate_data_dirs must use _find_ext_dir()
+# so built-in extensions (under EXTENSIONS_DIR) are found — the old
+# USER_EXTENSIONS_DIR-only path silently no-op'd for every built-in.
+#
+# Defect 3/4: _precreate_data_dirs must create dirs for any relative bind
+# source (not just "./data/..."), anchored on ext_dir (not INSTALL_DIR),
+# because Compose resolves relative paths against the compose file.
+#
+# Defect 5: _handle_install must verify the container reached "running"
+# state before reporting success — compose `up -d` returns 0 even for
+# Created/Exited/Restarting containers.
+
+
+class TestPrecreateDataDirs:
+
+    def _write_compose(self, ext_dir: Path, volumes: list[str]):
+        vol_yaml = "\n".join(f"      - {v}" for v in volumes)
+        ext_dir.mkdir(parents=True, exist_ok=True)
+        (ext_dir / "compose.yaml").write_text(
+            "services:\n"
+            "  svc:\n"
+            "    image: test:latest\n"
+            "    volumes:\n" + vol_yaml + "\n",
+            encoding="utf-8",
+        )
+
+    def test_creates_dirs_for_builtin_ext_via_find_ext_dir(self, tmp_path, monkeypatch):
+        """Defect 1/2: built-in extensions resolved via _find_ext_dir, not USER_EXTENSIONS_DIR."""
+        pytest.importorskip("yaml")
+        builtin_root = tmp_path / "builtin"
+        user_root = tmp_path / "user"
+        install_dir = tmp_path / "install"
+        builtin_root.mkdir()
+        user_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = builtin_root / "svc-b"
+        self._write_compose(ext_dir, ["./data/state:/state"])
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        _mod._precreate_data_dirs("svc-b")
+
+        # Dir lives under ext_dir, NOT INSTALL_DIR (Defect 4 anchor fix).
+        assert (ext_dir / "data" / "state").is_dir()
+        assert not (install_dir / "data" / "state").exists()
+
+    def test_creates_dirs_for_non_data_prefix(self, tmp_path, monkeypatch):
+        """Defect 3: relative bind sources outside './data/' must still be created."""
+        pytest.importorskip("yaml")
+        user_root = tmp_path / "user"
+        builtin_root = tmp_path / "builtin"
+        install_dir = tmp_path / "install"
+        user_root.mkdir()
+        builtin_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = user_root / "svc-u"
+        self._write_compose(ext_dir, ["./upload:/upload", "./data/state:/state"])
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        _mod._precreate_data_dirs("svc-u")
+
+        assert (ext_dir / "upload").is_dir()
+        assert (ext_dir / "data" / "state").is_dir()
+
+    def test_skips_named_volumes(self, tmp_path, monkeypatch):
+        """Named volumes (no '/') must not trigger filesystem creation."""
+        pytest.importorskip("yaml")
+        user_root = tmp_path / "user"
+        builtin_root = tmp_path / "builtin"
+        install_dir = tmp_path / "install"
+        user_root.mkdir()
+        builtin_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = user_root / "svc-n"
+        self._write_compose(ext_dir, ["named_vol:/var/lib/data"])
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        _mod._precreate_data_dirs("svc-n")
+
+        # Named volume must not materialize as a directory anywhere we own.
+        assert not (ext_dir / "named_vol").exists()
+        assert not (install_dir / "named_vol").exists()
+
+
+class TestInstallRunningStateVerification:
+    """Defect 5: `_handle_install` must poll container state before reporting success."""
+
+    def _install_source(self):
+        import inspect
+        return inspect.getsource(_mod.AgentHandler._handle_install)
+
+    def test_install_uses_find_ext_dir(self):
+        """Defect 1: _run_install resolves ext_dir via _find_ext_dir, not USER_EXTENSIONS_DIR."""
+        src = self._install_source()
+        assert "_find_ext_dir(service_id)" in src
+        assert "USER_EXTENSIONS_DIR / service_id" not in src
+
+    def test_install_polls_docker_inspect_state(self):
+        """State-poll loop must run `docker inspect` and check running state."""
+        src = self._install_source()
+        assert "docker" in src and "inspect" in src
+        assert "{{.State.Status}}" in src
+        assert 'state == "running"' in src
+
+    def test_install_writes_error_when_state_not_running(self):
+        """Failed state-poll must surface as progress error, not 'started'."""
+        src = self._install_source()
+        # The error path must come before (or instead of) the success write.
+        assert "did not reach running state within 15s" in src
+        # Error path uses the existing _write_progress("error", ...) API.
+        assert '_write_progress(service_id, "error"' in src

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -498,9 +498,12 @@ class TestHandleModelDownloadCancel:
 # so built-in extensions (under EXTENSIONS_DIR) are found — the old
 # USER_EXTENSIONS_DIR-only path silently no-op'd for every built-in.
 #
-# Defect 3/4: _precreate_data_dirs must create dirs for any relative bind
-# source (not just "./data/..."), anchored on ext_dir (not INSTALL_DIR),
-# because Compose resolves relative paths against the compose file.
+# Defect 3: _precreate_data_dirs must create dirs for any relative bind
+# source (not just "./data/..."), so extensions with "./upload:/..." style
+# mounts also get their dirs pre-created. Anchored on INSTALL_DIR because
+# Docker Compose v2 resolves relative bind paths against the project
+# directory (the first -f file's parent = INSTALL_DIR), not against the
+# individual fragment's directory.
 #
 # Defect 5: _handle_install must verify the container reached "running"
 # state before reporting success — compose `up -d` returns 0 even for
@@ -538,9 +541,10 @@ class TestPrecreateDataDirs:
 
         _mod._precreate_data_dirs("svc-b")
 
-        # Dir lives under ext_dir, NOT INSTALL_DIR (Defect 4 anchor fix).
-        assert (ext_dir / "data" / "state").is_dir()
-        assert not (install_dir / "data" / "state").exists()
+        # Dir lives under INSTALL_DIR (the Compose project directory),
+        # NOT under ext_dir — matching where Compose actually mounts.
+        assert (install_dir / "data" / "state").is_dir()
+        assert not (ext_dir / "data" / "state").exists()
 
     def test_creates_dirs_for_non_data_prefix(self, tmp_path, monkeypatch):
         """Defect 3: relative bind sources outside './data/' must still be created."""
@@ -560,8 +564,10 @@ class TestPrecreateDataDirs:
 
         _mod._precreate_data_dirs("svc-u")
 
-        assert (ext_dir / "upload").is_dir()
-        assert (ext_dir / "data" / "state").is_dir()
+        # Both non-"./data/" and "./data/..." mounts must materialise under
+        # INSTALL_DIR (the Compose project directory).
+        assert (install_dir / "upload").is_dir()
+        assert (install_dir / "data" / "state").is_dir()
 
     def test_skips_named_volumes(self, tmp_path, monkeypatch):
         """Named volumes (no '/') must not trigger filesystem creation."""

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -650,9 +650,28 @@ class TestInstallRunningStateVerification:
         assert 'state == "running"' in src
 
     def test_install_writes_error_when_state_not_running(self):
-        """Failed state-poll must surface as progress error, not 'started'."""
+        """Failed state-poll must surface as progress error, not 'started'.
+
+        The error message is built via f-string with the
+        manifest-driven `startup_timeout` rather than the literal "15s",
+        so we assert the constant prefix and the timeout reference, not
+        a hardcoded duration.
+        """
         src = self._install_source()
-        # The error path must come before (or instead of) the success write.
-        assert "did not reach running state within 15s" in src
         # Error path uses the existing _write_progress("error", ...) API.
         assert '_write_progress(service_id, "error"' in src
+        # Error message template carries the dynamic startup_timeout.
+        assert "did not reach running state within" in src
+        assert "{startup_timeout}s" in src
+
+    def test_install_supports_startup_check_opt_out(self):
+        """One-shot / setup-only extensions can set
+        `service.startup_check: false` in their manifest to skip the
+        running-state poll. The install completes after `compose up -d`
+        returns 0; the inspect loop is gated on `if startup_check:`.
+        """
+        src = self._install_source()
+        # Manifest field is read with True default for back-compat.
+        assert 'startup_check = install_service_def.get("startup_check", True)' in src
+        # The state-poll loop is conditionally entered.
+        assert "if startup_check:" in src

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -490,3 +490,126 @@ class TestHandleModelDownloadCancel:
         assert handler.parse_response()["status"] == "cancelling"
         assert _mod._model_download_cancel.is_set() is True
         assert proc.killed is True
+
+
+# --- _precreate_data_dirs + install flow (PR 2A regressions) ---
+#
+# Defect 1/2: _run_install and _precreate_data_dirs must use _find_ext_dir()
+# so built-in extensions (under EXTENSIONS_DIR) are found — the old
+# USER_EXTENSIONS_DIR-only path silently no-op'd for every built-in.
+#
+# Defect 3/4: _precreate_data_dirs must create dirs for any relative bind
+# source (not just "./data/..."), anchored on ext_dir (not INSTALL_DIR),
+# because Compose resolves relative paths against the compose file.
+#
+# Defect 5: _handle_install must verify the container reached "running"
+# state before reporting success — compose `up -d` returns 0 even for
+# Created/Exited/Restarting containers.
+
+
+class TestPrecreateDataDirs:
+
+    def _write_compose(self, ext_dir: Path, volumes: list[str]):
+        vol_yaml = "\n".join(f"      - {v}" for v in volumes)
+        ext_dir.mkdir(parents=True, exist_ok=True)
+        (ext_dir / "compose.yaml").write_text(
+            "services:\n"
+            "  svc:\n"
+            "    image: test:latest\n"
+            "    volumes:\n" + vol_yaml + "\n",
+            encoding="utf-8",
+        )
+
+    def test_creates_dirs_for_builtin_ext_via_find_ext_dir(self, tmp_path, monkeypatch):
+        """Defect 1/2: built-in extensions resolved via _find_ext_dir, not USER_EXTENSIONS_DIR."""
+        pytest.importorskip("yaml")
+        builtin_root = tmp_path / "builtin"
+        user_root = tmp_path / "user"
+        install_dir = tmp_path / "install"
+        builtin_root.mkdir()
+        user_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = builtin_root / "svc-b"
+        self._write_compose(ext_dir, ["./data/state:/state"])
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        _mod._precreate_data_dirs("svc-b")
+
+        # Dir lives under ext_dir, NOT INSTALL_DIR (Defect 4 anchor fix).
+        assert (ext_dir / "data" / "state").is_dir()
+        assert not (install_dir / "data" / "state").exists()
+
+    def test_creates_dirs_for_non_data_prefix(self, tmp_path, monkeypatch):
+        """Defect 3: relative bind sources outside './data/' must still be created."""
+        pytest.importorskip("yaml")
+        user_root = tmp_path / "user"
+        builtin_root = tmp_path / "builtin"
+        install_dir = tmp_path / "install"
+        user_root.mkdir()
+        builtin_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = user_root / "svc-u"
+        self._write_compose(ext_dir, ["./upload:/upload", "./data/state:/state"])
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        _mod._precreate_data_dirs("svc-u")
+
+        assert (ext_dir / "upload").is_dir()
+        assert (ext_dir / "data" / "state").is_dir()
+
+    def test_skips_named_volumes(self, tmp_path, monkeypatch):
+        """Named volumes (no '/') must not trigger filesystem creation."""
+        pytest.importorskip("yaml")
+        user_root = tmp_path / "user"
+        builtin_root = tmp_path / "builtin"
+        install_dir = tmp_path / "install"
+        user_root.mkdir()
+        builtin_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = user_root / "svc-n"
+        self._write_compose(ext_dir, ["named_vol:/var/lib/data"])
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        _mod._precreate_data_dirs("svc-n")
+
+        # Named volume must not materialize as a directory anywhere we own.
+        assert not (ext_dir / "named_vol").exists()
+        assert not (install_dir / "named_vol").exists()
+
+
+class TestInstallRunningStateVerification:
+    """Defect 5: `_handle_install` must poll container state before reporting success."""
+
+    def _install_source(self):
+        import inspect
+        return inspect.getsource(_mod.AgentHandler._handle_install)
+
+    def test_install_uses_find_ext_dir(self):
+        """Defect 1: _run_install resolves ext_dir via _find_ext_dir, not USER_EXTENSIONS_DIR."""
+        src = self._install_source()
+        assert "_find_ext_dir(service_id)" in src
+        assert "USER_EXTENSIONS_DIR / service_id" not in src
+
+    def test_install_polls_docker_inspect_state(self):
+        """State-poll loop must run `docker inspect` and check running state."""
+        src = self._install_source()
+        assert "docker" in src and "inspect" in src
+        assert "{{.State.Status}}" in src
+        assert 'state == "running"' in src
+
+    def test_install_writes_error_when_state_not_running(self):
+        """Failed state-poll must surface as progress error, not 'started'."""
+        src = self._install_source()
+        # The error path must come before (or instead of) the success write.
+        assert "did not reach running state within 15s" in src
+        # Error path uses the existing _write_progress("error", ...) API.
+        assert '_write_progress(service_id, "error"' in src

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -535,9 +535,12 @@ class TestHandleModelDownloadCancel:
 # so built-in extensions (under EXTENSIONS_DIR) are found — the old
 # USER_EXTENSIONS_DIR-only path silently no-op'd for every built-in.
 #
-# Defect 3/4: _precreate_data_dirs must create dirs for any relative bind
-# source (not just "./data/..."), anchored on ext_dir (not INSTALL_DIR),
-# because Compose resolves relative paths against the compose file.
+# Defect 3: _precreate_data_dirs must create dirs for any relative bind
+# source (not just "./data/..."), so extensions with "./upload:/..." style
+# mounts also get their dirs pre-created. Anchored on INSTALL_DIR because
+# Docker Compose v2 resolves relative bind paths against the project
+# directory (the first -f file's parent = INSTALL_DIR), not against the
+# individual fragment's directory.
 #
 # Defect 5: _handle_install must verify the container reached "running"
 # state before reporting success — compose `up -d` returns 0 even for
@@ -575,9 +578,10 @@ class TestPrecreateDataDirs:
 
         _mod._precreate_data_dirs("svc-b")
 
-        # Dir lives under ext_dir, NOT INSTALL_DIR (Defect 4 anchor fix).
-        assert (ext_dir / "data" / "state").is_dir()
-        assert not (install_dir / "data" / "state").exists()
+        # Dir lives under INSTALL_DIR (the Compose project directory),
+        # NOT under ext_dir — matching where Compose actually mounts.
+        assert (install_dir / "data" / "state").is_dir()
+        assert not (ext_dir / "data" / "state").exists()
 
     def test_creates_dirs_for_non_data_prefix(self, tmp_path, monkeypatch):
         """Defect 3: relative bind sources outside './data/' must still be created."""
@@ -597,8 +601,10 @@ class TestPrecreateDataDirs:
 
         _mod._precreate_data_dirs("svc-u")
 
-        assert (ext_dir / "upload").is_dir()
-        assert (ext_dir / "data" / "state").is_dir()
+        # Both non-"./data/" and "./data/..." mounts must materialise under
+        # INSTALL_DIR (the Compose project directory).
+        assert (install_dir / "upload").is_dir()
+        assert (install_dir / "data" / "state").is_dir()
 
     def test_skips_named_volumes(self, tmp_path, monkeypatch):
         """Named volumes (no '/') must not trigger filesystem creation."""


### PR DESCRIPTION
## What
Fix five clustered defects in the host agent's extension install flow that combined to produce silent install failures.

## Why
- Built-in extensions declaring a `post_install` hook had their hooks silently skipped — the ext_dir was hardcoded to the user-extensions directory so `_resolve_hook` never found the manifest.
- `_precreate_data_dirs` had the same hardcode, plus a prefix filter that only caught `./data/` bind-mount sources. Community extensions like label-studio (`./upload`, `./media`, `./www`), continue and sillytavern (`./config/...`) were skipped, Docker auto-created those dirs as `root:root`, and non-root containers broke on Linux.
- Relative paths in extension compose files were resolved against `INSTALL_DIR`, but Docker Compose resolves them against the compose file's directory — dirs were created in the wrong place.
- Post-`compose up -d` progress was written as "started" unconditionally on return-code zero, which Docker emits for Exited/Created/Restarting containers as well as Running. The dashboard showed green for crash-looping services.

## How
1. `_run_install` and `_precreate_data_dirs` now call `_find_ext_dir(service_id)`.
2. Prefix filter widened: any relative bind-mount source (no leading `/`, contains `/`) is now pre-created; named volumes are still skipped.
3. `dir_path` and the traversal safety check both anchor on `ext_dir`.
4. `_handle_install` polls `docker inspect --format '{{.State.Status}}|{{.State.Error}}'` for up to 15s (1s interval). Non-running -> `status=error` with `State.Error`; running -> `status=started` as before.

## Testing
- `python3 -m py_compile` clean.
- `ruff check` — all checks passed.
- `pytest tests/test_host_agent.py` — 44/44 pass (includes 6 new tests).
- `pytest tests/` — rest of suite green (two pre-existing Python-3.14 asyncio baseline failures in `test_main.py` and `test_gpu_detailed.py` are unrelated and reproduce on `main`).
- `make lint` — clean.
- `pre-commit` — gitleaks / private-key / large-file all pass.

## Review
Critique Guardian: APPROVED WITH WARNINGS. No required changes. CG flagged nice-to-have follow-ups tracked as separate fork issues.

## Known Considerations
- **15s post-up window** is a tuning choice. If a cold-boot image (e.g. qdrant / whisper on first disk-cache miss) takes longer to reach `running` state (not healthy — just running), operators can widen via follow-up.
- **Per-service lock held during poll** — previously fire-and-forget, now serializes concurrent enables for the same service for up to 15s. This is an improvement (no more races) but callers that polled rapidly will see the latency.

## Platform Impact
- **macOS:** defects #1 and #5 fully active; #2/#3/#4 partially masked by Docker Desktop's auto-creation of bind-mount dirs. Fix corrects behavior on all three regardless.
- **Linux:** all five defects fully active; rootless Docker / strict permissions make #2/#3 a hard fail. Fix required.
- **Windows (WSL2):** same as Linux (WSL2 Docker behaves as Linux).
