### PR TITLE
fix(stability): replace Hermes config and session writes atomically

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -10,7 +10,9 @@ the rest of the user's config.
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import tempfile
 from pathlib import Path
 
 
@@ -275,7 +277,19 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(updated)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return True
 
 

--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -283,6 +283,17 @@ def patch_config(
             f.write(updated)
             f.flush()
             os.fsync(f.fileno())
+        if path.exists():
+            try:
+                st = os.stat(path)
+                os.chmod(tmp_path, st.st_mode)
+                if hasattr(os, "chown"):
+                    try:
+                        os.chown(tmp_path, st.st_uid, st.st_gid)
+                    except OSError:
+                        pass
+            except OSError:
+                pass
         os.replace(tmp_path, str(path))
     except BaseException:
         try:

--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -152,17 +152,28 @@ if [ -n "$WIPE_IDS" ]; then
 
     for ID in $WIPE_IDS; do
         "$PYTHON_CMD" -c "
-import json, sys
+import json, sys, os, tempfile
 sessions_file = sys.argv[1]
 target_id = sys.argv[2]
-with open(sessions_file, 'r') as f:
+with open(sessions_file, 'r', encoding='utf-8') as f:
     data = json.load(f)
 to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get('sessionId') == target_id]
 for k in to_remove:
     del data[k]
     print(f'  Removed session key: {k}', file=sys.stderr)
-with open(sessions_file, 'w') as f:
-    json.dump(data, f, indent=2)
+fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(sessions_file), suffix='.tmp')
+try:
+    with os.fdopen(fd, 'w', encoding='utf-8') as f:
+        json.dump(data, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, sessions_file)
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 " "$SESSIONS_JSON" "$ID" 2>&1
     done
 

--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -167,6 +167,17 @@ try:
         json.dump(data, f, indent=2)
         f.flush()
         os.fsync(f.fileno())
+    if os.path.exists(sessions_file):
+        try:
+            st = os.stat(sessions_file)
+            os.chmod(tmp_path, st.st_mode)
+            if hasattr(os, 'chown'):
+                try:
+                    os.chown(tmp_path, st.st_uid, st.st_gid)
+                except OSError:
+                    pass
+        except OSError:
+            pass
     os.replace(tmp_path, sessions_file)
 except BaseException:
     try:

--- a/ods/tests/test-session-cleanup.sh
+++ b/ods/tests/test-session-cleanup.sh
@@ -246,6 +246,38 @@ else
 fi
 
 # ============================================================================
+# Test 11: Mode metadata is preserved across atomic replacement
+# ============================================================================
+MODE_DIR="$TEMP_DIR/mode_test"
+mkdir -p "$MODE_DIR"
+cat > "$MODE_DIR/sessions.json" <<'EOF'
+{
+  "session1": { "sessionId": "bloated-mode", "createdAt": "2024-01-01T00:00:00Z" }
+}
+EOF
+cat > "$MODE_DIR/bloated-mode.jsonl" <<'EOF'
+line1
+EOF
+# Truncate and write > 10 bytes to trigger cleanup with MAX_SIZE=5
+head -c 20 /dev/zero > "$MODE_DIR/bloated-mode.jsonl"
+chmod 0640 "$MODE_DIR/sessions.json"
+
+SESSIONS_DIR="$MODE_DIR" MAX_SIZE=5 bash "$SESSION_CLEANUP_SCRIPT" >/dev/null 2>&1 || true
+
+# Stat check portable: macOS vs Linux
+if [ "$(uname -s)" = "Darwin" ]; then
+    AFTER_MODE=$(stat -f "%Lp" "$MODE_DIR/sessions.json" 2>/dev/null || echo "")
+else
+    AFTER_MODE=$(stat -c "%a" "$MODE_DIR/sessions.json" 2>/dev/null || echo "")
+fi
+
+if [[ "$AFTER_MODE" == "640" ]]; then
+    pass "Mode metadata (0640) preserved across atomic sessions.json replacement"
+else
+    fail "Mode metadata not preserved (expected 640, got $AFTER_MODE)"
+fi
+
+# ============================================================================
 # Summary
 # ============================================================================
 echo ""


### PR DESCRIPTION
## Problem

In `ods/scripts/patch-hermes-config.py` and `ods/scripts/session-cleanup.sh`, config and session file updates previously used in-place writes or temporary files created with default `mkstemp` umask permissions (0600), which discarded target file mode permissions (`chmod`) and ownership (`chown`) during atomic replacement.

## Why the existing contract missed it

Atomic replacement via `os.replace(tmp_path, target)` creates a new inode with the permissions of `tmp_path`, so target permissions and ownership metadata were lost if not read and reapplied to `tmp_path` prior to replacement.

## Fix

1. Update `patch-hermes-config.py` and `session-cleanup.sh` to read existing file stat metadata (`st = os.stat(path)`) prior to replacement and preserve mode (`chmod`) and owner/group (`chown`) on `tmp_path`.
2. Clean up temporary files on exceptions in both write paths.

## Verification

Added regression tests (Test 11) to `ods/tests/test-session-cleanup.sh` verifying mode preservation (0640) across atomic replacement. Ran `bash ods/tests/test-session-cleanup.sh` locally: 16/16 passed. Tested `patch-hermes-config.py`: syntax and execution verified.