### PR TITLE
fix(install): drop dead env keys from offline mode setup

### DIFF
--- a/ods/installers/phases/09-offline.sh
+++ b/ods/installers/phases/09-offline.sh
@@ -30,23 +30,6 @@ elif [[ "$OFFLINE_MODE" == "true" ]] && ! $DRY_RUN; then
     _sed_i 's/^ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
     _sed_i 's/^OPENAI_API_KEY=.*/OPENAI_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
 
-    # Add offline mode config
-    cat >> "$INSTALL_DIR/.env" << 'OFFLINE_EOF'
-
-#=============================================================================
-# M1 Offline Mode Configuration
-#=============================================================================
-OFFLINE_MODE=true
-
-# Disable telemetry and update checks
-DISABLE_TELEMETRY=true
-DISABLE_UPDATE_CHECK=true
-
-# Use local RAG instead of web search
-WEB_SEARCH_ENABLED=false
-LOCAL_RAG_ENABLED=true
-OFFLINE_EOF
-
     # Create OpenClaw M1 config if OpenClaw is enabled
     if [[ "$ENABLE_OPENCLAW" == "true" ]]; then
         mkdir -p "$INSTALL_DIR/config/openclaw"


### PR DESCRIPTION
## Summary

Installer phase 09 appended `OFFLINE_MODE`, `DISABLE_TELEMETRY`, `DISABLE_UPDATE_CHECK`, `WEB_SEARCH_ENABLED` and `LOCAL_RAG_ENABLED` to `.env`. None of them exist in `.env.schema.json` and nothing in the codebase reads them (`OFFLINE_MODE` is an installer CLI flag set by `--offline`, not an env key), so every offline install left a `.env` that fails `ods env validate` with unknown-key errors (exit 2). This removes the dead block; offline mode is still marked by the `.offline-mode` marker file, the API-key blanking, and the OpenClaw M1 config.

## AI Assistance

AI-assisted repository search and edge-case enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [x] Core runtime
- [ ] Frontend
- [ ] Backend

## Validation

- `bash -n ods/installers/phases/09-offline.sh` - passed.
- `ods/scripts/validate-env.sh` against a `.env` containing the removed keys - failed (exit 2, all 5 unknown) proving the bug; the phase no longer writes them.
- `git diff --check origin/main...HEAD` - passed.
