### PR TITLE
fix(installer): block non-POSIX INSTALL_DIR + verify Docker Desktop sharing

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -165,6 +165,65 @@ def resolve_compose_flags() -> list:
     return result.stdout.strip().split()
 
 
+# Filesystem types that silently ignore POSIX ownership/permissions.
+# Used by _precreate_data_dirs to skip os.chown when running on exFAT/FAT/NTFS-fuseblk
+# instead of raising a misleading PermissionError.
+_NON_POSIX_FS = frozenset({
+    "exfat", "msdos", "vfat", "fat", "fat32", "fat16",
+    "ntfs", "ntfs-3g", "fuseblk", "9p", "drvfs",
+    "ms-dos",
+})
+
+
+def _fs_type(path: Path) -> str | None:
+    """Return the lowercased filesystem type for ``path``, or ``None``.
+
+    Linux: walk /proc/self/mountinfo to find the longest matching mountpoint.
+    macOS / BSD: shell out to ``stat -f %T`` (Python's ``os.statvfs_result``
+    does not expose ``f_basetype``).
+    """
+    try:
+        target = str(Path(path).resolve())
+    except OSError:
+        return None
+
+    mountinfo = Path("/proc/self/mountinfo")
+    if mountinfo.exists():
+        try:
+            best_match = ""
+            best_fstype: str | None = None
+            with mountinfo.open("r", encoding="utf-8") as f:
+                for line in f:
+                    parts = line.split()
+                    if "-" not in parts:
+                        continue
+                    sep_idx = parts.index("-")
+                    if sep_idx + 1 >= len(parts) or sep_idx < 5:
+                        continue
+                    mountpoint = parts[4]
+                    fstype = parts[sep_idx + 1]
+                    if target == mountpoint or target.startswith(mountpoint.rstrip("/") + "/"):
+                        if len(mountpoint) >= len(best_match):
+                            best_match = mountpoint
+                            best_fstype = fstype
+            if best_fstype:
+                return best_fstype.lower()
+        except OSError:
+            pass
+
+    try:
+        result = subprocess.run(
+            ["stat", "-f", "%T", target],
+            capture_output=True, text=True, timeout=5, check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip().lower()
+    except (FileNotFoundError, subprocess.SubprocessError):
+        pass
+
+    return None
+
+
 def _precreate_data_dirs(service_id: str):
     """Pre-create data directories for an extension with correct ownership."""
     ext_dir = USER_EXTENSIONS_DIR / service_id
@@ -210,7 +269,20 @@ def _precreate_data_dirs(service_id: str):
                 try:
                     dir_path.mkdir(parents=True, exist_ok=True)
                     if uid is not None and os.getuid() == 0:
-                        os.chown(str(dir_path), uid, uid)
+                        # Defense-in-depth: the installer preflight already
+                        # blocks non-POSIX filesystems at INSTALL_DIR, but
+                        # runtime extension installs (post-setup) can still
+                        # land on a non-POSIX volume. chown there is a silent
+                        # no-op or raises EPERM/EOPNOTSUPP — skip cleanly.
+                        fs = _fs_type(dir_path)
+                        if fs in _NON_POSIX_FS:
+                            logger.warning(
+                                "Skipping chown for %s on non-POSIX filesystem %s "
+                                "(extension may not function correctly)",
+                                dir_path, fs,
+                            )
+                        else:
+                            os.chown(str(dir_path), uid, uid)
                 except OSError as e:
                     logger.warning("Failed to pre-create %s: %s", dir_path, e)
 

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -111,6 +111,7 @@ source "${LIB_DIR}/constants.sh"
 source "${LIB_DIR}/ui.sh"
 source "${LIB_DIR}/tier-map.sh"
 source "${LIB_DIR}/detection.sh"
+source "${LIB_DIR}/preflight-fs.sh"
 source "${LIB_DIR}/env-generator.sh"
 
 # ── File-local helpers ──
@@ -190,6 +191,39 @@ if ! $DOCKER_RUNNING; then
     exit 1
 fi
 ai_ok "Docker Desktop running (v${DOCKER_VERSION})"
+
+# Filesystem POSIX-permission check
+# The .env file (chmod 600) lives at INSTALL_DIR; a non-POSIX FS makes that
+# a silent no-op and leaks secrets. Block install before any directory
+# creation so the user can pick a different path.
+test_install_dir_filesystem "$INSTALL_DIR"
+info_box "Filesystem:" "${INSTALL_FS_TYPE}"
+if $INSTALL_FS_FATAL; then
+    ai_err "INSTALL_DIR (${INSTALL_DIR}) is on a ${INSTALL_FS_TYPE} filesystem."
+    ai_err "Dream Server requires a POSIX-permission filesystem (apfs/hfs) so .env"
+    ai_err "secrets can be locked down with chmod 600. ${INSTALL_FS_TYPE} silently"
+    ai_err "ignores chmod/chown, leaving secrets world-readable."
+    ai "Pick a path on your APFS system volume (e.g. ~/dream-server) and re-run."
+    exit 1
+fi
+ai_ok "Filesystem supports POSIX permissions"
+
+# Docker Desktop file-sharing allowlist check
+# Bind-mounts of paths outside the allowlist fail with cryptic OCI errors at
+# `docker compose up`. Probe with a throwaway container so we surface a clear
+# message before any compose work starts.
+test_docker_desktop_sharing "$INSTALL_DIR"
+if ! $DOCKER_SHARE_OK; then
+    ai_err "Docker Desktop cannot bind-mount ${INSTALL_DIR}."
+    ai_err "Add the path to Docker Desktop > Settings > Resources > File Sharing,"
+    ai_err "apply, then re-run this installer."
+    if [[ -n "$DOCKER_SHARE_ERR" ]]; then
+        ai "Probe output:"
+        printf '%s\n' "$DOCKER_SHARE_ERR" | sed 's/^/    /'
+    fi
+    exit 1
+fi
+ai_ok "Docker Desktop file sharing OK"
 
 # Disk space
 test_disk_space "$INSTALL_DIR" 30

--- a/dream-server/installers/macos/lib/preflight-fs.sh
+++ b/dream-server/installers/macos/lib/preflight-fs.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server macOS Installer -- Filesystem & Docker Desktop Sharing Checks
+# ============================================================================
+# Part of: installers/macos/lib/
+# Purpose: Detect non-POSIX filesystems at the install path (which silently
+#          drop chmod/chown — leaking .env secrets) and Docker Desktop file
+#          sharing allowlist gaps (which surface as cryptic OCI mount errors).
+#
+# Provides:
+#   test_install_dir_filesystem() -- sets INSTALL_FS_TYPE, INSTALL_FS_FATAL
+#   test_docker_desktop_sharing() -- sets DOCKER_SHARE_OK, DOCKER_SHARE_ERR
+#
+# shellcheck disable=SC2034  # vars are read by install-macos.sh after sourcing
+#
+# Modder notes:
+#   POSIX-permission filesystems leave chmod 600 .env useful. Non-POSIX
+#   filesystems (exFAT/FAT/NTFS-via-fuseblk) make the chmod a no-op, so the
+#   secrets file ends up world-readable — treat that as fatal.
+#   Filesystems that hold containerised data subpaths only are warn-only.
+# ============================================================================
+
+# Resolve to the nearest existing path so `stat -f` doesn't fail when the
+# install dir hasn't been created yet (first install).
+_resolve_existing_parent() {
+    local p="$1"
+    while [[ -n "$p" && ! -e "$p" ]]; do
+        p="$(dirname "$p")"
+    done
+    [[ -z "$p" ]] && p="/"
+    printf '%s' "$p"
+}
+
+# Detect filesystem type at INSTALL_DIR's parent (where .env will live).
+# BSD `stat -f %T` returns short personality strings (apfs, hfs, msdos, exfat,
+# ntfs). diskutil gives a richer "File System Personality" line we fall back
+# to when stat returns something unexpected.
+test_install_dir_filesystem() {
+    local install_dir="${1:-$INSTALL_DIR}"
+    INSTALL_FS_TYPE=""
+    INSTALL_FS_FATAL=false
+
+    local probe
+    probe="$(_resolve_existing_parent "$install_dir")"
+
+    local fs_type=""
+    fs_type=$(stat -f %T "$probe" 2>/dev/null || true)
+
+    # `stat -f %T` on macOS sometimes returns just a short tag; cross-check
+    # with diskutil for stable personality identification.
+    if command -v diskutil >/dev/null 2>&1; then
+        # `diskutil info` only accepts mount points or device IDs. Subpaths
+        # (e.g. /Volumes/X/dreamserver) make it exit non-zero, which under
+        # `set -euo pipefail` would silently kill the entire installer. The
+        # personality lookup is an optional refinement on top of `stat -f %T`,
+        # so swallow non-zero — empty personality just means we keep the stat
+        # value.
+        local personality=""
+        personality=$(diskutil info "$probe" 2>/dev/null \
+            | awk -F': *' '/File System Personality/ {print $2; exit}' \
+            | tr '[:upper:]' '[:lower:]' || true)
+        if [[ -n "$personality" ]]; then
+            fs_type="$personality"
+        fi
+    fi
+
+    INSTALL_FS_TYPE="${fs_type:-unknown}"
+
+    case "$INSTALL_FS_TYPE" in
+        *exfat*|*msdos*|*fat32*|*fat16*|*"ms-dos"*|*ntfs*)
+            INSTALL_FS_FATAL=true
+            ;;
+    esac
+}
+
+# Smoke-test Docker Desktop's file-sharing allowlist by trying to bind-mount
+# the install dir into a throwaway alpine container. Docker Desktop responds
+# with a recognisable error when the path is not in the shared list.
+test_docker_desktop_sharing() {
+    local install_dir="${1:-$INSTALL_DIR}"
+    DOCKER_SHARE_OK=true
+    DOCKER_SHARE_ERR=""
+
+    if ! command -v docker >/dev/null 2>&1; then
+        DOCKER_SHARE_OK=false
+        DOCKER_SHARE_ERR="docker CLI not found"
+        return
+    fi
+
+    local probe
+    probe="$(_resolve_existing_parent "$install_dir")"
+
+    local out=""
+    out=$(docker run --rm -v "${probe}:/check:ro" alpine true 2>&1) || true
+
+    if echo "$out" | grep -qiE "not shared from the host|Mounts denied|file sharing|filesharing"; then
+        DOCKER_SHARE_OK=false
+        DOCKER_SHARE_ERR="$out"
+    fi
+}

