### PR TITLE
fix(dashboard-api): resolve n8n workflow identity without ambiguity

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -26,6 +26,27 @@ def _validate_workflow_id(workflow_id: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid workflow ID format")
 
 
+def find_installed_n8n_workflow(catalog_name: str, n8n_workflows: list[dict]) -> dict | None:
+    """Return the n8n workflow that corresponds to *catalog_name*, if any.
+
+    n8n stores whatever name the imported template carried, which is not
+    guaranteed to equal the catalog name, so the match is a containment test in
+    both directions. Every caller must use the same rule: the list endpoint
+    reporting a workflow as installed while disable/executions cannot find it
+    leaves the UI offering a Disable action that always 404s.
+    """
+    target = (catalog_name or "").lower()
+    if not target:
+        return None
+    for workflow in n8n_workflows:
+        name = (workflow.get("name") or "").lower()
+        if not name:
+            continue
+        if target in name or name in target:
+            return workflow
+    return None
+
+
 def load_workflow_catalog() -> dict:
     """Load workflow catalog from JSON file."""
     if not WORKFLOW_CATALOG_FILE.exists():
@@ -118,17 +139,11 @@ async def api_workflows(api_key: str = Depends(verify_api_key)):
     """Get workflow catalog with status and dependency info."""
     catalog = load_workflow_catalog()
     n8n_workflows = await get_n8n_workflows()
-    n8n_by_name = {w.get("name", "").lower(): w for w in n8n_workflows}
 
     workflows = []
     health_cache: dict[str, bool] = {}
     for wf in catalog.get("workflows", []):
-        wf_name_lower = wf["name"].lower()
-        installed = None
-        for n8n_name, n8n_wf in n8n_by_name.items():
-            if wf_name_lower in n8n_name or n8n_name in wf_name_lower:
-                installed = n8n_wf
-                break
+        installed = find_installed_n8n_workflow(wf["name"], n8n_workflows)
 
         dep_status = await check_workflow_dependencies(wf.get("dependencies", []), health_cache)
         all_deps_met = all(dep_status.values())
@@ -232,12 +247,7 @@ async def _remove_workflow(workflow_id: str):
     if not wf_info:
         raise HTTPException(status_code=404, detail=f"Workflow not found: {workflow_id}")
 
-    n8n_wf = None
-    wf_name_lower = wf_info["name"].lower()
-    for wf in n8n_workflows:
-        if wf_name_lower in wf.get("name", "").lower():
-            n8n_wf = wf
-            break
+    n8n_wf = find_installed_n8n_workflow(wf_info["name"], n8n_workflows)
     if not n8n_wf:
         raise HTTPException(status_code=404, detail="Workflow not installed in n8n")
 
@@ -282,12 +292,7 @@ async def workflow_executions(workflow_id: str, limit: int = 20, api_key: str = 
     if not wf_info:
         raise HTTPException(status_code=404, detail=f"Workflow not found: {workflow_id}")
 
-    n8n_wf = None
-    wf_name_lower = wf_info["name"].lower()
-    for wf in n8n_workflows:
-        if wf_name_lower in wf.get("name", "").lower():
-            n8n_wf = wf
-            break
+    n8n_wf = find_installed_n8n_workflow(wf_info["name"], n8n_workflows)
     if not n8n_wf:
         return {"executions": [], "message": "Workflow not installed"}
 

--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -30,21 +30,34 @@ def find_installed_n8n_workflow(catalog_name: str, n8n_workflows: list[dict]) ->
     """Return the n8n workflow that corresponds to *catalog_name*, if any.
 
     n8n stores whatever name the imported template carried, which is not
-    guaranteed to equal the catalog name, so the match is a containment test in
-    both directions. Every caller must use the same rule: the list endpoint
-    reporting a workflow as installed while disable/executions cannot find it
-    leaves the UI offering a Disable action that always 404s.
+    guaranteed to equal the catalog name, so a unique containment match remains
+    a compatibility fallback. Prefer a unique exact match and reject ambiguous
+    candidates: choosing the first substring match can delete or inspect an
+    unrelated user-created workflow merely because n8n returned it first.
+
+    Every caller must use the same rule. Otherwise the list endpoint can report
+    a different workflow from the one disable/executions operate on.
     """
-    target = (catalog_name or "").lower()
+    target = (catalog_name or "").casefold()
     if not target:
         return None
+
+    exact_matches = []
+    partial_matches = []
     for workflow in n8n_workflows:
-        name = (workflow.get("name") or "").lower()
+        name = (workflow.get("name") or "").casefold()
         if not name:
             continue
-        if target in name or name in target:
-            return workflow
-    return None
+        if name == target:
+            exact_matches.append(workflow)
+        elif target in name or name in target:
+            partial_matches.append(workflow)
+
+    if len(exact_matches) == 1:
+        return exact_matches[0]
+    if exact_matches:
+        return None
+    return partial_matches[0] if len(partial_matches) == 1 else None
 
 
 def load_workflow_catalog() -> dict:

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -938,3 +938,110 @@ def test_workflow_enable_rejects_path_traversal_in_catalog_file(test_client, mon
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Invalid workflow file path"
+
+
+# ---------------------------------------------------------------------------
+# Installed-workflow matching parity between list, disable and executions
+# ---------------------------------------------------------------------------
+
+
+def test_find_installed_n8n_workflow_matches_both_directions():
+    """Containment is symmetric: catalog-in-n8n and n8n-in-catalog both match."""
+    from routers.workflows import find_installed_n8n_workflow
+
+    n8n = [{"id": "1", "name": "Daily Digest"}]
+    # n8n name is a prefix of the catalog name
+    assert find_installed_n8n_workflow("Daily Digest Emailer", n8n) == n8n[0]
+    # catalog name is a prefix of the n8n name
+    assert find_installed_n8n_workflow("Daily", n8n) == n8n[0]
+    # unrelated names do not match
+    assert find_installed_n8n_workflow("Invoice Parser", n8n) is None
+    # empty names never match
+    assert find_installed_n8n_workflow("", n8n) is None
+    assert find_installed_n8n_workflow("Daily Digest", [{"id": "1", "name": ""}]) is None
+
+
+def _shorter_n8n_name_catalog(tmp_path, monkeypatch):
+    """Catalog whose name strictly contains the installed n8n workflow's name."""
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "digest-wf", "name": "Daily Digest Emailer", "description": "test",
+             "file": "digest.json", "dependencies": []}
+        ],
+        "categories": {},
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+    return [{"id": "42", "name": "Daily Digest", "active": True}]
+
+
+def test_workflow_list_and_disable_agree_on_installed(test_client, tmp_path, monkeypatch):
+    """A workflow the list reports as installed must be disableable.
+
+    The list endpoint matched containment in both directions while
+    _remove_workflow only matched catalog-name-in-n8n-name, so an n8n workflow
+    whose name was shorter than the catalog name showed a Disable action that
+    always answered 404.
+    """
+    n8n_workflows = _shorter_n8n_name_catalog(tmp_path, monkeypatch)
+
+    with patch("routers.workflows.get_n8n_workflows", new_callable=AsyncMock, return_value=n8n_workflows), \
+         patch("routers.workflows.check_n8n_available", new_callable=AsyncMock, return_value=True):
+        listed = test_client.get("/api/workflows", headers=test_client.auth_headers)
+    assert listed.status_code == 200
+    entry = listed.json()["workflows"][0]
+    assert entry["installed"] is True
+    assert entry["n8nId"] == "42"
+
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session_mock = AsyncMock()
+    session_mock.delete = MagicMock(return_value=ctx)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.get_n8n_workflows", new_callable=AsyncMock, return_value=n8n_workflows), \
+         patch("aiohttp.ClientSession", return_value=session_ctx):
+        disabled = test_client.post(
+            "/api/workflows/digest-wf/disable",
+            headers=test_client.auth_headers,
+        )
+
+    assert disabled.status_code == 200, disabled.json()
+    assert disabled.json()["status"] == "success"
+
+
+def test_workflow_executions_match_list_installed(test_client, tmp_path, monkeypatch):
+    """Executions must resolve the same n8n workflow the list reported."""
+    n8n_workflows = _shorter_n8n_name_catalog(tmp_path, monkeypatch)
+
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value={"data": [{"id": "100"}]})
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session_mock = AsyncMock()
+    session_mock.get = MagicMock(return_value=ctx)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.get_n8n_workflows", new_callable=AsyncMock, return_value=n8n_workflows), \
+         patch("aiohttp.ClientSession", return_value=session_ctx):
+        resp = test_client.get(
+            "/api/workflows/digest-wf/executions",
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["n8nId"] == "42"
+    assert data["executions"] == [{"id": "100"}]

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -945,9 +945,13 @@ def test_workflow_enable_rejects_path_traversal_in_catalog_file(test_client, mon
 # ---------------------------------------------------------------------------
 
 
-def test_find_installed_n8n_workflow_matches_both_directions():
-    """Containment is symmetric: catalog-in-n8n and n8n-in-catalog both match."""
+def test_find_installed_n8n_workflow_prefers_exact_then_unique_containment():
+    """Exact identity wins; a unique legacy containment match remains valid."""
     from routers.workflows import find_installed_n8n_workflow
+
+    exact = {"id": "exact", "name": "Daily Digest"}
+    extended = {"id": "extended", "name": "Daily Digest Extended"}
+    assert find_installed_n8n_workflow("daily digest", [extended, exact]) == exact
 
     n8n = [{"id": "1", "name": "Daily Digest"}]
     # n8n name is a prefix of the catalog name
@@ -959,6 +963,26 @@ def test_find_installed_n8n_workflow_matches_both_directions():
     # empty names never match
     assert find_installed_n8n_workflow("", n8n) is None
     assert find_installed_n8n_workflow("Daily Digest", [{"id": "1", "name": ""}]) is None
+
+
+def test_find_installed_n8n_workflow_rejects_ambiguous_candidates():
+    """No arbitrary first-match selection is made when a name is ambiguous."""
+    from routers.workflows import find_installed_n8n_workflow
+
+    assert find_installed_n8n_workflow(
+        "Daily Digest",
+        [
+            {"id": "1", "name": "Daily Digest"},
+            {"id": "2", "name": "DAILY DIGEST"},
+        ],
+    ) is None
+    assert find_installed_n8n_workflow(
+        "Daily Digest",
+        [
+            {"id": "1", "name": "Daily Digest Emailer"},
+            {"id": "2", "name": "Daily Digest Extended"},
+        ],
+    ) is None
 
 
 def _shorter_n8n_name_catalog(tmp_path, monkeypatch):
@@ -1016,6 +1040,89 @@ def test_workflow_list_and_disable_agree_on_installed(test_client, tmp_path, mon
 
     assert disabled.status_code == 200, disabled.json()
     assert disabled.json()["status"] == "success"
+
+
+def test_workflow_disable_prefers_exact_name_over_earlier_partial_match(
+    test_client, tmp_path, monkeypatch,
+):
+    """Disable targets the exact workflow, independent of n8n list ordering."""
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "digest-wf", "name": "Daily Digest", "description": "test",
+             "file": "digest.json", "dependencies": []}
+        ],
+        "categories": {},
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+    n8n_workflows = [
+        {"id": "wrong", "name": "Daily Digest Extended"},
+        {"id": "exact", "name": "daily digest"},
+    ]
+
+    resp_mock = AsyncMock()
+    resp_mock.status = 204
+    request_ctx = AsyncMock()
+    request_ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    request_ctx.__aexit__ = AsyncMock(return_value=False)
+    session_mock = AsyncMock()
+    session_mock.delete = MagicMock(return_value=request_ctx)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(
+        "routers.workflows.get_n8n_workflows",
+        new_callable=AsyncMock,
+        return_value=n8n_workflows,
+    ), patch("aiohttp.ClientSession", return_value=session_ctx):
+        response = test_client.delete(
+            "/api/workflows/digest-wf",
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 200
+    delete_url = session_mock.delete.call_args.args[0]
+    assert delete_url.endswith("/api/v1/workflows/exact")
+
+
+def test_workflow_disable_refuses_ambiguous_partial_matches(
+    test_client, tmp_path, monkeypatch,
+):
+    """Disable never deletes an arbitrary workflow when no name is unique."""
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "digest-wf", "name": "Daily Digest", "description": "test",
+             "file": "digest.json", "dependencies": []}
+        ],
+        "categories": {},
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+    n8n_workflows = [
+        {"id": "one", "name": "Daily Digest Emailer"},
+        {"id": "two", "name": "Daily Digest Extended"},
+    ]
+
+    with patch(
+        "routers.workflows.get_n8n_workflows",
+        new_callable=AsyncMock,
+        return_value=n8n_workflows,
+    ), patch("aiohttp.ClientSession") as session_cls:
+        response = test_client.delete(
+            "/api/workflows/digest-wf",
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Workflow not installed in n8n"
+    session_cls.assert_not_called()
 
 
 def test_workflow_executions_match_list_installed(test_client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Why this matters

The dashboard identifies catalog workflows in n8n by name. The previous first-substring rule made the result depend on n8n list order: with catalog `Daily Digest`, an earlier user workflow named `Daily Digest Extended` could be shown, inspected, or deleted instead of the exact installed workflow. If several partial candidates existed, ODS still chose one arbitrarily.

This is a reachable destructive path through authenticated `DELETE /api/workflows/{id}` and `POST /disable`; the same identity is also consumed by the workflow list and executions endpoint.

## Root cause and invariant

Root cause: list, disable, and executions originally used inconsistent containment scans, then this PR centralized the scan but still returned the first containment candidate.

Invariant: all consumers resolve the same n8n identity; a unique exact case-insensitive name wins regardless of response ordering, a unique containment match remains available for older templates whose catalog and imported names differ, and ambiguous identities never authorize a mutation.

## What changed

- Route list, disable, and executions through one `find_installed_n8n_workflow()` helper.
- Prefer one exact case-insensitive match over partial matches.
- Preserve the legacy compatibility fallback only when containment identifies exactly one workflow.
- Refuse duplicate exact names and multiple partial matches instead of selecting by n8n response order.
- Add public-route regressions proving list/disable parity, exact-target deletion, refusal of ambiguous deletion, and executions parity.

## Overlap check

Searched open and closed PRs semantically for workflow substring/exact-name matching and scanned every open PR changing `routers/workflows.py`.

- #2749 prefers an exact name only inside `_remove_workflow`, but retains arbitrary substring fallback and leaves list/executions on different selection behavior. This older #2114 is the canonical broader change: it now ports the exact-match advantage, rejects ambiguity, and applies one invariant to all three consumers with route-level tests.
- #2748 only bounds the executions `limit` parameter.
- #2055, #2187, #2343, #2423, #2469, #2473, #2495, and #2964 cover catalog I/O, dependencies, response validation, metadata, or n8n activation contracts; none owns workflow identity selection.

## Focused validation

- `cd ods/extensions/services/dashboard-api && pytest tests/test_workflows.py -q` — **51 passed**
- `git diff --check` — passed (Git emitted only the existing Windows LF/CRLF checkout notice)

The regression exercises the authenticated HTTP deletion boundary and asserts the exact n8n ID in the outgoing DELETE URL. No live n8n instance was used; mocked transport proves selection and mutation targeting, not live n8n compatibility.

## Design, compatibility, and rollback

Unique containment is retained because imported template names can legitimately be shorter than catalog display names. Ambiguous names are reported as not installed rather than guessed; this is deliberately fail-closed for deletion. Operators can disambiguate by renaming duplicate/prefix-colliding n8n workflows.

Rollback is a normal revert of the two commits, but restores order-dependent identity selection and the wrong-workflow deletion risk. Human review is requested because this protects a destructive lifecycle action.