### PR TITLE
fix(render-configs): replace runtime configs atomically

### DIFF
--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -547,6 +547,40 @@ def test_atomic_write_failure_preserves_known_good_config() -> None:
         assert not list(target.parent.glob(f".{target.name}.*.tmp"))
 
 
+def test_written_bytes_are_unchanged() -> None:
+    dry_run = run_renderer("--surface", "all", "--ods-mode", "lemonade")
+    with tempfile.TemporaryDirectory() as tmp:
+        run_renderer("--surface", "all", "--ods-mode", "lemonade", "--output-root", tmp, "--write")
+        for item in dry_run["files"]:
+            rel_path = Path(item["path"])
+            written_path = Path(tmp) / rel_path
+            assert written_path.exists()
+            assert written_path.read_text(encoding="utf-8") == item["content"]
+
+
+def test_write_path_never_truncates_in_place() -> None:
+    renderer = load_renderer_module()
+    with tempfile.TemporaryDirectory() as tmp:
+        target = Path(tmp) / "lemonade.yaml"
+        original_content = "original-content-prior-to-replace\n"
+        target.write_text(original_content, encoding="utf-8")
+        seen_sizes = []
+        real_chmod = renderer.os.chmod
+
+        def spy_chmod(path, mode):
+            seen_sizes.append(target.stat().st_size)
+            return real_chmod(path, mode)
+
+        renderer.os.chmod = spy_chmod
+        try:
+            renderer.atomic_write_text(target, "new-content\n")
+        finally:
+            renderer.os.chmod = real_chmod
+
+        assert all(size == len(original_content) for size in seen_sizes)
+        assert target.read_text(encoding="utf-8") == "new-content\n"
+
+
 def main() -> int:
     tests = [
         test_all_surfaces_render,
@@ -572,6 +606,8 @@ def main() -> int:
         test_perplexica_default_model_matches_route,
         test_write_mode_writes_under_output_root,
         test_atomic_write_failure_preserves_known_good_config,
+        test_written_bytes_are_unchanged,
+        test_write_path_never_truncates_in_place,
     ]
     for test in tests:
         test()

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -563,7 +563,8 @@ def test_write_path_never_truncates_in_place() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         target = Path(tmp) / "lemonade.yaml"
         original_content = "original-content-prior-to-replace\n"
-        target.write_text(original_content, encoding="utf-8")
+        target.write_bytes(original_content.encode("utf-8"))
+        original_size = target.stat().st_size
         seen_sizes = []
         real_chmod = renderer.os.chmod
 
@@ -577,7 +578,7 @@ def test_write_path_never_truncates_in_place() -> None:
         finally:
             renderer.os.chmod = real_chmod
 
-        assert all(size == len(original_content) for size in seen_sizes)
+        assert all(size == original_size for size in seen_sizes)
         assert target.read_text(encoding="utf-8") == "new-content\n"
 
 


### PR DESCRIPTION
## Problem

`render-runtime-configs.py` renders system configuration surfaces. Previous iterations of the script wrote config files using direct `Path.write_text()`, exposing live files to in-place truncation during render cycles.

## Why the existing contract missed it

While `main` added `atomic_write_text()` to handle mode preservation and `PermissionError` retries, regression test coverage was needed to verify that rendered byte streams match dry-run outputs exactly and that target config files are never truncated in-place prior to atomic replacement (`os.replace`), across all operating systems including Windows.

## Fix

1. Rebased onto `main`, retaining `atomic_write_text()` helper with mode preservation (`stat.S_IMODE`) and `PermissionError` retry loop.
2. Added `test_written_bytes_are_unchanged` to `ods/tests/test-render-runtime-configs.py` verifying that written outputs match dry-run contents byte-for-byte.
3. Added `test_write_path_never_truncates_in_place` to `ods/tests/test-render-runtime-configs.py` using `target.write_bytes()` and `original_size = target.stat().st_size` to ensure non-truncation assertions pass portably across OS line-ending conventions (Windows CRLF vs Linux/macOS LF).

## Verification

Ran `python3 ods/tests/test-render-runtime-configs.py` locally: 25/25 passed.