### PR TITLE
fix(windows): strip matched quote pairs when parsing env values in generator

### DIFF
--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -180,9 +180,19 @@ function Set-WindowsODSLemonadeModelConfiguration {
     }
     Write-Utf8NoBom -Path $envPath -Content $envContent
 
+function Strip-MatchedQuotePair {
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+    $v = $Value.Trim()
+    if ($v.Length -ge 2 -and (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'")))) {
+        return $v.Substring(1, $v.Length - 2)
+    }
+    return $v
+}
+
     if ([string]::IsNullOrWhiteSpace($Port)) {
         $portMatch = [regex]::Match($envContent, '(?m)^AMD_INFERENCE_PORT=([^\r\n]*)')
-        if ($portMatch.Success) { $Port = $portMatch.Groups[1].Value.Trim().Trim('"').Trim("'") }
+        if ($portMatch.Success) { $Port = Strip-MatchedQuotePair $portMatch.Groups[1].Value }
     }
     $parsedPort = 0
     if (-not [int]::TryParse($Port, [ref]$parsedPort) -or $parsedPort -lt 1 -or $parsedPort -gt 65535) {
@@ -191,7 +201,7 @@ function Set-WindowsODSLemonadeModelConfiguration {
 
     if ([string]::IsNullOrWhiteSpace($ApiKey)) {
         $keyMatch = [regex]::Match($envContent, '(?m)^LITELLM_LEMONADE_API_KEY=([^\r\n]*)')
-        if ($keyMatch.Success) { $ApiKey = $keyMatch.Groups[1].Value.Trim().Trim('"').Trim("'") }
+        if ($keyMatch.Success) { $ApiKey = Strip-MatchedQuotePair $keyMatch.Groups[1].Value }
     }
     if ([string]::IsNullOrWhiteSpace($ApiKey)) { $ApiKey = "not-needed" }
 

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -180,14 +180,16 @@ function Set-WindowsODSLemonadeModelConfiguration {
     }
     Write-Utf8NoBom -Path $envPath -Content $envContent
 
-function Strip-MatchedQuotePair {
-    param([string]$Value)
-    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
-    $v = $Value.Trim()
-    if ($v.Length -ge 2 -and (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'")))) {
-        return $v.Substring(1, $v.Length - 2)
+if (-not (Get-Command Strip-MatchedQuotePair -ErrorAction SilentlyContinue)) {
+    function Strip-MatchedQuotePair {
+        param([string]$Value)
+        if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+        $v = $Value.Trim()
+        if ($v.Length -ge 2 -and (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'")))) {
+            return $v.Substring(1, $v.Length - 2)
+        }
+        return $v
     }
-    return $v
 }
 
     if ([string]::IsNullOrWhiteSpace($Port)) {

--- a/ods/installers/windows/lib/llm-endpoint.ps1
+++ b/ods/installers/windows/lib/llm-endpoint.ps1
@@ -6,6 +6,21 @@
 #          Docker-backed NVIDIA/CPU installs and native AMD backends.
 # ============================================================================
 
+function Strip-MatchedQuotePair {
+    <#
+    .SYNOPSIS
+        Strip exactly one matching pair of surrounding quotes ("..." or '...').
+        Mismatched quotes and inner quote pairs are preserved verbatim.
+    #>
+    param([string]$Value)
+    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
+    $v = $Value.Trim()
+    if ($v.Length -ge 2 -and (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'")))) {
+        return $v.Substring(1, $v.Length - 2)
+    }
+    return $v
+}
+
 function Get-WindowsODSEnvMap {
     <#
     .SYNOPSIS
@@ -32,19 +47,7 @@ function Get-WindowsODSEnvMap {
             if ($line -match "^#" -or $line -eq "") { return }
             if ($line -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
                 $key = $Matches[1]
-                $val = $Matches[2]
-                # Strip exactly one matching pair of surrounding quotes.
-                # Trimming each quote character independently corrupts values
-                # that legitimately start or end with the other quote: a
-                # double-quoted "'literal'" loses its inner single quotes and
-                # KEY="'" collapses to empty. Mismatched quotes are kept
-                # verbatim, matching lib/safe-env.sh on Linux.
-                if ($val.Length -ge 2 -and (
-                        ($val.StartsWith('"') -and $val.EndsWith('"')) -or
-                        ($val.StartsWith("'") -and $val.EndsWith("'")))) {
-                    $val = $val.Substring(1, $val.Length - 2)
-                }
-                $result[$key] = $val
+                $result[$key] = Strip-MatchedQuotePair $Matches[2]
             }
         }
     } catch {

--- a/ods/tests/test-windows-llm-endpoint.sh
+++ b/ods/tests/test-windows-llm-endpoint.sh
@@ -252,6 +252,36 @@ finally {
     Remove-Item -LiteralPath $envFixture -Force -ErrorAction SilentlyContinue
 }
 
+# --- Set-WindowsODSLemonadeModelConfiguration & Strip-MatchedQuotePair quote handling ---
+$lemonadeTestDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ods-lemonade-test-" + [System.IO.Path]::GetRandomFileName())
+New-Item -ItemType Directory -Path $lemonadeTestDir | Out-Null
+$lemonadeEnv = Join-Path $lemonadeTestDir ".env"
+@'
+AMD_INFERENCE_PORT="8085"
+LITELLM_LEMONADE_API_KEY="'secret-key'"
+'@ | Set-Content -LiteralPath $lemonadeEnv -Encoding Ascii
+
+try {
+    $res = Set-WindowsODSLemonadeModelConfiguration -InstallDir $lemonadeTestDir -ModelId "test-model"
+    $yamlContent = Get-Content -LiteralPath $res.LiteLlmConfigPath -Raw
+    if ($yamlContent -notmatch "api_base: http://127.0.0.1:8085/api/v1") {
+        throw "Set-WindowsODSLemonadeModelConfiguration failed to parse quoted AMD_INFERENCE_PORT"
+    }
+    if ($yamlContent -notmatch "api_key: 'secret-key'") {
+        throw "Set-WindowsODSLemonadeModelConfiguration failed to preserve inner quotes in LITELLM_LEMONADE_API_KEY"
+    }
+
+    # Verify Strip-MatchedQuotePair preservation cases
+    if ((Strip-MatchedQuotePair '"hello"') -ne "hello") { throw "Strip-MatchedQuotePair double quote fail" }
+    if ((Strip-MatchedQuotePair "'hello'") -ne "hello") { throw "Strip-MatchedQuotePair single quote fail" }
+    if ((Strip-MatchedQuotePair '"''literal''"') -ne "'literal'") { throw "Strip-MatchedQuotePair inner quote fail" }
+    if ((Strip-MatchedQuotePair 'trailing"') -ne 'trailing"') { throw "Strip-MatchedQuotePair mismatched quote fail" }
+
+    Write-Host "[PASS] Set-WindowsODSLemonadeModelConfiguration & Strip-MatchedQuotePair quote handling"
+} finally {
+    Remove-Item -LiteralPath $lemonadeTestDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
 Write-Host "[PASS] Windows local LLM endpoint resolver"
 PS_EOF
 


### PR DESCRIPTION
## Problem

In PowerShell `env-generator.ps1`, `$Port` and `$ApiKey` values extracted from `$envContent` were cleaned using string method chaining:

```powershell
$Port = $portMatch.Groups[1].Value.Trim().Trim('"').Trim("'")
$ApiKey = $keyMatch.Groups[1].Value.Trim().Trim('"').Trim("'")
```

PowerShell's `.Trim('"').Trim("'")` removes all instances of double and single quote characters from both ends indiscriminately. This causes:
- Inner quote pairs to be destroyed (e.g. `'KEY="'` collapses to empty or `'KEY="'literal'"'` loses inner single quotes)
- Mismatched or unclosed quotes to be stripped unexpectedly
- Inconsistent parsing compared to the matched quote pair contract on Linux (`lib/safe-env.sh`), Windows (`compose-diagnostics.ps1`), and macOS (`ods-macos.sh`).

## Fix

Introduce a dedicated `Strip-MatchedQuotePair` helper function in PowerShell:

```powershell
function Strip-MatchedQuotePair {
    param([string]$Value)
    if ([string]::IsNullOrWhiteSpace($Value)) { return "" }
    $v = $Value.Trim()
    if ($v.Length -ge 2 -and (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'")))) {
        return $v.Substring(1, $v.Length - 2)
    }
    return $v
}
```

And update `$Port` and `$ApiKey` parsing in `env-generator.ps1` to use `Strip-MatchedQuotePair`.

## Threat model (honest scoping)

This is a parsing correctness and environment round-trip parity fix. It ensures that environment values containing internal quotes or single quotes round-trip consistently across Windows PowerShell env generators.

## Verification

- `tests/test-tier-map.sh` / contract validations pass cleanly.
- Verified `Strip-MatchedQuotePair` strips matching `"..."` and `'...'` pairs while preserving inner single quotes and mismatched quotes verbatim.
