### PR TITLE
fix: use 127.0.0.1 in installer + CLI healthcheck network calls

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -594,7 +594,7 @@ cmd_status() {
 
         # Launch health check in background
         (
-            url="http://localhost:${port}${health}"
+            url="http://127.0.0.1:${port}${health}"
             timeout="${SERVICE_HEALTH_TIMEOUTS[$sid]:-5}"
             if curl -sf --max-time "$timeout" "$url" > /dev/null 2>&1; then
                 echo "healthy|$name" > "$tmpdir/$sid"
@@ -705,7 +705,7 @@ cmd_status_json() {
         if [[ "$cat" != "core" && "$container_status" == "stopped" ]]; then
             status="stopped"
         else
-            local url="http://localhost:${port}${health}"
+            local url="http://127.0.0.1:${port}${health}"
             if curl -sf --max-time 5 "$url" > /dev/null 2>&1; then
                 status="healthy"
             else
@@ -893,7 +893,7 @@ cmd_dry_run() {
     if [[ -n "$api_key" ]]; then
         api_json=$(curl -sf --max-time 5 \
             -H "X-API-Key: ${api_key}" \
-            "http://localhost:${dashboard_port}/api/update/dry-run" 2>/dev/null || true)
+            "http://127.0.0.1:${dashboard_port}/api/update/dry-run" 2>/dev/null || true)
     fi
 
     local latest_ver="" changelog_url="" update_status=""
@@ -1237,7 +1237,7 @@ cmd_chat() {
 
     # Get model from llama-server if not specified
     if [[ -z "$model" ]]; then
-        model=$(curl -s "http://localhost:${_llm_port}/v1/models" | jq -r '.data[0].id // "local"')
+        model=$(curl -s "http://127.0.0.1:${_llm_port}/v1/models" | jq -r '.data[0].id // "local"')
     fi
 
     log "Sending to $model..."
@@ -1246,7 +1246,7 @@ cmd_chat() {
     local payload=$(jq -n --arg model "$model" --arg msg "$message" \
         '{model: $model, messages: [{role: "user", content: $msg}], max_tokens: 500}')
 
-    curl -s "http://localhost:${_llm_port}/v1/chat/completions" \
+    curl -s "http://127.0.0.1:${_llm_port}/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d "$payload" | jq -r '.choices[0].message.content // .error.message // "Error: no response"'
 }
@@ -2305,7 +2305,7 @@ cmd_stt() {
     port=$(_env_get_raw WHISPER_PORT)
     [[ -z "$port" ]] && port="9000"
     model_encoded="${model//\//%2F}"
-    url="http://localhost:${port}"
+    url="http://127.0.0.1:${port}"
 
     case "$subcmd" in
         current)

--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -188,7 +188,7 @@ log "[4/8] Checking LLM endpoint..."
 LLM_PORT="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-8080}}"
 # Also probe the actual mapped port in case docker remapped it
 EXTERNAL_PORT=$(docker port dream-llama-server 8080/tcp 2>/dev/null | head -1 | cut -d: -f2 || echo "$LLM_PORT")
-LLM_ENDPOINTS=("http://${SERVICE_HOST}:${EXTERNAL_PORT}" "http://localhost:${EXTERNAL_PORT}" "http://localhost:${LLM_PORT}")
+LLM_ENDPOINTS=("http://${SERVICE_HOST}:${EXTERNAL_PORT}" "http://127.0.0.1:${EXTERNAL_PORT}" "http://127.0.0.1:${LLM_PORT}")
 LLM_SERVICE_NAME="llama-server"
 LLM_START_CMD="docker compose up -d llama-server"
 
@@ -214,7 +214,7 @@ log ""
 
 # 5. Whisper STT check
 log "[5/8] Checking Whisper STT..."
-WHISPER_ENDPOINTS=("http://${SERVICE_HOST}:9000" "http://localhost:9000")
+WHISPER_ENDPOINTS=("http://${SERVICE_HOST}:9000" "http://127.0.0.1:9000")
 WHISPER_FOUND=false
 
 for ENDPOINT in "${WHISPER_ENDPOINTS[@]}"; do
@@ -232,7 +232,7 @@ log ""
 
 # 6. TTS check
 log "[6/8] Checking TTS (Kokoro)..."
-TTS_ENDPOINTS=("http://${SERVICE_HOST}:8880" "http://localhost:8880")
+TTS_ENDPOINTS=("http://${SERVICE_HOST}:8880" "http://127.0.0.1:8880")
 TTS_FOUND=false
 
 for ENDPOINT in "${TTS_ENDPOINTS[@]}"; do
@@ -250,7 +250,7 @@ log ""
 
 # 7. Embeddings check
 log "[7/8] Checking Embeddings..."
-EMBEDDING_ENDPOINTS=("http://${SERVICE_HOST}:8090" "http://localhost:8090")
+EMBEDDING_ENDPOINTS=("http://${SERVICE_HOST}:8090" "http://127.0.0.1:8090")
 EMBEDDING_FOUND=false
 
 for ENDPOINT in "${EMBEDDING_ENDPOINTS[@]}"; do
@@ -268,7 +268,7 @@ log ""
 
 # 8. Dashboard check (replaces LiveKit — more useful for all backends)
 log "[8/8] Checking Dashboard..."
-DASHBOARD_ENDPOINTS=("http://${SERVICE_HOST}:3001" "http://localhost:3001")
+DASHBOARD_ENDPOINTS=("http://${SERVICE_HOST}:3001" "http://127.0.0.1:3001")
 DASHBOARD_FOUND=false
 
 for ENDPOINT in "${DASHBOARD_ENDPOINTS[@]}"; do

--- a/dream-server/dream-update.sh
+++ b/dream-server/dream-update.sh
@@ -791,9 +791,9 @@ cmd_health() {
     
     # Check dashboard API health endpoint
     local dashboard_api_port="${DASHBOARD_API_PORT:-3002}"
-    if curl -sf "http://localhost:${dashboard_api_port}/health" &>/dev/null; then
+    if curl -sf "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
         log_ok "Dashboard API: healthy"
-    elif curl -sf "http://localhost:${dashboard_api_port}/api/status" &>/dev/null; then
+    elif curl -sf "http://127.0.0.1:${dashboard_api_port}/api/status" &>/dev/null; then
         log_ok "Dashboard API: responding"
     else
         log_warn "Dashboard API: not responding on port ${dashboard_api_port}"
@@ -801,7 +801,7 @@ cmd_health() {
     
     # Check llama-server health
     local llama_server_port="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-11434}}"
-    if curl -sf "http://localhost:${llama_server_port}/v1/models" &>/dev/null; then
+    if curl -sf "http://127.0.0.1:${llama_server_port}/v1/models" &>/dev/null; then
         log_ok "llama-server: healthy"
     else
         log_warn "llama-server: not responding on port ${llama_server_port}"

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -238,7 +238,7 @@ get_native_llama_status() {
         NATIVE_LLAMA_PID="$saved_pid"
 
         # Health check
-        if curl -sf --max-time 10 http://localhost:8080/health >/dev/null 2>&1; then
+        if curl -sf --max-time 10 http://127.0.0.1:8080/health >/dev/null 2>&1; then
             NATIVE_LLAMA_HEALTHY=true
         fi
     else
@@ -300,7 +300,7 @@ start_native_llama() {
     while [[ "$waited" -lt "$max_wait" ]]; do
         sleep 2
         waited=$((waited + 2))
-        if curl -sf --max-time 10 http://localhost:8080/health >/dev/null 2>&1; then
+        if curl -sf --max-time 10 http://127.0.0.1:8080/health >/dev/null 2>&1; then
             ai_ok "Native llama-server healthy"
             return
         fi
@@ -368,7 +368,7 @@ cmd_status() {
 
     # Parallel arrays (Bash 3.2 compatible)
     local ep_names=("LLM API" "Chat UI" "Dashboard" "OpenCode (IDE)")
-    local ep_urls=("http://localhost:8080/health" "http://localhost:3000" "http://localhost:3001" "http://localhost:3003")
+    local ep_urls=("http://127.0.0.1:8080/health" "http://127.0.0.1:3000" "http://127.0.0.1:3001" "http://127.0.0.1:3003")
 
     for ((i=0; i<${#ep_names[@]}; i++)); do
         local name="${ep_names[$i]}"
@@ -544,7 +544,7 @@ cmd_chat() {
         '{model: "default", messages: [{role: "user", content: $msg}], max_tokens: 500}')
 
     local response
-    response=$(curl -sf -X POST "http://localhost:8080/v1/chat/completions" \
+    response=$(curl -sf -X POST "http://127.0.0.1:8080/v1/chat/completions" \
         -H "Content-Type: application/json" \
         -d "$payload" 2>/dev/null) || {
         ai_err "Chat request failed."

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -721,7 +721,7 @@ else
         while [[ "$WAITED" -lt "$MAX_WAIT" ]]; do
             sleep 2
             WAITED=$((WAITED + 2))
-            if curl -sf --max-time 10 http://localhost:8080/health >/dev/null 2>&1; then
+            if curl -sf --max-time 10 http://127.0.0.1:8080/health >/dev/null 2>&1; then
                 HEALTHY=true
                 break
             fi
@@ -1163,7 +1163,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
     # macOS reassigns Whisper to 9100 if port 9000 is in use (AirPlay Receiver).
     WHISPER_PORT_RESOLVED="${WHISPER_PORT:-9000}"
-    WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
+    WHISPER_URL="http://127.0.0.1:${WHISPER_PORT_RESOLVED}"
     STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
 
     # Step 1: wait briefly for the models API to be ready (max 15s).

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -63,22 +63,22 @@ _check_health() {
 # Format: _check_health "name" "url" max_attempts timeout_per_request
 # llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)
 dream_progress 86 "health" "Waiting for LLM engine"
-_check_health "llama-server" "http://localhost:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15
+_check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15
 # Open WebUI: 150 attempts * adaptive backoff = up to ~20 minutes
 dream_progress 89 "health" "Waiting for Chat UI"
-_check_health "Open WebUI" "http://localhost:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 150 10
+_check_health "Open WebUI" "http://127.0.0.1:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 150 10
 # Perplexica: 150 attempts * adaptive backoff = up to ~20 minutes
 dream_progress 91 "health" "Waiting for Research engine"
-_check_health "Perplexica" "http://localhost:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 150 10
+_check_health "Perplexica" "http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 150 10
 # ComfyUI: 150 attempts * adaptive backoff = up to ~20 minutes (FLUX model loading is slow)
 if [[ "$ENABLE_COMFYUI" == "true" ]]; then
     dream_progress 93 "health" "Waiting for Image generation"
-    _check_health "ComfyUI" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 150 15
+    _check_health "ComfyUI" "http://127.0.0.1:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 150 15
 fi
 # Embeddings (TEI): model load on first run can take 1-2 minutes after start_period
 if [[ "$ENABLE_RAG" == "true" ]]; then
     dream_progress 94 "health" "Waiting for Embeddings"
-    _check_health "embeddings" "http://localhost:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 30 10
+    _check_health "embeddings" "http://127.0.0.1:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 30 10
 fi
 
 # Perplexica auto-config: seed chat model + embedding model on first boot.
@@ -87,7 +87,7 @@ fi
 # Retry up to 5 times with 10s delay — Perplexica may still be starting
 # (especially if it was stuck in "Created" state and started late).
 if $DOCKER_CMD inspect dream-perplexica &>/dev/null; then
-    PERPLEXICA_URL="http://localhost:${SERVICE_PORTS[perplexica]:-3004}"
+    PERPLEXICA_URL="http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}"
     PYTHON_CMD="python3"
     if [[ -f "$SCRIPT_DIR/lib/python-cmd.sh" ]]; then
         . "$SCRIPT_DIR/lib/python-cmd.sh"
@@ -155,12 +155,12 @@ fi
 
 # Extension service health checks with adaptive timeouts
 dream_progress 94 "health" "Checking extension services"
-[[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://localhost:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 150 10
-systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://localhost:3003/" 10 5
+[[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://127.0.0.1:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 150 10
+systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://127.0.0.1:3003/" 10 5
 # Whisper: 150 attempts * adaptive backoff = up to ~20 minutes (model download on first start)
 dream_progress 95 "health" "Checking voice services"
-[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://localhost:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 150 10
-[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://localhost:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 150 10
+[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://127.0.0.1:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 150 10
+[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://127.0.0.1:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 150 10
 
 # Pre-download the Whisper STT model so first transcription is instant.
 # Speaches does NOT auto-download on transcription requests — it returns 404.
@@ -178,7 +178,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     fi
     STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
     WHISPER_PORT_RESOLVED="${SERVICE_PORTS[whisper]:-9000}"
-    WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
+    WHISPER_URL="http://127.0.0.1:${WHISPER_PORT_RESOLVED}"
     STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
 
     # Step 1: wait briefly for the models API to be ready. Whisper's /health
@@ -218,9 +218,9 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
 fi
 
 dream_progress 96 "health" "Checking workflow and RAG services"
-[[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://localhost:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 150 10
-[[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 150 10
-[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && _check_health "DreamForge" "http://localhost:${SERVICE_PORTS[dreamforge]:-3010}${SERVICE_HEALTH[dreamforge]:-/health}" 150 10
+[[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://127.0.0.1:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 150 10
+[[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://127.0.0.1:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 150 10
+[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && _check_health "DreamForge" "http://127.0.0.1:${SERVICE_PORTS[dreamforge]:-3010}${SERVICE_HEALTH[dreamforge]:-/health}" 150 10
 
 dream_progress 97 "health" "Health checks complete"
 echo ""

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -307,13 +307,13 @@ fi
 if ! $DRY_RUN; then
     # Check Perplexica config was seeded (phase 12 may have failed silently)
     if $DOCKER_CMD inspect dream-perplexica &>/dev/null; then
-        _perplexica_status=$(curl -sf --max-time 5 "http://localhost:${SERVICE_PORTS[perplexica]:-3004}/api/config" 2>>"$LOG_FILE" | \
+        _perplexica_status=$(curl -sf --max-time 5 "http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}/api/config" 2>>"$LOG_FILE" | \
             "$PYTHON_CMD" -c "import sys,json;d=json.load(sys.stdin);print('ok' if d['values'].get('setupComplete') else 'needed')" 2>>"$LOG_FILE" || echo "skip")
         if [[ "$_perplexica_status" == "needed" ]]; then
             ai_warn "Perplexica config incomplete — running auto-setup..."
             if [[ -x "$INSTALL_DIR/scripts/repair/repair-perplexica.sh" ]]; then
                 bash "$INSTALL_DIR/scripts/repair/repair-perplexica.sh" \
-                    "http://localhost:${SERVICE_PORTS[perplexica]:-3004}" \
+                    "http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}" \
                     "${LLM_MODEL:-qwen3-30b-a3b}" >> "$LOG_FILE" 2>&1 && \
                     ai_ok "Perplexica configured" || \
                     ai_warn "Perplexica may need manual config at :${SERVICE_PORTS[perplexica]:-3004}"

--- a/dream-server/scripts/dream-preflight.sh
+++ b/dream-server/scripts/dream-preflight.sh
@@ -65,7 +65,7 @@ fi
 CURL_HEALTH_FLAGS=(--connect-timeout 3 --max-time 10)
 
 echo -n "llama-server API (port $LLM_PORT)... "
-if curl -sf "${CURL_HEALTH_FLAGS[@]}" "http://localhost:${LLM_PORT}${LLM_HEALTH}" >/dev/null 2>&1; then
+if curl -sf "${CURL_HEALTH_FLAGS[@]}" "http://127.0.0.1:${LLM_PORT}${LLM_HEALTH}" >/dev/null 2>&1; then
     echo -e "${GREEN}✓ healthy${NC}"
 else
     echo -e "${YELLOW}⚠ starting up${NC}"
@@ -75,7 +75,7 @@ fi
 
 # Check WebUI
 echo -n "Open WebUI (port $WEBUI_PORT)... "
-if curl -sf "${CURL_HEALTH_FLAGS[@]}" "http://localhost:${WEBUI_PORT}${WEBUI_HEALTH}" >/dev/null 2>&1; then
+if curl -sf "${CURL_HEALTH_FLAGS[@]}" "http://127.0.0.1:${WEBUI_PORT}${WEBUI_HEALTH}" >/dev/null 2>&1; then
     echo -e "${GREEN}✓ accessible${NC}"
 else
     echo -e "${YELLOW}⚠ not ready${NC}"
@@ -102,7 +102,7 @@ for sid in "${SERVICE_IDS[@]}"; do
     [[ "$port" == "0" ]] && continue
 
     echo -n "$name (port $port)... "
-    if curl -sf "${CURL_HEALTH_FLAGS[@]}" "http://localhost:${port}${health}" >/dev/null 2>&1; then
+    if curl -sf "${CURL_HEALTH_FLAGS[@]}" "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
         echo -e "${GREEN}✓ ready${NC}"
     else
         echo -e "${YELLOW}⚠ not ready${NC}"

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -173,7 +173,7 @@ test_service() {
         return 1
     fi
 
-    if curl -sf --max-time "$timeout" "http://localhost:${port}${health}" >/dev/null 2>&1; then
+    if curl -sf --max-time "$timeout" "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
         result_set "$sid" "ok"
         return 0
     fi

--- a/dream-server/scripts/validate.sh
+++ b/dream-server/scripts/validate.sh
@@ -67,18 +67,18 @@ check "Open WebUI running" "docker compose $COMPOSE_FLAGS ps open-webui 2>/dev/n
 echo ""
 echo "2. Health Endpoints"
 echo "───────────────────"
-check "llama-server health" "curl -sf --max-time 10 http://localhost:${LLM_PORT}${LLM_HEALTH}"
-check "llama-server models" "curl -sf --max-time 10 http://localhost:${LLM_PORT}/v1/models | grep -q model"
-check "WebUI reachable" "curl -sf --max-time 10 http://localhost:${WEBUI_PORT}${WEBUI_HEALTH} -o /dev/null"
+check "llama-server health" "curl -sf --max-time 10 http://127.0.0.1:${LLM_PORT}${LLM_HEALTH}"
+check "llama-server models" "curl -sf --max-time 10 http://127.0.0.1:${LLM_PORT}/v1/models | grep -q model"
+check "WebUI reachable" "curl -sf --max-time 10 http://127.0.0.1:${WEBUI_PORT}${WEBUI_HEALTH} -o /dev/null"
 
 echo ""
 echo "3. Inference Test"
 echo "─────────────────"
 printf "  %-30s " "Chat completion..."
-RESPONSE=$(curl -sf --max-time 30 "http://localhost:${LLM_PORT}/v1/chat/completions" \
+RESPONSE=$(curl -sf --max-time 30 "http://127.0.0.1:${LLM_PORT}/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d '{
-        "model": "'"$(curl -sf --max-time 10 "http://localhost:${LLM_PORT}/v1/models" | jq -r '.data[0].id // "local"')"'",
+        "model": "'"$(curl -sf --max-time 10 "http://127.0.0.1:${LLM_PORT}/v1/models" | jq -r '.data[0].id // "local"')"'",
         "messages": [{"role": "user", "content": "Say OK"}],
         "max_tokens": 10
     }' 2>/dev/null)
@@ -119,7 +119,7 @@ for sid in "${SERVICE_IDS[@]}"; do
 
     # Check if container is running
     if docker compose $COMPOSE_FLAGS ps "$sid" 2>/dev/null | grep -qE "Up|running"; then
-        check "$_name" "curl -sf --max-time 10 http://localhost:${_port}${_health}"
+        check "$_name" "curl -sf --max-time 10 http://127.0.0.1:${_port}${_health}"
     else
         printf "  %-30s ${YELLOW}○ SKIP (not enabled)${NC}\n" "$_name..."
     fi


### PR DESCRIPTION
## What
Replace `http://localhost:` with `http://127.0.0.1:` at 46 network-call sites across 10 bash files (installer phases, dream-cli, preflight scripts, macOS helpers). User-facing display echoes that copy-paste URLs to the operator are intentionally preserved as `localhost`.

## Why
On dual-stack hosts (Ubuntu 22.04+, modern Arch derivatives, newer WSL2 builds with IPv6 on by default) `/etc/hosts` lists `::1 localhost` before `127.0.0.1 localhost`. Each `curl http://localhost:` tries `::1` first, fails (services bind to `127.0.0.1`), and only then falls through to IPv4 — costing 2-8s per attempt. Across Phase 12's 14 services × 150 retries × 10s poll, the degraded path stretches to 20+ minutes. Compose-level healthchecks already follow the IPv4 rule; this migrates the bash-side probes too.

## How
Pure substring replacement at known network-call sites (curl/wget invocations and URL-vars feeding curl). Display-only echoes (Phase 13 summary lines, `scripts/dream-preflight.sh:114`, `install-macos.sh:1207` ai_warn) preserved.

Files changed:
- `installers/phases/12-health.sh` (14 sites)
- `installers/phases/13-summary.sh` (2 NETWORK sites — display echoes preserved)
- `installers/macos/install-macos.sh` (2 sites — ai_warn preserved)
- `installers/macos/dream-macos.sh` (4 sites)
- `scripts/health-check.sh` (1 site)
- `scripts/dream-preflight.sh` (3 sites — display L114 preserved)
- `scripts/validate.sh` (6 sites)
- `dream-cli` (6 sites)
- `dream-update.sh` (3 sites)
- `dream-preflight.sh` root-level (5 sites)

## Testing
**Automated**: bash -n PASS on all 10 files · shellcheck delta = 0 · make lint PASS · diff stat exactly +46/-46 (perfect symmetry). `tests/` directory deliberately untouched. Display-only echoes verified preserved by spot-check.

**Manual**: time Phase 12 healthcheck before/after on a dual-stack host; confirm `dream status` returns instantly; verify that Open WebUI's user-facing summary URL still renders as `localhost` (not `127.0.0.1`).

## Review
Critique Guardian: APPROVED WITH WARNINGS. CG manually re-verified zero accidental display-line changes. Three additional active sites with the same root cause exist but are deferred to a separate follow-up to keep this PR's scope crisp:
- `scripts/bootstrap-upgrade.sh` model-load loop (3 sites)
- `installers/macos/lib/env-generator.sh` Perplexica seed (3 sites)

Vestigial / latent-only sites (`02-detection.sh:56,134` LLM_HEALTHCHECK_URL with no consumers; `repair-perplexica.sh:7` default fallback whose primary caller now passes `127.0.0.1`) are also deferred.

CG also recommended a `lint-shell.yml` CI grep regression guard against new `http://localhost:` in curl/wget lines — to be filed as a separate fork issue.

## Known Considerations
**Scope is intentionally narrowed** to installer + CLI + preflight bash side. Bootstrap-upgrade and macOS Perplexica-seed sites share the same root cause and will land in a follow-up PR; bundling them here would inflate review surface for a mechanical sweep.

## Platform Impact
- **Linux**: primary beneficiary (Ubuntu 22.04+ dual-stack, Arch/CachyOS).
- **macOS Apple Silicon**: dual-stack default — `dream-macos.sh` and `install-macos.sh` updated; user-facing ai_warn URL preserved as `localhost`.
- **Windows/WSL2**: newer builds with IPv6 enabled benefit; same fix applies.