### PR TITLE
fix(templates): cleanup visiting set on dependency ordering exception

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -41,17 +41,19 @@ def _runtime_dependency_order(
         return _order
 
     _visiting.add(service_id)
-    for dep in read_direct_deps(service_id):
-        _runtime_dependency_order(
-            dep,
-            read_direct_deps,
-            _visiting=_visiting,
-            _visited=_visited,
-            _order=_order,
-        )
-        if dep not in _order:
-            _order.append(dep)
-    _visiting.remove(service_id)
+    try:
+        for dep in read_direct_deps(service_id):
+            _runtime_dependency_order(
+                dep,
+                read_direct_deps,
+                _visiting=_visiting,
+                _visited=_visited,
+                _order=_order,
+            )
+            if dep not in _order:
+                _order.append(dep)
+    finally:
+        _visiting.remove(service_id)
     _visited.add(service_id)
     return _order
 

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -1328,3 +1328,19 @@ def test_apply_template_blocking_calls_run_in_to_thread():
             f"{callee}() is called directly (without asyncio.to_thread). "
             f"All blocking helpers must run in the thread pool."
         )
+
+
+def test_runtime_dependency_order_cleans_up_visiting_set_on_exception():
+    from routers.templates import _runtime_dependency_order
+
+    visiting = set()
+
+    def failing_deps(sid):
+        if sid == "svc-a":
+            return ["svc-b"]
+        raise RuntimeError("dependency read failure")
+
+    with pytest.raises(RuntimeError):
+        _runtime_dependency_order("svc-a", failing_deps, _visiting=visiting)
+
+    assert "svc-a" not in visiting


### PR DESCRIPTION
## Problem

In `_runtime_dependency_order()` (`routers/templates.py`), depth-first search dependency traversal adds visiting service IDs to `_visiting` before recursing into dependencies:

```python
_visiting.add(service_id)
for dep in read_direct_deps(service_id):
    _runtime_dependency_order(...)
_visiting.remove(service_id)
```

If `read_direct_deps()` or a nested dependency lookup raises an exception (such as `HTTPException` or `RuntimeError`), `_visiting.remove(service_id)` is bypassed. If the `_visiting` set is re-used or referenced by upper-level handlers, unremoved service IDs lead to false-positive `HTTPException(400, "Circular dependency detected")` errors on subsequent dependency resolutions.

## Fix

Wrap recursive dependency traversal in a `try...finally:` block to ensure `_visiting.remove(service_id)` is always called upon scope exit:

```python
_visiting.add(service_id)
try:
    for dep in read_direct_deps(service_id):
        _runtime_dependency_order(
            dep,
            read_direct_deps,
            _visiting=_visiting,
            _visited=_visited,
            _order=_order,
        )
        if dep not in _order:
            _order.append(dep)
finally:
    _visiting.remove(service_id)
_visited.add(service_id)
return _order
```

## Threat model (honest scoping)

This is a dependency graph traversal safety fix. It guarantees state isolation for cycle detection sets during service template dependency resolution.

## Verification

Added unit test in `tests/test_templates.py`:

- `test_runtime_dependency_order_cleans_up_visiting_set_on_exception`
  - Verified that exceptions during dependency reading remove visited node IDs from the `_visiting` set.

- `pytest tests/test_templates.py` passed (32 passed in 0.54s).
