### PR TITLE
fix(mdns): strip only matched quote pairs when reading env file

### DIFF
--- a/ods/bin/ods-mdns.py
+++ b/ods/bin/ods-mdns.py
@@ -96,6 +96,13 @@ POLL_INTERVAL = _safe_positive_int_env("ODS_MDNS_POLL_INTERVAL", 30)
 _HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$")
 
 
+def _strip_env_quotes(value: str) -> str:
+    v = value.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in {"'", '"'}:
+        return v[1:-1]
+    return v
+
+
 def _read_env() -> dict[str, str]:
     """Return current .env values, ignoring comments and blank lines."""
     if not ENV_FILE.is_file():
@@ -106,7 +113,7 @@ def _read_env() -> dict[str, str]:
         if not stripped or stripped.startswith("#") or "=" not in stripped:
             continue
         key, _, value = stripped.partition("=")
-        env[key.strip()] = value.strip().strip('"').strip("'")
+        env[key.strip()] = _strip_env_quotes(value)
     return env
 
 

--- a/ods/tests/test_mdns_subdomains.py
+++ b/ods/tests/test_mdns_subdomains.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MDNS_SCRIPT = REPO_ROOT / "bin" / "ods-mdns.py"
@@ -97,3 +99,39 @@ if __name__ == "__main__":
     test_announcer_publishes_all_required_subdomains()
     test_announcer_does_not_advertise_unknown_subdomains()
     print("OK")
+
+
+def test_strip_env_quotes_preserves_inner_and_mismatched_quotes() -> None:
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("ods_mdns", MDNS_SCRIPT)
+    mdns = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mdns)
+
+    assert mdns._strip_env_quotes('"hello"') == "hello"
+    assert mdns._strip_env_quotes("'hello'") == "hello"
+    assert mdns._strip_env_quotes('"\'device\'"') == "'device'"
+    assert mdns._strip_env_quotes('trailing"') == 'trailing"'
+    assert mdns._strip_env_quotes('"') == '"'
+
+
+def test_read_env_strips_matched_quotes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib.util
+
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        'ODS_DEVICE_NAME="\'my-device\'"\n'
+        'MISMATCHED_VAL=val"\n'
+        'PLAIN_VAL=plain\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("ODS_INSTALL_DIR", str(tmp_path))
+
+    spec = importlib.util.spec_from_file_location("ods_mdns", MDNS_SCRIPT)
+    mdns = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mdns)
+
+    env = mdns._read_env()
+    assert env["ODS_DEVICE_NAME"] == "'my-device'"
+    assert env["MISMATCHED_VAL"] == 'val"'
+    assert env["PLAIN_VAL"] == "plain"


### PR DESCRIPTION
## Problem

In `_read_env()` (`ods-mdns.py`), `.env` key-value pairs are extracted using `value.strip().strip('"').strip("'")`:

```python
key, _, value = stripped.partition("=")
env[key.strip()] = value.strip().strip('"').strip("'")
```

Python's `str.strip()` chaining removes all runs of single and double quote characters from both ends indiscriminately. This causes:
- Inner quote pairs to be destroyed (e.g. `ODS_DEVICE_NAME="'device'"` is stripped down to `device`, destroying inner single quotes)
- Mismatched or unclosed quotes to be stripped unexpectedly
- Inconsistent environment parsing compared to the matched quote pair contract enforced on Linux (`lib/safe-env.sh`), Windows (`compose-diagnostics.ps1`), and macOS (`ods-macos.sh`).

## Fix

Introduce `_strip_env_quotes()` to strip only matching surrounding quote pairs (`"..."` or `'...'`), leaving inner and mismatched quotes intact:

```python
def _strip_env_quotes(value: str) -> str:
    v = value.strip()
    if len(v) >= 2 and v[0] == v[-1] and v[0] in {"'", '"'}:
        return v[1:-1]
    return v
```

And update `_read_env()` to use `_strip_env_quotes(value)`.

## Threat model (honest scoping)

This is a defensive environment parsing parity fix. It ensures that `.env` settings read by mDNS publisher service round-trip identically across platforms without stripping internal quote characters.

## Verification

- Verified `_strip_env_quotes()` strips matching `"..."` and `'...'` pairs while leaving inner quotes and mismatched quotes verbatim.
- Verified mDNS service script initializes cleanly.
