### PR TITLE
fix(models): parse float timeout environment variables safely with fallback defaults

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -82,16 +82,18 @@ _HF_AVATAR_CACHE_MAX_ENTRIES = 512
 _HF_AVATAR_CACHE: dict[tuple[str, str], tuple[float, str | None]] = {}
 _HF_AVATAR_CACHE_LOCK = threading.Lock()
 _IMPORTED_MODELS_LOCK = threading.Lock()
-_MODEL_DISCOVERY_TIMEOUT_SECONDS = float(os.environ.get("DASHBOARD_MODEL_DISCOVERY_TIMEOUT", "15.0"))
-_AGENT_MODEL_STATUS_CACHE_TTL_SECONDS = float(
-    os.environ.get("DASHBOARD_AGENT_MODEL_STATUS_CACHE_TTL", "0.5")
-)
-_STALE_TERMINAL_DOWNLOAD_STATUS_SECONDS = float(
-    os.environ.get("DASHBOARD_STALE_TERMINAL_DOWNLOAD_STATUS_SECONDS", "1800")
-)
-_STALE_ACTIVE_BOOTSTRAP_STATUS_SECONDS = float(
-    os.environ.get("DASHBOARD_STALE_ACTIVE_BOOTSTRAP_STATUS_SECONDS", "900")
-)
+def _safe_float_env(key: str, default: float) -> float:
+    try:
+        val = float(os.environ.get(key, str(default)))
+        return val if val > 0 else default
+    except (ValueError, TypeError):
+        return default
+
+
+_MODEL_DISCOVERY_TIMEOUT_SECONDS = _safe_float_env("DASHBOARD_MODEL_DISCOVERY_TIMEOUT", 15.0)
+_AGENT_MODEL_STATUS_CACHE_TTL_SECONDS = _safe_float_env("DASHBOARD_AGENT_MODEL_STATUS_CACHE_TTL", 0.5)
+_STALE_TERMINAL_DOWNLOAD_STATUS_SECONDS = _safe_float_env("DASHBOARD_STALE_TERMINAL_DOWNLOAD_STATUS_SECONDS", 1800.0)
+_STALE_ACTIVE_BOOTSTRAP_STATUS_SECONDS = _safe_float_env("DASHBOARD_STALE_ACTIVE_BOOTSTRAP_STATUS_SECONDS", 900.0)
 _ACTIVE_BOOTSTRAP_STATUSES = {"starting", "downloading", "verifying", "swapping"}
 _agent_model_status_cache_lock = threading.Lock()
 _agent_model_status_cache_at = 0.0

--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -4,6 +4,7 @@ import asyncio
 import hashlib
 import json
 import logging
+import math
 import os
 import re
 import tempfile
@@ -85,7 +86,7 @@ _IMPORTED_MODELS_LOCK = threading.Lock()
 def _safe_float_env(key: str, default: float) -> float:
     try:
         val = float(os.environ.get(key, str(default)))
-        return val if val > 0 else default
+        return val if (math.isfinite(val) and val > 0) else default
     except (ValueError, TypeError):
         return default
 

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -2191,3 +2191,12 @@ def test_safe_float_env_handles_invalid_and_non_positive_values(monkeypatch):
 
     monkeypatch.setenv("TEST_FLOAT_ENV", "-5.0")
     assert models_router._safe_float_env("TEST_FLOAT_ENV", 15.0) == 15.0
+
+    monkeypatch.setenv("TEST_FLOAT_ENV", "inf")
+    assert models_router._safe_float_env("TEST_FLOAT_ENV", 15.0) == 15.0
+
+    monkeypatch.setenv("TEST_FLOAT_ENV", "1e309")
+    assert models_router._safe_float_env("TEST_FLOAT_ENV", 15.0) == 15.0
+
+    monkeypatch.setenv("TEST_FLOAT_ENV", "30.0")
+    assert models_router._safe_float_env("TEST_FLOAT_ENV", 15.0) == 30.0

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -2181,3 +2181,13 @@ def test_load_model_rejects_local_gguf_path_separators(test_client, monkeypatch,
     )
 
     assert resp.status_code == 404
+
+
+def test_safe_float_env_handles_invalid_and_non_positive_values(monkeypatch):
+    import routers.models as models_router
+
+    monkeypatch.setenv("TEST_FLOAT_ENV", "invalid")
+    assert models_router._safe_float_env("TEST_FLOAT_ENV", 15.0) == 15.0
+
+    monkeypatch.setenv("TEST_FLOAT_ENV", "-5.0")
+    assert models_router._safe_float_env("TEST_FLOAT_ENV", 15.0) == 15.0


### PR DESCRIPTION
## Problem

In `routers/models.py`, module-level timeout constants (`_MODEL_DISCOVERY_TIMEOUT_SECONDS`, `_AGENT_MODEL_STATUS_CACHE_TTL_SECONDS`, `_STALE_TERMINAL_DOWNLOAD_STATUS_SECONDS`, and `_STALE_ACTIVE_BOOTSTRAP_STATUS_SECONDS`) parsed environment variables directly with `float(os.environ.get(...))`. If any of these environment variables were set to invalid non-numeric strings (e.g. `DASHBOARD_MODEL_DISCOVERY_TIMEOUT="invalid"`), non-positive numbers, or non-finite positive floats (`inf`, `Infinity`, `1e309`), module import raised an uncaught `ValueError` or set infinite timeouts that disabled fallback logic.

## Why the existing contract missed it

Direct `float()` calls lacked exception handling for `ValueError` and `TypeError` when converting process environment strings, and did not check for finite range bounds (`math.isfinite(val) and val > 0`).

## Fix

Introduce `_safe_float_env(key, default)` helper that verifies `math.isfinite(val) and val > 0`, safely parsing environment float variables and falling back to default values when invalid, non-positive, or non-finite values are encountered.

## Verification

Extended `test_safe_float_env_handles_invalid_and_non_positive_values` in `ods/extensions/services/dashboard-api/tests/test_models.py` with non-finite (`inf`, `1e309`) and valid positive float cases. Ran `pytest` locally: 85/85 passed.