### PR TITLE
fix(stability): write preflight report atomically

### DIFF
--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -82,8 +82,10 @@ fi
 
 "$PYTHON_CMD" - "$REPORT_FILE" "$TIER" "$RAM_GB" "$DISK_GB" "$GPU_BACKEND" "$GPU_VRAM_MB" "$GPU_NAME" "$PLATFORM_ID" "$COMPOSE_OVERLAYS" "$SCRIPT_DIR" "$ENV_MODE" "$STRICT" <<'PY'
 import json
+import os
 import pathlib
 import sys
+import tempfile
 from datetime import datetime, timezone
 
 (
@@ -344,7 +346,19 @@ report = {
 
 report_path = pathlib.Path(report_file)
 report_path.parent.mkdir(parents=True, exist_ok=True)
-report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+fd, tmp_path = tempfile.mkstemp(dir=str(report_path.parent), suffix=".tmp")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(json.dumps(report, indent=2) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, str(report_path))
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 
 if env_mode:
     def out(key, value):


### PR DESCRIPTION
## Summary

Prevent in-place truncation when writing the preflight assessment report.

Previously, `preflight-engine.sh` generated `data/preflight-report.json` by writing directly to the destination file using `Path.write_text()`. Since this truncates the file before writing the new contents, an interrupted write could leave the report incomplete or empty.

The preflight report is consumed by later installation phases to determine installation behavior, so preserving a consistent report across updates is important.

This change updates the report generation path to use atomic file replacement:

- Writes the generated JSON report to a temporary file in the destination directory.
- Flushes the file and synchronizes it to disk with `fsync()`.
- Atomically replaces the destination using `os.replace()`.

As a result, readers always observe either the complete previous report or the complete newly generated report, avoiding partially written or truncated output if the write is interrupted.

## Verification

Verified using the existing test suites:

- `bash ods/tests/test-preflight-resolver-bug.sh`
  - Passed

- `bash ods/tests/test-preflight-dashboard-port.sh`
  - Passed

- `make lint`
  - Passed.