### PR TITLE
fix(updates): strip matched quote pairs and allow leading whitespace in version reader

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -44,24 +44,32 @@ def _read_utf8(path: Path) -> str:
 def _read_current_version() -> str:
     """Read installed version from .env (preferred) or .version file."""
     env_file = Path(INSTALL_DIR) / ".env"
-    if env_file.exists():
+    if env_file.is_file():
         try:
             for line in _read_utf8(env_file).splitlines():
-                if line.startswith("ODS_VERSION="):
-                    return line.split("=", 1)[1].strip().strip("\"'")
-        except OSError:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#"):
+                    continue
+                if stripped.startswith("ODS_VERSION="):
+                    val = stripped.split("=", 1)[1].strip()
+                    if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
+                        return val[1:-1]
+                    return val
+        except (OSError, UnicodeError):
             pass
     version_file = Path(INSTALL_DIR) / ".version"
-    if version_file.exists():
+    if version_file.is_file():
         try:
             raw = _read_utf8(version_file).strip()
             if raw:
                 if raw.startswith("{"):
                     data = json.loads(raw)
                     if isinstance(data, dict) and data.get("version"):
-                        return str(data["version"])
+                        return str(data["version"]).strip()
+                if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+                    return raw[1:-1].strip()
                 return raw
-        except (OSError, json.JSONDecodeError, ValueError):
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError):
             pass
     manifest_file = Path(INSTALL_DIR) / "manifest.json"
     if manifest_file.exists():

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -598,3 +598,13 @@ def test_trigger_update_action_backup(test_client, monkeypatch):
     assert calls[0][0:2] == ("POST", "/v1/update/backup")
     assert calls[0][2]["backup_id"].startswith("dashboard-")
     assert calls[0][3] == 65
+
+
+def test_read_current_version_handles_leading_whitespace_and_matched_quotes(tmp_path, monkeypatch):
+    import routers.updates as updates_mod
+
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", tmp_path)
+    env_file = tmp_path / ".env"
+    env_file.write_text('  ODS_VERSION="\'2.1.0\'"\n', encoding="utf-8")
+
+    assert updates_mod._read_current_version() == "'2.1.0'"


### PR DESCRIPTION
## Problem

In `_read_current_version()` (`routers/updates.py`), `.env` version parsing checked line equality using `line.startswith("ODS_VERSION=")` and stripped quotes via `.strip().strip("\"'")`:

```python
for line in _read_utf8(env_file).splitlines():
    if line.startswith("ODS_VERSION="):
        return line.split("=", 1)[1].strip().strip("\"'")
```

This pattern suffered from two bugs:
1. Lines with leading whitespace (e.g., `  ODS_VERSION=2.0.0`) failed `.startswith()` checks and were skipped.
2. `.strip().strip("\"'")` indiscriminately stripped internal quotes from version values (e.g. `ODS_VERSION="'2.1.0'"` lost its inner quotes).

## Fix

Update `_read_current_version()` to ignore comment lines, strip leading whitespace before checking prefix assignment, strip matching surrounding quote pairs (`"..."` or `'...'`), and catch `UnicodeError`:

```python
def _read_current_version() -> str:
    """Read installed version from .env (preferred) or .version file."""
    env_file = Path(INSTALL_DIR) / ".env"
    if env_file.is_file():
        try:
            for line in _read_utf8(env_file).splitlines():
                stripped = line.strip()
                if not stripped or stripped.startswith("#"):
                    continue
                if stripped.startswith("ODS_VERSION="):
                    val = stripped.split("=", 1)[1].strip()
                    if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
                        return val[1:-1]
                    return val
        except (OSError, UnicodeError):
            pass
```

## Threat model (honest scoping)

This is a version reading robustness fix. It guarantees that version strings read from `.env` or `.version` files handle leading whitespace and preserve internal quotes accurately.

## Verification

Added unit test in `tests/test_updates.py`:

- `test_read_current_version_handles_leading_whitespace_and_matched_quotes`
  - Verified values with leading whitespace and inner single quotes preserve inner quotes correctly.

- `pytest tests/test_updates.py` passed (28 passed in 1.13s).
