### PR TITLE
fix(features): handle missing or non-dictionary requirements safely in feature calculator

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -31,7 +31,9 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
             pass
         gpu_vram_free_gb = gpu_vram_gb  # assumes zero current usage; Docker can't measure host memory pressure
 
-    req = feature["requirements"]
+    req = feature.get("requirements")
+    if not isinstance(req, dict):
+        req = {}
     vram_ok = gpu_vram_gb >= req.get("vram_gb", 0)
     vram_fits = gpu_vram_free_gb >= req.get("vram_gb", 0)
 

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -26,6 +26,29 @@ class TestCalculateFeatureStatusDefaults:
         assert result["setupTime"] == "Unknown"
         assert result["priority"] == 99
 
+    def test_missing_and_non_dict_requirements_use_defaults(self):
+        """Features with missing requirements, requirements=None, or non-dict requirements default safely."""
+        # 1. Missing requirements key
+        f_missing = {"id": "f_missing", "name": "Missing Req"}
+        res1 = calculate_feature_status(f_missing, [], None)
+        assert res1["id"] == "f_missing"
+        assert res1["status"] == "enabled"
+        assert res1["requirements"]["vramOk"] is True
+
+        # 2. requirements = None
+        f_none = {"id": "f_none", "name": "None Req", "requirements": None}
+        res2 = calculate_feature_status(f_none, [], None)
+        assert res2["id"] == "f_none"
+        assert res2["status"] == "enabled"
+        assert res2["requirements"]["vramOk"] is True
+
+        # 3. requirements = "invalid string"
+        f_str = {"id": "f_str", "name": "String Req", "requirements": "invalid"}
+        res3 = calculate_feature_status(f_str, [], None)
+        assert res3["id"] == "f_str"
+        assert res3["status"] == "enabled"
+        assert res3["requirements"]["vramOk"] is True
+
 
 class TestCalculateFeatureStatusAppleFallback:
 


### PR DESCRIPTION
### Problem
`calculate_feature_status()` in `ods/extensions/services/dashboard-api/routers/features.py` extracted `feature["requirements"]` directly without dict type validation. If a feature definition (e.g. dynamically loaded feature plugins or third-party feature manifests) lacked a `"requirements"` key or had `requirements=None`, calling `req.get(...)` raised an unhandled `KeyError` or `AttributeError`.

### Fix
Use `feature.get("requirements")` with an `isinstance(req, dict)` fallback check to ensure `req` is always a valid dictionary before accessing VRAM or service requirement fields.

### Threat Model
- **Fail-soft scoping:** Features with omitted or null requirements dictionaries default safely without crashing feature discovery endpoints (`/api/features`).
- **Side effects:** None; standard features with valid requirements dicts function identically.

### Verification
Ran the unit test suite (`pytest ods/extensions/services/dashboard-api/tests/test_features.py -q`):
```
....................                                                     [100%]
20 passed, 1 warning in 0.69s
```