### PR TITLE
fix(dreamforge): pin platform to linux/amd64

### DIFF
--- a/dream-server/extensions/services/dreamforge/compose.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.yaml
@@ -1,6 +1,7 @@
 services:
   dreamforge:
     image: ${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:v0.1.0}
+    platform: linux/amd64  # DreamForge image is amd64-only; Rosetta 2 emulation on Apple Silicon
     build:
       context: ./extensions/services/dreamforge
       dockerfile: Dockerfile.rust


### PR DESCRIPTION
## What
Pin `platform: linux/amd64` for the DreamForge service in `dream-server/extensions/services/dreamforge/compose.yaml` with an inline justification comment.

## Why
DreamForge ships as a single-arch `linux/amd64` image. On Apple Silicon hosts Docker emits a noisy `linux/amd64 != linux/arm64/v8` warning during install pulls when no platform is explicitly requested. The existing `extensions/services/embeddings/compose.yaml` already pins `platform: linux/amd64` for the same reason (TEI image is amd64-only) — this aligns DreamForge with that established convention.

## How
One-line addition between `image:` and `build:` with an inline comment. Two-space gutter, plain ASCII (no em-dash, per the maintainer's existing convention from commit `e4d0ca44`).

## Testing
- `python3 -c "import yaml; yaml.safe_load(...)"` — passes
- `make lint` — passes
- `docker compose -f docker-compose.base.yml -f docker-compose.apple.yml -f extensions/services/dreamforge/compose.yaml config --quiet` — passes
- pre-commit (gitleaks, private-key, large-file) — passes

Manual:
- macOS Apple Silicon: `docker compose pull dreamforge` no longer emits the platform-mismatch warning; `docker compose up -d dreamforge` starts under Rosetta 2 unchanged.
- Linux amd64 / Windows WSL2 amd64: no behavior change.

## Review
Independent verification confirmed the bug and selected this approach (compose pin) over a multi-arch CI workflow change — the latter would be scope creep for a fix-PR. Holistic review approved after adding the inline justification comment to match the `embeddings/compose.yaml` precedent.

## Known Considerations
- Stop-gap fix. Long-term solution is for `.github/workflows/build-dreamforge.yml` to add `docker/setup-buildx-action` with `platforms: linux/amd64,linux/arm64`, then drop this pin. Out of scope for this PR.

## Platform Impact
- **macOS Apple Silicon**: silences platform-mismatch warning. Rosetta 2 emulation continues as today; no functional regression.
- **macOS Intel**: no impact (native amd64).
- **Linux amd64 (NVIDIA/AMD/Intel/CPU/multigpu)**: no impact.
- **Linux arm64 (Jetson/GH200, not first-class supported)**: forces explicit emulation that was already implicit. Net neutral.
- **Windows WSL2 amd64**: no impact.