--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -84,5 +84,72 @@ if [[ -d "$INSTALL_DIR" ]]; then
     signal "Existing install detected. Secrets and data will be preserved."
 fi
 
+# Filesystem POSIX-permission check.
+# Phase 06 runs `chmod 600 $INSTALL_DIR/.env` to lock down secrets. On exFAT,
+# FAT32, fuseblk (NTFS via ntfs-3g), 9p and DrvFs that chmod is a silent no-op
+# — the secrets file ends up world-readable. Refuse install up front so the
+# user can pick a POSIX-native path.
+check_install_dir_filesystem() {
+    local probe="$INSTALL_DIR"
+    while [[ -n "$probe" && ! -e "$probe" ]]; do
+        probe="$(dirname "$probe")"
+    done
+    [[ -z "$probe" ]] && probe="/"
+
+    local fs_type=""
+    fs_type=$(stat -fc %T "$probe" 2>/dev/null || true)
+    fs_type="${fs_type,,}"  # lowercase
+    INSTALL_FS_TYPE="${fs_type:-unknown}"
+
+    case "$fs_type" in
+        fuseblk|msdos|exfat|vfat|fat|9p|drvfs|ntfs|ntfs-3g)
+            error "INSTALL_DIR ($INSTALL_DIR) is on a ${fs_type} filesystem.
+
+Dream Server stores secrets in $INSTALL_DIR/.env and locks them with
+chmod 600. ${fs_type} silently ignores POSIX permissions, which would
+leave the secrets file world-readable.
+
+Pick a path on a POSIX-native filesystem (ext4, btrfs, xfs, zfs) and
+re-run, e.g.:  INSTALL_DIR=\"\$HOME/dream-server\" $0"
+            ;;
+    esac
+    log "INSTALL_DIR filesystem: ${INSTALL_FS_TYPE}"
+}
+
+# Docker Desktop file-sharing probe — only meaningful when Docker Desktop
+# is in use (most Linux installs use the native daemon and skip this).
+check_docker_desktop_sharing() {
+    command -v docker >/dev/null 2>&1 || return 0
+
+    local os_string=""
+    os_string=$(docker info --format '{{json .OperatingSystem}}' 2>/dev/null || true)
+    case "$os_string" in
+        *"Docker Desktop"*) ;;
+        *) return 0 ;;
+    esac
+
+    local probe="$INSTALL_DIR"
+    while [[ -n "$probe" && ! -e "$probe" ]]; do
+        probe="$(dirname "$probe")"
+    done
+    [[ -z "$probe" ]] && probe="/"
+
+    local out=""
+    out=$(docker run --rm -v "${probe}:/check:ro" alpine true 2>&1) || true
+    if echo "$out" | grep -qiE "not shared from the host|Mounts denied|file sharing|filesharing"; then
+        error "Docker Desktop cannot bind-mount $INSTALL_DIR.
+
+Add the path to Docker Desktop > Settings > Resources > File Sharing,
+apply, then re-run this installer.
+
+Probe output:
+$(printf '%s\n' "$out" | sed 's/^/    /')"
+    fi
+    log "Docker Desktop file sharing OK"
+}
+
+check_install_dir_filesystem
+check_docker_desktop_sharing
+
 ai_ok "Pre-flight checks passed."
 signal "No cloud dependencies required for core operation."

