### PR TITLE
fix(updates): reject GitHub errors and malformed release payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -178,9 +178,23 @@ async def _refresh_release_cache() -> Optional[dict]:
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
+        # An error body is still valid JSON. GitHub answers an exhausted
+        # unauthenticated rate limit with 403 and {"message": ...}, which has
+        # no tag_name — so without these checks the empty result is cached for
+        # the full TTL and also becomes the allow_stale fallback, and the
+        # dashboard reports "up to date" while a release exists. The releases
+        # manifest below already validates its response this way.
+        response.raise_for_status()
         data = response.json()
+        if not isinstance(data, dict):
+            raise httpx.HTTPError(
+                f"unexpected release response: {type(data).__name__}"
+            )
+        tag = str(data.get("tag_name") or "").strip()
+        if not tag:
+            raise httpx.HTTPError("release response carried no tag_name")
         payload = {
-            "latest": data.get("tag_name", "").lstrip("v"),
+            "latest": tag.lstrip("v"),
             "changelog_url": data.get("html_url"),
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }

--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -7,7 +7,7 @@ import re
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Optional
+from typing import Optional, TypedDict
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -33,7 +33,14 @@ _GITHUB_RELEASES_API = f"https://api.github.com/repos/{_GITHUB_REPOSITORY}/relea
 _GITHUB_RELEASES_PAGE = f"https://github.com/{_GITHUB_REPOSITORY}/releases"
 _GITHUB_HEADERS = {"Accept": "application/vnd.github.v3+json"}
 _VERSION_CACHE_TTL = 300.0
-_version_cache: dict[str, object] = {"expires_at": 0.0, "payload": None}
+
+
+class _VersionCache(TypedDict):
+    expires_at: float
+    payload: Optional[dict]
+
+
+_version_cache: _VersionCache = {"expires_at": 0.0, "payload": None}
 _version_refresh_task: Optional[asyncio.Task] = None
 
 
@@ -128,8 +135,8 @@ def _get_cached_release_payload(allow_stale: bool = False) -> Optional[dict]:
     payload = _version_cache.get("payload")
     if payload is None:
         return None
-    if allow_stale or time.monotonic() < float(_version_cache.get("expires_at", 0.0)):
-        return payload  # type: ignore[return-value]
+    if allow_stale or time.monotonic() < _version_cache["expires_at"]:
+        return payload
     return None
 
 
@@ -141,6 +148,72 @@ def _normalize_version(value: Optional[str]) -> str:
     ``current`` and ``latest`` on the same footing.
     """
     return (value or "").strip().lstrip("v")
+
+
+def _parse_latest_release_response(response: httpx.Response) -> dict[str, Optional[str]]:
+    """Validate GitHub's latest-release contract before consumers use it."""
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, dict):
+        raise httpx.HTTPError(
+            f"unexpected release response: {type(data).__name__}"
+        )
+
+    tag = data.get("tag_name")
+    if not isinstance(tag, str) or not _normalize_version(tag):
+        raise httpx.HTTPError("release response carried no valid tag_name")
+
+    changelog_url = data.get("html_url")
+    if changelog_url is not None and not isinstance(changelog_url, str):
+        raise httpx.HTTPError("release response carried an invalid html_url")
+
+    return {
+        "latest": _normalize_version(tag),
+        "changelog_url": changelog_url or None,
+    }
+
+
+def _parse_release_manifest_response(response: httpx.Response) -> list[dict]:
+    """Validate and normalize GitHub's release-list response."""
+    response.raise_for_status()
+    data = response.json()
+    if not isinstance(data, list):
+        raise httpx.HTTPError(
+            f"unexpected releases response: {type(data).__name__}"
+        )
+
+    releases = []
+    for index, release in enumerate(data):
+        if not isinstance(release, dict):
+            raise httpx.HTTPError(f"release {index} was not an object")
+
+        tag = release.get("tag_name")
+        if not isinstance(tag, str) or not _normalize_version(tag):
+            raise httpx.HTTPError(f"release {index} carried no valid tag_name")
+
+        text = {}
+        for field in ("published_at", "name", "body", "html_url"):
+            value = release.get(field)
+            if value is not None and not isinstance(value, str):
+                raise httpx.HTTPError(f"release {index} carried an invalid {field}")
+            text[field] = value or ""
+
+        prerelease = release.get("prerelease", False)
+        if not isinstance(prerelease, bool):
+            raise httpx.HTTPError(f"release {index} carried an invalid prerelease")
+
+        body = text["body"]
+        releases.append(
+            {
+                "version": _normalize_version(tag),
+                "date": text["published_at"],
+                "title": text["name"],
+                "changelog": body[:500] + "..." if len(body) > 500 else body,
+                "url": text["html_url"],
+                "prerelease": prerelease,
+            }
+        )
+    return releases
 
 
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:
@@ -179,24 +252,9 @@ async def _refresh_release_cache() -> Optional[dict]:
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
-        # An error body is still valid JSON. GitHub answers an exhausted
-        # unauthenticated rate limit with 403 and {"message": ...}, which has
-        # no tag_name — so without these checks the empty result is cached for
-        # the full TTL and also becomes the allow_stale fallback, and the
-        # dashboard reports "up to date" while a release exists. The releases
-        # manifest below already validates its response this way.
-        response.raise_for_status()
-        data = response.json()
-        if not isinstance(data, dict):
-            raise httpx.HTTPError(
-                f"unexpected release response: {type(data).__name__}"
-            )
-        tag = str(data.get("tag_name") or "").strip()
-        if not tag:
-            raise httpx.HTTPError("release response carried no tag_name")
+        release = _parse_latest_release_response(response)
         payload = {
-            "latest": tag.lstrip("v"),
-            "changelog_url": data.get("html_url"),
+            **release,
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }
         _version_cache = {
@@ -246,14 +304,9 @@ async def get_release_manifest():
                 f"{_GITHUB_RELEASES_API}?per_page=5",
                 headers=_GITHUB_HEADERS,
             )
