### PR TITLE
fix(security): strip matched quote pairs and whitespace in dashboard api key initialization

### DIFF
--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -10,7 +10,11 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 logger = logging.getLogger(__name__)
 
-DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY")
+raw_key = (os.environ.get("DASHBOARD_API_KEY") or "").strip()
+if len(raw_key) >= 2 and raw_key[0] == raw_key[-1] and raw_key[0] in {"'", '"'}:
+    raw_key = raw_key[1:-1].strip()
+
+DASHBOARD_API_KEY = raw_key
 if not DASHBOARD_API_KEY:
     DASHBOARD_API_KEY = secrets.token_urlsafe(32)
     key_file = Path("/data/dashboard-api-key.txt")

--- a/ods/extensions/services/dashboard-api/tests/test_security.py
+++ b/ods/extensions/services/dashboard-api/tests/test_security.py
@@ -44,3 +44,10 @@ class TestVerifyApiKey:
         with pytest.raises(HTTPException) as exc_info:
             await security.verify_api_key(creds)
         assert exc_info.value.status_code == 403
+
+    def test_quoted_or_whitespace_key_is_normalized(self, monkeypatch):
+        monkeypatch.setenv("DASHBOARD_API_KEY", ' "my-secret-key" ')
+        import importlib
+        import security as sec_mod
+        importlib.reload(sec_mod)
+        assert sec_mod.DASHBOARD_API_KEY == "my-secret-key"


### PR DESCRIPTION
## Problem

In `security.py`, `DASHBOARD_API_KEY` was initialized directly from `os.environ.get("DASHBOARD_API_KEY")`:

```python
DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY")
if not DASHBOARD_API_KEY:
    ...
```

If `DASHBOARD_API_KEY` was supplied with surrounding whitespace or quoted string representations (e.g. `DASHBOARD_API_KEY="secret-key"` read from a config file), `DASHBOARD_API_KEY` retained the surrounding quotes or whitespace.

Furthermore, if the environment variable contained empty whitespace `"  "`, `if not DASHBOARD_API_KEY` evaluated to `False` (since non-empty strings are truthy), leaving the server configured with a whitespace API key instead of generating a fallback secret.

## Fix

Update `DASHBOARD_API_KEY` initialization to strip surrounding whitespace and matching quote pairs (`"..."` or `'...'`):

```python
raw_key = (os.environ.get("DASHBOARD_API_KEY") or "").strip()
if len(raw_key) >= 2 and raw_key[0] == raw_key[-1] and raw_key[0] in {"'", '"'}:
    raw_key = raw_key[1:-1].strip()

DASHBOARD_API_KEY = raw_key
if not DASHBOARD_API_KEY:
    DASHBOARD_API_KEY = secrets.token_urlsafe(32)
    ...
```

## Threat model (honest scoping)

This is a security configuration initialization fix. It ensures that quoted API keys read from `.env` files are unquoted properly and that whitespace-only keys do not bypass automatic fallback secret generation.

## Verification

Added unit test in `tests/test_security.py`:

- `test_quoted_or_whitespace_key_is_normalized`
  - Verified `DASHBOARD_API_KEY=' "my-secret-key" '` normalizes cleanly to `"my-secret-key"`.

- `pytest tests/test_security.py` passed (7 passed in 0.21s).
