### PR TITLE
fix(tailscale): validate host agent response shape in proxy helper

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/tailscale.py
+++ b/ods/extensions/services/dashboard-api/routers/tailscale.py
@@ -41,7 +41,11 @@ router = APIRouter(tags=["tailscale"])
 def _proxy_agent(path: str, timeout: int = 15) -> dict:
     """Forward a GET to the host-agent. Translates HTTPError → HTTPException."""
     try:
-        return request_agent_json("GET", path, timeout=timeout)
+        res = request_agent_json("GET", path, timeout=timeout)
+        if not isinstance(res, dict):
+            logger.warning("host-agent GET %s returned non-dict response: %r", path, res)
+            return {"running": False}
+        return res
     except AgentHTTPError as exc:
         logger.info("host-agent GET %s -> %s", path, exc.status_code)
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc

--- a/ods/extensions/services/dashboard-api/tests/test_tailscale.py
+++ b/ods/extensions/services/dashboard-api/tests/test_tailscale.py
@@ -130,3 +130,10 @@ def test_status_passes_through_500_when_agent_errors(test_client):
     with patch("routers.tailscale.request_agent_json", side_effect=err):
         resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
     assert resp.status_code == 500
+
+
+def test_status_handles_non_dict_agent_response(test_client):
+    with patch("routers.tailscale.request_agent_json", return_value="not a dict"):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json() == {"running": False}


### PR DESCRIPTION
## Problem

When the host-agent returns a non-dictionary JSON payload (e.g., boolean or primitive string response), `_proxy_agent` in `routers/tailscale.py` returned raw values directly. Downstream routes or caller code expecting a dictionary response could encounter unexpected type errors or invalid status parsing.

## Why the existing contract missed it

The proxy transport translated HTTP errors to `HTTPException` but assumed successful JSON responses from the host-agent were always dictionary instances.

## Fix

Validate that host-agent responses are dictionary instances in `_proxy_agent`. If a non-dictionary value is returned, log a warning and return `{"running": False}` safely.

## Verification

Added `test_status_handles_non_dict_agent_response` to `ods/extensions/services/dashboard-api/tests/test_tailscale.py`. Ran `pytest` locally: 9/9 passed.