### PR TITLE
fix(dashboard-api): guard null metric values in service resources calculation

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -164,9 +164,9 @@ async def service_resources(api_key: str = Depends(verify_api_key)):
                 "disk": disk,
             })
 
-    total_cpu = sum(s.get("cpu_percent", 0) for s in container_stats)
-    total_mem = sum(s.get("memory_used_mb", 0) for s in container_stats)
-    total_disk = sum(d.get("data_gb", 0) for d in disk_usage.values())
+    total_cpu = sum(s.get("cpu_percent") or 0 for s in container_stats)
+    total_mem = sum(s.get("memory_used_mb") or 0 for s in container_stats)
+    total_disk = sum(d.get("data_gb") or 0 for d in disk_usage.values())
 
     return {
         "services": services,

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -355,3 +355,25 @@ class TestServiceResources:
             "/v1/service/restart",
             {"service_id": "dashboard-api", "delay_seconds": 1},
         )
+
+    def test_null_metrics_in_stats_do_not_crash_resource_totals(self, test_client, monkeypatch):
+        """Container stats or disk payloads containing None values for metrics do not cause TypeError."""
+        self._clear_resource_cache()
+        monkeypatch.setattr("routers.resources.SERVICES", {"llama-server": {"name": "Llama Server"}})
+        monkeypatch.setattr("routers.resources.GPU_BACKEND", "nvidia")
+
+        fake_stats = [{"service_id": "llama-server", "cpu_percent": None, "memory_used_mb": None}]
+        fake_disk = {"llama-server": {"data_gb": None}}
+
+        with patch("routers.resources._fetch_container_stats", return_value=fake_stats), \
+             patch("routers.resources._scan_service_disk", return_value=fake_disk):
+            resp = test_client.get(
+                "/api/services/resources",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"]["cpu_percent"] == 0
+        assert data["totals"]["memory_used_mb"] == 0
+        assert data["totals"]["disk_data_gb"] == 0


### PR DESCRIPTION
## Problem

In `service_resources()` (`routers/resources.py`), total resource metrics are calculated across all container and disk stats using generators passed to `sum()`:

```python
total_cpu = sum(s.get("cpu_percent", 0) for s in container_stats)
total_mem = sum(s.get("memory_used_mb", 0) for s in container_stats)
total_disk = sum(d.get("data_gb", 0) for d in disk_usage.values())
```

`dict.get("key", 0)` returns `None` when a container stat payload or disk entry explicitly contains `"cpu_percent": None`, `"memory_used_mb": None`, or `"data_gb": None` (e.g. during container initialization or host agent polling transients).

Passing `None` to `sum()` raises an unhandled exception:

```python
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```

This causes requests to `GET /api/services/resources` to crash with HTTP 500.

## Fix

Update the metric sum expressions to fallback to `0` when a key value evaluates to `None`:

```python
total_cpu = sum(s.get("cpu_percent") or 0 for s in container_stats)
total_mem = sum(s.get("memory_used_mb") or 0 for s in container_stats)
total_disk = sum(d.get("data_gb") or 0 for d in disk_usage.values())
```

## Threat model (honest scoping)

This is a defensive robustness fix for transient container status payloads. When container stats or disk scans return explicit `None` metric values, the endpoint now falls back to `0` instead of breaking the dashboard resources API.

## Verification

Added unit test in `tests/test_resources.py`:

- `test_null_metrics_in_stats_do_not_crash_resource_totals`
  - Verifies `GET /api/services/resources` returns HTTP 200 with zero totals when metric dictionaries contain explicit `None` values.

- `pytest tests/test_resources.py` passed (21 passed in 0.84s).
