### PR TITLE
fix(install-context): write installation context atomically in build-installation-context.py

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -419,6 +419,8 @@ def build_soul(
         import shutil
         shutil.rmtree(output_path)
     previous = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
+    if previous == assembled:
+        return False
     fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_str)
     try:

--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -26,10 +26,13 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import socket
+import stat
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 # Service-id → (display name, one-line "what it does and how the user
@@ -416,9 +419,20 @@ def build_soul(
         import shutil
         shutil.rmtree(output_path)
     previous = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
-    if previous == assembled:
-        return False
-    output_path.write_text(assembled, encoding="utf-8")
+    import stat
+    import tempfile
+    fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(assembled)
+        if output_path.exists():
+            tmp_path.chmod(stat.S_IMODE(output_path.stat().st_mode))
+        os.replace(tmp_path, output_path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
     return True
 
 

--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -419,8 +419,6 @@ def build_soul(
         import shutil
         shutil.rmtree(output_path)
     previous = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
-    import stat
-    import tempfile
     fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
     tmp_path = Path(tmp_str)
     try:

--- a/ods/tests/test_build_installation_context.py
+++ b/ods/tests/test_build_installation_context.py
@@ -1,0 +1,44 @@
+"""Tests for build-installation-context.py atomic writing."""
+
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+import importlib.util
+spec = importlib.util.spec_from_file_location("build_inst_ctx", str(Path(__file__).parent.parent / "scripts" / "build-installation-context.py"))
+build_ctx = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build_ctx)
+
+
+def test_build_installation_context_writes_atomically_with_mode_preservation(tmp_path):
+    output_path = tmp_path / "SOUL.md"
+    original = "Original SOUL content\n"
+    output_path.write_text(original, encoding="utf-8")
+    output_path.chmod(0o644)
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("SOME_VAR=1\n", encoding="utf-8")
+
+    template_path = tmp_path / "template.md"
+    template_path.write_text("Template header\n", encoding="utf-8")
+
+    changed = build_ctx.build_soul(
+        env_path=env_path,
+        output_path=output_path,
+        template_path=template_path,
+        profile="default",
+    )
+
+    assert changed is True
+    assert output_path.exists()
+    assert "Template header" in output_path.read_text(encoding="utf-8")
+    assert stat.S_IMODE(output_path.stat().st_mode) == 0o644
+
+    # Verify no temp files remain
+    temps = list(tmp_path.glob("*.tmp"))
+    assert len(temps) == 0

--- a/ods/tests/test_build_installation_context.py
+++ b/ods/tests/test_build_installation_context.py
@@ -1,12 +1,8 @@
 """Tests for build-installation-context.py atomic writing."""
 
-import os
 import stat
 import sys
-import tempfile
 from pathlib import Path
-
-import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import importlib.util


### PR DESCRIPTION
## Problem

In `ods/scripts/build-installation-context.py`, generated SOUL installation context contents were written directly using `output_path.write_text(assembled, encoding="utf-8")`. This exposes live installation context files (`data/persona/SOUL.md`) to in-place truncation during render cycles.

## Fix

1. Update `build_soul()` in `build-installation-context.py` to write assembled context data to a temporary file via `tempfile.mkstemp` in `output_path.parent`.
2. Preserve existing file mode permissions (`stat.S_IMODE`) on the temporary file before calling `os.replace` for atomic replacement.

## Verification

Added `ods/tests/test_build_installation_context.py`. Ran `pytest ods/tests/test_build_installation_context.py`: 1/1 passed. `git diff --check` passed cleanly.