### PR TITLE
fix(restore): don't wipe live config from an empty backup config dir

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -439,12 +439,18 @@ restore_config() {
     done
 
     if [[ -d "$backup_dir/config" ]]; then
-        restored_any=true
-        if [[ -d "$ODS_DIR/config" ]]; then
-            rm -rf "$ODS_DIR/config"
+        # Only replace the live config when the backup actually has content;
+        # an empty or truncated backup config dir must not wipe the live one.
+        if [[ "$(find "$backup_dir/config" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')" != "0" ]]; then
+            restored_any=true
+            if [[ -d "$ODS_DIR/config" ]]; then
+                rm -rf "$ODS_DIR/config"
+            fi
+            cp -r "$backup_dir/config" "$ODS_DIR/"
+            log_success "Restored: config/"
+        else
+            log_warn "Skipped config/ (backup config dir is empty)"
         fi
-        cp -r "$backup_dir/config" "$ODS_DIR/"
-        log_success "Restored: config/"
     else
         log_warn "Skipped (not in backup): config/"
     fi


### PR DESCRIPTION
## Summary

`restore_config` removed `$ODS_DIR/config` and copied the backup's config dir whenever `$backup_dir/config` existed, even if that directory was empty or truncated by a partial/aborted backup. Restoring such a backup silently destroyed the working configuration. The function now checks that the backup's config dir actually contains entries before replacing the live config, and logs a warning instead when it is empty.

## AI Assistance

AI-assisted repository search and edge-case enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [x] Core runtime
- [ ] Frontend
- [ ] Backend

## Validation

- `bash -n ods/ods-restore.sh` - passed.
- Harness: empty backup config dir - live config preserved, warning logged.
- Harness: populated backup config dir - live config replaced correctly.
- `git diff --check origin/main...HEAD` - passed.
