### PR TITLE
fix(preset): validate and publish imported archives transactionally

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -93,6 +93,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== CLI preset restore user extensions ==="
 	@bash tests/test-cli-preset-restore-user-extensions.sh
+	@bash tests/test-preset-import-export.sh
 	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -109,6 +109,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== CLI preset restore user extensions ==="
 	@bash tests/test-cli-preset-restore-user-extensions.sh
+	@bash tests/test-preset-import-export.sh
 	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3081,6 +3081,118 @@ validate_preset_compatibility() {
     return 0
 }
 
+# Validate and extract one preset archive into a private staging directory.
+# The same open tar handle is used for inspection and extraction so the
+# archive cannot change between those two operations. Only regular files and
+# directories under one top-level preset root are accepted; links and special
+# files are unnecessary for preset data and could escape later reads.
+_extract_preset_archive() {
+    local archive="$1"
+    local destination="$2"
+    local py
+    py=$(command -v python3 || command -v python || true)
+    [[ -n "$py" ]] || {
+        log_error "Python is required to validate preset archives"
+        return 1
+    }
+
+    "$py" - "$archive" "$destination" <<'PYEOF'
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+
+archive = Path(sys.argv[1]).resolve(strict=True)
+destination = Path(sys.argv[2])
+
+try:
+    with tarfile.open(archive, mode="r:gz") as bundle:
+        members = bundle.getmembers()
+        if not members:
+            raise ValueError("archive is empty")
+
+        root = None
+        for member in members:
+            name = member.name
+            path = PurePosixPath(name)
+            if not name or "\\" in name or path.is_absolute():
+                raise ValueError(f"unsafe member path: {name!r}")
+            if not path.parts or any(part in ("", ".", "..") for part in path.parts):
+                raise ValueError(f"unsafe member path: {name!r}")
+            if ":" in path.parts[0]:
+                raise ValueError(f"unsafe preset root: {path.parts[0]!r}")
+            if root is None:
+                root = path.parts[0]
+                if root.startswith(".preset-import."):
+                    raise ValueError("reserved preset root")
+            elif path.parts[0] != root:
+                raise ValueError("archive contains multiple preset roots")
+            if not (member.isfile() or member.isdir()):
+                raise ValueError(f"unsupported archive member type: {name!r}")
+
+        for member in members:
+            bundle.extract(member, path=destination)
+except (OSError, tarfile.TarError, ValueError) as exc:
+    print(f"Invalid preset archive: {exc}", file=sys.stderr)
+    raise SystemExit(1)
+
+print(root)
+PYEOF
+}
+
+# Import in a subshell so the staging cleanup trap cannot leak into the main
+# CLI process. Existing presets are moved aside only after the staged preset
+# passes validation, and restored if publication fails.
+_import_preset_archive() (
+    local archive="$1"
+    [[ -f "$archive" ]] || error "Archive not found: $archive"
+
+    log "Validating archive..."
+    mkdir -p "$PRESETS_DIR"
+
+    local staging_dir
+    staging_dir=$(mktemp -d "$PRESETS_DIR/.preset-import.XXXXXX") \
+        || error "Failed to create preset import staging directory"
+    trap 'rm -rf "$staging_dir"' EXIT
+
+    local archive_name
+    if ! archive_name=$(_extract_preset_archive "$archive" "$staging_dir"); then
+        error "Preset archive validation failed"
+    fi
+
+    local staged_preset="$staging_dir/$archive_name"
+    [[ -f "$staged_preset/meta.txt" ]] \
+        || error "Invalid preset: missing meta.txt"
+    [[ -f "$staged_preset/extensions.list" ]] \
+        || error "Invalid preset: missing extensions.list"
+
+    local target="$PRESETS_DIR/$archive_name"
+    local previous=""
+    if [[ -e "$target" || -L "$target" ]]; then
+        warn "Preset '${archive_name}' already exists"
+        read -p "Overwrite? [y/N] " -n 1 -r
+        echo ""
+        [[ $REPLY =~ ^[Yy]$ ]] || { log "Cancelled."; return 0; }
+
+        previous="$staging_dir/.previous"
+        mv "$target" "$previous" \
+            || error "Failed to stage existing preset for replacement"
+    fi
+
+    if ! mv "$staged_preset" "$target"; then
+        if [[ -n "$previous" && -e "$previous" ]]; then
+            if ! mv "$previous" "$target"; then
+                trap - EXIT
+                log_error "Failed to restore the previous preset after publish failure"
+                log_error "Previous preset preserved at: $previous"
+            fi
+        fi
+        error "Failed to publish imported preset"
+    fi
+
+    success "Preset '${archive_name}' imported successfully"
+    log "Use 'ods preset load ${archive_name}' to apply it"
+)
+
 cmd_preset() {
     check_install
     sr_load
@@ -3265,49 +3377,7 @@ META
         import|i)
             local archive="${2:-}"
             [[ -z "$archive" ]] && { log "Usage: ods preset import <preset.tar.gz>"; exit 1; }
