### PR TITLE
chore(rust): pin toolchain 1.97.1 and add mise rust tasks

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,60 @@
+[tools]
+actionlint = "1.7.12"
+"npm:bash-language-server" = "5.6.0"
+"pipx:basedpyright" = "1.39.9"
+pre-commit = "4.6.0"
+ruff = "0.15.22"
+shellcheck = "0.11.0"
+shfmt = "3.13.1"
+zizmor = "1.27.0"
+
+# Rust version is owned by rust-toolchain.toml (Mode A). mise = tasks only.
+
+[tasks."rust:doctor"]
+description = "Show Rust ownership and active toolchain"
+dir = "{{config_root}}"
+run = """
+#!/usr/bin/env bash
+set -euo pipefail
+echo "== rustup =="
+rustup show
+echo
+echo "== binaries =="
+type -a rustup rustc cargo rustfmt clippy-driver rust-analyzer 2>/dev/null || true
+echo
+echo "== versions =="
+rustc --version
+cargo --version
+echo
+echo "== cargo installs =="
+cargo install --list || true
+"""
+
+[tasks."rust:fmt"]
+description = "Format Tauri installer crate"
+dir = "{{config_root}}/installer/src-tauri"
+run = "cargo fmt --all"
+
+[tasks."rust:fmt-check"]
+description = "Check formatting for Tauri installer crate"
+dir = "{{config_root}}/installer/src-tauri"
+run = "cargo fmt --all -- --check"
+
+[tasks."rust:lint"]
+description = "Clippy Tauri installer crate"
+dir = "{{config_root}}/installer/src-tauri"
+run = "cargo clippy --all-targets --all-features -- -D warnings"
+
+[tasks."rust:check"]
+description = "cargo check Tauri installer crate"
+dir = "{{config_root}}/installer/src-tauri"
+run = "cargo check --all-targets --all-features --locked"
+
+[tasks."rust:test"]
+description = "cargo test Tauri installer crate"
+dir = "{{config_root}}/installer/src-tauri"
+run = "cargo test --all-features --locked"
+
+[tasks."rust:ci"]
+description = "fmt-check + lint + test for Tauri installer"
+depends = ["rust:fmt-check", "rust:lint", "rust:test"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Portable Rust pin for ODS (Mode A: rustup + rust-toolchain.toml).
+# mise owns tasks only; do not add a competing [tools].rust pin here.
+[toolchain]
+channel = "1.97.1"
+profile = "default"
+components = ["rustfmt", "clippy", "rust-src"]
+targets = ["aarch64-apple-darwin", "wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary
Adds portable Rust toolchain pinning and mise task runners for the Tauri installer path.

- Add `rust-toolchain.toml` pinned to **1.97.1** with rustfmt/clippy/rust-src and `wasm32-unknown-unknown`
- Add `mise.toml` `rust:*` tasks (`doctor`, `fmt`, `fmt-check`, `lint`, `check`, `test`, `ci`)
- Ownership model: **rust-toolchain.toml owns Rust version**; mise owns tasks only (no direnv/`.envrc`)

## Validation
- Host: rustc/cargo 1.97.1; `wasm32-unknown-unknown` installed
- `cargo check` in `installer/src-tauri` (with local `installer/dist` placeholder for Tauri `frontendDist`)
- `mise run rust:doctor` passes after `mise trust`

## Notes
- Pre-existing `dead_code` warnings in installer crate remain unchanged
- Duplicate machine Rust homes cleanup is intentionally deferred
- Direct push to `Osmantic/ODS` was denied for `dlynch90`; this PR is opened from fork `dlynch90/ODS`
- ODS v2.5.3 tag checkout shares this upstream; hygiene is proposed once against `main`

## Test plan
- [ ] CI green on this PR
- [ ] `mise trust` + `mise run rust:doctor` in a clean checkout
- [ ] `cargo check` in `installer/src-tauri` after frontend dist exists or placeholder is present

Co-Authored-By: Oz <oz-agent@warp.dev>