### PR TITLE
fix(resources): handle permission and os errors safely during data directory scanning

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -53,8 +53,16 @@ def _scan_service_disk() -> dict[str, dict]:
     results = {}
     if not data_path.is_dir():
         return results
-    for child in data_path.iterdir():
-        if not child.is_dir():
+    try:
+        children = list(data_path.iterdir())
+    except (PermissionError, OSError) as exc:
+        logger.warning("Could not iterate data directory %s: %s", data_path, exc)
+        return results
+    for child in children:
+        try:
+            if not child.is_dir():
+                continue
+        except (PermissionError, OSError):
             continue
         service_id = _DATA_DIR_MAP.get(child.name, child.name)
         size_gb = dir_size_gb(child)

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -1,5 +1,6 @@
 """Tests for routers/resources.py — per-service resource metrics."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 from host_agent_client import AgentHTTPError, AgentUnavailable
@@ -62,6 +63,17 @@ class TestScanServiceDisk:
         monkeypatch.setattr("routers.resources.DATA_DIR", str(tmp_path))
         (tmp_path / "somefile.txt").write_text("not a directory")
 
+        result = _scan_service_disk()
+        assert result == {}
+
+    def test_permission_error_on_iterdir(self, tmp_path, monkeypatch):
+        """PermissionError when iterating DATA_DIR returns empty dict without raising."""
+        monkeypatch.setattr("routers.resources.DATA_DIR", str(tmp_path))
+
+        def mock_iterdir(self):
+            raise PermissionError("Permission denied")
+
+        monkeypatch.setattr(Path, "iterdir", mock_iterdir)
         result = _scan_service_disk()
         assert result == {}
 


### PR DESCRIPTION
### Problem
`_scan_service_disk()` in `ods/extensions/services/dashboard-api/routers/resources.py` called `data_path.iterdir()` directly without exception guards. If the data directory or any child directory encountered permission restrictions (e.g. `PermissionError`) or filesystem IO errors (`OSError`), the unhandled exception crashed `_scan_service_disk()` and caused the `/api/services/resources` endpoint to return an HTTP 500 error.

### Fix
Wrap `data_path.iterdir()` and `child.is_dir()` in `try ... except (PermissionError, OSError)` blocks in `_scan_service_disk()`. If iterating `/data` or checking a child directory encounters filesystem errors, a warning is logged and unreadable directories are skipped safely while returning all readable service disk usage entries.

### Threat Model
- **Fail-soft scoping:** Unreadable data subdirectories or broken permissions will no longer cause systemic failure of the service resource endpoint.
- **Side effects:** None; valid data directories continue to be mapped and measured accurately.

### Verification
Ran the unit test suite (`pytest ods/extensions/services/dashboard-api/tests/test_resources.py -q`):
```
.....................                                                    [100%]
21 passed, 1 warning in 0.70s
```