### PR TITLE
test(dashboard-api): decode JSON payload in Lemonade client chat completion test assertion

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -1,3 +1,4 @@
+import json
 import httpx
 import pytest
 
@@ -88,8 +89,9 @@ async def test_chat_completion_posts_openai_shape():
 
     assert payload["choices"][0]["message"]["content"] == "ok"
     assert seen["url"] == "http://lemonade:13305/api/v1/chat/completions"
-    assert b'"model":"Qwen3-0.6B-GGUF"' in seen["body"]
-    assert b'"temperature":0' in seen["body"]
+    sent_body = json.loads(seen["body"].decode("utf-8"))
+    assert sent_body["model"] == "Qwen3-0.6B-GGUF"
+    assert sent_body["temperature"] == 0
     await client.aclose()
 
 


### PR DESCRIPTION
## Problem

`test_chat_completion_posts_openai_shape` in `test_lemonade_client.py` asserted raw byte substring matches on the HTTP request body (`b'"model":"Qwen3-0.6B-GGUF"' in seen["body"]`). Standard JSON serializers can format key-value pairs with whitespace separators (e.g. `{"model": "Qwen3-0.6B-GGUF"}`), causing raw substring matching to fail brittlely despite valid JSON content.

## Why the existing contract missed it

The assertion checked compact unspaced JSON strings rather than parsing the JSON payload structure.

## Fix

Parse `seen["body"]` with `json.loads` and assert the dictionary values (`sent_body["model"]` and `sent_body["temperature"]`) directly.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_lemonade_client.py` locally: 9/9 passed.