### PR TITLE
fix(python): find the real interpreter when Windows Store aliases shadow PATH

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -195,6 +195,9 @@ jobs:
       - name: Issue-to-PR Security Contract Tests
         run: bash tests/test-issue-to-pr-security.sh
 
+      - name: Shared Python Resolver Tests
+        run: bash tests/test-python-cmd-resolver.sh
+
       - name: Upload Installer Simulation Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -60,6 +60,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== shared Python interpreter resolver ==="
+	@bash tests/test-python-cmd-resolver.sh
+	@echo ""
 	@echo "=== QR code helper LAN detection ==="
 	@bash tests/test-qrcode-helper.sh
 	@echo ""

--- a/ods/lib/python-cmd.sh
+++ b/ods/lib/python-cmd.sh
@@ -115,6 +115,19 @@ ods_detect_python_cmd() {
         return 0
     fi
 
+    # On Windows Git Bash the App Execution Aliases usually shadow both names on
+    # PATH, so the checks above reject python3 and python even when a real
+    # interpreter is installed under LOCALAPPDATA. Scan the same install
+    # locations the module-aware resolver uses instead of giving up.
+    local candidate
+    while IFS= read -r candidate; do
+        if _ods_python_runnable "$candidate"; then
+            _ods_python_cmd_cached="$candidate"
+            printf '%s' "${_ods_python_cmd_cached}"
+            return 0
+        fi
+    done < <(_ods_python_windows_candidates)
+
     echo "ERROR: Neither python3 nor python is available/runnable." >&2
     return 1
 }

--- a/ods/tests/test-python-cmd-resolver.sh
+++ b/ods/tests/test-python-cmd-resolver.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Test lib/python-cmd.sh: ods_detect_python_cmd interpreter discovery.
+#
+# The resolver deliberately rejects the Windows App Execution Aliases
+# (%LOCALAPPDATA%\Microsoft\WindowsApps\python*.exe) because they are Store
+# stubs, not interpreters. Those aliases ship enabled by default, so on Git
+# Bash they usually shadow BOTH `python3` and `python` on PATH. The resolver
+# must still find the real interpreter under LOCALAPPDATA instead of reporting
+# that no Python exists.
+#
+# Run from repo root:  bash ods/tests/test-python-cmd-resolver.sh
+# Or from ods: bash tests/test-python-cmd-resolver.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+RESOLVER="$ROOT_DIR/lib/python-cmd.sh"
+[[ -f "$RESOLVER" ]] || fail "lib/python-cmd.sh not found"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# A stub that behaves like a working interpreter for the resolver's probe
+# ("python -c 'import sys; sys.exit(0)'").
+write_working_python() {
+    local target="$1"
+    mkdir -p "$(dirname "$target")"
+    cat > "$target" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$target"
+}
+
+WINAPPS="$tmpdir/Local/Microsoft/WindowsApps"
+write_working_python "$WINAPPS/python"
+write_working_python "$WINAPPS/python3"
+
+REAL_PYTHON="$tmpdir/Local/Programs/Python/Python313/python.exe"
+write_working_python "$REAL_PYTHON"
+
+# The resolver caches its answer per shell, so every case runs in a fresh bash.
+resolve() {
+    env "$@" bash -c '. "$1"; ods_detect_python_cmd' bash "$RESOLVER" 2>/dev/null || true
+}
+
+echo "Test 1: both PATH names are WindowsApps aliases, real interpreter under LOCALAPPDATA"
+resolved="$(resolve "PATH=$WINAPPS:$PATH" "LOCALAPPDATA=$tmpdir/Local" ODS_PYTHON_CMD=)"
+[[ "$resolved" == "$REAL_PYTHON" ]] \
+    || fail "resolver returned '$resolved' instead of the LOCALAPPDATA interpreter '$REAL_PYTHON'"
+pass "resolver falls back to the LOCALAPPDATA interpreter"
+
+echo "Test 2: a usable PATH interpreter still wins over the LOCALAPPDATA fallback"
+REALBIN="$tmpdir/realbin"
+write_working_python "$REALBIN/python3"
+resolved="$(resolve "PATH=$REALBIN:$WINAPPS:$PATH" "LOCALAPPDATA=$tmpdir/Local" ODS_PYTHON_CMD=)"
+[[ "$resolved" == "python3" ]] \
+    || fail "resolver returned '$resolved' instead of the PATH python3"
+pass "PATH python3 keeps precedence over the LOCALAPPDATA fallback"
+
+echo "Test 3: no interpreter anywhere still fails loudly"
+empty_bin="$tmpdir/empty"
+mkdir -p "$empty_bin" "$tmpdir/NoPython"
+resolved="$(resolve "PATH=$WINAPPS:$empty_bin" "LOCALAPPDATA=$tmpdir/NoPython" ODS_PYTHON_CMD=)"
+[[ -z "$resolved" ]] || fail "resolver returned '$resolved' with no interpreter available"
+pass "resolver still reports failure when nothing is installed"
+
+echo "Test 4: ODS_PYTHON_CMD override is not bypassed by the fallback"
+resolved="$(resolve "PATH=$WINAPPS:$PATH" "LOCALAPPDATA=$tmpdir/Local" "ODS_PYTHON_CMD=$REALBIN/python3")"
+[[ "$resolved" == "$REALBIN/python3" ]] \
+    || fail "resolver returned '$resolved' instead of the ODS_PYTHON_CMD override"
+pass "ODS_PYTHON_CMD override keeps precedence"
+
+echo ""
+echo "All python-cmd resolver tests passed."


