### PR TITLE
fix(macos): replace backticks with single quotes in env-generator comment

### DIFF
--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -259,7 +259,7 @@ TIMEZONE=${tz}
 # NOTE: this value is only written on first install or --force (the macOS
 # env-generator early-returns when .env already exists). Users who re-run
 # ./install-macos.sh --langfuse on an existing install should instead use
-# post-install: `dream enable langfuse`.
+# post-install: 'dream enable langfuse'.
 LANGFUSE_ENABLED=${ENABLE_LANGFUSE:-false}
 LANGFUSE_NEXTAUTH_SECRET=${langfuse_nextauth_secret}
 LANGFUSE_SALT=${langfuse_salt}


### PR DESCRIPTION
## What
Replace backticks with single quotes at `installers/macos/lib/env-generator.sh:262` so the comment is no longer evaluated as a command substitution by the heredoc.

## Why
The .env-generation heredoc terminator at line 181 is `<< ENVEOF` — **unquoted**. That means Bash performs both variable expansion AND command substitution on the heredoc body. Variable expansion is intentional (lines 182–276 contain dozens of legitimate `${TIER_NAME}`, `$(if ... then ... fi)`, `${webui_secret}` references — quoting the terminator would break the entire heredoc).

The accidental side-effect: any literal backticks in the heredoc body are also evaluated. Line 262 contained:
```
# post-install: `dream enable langfuse`.
```
Which Bash interpreted as `` `dream enable langfuse` ``. The `dream` CLI is not yet on PATH at install time, so the install log emitted `dream: command not found` AND the empty result of the failed substitution was written into `.env`, silently truncating the comment to `# post-install: .` (the words `dream enable langfuse` disappear entirely).

## How
Single-character-class change at line 262:
```
- # post-install: `dream enable langfuse`.
+ # post-install: 'dream enable langfuse'.
```

Single quotes match the in-file convention at line 245 (`# here and run 'dream-macos.sh restart' to use a different model.`).

**Verified clean elsewhere:**
- `installers/phases/06-directories.sh:216` has the identical comment text but is OUTSIDE any heredoc → backticks inert there. No companion fix required.
- Linux installer uses different env-generation path. Clean.
- Windows installer uses PowerShell where backticks are line-continuation, not command substitution. Clean.

## Testing
- `bash -n installers/macos/lib/env-generator.sh` → PASS
- `shellcheck` → SC2006 (which previously flagged the backtick) is now eliminated, providing independent validation that the fix is complete
- Heredoc terminator confirmed still `<< ENVEOF` (variable expansion preserved)
- Zero backticks remain in the heredoc body
- gitleaks pre-commit → PASS

Manual (operator on macOS):
1. Run a fresh install (or `DRY_RUN=1` invocation)
2. Confirm install log around env-generation phase shows NO `dream: command not found` warning
3. After install: `cat $INSTALL_DIR/.env | grep -A0 "post-install"` → comment reads `# post-install: 'dream enable langfuse'.` (not the previously-truncated `# post-install: .`)

## Review
Critique Guardian APPROVED. No required changes.

CG noted (optional follow-up): a pre-commit / CI guard against future authors re-introducing backticks inside unquoted installer heredocs would be a useful regression shield. Filed as fork issue #509 for separate work.

## Platform Impact
| Platform | Impact |
|---|---|
| macOS | This is the fix — install log no longer noisy, generated `.env` comment now intact. |
| Linux | Unaffected (file is macOS-only; equivalent comment on Linux is outside any heredoc). |
| Windows / WSL2 | Unaffected (file is macOS-only; PowerShell backticks have different semantics anyway). |