--- a/dream-server/installers/windows/phases/01-preflight.ps1
+++ b/dream-server/installers/windows/phases/01-preflight.ps1
@@ -95,6 +95,83 @@ if (-not $preflight_docker.WSL2Backend) {
     Write-AIWarn "--Force specified, continuing without confirmed WSL2 backend."
 }
 
+# ── Filesystem POSIX-permission check ────────────────────────────────────────
+# Phase 06 (.env generation) writes secrets and relies on filesystem ACLs.
+# exFAT and FAT32 cannot represent per-user permissions at all, so the
+# secrets file ends up readable by every account on the machine. Refuse
+# install up front so the user can choose an NTFS/ReFS path. NTFS is fine
+# from native Windows; we only flag NTFS as fatal when the install path is
+# inside a 9p/DrvFs WSL mount (rare for this PowerShell installer, but kept
+# for safety when somebody runs install.ps1 from inside a WSL shell).
+$_fsProbe = $installDir
+while ($_fsProbe -and -not (Test-Path -LiteralPath $_fsProbe)) {
+    $_fsProbe = Split-Path -Parent $_fsProbe
+}
+if (-not $_fsProbe) { $_fsProbe = $installDir }
+
+$_fsType = ""
+try {
+    $_di = [System.IO.DriveInfo]::new($_fsProbe)
+    $_fsType = $_di.DriveFormat
+} catch {
+    # Path is on a non-Windows mount (e.g. WSL 9p) — DriveInfo throws.
+    $_fsType = ""
+}
+
+# WSL detection (when running install.ps1 from inside WSL)
+$_isWslPath = $false
+if ($_fsProbe -match "^(?i)/mnt/[a-z]/" -or $env:WSL_DISTRO_NAME) {
+    $_isWslPath = $true
+}
+
+Write-InfoBox "Filesystem:" $(if ($_fsType) { $_fsType } else { "unknown" })
+
+$_fsFatal = $false
+switch -Regex ($_fsType) {
+    "^(exFAT|FAT32|FAT)$" { $_fsFatal = $true }
+    "^NTFS$"              { if ($_isWslPath) { $_fsFatal = $true } }
+}
+
+if ($_fsFatal) {
+    Write-AIError "INSTALL_DIR ($installDir) is on a $_fsType filesystem."
+    Write-AIError "Dream Server stores secrets in .env and depends on filesystem"
+    Write-AIError "permissions. $_fsType cannot represent per-user permissions,"
+    Write-AIError "which would leave secrets readable by every account on this machine."
+    Write-AI "  Pick a path on an NTFS/ReFS volume (e.g. C:\Users\<you>\dream-server) and re-run."
+    exit 1
+}
+Write-AISuccess "Filesystem supports POSIX-style permissions"
+
+# ── Docker Desktop file-sharing allowlist check ──────────────────────────────
+# Bind-mounting a path outside the Docker Desktop file-sharing list fails at
+# `docker compose up` with a cryptic OCI error. Probe with a throwaway alpine
+# container so we surface a clear message before any compose work starts.
+$_shareOk = $true
+$_shareErr = ""
+try {
+    # PowerShell -v argument needs careful quoting for paths with spaces.
+    $_probeOut = & docker run --rm -v "${_fsProbe}:/check:ro" alpine true 2>&1
+    $_probeText = ($_probeOut -join "`n")
+    if ($_probeText -match "not shared from the host|Mounts denied|file sharing|filesharing") {
+        $_shareOk = $false
+        $_shareErr = $_probeText
+    }
+} catch {
+    $_shareOk = $false
+    $_shareErr = $_.Exception.Message
+}
+if (-not $_shareOk) {
+    Write-AIError "Docker Desktop cannot bind-mount $installDir."
+    Write-AIError "Add the path to Docker Desktop > Settings > Resources > File Sharing,"
+    Write-AIError "apply, then re-run this installer."
+    if ($_shareErr) {
+        Write-AI "  Probe output:"
+        $_shareErr -split "`n" | ForEach-Object { Write-Host "    $_" }
+    }
+    exit 1
+}
+Write-AISuccess "Docker Desktop file sharing OK"
+
 # ── Initial disk space check ─────────────────────────────────────────────────
 # 20 GB minimum before model size is known (tier-aware check happens in phase 04).
 $_disk = Test-DiskSpace -Path $installDir -RequiredGB 20


