### PR TITLE
fix(dashboard-api): support dictionary objects in Token Spy service lookup

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -182,12 +182,21 @@ async def _token_spy_service_status() -> dict[str, Any] | None:
 
 def _find_token_spy_service(services: list[Any] | None) -> dict[str, Any] | None:
     for service in services or []:
-        if getattr(service, "id", None) == TOKEN_SPY_SERVICE_ID:
+        service_id = service.get("id") if isinstance(service, dict) else getattr(service, "id", None)
+        if service_id == TOKEN_SPY_SERVICE_ID:
             return _service_status_to_dict(service)
     return None
 
 
 def _service_status_to_dict(service: Any) -> dict[str, Any]:
+    if isinstance(service, dict):
+        return {
+            "id": service.get("id"),
+            "name": service.get("name"),
+            "status": service.get("status"),
+            "port": service.get("port"),
+            "external_port": service.get("external_port", service.get("port")),
+        }
     return {
         "id": service.id,
         "name": service.name,

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -500,3 +500,18 @@ def test_usage_token_spy_key_falls_back_to_shared_data_file(tmp_path, monkeypatc
     monkeypatch.setattr(usage_router, "TOKEN_SPY_KEY_FILE", key_file)
 
     assert usage_router._token_spy_api_key() == "file-key"
+
+
+def test_find_token_spy_service_supports_dict_objects():
+    import routers.usage as usage_router
+
+    dict_services = [
+        {"id": "open-webui", "name": "Open WebUI", "status": "healthy", "port": 3000},
+        {"id": "token-spy", "name": "Token Spy", "status": "healthy", "port": 8088},
+    ]
+
+    res = usage_router._find_token_spy_service(dict_services)
+
+    assert res is not None
+    assert res["id"] == "token-spy"
+    assert res["status"] == "healthy"


### PR DESCRIPTION
## Problem

In `_find_token_spy_service()` (`routers/usage.py`), the Token Spy service status entry is extracted from the service health list using attribute access:

```python
def _find_token_spy_service(services: list[Any] | None) -> dict[str, Any] | None:
    for service in services or []:
        if getattr(service, "id", None) == TOKEN_SPY_SERVICE_ID:
            return _service_status_to_dict(service)
    return None
```

When `services` contains dictionary representations of service health statuses (e.g. from serialized status caches or external providers), `getattr(service, "id", None)` returns `None` because dictionary keys are not object attributes.

Additionally, `_service_status_to_dict(service)` accessed properties directly (`service.id`, `service.name`), raising `AttributeError` when passed a dictionary.

As a result, Token Spy service health status lookups failed whenever the status list contained dictionary objects.

## Fix

Update `_find_token_spy_service()` and `_service_status_to_dict()` to handle both object models and dictionary representations:

```python
def _find_token_spy_service(services: list[Any] | None) -> dict[str, Any] | None:
    for service in services or []:
        service_id = service.get("id") if isinstance(service, dict) else getattr(service, "id", None)
        if service_id == TOKEN_SPY_SERVICE_ID:
            return _service_status_to_dict(service)
    return None


def _service_status_to_dict(service: Any) -> dict[str, Any]:
    if isinstance(service, dict):
        return {
            "id": service.get("id"),
            "name": service.get("name"),
            "status": service.get("status"),
            "port": service.get("port"),
            "external_port": service.get("external_port", service.get("port")),
        }
    return {
        "id": service.id,
        "name": service.name,
        "status": service.status,
        "port": service.port,
        "external_port": getattr(service, "external_port", service.port),
    }
```

## Threat model (honest scoping)

This is a defensive normalization fix. If service status objects in the health cache are serialized as dictionaries, `_find_token_spy_service()` now resolves the service ID and status correctly instead of failing silently.

## Verification

Added unit test in `tests/test_usage.py`:

- `test_find_token_spy_service_supports_dict_objects`
  - Verifies that `_find_token_spy_service()` matches and formats `token-spy` when passed dictionary service representations.

- `pytest tests/test_usage.py` passed (21 passed in 0.55s).
