### PR TITLE
fix(installer): add sudo guard and replace silent || true on Phase 07 Node install

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -23,26 +23,33 @@ else
 
     # Ensure Node.js/npm is available (needed for Claude Code and Codex)
     if ! command -v npm &> /dev/null; then
+        # In non-interactive mode, fail fast if sudo requires a password — otherwise
+        # the sudo prompt hangs and the trailing error-mask silently skips Node.js,
+        # leaving downstream Claude Code / Codex CLI installs to be skipped without
+        # any visible failure. See pattern in 05-docker.sh:61-65.
+        if [[ "${INTERACTIVE:-true}" != "true" ]] && ! sudo -n true 2>/dev/null; then
+            error "Cannot install Node.js: sudo password required but running in --non-interactive mode. Re-run interactively or configure NOPASSWD sudo."
+        fi
         ai "Installing Node.js..."
         case "$PKG_MANAGER" in
             apt)
                 tmpfile=$(mktemp /tmp/nodesource-setup.XXXXXX.sh)
                 if curl -fsSL --max-time 300 https://deb.nodesource.com/setup_22.x -o "$tmpfile" 2>/dev/null; then
-                    sudo -E bash "$tmpfile" 2>&1 | tee -a "$LOG_FILE" || true
+                    sudo -E bash "$tmpfile" 2>&1 | tee -a "$LOG_FILE" || ai_warn "Failed to run NodeSource apt setup script (non-fatal — Claude Code/Codex CLI will be skipped)"
                 fi
                 rm -f "$tmpfile"
-                sudo apt-get install -y nodejs 2>&1 | tee -a "$LOG_FILE" || true
+                sudo apt-get install -y nodejs 2>&1 | tee -a "$LOG_FILE" || ai_warn "Failed to install nodejs via apt-get (non-fatal — Claude Code/Codex CLI will be skipped)"
                 ;;
             dnf)
                 sudo dnf module install -y nodejs:22 2>&1 | tee -a "$LOG_FILE" || \
-                    sudo dnf install -y nodejs 2>&1 | tee -a "$LOG_FILE" || true
+                    sudo dnf install -y nodejs 2>&1 | tee -a "$LOG_FILE" || ai_warn "Failed to install nodejs via dnf (non-fatal — Claude Code/Codex CLI will be skipped)"
                 ;;
             pacman)
-                sudo pacman -S --noconfirm --needed nodejs npm 2>&1 | tee -a "$LOG_FILE" || true
+                sudo pacman -S --noconfirm --needed nodejs npm 2>&1 | tee -a "$LOG_FILE" || ai_warn "Failed to install nodejs via pacman (non-fatal — Claude Code/Codex CLI will be skipped)"
                 ;;
             zypper)
                 sudo zypper --non-interactive install nodejs22 2>&1 | tee -a "$LOG_FILE" || \
-                    sudo zypper --non-interactive install nodejs 2>&1 | tee -a "$LOG_FILE" || true
+                    sudo zypper --non-interactive install nodejs 2>&1 | tee -a "$LOG_FILE" || ai_warn "Failed to install nodejs via zypper (non-fatal — Claude Code/Codex CLI will be skipped)"
                 ;;
             *)
                 ai_warn "Unknown package manager — cannot install Node.js automatically"


### PR DESCRIPTION
## What
Two coordinated changes in the Node install block of `installers/phases/07-devtools.sh`:
1. Insert canonical INTERACTIVE/`sudo -n` guard before the install case.
2. Replace 5 `|| true` masks (one per package-manager branch) with `|| ai_warn "..."`.

## Why
Bare sudo without an INTERACTIVE guard hangs on TTY in `--non-interactive` mode. The trailing `|| true` masks then silently swallow the failure (or any other install failure), and the downstream `ai_warn` at L87 just skips Claude Code / Codex CLI. Users see a "successful" install with missing dev tooling and no clear root cause.

## How
- Add the same guard pattern from `05-docker.sh:60-68` before the install case.
- Swap each branch's trailing `|| true` for `|| ai_warn "Failed to install nodejs via $PKG_MANAGER (non-fatal — Claude Code/Codex CLI will be skipped)"`. Inner `||` between fallback install attempts (dnf module:22 → bare nodejs; zypper nodejs22 → bare nodejs) preserved.
- Out-of-scope `|| true` in this file (npm config, daemon-reload, loginctl enable-linger) deliberately untouched.

## Testing
- `bash -n` / `shellcheck` / `make lint` clean (no new warnings; line numbers shift only).
- Manual Linux: `INTERACTIVE=false` on sudoless container hard-errors. With NOPASSWD + a deliberately-broken pkg manager: visible `ai_warn` line, downstream npm skip at L87 still fires.

## Review
Critique Guardian: APPROVED. Optional-component flow preserved; per-package-manager `ai_warn` matches CLAUDE.md "must tolerate" carve-out.

## Known Considerations
The 4 remaining `|| true` instances elsewhere in this file (L65 npm config, L216/L256 daemon-reload, L272 loginctl enable-linger) are out of scope for this fix. Worth a follow-up audit but bundling them here would expand review surface.

## Platform Impact
- **Linux**: fixed.
- **macOS**: not applicable. macOS uses Homebrew, separate installer file.
- **Windows**: not applicable. Windows uses winget, separate file.
- **WSL2**: covered (uses Linux installer path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)