### PR TITLE
fix(installer): gate Hermes 64K context floor on VRAM to stop llama-server OOM

### DIFF
--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -90,13 +90,42 @@ if ! $INTERACTIVE && [[ "$ENABLE_COMFYUI" == "true" ]]; then
 fi
 
 if [[ "${ENABLE_HERMES:-false}" == "true" && "${ODS_MODE:-local}" != "cloud" ]]; then
-    HERMES_CONTEXT_SIZE="${HERMES_CONTEXT_SIZE:-65536}"
+    # An explicitly-pinned HERMES_CONTEXT_SIZE is honored verbatim; otherwise the
+    # 64K default floor applies, gated by VRAM on discrete GPUs.
+    _hermes_floor_pinned=false
+    if [[ -n "${HERMES_CONTEXT_SIZE:-}" ]]; then
+        _hermes_floor_pinned=true
+    else
+        HERMES_CONTEXT_SIZE=65536
+    fi
     if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
-        ai_warn "Hermes enabled: increasing llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (64K floor)."
-        if [[ -n "${MODEL_RECOMMENDATION_REASON:-}" ]]; then
-            MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON} Hermes requires at least 64K context, so runtime context was raised to ${HERMES_CONTEXT_SIZE}."
+        # A discrete GPU too small to hold the 64K floor in VRAM keeps the
+        # VRAM-fit context -- forcing the floor OOM-kills llama-server (SIGKILL).
+        # CPU, unified-memory (Apple / AMD APU) backends and pinned floors are
+        # exempt from the gate.
+        _hermes_can_hold_floor=true
+        if [[ "$_hermes_floor_pinned" != "true" ]]; then
+            case "${GPU_BACKEND:-}" in
+                nvidia|amd|intel|jetson)
+                    if [[ "${GPU_MEMORY_TYPE:-}" != "unified" ]] \
+                        && [[ "${GPU_VRAM:-0}" =~ ^[0-9]+$ ]] \
+                        && (( GPU_VRAM > 0 )) && (( GPU_VRAM < 8192 )); then
+                        _hermes_can_hold_floor=false
+                        ai_warn "Hermes needs a 64K context floor, but this ${GPU_VRAM}MB GPU cannot hold it in VRAM. Keeping the ${MAX_CONTEXT}-token context selected for this hardware."
+                        if [[ -n "${MODEL_RECOMMENDATION_REASON:-}" ]]; then
+                            MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON} Hermes requires at least 64K context, but the ${GPU_VRAM}MB GPU cannot hold it; keeping VRAM-fit ${MAX_CONTEXT} context."
+                        fi
+                    fi
+                    ;;
+            esac
         fi
-        MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
+        if [[ "$_hermes_can_hold_floor" == "true" ]]; then
+            ai_warn "Hermes enabled: increasing llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (64K floor)."
+            if [[ -n "${MODEL_RECOMMENDATION_REASON:-}" ]]; then
+                MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON} Hermes requires at least 64K context, so runtime context was raised to ${HERMES_CONTEXT_SIZE}."
+            fi
+            MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
+        fi
     fi
 fi
 

