### PR TITLE
fix(langfuse): use 127.0.0.1 in healthcheck URLs

### DIFF
--- a/dream-server/extensions/services/langfuse/compose.yaml.disabled
+++ b/dream-server/extensions/services/langfuse/compose.yaml.disabled
@@ -54,7 +54,7 @@ services:
       langfuse-minio-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3000/api/public/health"]
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://127.0.0.1:3000/api/public/health"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -114,7 +114,7 @@ services:
       langfuse-minio-init:
         condition: service_completed_successfully
     healthcheck:
-      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3030/api/health"]
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://127.0.0.1:3030/api/health"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -185,7 +185,7 @@ services:
         soft: 262144
         hard: 262144
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8123/ping"]
       interval: 15s
       timeout: 5s
       retries: 5
@@ -253,7 +253,7 @@ services:
     networks:
       - langfuse-internal
     healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live"]
+      test: ["CMD-SHELL", "curl -sf http://127.0.0.1:9000/minio/health/live"]
       interval: 15s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## What
Sweep the four healthcheck URLs in `extensions/services/langfuse/compose.yaml.disabled` from `localhost` to `127.0.0.1`. **Line 30 `NEXTAUTH_URL` is intentionally left untouched.**

## Why
busybox `wget` in Alpine resolves `localhost` → `::1` first. The container has no IPv6 stack on the bridge network, so the connection is refused and busybox `wget` gives up without retrying the IPv4 address. langfuse-worker reports `(unhealthy)` permanently as a result.

This is exactly the failure mode the project memory documents ("healthchecks must use `127.0.0.1`, not `localhost`"). The other 12 built-in extensions already follow this convention (n8n, searxng, embeddings, etc.); langfuse was an outlier. langfuse-web / clickhouse / minio currently report healthy because curl / the clickhouse image's wget handle the IPv4 fallback better — but they're one image-update away from regressing, so the sweep is preventive.

## How
Single-file edit to `extensions/services/langfuse/compose.yaml.disabled`:

| Line | Service | URL |
|---|---|---|
| 57 | langfuse (web) | `localhost:3000/api/public/health` → `127.0.0.1:3000/api/public/health` |
| 117 | langfuse-worker | `localhost:3030/api/health` → `127.0.0.1:3030/api/health` |
| 188 | langfuse-clickhouse | `localhost:8123/ping` → `127.0.0.1:8123/ping` (CMD exec-array form) |
| 256 | langfuse-minio | `localhost:9000/minio/health/live` → `127.0.0.1:9000/minio/health/live` (curl) |

**Line 30 `NEXTAUTH_URL: "http://localhost:${LANGFUSE_PORT:-3006}"` is preserved** — that's an OAuth callback URL evaluated by browsers, not by busybox inside the container. Changing it would break NEXTAUTH callbacks for users accessing the langfuse web UI from their browser.

File is `.disabled` (not auto-loaded; activated via `dream enable langfuse`). YAML still parses cleanly.

## Testing
- `python3 -c "import yaml; yaml.safe_load(open('.../compose.yaml.disabled'))"` → PASS
- Diff scope verified: 4 lines changed (4-/4+), exactly the 4 healthcheck URLs
- `grep -n localhost compose.yaml.disabled` → only line 30 (`NEXTAUTH_URL`) remains, as intended
- gitleaks pre-commit → PASS

Manual (operator after `dream enable langfuse`):
1. `docker exec dream-langfuse-worker wget --quiet --tries=1 --spider http://127.0.0.1:3030/api/health; echo "exit=$?"` → `exit=0`
2. `docker exec dream-langfuse-worker wget --quiet --tries=1 --spider http://localhost:3030/api/health; echo "exit=$?"` → `exit=1` (confirms the IPv6 issue we're fixing)
3. `docker ps --filter name=dream-langfuse-worker --format '{{.Status}}'` → `(healthy)`
4. Web UI at `http://localhost:${LANGFUSE_PORT:-3006}/` reachable; OAuth login (NEXTAUTH callbacks) still works

## Review
Critique Guardian APPROVED. No required changes.

## Platform Impact
| Platform | Impact |
|---|---|
| macOS / Linux / Windows (WSL2) | Container-level change only. busybox/Alpine behaviour is identical across hosts. langfuse must be enabled to take effect (compose is `.disabled` by default). |
