### PR TITLE
fix(privacy-shield): safely parse SHIELD_PORT environment variable with quote stripping and default fallback

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/privacy.py
+++ b/ods/extensions/services/dashboard-api/routers/privacy.py
@@ -23,11 +23,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["privacy"])
 
 
+def _get_shield_port() -> int:
+    """Safely parse SHIELD_PORT from environment with fallback to default service port."""
+    default_port = int(SERVICES.get("privacy-shield", {}).get("port", 0))
+    raw = os.environ.get("SHIELD_PORT", "").strip("'\"").strip()
+    if not raw:
+        return default_port
+    try:
+        val = int(raw)
+        return val if val > 0 else default_port
+    except ValueError:
+        logger.warning("Invalid SHIELD_PORT value %r, falling back to default %d", raw, default_port)
+        return default_port
+
+
 @router.get("/api/privacy-shield/status", response_model=PrivacyShieldStatus)
 async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield status and configuration."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _get_shield_port()
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
 
     # Check health directly — no Docker socket needed
@@ -94,7 +108,7 @@ async def toggle_privacy_shield(request: PrivacyShieldToggle, api_key: str = Dep
 async def get_privacy_shield_stats(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield usage statistics."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _get_shield_port()
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
     shield_api_key = os.environ.get("SHIELD_API_KEY", "")
     if not shield_api_key:

--- a/ods/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy.py
@@ -291,3 +291,13 @@ def test_privacy_shield_stats_empty_shield_api_key(test_client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"error": "SHIELD_API_KEY not configured", "enabled": False}
     session_factory.assert_not_called()
+
+
+def test_get_shield_port_invalid_env_fallback(monkeypatch):
+    """_get_shield_port falls back cleanly to default service port when SHIELD_PORT is invalid."""
+    from routers.privacy import _get_shield_port
+    monkeypatch.setenv("SHIELD_PORT", "invalid")
+    assert _get_shield_port() == 0
+
+    monkeypatch.setenv("SHIELD_PORT", '"8080"')
+    assert _get_shield_port() == 8080


### PR DESCRIPTION
## Problem

In `routers/privacy.py`, `SHIELD_PORT` was read directly with `int(os.environ.get("SHIELD_PORT", ...))`. If `SHIELD_PORT` contains quotes or invalid non-numeric text, `int(...)` raises an unhandled `ValueError`, leading to HTTP 500 error tracebacks on `/api/privacy-shield/status` and `/api/privacy-shield/stats`.

## Why the existing contract missed it

Port lookup assumed environment values passed to `int()` were always valid unquoted integer strings.

## Fix

Added a `_get_shield_port()` helper function in `privacy.py` that strips quote pairs, validates numeric format, and falls back to the configured service default port on invalid inputs.

## Verification

Added `test_get_shield_port_invalid_env_fallback` to `ods/extensions/services/dashboard-api/tests/test_privacy.py`. Ran `pytest` locally: 18/18 passed.