### PR TITLE
docs(dashboard-api): add development workflow guide for the bake-vs-bind-mount trap

### DIFF
--- a/dream-server/CONTRIBUTING.md
+++ b/dream-server/CONTRIBUTING.md
@@ -15,6 +15,26 @@ No CLA. No committee. No waiting for permission. If it makes Dream Server better
 If you're adding or extending services, read these first:
 - [docs/EXTENSIONS.md](docs/EXTENSIONS.md) — how to add a new service in 30 minutes
 - [docs/INSTALLER-ARCHITECTURE.md](docs/INSTALLER-ARCHITECTURE.md) — how the installer works under the hood
+- [docs/DASHBOARD-API-DEVELOPMENT.md](docs/DASHBOARD-API-DEVELOPMENT.md) — how to actually iterate on the dashboard-api FastAPI backend without your changes silently no-op'ing
+
+## Dashboard API development
+
+If you're touching `extensions/services/dashboard-api/`, read [docs/DASHBOARD-API-DEVELOPMENT.md](docs/DASHBOARD-API-DEVELOPMENT.md) **before** you start editing.
+
+The short version: the dashboard-api `Dockerfile` copies the Python source into `/app/` at image build, and uvicorn imports from there. The compose service mounts `./extensions:/dream-server/extensions:ro` — but that bind-mount is for manifest and config discovery, not Python imports. Editing files under `extensions/services/dashboard-api/` on the host does **not** reload the running container. Your changes silently do nothing until the image is rebuilt.
+
+The recommended workflow is to run uvicorn natively on the host with `--reload`:
+
+```bash
+cd dream-server/extensions/services/dashboard-api
+pip install -r requirements.txt
+DREAM_INSTALL_DIR=/path/to/dream-server \
+  uvicorn main:app --host 127.0.0.1 --port 3002 --reload
+```
+
+Other services already reach the host via `host.docker.internal:host-gateway`, which is wired into the dashboard-api compose service, so the rest of the stack keeps working while you iterate. Hot-reload works natively on macOS and Linux; on WSL2, keep the repo on the WSL2 filesystem (not `/mnt/c/...`) for the watcher to behave.
+
+If you can't run native uvicorn for some reason, `docker cp <file> dream-dashboard-api:/app/<file>` followed by `docker compose restart dashboard-api` is a survivable stop-gap until the next image rebuild. The full guide covers why we did **not** ship a bind-mount overlay or a `uvicorn --reload` compose mode as the default.
 
 ## What We Care About Right Now
 

