### PR TITLE
fix(host-agent): strip only matched quote pairs when loading env file

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -952,6 +952,13 @@ def _normalize_model_download_status(status_path: Path, data: dict) -> dict:
         return {"status": "idle"}
 
 
+def _strip_env_quotes(value: str) -> str:
+    v = value.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in {"'", '"'}:
+        return v[1:-1]
+    return v
+
+
 def load_env(env_path: Path) -> dict:
     """Parse .env file, return dict of key=value pairs."""
     env = {}
@@ -963,7 +970,7 @@ def load_env(env_path: Path) -> dict:
             continue
         if "=" in line:
             key, _, val = line.partition("=")
-            env[key.strip()] = val.strip().strip("'\"")
+            env[key.strip()] = _strip_env_quotes(val)
     return env
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5819,3 +5819,20 @@ class TestObservabilityWire:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
+
+
+def test_load_env_strips_only_matched_quote_pairs(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("\n".join([
+        'QUOTED_DOUBLE="value_with_\'single\'_quotes"',
+        "QUOTED_SINGLE='value_with_\"double\"_quotes'",
+        'MISMATCHED="mismatched\'',
+        'PLAIN=plain_value',
+    ]), encoding="utf-8")
+
+    parsed = _mod.load_env(env_file)
+
+    assert parsed["QUOTED_DOUBLE"] == "value_with_'single'_quotes"
+    assert parsed["QUOTED_SINGLE"] == 'value_with_"double"_quotes'
+    assert parsed["MISMATCHED"] == '"mismatched\''
+    assert parsed["PLAIN"] == "plain_value"


### PR DESCRIPTION
## Problem

In `load_env()` (`ods-host-agent.py`), `.env` key-value pairs are extracted using `val.strip().strip("'\"")`:

```python
key, _, val = line.partition("=")
env[key.strip()] = val.strip().strip("'\"")
```

Python's `str.strip("'\"")` removes all runs of single and double quote characters from both ends indiscriminately. This causes:
- Inner quote pairs to be destroyed (e.g., `KEY="'value'"` is stripped down to `value`, destroying inner single quotes)
- Mismatched or unclosed quotes to be stripped unexpectedly
- Parsing divergence compared to the matched quote pair contract enforced on Linux (`lib/safe-env.sh`), Windows, and macOS (`dashboard-api`).

## Fix

Introduce `_strip_env_quotes()` to strip only matching surrounding quote pairs (`"..."` or `'...'`), leaving inner and mismatched quotes intact:

```python
def _strip_env_quotes(value: str) -> str:
    v = value.strip()
    if len(v) >= 2 and v[0] == v[-1] and v[0] in {"'", '"'}:
        return v[1:-1]
    return v
```

And update `load_env()` to use `_strip_env_quotes(val)`.

## Threat model (honest scoping)

This is a defensive environment round-trip parity fix. It ensures host agent `.env` parsing round-trips identically with the rest of the ecosystem when values contain embedded quotes.

## Verification

Added unit test in `tests/test_host_agent.py`:

- `test_load_env_strips_only_matched_quote_pairs`
  - Verifies double-quoted values preserve inner single quotes, single-quoted values preserve inner double quotes, and mismatched quotes stay verbatim.

- `pytest tests/test_host_agent.py -k test_load_env_strips_only_matched_quote_pairs` passed (1 passed in 0.34s).
