### PR TITLE
test(bats): fix _docker_cmd_arr assertion that's been red on main

### DIFF
--- a/dream-server/tests/bats-tests/docker-phase.bats
+++ b/dream-server/tests/bats-tests/docker-phase.bats
@@ -97,7 +97,12 @@ teardown() {
         }
         _docker_cmd_arr
     '
-    assert_output $'sudo\ndocker'
+    # `echo "sudo" "docker"` emits a single space-joined line — the same
+    # behaviour as the real function at installers/phases/05-docker.sh:27,
+    # whose consumer (`local -a cmd=($(_docker_cmd_arr))`) word-splits the
+    # single line into an array. Assertion was previously $'sudo\ndocker'
+    # (two newline-separated lines) which never matched.
+    assert_output 'sudo docker'
 }
 
 @test "_docker_cmd_arr: returns docker when DOCKER_CMD is empty" {


### PR DESCRIPTION
> **Merge first.** This is a 1-line test-assertion fix that unblocks the `integration-smoke` CI job for every other open PR (#974, #994, #998, #1000, #1015, #1016, #1017, #1018, #1019, #1020, #1024, #1030, #1055, #1057, etc.). All those PRs currently show one red CI job for the same reason — `not ok 67 _docker_cmd_arr: returns sudo docker when DOCKER_CMD is sudo docker` — caused by an assertion-vs-output mismatch in this test stub. Merging this first lets the rest of the queue go green without each PR doing a no-op rebase.

## What
One-line correction to `tests/bats-tests/docker-phase.bats:100` — change `assert_output $'sudo\ndocker'` to `assert_output 'sudo docker'`.

## Why
The `_docker_cmd_arr: returns sudo docker when DOCKER_CMD is sudo docker` test has been failing in every `integration-smoke` CI run on current `main`, blocking the `Lint-and-Test (Linux)` workflow across every open PR (verified across #974, #994, #998, #1000, #1015, #1016, #1017, #1018, #1019, #1020, #1024, #1030, #1055, #1057 — same `not ok 67` line in every run log).

The test's stub at line 94 (mirroring the real function at `installers/phases/05-docker.sh:27-32`):
```bash
_docker_cmd_arr() {
    case "${DOCKER_CMD:-docker}" in
        "sudo docker") echo "sudo" "docker" ;;
        *)             echo "docker" ;;
    esac
}
```

`echo "sudo" "docker"` emits a single space-joined line `"sudo docker\n"`. The assertion expected two newline-separated lines (`$'sudo\ndocker'`). That output never matched; the test was silently red since whenever it landed.

## How
The real function works correctly in production: its consumer at `installers/phases/05-docker.sh:36`
```bash
local -a cmd=($(_docker_cmd_arr))
```
word-splits the single-line stdout into a 2-element array. The function's contract is "emit one space-joined line"; the test should assert that.

```diff
-    assert_output $'sudo\ndocker'
+    # `echo "sudo" "docker"` emits a single space-joined line — the same
+    # behaviour as the real function at installers/phases/05-docker.sh:27,
+    # whose consumer (`local -a cmd=($(_docker_cmd_arr))`) word-splits the
+    # single line into an array. Assertion was previously $'sudo\ndocker'
+    # (two newline-separated lines) which never matched.
+    assert_output 'sudo docker'
```

Inline comment captures the contract (single-line stdout + word-splitting consumer) so a future "cleanup" PR doesn't revert this thinking it's wrong.

## Testing
- Local: `tests/bats/bats-core/bin/bats tests/bats-tests/docker-phase.bats` — case 2 (the previously-failing `_docker_cmd_arr: returns sudo docker`) now passes. Cases 3, 4, 5, 6 untouched and pass. Case 1 fails locally only because the dev machine's Docker daemon isn't reachable — that's environmental, unrelated.
- The companion `_docker_cmd_arr: returns docker when DOCKER_CMD is empty` test at line 103 already uses `assert_output "docker"` (single-line) and passes; this PR brings the sibling case into alignment with that pattern.

## Platform Impact
- **Linux CI** (primary): unblocks `integration-smoke` on every open PR.
- **macOS / WSL2 dev**: same fix; tests run identically.
- No production code touched.

## Out of Scope
The 12 pre-existing Python 3.14 asyncio-shim failures in `dashboard-api` tests (`test_workflows.py`, `test_gpu_detailed.py`, `test_main.py::test_gpu_cached_falsy`) are a separate concern; they predate this PR and don't affect the integration-smoke job.
