### PR TITLE
a11y(dashboard): add aria-hidden to TemplatePicker HardDrive icon

### DIFF
--- a/dream-server/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -93,7 +93,7 @@ export function TemplatePicker({ templates, onApplied, compact = false }) {
                 <span>{tmpl.services?.length || 0} services</span>
                 {tmpl.estimated_disk_gb && (
                   <span className="flex items-center gap-1">
-                    <HardDrive size={10} />
+                    <HardDrive size={10} aria-hidden="true" />
                     ~{tmpl.estimated_disk_gb}GB
                   </span>
                 )}


### PR DESCRIPTION
## What
Adds `aria-hidden="true"` to the decorative `<HardDrive size={10} />` glyph next to the disk-size label in `TemplatePicker.jsx`.

## Why
The four sibling status icons in the same component (`Loader2`, `AlertTriangle`, `Check`, default `Icon` at lines 66–71) already carry `aria-hidden="true"`. The `HardDrive` glyph was the lone outlier — screen readers were announcing it as a generic graphic between the service count and "~XGB" text, adding noise without conveying information not already in the adjacent text.

## How
Single-line attribute add: `<HardDrive size={10} aria-hidden="true" />`.

## Testing
- `npm run lint` — 0 errors (5 pre-existing warnings in unrelated hooks)
- `npm run build` — clean
- `npm test` — 35/35 vitest pass
- Manual: axe DevTools / Lighthouse audit — `HardDrive` SVG no longer flagged as decorative-without-aria-hidden

## Platform Impact
Pure JSX — identical on macOS, Linux, Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)