### PR TITLE
fix(setup): handle directory paths and unicode errors safely in persona prompt reader

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -33,10 +33,10 @@ def get_active_persona_prompt() -> str:
     persona_file = SETUP_CONFIG_DIR / "persona.json"
     if persona_file.is_file():
         try:
-            with open(persona_file) as f:
-                data = json.load(f)
-                return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
-        except (json.JSONDecodeError, OSError):
+            data = json.loads(persona_file.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and data.get("system_prompt"):
+                return str(data["system_prompt"])
+        except (json.JSONDecodeError, OSError, UnicodeError):
             logger.debug("Failed to read persona.json, using default prompt")
     return PERSONAS["general"]["system_prompt"]
 
@@ -51,18 +51,20 @@ async def setup_status(api_key: str = Depends(verify_api_key)):
     progress_file = SETUP_CONFIG_DIR / "setup-progress.json"
     if progress_file.is_file():
         try:
-            with open(progress_file) as f:
-                step = json.load(f).get("step", 0)
-        except (json.JSONDecodeError, OSError):
+            data = json.loads(progress_file.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                step = data.get("step", 0)
+        except (json.JSONDecodeError, OSError, UnicodeError):
             logger.debug("Failed to read setup-progress.json")
 
     persona = None
     persona_file = SETUP_CONFIG_DIR / "persona.json"
     if persona_file.is_file():
         try:
-            with open(persona_file) as f:
-                persona = json.load(f).get("persona")
-        except (json.JSONDecodeError, OSError):
+            data = json.loads(persona_file.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                persona = data.get("persona")
+        except (json.JSONDecodeError, OSError, UnicodeError):
             logger.debug("Failed to read persona.json for setup status")
 
     return {"first_run": first_run, "step": step, "persona": persona, "personas_available": list(PERSONAS.keys())}

--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -31,12 +31,12 @@ router = APIRouter(tags=["setup"])
 def get_active_persona_prompt() -> str:
     """Get the system prompt for the active persona."""
     persona_file = SETUP_CONFIG_DIR / "persona.json"
-    if persona_file.exists():
+    if persona_file.is_file():
         try:
             with open(persona_file) as f:
                 data = json.load(f)
                 return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
+        except (json.JSONDecodeError, OSError):
             logger.debug("Failed to read persona.json, using default prompt")
     return PERSONAS["general"]["system_prompt"]
 
@@ -45,24 +45,24 @@ def get_active_persona_prompt() -> str:
 async def setup_status(api_key: str = Depends(verify_api_key)):
     """Check if this is a first-run scenario."""
     setup_complete_file = SETUP_CONFIG_DIR / "setup-complete.json"
-    first_run = not setup_complete_file.exists()
+    first_run = not setup_complete_file.is_file()
 
     step = 0
     progress_file = SETUP_CONFIG_DIR / "setup-progress.json"
-    if progress_file.exists():
+    if progress_file.is_file():
         try:
             with open(progress_file) as f:
                 step = json.load(f).get("step", 0)
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
+        except (json.JSONDecodeError, OSError):
             logger.debug("Failed to read setup-progress.json")
 
     persona = None
     persona_file = SETUP_CONFIG_DIR / "persona.json"
-    if persona_file.exists():
+    if persona_file.is_file():
         try:
             with open(persona_file) as f:
                 persona = json.load(f).get("persona")
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
+        except (json.JSONDecodeError, OSError):
             logger.debug("Failed to read persona.json for setup status")
 
     return {"first_run": first_run, "step": step, "persona": persona, "personas_available": list(PERSONAS.keys())}

--- a/ods/extensions/services/dashboard-api/tests/test_setup.py
+++ b/ods/extensions/services/dashboard-api/tests/test_setup.py
@@ -77,6 +77,13 @@ def test_setup_status_first_run(test_client, setup_config_dir):
     assert data["persona"] is None
 
 
+def test_get_active_persona_prompt_handles_directory_persona_file(setup_config_dir):
+    from routers.setup import get_active_persona_prompt, PERSONAS
+    (setup_config_dir / "persona.json").mkdir(exist_ok=True)
+    prompt = get_active_persona_prompt()
+    assert prompt == PERSONAS["general"]["system_prompt"]
+
+
 def test_setup_status_already_complete(test_client, setup_config_dir):
     """When setup-complete.json exists, first_run is False."""
     (setup_config_dir / "setup-complete.json").write_text(

--- a/ods/extensions/services/dashboard-api/tests/test_setup.py
+++ b/ods/extensions/services/dashboard-api/tests/test_setup.py
@@ -84,6 +84,13 @@ def test_get_active_persona_prompt_handles_directory_persona_file(setup_config_d
     assert prompt == PERSONAS["general"]["system_prompt"]
 
 
+def test_get_active_persona_prompt_handles_unicode_decode_error(setup_config_dir):
+    from routers.setup import get_active_persona_prompt, PERSONAS
+    (setup_config_dir / "persona.json").write_bytes(b"\x80\xff\xfe invalid unicode")
+    prompt = get_active_persona_prompt()
+    assert prompt == PERSONAS["general"]["system_prompt"]
+
+
 def test_setup_status_already_complete(test_client, setup_config_dir):
     """When setup-complete.json exists, first_run is False."""
     (setup_config_dir / "setup-complete.json").write_text(


### PR DESCRIPTION
## Problem

In `get_active_persona_prompt()` and `setup_status()` (`routers/setup.py`), system prompt resolution and status checks inspected setup files (`persona.json`, `setup-progress.json`, `setup-complete.json`) using `.exists()` and `open()`:

```python
persona_file = SETUP_CONFIG_DIR / "persona.json"
if persona_file.exists():
    try:
        with open(persona_file) as f:
            data = json.load(f)
            return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
    except (FileNotFoundError, PermissionError, json.JSONDecodeError):
        ...
```

If `persona.json`, `setup-progress.json`, or `setup-complete.json` was created as a directory path (e.g. volume mounts) or contained invalid non-UTF8 binary bytes, `open()` or `json.load()` raised `IsADirectoryError` or `UnicodeDecodeError`. Neither exception was caught by `(FileNotFoundError, PermissionError, json.JSONDecodeError)` (as `UnicodeDecodeError` inherits from `ValueError`, not `OSError`), crashing setup endpoints with an unhandled exception.

## Fix

1. Update `get_active_persona_prompt()` and `setup_status()` in `routers/setup.py` to check `is_file()` across configuration paths (`persona.json`, `setup-progress.json`, `setup-complete.json`).
2. Read JSON files with `read_text(encoding="utf-8")` and catch `(json.JSONDecodeError, OSError, UnicodeError)` so that invalid non-UTF8 bytes fall back safely to default values.

## Threat model (honest scoping)

This is a setup configuration prompt reader safety fix. It guarantees that unreadable, corrupt non-UTF8, or directory-based persona JSON files fall back safely to the default system prompt without crashing the dashboard API.

## Verification

Added unit tests in `tests/test_setup.py`:
- `test_get_active_persona_prompt_handles_directory_persona_file`: Verified directory paths fall back to default prompt.
- `test_get_active_persona_prompt_handles_unicode_decode_error`: Verified non-UTF8 binary persona files (`b"\x80\xff\xfe invalid unicode"`) fall back cleanly to default system prompt without raising uncaught exceptions.

Ran `pytest tests/test_setup.py` locally: 26/26 passed.