-        releases = resp.json()
-        if not isinstance(releases, list):
-            raise httpx.HTTPError(f"unexpected releases response: {type(releases).__name__}")
+        releases = _parse_release_manifest_response(resp)
         return {
-            "releases": [
-                {"version": r.get("tag_name", "").lstrip("v"), "date": r.get("published_at", ""), "title": r.get("name", ""), "changelog": r.get("body", "")[:500] + "..." if len(r.get("body", "")) > 500 else r.get("body", ""), "url": r.get("html_url", ""), "prerelease": r.get("prerelease", False)}
-                for r in releases
-            ],
+            "releases": releases,
             "checked_at": datetime.now(timezone.utc).isoformat()
         }
     except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError, OSError):
@@ -312,9 +365,9 @@ async def get_update_dry_run():
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
-        data = resp.json()
-        latest = _normalize_version(data.get("tag_name")) or None
-        changelog_url = data.get("html_url") or None
+        release = _parse_latest_release_response(resp)
+        latest = release["latest"]
+        changelog_url = release["changelog_url"]
         if latest:
             def _parts(v: str) -> list[int]:
                 return ([int(x) for x in v.split(".") if x.isdigit()][:3] + [0, 0, 0])[:3]

--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -179,9 +179,23 @@ async def _refresh_release_cache() -> Optional[dict]:
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
+        # An error body is still valid JSON. GitHub answers an exhausted
+        # unauthenticated rate limit with 403 and {"message": ...}, which has
+        # no tag_name — so without these checks the empty result is cached for
+        # the full TTL and also becomes the allow_stale fallback, and the
+        # dashboard reports "up to date" while a release exists. The releases
+        # manifest below already validates its response this way.
+        response.raise_for_status()
         data = response.json()
