### PR TITLE
fix(api): tolerate null statistics from n8n in workflows list

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -135,7 +135,7 @@ async def api_workflows(api_key: str = Depends(verify_api_key)):
 
         executions = 0
         if installed:
-            executions = installed.get("statistics", {}).get("executions", {}).get("total", 0)
+            executions = ((installed.get("statistics") or {}).get("executions") or {}).get("total", 0)
 
         workflows.append({
             "id": wf["id"],

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -938,3 +938,20 @@ def test_workflow_enable_rejects_path_traversal_in_catalog_file(test_client, mon
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Invalid workflow file path"
+
+
+def test_workflows_tolerates_null_n8n_statistics(test_client, monkeypatch):
+    """GET /api/workflows with an n8n workflow whose statistics is null does
+    not crash the whole list with AttributeError."""
+    import routers.workflows as wf_mod
+
+    async def fake_get_n8n_workflows():
+        return [{"id": "wf-1", "name": "Document Q&A", "active": True, "statistics": None}]
+
+    monkeypatch.setattr(wf_mod, "get_n8n_workflows", fake_get_n8n_workflows)
+
+    resp = test_client.get("/api/workflows", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "workflows" in data
+


### PR DESCRIPTION
## Summary

`GET /api/workflows` 500'd when an installed n8n workflow reports `"statistics": null`. `installed.get("statistics", {})` returned `None` for a key present with a null value, and the subsequent `.get("executions")` raised `AttributeError`, taking down the whole workflow catalog response. The code now coalesces null `statistics` and `executions` to `{}` before reading `total`. Added a regression test with a null-statistics workflow.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [ ] Frontend
- [x] Backend

## Validation

- `python -m py_compile extensions/services/dashboard-api/routers/workflows.py` - passed.
- `cd extensions/services/dashboard-api && pytest tests/test_workflows.py` - passed (46 passed).
- `git diff --check origin/main...HEAD` - passed.
