### PR TITLE
fix(chromadb): switch healthcheck from bash /dev/tcp to python3 urllib

### DIFF
--- a/resources/dev/extensions-library/services/chromadb/compose.yaml
+++ b/resources/dev/extensions-library/services/chromadb/compose.yaml
@@ -18,7 +18,7 @@ services:
           memory: 2G
           cpus: '2.0'
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/127.0.0.1/8000 && printf \"GET /api/v2/heartbeat HTTP/1.0\\r\\nHost: 127.0.0.1\\r\\n\\r\\n\" >&3 && read -r line <&3 && [[ \"$$line\" == *\"200\"* ]]'"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v2/heartbeat')\""]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What
Replace chromadb's healthcheck command in `resources/dev/extensions-library/services/chromadb/compose.yaml` with a `python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v2/heartbeat')"` probe.

## Why
The previous bash-based probe relies on `bash` with `/dev/tcp` support and `[[ ]]` bashisms. It works today on `chromadb/chroma:1.5.3` but is fragile — if the image ever switches to a minimal bash build, the healthcheck silently fails. The chromadb image is Python-based, so `python3` and `urllib` (stdlib) are guaranteed. The new probe matches the established pattern used by 11 other extensions in this repo and the maintainer-authored `token-spy` built-in's exact CMD-SHELL form.

## How
Single-line `test:` replacement. Surrounding `interval`/`timeout`/`retries`/`start_period` unchanged. IPv4 (`127.0.0.1`) hardcoded per the project healthcheck convention (avoids IPv6 `::1` resolution issues).

## Testing
- YAML parse, `make lint`, `docker compose config --quiet`, pre-commit: all PASS
- python3 syntax sanity: raises `URLError`/`ConnectionRefusedError` on host without chromadb (correct semantic — probe exits non-zero on failure, zero on 200)
- YAML round-trip quote check: parses cleanly through compose into a valid shell command
- chromadb/chroma:1.5.3 confirmed multi-arch (amd64 + arm64) on Docker Hub — Apple Silicon native

Manual: `docker inspect dream-chromadb --format '{{.State.Health.Status}}'` after deploying chromadb extension → expect `healthy` after start_period.

## Review
Independent verification confirmed only the chromadb sub-claim of the broader healthcheck audit was still outstanding; piper-audio's timeout gap and milvus's port 9091 binding were both already resolved in commit `d420536a`. This PR addresses chromadb only.

## Known Considerations
- Optional future polish (separate PR): add `timeout=5` to the `urlopen` call for parity with `litellm`/`privacy-shield`/`tts` built-ins. Out of scope here; docker's `timeout: 10s` already bounds the probe.
- Optional future style normalization: switch to `["CMD", "python3", "-c", "..."]` array form to match the more numerous siblings (bark/crewai/invokeai/etc.). The current `CMD-SHELL` form has built-in precedent in `token-spy`, so it's acceptable as-is.

## Platform Impact
- Healthcheck is container-internal — platform-neutral.
- **macOS Apple Silicon**: chromadb/chroma:1.5.3 is multi-arch; native arm64 image used. No Rosetta.
- **Linux amd64 (NVIDIA/AMD/Intel/CPU)**: native amd64 image; no change.
- **Windows WSL2 amd64**: native amd64 image; no change.