### PR TITLE
fix(model-routes): strip matched quote pairs when reading internal router key

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/model_routes.py
+++ b/ods/extensions/services/dashboard-api/routers/model_routes.py
@@ -48,9 +48,13 @@ def _normal_probe_id(value: str) -> str:
 
 
 def _router_internal_key() -> str:
-    return os.environ.get("ODS_ROUTER_INTERNAL_KEY", "") or os.environ.get(
-        "DASHBOARD_API_KEY", ""
+    raw = (
+        os.environ.get("ODS_ROUTER_INTERNAL_KEY", "").strip()
+        or os.environ.get("DASHBOARD_API_KEY", "").strip()
     )
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+        raw = raw[1:-1].strip()
+    return raw
 
 
 def _sanitize_evidence(payload: Any, probe_id: str) -> dict[str, Any]:

--- a/ods/extensions/services/dashboard-api/tests/test_model_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_routes.py
@@ -244,3 +244,13 @@ def test_route_evidence_passes_through_instance_id(test_client, monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.json()["instanceId"] == "0b7f9d2c-8a41-4f0e-9d5b-1c2e3f4a5b6c"
+
+
+def test_router_internal_key_unquotes_matched_pairs(monkeypatch):
+    import routers.model_routes as mr
+
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", '"quoted-key"')
+    assert mr._router_internal_key() == "quoted-key"
+
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "'single-quoted'")
+    assert mr._router_internal_key() == "single-quoted"


### PR DESCRIPTION
## Problem

In `_router_internal_key()` (`routers/model_routes.py`), router authorization key resolution extracted `ODS_ROUTER_INTERNAL_KEY` and `DASHBOARD_API_KEY` using:

```python
def _router_internal_key() -> str:
    return os.environ.get("ODS_ROUTER_INTERNAL_KEY", "") or os.environ.get(
        "DASHBOARD_API_KEY", ""
    )
```

If `ODS_ROUTER_INTERNAL_KEY` or `DASHBOARD_API_KEY` was configured in `.env` with surrounding quotes (e.g. `ODS_ROUTER_INTERNAL_KEY="'secret'"`), `_router_internal_key()` returned `"\"secret\""`, causing outgoing HTTP authentication headers to the model switchboard to fail with HTTP 401/403 authorization errors.

## Fix

Update `_router_internal_key()` in `routers/model_routes.py` to strip matching surrounding quote pairs (`"..."` or `'...'`):

```python
def _router_internal_key() -> str:
    raw = (
        os.environ.get("ODS_ROUTER_INTERNAL_KEY", "").strip()
        or os.environ.get("DASHBOARD_API_KEY", "").strip()
    )
    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
        raw = raw[1:-1].strip()
    return raw
```

## Threat model (honest scoping)

This is a internal router key resolution safety fix. It guarantees that quoted API key environment variables resolve to unquoted bearer key tokens when querying model evidence endpoints.

## Verification

Added unit test in `tests/test_model_routes.py`:

- `test_router_internal_key_unquotes_matched_pairs`
  - Verified double-quoted (`"quoted-key"`) and single-quoted (`'single-quoted'`) keys are unquoted cleanly.

- `pytest tests/test_model_routes.py` passed (10 passed in 0.65s).
