### PR TITLE
fix(compose): drop unconditional depends_on: searxng from perplexica and openclaw

### DIFF
--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -36,9 +36,6 @@ services:
         reservations:
           cpus: '0.5'
           memory: 1G
-    depends_on:
-      searxng:
-        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL", "if [ \"$$OPENCLAW_HTTP_API\" = 'true' ]; then wget -qO- http://127.0.0.1:18790/v1/models || exit 1; else wget -qO- http://127.0.0.1:18789/ || exit 1; fi"]
       interval: 30s

--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -15,9 +15,6 @@ services:
       - perplexica-uploads:/home/perplexica/uploads
     ports:
       - "${BIND_ADDRESS:-127.0.0.1}:${PERPLEXICA_PORT:-3004}:3000"
-    depends_on:
-      searxng:
-        condition: service_healthy
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## What
Remove the unconditional `depends_on: searxng: condition: service_healthy` block from:
- `dream-server/extensions/services/perplexica/compose.yaml`
- `dream-server/extensions/services/openclaw/compose.yaml`

## Why
When a user disables searxng (renaming `compose.yaml` → `compose.yaml.disabled`, the convention `scripts/resolve-compose-stack.sh` uses to honor extension toggles), the resolver correctly skips searxng's compose — but has no logic to strip dangling cross-extension `depends_on:` references from peer extensions. `docker compose config` then refuses validation for the entire stack with:

```
service "perplexica" depends on undefined service "searxng"
```

Open WebUI, dashboard, llama-server, everything refuses to start. The error names a service the user has no relationship with. Recovery requires either re-enabling searxng or manually editing yaml.

`docker compose` semantics: `depends_on` merges **additively** across overlays — overlays cannot remove a base-level dependency. So once a base compose carries a cross-extension dep, no overlay can rescue a stack where that other extension is absent. The only correct fix is to delete the dep from the base compose itself.

Both perplexica and openclaw connect to searxng at runtime via the `searxng` hostname on the docker network (perplexica reads `SEARXNG_API_URL=http://searxng:8080`, openclaw reads `SEARXNG_BASE_URL=http://searxng:8080`). When searxng is absent, the hostname fails to resolve at request time → upstream UI error, not stack-startup crash. **Graceful degradation** is the correct behavior for an optional search backend.

When searxng IS enabled, the trade-off is: perplexica/openclaw no longer wait on searxng's healthcheck. Searxng's start-up window is short (`start_period: 10s`, healthcheck `wget --spider /healthz`); at worst, the first search request retries until searxng heals.

## How
6 lines removed total — 3 per file. The `depends_on:` map in each was searxng-only, so the entire map is gone. `compose.local.yaml` for both extensions retains its `depends_on: llama-server: service_healthy` (legitimate — llama-server is guaranteed-present in local/hybrid/lemonade modes).

## Testing
- YAML parse, `make lint`, pre-commit: all PASS
- **Critical regression test (the bug being fixed)**: `docker compose -f base.yml -f perplexica/compose.yaml -f openclaw/compose.yaml config --quiet` exits 0 — no `undefined service "searxng"` error.
- Sanity (searxng-enabled scenario): `... -f searxng/compose.yaml config --quiet` exits 0; both services resolve cleanly.
- Standalone per-file `docker compose config`: PASS for both.
- Programmatic post-edit confirmation: `services.perplexica.depends_on == None`, `services.openclaw.depends_on == None`.
- Sibling sweep: post-edit, ZERO `dream-server/extensions/services/*/compose.yaml` files contain cross-extension `depends_on:` — pattern is consistent across all 20 built-ins.

Manual: disable searxng via `compose.yaml.disabled` rename, run `dream-cli restart`. Stack starts cleanly. Re-enable, restart — back to normal. Same procedure on macOS / Linux / Windows-WSL2 (compose-graph fix is platform-neutral).

## Review
Independent verification confirmed the bug AND found the same anti-pattern in openclaw. Fix scoped to address both. Holistic five-pillar review approved on first pass.

## Known Considerations
- Trade-off: lose hard startup-ordering when searxng IS active. Acceptable per the graceful-degradation behavior of `SEARXNG_API_URL` / `SEARXNG_BASE_URL`.
- Optional future hardening (separate PR): contract test that scans `extensions/services/*/compose.yaml` and rejects any base cross-extension `depends_on:`. Would prevent regression at PR-review time.

## Platform Impact
- All three platforms equally affected by the bug; all three equally fixed. Pure compose-graph change resolved by `scripts/resolve-compose-stack.sh` — same code path everywhere.