--- a/dream-server/docs/DASHBOARD-API-DEVELOPMENT.md
+++ b/dream-server/docs/DASHBOARD-API-DEVELOPMENT.md
@@ -1,0 +1,139 @@
+# Dashboard API Development
+
+This guide covers how to iterate on `extensions/services/dashboard-api/` (the FastAPI backend that powers the Dashboard UI) without losing your sanity.
+
+## TL;DR
+
+- Editing `.py` files under `extensions/services/dashboard-api/` on the host **does not** reload the running `dream-dashboard-api` container. The image bakes a copy into `/app/` at build time.
+- Run uvicorn natively on the host with `--reload` for fast iteration. The rest of the stack already supports this via `host.docker.internal`.
+- Only rebuild the image (or `docker cp` as a stop-gap) when you actually need to ship the change.
+
+## The Trap
+
+The Dockerfile (`extensions/services/dashboard-api/Dockerfile`) does this at build time:
+
+```dockerfile
+WORKDIR /app
+COPY main.py config.py models.py security.py gpu.py helpers.py agent_monitor.py user_extensions.py ./
+COPY routers/ routers/
+...
+CMD uvicorn main:app --host 0.0.0.0 --port ${DASHBOARD_API_PORT}
+```
+
+Two consequences:
+
+1. The Python source lives at `/app/` inside the image. uvicorn is launched from that `WORKDIR` and imports `main:app` from `/app/main.py`. There is no live link back to the host filesystem.
+2. The compose service mounts the host repo at `/dream-server` (read-only) — see `docker-compose.base.yml`:
+
+   ```yaml
+   volumes:
+     - ./scripts:/dream-server/scripts:ro
+     - ./config:/dream-server/config:ro
+     - ./extensions:/dream-server/extensions:ro
+     - ./.env:/dream-server/.env:ro
+     ...
+   ```
+
+   That bind-mount exists so the API can **read manifests, scripts, and config** at runtime. It is not on Python's import path. Editing `dream-server/extensions/services/dashboard-api/routers/setup.py` on the host updates `/dream-server/extensions/services/dashboard-api/routers/setup.py` inside the container — a path nothing imports from. The running uvicorn keeps serving the baked `/app/routers/setup.py`.
+
+If you only test by editing host files and reloading the dashboard, your changes silently no-op. This has bitten contributors before; don't waste an afternoon on it.
+
+## Recommended Workflow: Native uvicorn
+
+Run the API directly on the host with hot-reload. The rest of the compose stack stays running in Docker; the dashboard container reaches your host process via `host.docker.internal`, which is already wired up in `docker-compose.base.yml` (`extra_hosts: ["host.docker.internal:host-gateway"]`).
+
+### One-time setup
+
+```bash
+cd dream-server/extensions/services/dashboard-api
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+### Each session
+
+Stop the container so the host port is free (run from the install root, where `docker-compose.base.yml` lives):
+
+```bash
+cd /path/to/dream-server && docker compose stop dashboard-api
+```
+
+Then run uvicorn natively. Set `DREAM_INSTALL_DIR` to the path of your installed Dream Server repo (the same path the container would see as `/dream-server`):
+
+```bash
+cd dream-server/extensions/services/dashboard-api
+DREAM_INSTALL_DIR=/path/to/dream-server \
+DREAM_DATA_DIR=/path/to/dream-server/data \
+DREAM_AGENT_PORT=7710 \
+DASHBOARD_API_KEY="$(grep ^DASHBOARD_API_KEY /path/to/dream-server/.env | cut -d= -f2-)" \
+DREAM_AGENT_KEY="$(grep ^DREAM_AGENT_KEY /path/to/dream-server/.env | cut -d= -f2-)" \
+  uvicorn main:app --host 127.0.0.1 --port 3002 --reload
+```
+
+uvicorn's `--reload` uses `watchfiles` and picks up edits to any `.py` file under the working directory.
+
+Other compose services that talk to the dashboard-api (notably the dashboard frontend) reach it on `http://127.0.0.1:3002` from the host or via `host.docker.internal:3002` from another container. No compose changes needed.
+
+Mirror any other env vars your code path reads (`OLLAMA_URL`, `LLM_MODEL`, `KOKORO_URL`, etc.) from the values in `.env`. A small wrapper script that exports the relevant subset is a reasonable thing to keep locally. Note that `DASHBOARD_API_KEY` and `DREAM_AGENT_KEY` are independent secrets (since PR #979 they are no longer aliased) — if you only export one, calls in the direction that needs the other will return 401.
+
+## Stop-gap: `docker cp`
+
+If running native uvicorn isn't an option (you only have Docker, you're debugging something that depends on the container's exact env, etc.), copy the file straight into `/app/` and restart the service:
+
+```bash
+cd dream-server/extensions/services/dashboard-api
+docker cp routers/setup.py dream-dashboard-api:/app/routers/setup.py
+docker compose restart dashboard-api
+```
+
+This survives until the next image rebuild, after which the baked copy wins again. It is a survivable stop-gap for hot patches; it is not a substitute for committing the change.
+
+## Permanent Change: Rebuild the Image
+
+Anything you want to ship has to make it into the image:
+
+```bash
+docker compose build dashboard-api
+docker compose up -d dashboard-api
+```
+
+This is what running installs pick up the next time they pull or rebuild.
+
+## Why Not Just Bind-Mount the Source? (Option B, rejected)
+
+Mapping `./extensions/services/dashboard-api:/app` would give "live edits in the container" at the cost of:
+
+1. **Writable mount required.** Python writes `__pycache__/` next to source files. A read-only bind-mount makes every import fail; a read-write mount lets the container scribble bytecode back into the contributor's working tree.
+2. **Breaks standalone use of the prebuilt image.** Anyone running `docker run light-heart-labs/dashboard-api` (or pulling the image without our compose file) would get an empty `/app/` because the bind-mount isn't there. The image would no longer be self-contained.
+3. **Divergent dev and prod images.** Dev would import from the bind-mount; prod from the baked copy. Bugs that depend on file layout, permissions, or pycache state would only show up on one path.
+
+Native uvicorn gets the same iteration speed without any of those drawbacks.
+
+## Why Not a `--reload` Compose Overlay? (Option C, rejected)
+
+The obvious alternative is a `docker-compose.dev.yml` that overrides the dashboard-api command:
+
+```yaml
+# rejected
+services:
+  dashboard-api:
+    command: uvicorn main:app --host 0.0.0.0 --port 3002 --reload --reload-dir /dream-server/extensions/services/dashboard-api
+```
+
+The trap: `WORKDIR` is still `/app`. uvicorn launches in `/app`, imports `main:app` from `/app/main.py`, and watches `/dream-server/extensions/services/dashboard-api/` for file changes. The watcher fires correctly, uvicorn reloads — and re-imports the **same baked `/app/` code**. The reload appears to work and the change appears to do nothing.
+
+To actually pick up host edits, the overlay has to also change `WORKDIR` (or wrap the command in `bash -c "cd /dream-server/extensions/services/dashboard-api && uvicorn ..."`) and ensure Python's import path points at the bind-mount. At that point you've effectively re-implemented Option B inside an overlay, with all of its drawbacks plus a confusing dev-only command. Running uvicorn on the host is shorter and clearer.
+
+## Cross-Platform Notes
+
+- **macOS (Apple Silicon / Intel).** Native uvicorn works perfectly. Watchfiles uses FSEvents; reloads are fast and reliable. No osxfs involvement because the source is on the host filesystem to begin with.
+- **Linux.** Native uvicorn works perfectly. Watchfiles uses inotify.
+- **Windows / WSL2.** Run the WSL2 instance (uvicorn) with the repo on the **WSL2 filesystem** (e.g. `~/DreamServer`). Editing on `/mnt/c/...` (the Windows NTFS mount) makes inotify watches unreliable — file change events drop or arrive late. Keep the working tree inside the WSL2 home directory, edit it via VS Code's WSL remote, and reload triggers behave the same as on Linux.
+
+## See Also
+
+- [EXTENSIONS.md](EXTENSIONS.md) — adding a new service extension.
+- [HOST-AGENT-API.md](HOST-AGENT-API.md) — the host-agent endpoints the dashboard-api calls into.
+- `extensions/services/dashboard-api/Dockerfile` — the source of truth for what gets baked into `/app/`.
+- `docker-compose.base.yml` — the dashboard-api service definition (volumes, env, `extra_hosts`).

--- a/dream-server/docs/DASHBOARD-API-DEVELOPMENT.md
+++ b/dream-server/docs/DASHBOARD-API-DEVELOPMENT.md
@@ -101,11 +101,14 @@ cd dream-server/extensions/services/dashboard-api
 source .venv/bin/activate
 DREAM_INSTALL_DIR=/path/to/dream-server \
 DREAM_DATA_DIR=/path/to/dream-server/data \
+DREAM_AGENT_HOST=127.0.0.1 \
 DREAM_AGENT_PORT=7710 \
 DASHBOARD_API_KEY="$(grep ^DASHBOARD_API_KEY /path/to/dream-server/.env | cut -d= -f2-)" \
 DREAM_AGENT_KEY="$(grep ^DREAM_AGENT_KEY /path/to/dream-server/.env | cut -d= -f2-)" \
   uvicorn main:app --host 127.0.0.1 --port 3002 --reload
 ```
+
+`DREAM_AGENT_HOST=127.0.0.1` is required when running uvicorn natively on the host — `config.py` defaults it to `host.docker.internal`, which Docker Desktop only injects inside containers. Without this override, any host-agent-backed dashboard-api route (extensions install/start, model download, `/v1/env/update`, etc.) fails DNS resolution and returns 502.
 
 uvicorn's `--reload` uses `watchfiles` and picks up edits to any `.py` file under the working directory. Vite hot-reloads JSX/CSS as you edit.
 

--- a/dream-server/docs/DASHBOARD-API-DEVELOPMENT.md
+++ b/dream-server/docs/DASHBOARD-API-DEVELOPMENT.md
@@ -5,7 +5,7 @@ This guide covers how to iterate on `extensions/services/dashboard-api/` (the Fa
 ## TL;DR
 
 - Editing `.py` files under `extensions/services/dashboard-api/` on the host **does not** reload the running `dream-dashboard-api` container. The image bakes a copy into `/app/` at build time.
-- Run uvicorn natively on the host with `--reload` for fast iteration. The rest of the stack already supports this via `host.docker.internal`.
+- Recommended dev workflow: stop **both** the `dashboard` and `dashboard-api` Docker containers to free host ports 3001 and 3002, then run **Vite dev server** for the dashboard frontend (`npm run dev` on port 3001) plus **native uvicorn** with `--reload` for the API (port 3002). Vite's built-in `/api` proxy already points at `localhost:3002`, so the two host processes wire up automatically. The rest of the compose stack (llama-server, host-agent, etc.) stays running.
 - Only rebuild the image (or `docker cp` as a stop-gap) when you actually need to ship the change.
 
 ## The Trap
@@ -38,31 +38,67 @@ Two consequences:
 
 If you only test by editing host files and reloading the dashboard, your changes silently no-op. This has bitten contributors before; don't waste an afternoon on it.
 
-## Recommended Workflow: Native uvicorn
+## Recommended Workflow: Vite + Native uvicorn
 
-Run the API directly on the host with hot-reload. The rest of the compose stack stays running in Docker; the dashboard container reaches your host process via `host.docker.internal`, which is already wired up in `docker-compose.base.yml` (`extra_hosts: ["host.docker.internal:host-gateway"]`).
+The clean dev story is to swap the **dashboard** and **dashboard-api** Docker containers out for host-side processes that share the same ports, leaving the rest of the compose stack (llama-server, host-agent, etc.) running. Vite's built-in proxy at `extensions/services/dashboard/vite.config.js` already routes `/api` to `http://localhost:3002`:
+
+```js
+// vite.config.js (already in repo, no change needed)
+server: {
+  port: 3001,
+  proxy: { '/api': { target: 'http://localhost:3002', changeOrigin: true } }
+}
+```
+
+So the dev proxy chain becomes:
+
+```
+browser → http://localhost:3001 (Vite dev)  → /api/* → http://localhost:3002 (host uvicorn)
+```
+
+### Why both containers must be stopped
+
+`docker-compose.base.yml` binds host port 3001 to the `dashboard` (nginx) container and host port 3002 to the `dashboard-api` (uvicorn) container — both with `${BIND_ADDRESS:-127.0.0.1}` defaults. If either is running, the matching host-side process refuses to bind.
+
+Stopping only `dashboard-api` (an earlier draft of this guide's recommendation) is **wrong**: the Docker `dashboard` container's nginx config hardcodes `proxy_pass http://dashboard-api:3002` (see `extensions/services/dashboard/nginx.conf`). Without the Docker dashboard-api running, every `/api/*` request the Docker nginx proxies returns 502 Bad Gateway. The correct path is to stop **both** containers and replace them with Vite + uvicorn running on the same host ports.
+
+You can keep the rest of the stack (`llama-server`, `dream-host-agent`, `qdrant`, etc.) running. Only the two dashboard containers need to step aside.
 
 ### One-time setup
 
 ```bash
+# API venv
 cd dream-server/extensions/services/dashboard-api
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+
+# Frontend deps
+cd ../dashboard
+npm install
 ```
 
 ### Each session
 
-Stop the container so the host port is free (run from the install root, where `docker-compose.base.yml` lives):
+Stop the two dashboard containers so host ports 3001 and 3002 are free:
 
 ```bash
-cd /path/to/dream-server && docker compose stop dashboard-api
+cd /path/to/dream-server
+docker compose stop dashboard dashboard-api
 ```
 
-Then run uvicorn natively. Set `DREAM_INSTALL_DIR` to the path of your installed Dream Server repo (the same path the container would see as `/dream-server`):
+Terminal 1 — Vite dev server (claims host port 3001):
+
+```bash
+cd dream-server/extensions/services/dashboard
+npm run dev
+```
+
+Terminal 2 — native uvicorn (claims host port 3002). Set `DREAM_INSTALL_DIR` to the path of your installed Dream Server repo (the same path the container sees as `/dream-server`):
 
 ```bash
 cd dream-server/extensions/services/dashboard-api
+source .venv/bin/activate
 DREAM_INSTALL_DIR=/path/to/dream-server \
 DREAM_DATA_DIR=/path/to/dream-server/data \
 DREAM_AGENT_PORT=7710 \
@@ -71,9 +107,15 @@ DREAM_AGENT_KEY="$(grep ^DREAM_AGENT_KEY /path/to/dream-server/.env | cut -d= -f
   uvicorn main:app --host 127.0.0.1 --port 3002 --reload
 ```
 
-uvicorn's `--reload` uses `watchfiles` and picks up edits to any `.py` file under the working directory.
+uvicorn's `--reload` uses `watchfiles` and picks up edits to any `.py` file under the working directory. Vite hot-reloads JSX/CSS as you edit.
 
-Other compose services that talk to the dashboard-api (notably the dashboard frontend) reach it on `http://127.0.0.1:3002` from the host or via `host.docker.internal:3002` from another container. No compose changes needed.
+Browse to **http://localhost:3001** (Vite). Backend traffic flows through Vite's proxy to your host uvicorn; the rest of the stack (host-agent on 7710, llama-server on 8080, etc.) is reached the same way it was via the Docker dashboard.
+
+When you're done, restart the production containers:
+
+```bash
+docker compose start dashboard dashboard-api
+```
 
 Mirror any other env vars your code path reads (`OLLAMA_URL`, `LLM_MODEL`, `KOKORO_URL`, etc.) from the values in `.env`. A small wrapper script that exports the relevant subset is a reasonable thing to keep locally. Note that `DASHBOARD_API_KEY` and `DREAM_AGENT_KEY` are independent secrets (since PR #979 they are no longer aliased) — if you only export one, calls in the direction that needs the other will return 401.
 


### PR DESCRIPTION
## What
Document how to iterate on the dashboard-api FastAPI backend without your changes silently no-op'ing — and explain why the obvious bind-mount and \`--reload\` overlay alternatives weren't shipped.

Two files:
- New: \`dream-server/docs/DASHBOARD-API-DEVELOPMENT.md\` — full guide (~140 lines).
- Updated: \`dream-server/CONTRIBUTING.md\` — short pointer to the new doc, slipped into the existing Getting Started link list and a brief inline summary.

## Why
The dashboard-api Dockerfile bakes the Python source into \`/app/\` at image build, and uvicorn imports from there. The compose service mounts \`./extensions:/dream-server/extensions:ro\` — but that mount exists for manifest and config discovery, not for Python imports. Editing files under \`extensions/services/dashboard-api/\` on the host therefore does **not** reload the running container; changes silently no-op until the image is rebuilt. Multiple contributors have hit this trap (and lost time tracking down why their change "did nothing"), so the gap is worth a focused doc rather than another retread.

## How
Pure documentation. No code, Dockerfile, compose, or installer change.

The guide:
1. States the trap up front (TL;DR + a "The Trap" section).
2. Recommends running uvicorn natively on the host with \`--reload\`, leveraging the existing \`host.docker.internal:host-gateway\` wiring on the dashboard-api compose service so the rest of the stack continues to talk to the host-side process.
3. Documents \`docker cp\` as a stop-gap until the next image rebuild.
4. Explains why **Option B** (bind-mount the source as the working directory) was not shipped — \`__pycache__\` writes, standalone-image breakage, dual prod/dev image divergence.
5. Explains why **Option C** (uvicorn \`--reload\` via a dev compose overlay) was not shipped — uvicorn launched from \`WORKDIR /app\` re-imports baked code regardless of \`--reload-dir\`; making it actually work would also require overriding \`WORKDIR\` (or wrapping the command), at which point you're effectively re-implementing Option B with extra steps.
6. Cross-platform notes — macOS / Linux / WSL2 (with the \`/mnt/c/...\` inotify caveat).

The doc references structural patterns (\`WORKDIR /app\`, \`COPY ... ./\`, \`CMD uvicorn ...\`) rather than specific line numbers, so it doesn't rot when the Dockerfile shifts.

## Testing
- markdownlint not installed locally, skipped.
- Internal links resolve (verified \`docs/EXTENSIONS.md\`, \`docs/HOST-AGENT-API.md\` exist).
- Technical accuracy cross-checked against the actual \`Dockerfile\` and \`docker-compose.base.yml\` — \`WORKDIR\`, COPY commands, CMD shape, \`extra_hosts\`, volumes block all match.
- No emojis, all code blocks language-tagged, single H1, no TODO/FIXME.
- \`cut -d= -f2-\` in the env-extraction example uses the range form (not \`-f2\`) so values containing \`=\` aren't truncated.
- Both \`DASHBOARD_API_KEY\` and \`DREAM_AGENT_KEY\` shown in the example so a copy-paster running native uvicorn doesn't immediately hit 401 from the host agent (since #979, the two keys are independent).

## Review
None required from external reviewers — observable on read. Local CG approved with the warnings above already addressed before submission.

## Known considerations
\`CONTRIBUTING.md\` is currently rebased frequently (open PR #973 may overwrite the link list and prose). If that lands first, this PR will need a small rebase touching only the link-list section and the new "Dashboard API development" subsection — no semantic conflict.

## Platform impact
- **macOS**: Recommended workflow (native uvicorn) works without caveats. Documentation is platform-aware.
- **Linux**: Same. inotify is reliable on the WSL2 filesystem.
- **Windows/WSL2**: Documentation includes the standard caveat to keep the repo on the WSL2 filesystem (\`~/...\`) rather than \`/mnt/c/...\` for uvicorn's watchfiles to behave.