### PR DESCRIPTION
## Problem

`lib/python-cmd.sh` has two interpreter resolvers. Both reject the Windows App Execution Aliases (`%LOCALAPPDATA%\Microsoft\WindowsApps\python*.exe`) — correctly, since those are Store stubs, not interpreters, and the repo already has a contract test pinning that rejection. Only one of them recovers afterwards:

| | rejects Store aliases | falls back to `%LOCALAPPDATA%` install locations |
|---|---|---|
| `ods_detect_python_cmd_with_module` | yes | yes (`_ods_python_windows_candidates`) |
| `ods_detect_python_cmd` | yes | **no — returns 1** |

The aliases ship enabled by default on Windows, so under Git Bash they usually shadow **both** `python3` and `python` on PATH. `_ods_python_runnable` only inspects the first PATH hit for each name, so both probes reject and the generic resolver reports that no Python exists.

Reproduced on a Windows host with a working Python 3.13 install, clean checkout, no local changes:

```
$ command -v python;  command -v python3
/c/Users/<user>/AppData/Local/Microsoft/WindowsApps/python
/c/Users/<user>/AppData/Local/Microsoft/WindowsApps/python3

$ bash -c '. ods/lib/python-cmd.sh; ods_detect_python_cmd'
ERROR: Neither python3 nor python is available/runnable.

$ bash -c '. ods/lib/python-cmd.sh; ods_detect_python_cmd_with_module json'
/c/Users/<user>/AppData/Local/Python/bin/python.exe
```

Same file, same host, same interpreter — the sibling resolver finds it.

## Why it matters on the install path

`Get-UsableWindowsBash` (`installers/windows/install-windows.ps1:143-175`) prefers `Git\bin\bash.exe`, and the Windows installer runs `scripts/bootstrap-upgrade.sh` through it as a Scheduled Task. That script resolves its interpreter with `ods_detect_python_cmd` before rendering runtime configs:

- `scripts/bootstrap-upgrade.sh:1441` — empty resolver result → `ERROR: runtime config renderer is unavailable for Windows Lemonade` and the LiteLLM route regeneration is abandoned.
- `scripts/bootstrap-upgrade.sh:2656` — falls back to the literal `python3`, whose `command -v` hit *is* the Store alias, so the render is attempted against the stub. On failure the swap rolls back and `exit 1`s with status `failed` — after the full model has already been downloaded and verified.
- `scripts/bootstrap-upgrade.sh:3086` — same alias fallback for the Perplexica config update.

Other affected callers include `scripts/ods-doctor.sh:379`, `scripts/preflight-engine.sh:78`, and `extensions/services/token-spy/session-manager.sh`.

## Fix

After the PATH probes, sweep the same `_ods_python_windows_candidates` locations the module-aware resolver already uses (13 lines, `installers/`-free). Precedence is unchanged: `ODS_PYTHON_CMD`, then `ODS_PYTHON_PREFER_SYSTEM`, then PATH `python3`/`python`, and only then the Windows install locations.

Does not touch `ods_detect_python_cmd_with_module`, so it does not overlap the hunk #1934 edits in the same file.

## Verification

New `tests/test-python-cmd-resolver.sh`, gated in `Makefile` (`make test`) and `.github/workflows/test-linux.yml`:

1. both PATH names are Store aliases + real interpreter under `LOCALAPPDATA` → resolver returns it (**fails on `main`: returns empty, exit 1**)
2. a usable PATH `python3` still wins over the fallback (precedence regression guard)
3. nothing installed anywhere → still fails loudly
4. `ODS_PYTHON_CMD` override still wins

```
$ bash tests/test-python-cmd-resolver.sh          # this branch
[PASS] resolver falls back to the LOCALAPPDATA interpreter
[PASS] PATH python3 keeps precedence over the LOCALAPPDATA fallback
[PASS] resolver still reports failure when nothing is installed
[PASS] ODS_PYTHON_CMD override keeps precedence

$ git checkout main -- ods/lib/python-cmd.sh && bash tests/test-python-cmd-resolver.sh
[FAIL] resolver returned '' instead of the LOCALAPPDATA interpreter
```

`bash -n` clean on both shell files; `test-linux.yml` parses.