### PR TITLE
fix(stability): write extensions catalog and SOUL.md context atomically

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import socket
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 # Service-id → (display name, one-line "what it does and how the user
@@ -410,7 +412,19 @@ def build_soul(
     previous = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
     if previous == assembled:
         return False
-    output_path.write_text(assembled, encoding="utf-8")
+    fd, tmp_path = tempfile.mkstemp(dir=str(output_path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(assembled)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(output_path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return True
 
 

--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -163,7 +165,19 @@ def main() -> None:
     }
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    fd, tmp_path = tempfile.mkstemp(dir=str(output_path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(output_path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
     print(f"Generated catalog with {len(entries)} extensions at {output_path}")
 


### PR DESCRIPTION
## Summary

Prevent in-place truncation when generating the extensions catalog and installation context.

Previously, both `generate-extensions-catalog.py` and `build-installation-context.py` wrote their output directly using `Path.write_text()`. Since this truncates the destination file before writing the new content, an interrupted write could leave the generated file incomplete or empty.

This change updates both write paths to use atomic file replacement:

- `generate-extensions-catalog.py`
  - Writes the generated `extensions-catalog.json` to a temporary file in the destination directory.
  - Flushes the file with `fsync()`.
  - Atomically replaces the destination using `os.replace()`.

- `build-installation-context.py`
  - Writes the generated `SOUL.md` to a temporary file in the destination directory.
  - Flushes the file with `fsync()`.
  - Atomically replaces the destination using `os.replace()`.

As a result, consumers of these generated artifacts always observe either the complete previous file or the complete newly generated file, avoiding partially written or truncated output if a write is interrupted.

## Verification

Verified using the project's existing checks:

- `make lint`
  - Passed.