### PR TITLE
fix(jupyter): convert command to exec-form list to avoid shell splitting

### DIFF
--- a/resources/dev/extensions-library/services/jupyter/compose.yaml
+++ b/resources/dev/extensions-library/services/jupyter/compose.yaml
@@ -11,7 +11,15 @@ services:
       - LLM_API_URL=${LLM_API_URL:-http://localhost:8000}
       - JUPYTER_TOKEN=${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set}
       - NB_PREFIX=/
-    command: start.sh jupyter lab --NotebookApp.token=${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set} --NotebookApp.password='' --NotebookApp.port=8888 --NotebookApp.ip=0.0.0.0 --NotebookApp.open_browser=False
+    command:
+      - start.sh
+      - jupyter
+      - lab
+      - --NotebookApp.token=${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set}
+      - --NotebookApp.password=
+      - --NotebookApp.port=8888
+      - --NotebookApp.ip=0.0.0.0
+      - --NotebookApp.open_browser=False
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## What
Convert the jupyter community extension's `command:` from shell-form scalar to YAML list (exec-form) in `resources/dev/extensions-library/services/jupyter/compose.yaml`.

## Why
Defensive hardening. The previous `command:` was a single shell-form string:
```yaml
command: start.sh jupyter lab --NotebookApp.token=${JUPYTER_TOKEN:?...} --NotebookApp.password='' --NotebookApp.port=8888 --NotebookApp.ip=0.0.0.0 --NotebookApp.open_browser=False
```
Compose passes shell-form to `/bin/sh -c "..."`, which interprets whitespace and shell metacharacters. `JUPYTER_TOKEN` is auto-generated by `setup.sh` as a 64-char hex string (no metacharacters), so the bug is not active in the default flow — but a paranoid operator setting `JUPYTER_TOKEN="my token with spaces"` in `.env` manually would have the token split on whitespace.

Of the 4 community extensions with `command:`, jupyter was the only one still using shell-form (aider, open-interpreter, milvus already use exec-form lists).

## How
Single-file conversion to YAML block list — each space-separated token becomes a list element:
```yaml
command:
  - start.sh
  - jupyter
  - lab
  - --NotebookApp.token=${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set}
  - --NotebookApp.password=
  - --NotebookApp.port=8888
  - --NotebookApp.ip=0.0.0.0
  - --NotebookApp.open_browser=False
```

**Critical detail:** `--NotebookApp.password=''` (shell-form, where the shell strips the quotes → empty argument) became `--NotebookApp.password=` (exec-form, no quotes — passes empty string verbatim). Writing `--NotebookApp.password=''` as a list element would have passed two literal single-quote characters to Jupyter, which would not behave as "no password." Implementer caught this nuance during the conversion.

## Testing
- YAML parse + structure check: `command` is `list`, `len == 8`, `cmd[4] == '--NotebookApp.password='` → PASS
- `JUPYTER_TOKEN=test docker compose config -q` → exit 0; renders password as empty correctly
- gitleaks + pre-commit hooks → PASS

Manual (operator after installing jupyter via dashboard):
1. `docker exec dream-jupyter ps -ef | grep jupyter` — each `--NotebookApp.X` should appear as a separate argv slot (no shell-level word splitting)
2. `curl -s -H "Authorization: token ${JUPYTER_TOKEN}" http://localhost:${JUPYTER_PORT:-8889}/api/status` → 200 OK
3. Adversarial: set `JUPYTER_TOKEN="my token with spaces"` in `.env`, restart jupyter, then `docker exec dream-jupyter ps -ef | grep token` — the `--NotebookApp.token=...` arg should contain the literal spaces in a single argv slot.

## Review
Critique Guardian APPROVED. No required changes.

## Known Considerations
**Out of scope:** `ports:` line uses bare `127.0.0.1:${JUPYTER_PORT:-8889}:8888` instead of the `${BIND_ADDRESS:-127.0.0.1}:${JUPYTER_PORT:-8889}:8888` pattern from PR #964. This pre-dates this PR (confirmed against `upstream/main`). Filed as fork issue #504 — covers a sweep of ~20 community extensions still using bare `127.0.0.1:`.

## Platform Impact
| Platform | Impact |
|---|---|
| macOS / Linux / Windows (WSL2) | Container-level change. YAML list/exec-form is spec-compliant on all Compose engines. Behaviour identical across hosts. |
