### PR TITLE
fix(dashboard): stop the usage sparkline losing the month you came from

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.history.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.history.test.jsx
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import Usage from './Usage' // eslint-disable-line no-unused-vars
+
+// The sparkline history store is keyed by period and read back per period, so
+// navigating between months must not drop the month you came from.
+const STORAGE_KEY = 'ods-usage-summary-history-v1'
+const MAY = '2026-05-01:2026-05-31'
+const APRIL = '2026-04-01:2026-04-30'
+
+function reportFor(start, end, spend) {
+  return {
+    period: { start, end },
+    source: { name: 'token-spy', status: 'ok', detail: null },
+    summary: {
+      spend_usd: spend,
+      requests: spend * 10,
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+      total_tokens: spend * 100,
+      tracked_providers: 1,
+      billing_providers: 1,
+      local_providers: 0,
+      untracked_providers: 0,
+      paid_cost_usd: spend,
+      local_cost_usd: 0,
+    },
+    daily: [],
+    models: [],
+    services: [],
+    sources: [],
+  }
+}
+
+function installFetchMock() {
+  let call = 0
+  vi.stubGlobal('fetch', vi.fn(async (url) => {
+    const text = String(url)
+    if (text.includes('/api/usage/readiness')) {
+      return { ok: true, json: async () => ({ status: 'ready', actions: {} }) }
+    }
+    const params = new URLSearchParams(text.split('?')[1] || '')
+    call += 1
+    return {
+      ok: true,
+      json: async () => reportFor(params.get('start'), params.get('end'), call),
+    }
+  }))
+}
+
+function storedPeriods() {
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return []
+  return [...new Set(JSON.parse(raw).filter(Boolean).map(item => item.period))].sort()
+}
+
+describe('Usage sparkline history retention', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date'] })
+    vi.setSystemTime(new Date('2026-05-16T12:00:00Z'))
+    window.localStorage.setItem(STORAGE_KEY, '[]')
+    installFetchMock()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    window.localStorage.clear()
+  })
+
+  it('keeps the current month when the selector moves to the previous one', async () => {
+    render(<Usage status={{}} />)
+    await waitFor(() => expect(storedPeriods()).toEqual([MAY]))
+
+    fireEvent.click(screen.getByLabelText('Previous month'))
+
+    await waitFor(() => expect(storedPeriods()).toContain(APRIL))
+    expect(storedPeriods()).toEqual([APRIL, MAY])
+  })
+
+  it('still has the original month after navigating back to it', async () => {
+    render(<Usage status={{}} />)
+    await waitFor(() => expect(storedPeriods()).toEqual([MAY]))
+
+    fireEvent.click(screen.getByLabelText('Previous month'))
+    await waitFor(() => expect(storedPeriods()).toContain(APRIL))
+    fireEvent.click(screen.getByLabelText('Next month'))
+    await waitFor(() => expect(storedPeriods()).toEqual([APRIL, MAY]))
+
+    const may = JSON.parse(window.localStorage.getItem(STORAGE_KEY))
+      .filter(item => item.period === MAY)
+    expect(may.length).toBeGreaterThan(1)
+  })
+
+  it('ages out samples older than 24h in every period', async () => {
+    const stale = Date.parse('2026-05-16T12:00:00Z') - 25 * 60 * 60 * 1000
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([
+      { ts: stale, period: APRIL, spend_usd: 9, total_tokens: 0, requests: 0, tracked_providers: 0 },
+      { ts: stale, period: MAY, spend_usd: 8, total_tokens: 0, requests: 0, tracked_providers: 0 },
+    ]))
+
+    render(<Usage status={{}} />)
+
+    await waitFor(() => expect(storedPeriods()).toEqual([MAY]))
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY))).toHaveLength(1)
+  })
+
+  it('renders when storage holds a malformed entry', async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify([null, 'nope']))
+
+    render(<Usage status={{}} />)
+
+    await waitFor(() => expect(screen.getByText('Usage')).toBeInTheDocument())
+    await waitFor(() => expect(storedPeriods()).toEqual([MAY]))
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -202,13 +202,18 @@ function buildSparkShape(values, width = 126, height = 46) {
 }
 
 const USAGE_HISTORY_KEY = 'ods-usage-summary-history-v1'
