### PR TITLE
fix(helpers): handle non-file paths and unicode errors safely in read json file

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -242,7 +242,7 @@ def is_plausible_single_request_tps(value) -> bool:
 
 def _read_json_file(path: Path, default):
     try:
-        if path.exists():
+        if path.is_file():
             return json.loads(path.read_text(encoding="utf-8"))
     except (json.JSONDecodeError, OSError) as e:
         logger.debug("Failed to read JSON file %s: %s", path, e)

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -244,7 +244,7 @@ def _read_json_file(path: Path, default):
     try:
         if path.is_file():
             return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as e:
+    except (json.JSONDecodeError, OSError, UnicodeError) as e:
         logger.debug("Failed to read JSON file %s: %s", path, e)
     return default
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1583,3 +1583,11 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+def test_read_json_file_returns_default_for_directory_path(tmp_path):
+    from helpers import _read_json_file
+    d = tmp_path / "test_dir"
+    d.mkdir()
+
+    assert _read_json_file(d, {"default": True}) == {"default": True}

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1585,9 +1585,15 @@ class TestDirSizeGb:
         assert _dir_size_cache.get(first_path) is None
 
 
-def test_read_json_file_returns_default_for_directory_path(tmp_path):
+def test_read_json_file_handles_unicode_decode_error_and_directories(tmp_path):
     from helpers import _read_json_file
+
+    # Directory path
     d = tmp_path / "test_dir"
     d.mkdir()
-
     assert _read_json_file(d, {"default": True}) == {"default": True}
+
+    # Non-UTF8 binary data file
+    f = tmp_path / "binary.json"
+    f.write_bytes(b"\x80\xff\xfe invalid unicode")
+    assert _read_json_file(f, {"default": True}) == {"default": True}


### PR DESCRIPTION
## Problem

In `_read_json_file()` (`helpers.py`), JSON file content reading was guarded using `if path.exists()`:

```python
def _read_json_file(path: Path, default):
    try:
        if path.exists():
            return json.loads(path.read_text(encoding="utf-8"))
    except (json.JSONDecodeError, OSError) as e:
        logger.debug("Failed to read JSON file %s: %s", path, e)
    return default
```

This caused two edge-case failures:
1. `path.exists()` returns `True` for directory paths (e.g. state directories created as volume mounts), causing `read_text()` to raise `IsADirectoryError`.
2. If `path` contained non-UTF8 binary data, `path.read_text(encoding="utf-8")` raised `UnicodeDecodeError`, which was not caught by `except (json.JSONDecodeError, OSError)` and crashed calling functions.

## Fix

Update `_read_json_file()` to verify `path.is_file()` before attempting to read text, and add `UnicodeError` to the exception handler:

```python
def _read_json_file(path: Path, default):
    try:
        if path.is_file():
            return json.loads(path.read_text(encoding="utf-8"))
    except (json.JSONDecodeError, OSError, UnicodeError) as e:
        logger.debug("Failed to read JSON file %s: %s", path, e)
    return default
```

## Threat model (honest scoping)

This is a fail-soft file reader safety fix. It ensures that reading JSON state files degrades safely to the default fallback if the path is a directory or contains invalid character encodings.

## Verification

Added unit test in `tests/test_helpers.py`:

- `test_read_json_file_handles_unicode_decode_error_and_directories`
  - Verified directory paths and non-UTF8 binary files return default fallback instead of raising uncaught exceptions.

- `pytest tests/test_helpers.py` passed (102 passed in 0.37s).
