### PR TITLE
fix(dashboard-api): wrap get_user_services_cached in asyncio.to_thread

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -806,7 +806,7 @@ async def extensions_catalog(
     from helpers import _CATALOG_HEALTH_TIMEOUT, check_service_health
     from user_extensions import get_user_services_cached
 
-    user_svc_configs = get_user_services_cached(USER_EXTENSIONS_DIR)
+    user_svc_configs = await asyncio.to_thread(get_user_services_cached, USER_EXTENSIONS_DIR)
 
     # Only health-check extensions that declare a health endpoint.  Use a
     # short per-probe timeout so one slow extension cannot stall the catalog
@@ -950,7 +950,7 @@ async def extension_detail(
     service_list = await get_all_services()
     services_by_id = {s.id: s for s in service_list}
 
-    user_svc_configs = get_user_services_cached(USER_EXTENSIONS_DIR)
+    user_svc_configs = await asyncio.to_thread(get_user_services_cached, USER_EXTENSIONS_DIR)
 
     # Same short per-probe timeout as the catalog fan-out — one slow user
     # extension must not block the detail view.


### PR DESCRIPTION
## What
`extensions_catalog` and `extension_detail` handlers now invoke `get_user_services_cached(USER_EXTENSIONS_DIR)` via `await asyncio.to_thread(...)` rather than calling the sync helper directly on the event loop.

## Why
On a 30-second cache miss, the sync helper performs `iterdir() + per-extension stat + YAML parse` synchronously. Every other inflight async request — GPU polling, service health, log streaming — stalls for the duration of the scan, most visible during dashboard navigation on populated `USER_EXTENSIONS_DIR` directories or slow volumes.

## How
Mirrors the pattern PR #1022 established in the same file for `_check_agent_health` (line 898) and `_fetch_agent_logs`. Two-line wrap, no helper extraction needed since `get_user_services_cached` already takes a single positional `Path` argument and is thread-safe (`threading.Lock` internally).

## Testing
- `python3 -m py_compile` clean
- `ruff check` clean
- `pytest tests/test_extensions.py` — 226 pass
- `pytest tests/test_routers.py` — 226 pass
- Full dashboard-api suite: 663 pass; 12 pre-existing baseline failures unaffected (test_gpu_detailed, test_workflows — Py3.14 baseline)

## Manual test
Populate `USER_EXTENSIONS_DIR` with several manifests, hit `/api/extensions/catalog` repeatedly with intervals just over 30s (force cache miss). Concurrently hit a fast async endpoint. Expected: no stall on the second endpoint during catalog scan.

## Platform Impact
Pure Python `asyncio.to_thread` — identical on macOS, Linux, Windows-WSL2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)