### PR DESCRIPTION
## What
Block install on a non-POSIX-permission filesystem at `INSTALL_DIR` (security regression), and pre-verify Docker Desktop's file-sharing allowlist before any compose-up. Per-platform detection across all three installers, plus a defense-in-depth guard in the host agent.

## Why
**Bug #1 — non-POSIX filesystems silently no-op chmod/chown:** Phase 06 runs `chmod 600 "$INSTALL_DIR/.env"` to lock down secrets. On exFAT, FAT32, fuseblk (NTFS via ntfs-3g), 9p, and DrvFs the chmod is a silent no-op — the kernel returns success but the permission bits are not stored. The .env file (containing `WEBUI_SECRET`, `DASHBOARD_API_KEY`, `DREAM_AGENT_KEY`, etc.) ends up world-readable on the host. **This is a security regression**, not just an install oddity.

**Bug #2 — Docker Desktop file-sharing allowlist not pre-verified:** macOS / Windows Docker Desktop maintains an allowlist of host paths that can be bind-mounted into containers. Custom install paths (`/opt/dreamserver`, `/mnt/external`, etc.) outside the default allowlist cause `docker compose up` to fail with a cryptic OCI error (`error mounting ... to rootfs`) on every service. No diagnostic guidance is surfaced.

Both gaps existed across all three platform installers with zero detection.

