### PR TITLE
fix(preflight): warn when UFW or firewalld is active on Linux

### DIFF
--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -151,5 +151,21 @@ $(printf '%s\n' "$out" | sed 's/^/    /')"
 check_install_dir_filesystem
 check_docker_desktop_sharing
 
+# Firewall check: warn if UFW or firewalld is active. The dashboard host agent
+# binds to the Docker bridge gateway (default 172.17.0.1:7710) and compose
+# containers reach it via the host INPUT chain. Default-DROP firewalls block
+# that traffic and the dashboard reports "Host agent is offline". Warn-only —
+# never abort install.
+if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
+    ai_warn "UFW is active. The dashboard host agent must be reachable from compose subnets."
+    ai_warn "After install, run:"
+    ai_warn "  sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent'"
+elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+    ai_warn "firewalld is active. The dashboard host agent must be reachable from compose subnets."
+    ai_warn "After install, run:"
+    ai_warn "  sudo firewall-cmd --permanent --add-rich-rule='rule family=\"ipv4\" source address=\"172.16.0.0/12\" port protocol=\"tcp\" port=\"7710\" accept'"
+    ai_warn "  sudo firewall-cmd --reload"
+fi
+
 ai_ok "Pre-flight checks passed."
 signal "No cloud dependencies required for core operation."

--- a/dream-server/scripts/linux-install-preflight.sh
+++ b/dream-server/scripts/linux-install-preflight.sh
@@ -206,6 +206,23 @@ else
         "Install jq for smoother tooling (see INSTALL-TROUBLESHOOTING.md)."
 fi
 
+# --- Host firewall (UFW / firewalld) ---
+# The dashboard host agent binds to the Docker bridge gateway (default
+# 172.17.0.1:7710) and compose containers reach it via the host INPUT chain.
+# Default-DROP firewalls block that traffic. Warn only — never fail.
+if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
+    append_check "FIREWALL_CHECK" "warn" \
+        "UFW active — may block container→host:7710 traffic" \
+        "sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent'"
+elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+    append_check "FIREWALL_CHECK" "warn" \
+        "firewalld active — may block container→host:7710 traffic" \
+        "sudo firewall-cmd --permanent --add-rich-rule='rule family=\"ipv4\" source address=\"172.16.0.0/12\" port protocol=\"tcp\" port=\"7710\" accept' && sudo firewall-cmd --reload"
+else
+    append_check "FIREWALL_CHECK" "pass" \
+        "No restrictive host firewall detected" ""
+fi
+
 # --- Compose files present (expected when run from repo tree) ---
 if [[ -f "$ROOT_DIR/docker-compose.base.yml" ]] || [[ -f "$ROOT_DIR/docker-compose.yml" ]]; then
     append_check "COMPOSE_FILES" "pass" "Compose files present under dream-server root" ""


### PR DESCRIPTION
## What
Add a warn-only firewall preflight to both `installers/phases/01-preflight.sh` and `scripts/linux-install-preflight.sh` that detects active UFW or firewalld and prints the exact remediation command.

## Why
The dashboard host agent binds to the Docker bridge gateway (default `172.17.0.1:7710`) on Linux. Compose containers reach it via Docker's `host-gateway` extra-host, traversing the host INPUT chain. UFW (Ubuntu/Debian/Arch derivatives) and firewalld (Fedora/RHEL/CentOS) with default-DROP block this traffic — the dashboard then reports "Host agent is offline" with no diagnostic chain. Live-confirmed on a CachyOS host: `sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp` resolves it.

## How
- `systemctl is-active --quiet ufw` / `systemctl is-active --quiet firewalld` instead of `ufw status` / `firewall-cmd --state`. systemctl reads PID 1 D-Bus state and works for any user; `ufw status` silently returns nothing for non-root callers on Ubuntu, so a naive detection would have missed UFW on the most common deployment path. (Verified live on a CachyOS host where UFW is active per systemctl but `ufw status` returns \"ERROR: You need to be root\".)
- `command -v <tool>` short-circuits when the tool isn't installed (graceful no-op on systems without UFW/firewalld; macOS / WSL / non-systemd Linux skip both branches).
- Phase 01 uses three sequential `ai_warn` calls (matching `lib/detection.sh:355` style); structured preflight uses `append_check FIREWALL_CHECK warn ... <remediation>` matching the existing 4-arg signature.
- Remediation rule is RFC 1918 supernet `172.16.0.0/12` → port 7710 only, scoped tightly. Auto-remediation deliberately not done (project pattern is warn-not-fix).

## Testing
**Automated**: bash -n + shellcheck PASS on both files · make lint PASS · `tests/contracts/test-preflight-fixtures.sh` PASS · mock-simulated all three branches (no firewall / UFW active / firewalld active) and confirmed expected output.

**Live-verified** on a CachyOS host: UFW active per `systemctl is-active`; new check correctly identifies it. Original `ufw status` check would have silently missed it.

**Manual**: Ubuntu UFW-active install → operator sees the `sudo ufw allow ...` command on screen; Fedora firewalld-active install → operator sees the rich-rule + reload commands.

## Review
Critique Guardian: APPROVED. CG noted recommended (non-blocking) follow-ups: add a `FIREWALL_CHECK` fixture to `tests/contracts/test-preflight-fixtures.sh`; live-verify the firewalld rich-rule on a Fedora host before claiming RHEL-family parity.

## Known Considerations
- Auto-remediation is intentionally out of scope — project pattern is warn-not-fix for environment gaps. Filed for future follow-up if maintainers want the option.
- Firewalld rich-rule has been validated against firewalld docs but not yet live-tested on a Fedora host.

## Platform Impact
- **Linux Ubuntu/Debian/Arch (UFW)**: warning surfaces with copy-paste remediation.
- **Linux Fedora/RHEL/CentOS (firewalld)**: warning surfaces with copy-paste rich-rule.
- **Linux Arch with no firewall installed**: silent (graceful).
- **macOS / Windows-WSL2**: unaffected — these scripts don't run on macOS, and Docker Desktop networking on WSL2/macOS doesn't share the issue.