### PR TITLE
fix(api): read user-data files as utf-8 with error tolerance

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -818,7 +818,7 @@ def get_model_info() -> Optional[ModelInfo]:
     if env_path.exists():
         try:
             env_values = {}
-            with open(env_path) as f:
+            with open(env_path, encoding="utf-8", errors="replace") as f:
                 for line in f:
                     if "=" not in line or line.lstrip().startswith("#"):
                         continue
@@ -908,7 +908,7 @@ def get_bootstrap_status() -> BootstrapStatus:
         return BootstrapStatus(active=False)
 
     try:
-        with open(status_file) as f:
+        with open(status_file, encoding="utf-8", errors="replace") as f:
             data = json.load(f)
 
         status = data.get("status", "")

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -147,7 +147,7 @@ def _read_installed_version() -> str:
     env_file = install_root / ".env"
     if env_file.exists():
         try:
-            for line in env_file.read_text().splitlines():
+            for line in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
                 if line.startswith("ODS_VERSION="):
                     env_version = line.split("=", 1)[1].strip().strip("\"'")
                     if env_version:

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -148,6 +148,16 @@ class TestGetModelInfo:
 # --- get_bootstrap_status ---
 
 
+    def test_tolerates_non_utf8_env_file(self, install_dir):
+        # A .env with non-UTF-8 bytes (e.g. written by a legacy Windows
+        # editor) must not crash get_model_info with UnicodeDecodeError.
+        env_file = install_dir / ".env"
+        env_file.write_bytes(b"LLM_MODEL=Qwen2.5-7B-Instruct" + bytes([10, 35, 32, 255, 10]))
+
+        info = get_model_info()
+        assert info is not None
+        assert info.name == "Qwen2.5-7B-Instruct"
+
 class TestGetBootstrapStatus:
 
     def test_inactive_when_no_file(self, data_dir):
@@ -282,6 +292,14 @@ class TestGetBootstrapStatus:
 
 # --- _update_lifetime_tokens ---
 
+
+    def test_tolerates_non_utf8_status_file(self, data_dir):
+        status_file = data_dir / "bootstrap-status.json"
+        status_file.write_bytes(b'{"status": "complete", "note": "' + bytes([255]) + b'"}')
+
+        status = get_bootstrap_status()
+        assert isinstance(status, BootstrapStatus)
+        assert status.active is False
 
 class TestUpdateLifetimeTokens:
 


### PR DESCRIPTION
## Summary

Three dashboard-api reads of user-written files used locale-default encoding and only guarded against `OSError`/`JSONDecodeError`, so a single non-UTF-8 byte in those files raised `UnicodeDecodeError` (a `ValueError` subclass) that escaped the guard and crashed the endpoint: `_read_installed_version` on `.env`, `get_model_info` on `.env`, and `get_bootstrap_status` on `bootstrap-status.json`. These files can be produced by Windows editors that emit legacy encodings. The reads now specify `encoding="utf-8", errors="replace"` at the I/O boundary. Added regression tests that plant a 0xFF byte in both `.env` and `bootstrap-status.json` and assert the callers no longer raise.

## AI Assistance

AI-assisted repository search and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [ ] Frontend
- [x] Backend

## Validation

- `python -m py_compile extensions/services/dashboard-api/main.py extensions/services/dashboard-api/helpers.py` - passed.
- `cd extensions/services/dashboard-api && pytest tests/test_helpers.py -k "non_utf8"` - passed (2 passed).
- `git diff --check origin/main...HEAD` - passed.
