### PR TITLE
fix(catalog): write extensions catalog atomically in generate-extensions-catalog.py

### DIFF
--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -163,8 +165,6 @@ def main() -> None:
     }
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    import os
-    import tempfile
     fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_str)
     content = json.dumps(catalog, indent=2, ensure_ascii=False) + "\n"

--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -163,7 +163,19 @@ def main() -> None:
     }
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    import os
+    import tempfile
+    fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    content = json.dumps(catalog, indent=2, ensure_ascii=False) + "\n"
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        os.replace(tmp_path, output_path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
 
     print(f"Generated catalog with {len(entries)} extensions at {output_path}")
 

--- a/ods/tests/test_generate_extensions_catalog.py
+++ b/ods/tests/test_generate_extensions_catalog.py
@@ -1,12 +1,8 @@
 """Tests for generate-extensions-catalog.py atomic generation."""
 
 import json
-import os
 import sys
-import tempfile
 from pathlib import Path
-
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import importlib.util

--- a/ods/tests/test_generate_extensions_catalog.py
+++ b/ods/tests/test_generate_extensions_catalog.py
@@ -1,0 +1,35 @@
+"""Tests for generate-extensions-catalog.py atomic generation."""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import importlib.util
+spec = importlib.util.spec_from_file_location("generate_catalog_mod", str(Path(__file__).parent.parent / "scripts" / "generate-extensions-catalog.py"))
+cat_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cat_mod)
+
+
+def test_generate_catalog_writes_atomically_without_leftover_temp(tmp_path, monkeypatch):
+    lib_dir = tmp_path / "library"
+    lib_dir.mkdir()
+    ext_dir = lib_dir / "ext-a"
+    ext_dir.mkdir()
+    (ext_dir / "compose.yaml").write_text("services: {}\n", encoding="utf-8")
+    (ext_dir / "manifest.yaml").write_text("id: ext-a\nname: Extension A\ndescription: Test\n", encoding="utf-8")
+
+    out_file = tmp_path / "output" / "catalog.json"
+    monkeypatch.setattr("sys.argv", ["generate-extensions-catalog.py", "--library-dir", str(lib_dir), "--output", str(out_file)])
+    cat_mod.main()
+
+    assert out_file.exists()
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert "extensions" in data
+    # Verify no remaining temporary files in parent directory
+    temps = list(out_file.parent.glob("*.tmp"))
+    assert len(temps) == 0


### PR DESCRIPTION
## Problem

In `ods/scripts/generate-extensions-catalog.py`, generated extensions catalog JSON files were written directly using `output_path.write_text(json.dumps(...))`. This exposes the catalog file (`ods/config/extensions-catalog.json`) to in-place truncation during catalog generation cycles.

## Fix

1. Update `generate-extensions-catalog.py` to write catalog JSON data to a temporary file via `tempfile.mkstemp` in `output_path.parent`.
2. Call `os.replace` to perform atomic replacement of the destination catalog path.

## Verification

Added `ods/tests/test_generate_extensions_catalog.py`. Ran `pytest ods/tests/test_generate_extensions_catalog.py`: 1/1 passed. `git diff --check` passed cleanly.