### PR TITLE
fix(tests): stub curl/jq in preflight existing-installation BATS test

### DIFF
--- a/dream-server/tests/bats-tests/preflight-phase.bats
+++ b/dream-server/tests/bats-tests/preflight-phase.bats
@@ -189,6 +189,13 @@ MOCK
     touch "$SCRIPT_DIR/docker-compose.base.yml"
     mkdir -p "$INSTALL_DIR"
 
+    # Stub curl and jq so the phase script doesn't try to auto-install them via sudo
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    printf '#!/bin/bash\necho "curl 8.0.0"\n' > "$BATS_TEST_TMPDIR/bin/curl"
+    printf '#!/bin/bash\necho "jq-1.7"\n'     > "$BATS_TEST_TMPDIR/bin/jq"
+    chmod +x "$BATS_TEST_TMPDIR/bin/curl" "$BATS_TEST_TMPDIR/bin/jq"
+    export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+
     run bash -c '
         export SCRIPT_DIR="'"$SCRIPT_DIR"'"
         export INSTALL_DIR="'"$INSTALL_DIR"'"


### PR DESCRIPTION
## Summary

- `tests/bats-tests/preflight-phase.bats` test `"preflight: detects existing installation"` was failing locally (and would fail in any CI environment without `jq` pre-installed).
- **Root cause:** `installers/phases/01-preflight.sh` checks for `jq` at line 47 *before* it reaches the existing-installation detection at line 82. Without a jq stub, the script tries `sudo apt-get install -y jq`, which requires a TTY → `error()` fires → subshell exits before the assertion target (`"Existing installation"`) is ever printed.
- **Fix:** Add `curl` and `jq` stubs to `$BATS_TEST_TMPDIR/bin` and export `PATH`, identical to the pattern already used by the adjacent `"preflight: passes when compose files exist"` test (lines 142–158).

## Test plan

- [x] `tests/bats-tests/preflight-phase.bats` — all 8 tests pass (was 7/8)
- [x] Full BATS suite — 243 tests pass (241 pass + 2 pre-existing `docker-phase.bats` failures unrelated to this change)
- [ ] No production code changed