### PR TITLE
fix(security): write generated API key files atomically

### DIFF
--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -15,7 +15,9 @@ if not DASHBOARD_API_KEY:
     DASHBOARD_API_KEY = secrets.token_urlsafe(32)
     key_file = Path("/data/dashboard-api-key.txt")
     key_file.parent.mkdir(parents=True, exist_ok=True)
-    key_file.write_text(DASHBOARD_API_KEY)
+    tmp_key_file = key_file.with_name(f".{key_file.name}.tmp")
+    tmp_key_file.write_text(DASHBOARD_API_KEY)
+    os.replace(str(tmp_key_file), str(key_file))
     key_file.chmod(0o600)
     logger.warning(
         "DASHBOARD_API_KEY not set. Generated temporary key and wrote to %s (mode 0600). "

--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -17,8 +17,8 @@ if not DASHBOARD_API_KEY:
     key_file.parent.mkdir(parents=True, exist_ok=True)
     tmp_key_file = key_file.with_name(f".{key_file.name}.tmp")
     tmp_key_file.write_text(DASHBOARD_API_KEY)
+    tmp_key_file.chmod(0o600)
     os.replace(str(tmp_key_file), str(key_file))
-    key_file.chmod(0o600)
     logger.warning(
         "DASHBOARD_API_KEY not set. Generated temporary key and wrote to %s (mode 0600). "
         "Set DASHBOARD_API_KEY in your .env file for production.", key_file

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -275,7 +275,9 @@ if not TOKEN_SPY_API_KEY:
     except FileNotFoundError:
         TOKEN_SPY_API_KEY = secrets.token_urlsafe(32)
         _key_file.parent.mkdir(parents=True, exist_ok=True)
-        _key_file.write_text(TOKEN_SPY_API_KEY)
+        tmp_key_file = _key_file.with_name(f".{_key_file.name}.tmp")
+        tmp_key_file.write_text(TOKEN_SPY_API_KEY)
+        os.replace(str(tmp_key_file), str(_key_file))
         _key_file.chmod(0o600)
         log.warning(
             "TOKEN_SPY_API_KEY not set. Generated key and wrote to %s (mode 0600).",

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -277,8 +277,8 @@ if not TOKEN_SPY_API_KEY:
         _key_file.parent.mkdir(parents=True, exist_ok=True)
         tmp_key_file = _key_file.with_name(f".{_key_file.name}.tmp")
         tmp_key_file.write_text(TOKEN_SPY_API_KEY)
+        tmp_key_file.chmod(0o600)
         os.replace(str(tmp_key_file), str(_key_file))
-        _key_file.chmod(0o600)
         log.warning(
             "TOKEN_SPY_API_KEY not set. Generated key and wrote to %s (mode 0600).",
             _key_file,


### PR DESCRIPTION
## Summary

Prevent in-place truncation when generating fallback API keys for Dashboard API and Token Spy.

Previously, both services generated a fallback API key when the corresponding environment variable was not set and wrote it directly to disk using `Path.write_text()`. Since this truncates the destination file before writing the new content, an interrupted write could leave the key file empty or partially written, preventing subsequent startups from using a valid persisted key.

This change updates both key generation paths to use atomic file replacement:

- `dashboard-api`
  - Writes the generated `dashboard-api-key.txt` to a temporary file in the target directory.
  - Atomically replaces the destination using `os.replace()`.

- `token-spy`
  - Writes the generated `token-spy-api-key.txt` to a temporary file in the target directory.
  - Atomically replaces the destination using `os.replace()`.

As a result, the persisted API key is always either the complete previous value or the complete newly generated value, avoiding partially written or truncated key files.

## Verification

Verified using the existing Python test suites:

- `python3 -m pytest -v ods/extensions/services/dashboard-api/tests/test_security.py`
  - **6 passed**

- `python3 -m pytest -v ods/extensions/services/token-spy/tests/test_usage_report.py`
  - **11 passed**

- `make lint`
  - Passed.