### PR TITLE
fix(nvidia-overlay): allow .env override of AUDIO_STT_MODEL default

### DIFF
--- a/dream-server/docker-compose.nvidia.yml
+++ b/dream-server/docker-compose.nvidia.yml
@@ -28,5 +28,5 @@ services:
 
   open-webui:
     environment:
-      AUDIO_STT_MODEL: "deepdml/faster-whisper-large-v3-turbo-ct2"
+      AUDIO_STT_MODEL: "${AUDIO_STT_MODEL:-deepdml/faster-whisper-large-v3-turbo-ct2}"
       ENABLE_IMAGE_GENERATION: "${ENABLE_IMAGE_GENERATION:-true}"


### PR DESCRIPTION
## What
One-line change to `docker-compose.nvidia.yml`: replace the hardcoded `AUDIO_STT_MODEL` literal with `\${AUDIO_STT_MODEL:-deepdml/faster-whisper-large-v3-turbo-ct2}` so users can override via `.env`.

## Why
Compose merging replaces overlay env keys at the key level. The overlay's bare literal silently overrode both `docker-compose.base.yml`'s `\${AUDIO_STT_MODEL:-Systran/faster-whisper-base}` and any user `.env` value. NVIDIA users couldn't switch Whisper models without editing the overlay file directly. AMD overlay correctly omits the key already.

## How
\`\`\`diff
-      AUDIO_STT_MODEL: "deepdml/faster-whisper-large-v3-turbo-ct2"
+      AUDIO_STT_MODEL: "\${AUDIO_STT_MODEL:-deepdml/faster-whisper-large-v3-turbo-ct2}"
\`\`\`
Default unchanged when `.env` is unset. `.env.schema.json` already registers `AUDIO_STT_MODEL`, so no schema update needed. This completes the env-var introduction work that originally added `AUDIO_STT_MODEL` to base.yml + env-generators but missed the NVIDIA overlay.

## Testing
**Automated**: `docker compose -f base -f nvidia config` validated for both unset (default `deepdml/...`) and override (`AUDIO_STT_MODEL=Systran/faster-whisper-base` resolves correctly). AMD overlay regression-guarded (still no `AUDIO_STT_MODEL` reference). make lint PASS · contract tests PASS.

**Manual**: `docker exec dream-webui env | grep AUDIO_STT_MODEL` should reflect `.env` value.

## Review
Critique Guardian: APPROVED. Same `\${VAR:-default}` shape as base.yml. Round-trip preservation through `.env` write path intact.

## Known Considerations
The CPU overlay (`docker-compose.cpu.yml`) has the identical bug and is tracked as a separate issue — intentionally not bundled here to keep scope tight.

## Platform Impact
- **macOS Apple Silicon**: not affected — uses native llama-server, no compose overlay.
- **Linux NVIDIA / Windows-WSL2-NVIDIA**: bug fixed.
- **AMD / CPU**: not affected (different overlays; CPU has its own tracker).