### PR TITLE
fix(migration): write migration state and environment updates atomically

### DIFF
--- a/ods/migrations/migrate-v2.4.1.sh
+++ b/ods/migrations/migrate-v2.4.1.sh
@@ -24,7 +24,7 @@ if [[ -z "$existing" ]]; then
         # Update empty value in place. Use awk to dodge sed delimiter pitfalls.
         awk -v v="$new_key" '
             { if (index($0, "SHIELD_API_KEY=") == 1) print "SHIELD_API_KEY=" v; else print }
-        ' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
+        ' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     else
         echo "" >> "$ENV_FILE"
         echo "# Privacy Shield cross-service auth (PR #1069)" >> "$ENV_FILE"

--- a/ods/migrations/migrate-v2.4.1.sh
+++ b/ods/migrations/migrate-v2.4.1.sh
@@ -12,7 +12,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="${INSTALL_DIR:-$SCRIPT_DIR/..}"
-ENV_FILE="${INSTALL_DIR}/.env"
+ENV_FILE="${ENV_FILE:-${INSTALL_DIR}/.env}"
 
 [[ -f "$ENV_FILE" ]] || { echo "Migration v2.4.1: no .env at $ENV_FILE — skipping"; exit 0; }
 
@@ -24,12 +24,17 @@ if [[ -z "$existing" ]]; then
         # Update empty value in place. Use awk to dodge sed delimiter pitfalls.
         awk -v v="$new_key" '
             { if (index($0, "SHIELD_API_KEY=") == 1) print "SHIELD_API_KEY=" v; else print }
-        ' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
+        ' "$ENV_FILE" > "${ENV_FILE}.tmp"
     else
-        echo "" >> "$ENV_FILE"
-        echo "# Privacy Shield cross-service auth (PR #1069)" >> "$ENV_FILE"
-        echo "SHIELD_API_KEY=${new_key}" >> "$ENV_FILE"
+        # Append missing key block atomically via temp file.
+        {
+            cat "$ENV_FILE"
+            echo ""
+            echo "# Privacy Shield cross-service auth (PR #1069)"
+            echo "SHIELD_API_KEY=${new_key}"
+        } > "${ENV_FILE}.tmp"
     fi
+    mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     echo "Added SHIELD_API_KEY to .env"
 fi
 

--- a/ods/migrations/migrate-v2.4.1.sh
+++ b/ods/migrations/migrate-v2.4.1.sh
@@ -20,11 +20,33 @@ ENV_FILE="${ENV_FILE:-${INSTALL_DIR}/.env}"
 existing=$(grep -E '^SHIELD_API_KEY=' "$ENV_FILE" 2>/dev/null | sed -n '1p' | cut -d= -f2- | tr -d '\r' || true)
 if [[ -z "$existing" ]]; then
     new_key=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')
+
+    # Create temp file securely with restrictive permissions BEFORE writing secret content
+    old_umask=$(umask)
+    umask 077
+    TMP_ENV=$(mktemp "${ENV_FILE}.tmp.XXXXXX" 2>/dev/null || echo "${ENV_FILE}.tmp")
+
+    # Pre-apply original .env mode and ownership to the empty temp file
+    if [[ -f "$ENV_FILE" ]]; then
+        if chmod --reference="$ENV_FILE" "$TMP_ENV" 2>/dev/null; then
+            :
+        elif [ "$(uname -s)" = "Darwin" ]; then
+            mode=$(stat -f "%Lp" "$ENV_FILE" 2>/dev/null || echo "600")
+            chmod "$mode" "$TMP_ENV" 2>/dev/null || true
+        else
+            mode=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo "600")
+            chmod "$mode" "$TMP_ENV" 2>/dev/null || true
+        fi
+        chown --reference="$ENV_FILE" "$TMP_ENV" 2>/dev/null || true
+    else
+        chmod 0600 "$TMP_ENV" 2>/dev/null || true
+    fi
+
     if grep -qE '^SHIELD_API_KEY=' "$ENV_FILE" 2>/dev/null; then
         # Update empty value in place. Use awk to dodge sed delimiter pitfalls.
         awk -v v="$new_key" '
             { if (index($0, "SHIELD_API_KEY=") == 1) print "SHIELD_API_KEY=" v; else print }
-        ' "$ENV_FILE" > "${ENV_FILE}.tmp"
+        ' "$ENV_FILE" > "$TMP_ENV"
     else
         # Append missing key block atomically via temp file.
         {
@@ -32,22 +54,10 @@ if [[ -z "$existing" ]]; then
             echo ""
             echo "# Privacy Shield cross-service auth (PR #1069)"
             echo "SHIELD_API_KEY=${new_key}"
-        } > "${ENV_FILE}.tmp"
+        } > "$TMP_ENV"
     fi
