### PR TITLE
fix(config): specify utf-8 encoding when reading extension manifest files

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -157,7 +157,7 @@ def _apply_host_native_llm_service_override(
 
 def _read_manifest_file(path: Path) -> dict[str, Any]:
     """Load a JSON or YAML extension manifest file."""
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     if path.suffix.lower() == ".json":
         data = json.loads(text)
     else:

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -485,3 +485,11 @@ class TestLoadExtensionManifests:
         assert "service.id is required" in errors[0]["error"]
         assert "no-id-svc" in errors[0]["file"]
         assert services == {}
+
+
+def test_read_manifest_file_uses_utf8_encoding(tmp_path):
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes('{"service": {"id": "test", "name": "Prénom Test"}}'.encode("utf-8"))
+
+    data = _read_manifest_file(manifest_path)
+    assert data["service"]["name"] == "Prénom Test"


### PR DESCRIPTION
## Problem

`_read_manifest_file()` in `config.py` read JSON/YAML extension manifest files using `path.read_text()` without an explicit `encoding="utf-8"` parameter. On platforms or environments with non-UTF-8 default locale encodings (such as Windows default CP1252 or GBK environments), reading manifests containing UTF-8 characters raised `UnicodeDecodeError` or corrupted non-ASCII text fields (e.g. extension names, descriptions, icons).

## Why the existing contract missed it

`read_text()` used the host system's default locale encoding instead of forcing UTF-8 encoding.

## Fix

Pass `encoding="utf-8"` to `path.read_text()` in `_read_manifest_file()`, ensuring cross-platform UTF-8 manifest parsing.

## Verification

Added `test_read_manifest_file_uses_utf8_encoding` to `ods/extensions/services/dashboard-api/tests/test_config.py`. Ran `pytest` locally: 43/43 passed.