### PR TITLE
fix(host-agent-client): guard unicode decode and non-text errors in error detail extraction

### DIFF
--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -106,13 +106,16 @@ async def _get_async_client() -> httpx.AsyncClient:
 
 
 def _error_detail(response: httpx.Response) -> tuple[str, str]:
-    text = response.text
+    try:
+        text = response.text
+    except (UnicodeDecodeError, httpx.ResponseNotRead):
+        text = "<non-text response>"
     detail: Any = None
     try:
         payload = response.json()
         if isinstance(payload, dict):
             detail = payload.get("error") or payload.get("detail")
-    except ValueError:
+    except (ValueError, UnicodeDecodeError, httpx.ResponseNotRead):
         pass
     if isinstance(detail, (dict, list)):
         detail = json.dumps(detail, separators=(",", ":"))

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -165,3 +165,16 @@ async def test_async_request_and_shutdown_close_both_pools(monkeypatch):
     assert sync_client.is_closed
     assert agent_client._async_client is None
     assert agent_client._sync_client is None
+
+
+def test_error_detail_handles_unicode_decode_error():
+    from unittest.mock import MagicMock, PropertyMock
+
+    mock_resp = MagicMock()
+    type(mock_resp).text = PropertyMock(side_effect=UnicodeDecodeError("utf-8", b"", 0, 1, "bad"))
+    mock_resp.status_code = 500
+    mock_resp.json.side_effect = ValueError()
+
+    detail, text = agent_client._error_detail(mock_resp)
+    assert detail == "Host agent returned HTTP 500"
+    assert text == "<non-text response>"


### PR DESCRIPTION
## Problem

In `_error_detail()` (`host_agent_client.py`), error payload formatting accessed `response.text` and `response.json()` without guarding against non-text responses:

```python
def _error_detail(response: httpx.Response) -> tuple[str, str]:
    text = response.text
    detail: Any = None
    try:
        payload = response.json()
        ...
    except ValueError:
        pass
```

When the host agent returned binary payload buffers (e.g., compressed diagnostic payloads or non-UTF8 binary responses), accessing `response.text` raised `UnicodeDecodeError` or `httpx.ResponseNotRead`, crashing error detail extraction and turning non-200 HTTP responses into unhandled exceptions.

## Fix

Wrap `response.text` and `response.json()` evaluation in `try...except (UnicodeDecodeError, httpx.ResponseNotRead)` blocks:

```python
def _error_detail(response: httpx.Response) -> tuple[str, str]:
    try:
        text = response.text
    except (UnicodeDecodeError, httpx.ResponseNotRead):
        text = "<non-text response>"
    detail: Any = None
    try:
        payload = response.json()
        if isinstance(payload, dict):
            detail = payload.get("error") or payload.get("detail")
    except (ValueError, UnicodeDecodeError, httpx.ResponseNotRead):
        pass
    if isinstance(detail, (dict, list)):
        detail = json.dumps(detail, separators=(",", ":"))
    if not isinstance(detail, str) or not detail.strip():
        detail = f"Host agent returned HTTP {response.status_code}"
    return detail, text
```

## Threat model (honest scoping)

This is a transport error formatting robustness fix. It ensures host agent error responses cleanly format status messages even when the endpoint returns binary or non-UTF8 content.

## Verification

Added unit test in `tests/test_host_agent_client.py`:

- `test_error_detail_handles_unicode_decode_error`
  - Verifies that `_error_detail()` falls back to `"<non-text response>"` and returns clean HTTP status details when decoding fails.

- `pytest tests/test_host_agent_client.py` passed (11 passed in 0.16s).
