### PR TITLE
fix(preflight): fail loudly when the log cannot be created

### DIFF
--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -97,7 +97,13 @@ pass() { log "${GREEN}✓${NC} $1"; PASS=$((PASS+1)); }
 fail() { log "${RED}✗${NC} $1"; FAIL=$((FAIL+1)); }
 warn() { log "${YELLOW}⚠${NC} $1"; WARN=$((WARN+1)); }
 
-echo "" > "$LOG_FILE"
+# Fail loudly if the log can't be created (e.g. root-owned install dir) instead
+# of dying silently under set -e on the first redirect to $LOG_FILE below.
+if ! : > "$LOG_FILE"; then
+    echo "ERROR: cannot write preflight log to $LOG_FILE; is $ODS_DIR writable by the current user?" >&2
+    exit 1
+fi
+
 log "========================================"
 log "ODS Pre-flight Check"
 log "Started: $(date)"


### PR DESCRIPTION
## Summary

`ods-preflight.sh` runs under `set -euo pipefail`, and its first write to the log (`echo "" > "$LOG_FILE"`) aborts the script with no explanation when the install dir isn't writable — e.g. a root-owned install run by a normal user. The redirect now fails loudly: the script verifies the log can be created first and prints a clear error to stderr before exiting 1, so the failure is diagnosed instead of silently dying.

## AI Assistance

AI-assisted repository search and edge-case enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [x] Core runtime
- [ ] Frontend
- [ ] Backend

## Validation

- `bash -n ods/ods-preflight.sh` - passed.
- Redirect-failure harness (unwritable log path) - exited 1 with clear ERROR message.
- `git diff --check origin/main...HEAD` - passed.
