### PR TITLE
fix(bootstrap): guard recursive install cleanup

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -84,7 +84,7 @@ install_dir_removal_is_safe() {
     [[ "${canonical_target#/}" == */* ]] || return 1
 
     case "$target_name" in
-        ods|ods-*|*-ods|dream-server|dreamserver) return 0 ;;
+        ods|ods-*|*-ods) return 0 ;;
     esac
     [[ -f "$target_dir/ods-cli" && -f "$target_dir/install-core.sh" ]] \
         || [[ -f "$target_dir/docker-compose.base.yml" && -d "$target_dir/installers" ]]

--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -65,8 +65,38 @@ format_git_clone_error() {
 }
 
 
+install_dir_removal_is_safe() {
+    local target_dir="${1:-}"
+    local target_parent target_name canonical_parent canonical_target canonical_home
+
+    [[ -n "$target_dir" && -d "$target_dir" && ! -L "$target_dir" ]] || return 1
+    target_parent=$(dirname -- "${target_dir%/}")
+    target_name=$(basename -- "${target_dir%/}")
+    [[ "$target_name" != "." && "$target_name" != ".." ]] || return 1
+    canonical_parent=$(cd -P -- "$target_parent" 2>/dev/null && pwd) || return 1
+    canonical_target="${canonical_parent%/}/$target_name"
+    [[ "$canonical_target" == /* ]] || return 1
+
+    canonical_home=$(cd -P -- "$ODS_BOOTSTRAP_ROOT" 2>/dev/null && pwd) || return 1
+    [[ "$canonical_target" != "$canonical_home" ]] || return 1
+    # Never delete the filesystem root or one of its direct children (such as
+    # /home, /Users, /Volumes, /mnt, or /opt), regardless of its name.
+    [[ "${canonical_target#/}" == */* ]] || return 1
+
+    case "$target_name" in
+        ods|ods-*|*-ods|dream-server|dreamserver) return 0 ;;
+    esac
+    [[ -f "$target_dir/ods-cli" && -f "$target_dir/install-core.sh" ]] \
+        || [[ -f "$target_dir/docker-compose.base.yml" && -d "$target_dir/installers" ]]
+}
+
 remove_install_dir() {
     local target_dir="$1"
+
+    if ! install_dir_removal_is_safe "$target_dir"; then
+        warn "Refusing to recursively remove an unrecognized or protected install path: $target_dir"
+        return 2
+    fi
 
     if rm -rf -- "$target_dir" 2>/dev/null; then
         return 0
@@ -376,7 +406,7 @@ if [[ -d "$INSTALL_DIR" ]]; then
         echo ""
         if [[ "$BOOTSTRAP_FORCE" == "true" ]]; then
             echo "  Removing incomplete install because --force was provided."
-            remove_install_dir "$INSTALL_DIR" || error "Failed to remove incomplete install at $INSTALL_DIR. Try: sudo rm -rf \"$INSTALL_DIR\""
+            remove_install_dir "$INSTALL_DIR" || error "Failed or refused to remove incomplete install at $INSTALL_DIR. Verify ODS_INSTALL_DIR points to an ODS checkout before removing it manually."
         elif [[ "$BOOTSTRAP_NON_INTERACTIVE" == "true" ]]; then
             echo "  Aborting. Re-run with --force to remove it automatically, or remove manually with: rm -rf $INSTALL_DIR"
             exit 1
@@ -384,7 +414,7 @@ if [[ -d "$INSTALL_DIR" ]]; then
             echo -n "  Remove and reinstall? [y/N] "
             read -r response
             if [[ "$response" =~ ^[Yy]$ ]]; then
-                remove_install_dir "$INSTALL_DIR" || error "Failed to remove incomplete install at $INSTALL_DIR. Try: sudo rm -rf \"$INSTALL_DIR\""
+                remove_install_dir "$INSTALL_DIR" || error "Failed or refused to remove incomplete install at $INSTALL_DIR. Verify ODS_INSTALL_DIR points to an ODS checkout before removing it manually."
             else
                 echo "  Aborting. Remove manually with: rm -rf $INSTALL_DIR"
                 exit 1

--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -83,9 +83,11 @@ install_dir_removal_is_safe() {
     # /home, /Users, /Volumes, /mnt, or /opt), regardless of its name.
     [[ "${canonical_target#/}" == */* ]] || return 1
 
-    case "$target_name" in
-        ods|ods-*|*-ods) return 0 ;;
-    esac
+    # The canonical default may be incomplete before it has any ODS marker.
+    # Name patterns alone are not evidence for custom paths: unrelated
+    # directories such as ods-photos or client-ods must never become eligible
+    # for recursive deletion.
+    [[ "$canonical_target" == "${canonical_home%/}/ods" ]] && return 0
     [[ -f "$target_dir/ods-cli" && -f "$target_dir/install-core.sh" ]] \
         || [[ -f "$target_dir/docker-compose.base.yml" && -d "$target_dir/installers" ]]
 }

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -231,8 +231,33 @@ assert_contains "$bootstrap" 'BOOTSTRAP_NON_INTERACTIVE=false' "bootstrap should
 assert_contains "$bootstrap" 'Removing incomplete install because --force was provided' "bootstrap --force should remove incomplete install dirs without prompting"
 assert_contains "$bootstrap" 'Re-run with --force to remove it automatically' "bootstrap --non-interactive should fail with a force hint instead of prompting"
 assert_contains "$bootstrap" 'remove_install_dir()' "bootstrap should centralize incomplete install cleanup"
+assert_contains "$bootstrap" 'install_dir_removal_is_safe "\$target_dir"' "bootstrap must validate an install path before recursive removal"
 assert_contains "$bootstrap" 'sudo -n rm -rf -- "\$target_dir"' "bootstrap --force should retry root-owned container data cleanup with sudo -n"
 assert_contains "$bootstrap" 'root-owned container data' "bootstrap sudo fallback should explain root-owned Docker data cleanup"
+
+echo "[contract] public bootstrap refuses protected and unrecognized removal targets"
+guard_functions="$tmpdir/bootstrap-removal-functions.sh"
+sed -n '/^install_dir_removal_is_safe() {/,/^}/p' "$bootstrap" > "$guard_functions"
+safe_named="$tmpdir/ods-incomplete"
+safe_marked="$tmpdir/custom-install"
+unrecognized="$tmpdir/photos"
+mkdir -p "$safe_named" "$safe_marked/installers" "$unrecognized"
+touch "$safe_marked/docker-compose.base.yml"
+bash -c '
+  set -euo pipefail
+  ODS_BOOTSTRAP_ROOT="$1"
+  source "$2"
+  safe_named="$3"
+  safe_marked="$4"
+  unrecognized="$5"
+
+  ! install_dir_removal_is_safe /
+  ! install_dir_removal_is_safe /tmp
+  ! install_dir_removal_is_safe "$ODS_BOOTSTRAP_ROOT"
+  ! install_dir_removal_is_safe "$unrecognized"
+  install_dir_removal_is_safe "$safe_named"
+  install_dir_removal_is_safe "$safe_marked"
+' bash "$tmpdir" "$guard_functions" "$safe_named" "$safe_marked" "$unrecognized"
 
 echo "[contract] public bootstrap can install from an exact commit SHA"
 sha_repo="$tmpdir/sha-ref-repo"

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -238,10 +238,12 @@ assert_contains "$bootstrap" 'root-owned container data' "bootstrap sudo fallbac
 echo "[contract] public bootstrap refuses protected and unrecognized removal targets"
 guard_functions="$tmpdir/bootstrap-removal-functions.sh"
 sed -n '/^install_dir_removal_is_safe() {/,/^}/p' "$bootstrap" > "$guard_functions"
-safe_named="$tmpdir/ods-incomplete"
+safe_named="$tmpdir/ods"
 safe_marked="$tmpdir/custom-install"
 unrecognized="$tmpdir/photos"
-mkdir -p "$safe_named" "$safe_marked/installers" "$unrecognized"
+ods_prefixed="$tmpdir/ods-photos"
+ods_suffixed="$tmpdir/client-ods"
+mkdir -p "$safe_named" "$safe_marked/installers" "$unrecognized" "$ods_prefixed" "$ods_suffixed"
 touch "$safe_marked/docker-compose.base.yml"
 bash -c '
   set -euo pipefail
@@ -250,14 +252,18 @@ bash -c '
   safe_named="$3"
   safe_marked="$4"
   unrecognized="$5"
+  ods_prefixed="$6"
+  ods_suffixed="$7"
 
   ! install_dir_removal_is_safe /
   ! install_dir_removal_is_safe /tmp
   ! install_dir_removal_is_safe "$ODS_BOOTSTRAP_ROOT"
   ! install_dir_removal_is_safe "$unrecognized"
+  ! install_dir_removal_is_safe "$ods_prefixed"
+  ! install_dir_removal_is_safe "$ods_suffixed"
   install_dir_removal_is_safe "$safe_named"
   install_dir_removal_is_safe "$safe_marked"
-' bash "$tmpdir" "$guard_functions" "$safe_named" "$safe_marked" "$unrecognized"
+' bash "$tmpdir" "$guard_functions" "$safe_named" "$safe_marked" "$unrecognized" "$ods_prefixed" "$ods_suffixed"
 
 echo "[contract] public bootstrap can install from an exact commit SHA"
 sha_repo="$tmpdir/sha-ref-repo"


### PR DESCRIPTION
## Summary
- validate and canonicalize an incomplete install path before either normal or sudo recursive cleanup
- reject the filesystem root, top-level system directories, the bootstrap home, symlinks, and unrecognized custom directories
- allow normal ODS-named targets and custom paths carrying an ODS checkout marker pair

Closes #2301

## Test plan
- [x] `bash -n ods/get-ods.sh ods/tests/contracts/test-installer-hardening.sh`
- [x] `bash ods/tests/contracts/test-installer-hardening.sh`
- [x] `git diff --check`

Generated with Codex