### PR TITLE
fix(features): strip matched quote pairs when parsing HOST_RAM_GB

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -26,7 +26,10 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     # fall back to HOST_RAM_GB. Unified memory = VRAM on Apple Silicon.
     if gpu_vram_gb == 0 and GPU_BACKEND == "apple":
         try:
-            gpu_vram_gb = float(os.environ.get("HOST_RAM_GB", "0") or "0")
+            raw_ram = (os.environ.get("HOST_RAM_GB", "0") or "0").strip()
+            if len(raw_ram) >= 2 and raw_ram[0] == raw_ram[-1] and raw_ram[0] in {"'", '"'}:
+                raw_ram = raw_ram[1:-1].strip()
+            gpu_vram_gb = float(raw_ram)
         except (ValueError, TypeError):
             pass
         gpu_vram_free_gb = gpu_vram_gb  # assumes zero current usage; Docker can't measure host memory pressure

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -408,3 +408,18 @@ class TestFeatureEnableInstructions:
             headers=test_client.auth_headers,
         )
         assert resp.status_code == 404
+
+
+def test_calculate_feature_status_handles_quoted_host_ram_gb(monkeypatch):
+    from routers.features import calculate_feature_status
+
+    feature = {
+        "id": "test-feature",
+        "name": "Test Feature",
+        "requirements": {"vram_gb": 16, "services": []},
+        "enabled_services_all": [],
+    }
+    monkeypatch.setenv("HOST_RAM_GB", '"32"')
+    with patch("routers.features.GPU_BACKEND", "apple"):
+        res = calculate_feature_status(feature, [], None)
+        assert res["requirements"]["vramOk"] is True


### PR DESCRIPTION
## Problem

In `calculate_feature_status()` (`routers/features.py`), Apple Silicon RAM fallback parsed `HOST_RAM_GB` using `float(os.environ.get("HOST_RAM_GB", "0") or "0")`:

```python
if gpu_vram_gb == 0 and GPU_BACKEND == "apple":
    try:
        gpu_vram_gb = float(os.environ.get("HOST_RAM_GB", "0") or "0")
    except (ValueError, TypeError):
        pass
```

If `HOST_RAM_GB` was configured in `.env` with surrounding quotes (e.g. `HOST_RAM_GB="32"`), `float(...)` raised an unhandled `ValueError`, defaulting `gpu_vram_gb` to `0` and incorrectly marking VRAM-dependent features as insufficient.

## Fix

Update `HOST_RAM_GB` parsing in `routers/features.py` to strip matching surrounding quote pairs (`"..."` or `'...'`):

```python
if gpu_vram_gb == 0 and GPU_BACKEND == "apple":
    try:
        raw_ram = (os.environ.get("HOST_RAM_GB", "0") or "0").strip()
        if len(raw_ram) >= 2 and raw_ram[0] == raw_ram[-1] and raw_ram[0] in {"'", '"'}:
            raw_ram = raw_ram[1:-1].strip()
        gpu_vram_gb = float(raw_ram)
    except (ValueError, TypeError):
        pass
```

## Threat model (honest scoping)

This is a features router environment variable safety fix. It guarantees that quoted `HOST_RAM_GB` strings correctly convert to float memory values when evaluating Apple Silicon hardware capability.

## Verification

Added unit test in `tests/test_features.py`:

- `test_calculate_feature_status_handles_quoted_host_ram_gb`
  - Verified quoted `HOST_RAM_GB` strings (e.g. `"32"`) parse to float and evaluate `vramOk` correctly.

- `pytest tests/test_features.py` passed (20 passed in 0.50s).