+// Per-period sparkline depth, and an overall guard so the entry never grows
+// without limit once several periods share the store.
+const HISTORY_SAMPLES_PER_PERIOD = 240
+const HISTORY_SAMPLES_TOTAL = 960
 let memoryUsageHistory = []
 
 function readUsageHistory() {
   if (typeof window === 'undefined') return memoryUsageHistory
   try {
     const raw = window.localStorage?.getItem(USAGE_HISTORY_KEY)
-    return raw ? JSON.parse(raw) : memoryUsageHistory
+    const parsed = raw ? JSON.parse(raw) : memoryUsageHistory
+    return Array.isArray(parsed) ? parsed.filter(Boolean) : memoryUsageHistory
   } catch {
     return memoryUsageHistory
   }
@@ -242,16 +247,24 @@ function usageSampleFromReport(report) {
 function appendUsageHistory(report) {
   const sample = usageSampleFromReport(report)
   const cutoff = Date.now() - 24 * 60 * 60 * 1000
-  const samples = readUsageHistory()
-    .filter(item => item && item.ts >= cutoff && item.period === sample.period)
+  // Age out everything first, then split by period. Samples belonging to other
+  // periods are carried through untouched: the store is keyed by period (the
+  // month selector reads it back that way), so persisting only the period we
+  // just fetched would erase the sparkline history of the month the user
+  // navigated away from.
+  const live = readUsageHistory().filter(item => item && item.ts >= cutoff)
+  const samples = live.filter(item => item.period === sample.period)
+  const others = live.filter(item => item.period !== sample.period)
   const previous = samples[samples.length - 1]
   const changed = !previous ||
     previous.spend_usd !== sample.spend_usd ||
     previous.total_tokens !== sample.total_tokens ||
     previous.requests !== sample.requests ||
     previous.tracked_providers !== sample.tracked_providers
-  const next = changed ? [...samples, sample].slice(-240) : samples
-  writeUsageHistory(next)
+  const next = changed
+    ? [...samples, sample].slice(-HISTORY_SAMPLES_PER_PERIOD)
+    : samples
+  writeUsageHistory([...others, ...next].slice(-HISTORY_SAMPLES_TOTAL))
   return next
 }
 
@@ -266,7 +279,9 @@ function useUsageReport(range, reloadToken = 0) {
   const [report, setReport] = useState(() => emptyReport(range.start, range.end))
   const [previousReport, setPreviousReport] = useState(null)
   const [readiness, setReadiness] = useState(EMPTY_READINESS)
-  const [history, setHistory] = useState(() => readUsageHistory().filter(item => item.period === `${range.start}:${range.end}`))
+  const [history, setHistory] = useState(
+    () => readUsageHistory().filter(item => item.period === `${range.start}:${range.end}`),
+  )
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
 


### PR DESCRIPTION
## Problem

`appendUsageHistory()` narrowed the stored samples to the period it had just fetched and wrote **that** back as the whole store:

```js
const samples = readUsageHistory()
  .filter(item => item && item.ts >= cutoff && item.period === sample.period)
...
writeUsageHistory(next)
```

`localStorage['ods-usage-summary-history-v1']` is a single array covering every period, and the page reads it back per period — `useUsageReport` seeds its state with

```js
useState(() => readUsageHistory().filter(item => item.period === `${range.start}:${range.end}`))
```

So the reader expects several periods to coexist while the writer keeps exactly one.

**What the user sees:** click ◀ on the month selector and the month you were just looking at is deleted from storage. The Cost Estimate / Tokens / Requests sparklines lose their live signal and `seriesFromHistory` silently falls back to the report's daily series, so the tile stops showing how the number actually moved during the session. Navigate back and forth and you never accumulate history for either month.

The page polls both the current and previous month every 10s but only appends the current one, so this fires on every month switch, not just an unusual one.

## Fix

Age everything out by the 24h cutoff first, then split: samples for the fetched period get the new sample appended, samples for other periods are carried through untouched.

`appendUsageHistory` still returns only the fetched period's samples, so `setHistory` and the sparklines are unchanged.

Per-period depth stays at 240; an overall cap keeps the entry bounded now that several periods can share it.

**Also**: the store is parsed straight out of `localStorage`, and a malformed entry made `useUsageReport`'s initial `item.period` lookup throw *during render* — the Usage page went blank rather than starting from an empty history. `readUsageHistory` now drops non-array / falsy entries.

## Verification

`src/pages/Usage.history.test.jsx` drives the real page through the month selector (no test-only exports — it asserts against `localStorage` directly). 4 cases, **3 red before the fix**:

```
× keeps the current month when the selector moves to the previous one
  expected [ '2026-04-01:2026-04-30' ] to deeply equal
           [ '2026-04-01:2026-04-30', '2026-05-01:2026-05-31' ]
× still has the original month after navigating back to it
  expected [ '2026-05-01:2026-05-31' ] to deeply equal
           [ '2026-04-01:2026-04-30', '2026-05-01:2026-05-31' ]
× renders when storage holds a malformed entry
```

The fourth case (24h ageing applied across every period) passes before and after — it guards the fix against over-keeping.

Dashboard suite: **222 passed (24 files)**. `npm run lint` clean, production compile clean.
