### PR TITLE
fix(setup): tolerate malformed persisted state shapes

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -35,7 +35,11 @@ def get_active_persona_prompt() -> str:
         try:
             with open(persona_file) as f:
                 data = json.load(f)
-                return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
+                if isinstance(data, dict):
+                    prompt = data.get("system_prompt")
+                    if isinstance(prompt, str):
+                        return prompt
+                logger.debug("persona.json must contain a string system_prompt")
         except (FileNotFoundError, PermissionError, json.JSONDecodeError):
             logger.debug("Failed to read persona.json, using default prompt")
     return PERSONAS["general"]["system_prompt"]
@@ -52,7 +56,11 @@ async def setup_status(api_key: str = Depends(verify_api_key)):
     if progress_file.exists():
         try:
             with open(progress_file) as f:
-                step = json.load(f).get("step", 0)
+                data = json.load(f)
+                if isinstance(data, dict) and type(data.get("step")) is int:
+                    step = data["step"]
+                else:
+                    logger.debug("setup-progress.json has an invalid shape")
         except (FileNotFoundError, PermissionError, json.JSONDecodeError):
             logger.debug("Failed to read setup-progress.json")
 
@@ -61,7 +69,11 @@ async def setup_status(api_key: str = Depends(verify_api_key)):
     if persona_file.exists():
         try:
             with open(persona_file) as f:
-                persona = json.load(f).get("persona")
+                data = json.load(f)
+                if isinstance(data, dict) and isinstance(data.get("persona"), str):
+                    persona = data["persona"]
+                else:
+                    logger.debug("persona.json has an invalid shape")
         except (FileNotFoundError, PermissionError, json.JSONDecodeError):
             logger.debug("Failed to read persona.json for setup status")
 

--- a/ods/extensions/services/dashboard-api/tests/test_setup.py
+++ b/ods/extensions/services/dashboard-api/tests/test_setup.py
@@ -125,6 +125,33 @@ def test_setup_status_tolerates_corrupt_progress_file(test_client, setup_config_
     assert resp.json()["step"] == 0
 
 
+def test_setup_status_tolerates_non_object_state_files(test_client, setup_config_dir):
+    (setup_config_dir / "setup-progress.json").write_text("[]")
+    (setup_config_dir / "persona.json").write_text("[]")
+
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["step"] == 0
+    assert resp.json()["persona"] is None
+
+
+def test_active_persona_prompt_tolerates_invalid_value_type(
+    setup_config_dir, monkeypatch
+):
+    import routers.setup as setup_router
+
+    monkeypatch.setattr(setup_router, "SETUP_CONFIG_DIR", setup_config_dir)
+    (setup_config_dir / "persona.json").write_text(
+        json.dumps({"system_prompt": ["not", "a", "string"]})
+    )
+
+    assert (
+        setup_router.get_active_persona_prompt()
+        == setup_router.PERSONAS["general"]["system_prompt"]
+    )
+
+
 # ---------------------------------------------------------------------------
 # POST /api/setup/persona
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- validate persisted setup progress and persona JSON containers before field access
- fall back to safe setup defaults when stored values have unexpected types
- keep the active persona prompt contract string-only

## Test plan
- python -m pytest tests/test_setup.py -q (26 passed)