### PR TITLE
test: isolate host-agent activation fixtures

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2767,6 +2767,9 @@ class TestModelActivationModeAndMacosBridge:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        # This bridge-focused fixture must not discover or restart a managed
+        # OpenCode instance from the developer host.
+        monkeypatch.setattr(_mod, "_capture_opencode_config", lambda: None)
         monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(_mod, "_require_macos_bridge_manager", record_preflight)
         monkeypatch.setattr(_mod, "_stop_macos_native_llama_server", record_stop)
@@ -2938,6 +2941,9 @@ class TestModelActivationLemonadePersistence:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        # Keep the Lemonade persistence transaction isolated from any real
+        # OpenCode configuration installed on the test host.
+        monkeypatch.setattr(_mod, "_capture_opencode_config", lambda: None)
         monkeypatch.setattr(
             _mod,
             "_resolve_lemonade_model_id",


### PR DESCRIPTION
## Summary

- isolate two model-activation fixtures from any OpenCode configuration installed on the developer host
- preserve the production LiteLLM dependency guard and managed OpenCode restart behavior
- make the dashboard API suite deterministic on machines that already run ODS OpenCode

## Root cause

The bridge and Lemonade persistence tests did not own an OpenCode fixture. On a configured workstation, `_capture_opencode_config()` discovered the real host configuration. The tests then attempted to restart the host OpenCode service or classified it as an active Lemonade consumer, failing before reaching the behavior they intended to verify.

Both fixtures now explicitly declare that OpenCode is outside their scope. Dedicated OpenCode activation tests continue covering configuration updates, restart ordering, LiteLLM readiness, and rollback behavior.

## Validation

- both failures reproduced on untouched `origin/main`
- focused pair before fix: 2 failed
- focused pair after fix: 2 passed
- complete dashboard API suite: 1,692 passed, 1 existing warning
- `make -C ods lint`: passed
- `git diff --check`: passed

## Risk

Test-only change. Production activation, rollback, LiteLLM dependency, and OpenCode restart code is unchanged.

