### PR TITLE
fix(gpu): strip matched quote pairs when reading environment variables in gpu router

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -164,7 +164,10 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
 
 
 def _clean_env(name: str) -> str:
-    return os.environ.get(name, "").strip()
+    val = os.environ.get(name, "").strip()
+    if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
+        return val[1:-1].strip()
+    return val
 
 
 def _join_url(base_url: str, path: str) -> str:

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -549,3 +549,13 @@ class TestGetGpuInfoDispatcher:
 
         result = get_gpu_info()
         assert result is None
+
+
+def test_clean_env_strips_matched_quotes(monkeypatch):
+    import routers.gpu as gpu_router
+
+    monkeypatch.setenv("AMD_INFERENCE_BACKEND", '"rocm"')
+    assert gpu_router._clean_env("AMD_INFERENCE_BACKEND") == "rocm"
+
+    monkeypatch.setenv("AMD_INFERENCE_BACKEND", "'vulkan'")
+    assert gpu_router._clean_env("AMD_INFERENCE_BACKEND") == "vulkan"


### PR DESCRIPTION
## Problem

In `_clean_env()` (`routers/gpu.py`), GPU router environment variable values were parsed using `os.environ.get(name, "").strip()`:

```python
def _clean_env(name: str) -> str:
    return os.environ.get(name, "").strip()
```

If variables like `AMD_INFERENCE_BACKEND` or `AMD_INFERENCE_LOCATION` were configured in `.env` with surrounding quotes (e.g. `AMD_INFERENCE_BACKEND="'rocm'"`), `_clean_env()` returned `"\"rocm\""`, causing string equality checks (e.g., `backend not in {"", "unknown"}`) and URL builders to fail unexpectedly.

## Fix

Update `_clean_env()` in `routers/gpu.py` to strip matching surrounding quote pairs (`"..."` or `'...'`):

```python
def _clean_env(name: str) -> str:
    val = os.environ.get(name, "").strip()
    if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
        return val[1:-1].strip()
    return val
```

## Threat model (honest scoping)

This is a GPU backend environment parsing safety fix. It guarantees that quoted environment variables read by the GPU router resolve correctly to their unquoted runtime values.

## Verification

Added unit test in `tests/test_gpu.py`:

- `test_clean_env_strips_matched_quotes`
  - Verified double-quoted (`"rocm"`) and single-quoted (`'vulkan'`) environment variables strip surrounding quotes cleanly.

- `pytest tests/test_gpu.py` passed (51 passed in 0.42s).
