### PR TITLE
fix(dashboard-api): tighten exception handling in updates/workflows/privacy

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/privacy.py
+++ b/dream-server/extensions/services/dashboard-api/routers/privacy.py
@@ -100,6 +100,6 @@ async def get_privacy_shield_stats(api_key: str = Depends(verify_api_key)):
                     return await resp.json()
                 else:
                     return {"error": "Privacy Shield not responding", "status": resp.status}
-    except (aiohttp.ClientError, OSError):
+    except (asyncio.TimeoutError, aiohttp.ClientError, OSError):
         logger.exception("Cannot reach Privacy Shield")
         return {"error": "Cannot reach Privacy Shield", "enabled": False}

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -325,10 +325,13 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
             raise HTTPException(status_code=500, detail="Backup failed")
     elif action.action == "update":
         async def run_update():
-            proc = await asyncio.create_subprocess_exec(
-                str(script_path), "update",
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-            )
-            await proc.communicate()
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    str(script_path), "update",
+                    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+                )
+                await proc.communicate()
+            except OSError:
+                logger.exception("update task failed")
         background_tasks.add_task(run_update)
         return {"success": True, "message": "Update started in background. Check logs for progress."}

--- a/dream-server/extensions/services/dashboard-api/routers/workflows.py
+++ b/dream-server/extensions/services/dashboard-api/routers/workflows.py
@@ -213,6 +213,8 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
                 else:
                     error_text = await resp.text()
                     raise HTTPException(status_code=resp.status, detail=f"n8n API error: {error_text}")
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="n8n workflow add timed out")
     except aiohttp.ClientError as e:
         raise HTTPException(status_code=503, detail=f"Cannot reach n8n: {e}")
 
@@ -245,6 +247,8 @@ async def _remove_workflow(workflow_id: str):
                 else:
                     error_text = await resp.text()
                     raise HTTPException(status_code=resp.status, detail=f"n8n API error: {error_text}")
+    except asyncio.TimeoutError:
+        raise HTTPException(status_code=504, detail="n8n workflow remove timed out")
     except aiohttp.ClientError as e:
         raise HTTPException(status_code=503, detail=f"Cannot reach n8n: {e}")
 


### PR DESCRIPTION
## What
Three narrow exception-handling fixes:
- `routers/updates.py` — wrap `run_update` background task in `try/except OSError + logger.exception`.
- `routers/workflows.py` — `enable_workflow` and `_remove_workflow` add `asyncio.TimeoutError → 504` ahead of the existing `aiohttp.ClientError → 503`.
- `routers/privacy.py` — `get_privacy_shield_stats` adds `asyncio.TimeoutError` to the existing `(aiohttp.ClientError, OSError)` tuple.

## Why
- Background `dream-update.sh` exec failures (file removed, chmod -x, PATH change) were silently swallowed by FastAPI's `BackgroundTasks` runner. Client received 200 "update_started", no log entry, update never ran.
- aiohttp's `ClientTimeout` raises `asyncio.TimeoutError`, which isn't an `aiohttp.ClientError` subclass — n8n slow-start / unreachable surfaced as raw 500s instead of 504/503 with descriptive detail.
- `privacy.py:35` (`get_privacy_shield_status`) already lists `asyncio.TimeoutError` explicitly; `:103` (`get_privacy_shield_stats`) was missing it for documentation/intent symmetry.

## How
Narrow `except OSError:` (matches the established pattern of 18 other `except OSError:` clauses in `routers/`) and explicit `asyncio.TimeoutError → 504` clauses for differentiated user-visible status. Closures correctly capture module-level `logger`.

## Testing
- `python3 -m py_compile` clean on all 3 files
- `ruff check` clean
- 684 tests pass; pre-existing 12 baseline failures unaffected
- Pre-commit hooks pass (gitleaks, private-key, large-file)

## Manual test plan (per platform — equivalent across all 3)
1. `chmod -x` `dream-update.sh`, hit `/api/updates` with `action: \"update\"` → expect 200 + `logger.exception` line in container logs.
2. Stop n8n, hit \"Add Workflow\" → expect HTTP 504 with \`\"n8n workflow add timed out\"\` (not raw 500).
3. Stop privacy-shield, hit `/api/privacy/stats` → expect graceful JSON error (not raw 500).

## Known Considerations / Follow-ups
- `run_update` does not track `proc.returncode`; non-zero exit from `dream-update.sh` still produces no log either. Same silent-failure shape, distinct code path — separate follow-up worth filing.
- On Python 3.11+, `asyncio.TimeoutError` is now an alias for `TimeoutError` which is an `OSError` subclass. The explicit `asyncio.TimeoutError` entry in `privacy.py:103`'s tuple is technically redundant with `OSError`, but matches the pre-existing pattern at `privacy.py:35` for documentation/intent symmetry. Cleaning both for purity is a separate stylistic PR.
- File overlap with #1069 (privacy-shield auth): both touch `privacy.py:get_privacy_shield_stats`. Whichever lands second will need a small rebase.

## Platform Impact
Pure Python — identical on macOS, Linux, Windows-WSL2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)