### PR TITLE
fix(backup): load the shared rsync helper from the script, not the target

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -99,6 +99,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
+	@bash tests/test-restore-safety-ux.sh
 	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -29,7 +29,12 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 
 # Source shared rsync utilities
-. "$ODS_DIR/lib/rsync.sh"
+# Shared helpers ship with this script, so resolve them from SCRIPT_DIR.
+# ODS_DIR names the install being backed up/restored and is caller-
+# overridable; sourcing our own library through it makes the tool load a
+# different install's code, or die before it can report anything when the
+# target has no lib/ at all.
+. "$SCRIPT_DIR/lib/rsync.sh"
 
 # Convert bytes to a human-friendly string (best-effort)
 fmt_bytes() {

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -26,7 +26,12 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 log_step() { echo -e "${CYAN}[STEP]${NC} $*"; }
 
 # Source shared rsync utilities
-. "$ODS_DIR/lib/rsync.sh"
+# Shared helpers ship with this script, so resolve them from SCRIPT_DIR.
+# ODS_DIR names the install being backed up/restored and is caller-
+# overridable; sourcing our own library through it makes the tool load a
+# different install's code, or die before it can report anything when the
+# target has no lib/ at all.
+. "$SCRIPT_DIR/lib/rsync.sh"
 
 # Convert bytes to a human-friendly string (best-effort)
 fmt_bytes() {


### PR DESCRIPTION
## Problem

`ods-backup.sh` and `ods-restore.sh` source their own library through `ODS_DIR`:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
ODS_DIR="${ODS_DIR:-$SCRIPT_DIR}"
BACKUP_ROOT="${ODS_DIR}/.backups"
...
. "$ODS_DIR/lib/rsync.sh"
```

`ODS_DIR` names **the install being backed up or restored**. It is caller-overridable — that is the whole point of the variable, and `BACKUP_ROOT` is derived from it. Two things follow:

- Point it at another install and the running script executes *that* install's copy of the helper, across versions.
- Point it at a directory with no `lib/` and the script dies on the source line, before any ODS diagnostics run:

```
ods-restore.sh: line 29: .../lib/rsync.sh: No such file or directory
```

`tests/test-restore-safety-ux.sh` already trips on this — it builds a backup-root fixture, sets `ODS_DIR` to it, and never reaches the confirmation prompt it means to test:

```
ℹ Restore should cancel unless backup ID is typed
✗ Expected rc=0 on cancel, got 1
```

The suite is in neither `make test` nor any workflow, so that has been red unnoticed.

## Fix

Resolve the shared helper from `SCRIPT_DIR`, where it actually ships, and leave `ODS_DIR` to name the data root. One line in each script. Then run the suite from `make test`.

## Tests

```
# on main
tests/test-restore-safety-ux.sh   ✗ Expected rc=0 on cancel, got 1

# with this change
✓ Restore cancels if confirmation doesn't match backup id
✓ Forced restore runs without interactive confirmation
```

`test-backup-restore-cli.sh` and `test-update-script-backup.sh` still pass. `test-backup-restore-roundtrip.sh` and `test-backup-integrity.sh` fail identically before and after on my box (no `rsync` binary available locally) — unchanged by this diff.