-            [[ -f "$archive" ]] || error "Archive not found: $archive"
-
-            log "Validating archive..."
-
-            # Security: Check for path traversal
-            if tar tzf "$archive" 2>/dev/null | grep -qE '(^/|\.\./|\.\.\\)'; then
-                error "Archive contains unsafe paths (absolute or ../) — refusing to import"
-            fi
-
-            # Validate archive structure
-            local archive_name
-            archive_name=$(tar tzf "$archive" 2>/dev/null | sed -n '1p' | cut -d/ -f1)
-            [[ -z "$archive_name" ]] && error "Invalid archive structure"
-
-            # Check if preset already exists
-            if [[ -d "${PRESETS_DIR}/${archive_name}" ]]; then
-                warn "Preset '${archive_name}' already exists"
-                read -p "Overwrite? [y/N] " -n 1 -r
-                echo ""
-                [[ $REPLY =~ ^[Yy]$ ]] || { log "Cancelled."; return 0; }
-                rm -rf "${PRESETS_DIR}/${archive_name}"
-            fi
-
-            # Extract archive
-            mkdir -p "$PRESETS_DIR"
-            cd "$PRESETS_DIR"
-            if tar xzf "$archive" 2>/dev/null; then
-                # Validate extracted preset
-                if [[ ! -f "${archive_name}/meta.txt" ]]; then
-                    rm -rf "${archive_name}"
-                    error "Invalid preset: missing meta.txt"
-                fi
-                if [[ ! -f "${archive_name}/extensions.list" ]]; then
-                    rm -rf "${archive_name}"
-                    error "Invalid preset: missing extensions.list"
-                fi
-
-                success "Preset '${archive_name}' imported successfully"
-                log "Use 'ods preset load ${archive_name}' to apply it"
-            else
-                error "Failed to extract archive"
-            fi
-            cd "$INSTALL_DIR"
+            _import_preset_archive "$archive"
             ;;
 
         diff|d)

--- a/ods/tests/test-preset-import-export.sh
+++ b/ods/tests/test-preset-import-export.sh
@@ -40,6 +40,25 @@ info() {
     echo -e "${BLUE}ℹ${NC} $1"
 }
 
