### PR TITLE
fix(host-agent): surface docker-bridge detection failure cause

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -134,6 +134,12 @@ def _detect_docker_bridge_gateway() -> str:
                 _ipaddress.ip_address(addr)  # validate — Docker can return "<no value>"
                 logger.info("Detected Docker bridge gateway: %s", addr)
                 return addr
+        else:
+            logger.warning(
+                "Docker bridge gateway detection failed (exit %d): %s",
+                result.returncode,
+                result.stderr.strip() or "<no stderr>",
+            )
     except ValueError:
         logger.debug("Docker bridge returned non-IP value, ignoring")
     except (subprocess.SubprocessError, OSError) as exc:


### PR DESCRIPTION
## What
Six-line additive fix to `_detect_docker_bridge_gateway()` in `bin/dream-host-agent.py`: add an `else:` branch that logs `result.returncode` and `result.stderr` at WARNING when `docker network inspect` exits non-zero.

## Why
The function checked `if result.returncode == 0:` but had no companion `else` — a non-zero exit (typically permission-denied for a host agent whose process lacks docker group membership) silently fell through to `return ""`. The downstream warning ("Containers may not reach the agent…") fires correctly, but the actual root cause (docker socket permission, missing daemon, etc.) never appears in journalctl, leaving operators no diagnostic trail.

## How
\`\`\`python
        if result.returncode == 0:
            …
+       else:
+           logger.warning(
+               "Docker bridge gateway detection failed (exit %d): %s",
+               result.returncode,
+               result.stderr.strip() or "<no stderr>",
+           )
\`\`\`
- `else:` paired with `if returncode == 0` (only sibling branch in the `try:` block).
- Lazy `%d`/`%s` formatting matches the file's existing logger idiom.
- `result.stderr.strip() or \"<no stderr>\"` safe — `subprocess.run(..., text=True)` guarantees `str`.
- Function still returns `\"\"` on failure; caller behavior unchanged.

## Testing
**Automated**: `python3 -m py_compile` PASS · `ast.parse` PASS · diff is exactly +6 lines, one file. ruff/flake8/mypy not installed locally — CI `lint-python.yml` is the gate.

**Manual**: stop host agent, `chmod 000 /var/run/docker.sock`, restart agent, expect `WARNING ... Docker bridge gateway detection failed (exit N): permission denied …` in journalctl.

## Review
Critique Guardian: APPROVED. CG noted a related pre-existing path: the sibling `except (subprocess.SubprocessError, OSError)` clause still logs at `debug`, so a missing `docker` binary or OSError-flavored permission denial remains silent in default journalctl. Same class as this fix, distinct code path — to be filed as a separate fork issue.

## Known Considerations
This PR addresses **the silent fallback** only — the surgical fix. The sibling architectural concern from the original bug report — `systemd --user` inheriting stale supplementary groups so the host agent can't reach the docker socket on fresh installs — is paused pending operator design decision (likely requires moving the unit to system-mode).

## Platform Impact
- **Linux**: bug fixed; warning now surfaces in journalctl.
- **macOS / Windows-WSL2**: not affected — `_detect_docker_bridge_gateway()` is guarded by an early-return on `platform.system() != "Linux"`.