### PR TITLE
fix(extensions): mirror manifest depends_on in anythingllm / localai / continue

### DIFF
--- a/resources/dev/extensions-library/services/anythingllm/compose.yaml
+++ b/resources/dev/extensions-library/services/anythingllm/compose.yaml
@@ -3,6 +3,9 @@ services:
     image: mintplexlabs/anythingllm:1.11.1
     container_name: dream-anythingllm
     restart: unless-stopped
+    depends_on:
+      ollama:
+        condition: service_healthy
     security_opt:
       - no-new-privileges:true
     environment:

--- a/resources/dev/extensions-library/services/continue/compose.amd.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.amd.yaml
@@ -1,0 +1,11 @@
+# AMD backend overlay for continue.
+# Wait for the containerized llama-server before starting. Kept out of
+# base compose.yaml because `depends_on` merges additively across overlays
+# and the macOS (apple) backend runs llama-server natively with replicas: 0;
+# a service_healthy condition on a 0-replica service would hang forever.
+# See sibling compose.apple.yaml for the macOS-specific sidecar wait.
+services:
+  continue:
+    depends_on:
+      llama-server:
+        condition: service_healthy

--- a/resources/dev/extensions-library/services/continue/compose.apple.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.apple.yaml
@@ -1,0 +1,12 @@
+# macOS Apple Silicon overlay for continue.
+# On macOS, llama-server runs natively on the host (replicas: 0 in Docker).
+# The macOS core overlay provides a `llama-server-ready` sidecar that polls
+# the native llama-server via host.docker.internal. Containers that would
+# normally depend on `llama-server: service_healthy` must instead wait on
+# the sidecar, mirroring the open-webui pattern in
+# dream-server/installers/macos/docker-compose.macos.yml.
+services:
+  continue:
+    depends_on:
+      llama-server-ready:
+        condition: service_healthy

--- a/resources/dev/extensions-library/services/continue/compose.cpu.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.cpu.yaml
@@ -1,0 +1,11 @@
+# CPU backend overlay for continue.
+# Wait for the containerized llama-server before starting. Kept out of
+# base compose.yaml because `depends_on` merges additively across overlays
+# and the macOS (apple) backend runs llama-server natively with replicas: 0;
+# a service_healthy condition on a 0-replica service would hang forever.
+# See sibling compose.apple.yaml for the macOS-specific sidecar wait.
+services:
+  continue:
+    depends_on:
+      llama-server:
+        condition: service_healthy

--- a/resources/dev/extensions-library/services/continue/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.nvidia.yaml
@@ -1,0 +1,11 @@
+# NVIDIA backend overlay for continue.
+# Wait for the containerized llama-server before starting. Kept out of
+# base compose.yaml because `depends_on` merges additively across overlays
+# and the macOS (apple) backend runs llama-server natively with replicas: 0;
+# a service_healthy condition on a 0-replica service would hang forever.
+# See sibling compose.apple.yaml for the macOS-specific sidecar wait.
+services:
+  continue:
+    depends_on:
+      llama-server:
+        condition: service_healthy

--- a/resources/dev/extensions-library/services/localai/compose.yaml
+++ b/resources/dev/extensions-library/services/localai/compose.yaml
@@ -2,6 +2,9 @@ services:
   localai:
     image: localai/localai:v3.12.1-aio-cpu@sha256:4cbc20c59558ed6c1cae9bc3f6ae34d75d390b370aa8ac62a59327089fa56cec
     container_name: dream-localai
+    depends_on:
+      llama-server:
+        condition: service_healthy
     networks:
       - dream-network
     ports:


### PR DESCRIPTION
## What
Mirror manifest-level `depends_on` into Docker Compose for three community extensions that were racing their dependencies on first start.

## Why
- `anythingllm` declared `depends_on: [ollama]` in manifest but not compose -> anythingllm's first MongoDB/Ollama call could fire before Ollama had loaded its model.
- `localai` declared `depends_on: [llama-server]` similarly.
- `continue` declared `depends_on: [llama-server]` similarly, BUT `continue` runs on Apple Silicon too, where `llama-server` has `replicas: 0` (native host process, not a container). A naive base `depends_on: llama-server: condition: service_healthy` would additively merge on macOS and deadlock continue waiting on a 0-replica service's health.

## How
- For `anythingllm` / `localai` (gpu_backends exclude apple): add `depends_on` directly to the base `compose.yaml`.
- For `continue` (gpu_backends include apple): leave the base lean and add per-backend overlays the resolver already picks up:
  - `compose.{nvidia,amd,cpu}.yaml` -> `depends_on: llama-server`
  - `compose.apple.yaml` -> `depends_on: llama-server-ready`

The `llama-server-ready` sidecar is the established macOS pattern (already used by `open-webui` in `installers/macos/docker-compose.macos.yml`).

`scripts/resolve-compose-stack.sh` at line 234 already globs `compose.{gpu_backend}.yaml` for user-installed extensions, so the new overlays are picked up automatically — no resolver changes needed.

## Testing
- YAML parse on all 6 touched files — OK.
- Per-backend merge verify via `docker compose config`:
  - nvidia/amd/cpu -> `continue.depends_on: {llama-server: service_healthy}`
  - apple -> `continue.depends_on: {llama-server-ready: service_healthy}`
  - No cross-contamination. Apple never inherits the 0-replica `llama-server` dep — deadlock condition eliminated.
- `make lint` + pre-commit — clean.

## Review
Critique Guardian: APPROVED (no required changes). Verified auto-dep enable flow (`routers/extensions.py:_get_missing_deps_transitive`) so hard-fail of missing `ollama` on anythingllm enable is prevented by the dashboard-api install path.

## Platform Impact
- **macOS (Apple Silicon):** continue uses `llama-server-ready` sidecar; no contact with 0-replica `llama-server`. Other two extensions excluded by gpu_backends.
- **Linux (NVIDIA/AMD/CPU):** all three extensions gain a service_healthy gate on their documented dependency.
- **Windows (WSL2):** same as Linux.
