### PR TITLE
fix(restore): reject archives whose root doesn't match the backup id

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -224,6 +224,17 @@ extract_backup() {
             log_error "Backup archive contains unsafe paths (absolute or ../) — refusing to extract" >&2
             return 1
         fi
+        # Archives are created as "<backup_id>.tar.gz" wrapping a top-level
+        # directory named after the backup id (see ods-backup.sh). Refuse an
+        # archive whose root doesn't match, so a renamed or corrupt archive
+        # can't unpack elsewhere and leave the caller restoring from an empty
+        # directory.
+        if archive_root=$(tar -tzf "$compressed" 2>/dev/null | awk -F/ 'NF { print $1; exit }'); then
+            if [[ -n "$archive_root" && "$archive_root" != "$backup_id" ]]; then
+                log_error "Backup archive root '${archive_root}/' does not match backup id '$backup_id' — refusing to extract" >&2
+                return 1
+            fi
+        fi
         log_info "Extracting compressed backup..." >&2
         mkdir -p "$uncompressed"
         if ! tar xzf "$compressed" --no-same-owner -C "$BACKUP_ROOT"; then


### PR DESCRIPTION
## Summary

`extract_backup` created `$BACKUP_ROOT/<id>` and then unpacked the archive with `tar xzf ... -C $BACKUP_ROOT`, trusting the archive's top-level directory name. A renamed or corrupt archive whose root differs from the requested backup id extracted into `$BACKUP_ROOT/<something-else>`, leaving the caller to restore from an empty directory it had just created — a silent no-op restore. Archives are created by `ods-backup.sh` as `tar czf <id>.tar.gz ... <id>`, so the first path component must equal the backup id. The function now verifies the archive's first entry matches the backup id before extracting and refuses otherwise.

## AI Assistance

AI-assisted repository search and edge-case enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [x] Core runtime
- [ ] Frontend
- [ ] Backend

## Validation

- `bash -n ods/ods-restore.sh` - passed.
- Harness with root=evil archive requested as backup-123 - rejected with clear error, nothing extracted.
- Harness with matching archive - extracted correctly.
- `git diff --check origin/main...HEAD` - passed.
