### PR TITLE
refactor(dashboard-api): deduplicate GPU helpers and migrate to lifespan

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -24,6 +24,7 @@ import shutil
 import time
 import urllib.error
 import urllib.request
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -228,21 +229,26 @@ def _infer_tier(gpu_info) -> str:
     return "Minimal"
 
 
+def _infer_gpu_count(gpu_info) -> int:
+    """Infer GPU count from the GPU_COUNT env var or the display name."""
+    gpu_count_env = os.environ.get("GPU_COUNT", "")
+    if gpu_count_env.isdigit():
+        return int(gpu_count_env)
+    if " × " in gpu_info.name:
+        try:
+            return int(gpu_info.name.rsplit(" × ", 1)[-1])
+        except ValueError:
+            pass
+    if " + " in gpu_info.name:
+        return gpu_info.name.count(" + ") + 1
+    return 1
+
+
 def _serialize_gpu(gpu_info) -> Optional[dict]:
     if not gpu_info:
         return None
 
-    gpu_count = 1
-    gpu_count_env = os.environ.get("GPU_COUNT", "")
-    if gpu_count_env.isdigit():
-        gpu_count = int(gpu_count_env)
-    elif " × " in gpu_info.name:
-        try:
-            gpu_count = int(gpu_info.name.rsplit(" × ", 1)[-1])
-        except ValueError:
-            pass
-    elif " + " in gpu_info.name:
-        gpu_count = gpu_info.name.count(" + ") + 1
+    gpu_count = _infer_gpu_count(gpu_info)
 
     gpu_data = {
         "name": gpu_info.name,
@@ -860,10 +866,19 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
 
 # --- App ---
 
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    asyncio.create_task(collect_metrics())
+    asyncio.create_task(_poll_service_health())
+    asyncio.create_task(gpu_router.poll_gpu_history())
+    yield
+
+
 app = FastAPI(
     title="Dream Server Dashboard API",
     version="2.0.0",
-    description="System status API for Dream Server Dashboard"
+    description="System status API for Dream Server Dashboard",
+    lifespan=_lifespan,
 )
 
 # --- CORS ---
@@ -1132,19 +1147,6 @@ async def _build_api_status() -> dict:
 
     gpu_data = None
     if gpu_info:
-        # Infer gpu_count from display name ("RTX 4090 × 2") or env var GPU_COUNT
-        gpu_count = 1
-        gpu_count_env = os.environ.get("GPU_COUNT", "")
-        if gpu_count_env.isdigit():
-            gpu_count = int(gpu_count_env)
-        elif " \u00d7 " in gpu_info.name:
-            try:
-                gpu_count = int(gpu_info.name.rsplit(" \u00d7 ", 1)[-1])
-            except ValueError:
-                pass
-        elif " + " in gpu_info.name:
-            gpu_count = gpu_info.name.count(" + ") + 1
-
         gpu_data = {
             "name": gpu_info.name,
             "vramUsed": round(gpu_info.memory_used_mb / 1024, 1),
@@ -1153,7 +1155,7 @@ async def _build_api_status() -> dict:
             "temperature": gpu_info.temperature_c,
             "memoryType": gpu_info.memory_type,
             "backend": gpu_info.gpu_backend,
-            "gpu_count": gpu_count,
+            "gpu_count": _infer_gpu_count(gpu_info),
         }
         if gpu_info.power_w is not None:
             gpu_data["powerDraw"] = gpu_info.power_w
@@ -1175,21 +1177,7 @@ async def _build_api_status() -> dict:
             "eta": bootstrap_info.eta_seconds, "speedMbps": bootstrap_info.speed_mbps
         }
 
-    tier = "Unknown"
-    if gpu_info:
-        vram_gb = gpu_info.memory_total_mb / 1024
-        if gpu_info.memory_type == "unified" and gpu_info.gpu_backend == "amd":
-            tier = "Strix Halo 90+" if vram_gb >= 90 else "Strix Halo Compact"
-        elif vram_gb >= 80:
-            tier = "Professional"
-        elif vram_gb >= 24:
-            tier = "Prosumer"
-        elif vram_gb >= 16:
-            tier = "Standard"
-        elif vram_gb >= 8:
-            tier = "Entry"
-        else:
-            tier = "Minimal"
+    tier = _infer_tier(gpu_info)
 
     result = {
         "gpu": gpu_data, "services": services_data, "model": model_data,
@@ -1461,16 +1449,6 @@ async def _poll_service_health():
         except Exception:
             logger.exception("Service health poll failed")
         await asyncio.sleep(_SERVICE_POLL_INTERVAL)
-
-
-# --- Startup ---
-
-@app.on_event("startup")
-async def startup_event():
-    """Start background tasks."""
-    asyncio.create_task(collect_metrics())
-    asyncio.create_task(_poll_service_health())
-    asyncio.create_task(gpu_router.poll_gpu_history())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three focused code-quality fixes in `main.py`, no behaviour change:

- **Extract `_infer_gpu_count()`** — the GPU count inference block (env var `GPU_COUNT` → display name `× N` → display name `+ N`) was copy-pasted verbatim between `_serialize_gpu` and `_build_api_status`. Extracted into one function, used in both places.
- **Use `_infer_tier()` in `_build_api_status`** — `_infer_tier()` already existed but `_build_api_status` inlined the identical 12-line VRAM threshold chain instead of calling it. Replaced with a single `tier = _infer_tier(gpu_info)` call.
- **Migrate to FastAPI lifespan** — replaces the deprecated `@app.on_event("startup")` pattern with an `@asynccontextmanager` lifespan function passed to `FastAPI(lifespan=...)`. Eliminates the `DeprecationWarning` that appeared in every test run.

## Test plan

- [x] All 666 dashboard-api tests pass (`pytest tests/ -v`)
- [x] No `on_event` DeprecationWarning in test output
- [ ] No new tests needed (pure refactor — no logic changed)