### PR TITLE
fix(config): strip matched quote pairs and allow leading whitespace in env file reader

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -93,11 +93,18 @@ def _find_env_file_value(key: str) -> tuple[bool, str]:
     env_path = Path(INSTALL_DIR) / ".env"
     found = False
     value = ""
+    prefix = f"{key}="
     try:
         for line in env_path.read_text(encoding="utf-8").splitlines():
-            if line.startswith(f"{key}="):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith(prefix):
                 found = True
-                value = line.split("=", 1)[1].strip().strip("\"'")
+                val = stripped.split("=", 1)[1].strip()
+                if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
+                    val = val[1:-1]
+                value = val
     except (OSError, UnicodeError):
         pass
     return found, value

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -67,6 +67,16 @@ def test_live_env_value_preserves_explicit_empty_value(monkeypatch, tmp_path):
     assert config.read_live_env_value("LEMONADE_MODEL", "fallback") == ""
 
 
+def test_live_env_value_handles_leading_whitespace_and_matched_quotes(monkeypatch, tmp_path):
+    (tmp_path / ".env").write_text(
+        "  LLM_MODEL=\"'llama-3.2-1b'\"\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(config, "INSTALL_DIR", str(tmp_path))
+
+    assert config.read_live_env_value("LLM_MODEL") == "'llama-3.2-1b'"
+
+
 class TestReadManifestFile:
 
     def test_reads_yaml(self, tmp_path):


### PR DESCRIPTION
## Problem

In `_find_env_file_value()` (`config.py`), `.env` key-value pairs are read using `if line.startswith(f"{key}=")` and cleaned via `line.split("=", 1)[1].strip().strip("\"'")`:

```python
for line in env_path.read_text(encoding="utf-8").splitlines():
    if line.startswith(f"{key}="):
        found = True
        value = line.split("=", 1)[1].strip().strip("\"'")
```

This pattern had two subtle edge-case bugs:
1. Lines with leading whitespace (e.g. `  LLM_MODEL=foo`) failed `line.startswith(prefix)` and were missed.
2. `strip().strip("\"'")` removes all double and single quote characters from both ends indiscriminately, destroying inner quotes (e.g. `LLM_MODEL="'llama-3.2-1b'"` lost its inner single quotes).

## Fix

Update `_find_env_file_value()` in `config.py` to:
- Ignore comment lines starting with `#` and strip leading whitespace before checking key assignment prefix
- Strip only matching surrounding quote pairs (`"..."` or `'...'`), leaving inner single/double quotes verbatim.

```python
def _find_env_file_value(key: str) -> tuple[bool, str]:
    """Return the last persisted value and distinguish missing from empty."""
    env_path = Path(INSTALL_DIR) / ".env"
    found = False
    value = ""
    prefix = f"{key}="
    try:
        for line in env_path.read_text(encoding="utf-8").splitlines():
            stripped = line.strip()
            if not stripped or stripped.startswith("#"):
                continue
            if stripped.startswith(prefix):
                found = True
                val = stripped.split("=", 1)[1].strip()
                if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
                    val = val[1:-1]
                value = val
    except (OSError, UnicodeError):
        pass
    return found, value
```

## Threat model (honest scoping)

This is a configuration reader correctness fix. It ensures that `.env` settings read by `read_live_env_value()` in `config.py` correctly handle leading whitespace and preserve internal quotes when parsing persisted configuration keys.

## Verification

Added unit test in `tests/test_config.py`:

- `test_live_env_value_handles_leading_whitespace_and_matched_quotes`
  - Verifies values with leading whitespace and internal single quotes preserve inner quotes correctly.

- `pytest tests/test_config.py` passed (43 passed in 0.19s).
