### PR TITLE
fix(model-router): retain routes on malformed endpoint config

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -330,14 +330,27 @@ def _load_endpoints() -> dict[str, dict[str, Any]]:
     endpoints: dict[str, dict[str, Any]] = {}
     try:
         raw = json.loads(ENDPOINTS_PATH.read_text(encoding="utf-8"))
-        for entry in raw.get("endpoints", []):
-            endpoint_id = str(entry.get("id") or "")
-            base_url = str(entry.get("baseUrl") or "")
+        if not isinstance(raw, dict):
+            raise ValueError("root must be a JSON object")
+        entries = raw.get("endpoints")
+        if not isinstance(entries, list):
+            raise ValueError("endpoints must be a JSON array")
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise ValueError("each endpoint must be a JSON object")
+            endpoint_id = entry.get("id")
+            base_url = entry.get("baseUrl")
+            api_key_env = entry.get("apiKeyEnv", "")
+            if not all(
+                isinstance(value, str)
+                for value in (endpoint_id, base_url, api_key_env)
+            ):
+                raise ValueError("endpoint fields must be strings")
             if not endpoint_id or not base_url.startswith(("http://", "https://")):
                 continue
             endpoints[endpoint_id] = {
                 "baseUrl": base_url.rstrip("/"),
-                "apiKeyEnv": str(entry.get("apiKeyEnv") or ""),
+                "apiKeyEnv": api_key_env,
             }
     except (OSError, ValueError) as exc:
         logger.error("endpoints allowlist unreadable; retaining previous: %s", exc)

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -112,6 +112,27 @@ def _signed_marker(probe_id: str, key: str = "probe-secret") -> str:
     return f"[ODS_PROBE id={probe_id} sig={sig}]"
 
 
+@pytest.mark.parametrize(
+    "invalid_document",
+    [
+        [],
+        {"endpoints": [None]},
+        {"endpoints": [{"id": ["not-a-string"], "baseUrl": "http://new"}]},
+    ],
+)
+def test_endpoint_loader_retains_last_good_config(router, invalid_document):
+    mod, _client, _write_state, _calls = router
+    expected = mod._load_endpoints()
+    assert "llama-server-default" in expected
+
+    mod.ENDPOINTS_PATH.write_text(
+        json.dumps(invalid_document),
+        encoding="utf-8",
+    )
+
+    assert mod._load_endpoints() == expected
+
+
 def test_internal_key_falls_back_to_dashboard_api_key(monkeypatch):
     monkeypatch.delenv("ODS_ROUTER_INTERNAL_KEY", raising=False)
     monkeypatch.setenv("DASHBOARD_API_KEY", "dashboard-secret")

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -795,6 +795,42 @@ class TestEndpointsReload:
         assert still_ok.status_code == 200
         assert calls[-1]["url"].startswith("http://upstream:8080")
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            [],
+            {},
+            {"endpoints": None},
+            {"endpoints": {}},
+            {"endpoints": [None]},
+            {"endpoints": ["http://unexpected:8080"]},
+            {"endpoints": [{"id": ["not-a-string"], "baseUrl": "http://new"}]},
+            {"endpoints": [{"id": "new", "baseUrl": 8080}]},
+            {"endpoints": [{"id": "new", "baseUrl": "http://new", "apiKeyEnv": False}]},
+        ],
+    )
+    def test_wrong_shape_rewrite_retains_routable_last_good_allowlist(
+        self, router, tmp_path, payload
+    ):
+        mod, client, write_state, calls = router
+        write_state()
+        assert client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "warm cache"}],
+        }).status_code == 200
+
+        self._endpoints_path(tmp_path).write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        still_ok = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "after rewrite"}],
+        })
+
+        assert still_ok.status_code == 200
+        assert calls[-1]["url"].startswith("http://upstream:8080")
+
     def test_health_reports_allowlist_health(self, router, tmp_path):
         mod, client, write_state, calls = router
         healthy = client.get("/health")


### PR DESCRIPTION
## Summary
- validate the endpoint document root, endpoint array, entries, and string fields
- retain the last-known-good allowlist when a rewritten config has an invalid shape
- cover malformed roots, entries, and field values

## Test plan
- python -m pytest tests/test_router.py -q (51 passed)