### PR TITLE
fix(perplexica): bind Next.js 16 to 0.0.0.0 inside container

### DIFF
--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -9,6 +9,7 @@ services:
       - SEARXNG_API_URL=http://searxng:8080
       - OPENAI_BASE_URL=${LLM_API_URL:-http://llama-server:8080}/v1
       - OPENAI_API_KEY=${OPENAI_API_KEY:-no-key}
+      - HOSTNAME=0.0.0.0
     volumes:
       - perplexica-data:/home/perplexica/data
       - perplexica-uploads:/home/perplexica/uploads


### PR DESCRIPTION
## What
Add `HOSTNAME=0.0.0.0` to the perplexica service environment so Next.js 16 binds the loopback interface inside the container.

## Why
The pinned `itzcrazykns1337/perplexica:slim-latest` image ships **Next.js 16.0.7**. Next 16 changed the standalone-server bind behaviour: it reads `process.env.HOSTNAME` (defaulting to the container's hostname / Docker bridge IP) and listens *only* on that interface. The healthcheck at `extensions/services/perplexica/compose.yaml:29` probes `http://127.0.0.1:3000/`, which always returns `ECONNREFUSED` because nothing is bound to loopback. The container ends up permanently `(unhealthy)` even though it serves traffic correctly via the bridge IP.

This is a real binding mismatch, not a probe mistake — commit `67a57973` (PR #977) intentionally moved the healthcheck to `127.0.0.1` to match the project-wide convention; the convention is correct, the upstream image's bind default is what's incompatible.

## How
Single-line addition to `extensions/services/perplexica/compose.yaml`:
```yaml
      - HOSTNAME=0.0.0.0
```
Placed after the existing `OPENAI_API_KEY` line in the env list (list-form `- KEY=VALUE`, matching `n8n/compose.yaml` and `searxng/compose.yaml` style).

The host-side `${BIND_ADDRESS:-127.0.0.1}:${PERPLEXICA_PORT:-3004}:3000` mapping is untouched, so the loopback default for host-side LAN exposure is preserved (LAN mode still requires the operator to opt in via `--lan` / dashboard / `BIND_ADDRESS=0.0.0.0` in `.env`).

## Testing
- `python3 -c "import yaml; yaml.safe_load(open('.../perplexica/compose.yaml'))"` → PASS
- `docker compose -f docker-compose.base.yml -f extensions/services/searxng/compose.yaml -f extensions/services/perplexica/compose.yaml config -q` → exit 0 (with the standard env stubs)
- gitleaks pre-commit → PASS
- No automated test exists for compose-level Next.js binding behaviour; the Compose healthcheck IS the regression test (once the container reaches `(healthy)`, the bind is confirmed).

Manual (operator on macOS dev install):
1. `dream restart perplexica`
2. After ~60s: `docker ps --filter name=dream-perplexica --format '{{.Status}}'` → `Up X minutes (healthy)`
3. `docker exec dream-perplexica node -e "require('http').get('http://127.0.0.1:3000/',r=>console.log(r.statusCode))"` → `200`
4. `docker logs dream-perplexica | grep "Local:"` → Next.js banner reports `http://0.0.0.0:3000` (no longer container hostname)
5. `curl -s http://localhost:3004/ | head -c 100` → returns HTML (host-side loopback access still works)

## Review
Critique Guardian APPROVED. No required changes.

## Platform Impact
| Platform | Impact |
|---|---|
| macOS (Apple Silicon, Docker Desktop) | Healthcheck transitions to `(healthy)`. Otherwise unchanged. |
| Linux (NVIDIA / AMD, native Docker) | Same. Container-internal change. |
| Windows / WSL2 (Docker Desktop) | Same. Container-internal change. |