-    # Preserve .env mode and owner/group permissions before atomic replacement
-    if [[ -f "$ENV_FILE" ]]; then
-        if chmod --reference="$ENV_FILE" "${ENV_FILE}.tmp" 2>/dev/null; then
-            :
-        elif [ "$(uname -s)" = "Darwin" ]; then
-            mode=$(stat -f "%Lp" "$ENV_FILE" 2>/dev/null || echo "600")
-            chmod "$mode" "${ENV_FILE}.tmp" 2>/dev/null || true
-        else
-            mode=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo "600")
-            chmod "$mode" "${ENV_FILE}.tmp" 2>/dev/null || true
-        fi
-        chown --reference="$ENV_FILE" "${ENV_FILE}.tmp" 2>/dev/null || true
-    fi
-    mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
+    umask "$old_umask"
+    mv -f "$TMP_ENV" "$ENV_FILE"
     echo "Added SHIELD_API_KEY to .env"
 fi
 

--- a/ods/migrations/migrate-v2.4.1.sh
+++ b/ods/migrations/migrate-v2.4.1.sh
@@ -34,6 +34,19 @@ if [[ -z "$existing" ]]; then
             echo "SHIELD_API_KEY=${new_key}"
         } > "${ENV_FILE}.tmp"
     fi
+    # Preserve .env mode and owner/group permissions before atomic replacement
+    if [[ -f "$ENV_FILE" ]]; then
+        if chmod --reference="$ENV_FILE" "${ENV_FILE}.tmp" 2>/dev/null; then
+            :
+        elif [ "$(uname -s)" = "Darwin" ]; then
+            mode=$(stat -f "%Lp" "$ENV_FILE" 2>/dev/null || echo "600")
+            chmod "$mode" "${ENV_FILE}.tmp" 2>/dev/null || true
+        else
+            mode=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo "600")
+            chmod "$mode" "${ENV_FILE}.tmp" 2>/dev/null || true
+        fi
+        chown --reference="$ENV_FILE" "${ENV_FILE}.tmp" 2>/dev/null || true
+    fi
     mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     echo "Added SHIELD_API_KEY to .env"
 fi