+# Print one `case` arm of ods-cli, from its pattern line to the `;;` that ends
+# it. Every assertion below is about what a command's implementation does, and
+# a fixed `grep -A<N>` window answers a different question: whether a line
+# happens to sit within N lines of the pattern. Adding a statement to a command
+# pushes later statements out of the window and turns a correct implementation
+# into a failing assertion.
+case_body() {
+    awk -v pat="$1" '
+        {
+            line = $0
+            sub(/^[[:space:]]+/, "", line)
+            sub(/[[:space:]]+$/, "", line)
+        }
+        !inside && line == pat { inside = 1; next }
+        inside && line == ";;" { exit }
+        inside { print }
+    ' "$ODS_CLI"
+}
+
 # Test 1: Verify ods-cli syntax
 test_syntax() {
     info "Test 1: Validating ods-cli syntax"
@@ -77,7 +96,7 @@ test_import_in_help() {
 # Test 4: Verify export case exists
 test_export_case() {
     info "Test 4: Checking if 'export' case exists in cmd_preset"
-    if grep -A2 "export|e)" "$ODS_CLI" 2>/dev/null | grep -q "preset export"; then
+    if case_body "export|e)" | grep -q "preset export"; then
         pass "'export' case exists in cmd_preset"
         return 0
     else
@@ -89,7 +108,7 @@ test_export_case() {
 # Test 5: Verify import case exists
 test_import_case() {
     info "Test 5: Checking if 'import' case exists in cmd_preset"
-    if grep -A2 "import|i)" "$ODS_CLI" 2>/dev/null | grep -q "preset import"; then
+    if case_body "import|i)" | grep -q "preset import"; then
         pass "'import' case exists in cmd_preset"
         return 0
     else
@@ -101,7 +120,7 @@ test_import_case() {
 # Test 6: Verify export uses tar
 test_export_uses_tar() {
     info "Test 6: Checking if export uses tar for archiving"
-    if grep -A20 "export|e)" "$ODS_CLI" 2>/dev/null | grep -q "tar czf"; then
+    if case_body "export|e)" | grep -q "tar czf"; then
         pass "Export uses tar for archiving"
         return 0
     else
@@ -113,7 +132,7 @@ test_export_uses_tar() {
 # Test 7: Verify import validates path traversal
 test_import_security() {
     info "Test 7: Checking if import validates against path traversal"
-    if grep -A30 "import|i)" "$ODS_CLI" 2>/dev/null | grep -q "path traversal"; then
+    if case_body "import|i)" | grep -q "path traversal"; then
         pass "Import checks for path traversal attacks"
         return 0
     else
@@ -125,7 +144,7 @@ test_import_security() {
 # Test 8: Verify export validates preset exists
 test_export_validation() {
     info "Test 8: Checking if export validates preset exists"
-    if grep -A10 "export|e)" "$ODS_CLI" 2>/dev/null | grep -q "Preset not found"; then
+    if case_body "export|e)" | grep -q "Preset not found"; then
         pass "Export validates preset existence"
         return 0
     else
@@ -137,7 +156,7 @@ test_export_validation() {
 # Test 9: Verify import validates archive structure
 test_import_validation() {
     info "Test 9: Checking if import validates archive structure"
-    if grep -A50 "import|i)" "$ODS_CLI" 2>/dev/null | grep -q "meta.txt"; then
+    if case_body "import|i)" | grep -q "meta.txt"; then
         pass "Import validates archive structure"
         return 0
     else
@@ -149,7 +168,7 @@ test_import_validation() {
 # Test 10: Verify export creates relative paths
 test_export_relative_paths() {
     info "Test 10: Checking if export avoids absolute paths"
-    if grep -A15 "export|e)" "$ODS_CLI" 2>/dev/null | grep -q "cd.*PRESETS_DIR"; then
+    if case_body "export|e)" | grep -q 'cd "$PRESETS_DIR"'; then
         pass "Export creates relative paths"
         return 0
     else
@@ -161,7 +180,7 @@ test_export_relative_paths() {
 # Test 11: Verify import handles overwrite confirmation
 test_import_overwrite() {
     info "Test 11: Checking if import handles existing presets"
-    if grep -A30 "import|i)" "$ODS_CLI" 2>/dev/null | grep -q "already exists"; then
+    if case_body "import|i)" | grep -q "already exists"; then
         pass "Import handles overwrite confirmation"
         return 0
     else

--- a/ods/tests/test-preset-import-export.sh
+++ b/ods/tests/test-preset-import-export.sh
@@ -6,6 +6,7 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ODS_CLI="$SCRIPT_DIR/../ods-cli"
+ODS_ROOT="$SCRIPT_DIR/.."
 TEST_DIR="$(mktemp -d)"
 
 # Colors
@@ -57,6 +58,31 @@ case_body() {
         inside && line == ";;" { exit }
         inside { print }
     ' "$ODS_CLI"
+}
+
+make_install_fixture() {
+    local name="$1"
+    local install_dir="$TEST_DIR/$name/install"
+
+    mkdir -p \
+        "$install_dir/extensions/services" \
+        "$install_dir/lib" \
+        "$install_dir/presets"
+    cp "$ODS_CLI" "$install_dir/ods-cli"
+    cp "$ODS_ROOT/lib/service-registry.sh" "$install_dir/lib/"
+    cp "$ODS_ROOT/lib/python-cmd.sh" "$install_dir/lib/"
+    printf 'services: {}\n' > "$install_dir/docker-compose.base.yml"
+    printf '%s\n' "$install_dir"
+}
+
+write_valid_preset() {
+    local preset_dir="$1"
+    local marker="${2:-archive}"
+
+    mkdir -p "$preset_dir"
+    printf 'created=2026-08-24T00:00:00Z\n' > "$preset_dir/meta.txt"
+    printf 'enabled:dashboard\n' > "$preset_dir/extensions.list"
+    printf '%s\n' "$marker" > "$preset_dir/marker.txt"
 }
 
 # Test 1: Verify ods-cli syntax
@@ -132,7 +158,8 @@ test_export_uses_tar() {
 # Test 7: Verify import validates path traversal
 test_import_security() {
     info "Test 7: Checking if import validates against path traversal"
-    if case_body "import|i)" | grep -q "path traversal"; then
+    if case_body "import|i)" | grep -q '_import_preset_archive "$archive"' \
+        && grep -q 'path.is_absolute()' "$ODS_CLI"; then
         pass "Import checks for path traversal attacks"
         return 0
     else
@@ -156,7 +183,9 @@ test_export_validation() {
 # Test 9: Verify import validates archive structure
 test_import_validation() {
     info "Test 9: Checking if import validates archive structure"
-    if case_body "import|i)" | grep -q "meta.txt"; then
+    if case_body "import|i)" | grep -q '_import_preset_archive "$archive"' \
+        && grep -q 'staged_preset/meta.txt' "$ODS_CLI" \
+        && grep -q 'staged_preset/extensions.list' "$ODS_CLI"; then
         pass "Import validates archive structure"
         return 0
     else
@@ -180,7 +209,8 @@ test_export_relative_paths() {
 # Test 11: Verify import handles overwrite confirmation
 test_import_overwrite() {
     info "Test 11: Checking if import handles existing presets"
-    if case_body "import|i)" | grep -q "already exists"; then
+    if case_body "import|i)" | grep -q '_import_preset_archive "$archive"' \
+        && grep -q 'Overwrite? \[y/N\]' "$ODS_CLI"; then
         pass "Import handles overwrite confirmation"
         return 0
     else
@@ -201,6 +231,202 @@ test_usage_updated() {
     fi
 }
 
+# Test 13: one archive must not be able to mutate a different preset root.
+test_import_rejects_multiple_roots_without_mutation() {
+    info "Test 13: Rejecting multi-root archives before preset mutation"
+    local fixture install_dir archive_src archive before output
+    fixture="$TEST_DIR/multi-root"
+    install_dir=$(make_install_fixture "multi-root")
+    archive_src="$fixture/archive"
+    archive="$fixture/multi-root.tar.gz"
+    output="$fixture/output.log"
+
+    write_valid_preset "$archive_src/good"
+    mkdir -p "$archive_src/victim" "$install_dir/presets/victim"
+    printf 'archive replacement\n' > "$archive_src/victim/marker.txt"
+    printf 'operator data\n' > "$install_dir/presets/victim/marker.txt"
+    before="$fixture/victim-marker.before"
+    cp "$install_dir/presets/victim/marker.txt" "$before"
+    tar -czf "$archive" -C "$archive_src" good victim
+
+    if ODS_HOME="$install_dir" bash "$install_dir/ods-cli" preset import "$archive" >"$output" 2>&1; then
+        fail "Import accepted an archive with multiple preset roots"
+        return 0
+    fi
+
+    if ! cmp -s "$before" "$install_dir/presets/victim/marker.txt" \
+        || [[ -e "$install_dir/presets/good" ]]; then
+        fail "Rejected multi-root archive mutated the preset store"
+        return 0
+    fi
+
+    pass "Multi-root archive is rejected without touching any preset"
+}
+
+# Test 14: validation must happen before an existing preset is replaced.
+test_import_preserves_existing_preset_on_validation_failure() {
+    info "Test 14: Preserving an existing preset when validation fails"
+    local fixture install_dir archive_src archive before output
+    fixture="$TEST_DIR/invalid-overwrite"
+    install_dir=$(make_install_fixture "invalid-overwrite")
+    archive_src="$fixture/archive"
+    archive="$fixture/replace.tar.gz"
+    output="$fixture/output.log"
+
+    write_valid_preset "$install_dir/presets/replace" "operator data"
+    mkdir -p "$archive_src/replace"
+    printf 'enabled:dashboard\n' > "$archive_src/replace/extensions.list"
+    printf 'archive replacement\n' > "$archive_src/replace/marker.txt"
+    before="$fixture/replace-marker.before"
+    cp "$install_dir/presets/replace/marker.txt" "$before"
+    tar -czf "$archive" -C "$archive_src" replace
+
+    if printf 'y\n' | ODS_HOME="$install_dir" bash "$install_dir/ods-cli" preset import "$archive" >"$output" 2>&1; then
+        fail "Import accepted a preset with no meta.txt"
+        return 0
+    fi
+
+    if ! cmp -s "$before" "$install_dir/presets/replace/marker.txt"; then
+        fail "Invalid replacement destroyed the existing preset"
+        return 0
+    fi
+
+    pass "Invalid replacement leaves the existing preset byte-identical"
+}
+
+# Test 15: checking a relative path before changing directory must not make the
+# later extraction resolve that same path from a different working directory.
+test_import_accepts_relative_archive_path() {
+    info "Test 15: Importing a valid archive through a relative path"
+    local fixture install_dir archive_src output
+    fixture="$TEST_DIR/relative-path"
+    install_dir=$(make_install_fixture "relative-path")
+    archive_src="$fixture/archive"
+    output="$fixture/output.log"
+
+    write_valid_preset "$archive_src/portable"
+    tar -czf "$fixture/portable.tar.gz" -C "$archive_src" portable
+
+    if ! (
+        cd "$fixture"
+        ODS_HOME="$install_dir" bash "$install_dir/ods-cli" preset import portable.tar.gz >"$output" 2>&1
+    ); then
+        fail "Valid relative archive path could not be imported"
+        return 0
+    fi
+
+    if [[ ! -f "$install_dir/presets/portable/meta.txt" || ! -f "$install_dir/presets/portable/extensions.list" ]]; then
+        fail "Relative archive import did not publish the validated preset"
+        return 0
+    fi
+
+    pass "Valid relative archive imports successfully"
+}
+
+# Test 16: links are unnecessary for preset data and can make later reads
+# escape the imported preset directory.
+test_import_rejects_links() {
+    info "Test 16: Rejecting archives that contain links"
+    local fixture install_dir archive_src archive output
+    fixture="$TEST_DIR/link-entry"
+    install_dir=$(make_install_fixture "link-entry")
+    archive_src="$fixture/archive"
+    archive="$fixture/link.tar.gz"
+    output="$fixture/output.log"
+
+    write_valid_preset "$archive_src/linked"
+    ln -s /etc/passwd "$archive_src/linked/external"
+    tar -czf "$archive" -C "$archive_src" linked
+
+    if ODS_HOME="$install_dir" bash "$install_dir/ods-cli" preset import "$archive" >"$output" 2>&1; then
+        fail "Import accepted an archive containing a symbolic link"
+        return 0
+    fi
+    if [[ -e "$install_dir/presets/linked" || -L "$install_dir/presets/linked" ]]; then
+        fail "Rejected link archive published a partial preset"
+        return 0
+    fi
+
+    pass "Link-bearing archive is rejected before publication"
+}
+
+# Test 17: the successful overwrite path must publish the fully validated
+# staged tree, not merge archive contents into the old preset.
+test_import_replaces_existing_preset_after_validation() {
+    info "Test 17: Replacing an existing preset after validation"
+    local fixture install_dir archive_src archive output
+    fixture="$TEST_DIR/valid-overwrite"
+    install_dir=$(make_install_fixture "valid-overwrite")
+    archive_src="$fixture/archive"
+    archive="$fixture/replace.tar.gz"
+    output="$fixture/output.log"
+
+    write_valid_preset "$install_dir/presets/replace" "operator data"
+    printf 'old-only\n' > "$install_dir/presets/replace/old-only.txt"
+    write_valid_preset "$archive_src/replace" "archive data"
+    tar -czf "$archive" -C "$archive_src" replace
+
+    if ! printf 'y\n' | ODS_HOME="$install_dir" bash "$install_dir/ods-cli" preset import "$archive" >"$output" 2>&1; then
+        fail "Valid replacement archive was rejected"
+        return 0
+    fi
+    if [[ "$(cat "$install_dir/presets/replace/marker.txt")" != "archive data" \
+        || -e "$install_dir/presets/replace/old-only.txt" ]]; then
+        fail "Validated replacement was merged with stale preset contents"
+        return 0
+    fi
+
+    pass "Validated replacement atomically supersedes the old preset"
+}
+
+# Test 18: if the final publish move fails, the previous preset must be put
+# back before the command exits non-zero.
+test_import_rolls_back_failed_publish() {
+    info "Test 18: Restoring the previous preset after publish failure"
+    local fixture install_dir archive_src archive before output real_mv
+    fixture="$TEST_DIR/publish-rollback"
+    install_dir=$(make_install_fixture "publish-rollback")
+    archive_src="$fixture/archive"
+    archive="$fixture/replace.tar.gz"
+    before="$fixture/replace-marker.before"
+    output="$fixture/output.log"
+    real_mv=$(command -v mv)
+
+    write_valid_preset "$install_dir/presets/replace" "operator data"
+    cp "$install_dir/presets/replace/marker.txt" "$before"
+    write_valid_preset "$archive_src/replace" "archive data"
+    tar -czf "$archive" -C "$archive_src" replace
+
+    mkdir -p "$fixture/bin"
+    cat > "$fixture/bin/mv" <<'MV_STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+src="${1:-}"
+dst="${2:-}"
+if [[ "$src" == */.preset-import.*/replace && "$dst" == */presets/replace ]]; then
+    exit 73
+fi
+exec "$REAL_MV" "$@"
+MV_STUB
+    chmod +x "$fixture/bin/mv"
+
+    if printf 'y\n' | PATH="$fixture/bin:$PATH" REAL_MV="$real_mv" \
+        ODS_HOME="$install_dir" bash "$install_dir/ods-cli" preset import "$archive" >"$output" 2>&1; then
+        fail "Import reported success after the publish move failed"
+        return 0
+    fi
+    if ! cmp -s "$before" "$install_dir/presets/replace/marker.txt"; then
+        fail "Publish failure did not restore the previous preset"
+        return 0
+    fi
+    if compgen -G "$install_dir/presets/.preset-import.*" >/dev/null; then
+        fail "Successful rollback leaked its staging directory"
+        return 0
+    fi
+
+    pass "Publish failure restores the previous preset and cleans staging"
+}
+
 # Run all tests
 echo ""
 echo -e "${BLUE}━━━ Preset Import/Export Tests ━━━${NC}"
@@ -218,6 +444,12 @@ test_import_validation
 test_export_relative_paths
 test_import_overwrite
 test_usage_updated
+test_import_rejects_multiple_roots_without_mutation
+test_import_preserves_existing_preset_on_validation_failure
+test_import_accepts_relative_archive_path
+test_import_rejects_links
+test_import_replaces_existing_preset_after_validation
+test_import_rolls_back_failed_publish
 
 # Summary
 echo ""


### PR DESCRIPTION
## Summary

- keep the original case-arm assertions and wire the preset import/export suite into `make test`
- validate every tar member from one open archive handle before extraction
- accept exactly one preset root containing regular files/directories; reject traversal, links, special files, and multi-root archives
- extract into a private directory inside the preset store, validate required files, then publish by same-filesystem rename
- restore the previous preset if publication fails
- preserve valid relative archive paths without changing the CLI working directory

## Why this matters

`ods preset import` is a production CLI path that accepts an operator-supplied archive. It previously derived the preset name from only the first member, removed an existing preset before validating the replacement, and extracted the whole archive directly into `PRESETS_DIR`.

A reproducible archive whose first root was `good/` and whose second root was `victim/` returned success while overwriting an existing `presets/victim/marker.txt`. A same-root archive missing `meta.txt` deleted the operator's previous preset before failing. A valid relative archive path also failed because the command checked it before `cd $PRESETS_DIR` and extracted it after that directory change.

Root cause: archive inspection, extraction, validation, and publication were interleaved against the live preset store.

## Behavioral invariant

A preset import may mutate exactly one target preset only after every archive member and both required files have been validated. Any rejection leaves all presets byte-identical. If final publication fails, the previous target is restored before the command returns non-zero.

## Implementation

The CLI uses the installer-guaranteed Python runtime and `tarfile` to inspect and extract from the same open handle. Member paths must be relative and remain under one top-level root; only regular files and directories are accepted. The staged tree must contain `meta.txt` and `extensions.list` before the overwrite prompt appears.

Staging lives inside `PRESETS_DIR`, so target replacement uses same-filesystem renames. The previous target is first moved into the private staging directory; a failed publish moves it back. If recovery itself fails, cleanup is disarmed and the recovery path is printed instead of deleting the last copy.

## Overlap check

Searched open and closed PRs for preset import, archive traversal, multi-root archives, overwrite validation, and the changed production file `ods/ods-cli`.

- merged #111 introduced preset import/export
- merged #739 fixed relative output handling for preset export
- no open or closed PR validates all preset archive members or stages import publication
- restore-focused #2346 and #2720 operate on `ods-restore.sh`, not the preset command or preset store

This updates the existing canonical tang-vu PR instead of opening another PR under the current backlog gate.

## Regression coverage

`tests/test-preset-import-export.sh` now executes the installed CLI boundary and proves:

- a multi-root archive is rejected without changing an unrelated preset
- an invalid replacement leaves the old preset byte-identical
- a valid relative archive imports successfully
- an archive containing a symbolic link is rejected before publication
- a valid replacement removes stale files and publishes the staged tree
- an injected final-move failure restores the previous preset and cleans staging

The earlier mutation-resistant case-arm assertions remain, and the suite runs from `make test`.

## Validation

- `bash tests/test-preset-import-export.sh` — 18 passed
- `bash -n ods-cli tests/test-preset-import-export.sh` — passed
- `shellcheck --rcfile /dev/null --severity=error ods-cli tests/test-preset-import-export.sh` — passed
- `make lint` — passed
- `bash tests/test-cli-enable-compose-reconciliation.sh` — passed
- `bash tests/test-ods-list-json-escaping.sh` — passed
- `bash tests/test-phase-c-p1.sh` — 7 passed, 0 failed, 9 auth-dependent skips
- `git diff --check` — passed
- GitHub CI at `b810091d` — all required checks passed, including integration-smoke, API/frontend, ShellCheck, PowerShell on Windows and Ubuntu, and the 10-distro matrix
- `bash tests/contracts/test-installer-contracts.sh` passed the affected CLI and preceding platform contracts, then reached the existing Windows-checkout CRLF failure at `Hermes template bounds each model turn`; neither Hermes file is changed here, and #2715 covers repository-wide LF normalization

## Cross-platform behavior and rollback

The archive policy and Python extraction path are shared by Linux, macOS, and WSL. The shell publication path uses Bash 4, portable `mktemp`, `mv`, and `rm` forms without GNU-only flags. No persisted format changes are introduced: exported `.tar.gz` presets remain compatible.

Reverting this PR restores direct extraction into the live preset store and the pre-validation delete behavior; no data migration rollback is required.