## How
Per-platform filesystem-type detection at the nearest existing parent of `INSTALL_DIR`, plus a Docker Desktop bind-mount probe. Treats the non-POSIX FS types as **fatal** (refuse install with clear remediation message); host agent skips chown gracefully when an extension data directory lands on a non-POSIX FS at runtime.

| Platform | New / changed file | Mechanism |
|---|---|---|
| Linux | `installers/phases/01-preflight.sh` | `check_install_dir_filesystem` using GNU `stat -fc %T`; `check_docker_desktop_sharing` gated on `docker info` containing "Docker Desktop" |
| macOS | NEW `installers/macos/lib/preflight-fs.sh` + `installers/macos/install-macos.sh` integration | BSD `stat -f %T` + `diskutil info` personality cross-check; alpine bind-mount probe |
| Windows / WSL2 | `installers/windows/phases/01-preflight.ps1` | `[System.IO.DriveInfo]::DriveFormat`; WSL DrvFs detection via `^/mnt/[a-z]/` regex or `$env:WSL_DISTRO_NAME` |
| Host agent | `bin/dream-host-agent.py` | New `_NON_POSIX_FS` frozenset (12 entries) + `_fs_type()` helper (parses `/proc/self/mountinfo` on Linux, falls back to `stat -f %T` on BSD); `_precreate_data_dirs` skips `os.chown` with `logger.warning` when target dir is on a non-POSIX FS |

Fatal types (operator decision): exFAT, FAT16/32, fuseblk, NTFS-fuseblk, NTFS-on-WSL-mount, 9p, DrvFs, ntfs-3g.
Native types (allowed): apfs, hfs, ext2/3/4, btrfs, xfs, zfs, f2fs, NTFS-on-native-Windows.

