### PR TITLE
fix(talk): strip matched quote pairs from vision model name

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -123,7 +123,10 @@ def _require_hermes_talk_compatible() -> dict[str, Any]:
 def _vision_model_name() -> str:
     """Lemonade name of the vision-capable model. Defaults match the strix
     user.* registration we ship; operators can override per-host via env."""
-    return os.environ.get("ODS_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
+    raw = (os.environ.get("ODS_TALK_VISION_MODEL") or "user.Qwen3.6-35B-A3B-Vision").strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
+        return raw[1:-1].strip()
+    return raw
 
 
 def _vision_backend_base_url() -> str:

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1096,3 +1096,10 @@ def test_ods_talk_hermes_timeout_is_env_configurable(monkeypatch):
 
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "5")
     assert hermes_bridge._request_timeout() == 10
+
+
+def test_vision_model_name_strips_matched_quotes(monkeypatch):
+    import routers.talk as talk_router
+
+    monkeypatch.setenv("ODS_TALK_VISION_MODEL", '"user.Custom-Vision"')
+    assert talk_router._vision_model_name() == "user.Custom-Vision"


### PR DESCRIPTION
## Problem

In `_vision_model_name()` (`routers/talk.py`), vision model resolution extracted `ODS_TALK_VISION_MODEL` using `os.environ.get("ODS_TALK_VISION_MODEL", ...)`:

```python
def _vision_model_name() -> str:
    return os.environ.get("ODS_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
```

If `ODS_TALK_VISION_MODEL` was configured in `.env` with surrounding quotes (e.g. `ODS_TALK_VISION_MODEL="'user.Qwen3.6-35B-A3B-Vision'"`), `_vision_model_name()` returned `"\"user.Qwen3.6-35B-A3B-Vision\""`, causing multimodal chat completions requests to fail with model not found errors.

## Fix

Update `_vision_model_name()` in `routers/talk.py` to strip matching surrounding quote pairs (`"..."` or `'...'`):

```python
def _vision_model_name() -> str:
    raw = (os.environ.get("ODS_TALK_VISION_MODEL") or "user.Qwen3.6-35B-A3B-Vision").strip()
    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
        return raw[1:-1].strip()
    return raw
```

## Threat model (honest scoping)

This is a talk router model configuration safety fix. It guarantees that quoted vision model identifiers in `.env` resolve to clean unquoted model names when constructing chat completion payloads.

## Verification

Added unit test in `tests/test_talk.py`:

- `test_vision_model_name_strips_matched_quotes`
  - Verified quoted vision model names (e.g. `"user.Custom-Vision"`) are unquoted cleanly.

- `pytest tests/test_talk.py` passed (38 passed in 1.52s).
