### PR TITLE
fix(api): tolerate null release body in release manifest

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -236,7 +236,7 @@ async def get_release_manifest():
             raise httpx.HTTPError(f"unexpected releases response: {type(releases).__name__}")
         return {
             "releases": [
-                {"version": r.get("tag_name", "").lstrip("v"), "date": r.get("published_at", ""), "title": r.get("name", ""), "changelog": r.get("body", "")[:500] + "..." if len(r.get("body", "")) > 500 else r.get("body", ""), "url": r.get("html_url", ""), "prerelease": r.get("prerelease", False)}
+                {"version": r.get("tag_name", "").lstrip("v"), "date": r.get("published_at", ""), "title": r.get("name", ""), "changelog": (r.get("body") or "")[:500] + "..." if len((r.get("body") or "")) > 500 else (r.get("body") or ""), "url": r.get("html_url", ""), "prerelease": r.get("prerelease", False)}
                 for r in releases
             ],
             "checked_at": datetime.now(timezone.utc).isoformat()

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -236,6 +236,38 @@ def test_releases_manifest_with_mocked_github(test_client):
     datetime.fromisoformat(data["checked_at"])  # valid ISO-8601 (regression: no trailing "Z" after the offset)
 
 
+def test_releases_manifest_null_release_body(test_client):
+    """GET /api/releases/manifest tolerates a null release body (no TypeError)."""
+    releases = [
+        {
+            "tag_name": "v1.6.0",
+            "published_at": "2026-01-01T00:00:00Z",
+            "name": "Release 1.6.0",
+            "body": None,
+            "html_url": "https://github.com/test/releases/v1.6.0",
+            "prerelease": False,
+        }
+    ]
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = releases
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/releases/manifest", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["releases"][0]["changelog"] == ""
+
+
 def test_releases_manifest_github_error_fallback(test_client, tmp_path, monkeypatch):
     """GET /api/releases/manifest falls back to local version on httpx error."""
     import routers.updates as updates_mod


### PR DESCRIPTION
## Summary

GitHub's releases API sends `"body": null` for releases without release notes. In `get_release_manifest`, `r.get("body", "")` returns `None` for a key present with a null value, so the changelog truncation `None[:500]` raised `TypeError`, turning `GET /api/releases/manifest` into a 500. The changelog now coalesces the body to an empty string before truncating. Added a regression test with a null-body release.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [ ] Frontend
- [x] Backend

## Validation

- `python -m py_compile extensions/services/dashboard-api/routers/updates.py` - passed.
- `cd extensions/services/dashboard-api && pytest tests/test_updates.py` - passed (28 passed).
- `git diff --check origin/main...HEAD` - passed.
