### PR TITLE
fix(forge): disable bundled syncthing public-relay on default install

### DIFF
--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -9,6 +9,7 @@ services:
       - FORGE_PORT_HOST=7861
       - FORGE_ARGS=--api --listen
       - AUTO_UPDATE=false
+      - SUPERVISOR_NO_AUTOSTART=syncthing
     volumes:
       - ./data/forge/models:/opt/stable-diffusion-webui-forge/models:rw
       - ./data/forge/outputs:/opt/stable-diffusion-webui-forge/outputs:rw


### PR DESCRIPTION
## What
One-line addition to the Forge community extension's compose env block: `SUPERVISOR_NO_AUTOSTART=syncthing`. Disables the syncthing supervisord program inside the ai-dock container so it never joins the public relay.

## Why
The bundled `ghcr.io/ai-dock/stable-diffusion-webui-forge` image autostarts a syncthing instance via supervisord. On first boot it joins a public relay (`relay://151.245.112.124:22067`), performs STUN against `stun.miwifi.com`, and announces the container's external IP. Direct conflict with the project's "fully local, sovereign" positioning — every Forge install would phone home unless the operator manually intervened.

## How
ai-dock's base image init script (`init_toggle_supervisor_autostart`) reads `SUPERVISOR_NO_AUTOSTART` (comma-separated supervisord program names) and rewrites `autostart=false` in `/etc/supervisor/supervisord/conf.d/<name>.conf` *before* supervisord launches. Verified mechanism by reading the upstream init source. Setting the env var to `syncthing` is sufficient; comma-separated grammar future-proofs disabling additional programs in a follow-up.

\`\`\`diff
 environment:
   - FORGE_PORT_HOST=7861
   - FORGE_ARGS=--api --listen
   - AUTO_UPDATE=false
+  - SUPERVISOR_NO_AUTOSTART=syncthing
\`\`\`

## Testing
**Automated**: `python3 yaml.safe_load` PASS · `docker compose config` rendered all 4 env entries cleanly · diff is +1 line, one file.

**Manual** (operator):
1. `docker exec dream-forge cat /etc/supervisor/supervisord/conf.d/syncthing.conf | grep autostart` → `autostart=false`.
2. `docker exec dream-forge supervisorctl status syncthing` → STOPPED (or absent).
3. `docker exec dream-forge ss -tlnp 2>/dev/null | grep 22000` → empty.
4. `docker logs dream-forge | grep -i 'Joined relay'` → empty.
5. `curl -sf http://127.0.0.1:7861/` → Forge UI still responsive.

## Review
Critique Guardian: APPROVED. CG noted three optional follow-ups for separate PRs: README "Privacy: syncthing relay disabled" note; defense-in-depth sweep of other ai-dock supervisord programs (`cloudflared`, `quicktunnel`, `serviceportal`, `sshd`); bind-address alignment of `resources/dev/extensions-library/services/**` to the `\${BIND_ADDRESS:-127.0.0.1}:` pattern (which the broader sweep PR didn't cover for this dir).

## Known Considerations
This PR addresses the **public-relay phone-home** only. The two sibling concerns from the original bug report — host-agent install reporting `started` while the wrapped Forge process FATAL'd, and the bundled Torch+CUDA mismatch with RTX 30-series Mobile (sm_86) — are paused. The first is architectural (changes start-status semantics for all extensions); the second is image-level and needs hardware testing before we can document a supported CUDA matrix.

## Platform Impact
- **Linux + Windows-WSL2 NVIDIA**: bug fixed (bundled image is amd64; manifest `gpu_backends: [nvidia]`).
- **macOS Apple Silicon**: not affected — image excluded by `gpu_backends` filter.