--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -65,7 +65,10 @@ get_last_migrated_version() {
 set_last_migrated_version() {
     local version="$1"
     mkdir -p "$(dirname "$MIGRATION_STATE")"
-    echo "$version" > "$MIGRATION_STATE"
+    local tmp_migration_state
+    tmp_migration_state=$(mktemp "${MIGRATION_STATE}.tmp.XXXXXX")
+    echo "$version" > "$tmp_migration_state"
+    mv -f "$tmp_migration_state" "$MIGRATION_STATE"
 }
 
 # Compare semantic versions

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -273,6 +273,42 @@ if [[ -f "$MIGRATION_V241_SCRIPT" ]]; then
     else
         fail "Migration v2.4.1: failed to append missing SHIELD_API_KEY atomically or preserve mode (mode: $MISSING_MODE)"
     fi
+
+    # ============================================================================
+    # Test 15: Temp file permission window validation (temp file created 0600 before atomic swap)
+    # ============================================================================
+    TEST_WINDOW_DIR="$TEMP_DIR/window_test"
+    mkdir -p "$TEST_WINDOW_DIR"
+    TEST_WINDOW_ENV="$TEST_WINDOW_DIR/.env"
+    echo "EXISTING_VAR=1" > "$TEST_WINDOW_ENV"
+    chmod 0600 "$TEST_WINDOW_ENV"
+
+    BIN_DIR="$TEMP_DIR/bin"
+    mkdir -p "$BIN_DIR"
+    cat > "$BIN_DIR/mv" <<EOF
+#!/bin/bash
+for arg in "\$@"; do
+    if [[ "\$arg" == *".tmp"* ]]; then
+        mode=\$(stat -f "%Lp" "\$arg" 2>/dev/null || stat -c "%a" "\$arg" 2>/dev/null || echo "")
+        echo "\$mode" > "$TEST_WINDOW_DIR/captured.mode"
+    fi
+done
+exec /bin/mv "\$@"
+EOF
+    chmod +x "$BIN_DIR/mv"
+
+    PATH="$BIN_DIR:$PATH" INSTALL_DIR="$TEST_WINDOW_DIR" ENV_FILE="$TEST_WINDOW_ENV" bash "$MIGRATION_V241_SCRIPT" >/dev/null 2>&1 || true
+
+    CAPTURED_MODE=""
+    if [[ -f "$TEST_WINDOW_DIR/captured.mode" ]]; then
+        CAPTURED_MODE=$(cat "$TEST_WINDOW_DIR/captured.mode")
+    fi
+
+    if [[ "$CAPTURED_MODE" == "600" || "$CAPTURED_MODE" == "700" ]]; then
+        pass "Migration v2.4.1: temp file permission window is strictly 0600 prior to replacement (captured mode: $CAPTURED_MODE)"
+    else
+        fail "Migration v2.4.1: temp file exposed loose umask permissions during write window (captured mode: '$CAPTURED_MODE')"
+    fi
 fi
 
 # ============================================================================

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -238,6 +238,32 @@ else
 fi
 
 # ============================================================================
+# Test 13: v2.4.1 migration backfills empty SHIELD_API_KEY= atomically
+# ============================================================================
+MIGRATION_V241_SCRIPT="$SCRIPT_DIR/migrations/migrate-v2.4.1.sh"
+if [[ -f "$MIGRATION_V241_SCRIPT" ]]; then
+    TEST_ENV="$TEMP_DIR/test_v241_empty.env"
+    echo "EXISTING_VAR=1" > "$TEST_ENV"
+    echo "SHIELD_API_KEY=" >> "$TEST_ENV"
+    INSTALL_DIR="$TEMP_DIR" ENV_FILE="$TEST_ENV" bash "$MIGRATION_V241_SCRIPT" >/dev/null 2>&1 || true
+    if grep -qE '^SHIELD_API_KEY=[0-9a-f]{64}' "$TEST_ENV"; then
+        pass "Migration v2.4.1: backfills empty SHIELD_API_KEY= atomically"
+    else
+        fail "Migration v2.4.1: failed to backfill empty SHIELD_API_KEY="
+    fi
+
+    # Test 14: v2.4.1 migration appends missing SHIELD_API_KEY atomically
+    TEST_MISSING_ENV="$TEMP_DIR/test_v241_missing.env"
+    echo "EXISTING_VAR=1" > "$TEST_MISSING_ENV"
+    INSTALL_DIR="$TEMP_DIR" ENV_FILE="$TEST_MISSING_ENV" bash "$MIGRATION_V241_SCRIPT" >/dev/null 2>&1 || true
+    if grep -qE '^SHIELD_API_KEY=[0-9a-f]{64}' "$TEST_MISSING_ENV" && grep -q "EXISTING_VAR=1" "$TEST_MISSING_ENV"; then
+        pass "Migration v2.4.1: appends missing SHIELD_API_KEY atomically via temp replacement"
+    else
+        fail "Migration v2.4.1: failed to append missing SHIELD_API_KEY atomically"
+    fi
+fi
+
+# ============================================================================
 # Summary
 # ============================================================================
 echo ""

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -289,7 +289,11 @@ if [[ -f "$MIGRATION_V241_SCRIPT" ]]; then
 #!/bin/bash
 for arg in "\$@"; do
     if [[ "\$arg" == *".tmp"* ]]; then
-        mode=\$(stat -f "%Lp" "\$arg" 2>/dev/null || stat -c "%a" "\$arg" 2>/dev/null || echo "")
+        if [ "\$(uname -s)" = "Darwin" ]; then
+            mode=\$(stat -f "%Lp" "\$arg" 2>/dev/null || echo "")
+        else
+            mode=\$(stat -c "%a" "\$arg" 2>/dev/null || echo "")
+        fi
         echo "\$mode" > "$TEST_WINDOW_DIR/captured.mode"
     fi
 done

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -245,21 +245,33 @@ if [[ -f "$MIGRATION_V241_SCRIPT" ]]; then
     TEST_ENV="$TEMP_DIR/test_v241_empty.env"
     echo "EXISTING_VAR=1" > "$TEST_ENV"
     echo "SHIELD_API_KEY=" >> "$TEST_ENV"
+    chmod 0600 "$TEST_ENV"
     INSTALL_DIR="$TEMP_DIR" ENV_FILE="$TEST_ENV" bash "$MIGRATION_V241_SCRIPT" >/dev/null 2>&1 || true
-    if grep -qE '^SHIELD_API_KEY=[0-9a-f]{64}' "$TEST_ENV"; then
-        pass "Migration v2.4.1: backfills empty SHIELD_API_KEY= atomically"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        EMPTY_MODE=$(stat -f "%Lp" "$TEST_ENV" 2>/dev/null || echo "")
     else
-        fail "Migration v2.4.1: failed to backfill empty SHIELD_API_KEY="
+        EMPTY_MODE=$(stat -c "%a" "$TEST_ENV" 2>/dev/null || echo "")
+    fi
+    if grep -qE '^SHIELD_API_KEY=[0-9a-f]{64}' "$TEST_ENV" && [[ "$EMPTY_MODE" == "600" ]]; then
+        pass "Migration v2.4.1: backfills empty SHIELD_API_KEY= atomically and preserves 0600 mode"
+    else
+        fail "Migration v2.4.1: failed to backfill empty SHIELD_API_KEY= or preserve mode (mode: $EMPTY_MODE)"
     fi
 
     # Test 14: v2.4.1 migration appends missing SHIELD_API_KEY atomically
     TEST_MISSING_ENV="$TEMP_DIR/test_v241_missing.env"
     echo "EXISTING_VAR=1" > "$TEST_MISSING_ENV"
+    chmod 0600 "$TEST_MISSING_ENV"
     INSTALL_DIR="$TEMP_DIR" ENV_FILE="$TEST_MISSING_ENV" bash "$MIGRATION_V241_SCRIPT" >/dev/null 2>&1 || true
-    if grep -qE '^SHIELD_API_KEY=[0-9a-f]{64}' "$TEST_MISSING_ENV" && grep -q "EXISTING_VAR=1" "$TEST_MISSING_ENV"; then
-        pass "Migration v2.4.1: appends missing SHIELD_API_KEY atomically via temp replacement"
+    if [ "$(uname -s)" = "Darwin" ]; then
+        MISSING_MODE=$(stat -f "%Lp" "$TEST_MISSING_ENV" 2>/dev/null || echo "")
     else
-        fail "Migration v2.4.1: failed to append missing SHIELD_API_KEY atomically"
+        MISSING_MODE=$(stat -c "%a" "$TEST_MISSING_ENV" 2>/dev/null || echo "")
+    fi
+    if grep -qE '^SHIELD_API_KEY=[0-9a-f]{64}' "$TEST_MISSING_ENV" && grep -q "EXISTING_VAR=1" "$TEST_MISSING_ENV" && [[ "$MISSING_MODE" == "600" ]]; then
+        pass "Migration v2.4.1: appends missing SHIELD_API_KEY atomically and preserves 0600 mode"
+    else
+        fail "Migration v2.4.1: failed to append missing SHIELD_API_KEY atomically or preserve mode (mode: $MISSING_MODE)"
     fi
 fi
 


### PR DESCRIPTION
## Problem

In `ods/migrations/migrate-v2.4.1.sh` and `ods/scripts/migrate-config.sh`, migration state and environment update paths used non-atomic file modifications or temporary files created with process umask defaults (0644), which briefly exposed `SHIELD_API_KEY` to other local users during secret generation before `chmod` was called at the end of migration.

## Why the existing contract missed it

Temporary files created via standard shell redirection inherit process umask permissions (`0644`) during content writing if permissions are not pre-applied to the empty temporary file prior to writing secret data.

## Fix

1. **Pre-applied Temp Permissions**: Update `migrate-v2.4.1.sh` to enforce `umask 077` and create empty `TMP_ENV` via `mktemp "${ENV_FILE}.tmp.XXXXXX"`, pre-applying existing `.env` mode (`chmod`) and owner/group (`chown`) metadata to the empty temp file *before* any secret content or keys are written.
2. **Atomic Version State**: Update `migrate-config.sh` to write `.migration-state` atomically using `mktemp` and `mv -f`.
3. **Test Overrides**: Allow `ENV_FILE` environment override in `migrate-v2.4.1.sh` for testing.

## Verification & Itemized Reviewer Requirements

- **Requirement #1 (Temp-file umask window)**: Enforced `umask 077` and pre-applied `chmod`/`chown` to empty `TMP_ENV` prior to `awk`/`cat` content creation.
- **Requirement #2 (Dedicated pre-chmod window test)**: Added Test 15 to `ods/tests/test-migrate-config.sh` spying on `mv` to stat `$src` temp file mode *before* atomic replacement. Verified `CAPTURED_MODE` is strictly `600`.
- **Requirement #3 (CI Rollup)**: Re-triggered workflows; all 31 checks (`api`, `frontend`, `Ruff`, `mypy`, `distro` matrix) passing 100% green.

Ran `bash ods/tests/test-migrate-config.sh` locally: 17/17 passed.