### PR TITLE
fix(installer): add INTERACTIVE/sudo-n guard to Phase 01 jq install

### DIFF
--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -46,6 +46,11 @@ log "curl: $(curl --version 2>/dev/null | sed -n '1p')"
 
 if ! command -v jq &> /dev/null; then
     log "jq not found - attempting auto-install..."
+    # In non-interactive mode, fail fast if sudo requires a password
+    # (otherwise the bare `sudo <pkgmgr>` below hangs on a TTY prompt that never comes).
+    if [[ "${INTERACTIVE:-true}" != "true" ]] && ! sudo -n true 2>/dev/null; then
+        error "Cannot install jq: sudo password required but running in --non-interactive mode. Re-run interactively or configure NOPASSWD sudo for the package manager."
+    fi
     case "$PKG_MANAGER" in
         dnf)    sudo dnf install -y jq ;;
         pacman) sudo pacman -S --noconfirm jq ;;


### PR DESCRIPTION
## What
Add an INTERACTIVE / `sudo -n` guard before the bare-sudo `jq` install in `installers/phases/01-preflight.sh:49`.

## Why
In `--non-interactive` mode without NOPASSWD sudo, the existing bare-sudo block hangs on a TTY password prompt that never arrives. Phase 05 already has the canonical guard; Phase 01 lacked it.

## How
Insert the same `[[ "${INTERACTIVE:-true}" != "true" ]] && ! sudo -n true 2>/dev/null` guard (verbatim from `05-docker.sh:60-68`) before the case block. On guard hit, call `error` for fail-fast.

## Testing
- `bash -n` clean
- `shellcheck` delta-clean (no new warnings)
- `make lint` clean
- Manual Linux: `INTERACTIVE=false` on a sudoless container hard-errors with the new message instead of hanging. With NOPASSWD: jq installs normally.

## Review
Critique Guardian: APPROVED. Verbatim copy of the established Phase 05 pattern; no security/quality regression.

## Platform Impact
- **Linux**: fixed. Bug only triggers in `--non-interactive` without NOPASSWD; pure UX/reliability improvement.
- **macOS**: not applicable. macOS uses `installers/macos/install-macos.sh` (separate preflight, no jq sudo path).
- **Windows / WSL2**: not applicable. Windows installer (`installers/windows/phases/01-preflight.ps1`) has no jq install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)