### PR TITLE
fix(privacy): handle invalid non-integer port values safely in privacy shield endpoints

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/privacy.py
+++ b/ods/extensions/services/dashboard-api/routers/privacy.py
@@ -23,11 +23,21 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["privacy"])
 
 
+def _safe_port(val: any, default: int = 0) -> int:
+    try:
+        raw = str(val or "").strip()
+        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+            raw = raw[1:-1].strip()
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
 @router.get("/api/privacy-shield/status", response_model=PrivacyShieldStatus)
 async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield status and configuration."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _safe_port(os.environ.get("SHIELD_PORT"), _ps.get("port", 0))
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
 
     # Check health directly — no Docker socket needed
@@ -94,7 +104,7 @@ async def toggle_privacy_shield(request: PrivacyShieldToggle, api_key: str = Dep
 async def get_privacy_shield_stats(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield usage statistics."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _safe_port(os.environ.get("SHIELD_PORT"), _ps.get("port", 0))
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
     shield_api_key = os.environ.get("SHIELD_API_KEY", "")
     if not shield_api_key:

--- a/ods/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy.py
@@ -291,3 +291,11 @@ def test_privacy_shield_stats_empty_shield_api_key(test_client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"error": "SHIELD_API_KEY not configured", "enabled": False}
     session_factory.assert_not_called()
+
+
+def test_privacy_shield_status_handles_invalid_and_quoted_port(test_client, monkeypatch):
+    import routers.privacy as privacy_router
+
+    assert privacy_router._safe_port('"8080"') == 8080
+    assert privacy_router._safe_port("invalid") == 0
+    assert privacy_router._safe_port(None) == 0


### PR DESCRIPTION
## Problem

In `get_privacy_shield_status()` and `get_privacy_shield_stats()` (`routers/privacy.py`), `SHIELD_PORT` configuration was read using `int(os.environ.get("SHIELD_PORT", ...))`:

```python
shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
```

If `SHIELD_PORT` was set to a non-integer string (e.g. `"auto"`) or contained surrounding quotes (e.g. `"\"8080\""`), `int(...)` raised an unhandled `ValueError`, crashing the Privacy Shield endpoints with HTTP 500.

## Fix

Introduce `_safe_port()` helper to unquote matched quote pairs and safely parse port integers with a fallback default:

```python
def _safe_port(val: any, default: int = 0) -> int:
    try:
        raw = str(val or "").strip()
        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
            raw = raw[1:-1].strip()
        return int(raw)
    except (ValueError, TypeError):
        return default
```

## Threat model (honest scoping)

This is a port configuration parsing safety fix. It guarantees that Privacy Shield status and statistics endpoints handle quoted or invalid port strings without raising unhandled internal server errors.

## Verification

Added unit test in `tests/test_privacy.py`:

- `test_privacy_shield_status_handles_invalid_and_quoted_port`
  - Verified quoted port strings (e.g. `"\"8080\""`) are parsed cleanly and invalid strings fall back to `0`.

- `pytest tests/test_privacy.py` passed (18 passed in 0.55s).