--- a/ods/installers/windows/phases/03-features.ps1
+++ b/ods/installers/windows/phases/03-features.ps1
@@ -152,11 +152,24 @@ if ($enableComfyui -and $gpuInfo.Backend -eq "amd" -and -not $cloudMode) {
 if ($enableHermes -and -not $cloudMode) {
     $hermesContextSize = 65536
     if ([int]$tierConfig.MaxContext -lt $hermesContextSize) {
-        Write-AIWarn "Hermes enabled: increasing llama context from $($tierConfig.MaxContext) to $hermesContextSize (64K floor)."
-        if ($tierConfig.ContainsKey("RecommendationReason") -and $tierConfig.RecommendationReason) {
-            $tierConfig.RecommendationReason = "$($tierConfig.RecommendationReason) Hermes requires at least 64K context, so runtime context was raised to $hermesContextSize."
+        # A discrete GPU too small to hold the 64K floor in VRAM keeps the
+        # VRAM-fit context -- forcing the floor OOM-kills llama-server (SIGKILL).
+        # Unified-memory (AMD APU) and CPU backends are exempt from the gate.
+        $hermesCanHoldFloor = $true
+        if ($gpuInfo.Backend -in @("nvidia", "amd", "intel") -and $gpuInfo.MemoryType -ne "unified" -and [int]$gpuInfo.VramMB -gt 0 -and [int]$gpuInfo.VramMB -lt 8192) {
+            $hermesCanHoldFloor = $false
+            Write-AIWarn "Hermes needs a 64K context floor, but this $($gpuInfo.VramMB)MB GPU cannot hold it in VRAM. Keeping the $($tierConfig.MaxContext)-token context selected for this hardware."
+            if ($tierConfig.ContainsKey("RecommendationReason") -and $tierConfig.RecommendationReason) {
+                $tierConfig.RecommendationReason = "$($tierConfig.RecommendationReason) Hermes requires at least 64K context, but the $($gpuInfo.VramMB)MB GPU cannot hold it; keeping VRAM-fit $($tierConfig.MaxContext) context."
+            }
         }
-        $tierConfig.MaxContext = $hermesContextSize
+        if ($hermesCanHoldFloor) {
+            Write-AIWarn "Hermes enabled: increasing llama context from $($tierConfig.MaxContext) to $hermesContextSize (64K floor)."
+            if ($tierConfig.ContainsKey("RecommendationReason") -and $tierConfig.RecommendationReason) {
+                $tierConfig.RecommendationReason = "$($tierConfig.RecommendationReason) Hermes requires at least 64K context, so runtime context was raised to $hermesContextSize."
+            }
+            $tierConfig.MaxContext = $hermesContextSize
+        }
     }
 }
 

--- a/ods/tests/test-hermes-context-floor.sh
+++ b/ods/tests/test-hermes-context-floor.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 # Regression guard for constrained hardware: enabling Hermes must preserve a
 # usable runtime profile. Hermes needs a 64K floor, but it must not inflate
-# 8GB-class installs to 128K and starve llama-server VRAM.
+# 8GB-class installs to 128K and starve llama-server VRAM, and it must NOT
+# force the 64K floor onto a discrete GPU whose VRAM cannot hold it (that
+# OOM-kills llama-server with SIGKILL at boot).
 
 set -euo pipefail
 
@@ -11,8 +13,9 @@ cd "$ROOT_DIR"
 pass() { echo "  PASS: $1"; }
 fail() { echo "  FAIL: $1" >&2; exit 1; }
 
+# Usage: run_linux_phase_with_context INPUT_CONTEXT [BACKEND] [VRAM_MB] [MEMTYPE] [HERMES_CTX]
 run_linux_phase_with_context() {
-    local input_context="$1"
+    local input_context="$1" backend="${2:-cpu}" vram="${3:-0}" memtype="${4:-discrete}" hermes_ctx="${5:-}"
     (
         set -euo pipefail
         INTERACTIVE=false
@@ -31,7 +34,10 @@ run_linux_phase_with_context() {
         MODEL_RECOMMENDATION_REASON="selector chose ${input_context} context"
         SCRIPT_DIR="/tmp/ods-context-floor-no-compose"
         GPU_COUNT=1
-        GPU_BACKEND=cpu
+        GPU_BACKEND="$backend"
+        GPU_VRAM="$vram"
+        GPU_MEMORY_TYPE="$memtype"
+        HERMES_CONTEXT_SIZE="$hermes_ctx"
         HOST_ARCH=x86_64
 
         ods_progress() { :; }
@@ -60,6 +66,33 @@ large_context="$(printf '%s\n' "$large" | sed -n '1p')"
 [[ "$large_context" == "131072" ]] \
     || fail "Linux Hermes floor should not reduce existing 128K context, got ${large_context}"
 pass "Linux Hermes floor preserves 128K-capable contexts"
+
+low_vram="$(run_linux_phase_with_context 8192 nvidia 4096)"
+low_vram_context="$(printf '%s\n' "$low_vram" | sed -n '1p')"
+low_vram_reason="$(printf '%s\n' "$low_vram" | sed -n '2p')"
+[[ "$low_vram_context" == "8192" ]] \
+    || fail "Linux Hermes floor must NOT lift context on a 4096MB GPU (would OOM-kill llama-server), got ${low_vram_context}"
+[[ "$low_vram_reason" == *"cannot hold it"* ]] \
+    || fail "Linux Hermes floor should annotate that a low-VRAM GPU cannot hold the 64K floor"
+pass "Linux Hermes floor keeps VRAM-fit context on a 4GB discrete GPU"
+
+ok_vram="$(run_linux_phase_with_context 8192 nvidia 8192)"
+ok_vram_context="$(printf '%s\n' "$ok_vram" | sed -n '1p')"
+[[ "$ok_vram_context" == "65536" ]] \
+    || fail "Linux Hermes floor should still lift context on an 8GB GPU, got ${ok_vram_context}"
+pass "Linux Hermes floor lifts context when VRAM can hold the 64K floor"
+
+apu="$(run_linux_phase_with_context 8192 amd 4096 unified)"
+apu_context="$(printf '%s\n' "$apu" | sed -n '1p')"
+[[ "$apu_context" == "65536" ]] \
+    || fail "Linux Hermes floor should lift context on AMD unified-memory APUs, got ${apu_context}"
+pass "Linux Hermes floor exempts AMD unified-memory APUs from the VRAM gate"
+
+pinned="$(run_linux_phase_with_context 8192 nvidia 4096 discrete 65536)"
+pinned_context="$(printf '%s\n' "$pinned" | sed -n '1p')"
+[[ "$pinned_context" == "65536" ]] \
+    || fail "Linux Hermes floor should honor an explicitly pinned HERMES_CONTEXT_SIZE, got ${pinned_context}"
+pass "Linux Hermes floor honors an explicitly pinned HERMES_CONTEXT_SIZE"
 
 grep -Eq 'hermesContextSize[[:space:]]*=[[:space:]]*65536' installers/windows/phases/03-features.ps1 \
     || fail "Windows Hermes floor must be 64K"


### PR DESCRIPTION
## Summary

Enabling Hermes unconditionally raised the llama-server context window to the 64K floor on every install. On discrete GPUs whose VRAM cannot hold a 64K context (reproduced on a 4 GB GTX 1650 with the Qwen3.5-2B Q4_K_M catalog model), this fills VRAM to 100% and the container is OOM-killed by the kernel at boot (exit 137 / SIGKILL). The Hermes floor in `installers/phases/03-features.sh`, `installers/windows/phases/03-features.ps1`, and `installers/macos/install-macos.sh` is an unconditional lift with no VRAM gating, and `scripts/select-model.py` had already computed a VRAM-fit context (8K for 4 GB) that phase 03 then clobbered.

This change gates the 64K floor on discrete-GPU VRAM: when a discrete NVIDIA/AMD/Intel/Jetson GPU has `0 < VRAM < 8192 MiB` and memory is not unified, the phase keeps the model-selector's VRAM-fit `MAX_CONTEXT` and annotates the recommendation reason instead of forcing the floor. CPU, unified-memory (Apple Silicon / AMD APU) backends, and an explicitly pinned `HERMES_CONTEXT_SIZE` remain exempt and keep the current floor behavior. macOS is unchanged (Apple-Silicon-only, unified memory). Follows discussion https://github.com/Osmantic/ODS/discussions/2307.

### Behavior and invariants

| Invariant | Implementation |
|---|---|
| Hermes still gets a 64K floor where VRAM can hold it | `MAX_CONTEXT < HERMES_CONTEXT_SIZE` raise preserved for CPU, unified-memory, and >=8GB discrete GPUs |
| Low-VRAM discrete GPUs never get a floor that OOM-kills llama-server | gate keeps VRAM-fit `MAX_CONTEXT` when `0 < GPU_VRAM < 8192` and `GPU_MEMORY_TYPE != unified` |
| Explicit operator override is honored | a pre-set `HERMES_CONTEXT_SIZE` skips the gate (Linux; Windows floor is hardcoded as before) |
| Recommendation reason stays truthful | gate appends a distinct note instead of claiming the floor was raised |
| macOS behavior unchanged | Apple-Silicon-only unified-memory target; no discrete low-VRAM path exists |

## AI Assistance

AI-assisted repository search, root-cause triage (live OOM repro: container Exited 137, VRAM 4095/4096 MiB, health endpoint dead), and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [x] Installer
- [ ] Core runtime
- [ ] Compose
- [ ] Windows installer
- [ ] CI / workflows

## Validation

- `bash -n installers/phases/03-features.sh tests/test-hermes-context-floor.sh` - passed.
- `bash -n` over every `.sh` under `installers/`, `tests/`, `scripts/`, `lib/` - passed.
- `bash tests/test-hermes-context-floor.sh` - passed (8 passed).
- `bash tests/test-installer-context-parity.sh` - passed (73 passed).
- `bash tests/test-windows-service-plan.sh` - passed (20 passed).
- `bash tests/test-phase03-multigpu-tty.sh` - passed (static contract; PTY lane skipped: util-linux unavailable on Windows host).
- `[System.Management.Automation.Language.Parser]::ParseFile` on `installers/windows/phases/03-features.ps1` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `make lint` / `make test` - not run: GNU `make` unavailable on the Windows host; the equivalent shell/PowerShell syntax gates above were run locally and the remaining lint (lint-shell, lint-powershell) and test (test-linux) gates run in CI.