### PR TITLE
test(dashboard-api): add setup router test coverage — 22 tests

### DIFF
--- a/dream-server/extensions/services/dashboard-api/tests/test_setup.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_setup.py
@@ -1,0 +1,219 @@
+"""Tests for routers/setup.py — setup wizard, persona selection, and completion."""
+
+import json
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement — 401 without Bearer token
+# ---------------------------------------------------------------------------
+
+
+def test_setup_persona_requires_auth(test_client):
+    resp = test_client.post("/api/setup/persona", json={"persona": "general"})
+    assert resp.status_code == 401
+
+
+def test_setup_complete_requires_auth(test_client):
+    resp = test_client.post("/api/setup/complete")
+    assert resp.status_code == 401
+
+
+def test_list_personas_requires_auth(test_client):
+    resp = test_client.get("/api/setup/personas")
+    assert resp.status_code == 401
+
+
+def test_get_persona_info_requires_auth(test_client):
+    resp = test_client.get("/api/setup/persona/general")
+    assert resp.status_code == 401
+
+
+def test_setup_diagnostics_requires_auth(test_client):
+    resp = test_client.post("/api/setup/test")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /api/setup/status
+# ---------------------------------------------------------------------------
+
+
+def test_setup_status_first_run(test_client, setup_config_dir):
+    """When setup-complete.json is absent, first_run is True and step is 0."""
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["first_run"] is True
+    assert data["step"] == 0
+    assert data["persona"] is None
+
+
+def test_setup_status_already_complete(test_client, setup_config_dir):
+    """When setup-complete.json exists, first_run is False."""
+    (setup_config_dir / "setup-complete.json").write_text(
+        json.dumps({"completed_at": "2025-01-01T00:00:00+00:00", "version": "1.0.0"})
+    )
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["first_run"] is False
+
+
+def test_setup_status_with_progress_step(test_client, setup_config_dir):
+    """Progress step is read from setup-progress.json."""
+    (setup_config_dir / "setup-progress.json").write_text(
+        json.dumps({"step": 2, "persona_selected": True})
+    )
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["step"] == 2
+
+
+def test_setup_status_with_active_persona(test_client, setup_config_dir):
+    """Active persona ID is returned when persona.json exists."""
+    (setup_config_dir / "persona.json").write_text(
+        json.dumps({"persona": "coding", "name": "Coding Buddy"})
+    )
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["persona"] == "coding"
+
+
+def test_setup_status_includes_personas_available(test_client, setup_config_dir):
+    """personas_available lists at least the built-in persona keys."""
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    available = resp.json()["personas_available"]
+    assert "general" in available
+    assert "coding" in available
+    assert "creative" in available
+
+
+def test_setup_status_tolerates_corrupt_progress_file(test_client, setup_config_dir):
+    """Corrupt setup-progress.json falls back to step=0 without crashing."""
+    (setup_config_dir / "setup-progress.json").write_text("not-valid-json{{")
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["step"] == 0
+
+
+# ---------------------------------------------------------------------------
+# POST /api/setup/persona
+# ---------------------------------------------------------------------------
+
+
+def test_setup_persona_valid(test_client, setup_config_dir):
+    """Valid persona ID returns 200 and writes persona.json."""
+    resp = test_client.post(
+        "/api/setup/persona",
+        json={"persona": "general"},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["persona"] == "general"
+    assert "name" in data
+    # File was written
+    persona_file = setup_config_dir / "persona.json"
+    assert persona_file.exists()
+    stored = json.loads(persona_file.read_text())
+    assert stored["persona"] == "general"
+
+
+def test_setup_persona_invalid(test_client, setup_config_dir):
+    """Unknown persona ID returns 400."""
+    resp = test_client.post(
+        "/api/setup/persona",
+        json={"persona": "nonexistent"},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 400
+
+
+def test_setup_persona_stores_system_prompt(test_client, setup_config_dir):
+    """persona.json written by setup_persona contains the system_prompt field."""
+    test_client.post(
+        "/api/setup/persona",
+        json={"persona": "coding"},
+        headers=test_client.auth_headers,
+    )
+    stored = json.loads((setup_config_dir / "persona.json").read_text())
+    assert "system_prompt" in stored
+    assert len(stored["system_prompt"]) > 10
+
+
+def test_setup_persona_updates_progress(test_client, setup_config_dir):
+    """Selecting a persona advances the progress step to 2."""
+    test_client.post(
+        "/api/setup/persona",
+        json={"persona": "creative"},
+        headers=test_client.auth_headers,
+    )
+    progress = json.loads((setup_config_dir / "setup-progress.json").read_text())
+    assert progress["step"] == 2
+    assert progress["persona_selected"] is True
+
+
+# ---------------------------------------------------------------------------
+# POST /api/setup/complete
+# ---------------------------------------------------------------------------
+
+
+def test_setup_complete_creates_marker(test_client, setup_config_dir):
+    """POST /api/setup/complete returns 200 and creates setup-complete.json."""
+    resp = test_client.post("/api/setup/complete", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert (setup_config_dir / "setup-complete.json").exists()
+
+
+def test_setup_complete_removes_progress_file(test_client, setup_config_dir):
+    """POST /api/setup/complete deletes setup-progress.json if it exists."""
+    (setup_config_dir / "setup-progress.json").write_text(json.dumps({"step": 2}))
+    test_client.post("/api/setup/complete", headers=test_client.auth_headers)
+    assert not (setup_config_dir / "setup-progress.json").exists()
+
+
+def test_setup_complete_idempotent(test_client, setup_config_dir):
+    """Calling complete twice does not error."""
+    test_client.post("/api/setup/complete", headers=test_client.auth_headers)
+    resp = test_client.post("/api/setup/complete", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/setup/personas  and  GET /api/setup/persona/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_list_personas_returns_all(test_client, setup_config_dir):
+    """GET /api/setup/personas lists all built-in personas."""
+    resp = test_client.get("/api/setup/personas", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    ids = {p["id"] for p in resp.json()["personas"]}
+    assert ids >= {"general", "coding", "creative"}
+
+
+def test_list_personas_includes_name_and_icon(test_client, setup_config_dir):
+    """Each persona entry has name and icon fields."""
+    resp = test_client.get("/api/setup/personas", headers=test_client.auth_headers)
+    for persona in resp.json()["personas"]:
+        assert "name" in persona
+        assert "icon" in persona
+
+
+def test_get_persona_info_valid(test_client, setup_config_dir):
+    """GET /api/setup/persona/general returns the persona details."""
+    resp = test_client.get("/api/setup/persona/general", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["id"] == "general"
+    assert "name" in data
+    assert "system_prompt" in data
+
+
+def test_get_persona_info_not_found(test_client, setup_config_dir):
+    """GET /api/setup/persona/<unknown> returns 404."""
+    resp = test_client.get("/api/setup/persona/unknown-persona", headers=test_client.auth_headers)
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- `routers/setup.py` (212 lines, 7 endpoints — setup wizard status, persona selection, completion, persona lookup, and listing) had zero dedicated tests. `test_routers.py` contained only a single auth check for this router.
- Add `tests/test_setup.py` with 22 tests covering all stable, non-streaming endpoints. The streaming `POST /api/setup/test` and `POST /api/chat` endpoints (which require aiohttp/subprocess mocking) are deferred to a follow-up PR to keep scope small.

## What's tested

| Group | Tests |
|-------|-------|
| Auth (5) | `POST /persona`, `POST /complete`, `POST /test`, `GET /personas`, `GET /persona/{id}` all return 401 without Bearer token |
| `GET /api/setup/status` (6) | first_run T/F, progress step from file, active persona from file, `personas_available` list, corrupt progress file tolerance |
| `POST /api/setup/persona` (4) | valid id → 200 + persona.json written + system_prompt stored + progress step=2; invalid id → 400 |
| `POST /api/setup/complete` (3) | creates marker, deletes progress file, idempotent |
| `GET /api/setup/personas` + `GET /api/setup/persona/{id}` (4) | list returns all builtins with name/icon; valid id → 200 with fields; unknown id → 404 |

Uses the existing `setup_config_dir` fixture from `conftest.py` (patches both `config.SETUP_CONFIG_DIR` and `routers.setup.SETUP_CONFIG_DIR` to an isolated `tmp_path`). No new fixtures or production code changes.

## Test plan

- [x] `pytest tests/test_setup.py -v` — 22/22 passed
- [x] `pytest tests/ -q` — 688 passed (666 pre-existing + 22 new), no regressions