### PR TITLE
harden(resolver): boundary-check compose_file against extension dir

### DIFF
--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -177,7 +177,24 @@ if ext_dir.exists():
             # Get compose file from manifest
             compose_rel = service.get("compose_file", "")
             if compose_rel and not compose_rel.endswith(".disabled"):
+                # Validate compose_file stays inside its extension's directory.
+                # Path.relative_to() does lexical part-prefix matching, so a
+                # `..`-traversal ("../../../etc/passwd") still string-matches
+                # script_dir without escape detection; an absolute compose_file
+                # ("/etc/shadow") replaces service_dir entirely under `/`. Both
+                # would otherwise reach docker compose `-f`. Boundary-check on
+                # fully resolved paths, but keep the unresolved compose_path
+                # for the emit so the existing relative_to(script_dir) contract
+                # still holds on systems where script_dir contains symlinks
+                # (macOS /var -> /private/var would mismatch otherwise).
                 compose_path = service_dir / compose_rel
+                try:
+                    compose_path.resolve().relative_to(service_dir.resolve())
+                except ValueError:
+                    print(f"WARNING: {service_dir.name}: compose_file '{compose_rel}' "
+                          f"escapes the extension directory; skipping",
+                          file=sys.stderr)
+                    continue
                 if compose_path.exists():
                     resolved.append(str(compose_path.relative_to(script_dir)))
                 elif (service_dir / f"{compose_rel}.disabled").exists():

--- a/dream-server/tests/test-resolve-compose-resilient.sh
+++ b/dream-server/tests/test-resolve-compose-resilient.sh
@@ -164,6 +164,77 @@ else
     fail "JSON parse error: --skip-broken should not exit"
 fi
 
+# ============================================================================
+# 11. Path-traversal hardening: compose_file with .. must not escape ext dir
+# ============================================================================
+# Clean prior broken-ext fixture so it doesn't interfere with traversal checks.
+rm -rf "$TEMP_DIR/extensions/services/broken-ext"
+
+mkdir -p "$TEMP_DIR/extensions/services/traversal-ext"
+cat > "$TEMP_DIR/extensions/services/traversal-ext/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: traversal-ext
+  name: Traversal Test
+  compose_file: "../../../../../../etc/passwd"
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+
+traversal_exit=0
+traversal_stderr_file="$TEMP_DIR/traversal.stderr"
+traversal_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$traversal_stderr_file") || traversal_exit=$?
+traversal_stderr=$(cat "$traversal_stderr_file")
+
+if [[ $traversal_exit -ne 0 ]]; then
+    fail "Traversal compose_file caused resolver to crash (exit $traversal_exit)"
+elif echo "$traversal_stdout" | grep -q "etc/passwd"; then
+    fail "Traversal path INCLUDED in resolved stack (security regression)"
+else
+    pass "Traversal compose_file rejected from resolved stack"
+fi
+
+if echo "$traversal_stderr" | grep -qi "WARNING.*traversal-ext.*escapes"; then
+    pass "WARNING emitted for traversal-ext compose_file"
+else
+    fail "Expected WARNING for traversal-ext compose_file"
+fi
+
+# ============================================================================
+# 12. Path-traversal hardening: absolute compose_file must not crash resolver
+# ============================================================================
+mkdir -p "$TEMP_DIR/extensions/services/absolute-ext"
+cat > "$TEMP_DIR/extensions/services/absolute-ext/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: absolute-ext
+  name: Absolute Path Test
+  compose_file: "/etc/shadow"
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+
+abs_exit=0
+abs_stderr_file="$TEMP_DIR/absolute.stderr"
+abs_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$abs_stderr_file") || abs_exit=$?
+abs_stderr=$(cat "$abs_stderr_file")
+
+if [[ $abs_exit -ne 0 ]]; then
+    fail "Resolver crashed on absolute compose_file (DoS regression, exit $abs_exit)"
+elif echo "$abs_stdout" | grep -q "/etc/shadow"; then
+    fail "Absolute path INCLUDED in resolved stack (security regression)"
+else
+    pass "Resolver handled absolute compose_file gracefully"
+fi
+
+if echo "$abs_stderr" | grep -qi "WARNING.*absolute-ext.*escapes"; then
+    pass "WARNING emitted for absolute-ext compose_file"
+else
+    fail "Expected WARNING for absolute-ext compose_file"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## What
Hardens the inline-Python extension loop in `scripts/resolve-compose-stack.sh` against two related vulnerabilities in the manifest's `compose_file` field:
1. `..`-traversal: a malicious user-installed manifest can point `compose_file` at a host file outside its own extension directory (`/etc/passwd`, etc.) and the resolver will include it in the `-f` flags passed to `docker compose`.
2. Absolute path: `compose_file: /etc/shadow` triggers an unhandled `ValueError` in `Path.relative_to()` that propagates to the existing `else: raise` branch, crashing the resolver (DoS).

## Why
`Path.relative_to()` uses **lexical part-prefix matching**, NOT path resolution. A path like `service_dir/../../../../../../etc/passwd` retains its `..` segments unresolved; `relative_to(script_dir)` still finds `script_dir`'s components at the front and returns successfully. The traversal segments persist, `compose_path.exists()` follows them, and the resolved file is appended to `COMPOSE_FLAGS`. Trust boundary: built-in extensions ship from this repo (low risk), but post-PR #909/#926/#907 user-installed extensions widen the surface considerably.

## How
Adds a `try: compose_path.resolve().relative_to(service_dir.resolve())` boundary check between the join and the existence check:
```python
compose_path = service_dir / compose_rel
try:
    compose_path.resolve().relative_to(service_dir.resolve())
except ValueError:
    print(f"WARNING: {service_dir.name}: compose_file '{compose_rel}' "
          f"escapes the extension directory; skipping", file=sys.stderr)
    continue
if compose_path.exists():
    resolved.append(str(compose_path.relative_to(script_dir)))
```
- **Resolves both sides** to handle macOS `/var → /private/var` symlink dance (an unresolved `script_dir` would false-positive-reject legitimate `/var/folders/...` paths)
- **Bound to `service_dir`** (stricter than `script_dir`) — each extension's compose must live in its own directory
- **Narrow `try/except`** — catches only `ValueError`, no Exception swallowing
- **Emit unchanged** — `relative_to(script_dir)` still produces the relative path docker-compose expects

## Testing
- `tests/test-resolve-compose-resilient.sh`: 13/13 assertions pass (9 prior + 4 new — traversal rejection + WARNING + absolute-path no-crash + WARNING)
- Negative test: removing the boundary check causes 2 WARNING-assertion tests to fail
- Live macOS test: synthetic manifest with `compose_file: ../../../../../../etc/passwd` correctly emits WARNING + skip, exit 0; legitimate `/var/folders/...` extensions resolve cleanly

## Known Considerations
- The user-extension loop on `main` currently uses literal `service_dir / "compose.yaml"` (not vulnerable). When a future PR introduces manifest-driven `compose_file` reading in that loop, the same boundary check needs to be ported. Tracked as a follow-up.
- TOCTOU: between resolve-time and docker-compose `open()`, a file could be replaced with a symlink. Acceptable risk — the resolver and docker-compose run as the same UID; the threat model is malicious manifest content, not filesystem race.

## Platform Impact
- **macOS**: implementation handles the `/var → /private/var` symlink quirk via resolve-both-sides
- **Linux**: identical Python pathlib semantics
- **Windows/WSL2**: WSL2 uses Linux semantics; native Windows is out of scope (resolver is bash)
