### PR TITLE
fix(compose): drop CPU overlay AUDIO_STT_MODEL literal; make AMD memory limit env-driven

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -58,7 +58,7 @@ services:
       resources:
         limits:
           cpus: '${LLAMA_CPU_LIMIT:-16.0}'
-          memory: 110G
+          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-110G}
         reservations:
           cpus: '${LLAMA_CPU_RESERVATION:-4.0}'
           memory: 8G

--- a/dream-server/docker-compose.cpu.yml
+++ b/dream-server/docker-compose.cpu.yml
@@ -33,7 +33,3 @@ services:
         reservations:
           cpus: '${LLAMA_CPU_RESERVATION:-1.0}'
           memory: 2G
-
-  open-webui:
-    environment:
-      AUDIO_STT_MODEL: "deepdml/faster-whisper-large-v3-turbo-ct2"


### PR DESCRIPTION
## What
Two related compose-overlay drift fixes:
- `dream-server/docker-compose.cpu.yml`: drop the now-empty `open-webui:` block (was overriding `AUDIO_STT_MODEL` to turbo)
- `dream-server/docker-compose.amd.yml`: replace literal `memory: 110G` with `${LLAMA_SERVER_MEMORY_LIMIT:-110G}`

## Why
**CPU overlay**: PR #985 made `AUDIO_STT_MODEL` env-driven (`${AUDIO_STT_MODEL:-Systran/faster-whisper-base}` in `docker-compose.base.yml`). The cpu overlay's residual literal `AUDIO_STT_MODEL: "deepdml/faster-whisper-large-v3-turbo-ct2"` overrode that interpolation, so on CPU-only Linux installs:
1. Phase 06 of the installer correctly writes `AUDIO_STT_MODEL=Systran/faster-whisper-base` to `.env`
2. Phase 12 pre-downloads only the base model
3. Open WebUI's container env is forced to turbo by the overlay literal
4. Whisper 404s on every transcription

The NVIDIA overlay's identical literal is **intentional** — for NVIDIA, Phase 06 also picks turbo, so the literal is a redundant safety net (per #985's design). Only the cpu overlay drifted.

**AMD overlay**: 5 of 6 GPU overlays use `${LLAMA_SERVER_MEMORY_LIMIT:-N}` (NVIDIA 64G, Apple 32G, Intel/Arc 24G, CPU 6G). `.env.schema.json` registers the variable as a tunable string. The amd overlay's literal `memory: 110G` made AMD the only platform where users couldn't tune llama-server's memory cap.

`tier0.yml`'s literal `memory: 4G` is a deliberate hard cap for <8 GB RAM hosts and was left alone.

## How
- cpu.yml: removed the entire `open-webui:` block (3 + leading-blank lines). Container inherits the base's env-var interpolation.
- amd.yml: 1-line substitution. The 110G default is preserved as the AMD-specific fallback so existing AMD installs without the env var keep current byte-for-byte behavior.

## Testing
- YAML parse, `make lint`, `docker compose config --quiet`, pre-commit: all PASS
- Functional substitution checks:
  - cpu env unset → resolves `Systran/faster-whisper-base`
  - cpu env override → propagates correctly
  - amd env unset → resolves 110G (fallback preserved)
  - amd env override `LLAMA_SERVER_MEMORY_LIMIT=32G` → resolves 32G
- Cross-overlay non-regression sweep (nvidia, intel, arc, apple, multigpu, tier0): all PASS

Manual:
- Linux CPU: `docker exec dream-open-webui env | grep AUDIO_STT_MODEL` should equal `Systran/faster-whisper-base` post-install
- Linux AMD: set `LLAMA_SERVER_MEMORY_LIMIT=32G` in `.env`, `dream restart`, then `docker inspect dream-llama-server --format '{{.HostConfig.Memory}}'` should equal `34359738368` (32 GiB) — was `118111600640` (110 GiB) before

## Review
Independent verification confirmed both bugs are real and isolated to these two overlays; cross-overlay scan found no other drift on AUDIO_STT_MODEL or LLAMA_SERVER_MEMORY_LIMIT.

## Known Considerations
- Schema default `LLAMA_SERVER_MEMORY_LIMIT="64G"` and AMD's compose fallback `:-110G` differ. This matches the codebase's existing pattern: schema default applies to installer env-generation; per-backend overlay fallback applies at compose-time when `.env` is silent. Same divergence already exists for nvidia/apple/intel/arc/cpu — not a regression.
- A potential follow-up (separate PR, not this one) would have installer phases write `LLAMA_SERVER_MEMORY_LIMIT` to `.env` per-backend so the schema default becomes load-bearing. That's a design decision, not a bug.

## Platform Impact
- **Linux CPU**: STT now works on first install (was 404 on every transcription).
- **Linux AMD**: `LLAMA_SERVER_MEMORY_LIMIT` env var now honored (was silently ignored).
- **Linux NVIDIA / Intel / Arc / multigpu / tier0**: no behavior change.
- **macOS Apple Silicon**: no behavior change (`llama-server.replicas: 0`, no AUDIO_STT_MODEL override).
- **Windows AMD**: no behavior change (`llama-server.replicas: 0`, no override).