### PR TITLE
fix(migrate): stop copying DATA_DIR into itself during backup

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -112,9 +112,15 @@ cmd_backup() {
     cp "${INSTALL_DIR}/docker-compose.yml" "$backup_path/" 2>&1 || cp_exit=$?
     cp -r "${INSTALL_DIR}/config" "$backup_path/" 2>&1 || cp_exit=$?
 
-    # Backup user data references
-    cp -r "${DATA_DIR}" "$backup_path/data/" 2>&1 || cp_exit=$?
-    
+    # Backup user data references. Skip the backups dir itself — it lives
+    # inside DATA_DIR, and copying the whole tree into one of its own
+    # subdirectories makes cp refuse ("cannot copy a directory into itself"),
+    # so the data backup silently fails.
+    mkdir -p "$backup_path/data"
+    while IFS= read -r -d '' entry; do
+        cp -r "$entry" "$backup_path/data/" 2>&1 || cp_exit=$?
+    done < <(find "$DATA_DIR" -mindepth 1 -maxdepth 1 ! -name backups -print0)
+
     log_success "Configuration backed up to: $backup_path"
     echo "$backup_path"
 }


### PR DESCRIPTION
## Summary

`cmd_backup` in migrate-config.sh did `cp -r "$DATA_DIR" "$backup_path/data/"` where `backup_path` lives under `DATA_DIR/backups`. GNU cp refuses with "cannot copy a directory into itself", the error was swallowed by `|| cp_exit=$?`, and the script still printed success — so the user-data portion of the backup silently never happened. The copy now iterates `DATA_DIR`'s top-level entries while excluding the `backups` dir, so the data tree is captured without copying the directory into itself.

## AI Assistance

AI-assisted repository search and edge-case enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [x] Core runtime
- [ ] Frontend
- [ ] Backend

## Validation

- `bash -n ods/scripts/migrate-config.sh` - passed.
- Harness with real DATA_DIR tree - backup captured data/n8n and models, no "into itself" refusal.
- `git diff --check origin/main...HEAD` - passed.
