### PR TITLE
fix(api): skip empty choices chunks in vision stream

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -230,7 +230,7 @@ async def _stream_vision_chat(image_bytes: bytes, content_type: str, prompt_text
                         chunk = json.loads(payload_str)
                     except json.JSONDecodeError:
                         continue
-                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    delta = (chunk.get("choices") or [{}])[0].get("delta", {})
                     text = delta.get("content")
                     if isinstance(text, str) and text:
                         accumulated.append(text)

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1186,3 +1186,47 @@ def test_ods_talk_hermes_timeout_is_env_configurable(monkeypatch):
 
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "5")
     assert hermes_bridge._request_timeout() == 10
+
+
+def test_vision_stream_tolerates_empty_choices_chunk(monkeypatch):
+    """_stream_vision_chat skips keepalive/role chunks whose choices array is
+    empty instead of crashing the SSE stream with IndexError."""
+    import asyncio
+    import json
+
+    from unittest.mock import AsyncMock, Mock, patch
+
+    from routers.talk import _stream_vision_chat
+
+    async def fake_aiter_lines():
+        yield 'data: {"choices": []}'
+        yield 'data: {"choices": [{"delta": {"content": "Red"}}]}'
+        yield "data: [DONE]"
+
+    mock_resp = AsyncMock()
+    mock_resp.status_code = 200
+    mock_resp.aiter_lines = fake_aiter_lines
+
+    mock_cm = AsyncMock()
+    mock_cm.__aenter__.return_value = mock_resp
+    mock_cm.__aexit__.return_value = False
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__.return_value = mock_client
+    mock_client.__aexit__.return_value = False
+    mock_client.stream = Mock(return_value=mock_cm)
+
+    async def consume():
+        events = []
+        async for ev in _stream_vision_chat(b"fake", "image/png", "what is this?"):
+            events.append(json.loads(ev.decode("utf-8")[5:]))
+        return events
+
+    with patch("routers.talk.httpx.AsyncClient", return_value=mock_client):
+        events = asyncio.run(consume())
+
+    texts = [e["text"] for e in events if e["type"] == "delta"]
+    assert "Red" in texts
+    assert any(e["type"] == "complete" for e in events)
+    assert any(e["type"] == "done" for e in events)
+


### PR DESCRIPTION
## Summary

The vision chat SSE stream crashed mid-response on role/keepalive chunks. `delta = chunk.get("choices", [{}])[0]` only uses the `[{}]` fallback when the `choices` key is absent; when the backend sends `"choices": []`, the `.get` returns the empty array and `[0]` raises `IndexError`, killing the stream and the accumulated reply. The code now coalesces a falsy `choices` value to `[{}]` before indexing. Added a regression test that feeds an empty-choices chunk followed by a content chunk and asserts the stream completes.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [ ] Frontend
- [x] Backend

## Validation

- `python -m py_compile extensions/services/dashboard-api/routers/talk.py` - passed.
- `cd extensions/services/dashboard-api && pytest tests/test_talk.py` - passed (40 passed).
- `git diff --check origin/main...HEAD` - passed.
