### PR TITLE
fix(performance-oracle): handle unicode decoding errors safely when reading env file

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -142,7 +142,7 @@ def read_env_file_value(key: str, install_dir: str | Path) -> str:
         for line in env_path.read_text(encoding="utf-8").splitlines():
             if line.startswith(f"{key}="):
                 return line.split("=", 1)[1].strip().strip("\"'")
-    except OSError:
+    except (OSError, UnicodeError):
         pass
     return ""
 

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -1381,3 +1381,11 @@ def test_published_exact_matches_gguf_stem_identity(data_dir):
     assert perf["source"] == "published_exact"
     assert perf["tokensPerSec"] == 43.7
     assert perf["sourceUrl"] == "https://example.test/stem-bench"
+
+
+def test_read_env_file_value_handles_unicode_decode_error(tmp_path):
+    from performance_oracle import read_env_file_value
+    (tmp_path / ".env").write_bytes(b"\x80\xff\xfe invalid unicode")
+
+    val = read_env_file_value("KEY", tmp_path)
+    assert val == ""


### PR DESCRIPTION
## Problem

`read_env_file_value()` in `performance_oracle.py` read environment configuration lines from `.env` using `env_path.read_text(encoding="utf-8")`. If `.env` contained invalid non-UTF8 binary data or corrupted bytes, `read_text()` raised an uncaught `UnicodeDecodeError` because `except OSError:` only caught filesystem OS errors.

## Why the existing contract missed it

`UnicodeDecodeError` inherits from `UnicodeError` -> `ValueError` -> `Exception`, not `OSError`, allowing binary file decoding errors to escape exception handling.

## Fix

Update `read_env_file_value()` exception tuple to `except (OSError, UnicodeError):`, ensuring corrupted `.env` file reads fall back safely to empty values without raising uncaught exceptions.

## Verification

Added `test_read_env_file_value_handles_unicode_decode_error` to `ods/extensions/services/dashboard-api/tests/test_performance_oracle.py`. Ran `pytest` locally: 43/43 passed.