### PR TITLE
fix(helpers): validate finite float values in prometheus metrics parser

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -458,12 +458,16 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
             metric_name = parts[0].split("{", 1)[0]
             if metric_name.endswith("tokens_predicted_total"):
                 try:
-                    metrics["tokens_predicted_total"] = float(parts[-1])
+                    val = float(parts[-1])
+                    if math.isfinite(val):
+                        metrics["tokens_predicted_total"] = val
                 except ValueError:
                     pass
             if metric_name.endswith("tokens_predicted_seconds_total"):
                 try:
-                    metrics["tokens_predicted_seconds_total"] = float(parts[-1])
+                    val = float(parts[-1])
+                    if math.isfinite(val):
+                        metrics["tokens_predicted_seconds_total"] = val
                 except ValueError:
                     pass
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1564,3 +1564,24 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+@pytest.mark.asyncio
+async def test_get_llama_metrics_ignores_nan_and_inf_prometheus_values(monkeypatch):
+    from helpers import get_llama_metrics
+    from unittest.mock import AsyncMock, MagicMock
+
+    fake_services = {"llama-server": {"host": "localhost", "port": 8080}}
+    monkeypatch.setattr("helpers.SERVICES", fake_services)
+    monkeypatch.setattr("helpers.LLM_BACKEND", "llama.cpp")
+    monkeypatch.setattr("helpers.get_loaded_model", AsyncMock(return_value="test-model"))
+
+    mock_resp = MagicMock()
+    mock_resp.text = "llamacpp:tokens_predicted_total NaN\nllamacpp:tokens_predicted_seconds_total Inf\n"
+    mock_client = AsyncMock()
+    mock_client.get.return_value = mock_resp
+    monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+    res = await get_llama_metrics()
+    assert res["token_count_mode"] == "cumulative"
+    assert res["tokens_per_second"] == 0.0


### PR DESCRIPTION
## Problem

In `get_llama_metrics()` (`helpers.py`), Prometheus metrics lines are parsed by splitting lines and converting values using `float(parts[-1])`:

```python
if metric_name.endswith("tokens_predicted_total"):
    try:
        metrics["tokens_predicted_total"] = float(parts[-1])
    except ValueError:
        pass
```

When Prometheus endpoints emit non-finite values such as `NaN` or `Inf` (e.g., when counters reset or model metrics uninitialize), `float("NaN")` and `float("Inf")` parse without raising `ValueError`. Non-finite floats then propagate into token throughput calculations and arithmetic comparison operations.

## Fix

Validate `math.isfinite(val)` prior to accepting parsed Prometheus float values:

```python
if metric_name.endswith("tokens_predicted_total"):
    try:
        val = float(parts[-1])
        if math.isfinite(val):
            metrics["tokens_predicted_total"] = val
    except ValueError:
        pass
if metric_name.endswith("tokens_predicted_seconds_total"):
    try:
        val = float(parts[-1])
        if math.isfinite(val):
            metrics["tokens_predicted_seconds_total"] = val
    except ValueError:
        pass
```

## Threat model (honest scoping)

This is a telemetry parser validation fix. It guarantees that invalid non-finite metric values (`NaN`/`Inf`) emitted by upstream inference services do not pollute dashboard metrics.

## Verification

Added unit test in `tests/test_helpers.py`:

- `test_get_llama_metrics_ignores_nan_and_inf_prometheus_values`
  - Verified `NaN` and `Inf` metric lines are safely skipped and cause fallback handling.

- `pytest tests/test_helpers.py` passed (102 passed in 0.35s).
