### PR TITLE
fix(cold-storage): verify archive/restore moves and create cold dir

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -148,6 +148,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
+	@echo ""
+	@echo "=== llm-cold-storage archive/restore safety ==="
+	@bash tests/test-llm-cold-storage.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -77,15 +77,22 @@ get_last_access_days() {
     fi
     local now
     now="$(date +%s)"
-    local age_secs
-    age_secs="$(echo "$now - ${newest_atime%.*}" | bc)"
-    echo "$(( age_secs / 86400 ))"
+    # Epoch math is integer-only; bash arithmetic avoids a bc dependency
+    # (bc is absent on minimal images, and an empty result here would make
+    # every model look recent and silently disable archiving).
+    echo "$(( (now - ${newest_atime%.*}) / 86400 ))"
 }
 
 do_archive() {
     local dry_run="${1:-true}"
     local archived=0
     local skipped=0
+    local failed=0
+
+    if [[ "$dry_run" != "true" ]] && ! mkdir -p "$COLD_DIR"; then
+        log "ERROR: cannot create cold storage directory: $COLD_DIR"
+        exit 1
+    fi
 
     log "========== LLM cold storage scan started (dry_run=$dry_run) =========="
 
@@ -119,14 +126,34 @@ do_archive() {
         if (( idle_days >= MAX_IDLE_DAYS )); then
             if [[ "$dry_run" == "true" ]]; then
                 log "WOULD ARCHIVE: $name ($size, idle ${idle_days}d)"
-            else
-                log "ARCHIVING: $name ($size, idle ${idle_days}d)"
-                # Move to cold storage
-                mv "$model_dir" "$COLD_DIR/$name"
-                # Create symlink so HF cache still resolves
-                ln -s "$COLD_DIR/$name" "${model_dir%/}"
-                log "ARCHIVED: $name -> $COLD_DIR/$name"
+                ((archived++))
+                continue
             fi
+            log "ARCHIVING: $name ($size, idle ${idle_days}d)"
+            # `mv dir existing-dir` nests the source INSIDE the destination
+            # instead of replacing it, which corrupts the archive layout —
+            # refuse instead.
+            if [[ -e "$COLD_DIR/$name" ]]; then
+                log "ERROR: already exists in cold storage, skipping: $COLD_DIR/$name"
+                ((failed++))
+                continue
+            fi
+            if ! mv "$model_dir" "$COLD_DIR/$name"; then
+                log "ERROR: move failed, model left in place: $name"
+                ((failed++))
+                continue
+            fi
+            # Symlink so HF cache resolution still finds the model. If it
+            # cannot be created, move the model back — a moved model without
+            # a symlink silently breaks cache lookups.
+            if ! ln -s "$COLD_DIR/$name" "${model_dir%/}"; then
+                log "ERROR: symlink failed, moving $name back to cache"
+                mv "$COLD_DIR/$name" "${model_dir%/}" || \
+                    log "ERROR: move back failed too — model is stranded at $COLD_DIR/$name"
+                ((failed++))
+                continue
+            fi
+            log "ARCHIVED: $name -> $COLD_DIR/$name"
             ((archived++))
         else
             log "SKIP (recent, ${idle_days}d): $name ($size)"
@@ -134,7 +161,8 @@ do_archive() {
         fi
     done
 
-    log "========== Scan complete: $archived archived, $skipped skipped =========="
+    log "========== Scan complete: $archived archived, $skipped skipped, $failed failed =========="
+    (( failed == 0 )) || exit 1
 }
 
 do_restore() {
@@ -158,13 +186,24 @@ do_restore() {
         rm "$cache_path"
     fi
 
+    # A real directory here (e.g. partially re-downloaded model) would make
+    # `mv` nest the restored model inside it instead of replacing it.
+    if [[ -e "$cache_path" ]]; then
+        echo "ERROR: $cache_path already exists and is not a symlink; refusing to overwrite"
+        exit 1
+    fi
+
     log "RESTORING: $name to $cache_path"
-    mv "$cold_path" "$cache_path"
+    if ! mv "$cold_path" "$cache_path"; then
+        log "ERROR: restore move failed for $name"
+        exit 1
+    fi
     log "RESTORED: $name"
     echo "Restored: $name"
 }
 
 do_restore_all() {
+    local failed=0
     log "========== Restoring all archived models =========="
     for cold_model in "$COLD_DIR"/models--*/; do
         [[ -d "$cold_model" ]] || continue
@@ -176,11 +215,22 @@ do_restore_all() {
             rm "$cache_path"
         fi
 
+        if [[ -e "$cache_path" ]]; then
+            log "ERROR: $cache_path already exists and is not a symlink; skipping $name"
+            ((failed++))
+            continue
+        fi
+
         log "RESTORING: $name"
-        mv "$cold_model" "$cache_path"
+        if ! mv "${cold_model%/}" "$cache_path"; then
+            log "ERROR: restore move failed for $name"
+            ((failed++))
+            continue
+        fi
         log "RESTORED: $name"
     done
-    log "========== All models restored =========="
+    log "========== Restore complete ($failed failed) =========="
+    (( failed == 0 )) || exit 1
 }
 
 show_status() {

--- a/ods/tests/test-llm-cold-storage.sh
+++ b/ods/tests/test-llm-cold-storage.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Functional tests for scripts/llm-cold-storage.sh archive/restore safety:
+#  - first-run archive creates the cold dir and verifies the move + symlink
+#  - failed moves are reported (non-zero exit), not logged as ARCHIVED
+#  - restore refuses to nest into an existing real directory
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLD_SCRIPT="$SCRIPT_DIR/../scripts/llm-cold-storage.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; exit 1; }
+info() { echo -e "${BLUE}ℹ${NC} $1"; }
+
+[[ -f "$COLD_SCRIPT" ]] || fail "llm-cold-storage.sh not found at $COLD_SCRIPT"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+MODEL="models--Test--IdleModel"
+
+# Fresh fixture: one idle model in the fake HF cache. Idle-ness comes from
+# an atime far in the past (script archives models idle 7+ days).
+make_fixture() {
+    rm -rf "$TMP_ROOT/hub" "$TMP_ROOT/cold" "$TMP_ROOT/log"
+    mkdir -p "$TMP_ROOT/hub/$MODEL/snapshots"
+    echo "weights" > "$TMP_ROOT/hub/$MODEL/snapshots/model.bin"
+    touch -a -t 202601010000 "$TMP_ROOT/hub/$MODEL/snapshots/model.bin"
+    mkdir -p "$TMP_ROOT/log"
+}
+
+run_cold() {
+    HF_CACHE="$TMP_ROOT/hub" \
+    COLD_DIR="$TMP_ROOT/cold" \
+    LOG_FILE="$TMP_ROOT/log/cold.log" \
+        bash "$COLD_SCRIPT" "$@"
+}
+
+info "Test 1: --execute on a fresh system creates COLD_DIR and archives"
+make_fixture
+# COLD_DIR intentionally does not exist yet — first run must create it.
+run_cold --execute >/dev/null
+[[ -d "$TMP_ROOT/cold/$MODEL" ]] || fail "model not moved to cold storage"
+[[ -L "$TMP_ROOT/hub/$MODEL" ]] || fail "cache symlink not created"
+[[ "$(readlink "$TMP_ROOT/hub/$MODEL")" == "$TMP_ROOT/cold/$MODEL" ]] || fail "symlink points to wrong target"
+pass "first-run archive moves model and leaves a symlink"
+
+info "Test 2: re-running --execute skips the already-archived symlink"
+run_cold --execute >/dev/null
+[[ -d "$TMP_ROOT/cold/$MODEL" && ! -d "$TMP_ROOT/cold/$MODEL/$MODEL" ]] || fail "re-run nested or duplicated the archive"
+pass "second run is idempotent"
+
+info "Test 3: --restore moves the model back and removes the symlink"
+run_cold --restore "Test/IdleModel" >/dev/null
+[[ -d "$TMP_ROOT/hub/$MODEL" && ! -L "$TMP_ROOT/hub/$MODEL" ]] || fail "model not restored as a real directory"
+[[ ! -e "$TMP_ROOT/cold/$MODEL" ]] || fail "cold copy still present after restore"
+pass "restore round-trip works"
+
+info "Test 4: archive fails loudly when the cold destination already exists"
+make_fixture
+mkdir -p "$TMP_ROOT/cold/$MODEL"
+echo "stale" > "$TMP_ROOT/cold/$MODEL/marker"
+set +e
+run_cold --execute >/dev/null 2>&1
+rc=$?
+set -e
+[[ $rc -ne 0 ]] || fail "expected non-zero exit when destination exists"
+[[ -d "$TMP_ROOT/hub/$MODEL" && ! -L "$TMP_ROOT/hub/$MODEL" ]] || fail "model should be left in place on failure"
+[[ -f "$TMP_ROOT/cold/$MODEL/marker" ]] || fail "existing cold entry must not be clobbered"
+grep -q "ERROR" "$TMP_ROOT/log/cold.log" || fail "failure not logged as ERROR"
+! grep -q "^.*ARCHIVED: $MODEL" "$TMP_ROOT/log/cold.log" || fail "failed archive must not log ARCHIVED"
+pass "destination collision is a reported failure, not a fake success"
+
+info "Test 5: restore refuses to overwrite a real directory in the cache"
+make_fixture
+run_cold --execute >/dev/null
+# Simulate a partial re-download: replace the symlink with a real directory.
+rm "$TMP_ROOT/hub/$MODEL"
+mkdir -p "$TMP_ROOT/hub/$MODEL"
+echo "partial" > "$TMP_ROOT/hub/$MODEL/partial.bin"
+set +e
+run_cold --restore "Test/IdleModel" >/dev/null 2>&1
+rc=$?
+set -e
+[[ $rc -ne 0 ]] || fail "expected non-zero exit when cache path is a real directory"
+[[ -d "$TMP_ROOT/cold/$MODEL" ]] || fail "cold copy must remain when restore is refused"
+[[ ! -d "$TMP_ROOT/hub/$MODEL/$MODEL" ]] || fail "restore must not nest into the existing directory"
+pass "restore refuses to nest into an existing directory"
+
+echo ""
+pass "All llm-cold-storage tests passed"


### PR DESCRIPTION
## Problem

`scripts/llm-cold-storage.sh` runs without `set -e` and never checks the results of its destructive operations:

1. The first `--execute` run fails but reports success because nothing creates `$COLD_DIR`.
2. A failed `ln -s` after a successful `mv` can strand the model outside the Hugging Face cache.
3. Moving into an existing destination nests directories instead of replacing or refusing the collision.
4. Integer-only age calculation unnecessarily depends on `bc`; when it is unavailable, archiving is silently disabled.

## Fix

- Create `$COLD_DIR` before real archive operations and fail visibly if it is unusable.
- Refuse destination collisions on archive and restore.
- Check every `mv`; roll the model back when symlink creation fails.
- Count failures and return non-zero if any operation fails.
- Use Bash arithmetic for the age calculation.

## Why this matters

Issue #3141 reproduces the production failure on a stock first run: the script logs `ARCHIVED`, increments the success count, and exits successfully even though the model never moved. False success on a destructive storage path can leave operators with neither reclaimed space nor a trustworthy recovery record.

Fixes #3141.

## Overlap check

Refreshed 2026-08-25. Searched open and closed PRs and issues for `llm-cold-storage`, `COLD_DIR`, archive/restore moves, and the changed production path `ods/scripts/llm-cold-storage.sh`. No merged equivalent or competing implementation was found. PR #1797 predates issue #3141 and its boundary tests reproduce the same first-run failure, so this PR is the canonical implementation for that report.

## Test plan

`tests/test-llm-cold-storage.sh`, wired into `make test`, exercises the public script boundary:

- first-run archive creates the cold directory, moves the model, and leaves a symlink;
- a second run is idempotent;
- restore completes a round trip;
- archive collision returns non-zero without a false `ARCHIVED` receipt;
- restore onto a real directory is refused and preserves the cold copy.

Validation already recorded on this head:

- all five focused tests pass on Linux/WSL (the first fails against upstream `main` with the reported missing-directory error);
- ShellCheck passes for the production script and regression test;
- the full GitHub Actions matrix is green, including Linux integration, distro and macOS smoke, PowerShell lint, dashboard, env validation, and secret scan.

## Compatibility and rollback

Dry-run behavior is unchanged. Existing archive layouts and restore syntax remain compatible. Reverting the PR restores the previous best-effort behavior but also restores the false-success and collision risks.