Docker Desktop probe runs `docker run --rm -v "$INSTALL_DIR:/check:ro" alpine true` and parses stderr for "not shared from the host", "Mounts denied", "file sharing", "filesharing" — fatal exit with remediation guidance pointing to `Settings > Resources > File Sharing`.

Order of execution: filesystem check runs **after** INSTALL_DIR validation but **before** any `mkdir -p` / `chmod`; DD probe runs **after** Docker daemon check but **before** any compose-up.

Dashboard `PreFlightChecks.jsx` UI integration is deferred to a follow-up PR (separable scope).

## Testing
- `bash -n` on all 3 modified shell files + new lib → PASS
- `python3 -m py_compile` + `ruff` on `dream-host-agent.py` → PASS
- `shellcheck -e SC1090,SC1091,SC2034` → clean (one pre-existing SC2153 INFO on `install-macos.sh:240` for `OLLAMA_PID`, baseline-confirmed unrelated)
- `_NON_POSIX_FS` content sanity: 12 entries verified (exfat, fat, fat16, fat32, fuseblk, ms-dos, msdos, ntfs, ntfs-3g, vfat, 9p, drvfs)
- `tests/test-preflight.sh` → 19/19 PASS
- `tests/test-linux-install-preflight.sh` → 7/7 PASS
- `tests/test-preflight-fixtures.sh` → 4/4 PASS
- All other dashboard-api tests pass (one pre-existing asyncio/Python 3.14 failure in `test_gpu_detailed.py` is unrelated baseline)
- PowerShell parse + BATS coverage: `pwsh` and `bats` not on dev box; CI `lint-powershell.yml` and BATS jobs gate them

Manual (operator, per platform):

**macOS** — install on APFS volume → `✓ Filesystem supports POSIX permissions` + `✓ Docker Desktop file sharing OK`. Install on `/Volumes/<exfat-drive>/...` → fatal error, install aborts, no `.env` created. Install on `/opt/dream-test` (not in DD allowlist) → fatal error pointing to DD settings.

**Linux native Docker** — install on ext4 → both checks pass (DD probe skipped). Install on exFAT mount → fatal. Install on fuseblk (NTFS via ntfs-3g) → fatal.

**Linux Docker Desktop** — both checks run; DD allowlist enforced same as macOS.

**Windows WSL2** — install to NTFS native Windows path → passes. Install to exFAT external drive → fatal. Install from inside WSL on a `/mnt/c/...` path → NTFS-on-WSL detected → fatal.

**Host agent runtime** — install an extension at runtime onto a non-POSIX volume → host agent logs `Skipping chown for ... on non-POSIX filesystem ...` instead of raising EPERM.

## Review
Critique Guardian APPROVED WITH WARNINGS (5 non-blocking, all operator's-call):
1. BATS / pytest coverage for new functions absent → filed as fork issue **#505** (defer to follow-up test PR; would push this PR past M-size).
2. Linux `error()` message uses `$0` which resolves to `install-core.sh` orchestrator path when sourced; cosmetic only.
3. Windows residual gap: `install.ps1` invoked from inside WSL with non-`/mnt/[a-z]/` Linux path falls through if `WSL_DISTRO_NAME` isn't propagated. Vanishingly rare configuration.
4. `docker run alpine` cold pull adds 5–30s on first install; minor UX. Could `docker image inspect alpine` first.
5. Networked filesystems (NFS / SMB / CIFS) not flagged — POSIX permissions on SMB are advisory; edge case residual leak surface → filed as fork issue **#506**.

## Platform Impact
| Platform | Impact |
|---|---|
| macOS (Apple Silicon, Docker Desktop) | NEW preflight checks. APFS + paths inside DD-shared list pass cleanly. exFAT and unshared-paths now fail-loud at install time instead of silent broken-secrets / broken-binds. |
| Linux (NVIDIA / AMD, native Docker) | NEW filesystem check. DD probe is skipped on native Docker. ext4/btrfs/xfs/zfs pass. exFAT/fuseblk fail-loud. |
| Linux (Docker Desktop) | Both checks active (same as macOS). |
| Windows / WSL2 (Docker Desktop) | NEW filesystem check + DD probe. NTFS-on-Windows passes. exFAT and NTFS-on-WSL fail-loud. |
| Host agent (all platforms) | Defense-in-depth runtime guard. Logs warning + skips chown when target dir is on a non-POSIX FS instead of raising EPERM. |
