### PR TITLE
fix(host-agent): write the model-state record under ODS_DATA_DIR

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -194,6 +194,23 @@ _MODEL_TIERS = frozenset({
 _MIN_MODEL_CONTEXT = 1024
 _MAX_MODEL_CONTEXT = 9007199254740991
 
+
+def _model_state_path() -> Path:
+    """Location of the Model Switchboard state record.
+
+    Tracks DATA_DIR, not INSTALL_DIR/data: every reader resolves the record
+    under ODS_DATA_DIR — the model-router bind-mount in
+    docker-compose.base.yml and the dashboard-api state endpoint both do —
+    so a writer anchored to the install tree publishes where nothing reads.
+
+    DATA_DIR is only assigned once main() has parsed .env. Falling back to
+    the install-tree default keeps a caller that runs before that from
+    resolving a bare relative path and dropping the record into whatever
+    the working directory happens to be.
+    """
+    base = DATA_DIR if DATA_DIR != Path() else INSTALL_DIR / "data"
+    return base / "model-state.json"
+
 # Per-service locks to prevent concurrent start+stop races on the same service
 _service_locks: dict[str, threading.Lock] = collections.defaultdict(threading.Lock)
 _ALLOWED_CORE_RECREATE_IDS = frozenset({
@@ -8417,7 +8434,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                             (switchboard_run or {}).get("capabilities") or {}
                         )
                         _switchboard_state.record_verified_route(
-                            INSTALL_DIR / "data" / "model-state.json",
+                            _model_state_path(),
                             catalog_id=str(model_id),
                             runtime_model_id=verified_runtime_identity,
                             backend_kind=(
@@ -12499,14 +12516,6 @@ def main():
         logger.error("Neither ODS_AGENT_KEY nor DASHBOARD_API_KEY set in .env")
         sys.exit(1)
     GPU_BACKEND = env.get("GPU_BACKEND", "nvidia")
-    if _switchboard_state is not None:
-        try:
-            _switchboard_state.initialize_if_missing(
-                INSTALL_DIR / "data" / "model-state.json", env
-            )
-        except Exception as exc:
-            logger.warning("switchboard state init skipped: %s", exc)
-        _schedule_initial_switchboard_verification("startup")
     STARTUP_ODS_MODE = _normalize_ods_mode(env.get("ODS_MODE"))
     TIER = env.get("TIER", "1")
     GPU_COUNT = env.get("GPU_COUNT", "1")
@@ -12516,6 +12525,15 @@ def main():
         "ODS_USER_EXTENSIONS_DIR",
         str(DATA_DIR / "user-extensions"),
     ))
+    # Runs after DATA_DIR is resolved: the readers (router bind-mount,
+    # dashboard-api) locate the record under ODS_DATA_DIR, so the writer has
+    # to agree before anything is written.
+    if _switchboard_state is not None:
+        try:
+            _switchboard_state.initialize_if_missing(_model_state_path(), env)
+        except Exception as exc:
+            logger.warning("switchboard state init skipped: %s", exc)
+        _schedule_initial_switchboard_verification("startup")
     EXTENSIONS_DIR = INSTALL_DIR / "extensions" / "services"
     ODS_VERSION = env.get("ODS_VERSION", VERSION)
 

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -1776,7 +1776,7 @@ def load_env(env_path: Path) -> dict:
 
 
 def _switchboard_state_path() -> Path:
-    return INSTALL_DIR / "data" / "model-state.json"
+    return _model_state_path()
 
 
 def _switchboard_state_needs_initial_verification(path: Path) -> bool:

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -6644,3 +6645,62 @@ class TestObservabilityWire:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
+
+
+class TestModelStatePath:
+    """The switchboard state record must live where its readers look.
+
+    Readers resolve it under ODS_DATA_DIR: the model-router bind-mount
+    (docker-compose.base.yml, ``${ODS_DATA_DIR:-./data}/model-state.json``)
+    and the dashboard-api ``/api/models/state`` endpoint. A writer anchored to
+    INSTALL_DIR/data publishes where nothing reads.
+    """
+
+    def test_tracks_data_dir_when_ods_data_dir_is_relocated(self, tmp_path, monkeypatch):
+        install_dir = tmp_path / "ods"
+        data_dir = tmp_path / "elsewhere" / "ods-data"
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "DATA_DIR", data_dir)
+
+        assert _mod._model_state_path() == data_dir / "model-state.json"
+        # The install tree must not be used as a second, divergent location.
+        assert _mod._model_state_path() != install_dir / "data" / "model-state.json"
+
+    def test_matches_install_tree_on_the_default_layout(self, tmp_path, monkeypatch):
+        install_dir = tmp_path / "ods"
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "DATA_DIR", install_dir / "data")
+
+        assert _mod._model_state_path() == install_dir / "data" / "model-state.json"
+
+    def test_falls_back_to_the_install_tree_before_data_dir_is_parsed(self, tmp_path, monkeypatch):
+        """DATA_DIR is only assigned once main() has read .env.
+
+        Resolving against the unset module default would yield a bare
+        relative path and drop the record into the working directory.
+        """
+        install_dir = tmp_path / "ods"
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "DATA_DIR", Path())
+
+        assert _mod._model_state_path() == install_dir / "data" / "model-state.json"
+        assert _mod._model_state_path().is_absolute()
+
+    def test_no_writer_anchors_the_record_to_the_install_tree(self):
+        """Both writers must go through the helper.
+
+        The startup reconstruction and the post-activation record each built
+        ``INSTALL_DIR / "data" / "model-state.json"`` inline, which silently
+        diverged from every reader once ODS_DATA_DIR was set. The helper is
+        the one place allowed to name the install-tree fallback.
+        """
+        source = _agent_path.read_text(encoding="utf-8")
+        assert source.count('INSTALL_DIR / "data" / "model-state.json"') == 0
+        for writer in ("initialize_if_missing(", "record_verified_route("):
+            first_args = re.findall(
+                re.escape(writer) + r"\s*([^,\n)]+)", source
+            )
+            assert first_args, f"{writer} call site not found"
+            for call in first_args:
+                assert "INSTALL_DIR" not in call, f"{writer} still anchors to INSTALL_DIR"
+        assert source.count("_model_state_path()") >= 2


