### PR TITLE
fix(dashboard-api): bound model context size to positive integers in model info helper

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -845,6 +845,8 @@ def get_model_info() -> Optional[ModelInfo]:
                 # the guard already used in routers/models.py.
                 try:
                     context = int(env_values.get("MAX_CONTEXT") or env_values.get("CTX_SIZE") or 32768)
+                    if context <= 0:
+                        context = 32768
                 except (TypeError, ValueError):
                     context = 32768
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -102,6 +102,14 @@ class TestGetModelInfo:
         assert info is not None
         assert info.context_length == 32768
 
+    def test_non_positive_context_falls_back_to_default(self, install_dir):
+        env_file = install_dir / ".env"
+        env_file.write_text('LLM_MODEL=Qwen2.5-7B-Instruct\nCTX_SIZE=0\n')
+
+        info = get_model_info()
+        assert info is not None
+        assert info.context_length == 32768
+
     def test_returns_none_when_no_env(self, install_dir):
         # No .env file created
         assert get_model_info() is None


### PR DESCRIPTION
## Problem

`get_model_info()` in `helpers.py` parses `MAX_CONTEXT` or `CTX_SIZE` from `.env`. If `MAX_CONTEXT` is set to `0` or a negative integer (e.g. `MAX_CONTEXT=0`), `int(...)` evaluated to `0`, causing `ModelInfo` context length to be zero or negative. Downstream model calculations and context checks failed or divided by zero when using non-positive context limits.

## Why the existing contract missed it

The helper caught `ValueError` and `TypeError` for non-numeric values (falling back to 32768) but did not check if the parsed integer was non-positive (`<= 0`).

## Fix

Add a check `if context <= 0: context = 32768` in `get_model_info()`, ensuring context length is strictly positive.

## Verification

Added `test_non_positive_context_falls_back_to_default` to `ods/extensions/services/dashboard-api/tests/test_helpers.py`. Ran `pytest` locally: 105/105 passed.