### PR TITLE
fix(tailscale): fall back to offline payload when host agent is unreachable

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/tailscale.py
+++ b/ods/extensions/services/dashboard-api/routers/tailscale.py
@@ -68,4 +68,9 @@ async def tailscale_status() -> dict:
         dns_name, ips, online}, "magic_dns_suffix": "...", "tailnet_name": "..."}`
         — fully on the tailnet
     """
-    return await asyncio.to_thread(_proxy_agent, "/v1/tailscale/status", 15)
+    try:
+        return await asyncio.to_thread(_proxy_agent, "/v1/tailscale/status", 15)
+    except HTTPException as exc:
+        if exc.status_code in {503, 504}:
+            return {"running": False, "authenticated": False, "detail": exc.detail}
+        raise

--- a/ods/extensions/services/dashboard-api/tests/test_tailscale.py
+++ b/ods/extensions/services/dashboard-api/tests/test_tailscale.py
@@ -99,30 +99,34 @@ def test_status_when_fully_joined(test_client):
 # ---------------------------------------------------------------------------
 
 
-def test_status_returns_503_when_agent_unreachable(test_client):
+def test_status_returns_200_offline_when_agent_unreachable(test_client):
     with patch(
         "routers.tailscale.request_agent_json",
         side_effect=AgentUnavailable("connection refused"),
     ):
         resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
-    assert resp.status_code == 503
+    assert resp.status_code == 200
+    assert resp.json()["running"] is False
+    assert resp.json()["authenticated"] is False
 
 
-def test_status_returns_504_when_agent_request_times_out(test_client):
+def test_status_returns_200_offline_when_agent_request_times_out(test_client):
     with patch(
         "routers.tailscale.request_agent_json",
         side_effect=AgentTimeout("timed out"),
     ):
         resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
-    assert resp.status_code == 504
+    assert resp.status_code == 200
+    assert resp.json()["running"] is False
+    assert resp.json()["authenticated"] is False
 
 
 def test_status_passes_through_504_timeout(test_client):
     err = _mock_agent_http_error(504, {"error": "docker exec timed out"})
     with patch("routers.tailscale.request_agent_json", side_effect=err):
         resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
-    assert resp.status_code == 504
-    assert "timed out" in resp.json()["detail"]
+    assert resp.status_code == 200
+    assert resp.json()["running"] is False
 
 
 def test_status_passes_through_500_when_agent_errors(test_client):


### PR DESCRIPTION
## Problem

In `tailscale_status()` (`routers/tailscale.py`), Tailscale status endpoint resolution forwarded requests to `_proxy_agent("/v1/tailscale/status")`:

```python
@router.get("/api/tailscale/status", dependencies=[Depends(verify_api_key)])
async def tailscale_status() -> dict:
    return await asyncio.to_thread(_proxy_agent, "/v1/tailscale/status", 15)
```

If the host agent returned HTTP 503 (`AgentUnavailable`) or HTTP 504 (`AgentTimeout`) when the host daemon was down or running in standalone development mode, `_proxy_agent` raised `HTTPException(503)` or `HTTPException(504)`.

This violated the endpoint's API contract (which promises to always return HTTP 200 with `running: false` status rather than throwing HTTP errors for unconfigured or unreachable daemons).

## Fix

Catch `HTTPException` with status codes 503 or 504 in `tailscale_status()` and return an offline payload (`{"running": false, "authenticated": false, "detail": ...}`):

```python
@router.get("/api/tailscale/status", dependencies=[Depends(verify_api_key)])
async def tailscale_status() -> dict:
    try:
        return await asyncio.to_thread(_proxy_agent, "/v1/tailscale/status", 15)
    except HTTPException as exc:
        if exc.status_code in {503, 504}:
            return {"running": False, "authenticated": False, "detail": exc.detail}
        raise
```

## Threat model (honest scoping)

This is an API contract compliance fix. It guarantees that the remote access settings section of the dashboard UI displays an offline state gracefully instead of throwing HTTP 503 errors when host agents are unavailable.

## Verification

Updated unit tests in `tests/test_tailscale.py`:

- `test_status_returns_200_offline_when_agent_unreachable`
- `test_status_returns_200_offline_when_agent_request_times_out`
  - Verified `HTTP 200` with `running=False` is returned when host agent calls time out or fail.

- `pytest tests/test_tailscale.py` passed (8 passed in 0.50s).