+        if not isinstance(data, dict):
+            raise httpx.HTTPError(
+                f"unexpected release response: {type(data).__name__}"
+            )
+        tag = str(data.get("tag_name") or "").strip()
+        if not tag:
+            raise httpx.HTTPError("release response carried no tag_name")
         payload = {
-            "latest": data.get("tag_name", "").lstrip("v"),
+            "latest": tag.lstrip("v"),
             "changelog_url": data.get("html_url"),
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -598,3 +598,98 @@ def test_trigger_update_action_backup(test_client, monkeypatch):
     assert calls[0][0:2] == ("POST", "/v1/update/backup")
     assert calls[0][2]["backup_id"].startswith("dashboard-")
     assert calls[0][3] == 65
+
+
+def _mock_github_client(json_body, *, status_error=None):
+    """An httpx.AsyncClient stand-in returning one canned release response."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = json_body
+    if status_error is not None:
+        mock_resp.raise_for_status.side_effect = status_error
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _reset_version_cache(monkeypatch, updates_mod, payload=None, expires_at=0.0):
+    monkeypatch.setattr(
+        updates_mod, "_version_cache",
+        {"expires_at": expires_at, "payload": payload},
+    )
+    monkeypatch.setattr(updates_mod, "_version_refresh_task", None)
+
+
+class TestReleaseCacheRejectsNonReleases:
+    """A GitHub error body is valid JSON and must not be cached as a release.
+
+    The unauthenticated API is limited to 60 requests/hour/IP and answers an
+    exhausted budget with 403 and a JSON {"message": ...}. Treating that as a
+    lookup pins latest to empty for the whole TTL and poisons the stale
+    fallback, so the dashboard reports no update while one exists.
+    """
+
+    def test_error_status_does_not_populate_the_cache(self, test_client, monkeypatch):
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client(
+            {"message": "API rate limit exceeded", "documentation_url": "https://docs"},
+            status_error=httpx.HTTPStatusError(
+                "403", request=MagicMock(), response=MagicMock()
+            ),
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["latest"] is None
+        assert updates_mod._version_cache["payload"] is None
+
+    def test_body_without_a_tag_does_not_populate_the_cache(self, test_client, monkeypatch):
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client({"message": "Not Found"})
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["latest"] is None
+        assert updates_mod._version_cache["payload"] is None
+
+    def test_a_list_body_does_not_crash_the_refresh(self, test_client, monkeypatch):
+        """`.get` on a list would raise AttributeError, which the refresh's
+        except clause does not cover."""
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client([{"tag_name": "v9.9.9"}])
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["latest"] is None
+        assert updates_mod._version_cache["payload"] is None
+
+    def test_a_real_release_still_populates_the_cache(self, test_client, monkeypatch):
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client(
+            {"tag_name": "v3.1.4", "html_url": "https://github.com/test/3.1.4"}
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.json()["latest"] == "3.1.4"
+        assert updates_mod._version_cache["payload"]["latest"] == "3.1.4"

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -721,4 +721,148 @@ class TestReleaseCacheRejectsNonReleases:
             resp = test_client.get("/api/version", headers=test_client.auth_headers)
 
         assert resp.json()["latest"] == "3.1.4"
-        assert updates_mod._version_cache["payload"]["latest"] == "3.1.4"
+        cached_payload = updates_mod._version_cache["payload"]
+        assert isinstance(cached_payload, dict)
+        assert cached_payload["latest"] == "3.1.4"
+
+
+class TestReleaseEndpointsRejectNonReleases:
+    """Every GitHub Releases consumer must reject errors and malformed data."""
+
+    def test_manifest_rejects_error_status_with_release_shaped_body(
+        self, test_client, tmp_path, monkeypatch
+    ):
+        import routers.updates as updates_mod
+
+        (tmp_path / ".version").write_text("1.2.3", encoding="utf-8")
+        monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(tmp_path))
+        request = httpx.Request("GET", updates_mod._GITHUB_RELEASES_API)
+        response = httpx.Response(403, request=request)
+        client = _mock_github_client(
+            [{"tag_name": "v9.9.9"}],
+            status_error=httpx.HTTPStatusError(
+                "rate limited", request=request, response=response
+            ),
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get(
+                "/api/releases/manifest", headers=test_client.auth_headers
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["releases"][0]["version"] == "1.2.3"
+        assert resp.json()["error"] == "Could not fetch release information"
+
+    def test_manifest_rejects_non_object_release(
+        self, test_client, tmp_path, monkeypatch
+    ):
+        import routers.updates as updates_mod
+
+        (tmp_path / ".version").write_text("1.2.3", encoding="utf-8")
+        monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(tmp_path))
+        client = _mock_github_client(["not-a-release"])
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get(
+                "/api/releases/manifest", headers=test_client.auth_headers
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["releases"][0]["version"] == "1.2.3"
+        assert resp.json()["error"] == "Could not fetch release information"
+
+    def test_manifest_accepts_null_optional_fields(self, test_client):
+        """GitHub uses null for optional fields such as missing release notes."""
+        client = _mock_github_client(
+            [
+                {
+                    "tag_name": "v1.6.0",
+                    "published_at": None,
+                    "name": None,
+                    "body": None,
+                    "html_url": None,
+                    "prerelease": False,
+                }
+            ]
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get(
+                "/api/releases/manifest", headers=test_client.auth_headers
+            )
+
+        assert resp.status_code == 200
+        release = resp.json()["releases"][0]
+        assert release == {
+            "version": "1.6.0",
+            "date": "",
+            "title": "",
+            "changelog": "",
+            "url": "",
+            "prerelease": False,
+        }
+
+    def test_dry_run_rejects_error_status_with_release_shaped_body(
+        self, test_client, tmp_path, monkeypatch
+    ):
+        import routers.updates as updates_mod
+
+        monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(tmp_path))
+        request = httpx.Request("GET", f"{updates_mod._GITHUB_RELEASES_API}/latest")
+        response = httpx.Response(403, request=request)
+        client = _mock_github_client(
+            {"tag_name": "v9.9.9", "html_url": "https://example.invalid/release"},
+            status_error=httpx.HTTPStatusError(
+                "rate limited", request=request, response=response
+            ),
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get(
+                "/api/update/dry-run", headers=test_client.auth_headers
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["latest_version"] is None
+        assert data["update_available"] is False
+        assert "rate limited" in data["version_check_error"]
+
+    def test_dry_run_reports_missing_release_tag(
+        self, test_client, tmp_path, monkeypatch
+    ):
+        import routers.updates as updates_mod
+
+        monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(tmp_path))
+        client = _mock_github_client({"message": "Not Found"})
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get(
+                "/api/update/dry-run", headers=test_client.auth_headers
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["latest_version"] is None
+        assert data["update_available"] is False
+        assert "tag_name" in data["version_check_error"]
+
+    def test_dry_run_rejects_non_object_release(
+        self, test_client, tmp_path, monkeypatch
+    ):
+        import routers.updates as updates_mod
+
+        monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(tmp_path))
+        client = _mock_github_client([{"tag_name": "v9.9.9"}])
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get(
+                "/api/update/dry-run", headers=test_client.auth_headers
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["latest_version"] is None
+        assert data["update_available"] is False
+        assert "unexpected release response" in data["version_check_error"]

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -627,3 +627,98 @@ def test_trigger_update_action_backup(test_client, monkeypatch):
     assert calls[0][0:2] == ("POST", "/v1/update/backup")
     assert calls[0][2]["backup_id"].startswith("dashboard-")
     assert calls[0][3] == 65
+
+
+def _mock_github_client(json_body, *, status_error=None):
+    """An httpx.AsyncClient stand-in returning one canned release response."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = json_body
+    if status_error is not None:
+        mock_resp.raise_for_status.side_effect = status_error
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+def _reset_version_cache(monkeypatch, updates_mod, payload=None, expires_at=0.0):
+    monkeypatch.setattr(
+        updates_mod, "_version_cache",
+        {"expires_at": expires_at, "payload": payload},
+    )
+    monkeypatch.setattr(updates_mod, "_version_refresh_task", None)
+
+
+class TestReleaseCacheRejectsNonReleases:
+    """A GitHub error body is valid JSON and must not be cached as a release.
+
+    The unauthenticated API is limited to 60 requests/hour/IP and answers an
+    exhausted budget with 403 and a JSON {"message": ...}. Treating that as a
+    lookup pins latest to empty for the whole TTL and poisons the stale
+    fallback, so the dashboard reports no update while one exists.
+    """
+
+    def test_error_status_does_not_populate_the_cache(self, test_client, monkeypatch):
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client(
+            {"message": "API rate limit exceeded", "documentation_url": "https://docs"},
+            status_error=httpx.HTTPStatusError(
+                "403", request=MagicMock(), response=MagicMock()
+            ),
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["latest"] is None
+        assert updates_mod._version_cache["payload"] is None
+
+    def test_body_without_a_tag_does_not_populate_the_cache(self, test_client, monkeypatch):
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client({"message": "Not Found"})
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["latest"] is None
+        assert updates_mod._version_cache["payload"] is None
+
+    def test_a_list_body_does_not_crash_the_refresh(self, test_client, monkeypatch):
+        """`.get` on a list would raise AttributeError, which the refresh's
+        except clause does not cover."""
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client([{"tag_name": "v9.9.9"}])
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        assert resp.json()["latest"] is None
+        assert updates_mod._version_cache["payload"] is None
+
+    def test_a_real_release_still_populates_the_cache(self, test_client, monkeypatch):
+        import routers.updates as updates_mod
+
+        _reset_version_cache(monkeypatch, updates_mod)
+        client = _mock_github_client(
+            {"tag_name": "v3.1.4", "html_url": "https://github.com/test/3.1.4"}
+        )
+
+        with patch("routers.updates.httpx.AsyncClient", return_value=client):
+            resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+        assert resp.json()["latest"] == "3.1.4"
+        assert updates_mod._version_cache["payload"]["latest"] == "3.1.4"


### PR DESCRIPTION
## Summary

- reject non-2xx GitHub Releases responses before reading their JSON bodies
- validate the latest-release object once for both /api/version and /api/update/dry-run
- validate and normalize every /api/releases/manifest item, including GitHub's legitimate null optional fields
- keep stale-cache and local-manifest fallbacks intact instead of converting upstream failures into false no-update results or HTTP 500s

## Why this matters

All three authenticated dashboard update paths call GitHub's Releases API. GitHub rate-limit, 404, and 5xx bodies are valid JSON. Before this change, /api/version could cache an empty release for five minutes, dry-run could report no update with no error, and a malformed manifest item could escape as AttributeError. Operators could therefore receive a false up-to-date result precisely when GitHub lookup failed.

Reachable production path: dashboard version badge or update preview -> dashboard-api updates router -> GitHub Releases API -> cached/computed update state shown to the operator.

## Root cause and invariant

Root cause: the consumers parsed JSON before enforcing HTTP success, and each endpoint applied a different incomplete shape check.

Invariant: a GitHub response may affect update state only when its HTTP status is successful and its payload matches the expected release schema. Upstream errors must use the existing explicit stale/local/error path.

## Implementation

- Add one latest-release parser shared by the cache refresh and dry-run paths.
- Require a non-empty normalized tag_name and a string-or-null html_url.
- Add a release-list parser that requires object entries, validates field types, accepts null optional strings, and preserves changelog truncation.
- Type the in-memory version cache so the touched update path passes focused mypy checks.
- Continue catching only the existing narrow I/O and decoding exception classes.

## Overlap check

Searched open and closed PRs by semantic release/update terms and by the changed production files routers/updates.py and tests/test_updates.py.

- #2468 is a later same-author PR over the same files. This PR is now the stricter superset: it also enforces HTTP status, requires a usable tag, covers release-shaped error bodies, and retains all useful malformed-field coverage. #2468 was closed after this canonical PR passed all CI because no independent behavior remained.
- #2341 covers GitHub body: null. Its stronger public-boundary regression was ported here; this parser preserves that valid GitHub contract.
- #2095 changes semantic-version ordering after a valid payload is received, so its behavior is independent even though it touches the same files.
- #2822 and #2550 concern local manifest/version-file reads, not remote response validation.

No new PR was opened; this updates the earlier canonical #2108.

## Regression tests

The tests exercise authenticated HTTP endpoints rather than implementation-only helpers:

- /api/version rejects 403, missing-tag, and list payloads without poisoning the cache, while a real release still caches.
- /api/releases/manifest rejects a release-shaped 403 and non-object entries, falls back to the installed version, and accepts null optional GitHub fields.
- /api/update/dry-run rejects a release-shaped 403, missing tag, and list payload while returning an explicit version_check_error.

Red evidence before the endpoint-wide fix: 5 new boundary tests failed while 33 passed. Green result: 39 passed.

## Validation

- python -m pytest tests/test_updates.py -q: 39 passed
- full dashboard-api suite: 2,112 passed, 14 skipped; one unrelated Windows-host failure because the account lacks symlink privilege (WinError 1314 in test_user_extensions.py)
- Ruff CI command over ods/: passed
- focused mypy with imports skipped: no issues in the two changed files
- workflow-style mypy reaches one pre-existing config.py:466 annotation error; no touched-file error remains
- Python compile check: passed
- git diff --check: passed
- GitHub CI at f03ce0bd: all required checks passed, including API, Ruff, mypy, integration-smoke, PowerShell on Windows and Ubuntu, and the 10-distro matrix

## Cross-platform and rollback

The change is pure Python at the HTTP boundary and adds no platform-specific filesystem behavior. Focused tests passed on Windows; GitHub CI covers the Linux runtime. There is no persisted-state or API-schema migration. Reverting the two PR commits restores the previous permissive parsing behavior.