### PR TITLE
fix(resources): handle permission and os errors safely during data directory scanning

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -53,13 +53,21 @@ def _scan_service_disk() -> dict[str, dict]:
     results = {}
     if not data_path.is_dir():
         return results
-    for child in data_path.iterdir():
-        if not child.is_dir():
+    try:
+        children = list(data_path.iterdir())
+    except OSError as e:
+        logger.debug("Failed to list data directory %s: %s", data_path, e)
+        return results
+    for child in children:
+        try:
+            if not child.is_dir():
+                continue
+            service_id = _DATA_DIR_MAP.get(child.name, child.name)
+            size_gb = dir_size_gb(child)
+            if size_gb > 0:
+                results[service_id] = {"data_gb": size_gb, "path": f"data/{child.name}"}
+        except OSError:
             continue
-        service_id = _DATA_DIR_MAP.get(child.name, child.name)
-        size_gb = dir_size_gb(child)
-        if size_gb > 0:
-            results[service_id] = {"data_gb": size_gb, "path": f"data/{child.name}"}
     return results
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -355,3 +355,14 @@ class TestServiceResources:
             "/v1/service/restart",
             {"service_id": "dashboard-api", "delay_seconds": 1},
         )
+
+
+def test_scan_service_disk_handles_os_error(monkeypatch):
+    from routers.resources import _scan_service_disk
+    from pathlib import Path
+
+    def failing_iterdir(self):
+        raise OSError("Permission denied")
+
+    monkeypatch.setattr(Path, "iterdir", failing_iterdir)
+    assert _scan_service_disk() == {}


### PR DESCRIPTION
## Problem

In `_scan_service_disk()` (`routers/resources.py`), data directory disk usage scanning iterated over `/data` children using `data_path.iterdir()`:

```python
def _scan_service_disk() -> dict[str, dict]:
    data_path = Path(DATA_DIR)
    results = {}
    if not data_path.is_dir():
        return results
    for child in data_path.iterdir():
        if not child.is_dir():
            continue
```

If the `/data` mount or subfolder had restricted permissions or filesystem errors (e.g. `PermissionError` or stale volume mount `OSError`), calling `data_path.iterdir()` or `child.is_dir()` raised `OSError`, crashing the resource metrics endpoint with HTTP 500.

## Fix

Wrap `data_path.iterdir()` and per-child folder inspections in `try...except OSError:` blocks to skip unreadable directories gracefully:

```python
def _scan_service_disk() -> dict[str, dict]:
    """Scan /data/* directories and map to services."""
    data_path = Path(DATA_DIR)
    results = {}
    if not data_path.is_dir():
        return results
    try:
        children = list(data_path.iterdir())
    except OSError as e:
        logger.debug("Failed to list data directory %s: %s", data_path, e)
        return results
    for child in children:
        try:
            if not child.is_dir():
                continue
            service_id = _DATA_DIR_MAP.get(child.name, child.name)
            size_gb = dir_size_gb(child)
            if size_gb > 0:
                results[service_id] = {"data_gb": size_gb, "path": f"data/{child.name}"}
        except OSError:
            continue
    return results
```

## Threat model (honest scoping)

This is a disk scanner error handling fix. It guarantees that resource monitoring endpoints remain operational even if certain `/data` subdirectories raise permission or filesystem errors.

## Verification

Added unit test in `tests/test_resources.py`:

- `test_scan_service_disk_handles_os_error`
  - Verified `OSError` during `iterdir()` returns empty disk usage mapping without crashing.

- `pytest tests/test_resources.py` passed (21 passed in 0.54s).
