### PR TITLE
fix(cli): complete every command and service ods-cli resolves

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -105,6 +105,9 @@ jobs:
       - name: CLI Enable Compose Reconciliation Tests
         run: bash tests/test-cli-enable-compose-reconciliation.sh
 
+      - name: CLI Completion Parity Tests
+        run: bash tests/test-cli-completion-parity.sh
+
       - name: Windows Missing Service Hint Tests
         run: bash tests/test-windows-missing-service-hints.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -75,6 +75,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
+	@bash tests/test-cli-completion-parity.sh
 	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh

--- a/ods/completions/ods-cli.bash
+++ b/ods/completions/ods-cli.bash
@@ -6,12 +6,15 @@ _ods_completion() {
     local cur prev words cword
     _init_completion || return
 
-    # Main commands and their aliases
-    local main_commands="gpu status status-json list enable disable preset mode model backup restore logs restart start stop update shell config chat benchmark doctor help version"
-    local aliases="g s ls p m l r u sh cfg c bench b diag d h v"
+    # Main commands and their aliases.
+    # Keep in sync with the dispatch table at the bottom of ods-cli;
+    # tests/test-cli-completion-parity.sh fails the build when they drift.
+    local main_commands="gpu status status-json list enable disable purge preset mode model remote-provider stt backup restore rollback logs restart repair start stop update shell config chat benchmark doctor audit template agent help version"
+    local aliases="g s ls p m l log r fix u sh cfg c bench b diag d tmpl h v"
 
-    # Service names (from ods-cli aliases section)
-    local services="ape policy guard embeddings embed llama-server llm n8n workflows open-webui web ui webui opencode opencode-web qdrant vector searxng search tts kokoro whisper voice stt"
+    # Service ids and aliases, from extensions/services/*/manifest.yaml.
+    # tests/test-cli-completion-parity.sh fails the build when they drift.
+    local services="agent ape brave brave-search comfyui dashboard dashboard-api embed embeddings gateway guard hermes hermes-agent hermes-gate hermes-proxy kokoro langfuse litellm llama-server llm model-router n8n observability ods-proxy open-webui openclaw opencode opencode-web perplexica policy privacy-shield proxy qdrant remote remote-provider-egress remote-provider-ssh-tunnel search searxng stt tailscale token-spy traces tts ui vector voice vpn web webui whisper workflows"
 
     case $cword in
         1)
@@ -26,7 +29,7 @@ _ods_completion() {
                     return 0
                     ;;
                 preset|p)
-                    COMPREPLY=($(compgen -W "save load list delete export import" -- "$cur"))
+                    COMPREPLY=($(compgen -W "save load list delete export import diff" -- "$cur"))
                     return 0
                     ;;
                 mode|m)
@@ -35,6 +38,30 @@ _ods_completion() {
                     ;;
                 model)
                     COMPREPLY=($(compgen -W "current list swap" -- "$cur"))
+                    return 0
+                    ;;
+                remote-provider)
+                    COMPREPLY=($(compgen -W "status plan configure test disable remove peer-models help" -- "$cur"))
+                    return 0
+                    ;;
+                stt)
+                    COMPREPLY=($(compgen -W "current status download" -- "$cur"))
+                    return 0
+                    ;;
+                repair|fix)
+                    COMPREPLY=($(compgen -W "voice stt tts hermes-workers slash-workers" -- "$cur"))
+                    return 0
+                    ;;
+                template|tmpl)
+                    COMPREPLY=($(compgen -W "list preview apply" -- "$cur"))
+                    return 0
+                    ;;
+                agent)
+                    COMPREPLY=($(compgen -W "status start stop restart logs" -- "$cur"))
+                    return 0
+                    ;;
+                audit)
+                    COMPREPLY=($(compgen -W "--json --strict $services" -- "$cur"))
                     return 0
                     ;;
                 config|cfg)
@@ -49,7 +76,7 @@ _ods_completion() {
                     COMPREPLY=($(compgen -W "--json" -- "$cur"))
                     return 0
                     ;;
-                enable|disable|logs|log|l|restart|r|start|stop|shell|sh)
+                enable|disable|purge|logs|log|l|restart|r|start|stop|shell|sh)
                     # Complete with service names
                     COMPREPLY=($(compgen -W "$services" -- "$cur"))
                     return 0
@@ -81,7 +108,7 @@ _ods_completion() {
                     ;;
                 preset|p)
                     case $prev in
-                        save|load|delete)
+                        save|load|delete|diff)
                             # Complete with existing preset names
                             local preset_dir="${ODS_HOME:-$HOME/ods}/.presets"
                             if [[ -d "$preset_dir" ]]; then

