### PR TITLE
fix(extensions): piper-audio healthcheck timeout gap; publish milvus health port

### DIFF
--- a/resources/dev/extensions-library/services/milvus/compose.yaml
+++ b/resources/dev/extensions-library/services/milvus/compose.yaml
@@ -4,6 +4,7 @@ services:
     container_name: dream-milvus
     ports:
       - "127.0.0.1:${MILVUS_PORT:-19530}:19530"
+      - "${BIND_ADDRESS:-127.0.0.1}:9091:9091"
     volumes:
       - ./data/milvus:/var/lib/milvus
     environment:

--- a/resources/dev/extensions-library/services/piper-audio/compose.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/compose.yaml
@@ -31,7 +31,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "echo '{\"type\": \"describe\"}' | nc -w 1 127.0.0.1 10200 | grep -q piper"]
       interval: 30s
-      timeout: 30s
+      timeout: 10s
       retries: 3
       start_period: 60s
     networks:


### PR DESCRIPTION
## What
Two confirmed community-extension healthcheck fixes. Scope was shrunk during runtime verification — the chromadb defect from the original issue was empirically disproven.

## Why
- **piper-audio:** `timeout: 30s` equal to `interval: 30s` left zero idle time between probes if a probe ran to timeout, producing CPU / log noise. The inner `nc -w 1` probe self-terminates in ~1s; the Docker-layer timeout ceiling just needs to accommodate the probe.
- **milvus:** manifest declares `health_port: 9091` and `health: /healthz`. The compose healthcheck (running *inside* the container) works fine, but the port was never published to the host, so any external probe — operator debug, LAN monitoring, future host-side tooling — got connection refused on `127.0.0.1:9091`.
- **chromadb:** original issue speculated that the `bash /dev/tcp` + `[[ ]]` probe assumed bash in what might be an Alpine/busybox image. Runtime verification on `chromadb/chroma:1.5.3` (exact tag pinned in the compose) found full GNU bash 5.2.37 with working `/dev/tcp`; wget, curl, nc, python3 are ALL absent — the existing probe is actually the best available tool for that image. No change needed.

## How
1. `piper-audio/compose.yaml:34` — `timeout: 30s` -> `timeout: 10s`.
2. `milvus/compose.yaml` — append `"${BIND_ADDRESS:-127.0.0.1}:9091:9091"` to the `ports:` list. Using the `${BIND_ADDRESS:-127.0.0.1}` pattern keeps the new line consistent with the upcoming BIND_ADDRESS sweep on the existing 19530 line (no merge conflict).

## Testing
- YAML parse on both files — OK.
- `docker compose config` for both — quiet exit.
- Merged config for milvus confirms BOTH 19530 AND 9091 appear in the `ports:` list.
- `make lint` + pre-commit — clean.

## Review
Critique Guardian: APPROVED (no required changes).
- chromadb drop justified: compose pins `chromadb/chroma:1.5.3` exactly — same image verifier tested.
- CG flagged a separate latent bug (tracked as follow-up): `dashboard-api` user-extension health polling at `user_extensions.py:83-89` does not extract `health_port` from manifest (unlike `config.py:136` for built-ins), so dashboard-api probes milvus on port 19530 (gRPC) instead of 9091. Publishing 9091 here doesn't fix that; it's a separate issue.

## Platform Impact
- **macOS / Linux / Windows (WSL2):** Docker healthcheck timeout and port publication are engine-level and platform-neutral.
