### PR TITLE
fix(model-state): handle unicode decoding errors safely when reading state schema and file

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/model_state.py
+++ b/ods/extensions/services/dashboard-api/routers/model_state.py
@@ -63,7 +63,7 @@ def _validate_document(doc: Any) -> list[str]:
         schema = json.loads(_schema_path().read_text(encoding="utf-8"))
         Draft202012Validator.check_schema(schema)
         validator = Draft202012Validator(schema)
-    except (OSError, ValueError, SchemaError) as exc:
+    except (OSError, UnicodeError, ValueError, SchemaError) as exc:
         return [f"state schema unavailable or invalid: {exc}"]
 
     errors = []
@@ -109,7 +109,7 @@ async def get_model_state(api_key: str = Depends(verify_api_key)):
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return _invalid_response([], exists=False)
-    except OSError as exc:
+    except (OSError, UnicodeError) as exc:
         logger.warning("model-state read failed: %s", exc)
         return _invalid_response([f"read failed: {exc}"])
 

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -504,3 +504,15 @@ class TestObserveHook:
             return_proof=True,
             cancel_event=cancel_event,
         ) == {}
+
+
+def test_get_model_state_handles_unicode_decode_error(tmp_path, monkeypatch, test_client):
+    state_file = tmp_path / "model-state.json"
+    state_file.write_bytes(b"\x80\x81\x82")
+    monkeypatch.setenv("ODS_DATA_DIR", str(tmp_path))
+
+    resp = test_client.get("/api/models/state", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["valid"] is False
+    assert any("read failed" in err for err in data["errors"])


### PR DESCRIPTION
## Problem

In `get_model_state()` and `_validate_document()` (`routers/model_state.py`), model state reading loaded `model-state.json` and its JSON schema using `.read_text(encoding="utf-8")`:

```python
# _validate_document
except (OSError, ValueError, SchemaError) as exc:

# get_model_state
except OSError as exc:
    logger.warning("model-state read failed: %s", exc)
    return _invalid_response([f"read failed: {exc}"])
```

If `model-state.json` contained corrupted non-UTF8 binary data, `path.read_text()` raised `UnicodeDecodeError`. Because `UnicodeDecodeError` is not a subclass of `OSError`, it bypassed `except OSError:` in `get_model_state()`, raising an unhandled HTTP 500 error instead of returning a fail-soft diagnostic error payload.

## Fix

Add `UnicodeError` to the caught exception tuples in both `_validate_document()` and `get_model_state()`:

```python
# _validate_document
except (OSError, UnicodeError, ValueError, SchemaError) as exc:

# get_model_state
except (OSError, UnicodeError) as exc:
    logger.warning("model-state read failed: %s", exc)
    return _invalid_response([f"read failed: {exc}"])
```

## Threat model (honest scoping)

This is a model state reader robustness fix. It guarantees that corrupted or non-UTF8 binary state files return sanitized fail-soft diagnostic responses rather than 500 internal server errors.

## Verification

Added unit test in `tests/test_model_state.py`:

- `test_get_model_state_handles_unicode_decode_error`
  - Verified non-UTF8 binary data files return `valid=False` with `"read failed"` diagnostics without crashing.

- `pytest tests/test_model_state.py` passed (30 passed in 0.91s).