--- a/ods/completions/ods-cli.bash
+++ b/ods/completions/ods-cli.bash
@@ -110,7 +110,7 @@ _ods_completion() {
                     case $prev in
                         save|load|delete|diff)
                             # Complete with existing preset names
-                            local preset_dir="${ODS_HOME:-$HOME/ods}/.presets"
+                            local preset_dir="${ODS_HOME:-$HOME/ods}/presets"
                             if [[ -d "$preset_dir" ]]; then
                                 local presets=$(ls -1 "$preset_dir" 2>/dev/null | sed 's/\.preset$//')
                                 COMPREPLY=($(compgen -W "$presets" -- "$cur"))
@@ -119,7 +119,7 @@ _ods_completion() {
                             ;;
                         export)
                             # Complete with existing preset names for export
-                            local preset_dir="${ODS_HOME:-$HOME/ods}/.presets"
+                            local preset_dir="${ODS_HOME:-$HOME/ods}/presets"
                             if [[ -d "$preset_dir" ]]; then
                                 local presets=$(ls -1 "$preset_dir" 2>/dev/null | sed 's/\.preset$//')
                                 COMPREPLY=($(compgen -W "$presets" -- "$cur"))

--- a/ods/tests/test-cli-completion-parity.sh
+++ b/ods/tests/test-cli-completion-parity.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Keep completions/ods-cli.bash in sync with the ods-cli dispatch table.
+#
+# A command that is dispatched but missing from the completion word list is
+# invisible to tab-completion, and a completion entry with no dispatch case
+# advertises a command that errors out. Both drift silently because nothing
+# else reads the completion file.
+#
+# Run from ods/:  bash tests/test-cli-completion-parity.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI="$ROOT_DIR/ods-cli"
+COMPLETION="$ROOT_DIR/completions/ods-cli.bash"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$CLI" ]] || fail "ods-cli not found at $CLI"
+[[ -f "$COMPLETION" ]] || fail "completion not found at $COMPLETION"
+
+# Commands the CLI actually dispatches, one per line. Flag-style entries
+# (--help/-h/...) are not completed as commands and are dropped.
+dispatched_commands() {
+    awk '/^case "\$\{1:-help\}" in$/ {inside=1; next}
+         inside && /^esac$/ {exit}
+         inside && match($0, /^ +[a-z0-9|_-]+\)/) {
+             split(substr($0, RSTART, RLENGTH - 1), parts, "|")
+             for (i in parts) {
+                 gsub(/^ +| +$/, "", parts[i])
+                 if (parts[i] != "" && parts[i] != "*" && parts[i] !~ /^-/) print parts[i]
+             }
+         }' "$CLI" | sort -u
+}
+
+# Words offered for the first argument: main_commands plus aliases.
+completed_commands() {
+    sed -n 's/.*local main_commands="\([^"]*\)".*/\1/p;s/.*local aliases="\([^"]*\)".*/\1/p' \
+        "$COMPLETION" | tr ' ' '\n' | sed '/^$/d' | sort -u
+}
+
+dispatched="$(dispatched_commands)"
+completed="$(completed_commands)"
+
+[[ -n "$dispatched" ]] || fail "could not parse the ods-cli dispatch table"
+[[ -n "$completed" ]] || fail "could not parse main_commands/aliases from the completion"
+
+missing="$(comm -23 <(printf '%s\n' "$dispatched") <(printf '%s\n' "$completed") | tr '\n' ' ')"
+missing="${missing% }"
+[[ -z "$missing" ]] || fail "dispatched but not completable: $missing"
+pass "every dispatched command is offered by the completion"
+
+phantom="$(comm -13 <(printf '%s\n' "$dispatched") <(printf '%s\n' "$completed") | tr '\n' ' ')"
+phantom="${phantom% }"
+[[ -z "$phantom" ]] || fail "completed but not dispatched: $phantom"
+pass "the completion offers no command ods-cli cannot run"
+
+# Commands that take a subcommand need a second-level branch, otherwise the
+# completion silently falls through to "no suggestions".
+for cmd in gpu preset mode model remote-provider stt repair template agent config; do
+    grep -qE "^[[:space:]]+([a-z0-9|_-]+\|)?${cmd}(\||\))" "$COMPLETION" \
+        || fail "no second-level completion branch for '$cmd'"
+done
+pass "every sub-commanded command has a second-level branch"
+
+# Service completion is a hand-maintained word list. Every service id and
+# alias the CLI can resolve has to be in it, or `ods logs <TAB>` silently
+# omits services the user can name.
+manifest_service_names() {
+    for manifest in "$ROOT_DIR"/extensions/services/*/manifest.yaml; do
+        awk '/^  id:/ { print $2 }
+             /^  aliases:/ {
+                 line = $0
+                 sub(/^[^[]*\[/, "", line)
+                 sub(/\].*$/, "", line)
+                 gsub(/[ \t]/, "", line)
+                 n = split(line, parts, ",")
+                 for (i = 1; i <= n; i++) if (parts[i] != "") print parts[i]
+             }' "$manifest"
+    done | sort -u
+}
+
+completed_services() {
+    sed -n 's/.*local services="\([^"]*\)".*/\1/p' "$COMPLETION" \
+        | tr ' ' '\n' | sed '/^$/d' | sort -u
+}
+
+manifest_names="$(manifest_service_names)"
+completed_names="$(completed_services)"
+
+[[ -n "$manifest_names" ]] || fail "could not parse service names from the manifests"
+[[ -n "$completed_names" ]] || fail "could not parse the service word list from the completion"
+
+missing_services="$(comm -23 <(printf '%s\n' "$manifest_names") <(printf '%s\n' "$completed_names") | tr '\n' ' ')"
+missing_services="${missing_services% }"
+[[ -z "$missing_services" ]] || fail "services the CLI resolves but the completion omits: $missing_services"
+pass "every service id and alias is offered by the completion"
+
+phantom_services="$(comm -13 <(printf '%s\n' "$manifest_names") <(printf '%s\n' "$completed_names") | tr '\n' ' ')"
+phantom_services="${phantom_services% }"
+[[ -z "$phantom_services" ]] || fail "completion offers unknown service names: $phantom_services"
+pass "the completion offers no unknown service name"
+
+# The mode values are a closed set in cmd_mode; keep the completion identical.
+mode_cases="$(awk '/^cmd_mode\(\)/ {inside=1}
+                   inside && match($0, /^ +[a-z|]+\)/) {
+                       word = substr($0, RSTART, RLENGTH - 1)
+                       gsub(/^ +/, "", word)
+                       if (word != "*") { print word; exit }
+                   }' "$CLI" | tr '|' ' ')"
+mode_completion="$(sed -n '/mode|m)/,/;;/p' "$COMPLETION" \
+    | sed -n 's/.*compgen -W "\([^"]*\)".*/\1/p')"
+for value in $mode_cases; do
+    grep -qw -- "$value" <<< "$mode_completion" \
+        || fail "mode value '$value' accepted by cmd_mode but not completed"
+done
+pass "mode values match cmd_mode"
+
+echo "[PASS] ods-cli completion parity"

--- a/ods/tests/test-cli-completion-parity.sh
+++ b/ods/tests/test-cli-completion-parity.sh
@@ -117,4 +117,34 @@ for value in $mode_cases; do
 done
 pass "mode values match cmd_mode"
 
+# Exercise the completion function at its public Bash boundary. ods-cli stores
+# each saved preset as a directory under INSTALL_DIR/presets; a stale
+# .presets lookup leaves load/delete/export/diff with no useful suggestions.
+completion_home="$(mktemp -d)"
+trap 'rm -rf -- "$completion_home"' EXIT
+mkdir -p "$completion_home/presets/gaming" "$completion_home/.presets/legacy"
+export ODS_HOME="$completion_home"
+
+completion_action=""
+_init_completion() {
+    words=(ods preset "$completion_action" "")
+    cword=3
+    prev="$completion_action"
+    cur=""
+}
+
+# Sourcing registers the completion and exposes _ods_completion just as an
+# interactive Bash session does.
+# shellcheck source=../completions/ods-cli.bash
+source "$COMPLETION"
+for completion_action in save load delete export diff; do
+    COMPREPLY=()
+    _ods_completion
+    [[ " ${COMPREPLY[*]} " == *" gaming "* ]] \
+        || fail "preset '$completion_action' does not complete saved preset 'gaming'"
+    [[ " ${COMPREPLY[*]} " != *" legacy "* ]] \
+        || fail "preset '$completion_action' still reads the obsolete .presets directory"
+done
+pass "preset actions complete names from the ods-cli presets directory"
+
 echo "[PASS] ods-cli completion parity"


### PR DESCRIPTION
Fixes #3144

## Problem  `completions/ods-cli.bash` carries two hand-maintained word lists, and both have fallen behind the code they mirror.  ### 1. Commands  ```bash local main_commands="gpu status status-json list enable disable preset mode model backup restore logs restart start stop update shell config chat benchmark doctor help version" local aliases="g s ls p m l r u sh cfg c bench b diag d h v" ```  Diffed against the dispatch table at the bottom of `ods-cli` ? **8 commands + 3 aliases dispatched but not completable**:  | Command | Dispatch | In `ods help` | |---|---|---| | `purge` | `purge)  shift; cmd_purge "$@"` | yes | | `remote-provider` | `remote-provider) shift; cmd_remote_provider "$@"` | yes | | `stt` | `stt)  shift; cmd_stt "$@"` | yes | | `rollback` | `rollback)  cmd_rollback` | yes | | `repair` / `fix` | `repair\|fix) shift; cmd_repair "$@"` | yes | | `audit` | `audit)  shift; cmd_audit "$@"` | yes | | `template` / `tmpl` | `template\|tmpl) shift; cmd_template "$@"` | yes | | `agent` | `agent)  shift; cmd_agent "$@"` | yes | | `log` (alias of `logs`) | `logs\|log\|l)` | ? |  None had a second-level branch either, so `ods agent <TAB>` offered nothing even though `cmd_agent` accepts a closed set. `preset` was also missing the `diff` action `cmd_preset` already handles.  ### 2. Services  ```bash local services="ape policy guard embeddings embed llama-server llm n8n workflows open-webui web ui webui opencode opencode-web qdrant vector searxng search tts kokoro whisper voice stt" ```  That is **24 of the 51 ids and aliases** declared across `extensions/services/*/manifest.yaml`. It feeds the `enable|disable|purge|logs|restart|start|stop|shell` branch, so **17 of 27 services could not be tab-completed at all**:  `brave-search`/`brave`, `comfyui`, `dashboard`, `dashboard-api`, `hermes`/`agent`/`hermes-agent`, `hermes-proxy`/`hermes-gate`, `langfuse`/`observability`/`traces`, `litellm`, `model-router`, `ods-proxy`/`proxy`/`gateway`, `openclaw`, `perplexica`, `privacy-shield`, `remote-provider-egress`, `remote-provider-ssh-tunnel`, `tailscale`/`remote`/`vpn`, `token-spy`.  Neither list has phantom entries, so this is pure drift from things added after the completion was written.  ## Fix  - Adds the 8 commands and 3 aliases to `main_commands` / `aliases`. - Adds second-level branches for `remote-provider`, `stt`, `repair|fix`, `template|tmpl`, `agent`, `audit`, each using the exact word set its `cmd_*` function accepts. - `purge` joins the service-name branch, since it takes a service like `enable`/`disable`. - Adds `diff` to the `preset` action list and to the preset-name branch. - Regenerates the service word list from the manifests (all 51 ids + aliases).  No behaviour change to `ods-cli` itself.  ## Tests  New `tests/test-cli-completion-parity.sh`, wired into `make test` and `.github/workflows/test-linux.yml`.  It parses both sides rather than hardcoding lists, so it keeps working as commands and services are added:  1. every dispatched command (flag-style entries excluded) appears in `main_commands` or `aliases`; 2. every completion word is dispatched ? no phantom commands; 3. every command that takes a subcommand has a second-level branch; 4. every service id and alias in `extensions/services/*/manifest.yaml` appears in the service word list; 5. the service word list contains no unknown name; 6. the `mode` word list matches the closed set in `cmd_mode`.  Verified red against the pre-fix completion file:  ``` [FAIL] dispatched but not completable: agent audit fix log purge remote-provider repair rollback stt template tmpl ```  and, once the command list is fixed but the service list is not:  ``` [FAIL] services the CLI resolves but the completion omits: agent brave brave-search comfyui dashboard dashboard-api        gateway hermes hermes-agent hermes-gate hermes-proxy langfuse litellm model-router observability ods-proxy        openclaw perplexica privacy-shield proxy remote remote-provider-egress remote-provider-ssh-tunnel tailscale        token-spy traces vpn ```  Green after ? 6 checks pass. `bash -n` clean on both changed shell files. 
## Why this matters

The shipped completion is a user-facing CLI path. On current main, ods-cli persists presets under INSTALL_DIR/presets while every preset-name completion reads ODS_HOME/.presets. Consequently save/load/delete/export/diff cannot suggest the presets the CLI actually created. The follow-up exercises the registered Bash completion function and preserves the invariant that completion and command storage resolve the same directory.

## Overlap check

Searched open and closed upstream PRs for preset completion, .presets, presets/, and completions/ods-cli.bash. This existing tang-vu PR is the only open PR owning the production completion file and already carries the command/service parity test, so #3144 is incorporated here instead of opening a duplicate. No closed PR covers the directory mismatch.
