### PR TITLE
fix(agents): guard null last_update timestamp in agent metrics html endpoint

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -34,7 +34,7 @@ class AgentMetrics:
             "tokens_per_second": round(self.tokens_per_second, 2),
             "error_rate_1h": round(self.error_rate_1h, 2),
             "queue_depth": self.queue_depth,
-            "last_update": self.last_update.isoformat()
+            "last_update": self.last_update.isoformat() if hasattr(self.last_update, "isoformat") else str(self.last_update or "")
         }
 
 

--- a/ods/extensions/services/dashboard-api/routers/agents.py
+++ b/ods/extensions/services/dashboard-api/routers/agents.py
@@ -27,8 +27,14 @@ async def get_agent_metrics_html(api_key: str = Depends(verify_api_key)):
 
     cluster_class = "status-ok" if cluster.get("failover_ready") else "status-warn"
     failover_text = "Ready \u2705" if cluster.get("failover_ready") else "Single GPU \u26a0\ufe0f"
-    last_update = agent.get("last_update", "")
-    last_update_time = last_update.split("T")[1][:8] if "T" in last_update else "N/A"
+    last_update = agent.get("last_update") or ""
+    if not isinstance(last_update, str):
+        last_update = str(last_update)
+    last_update_time = (
+        last_update.split("T")[1][:8]
+        if "T" in last_update and len(last_update.split("T")) > 1
+        else "N/A"
+    )
 
     # Escape all interpolated values for HTML safety
     def esc(value):

--- a/ods/extensions/services/dashboard-api/tests/test_agents.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agents.py
@@ -57,6 +57,16 @@ class TestGetAgentMetricsHtml:
         # Restore original
         agent_metrics.last_update = original_last_update
 
+    def test_handles_null_last_update_timestamp(self, test_client, monkeypatch):
+        """Null or missing last_update should render N/A instead of crashing."""
+        from agent_monitor import agent_metrics
+
+        monkeypatch.setattr(agent_metrics, "last_update", None)
+
+        resp = test_client.get("/api/agents/metrics.html", headers=test_client.auth_headers)
+        assert resp.status_code == 200
+        assert "Updated: N/A" in resp.text
+
 
 # --- GET /api/agents/cluster ---
 


### PR DESCRIPTION
## Problem

In `get_agent_metrics_html()` (`routers/agents.py`), agent timestamp formatting evaluated `last_update = agent.get("last_update", "")` and split on `"T"`:

```python
last_update = agent.get("last_update", "")
last_update_time = last_update.split("T")[1][:8] if "T" in last_update else "N/A"
```

If `agent_metrics.last_update` was `None` or non-datetime, `AgentMetrics.to_dict()` raised `AttributeError: 'NoneType' object has no attribute 'isoformat'`. Furthermore, if `agent.get("last_update")` returned `None`, `"T" in last_update` raised `TypeError: argument of type 'NoneType' is not iterable`, causing 500 Internal Server Error when fetching `/api/agents/metrics.html`.

## Fix

Update `AgentMetrics.to_dict()` and `get_agent_metrics_html()` to safely handle `None` or non-string timestamp values:

```python
# agent_monitor.py
"last_update": self.last_update.isoformat() if hasattr(self.last_update, "isoformat") else str(self.last_update or "")

# routers/agents.py
last_update = agent.get("last_update") or ""
if not isinstance(last_update, str):
    last_update = str(last_update)
last_update_time = (
    last_update.split("T")[1][:8]
    if "T" in last_update and len(last_update.split("T")) > 1
    else "N/A"
)
```

## Threat model (honest scoping)

This is a robust HTML fragment formatting fix. It guarantees that uninitialized or missing agent timestamps render `"Updated: N/A"` safely without raising 500 server errors.

## Verification

Added unit test in `tests/test_agents.py`:

- `test_handles_null_last_update_timestamp`
  - Verified `/api/agents/metrics.html` renders `"Updated: N/A"` cleanly when `last_update` is `None`.

- `pytest tests/test_agents.py` passed (7 passed in 0.64s).
