### PR TITLE
fix(hermes): replace Hermes config atomically in patch-hermes-config.py

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -293,8 +293,6 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    import stat
-    import tempfile
     fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_str)
     try:

--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -10,7 +10,10 @@ the rest of the user's config.
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import stat
+import tempfile
 from pathlib import Path
 
 
@@ -290,7 +293,20 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
+    import stat
+    import tempfile
+    fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(updated)
+        if path.exists():
+            tmp_path.chmod(stat.S_IMODE(path.stat().st_mode))
+        os.replace(tmp_path, path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
     return True
 
 

--- a/ods/tests/test-patch-hermes-config.py
+++ b/ods/tests/test-patch-hermes-config.py
@@ -1,12 +1,8 @@
 """Tests for patch-hermes-config.py atomic writing and configuration patching."""
 
-import os
 import stat
 import sys
-import tempfile
 from pathlib import Path
-
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import importlib.util

--- a/ods/tests/test-patch-hermes-config.py
+++ b/ods/tests/test-patch-hermes-config.py
@@ -1,0 +1,32 @@
+"""Tests for patch-hermes-config.py atomic writing and configuration patching."""
+
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import importlib.util
+spec = importlib.util.spec_from_file_location("patch_hermes_config", str(Path(__file__).parent.parent / "scripts" / "patch-hermes-config.py"))
+patch_hermes = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(patch_hermes)
+
+
+def test_patch_hermes_config_writes_atomically_and_preserves_mode(tmp_path):
+    target = tmp_path / "config.yaml"
+    original = "model: old-model\nbase_url: http://localhost:11434\n"
+    target.write_text(original, encoding="utf-8")
+    target.chmod(0o640)
+
+    changed = patch_hermes.patch_config(
+        target,
+        model="new-model",
+        base_url="http://localhost:8000",
+        context_length=8192,
+    )
+    assert changed is True
+    assert "new-model" in target.read_text(encoding="utf-8")
+    assert stat.S_IMODE(target.stat().st_mode) == 0o640


### PR DESCRIPTION
## Problem

In `ods/scripts/patch-hermes-config.py`, updated Hermes configuration contents were previously written directly using `path.write_text(updated, encoding="utf-8")`. This exposes live Hermes configuration files (`data/hermes/config.yaml`) to in-place truncation during patch execution.

## Fix

1. Update `patch_config()` in `patch-hermes-config.py` to write updated YAML configurations to a temporary file via `tempfile.mkstemp` in `path.parent`.
2. Preserve existing file mode permissions (`stat.S_IMODE`) on the temporary file before calling `os.replace` for atomic replacement.

## Verification

Added `ods/tests/test-patch-hermes-config.py`. Ran `pytest ods/tests/test-patch-hermes-config.py`: 1/1 passed. `git diff --check` passed cleanly.