### PR TITLE
fix(dashboard-api): bound array length and metadata count during GGUF inspection

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -134,6 +134,8 @@ def _skip_value(reader: _Reader, value_type: int, depth: int = 0) -> None:
             raise ValueError("GGUF array nesting too deep")
         item_type = reader.unpack("<I")
         length = reader.unpack("<Q")
+        if length > len(reader.data):
+            raise ValueError(f"GGUF array length {length} exceeds file buffer size")
         for _ in range(length):
             _skip_value(reader, item_type, depth + 1)
         return
@@ -145,6 +147,8 @@ def _read_array(reader: _Reader, depth: int = 0) -> Any:
         raise ValueError("GGUF array nesting too deep")
     item_type = reader.unpack("<I")
     length = reader.unpack("<Q")
+    if length > len(reader.data):
+        raise ValueError(f"GGUF array length {length} exceeds file buffer size")
     if item_type not in _STRUCTS and item_type not in (8, 9):
         raise ValueError(f"unsupported GGUF array type: {item_type}")
 
@@ -203,6 +207,8 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
         version = reader.unpack("<I")
         tensor_count = reader.unpack("<Q")
         metadata_count = reader.unpack("<Q")
+        if metadata_count > len(data):
+            raise ValueError(f"GGUF metadata count {metadata_count} exceeds file buffer size")
         metadata: dict[str, Any] = {}
         for _ in range(metadata_count):
             key = reader.string()

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -327,3 +327,15 @@ def test_boolean_metadata_value_is_ignored_for_integer_fields(tmp_path):
 
     assert result["readable"] is True
     assert result["context_length"] is None
+
+
+def test_oversized_metadata_count_degrades_gracefully(tmp_path):
+    # GGUF header with valid magic/version but astronomically large metadata_count
+    import struct
+    content = b"GGUF" + struct.pack("<IQQ", 3, 10, 999999999999)
+    p = tmp_path / "corrupt.gguf"
+    p.write_bytes(content)
+
+    res = inspect_gguf(p)
+    assert res["readable"] is False
+    assert "exceeds file buffer size" in res["error"]


### PR DESCRIPTION
## Problem

When inspecting untrusted or corrupted GGUF model files, `_skip_value()` and `_read_array()` in `gguf_inspector.py` looped over `range(length)` for array items without checking if `length` exceeds the total metadata buffer size (`len(reader.data)`). Similarly, `metadata_count` in `inspect_gguf()` ran `range(metadata_count)` unbounded. A corrupted or crafted file with an astronomical header length (e.g. 2^63 - 1) caused CPU resource exhaustion loops.

## Why the existing contract missed it

The inspector checked for max array nesting depth (`_MAX_ARRAY_DEPTH`) but did not validate that parsed array lengths or metadata count headers fit within the size of the read buffer.

## Fix

Bound array `length` and `metadata_count` against `len(reader.data)` before initiating loops in `_skip_value()`, `_read_array()`, and `inspect_gguf()`. If an array length or metadata count exceeds buffer size, raise a `ValueError`, allowing `inspect_gguf()` to fail closed safely with a degraded result.

## Verification

Added `test_oversized_metadata_count_degrades_gracefully` to `ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py`. Ran `pytest` locally: 28/28 passed.