### PR TITLE
ci: enforce least-privilege workflow defaults

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -8,6 +8,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 concurrency:
   group: issue-triage-${{ github.event.issue.number }}
   cancel-in-progress: false

--- a/.github/workflows/autonomous-code-scanner.yml
+++ b/.github/workflows/autonomous-code-scanner.yml
@@ -19,6 +19,9 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+
 concurrency:
   group: autonomous-code-scanner
   cancel-in-progress: false

--- a/.github/workflows/autonomous-code-scanner.yml
+++ b/.github/workflows/autonomous-code-scanner.yml
@@ -759,6 +759,7 @@ jobs:
     name: Create Pull Requests
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
       pull-requests: write
       issues: write

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -8,6 +8,10 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: issue-to-pr-${{ github.event.issue.number }}
   cancel-in-progress: true
@@ -322,6 +326,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       pr_number: ${{ steps.create.outputs.pull-request-number }}
       pr_url: ${{ steps.create.outputs.pull-request-url }}

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: issue-to-pr-${{ github.event.issue.number }}
@@ -24,6 +23,9 @@ jobs:
     name: Validate Issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     if: >-
       github.event.label.name == 'ai-implement' &&
       github.event.issue.user.login != 'claude[bot]' &&

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   powershell-lint:
     strategy:

--- a/.github/workflows/nightly-code-review.yml
+++ b/.github/workflows/nightly-code-review.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: nightly-code-review
   cancel-in-progress: false

--- a/.github/workflows/nightly-code-review.yml
+++ b/.github/workflows/nightly-code-review.yml
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: nightly-code-review
@@ -31,6 +30,9 @@ jobs:
     name: Pre-flight Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_changes: ${{ steps.detect.outputs.has_changes }}
       skip: ${{ steps.dedup.outputs.skip }}
@@ -77,6 +79,8 @@ jobs:
 
   code-review:
     name: Claude Code Review
+    permissions:
+      contents: read
     needs: preflight
     if: needs.preflight.outputs.has_changes == 'true' && needs.preflight.outputs.skip != 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-docs-update.yml
+++ b/.github/workflows/nightly-docs-update.yml
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: nightly-docs-update
@@ -31,6 +30,9 @@ jobs:
     name: Detect Doc-Affecting Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       affected_docs: ${{ steps.check.outputs.affected_docs }}

--- a/.github/workflows/nightly-docs-update.yml
+++ b/.github/workflows/nightly-docs-update.yml
@@ -18,6 +18,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  pull-requests: read
+
 concurrency:
   group: nightly-docs-update
   cancel-in-progress: false
@@ -162,6 +166,9 @@ jobs:
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 concurrency:
   group: release-notes
   cancel-in-progress: false

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   token-spy-postgres:
     runs-on: ubuntu-latest
@@ -242,6 +245,9 @@ jobs:
 
       - name: Issue-to-PR Security Contract Tests
         run: bash tests/test-issue-to-pr-security.sh
+
+      - name: Workflow Permissions Contract Tests
+        run: bash tests/test-workflow-permissions.sh
 
       - name: Upload Installer Simulation Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   env-schema:
     runs-on: ubuntu-latest

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -143,6 +143,9 @@ test: ## Run unit and contract tests
 	@echo "=== issue-to-pr security check ==="
 	@bash tests/test-issue-to-pr-security.sh
 	@echo ""
+	@echo "=== workflow permissions contract ==="
+	@bash tests/test-workflow-permissions.sh
+	@echo ""
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
 	@echo ""

--- a/ods/tests/test-workflow-permissions.sh
+++ b/ods/tests/test-workflow-permissions.sh
@@ -10,6 +10,17 @@ fail() {
     exit 1
 }
 
