### PR TITLE
fix(talk): ensure active model compatibility is a dictionary before item assignment

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -89,8 +89,10 @@ def _active_model_app_compatibility() -> dict[str, Any]:
         entry or {},
         runtime_context=model_compatibility_runtime_context(INSTALL_DIR),
     )
+    if not isinstance(compatibility, dict):
+        compatibility = {}
     compatibility["activeModel"] = {
-        "id": entry.get("id") if entry else None,
+        "id": entry.get("id") if isinstance(entry, dict) else None,
         "model": model_name or None,
         "gguf": gguf or None,
     }

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1096,3 +1096,14 @@ def test_ods_talk_hermes_timeout_is_env_configurable(monkeypatch):
 
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "5")
     assert hermes_bridge._request_timeout() == 10
+
+
+def test_active_model_app_compatibility_handles_non_dict_return(monkeypatch):
+    """_active_model_app_compatibility returns dict safely when model_app_compatibility returns non-dict."""
+    from routers.talk import _active_model_app_compatibility
+    monkeypatch.setattr("routers.talk.model_app_compatibility", lambda *a, **kw: None)
+    monkeypatch.setattr("routers.talk.find_catalog_model", lambda *a, **kw: None)
+
+    res = _active_model_app_compatibility()
+    assert isinstance(res, dict)
+    assert "activeModel" in res


### PR DESCRIPTION
## Problem

In `routers/talk.py`, `_active_model_app_compatibility()` invokes `model_app_compatibility()` and immediately assigns `compatibility["activeModel"] = ...`. Under edge cases where `model_app_compatibility()` returns `None` or a non-dictionary value, this causes an unhandled `TypeError: 'NoneType' object does not support item assignment` when computing Talk status or model viability.

## Why the existing contract missed it

Assumed `model_app_compatibility()` always returns a dictionary instance without defensive type verification before key assignment.

## Fix

Ensure `compatibility` is initialized to `{}` if `model_app_compatibility()` returns non-dict, and check `isinstance(entry, dict)` safely when reading model catalog ID.

## Verification

Added `test_active_model_app_compatibility_handles_non_dict_return` to `ods/extensions/services/dashboard-api/tests/test_talk.py`. Ran `pytest` locally: 38/38 passed.