### PR TITLE
fix(bootstrap): guard rm -rf against unsafe install paths (#2301)

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -65,8 +65,28 @@ format_git_clone_error() {
 }
 
 
+# INSTALL_DIR is taken verbatim from $ODS_INSTALL_DIR, so a typo like
+# ODS_INSTALL_DIR=~ or =/ must never reach `rm -rf`. Canonicalize (resolving
+# .., symlinks, trailing slashes) and refuse critical roots. The only caller
+# has already confirmed the dir exists, so `cd` + `pwd -P` is reliable.
+_ods_is_unsafe_rm_target() {
+    local dir="$1" resolved
+    [[ -z "$dir" ]] && return 0
+    resolved=$(cd -- "$dir" 2>/dev/null && pwd -P) || return 0
+    [[ "$resolved" == "${HOME%/}" ]] && return 0
+    case "$resolved" in
+        /|/home|/root|/usr|/etc|/var|/bin|/sbin|/lib|/lib64|/opt|/boot|/dev|/proc|/sys|/tmp|/mnt|/media|/srv|/Users|/Applications|/System|/Library)
+            return 0 ;;
+    esac
+    return 1
+}
+
 remove_install_dir() {
     local target_dir="$1"
+
+    if _ods_is_unsafe_rm_target "$target_dir"; then
+        error "Refusing to 'rm -rf' unsafe install path: '${target_dir:-<empty>}'. Set ODS_INSTALL_DIR to a dedicated directory such as \$HOME/ods."
+    fi
 
     if rm -rf -- "$target_dir" 2>/dev/null; then
         return 0

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -233,6 +233,34 @@ assert_contains "$bootstrap" 'Re-run with --force to remove it automatically' "b
 assert_contains "$bootstrap" 'remove_install_dir()' "bootstrap should centralize incomplete install cleanup"
 assert_contains "$bootstrap" 'sudo -n rm -rf -- "\$target_dir"' "bootstrap --force should retry root-owned container data cleanup with sudo -n"
 assert_contains "$bootstrap" 'root-owned container data' "bootstrap sudo fallback should explain root-owned Docker data cleanup"
+assert_contains "$bootstrap" '_ods_is_unsafe_rm_target' "bootstrap must guard rm -rf against unsafe install paths"
+assert_contains "$bootstrap" 'Refusing to .rm -rf. unsafe install path' "bootstrap should refuse to delete critical roots"
+
+echo "[contract] bootstrap refuses rm -rf on \$HOME / critical roots"
+guard_probe=$(cat <<'EOF'
+set -euo pipefail
+error() { echo "REFUSED: $*"; exit 1; }
+EOF
+)
+# Pull the guard + remove_install_dir out of the bootstrap without running it.
+guard_src=$(awk '/^_ods_is_unsafe_rm_target\(\)/{p=1} p; /^}/{if(p&&++c==2)exit}' "$bootstrap")
+for bad in "$HOME" "/" "/home" ""; do
+    if HOME="$HOME" bash -c "$guard_probe
+$guard_src
+remove_install_dir \"$bad\"" 2>/dev/null; then
+        echo "[FAIL] remove_install_dir did not refuse unsafe path: '${bad:-<empty>}'"
+        exit 1
+    fi
+done
+# A dedicated subdir must still be removable.
+guard_ok_dir="$tmpdir/guard-ok/ods"
+mkdir -p "$guard_ok_dir"
+if ! HOME="$HOME" bash -c "$guard_probe
+$guard_src
+remove_install_dir \"$guard_ok_dir\"" 2>/dev/null || [[ -d "$guard_ok_dir" ]]; then
+    echo "[FAIL] remove_install_dir refused a legitimate dedicated install dir"
+    exit 1
+fi
 
 echo "[contract] public bootstrap can install from an exact commit SHA"
 sha_repo="$tmpdir/sha-ref-repo"


### PR DESCRIPTION
ODS_INSTALL_DIR is taken verbatim from the environment and reaches
`rm -rf` via remove_install_dir(), with no check that the target isn't
$HOME, /, or another critical root. A typo like ODS_INSTALL_DIR=~ or =/
on an incomplete-install path could wipe the whole tree (worse with the
sudo retry).

Add _ods_is_unsafe_rm_target(): canonicalize the path (resolving ..,
symlinks, trailing slashes) and refuse $HOME, /, empty, and critical
system roots. Guard runs at the single choke point in remove_install_dir(),
covering both call sites and any future caller.

Contract test asserts the guard exists and refuses $HOME/'/'/empty while
still removing a dedicated .../ods dir.