### PR DESCRIPTION
﻿## Problem

The Model Switchboard has one writer (the host agent) and several readers. The writer hardcoded the install tree; the readers all honour `ODS_DATA_DIR`.

Writer — `bin/ods-host-agent.py`, both sites built the path inline:
```python
_switchboard_state.initialize_if_missing(INSTALL_DIR / "data" / "model-state.json", env)
_switchboard_state.record_verified_route(INSTALL_DIR / "data" / "model-state.json", ...)
```

Readers:
| Reader | Path |
|---|---|
| model-router (bind-mount, `docker-compose.base.yml:315`) | `${ODS_DATA_DIR:-./data}/model-state.json` |
| dashboard-api `/api/models/state` (`routers/model_state.py:32`) | `os.environ.get("ODS_DATA_DIR") or DATA_DIR` |
| host agent itself, every other data path | `DATA_DIR` |

`ODS_DATA_DIR` is a supported, documented setting (`docs/HOST-AGENT-API.md:30`, "Data directory root"). When it points off the install tree, the writer publishes to a path nobody reads.

The router failure is the harsh one: its mount **source** no longer exists, so Docker creates a **directory** there. The container then gets a directory where it expects a file, `STATE_PATH.read_text()` raises `IsADirectoryError`, and the router answers `503 no_active_route` for the life of the install. `/health` keeps returning 200 throughout, so nothing restarts it.

## Fix

Route both writers through a `_model_state_path()` helper anchored to `DATA_DIR`.

Also moves startup reconstruction to **after** `DATA_DIR` is assigned — it previously ran ~8 lines earlier, while `DATA_DIR` was still the module-level `Path()` default, so the helper could not simply be dropped in at the old position.

## Verification

3 new tests in `TestModelStatePath`, all **red before the fix**:
- relocated `ODS_DATA_DIR` resolves under the data dir, not the install tree
- default layout still resolves to `<install>/data/model-state.json` (no behaviour change for standard installs)
- no call site anchors the record to the install tree (regression guard on the actual bug)

`test_host_agent.py`: 207 passed. The single failure (`test_activation_never_persists_blank_lemonade_model_during_restore`) reproduces on a clean `main` checkout here and is unrelated. `py_compile` clean.

## Why this matters

Installations that relocate `ODS_DATA_DIR` need the host-agent writer, dashboard reader, and container bind mount to agree on the model-state record or model activation status becomes stale or invisible.

## Overlap check

Triage refresh (2026-08-08): searched open and closed Osmantic/ODS PRs by semantic keywords (model state ODS_DATA_DIR), inspected the changed production files, and checked patch equivalence against current upstream/main. No strict duplicate or merged equivalent was found.

## Test plan

- [x] `pytest ods/extensions/services/dashboard-api/tests/test_host_agent.py`