+job_block() {
+    local workflow="$1"
+    local job="$2"
+
+    awk -v header="  ${job}:" '
+        $0 == header { in_job = 1 }
+        in_job && $0 ~ /^  [[:alnum:]_-]+:$/ && $0 != header { exit }
+        in_job { print }
+    ' "$workflow"
+}
+
 for workflow in "$WORKFLOW_DIR"/*.yml; do
     [[ -f "$workflow" ]] || continue
     grep -q '^permissions:$' "$workflow" \
@@ -22,15 +33,35 @@ done
 [[ "$checked" -gt 0 ]] || fail "no workflow files found"
 
 issue_to_pr="$WORKFLOW_DIR/issue-to-pr.yml"
-grep -q '^  pull-requests: read$' "$issue_to_pr" \
-    || fail "issue-to-pr deduplication needs pull-request read access"
+! grep -q '^  pull-requests: read$' "$issue_to_pr" \
+    || fail "issue-to-pr grants pull-request read access to every job"
+validate_block="$(job_block "$issue_to_pr" validate)"
+grep -q '^      pull-requests: read$' <<< "$validate_block" \
+    || fail "issue-to-pr validation needs pull-request read access"
 grep -q '^      issues: write$' "$issue_to_pr" \
     || fail "issue-to-pr creation job needs issue comment access"
 
+nightly_review="$WORKFLOW_DIR/nightly-code-review.yml"
+! grep -q '^  pull-requests: read$' "$nightly_review" \
+    || fail "nightly code review grants pull-request read access to every job"
+preflight_block="$(job_block "$nightly_review" preflight)"
+grep -q '^      pull-requests: read$' <<< "$preflight_block" \
+    || fail "nightly code review preflight needs pull-request read access"
+
 nightly_docs="$WORKFLOW_DIR/nightly-docs-update.yml"
+! grep -q '^  pull-requests: read$' "$nightly_docs" \
+    || fail "nightly docs grants pull-request read access to every job"
+detect_block="$(job_block "$nightly_docs" detect-changes)"
+grep -q '^      pull-requests: read$' <<< "$detect_block" \
+    || fail "nightly docs detection needs pull-request read access"
 grep -q '^      contents: write$' "$nightly_docs" \
     || fail "nightly docs PR job needs scoped contents write access"
 grep -q '^      pull-requests: write$' "$nightly_docs" \
     || fail "nightly docs PR job needs scoped pull-request write access"
+
+scanner="$WORKFLOW_DIR/autonomous-code-scanner.yml"
+create_prs_block="$(job_block "$scanner" create-prs)"
+grep -q '^      actions: read$' <<< "$create_prs_block" \
+    || fail "autonomous scanner PR job needs action artifact read access"
 
 echo "test-workflow-permissions: $checked workflows checked"

--- a/ods/tests/test-workflow-permissions.sh
+++ b/ods/tests/test-workflow-permissions.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW_DIR="$ROOT_DIR/.github/workflows"
+checked=0
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+for workflow in "$WORKFLOW_DIR"/*.yml; do
+    [[ -f "$workflow" ]] || continue
+    grep -q '^permissions:$' "$workflow" \
+        || fail "$(basename "$workflow") has no workflow-level permissions default"
+    ! grep -qE '^permissions:[[:space:]]*write-all|^[[:space:]]+actions:[[:space:]]+write$' "$workflow" \
+        || fail "$(basename "$workflow") grants an overbroad workflow-level permission"
+    checked=$((checked + 1))
+done
+
+[[ "$checked" -gt 0 ]] || fail "no workflow files found"
+
+issue_to_pr="$WORKFLOW_DIR/issue-to-pr.yml"
+grep -q '^  pull-requests: read$' "$issue_to_pr" \
+    || fail "issue-to-pr deduplication needs pull-request read access"
+grep -q '^      issues: write$' "$issue_to_pr" \
+    || fail "issue-to-pr creation job needs issue comment access"
+
+nightly_docs="$WORKFLOW_DIR/nightly-docs-update.yml"
+grep -q '^      contents: write$' "$nightly_docs" \
+    || fail "nightly docs PR job needs scoped contents write access"
+grep -q '^      pull-requests: write$' "$nightly_docs" \
+    || fail "nightly docs PR job needs scoped pull-request write access"
+
+echo "test-workflow-permissions: $checked workflows checked"


### PR DESCRIPTION
## Summary
- give every previously unscoped workflow an explicit read-only default
- retain write access only on jobs that create PRs, update releases, or comment on issues
- add a repository-wide contract so future workflows cannot silently inherit repository defaults

Closes #2300

## Test plan
- [x] `bash ods/tests/test-workflow-permissions.sh` (19 workflows checked)
- [x] `bash ods/tests/test-issue-to-pr-security.sh` (12 passed)
- [x] parse every workflow with PyYAML
- [x] `git diff --check`

Generated with Codex