### PR TITLE
fix(privacy): fail closed on key persistence errors

### DIFF
--- a/ods/extensions/services/privacy-shield/key_management.py
+++ b/ods/extensions/services/privacy-shield/key_management.py
@@ -8,33 +8,37 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import tempfile
+from pathlib import Path
 from typing import Optional
 
 
 def load_persisted_key(path: str) -> Optional[str]:
     try:
-        if not os.path.exists(path):
-            return None
-        with open(path, "r", encoding="utf-8") as f:
-            key = f.read().strip()
-        return key or None
-    except Exception:
-        logging.exception("Failed to read persisted SHIELD_API_KEY")
+        key = Path(path).read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
         return None
+    return key or None
 
 
 def persist_key(path: str, key: str) -> None:
+    key_path = Path(path)
+    key_path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{key_path.name}.",
+        suffix=".tmp",
+        dir=key_path.parent,
+    )
+    temporary = Path(temporary_name)
     try:
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(key)
-        try:
-            os.chmod(path, 0o600)
-        except Exception:
-            # Best-effort only (may fail on some mounts/platforms)
-            pass
-    except Exception:
-        logging.exception("Failed to persist generated SHIELD_API_KEY")
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            os.fchmod(handle.fileno(), 0o600)
+            handle.write(key)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, key_path)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def resolve_shield_api_key(env_key: Optional[str], key_path: str) -> str:

--- a/ods/extensions/services/privacy-shield/tests/test_key_management.py
+++ b/ods/extensions/services/privacy-shield/tests/test_key_management.py
@@ -2,11 +2,13 @@ import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
+from unittest import mock
 
 # Allow running this test from repo root without installing the service as a package.
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from key_management import resolve_shield_api_key, persist_key
+from key_management import load_persisted_key, resolve_shield_api_key, persist_key
 
 
 class TestKeyManagement(unittest.TestCase):
@@ -29,6 +31,27 @@ class TestKeyManagement(unittest.TestCase):
             self.assertTrue(isinstance(key, str) and len(key) > 0)
             with open(key_path, "r", encoding="utf-8") as f:
                 self.assertEqual(f.read().strip(), key)
+
+    @unittest.skipIf(os.name == "nt", "POSIX mode bits are not enforced on Windows")
+    def test_persisted_key_is_private(self):
+        with tempfile.TemporaryDirectory() as d:
+            key_path = os.path.join(d, "shield_api_key")
+
+            persist_key(key_path, "persisted")
+
+            self.assertEqual(os.stat(key_path).st_mode & 0o777, 0o600)
+
+    def test_read_errors_are_not_treated_as_missing_keys(self):
+        with mock.patch.object(Path, "read_text", side_effect=PermissionError("denied")):
+            with self.assertRaises(PermissionError):
+                load_persisted_key("/unreadable/shield_api_key")
+
+    def test_persist_errors_do_not_return_ephemeral_keys(self):
+        with mock.patch(
+            "key_management.persist_key", side_effect=PermissionError("denied")
+        ):
+            with self.assertRaises(PermissionError):
+                resolve_shield_api_key(None, "/unwritable/shield_api_key")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- let unexpected key-file read and write failures propagate to service startup
- persist generated credentials through a mode-0600 temporary file and atomic replace
- cover unreadable state, persistence failure, and private file permissions

## Why this matters

Privacy Shield previously treated every persisted-key read error as “missing” and swallowed every write error. The proxy could start with a newly generated but unpersisted key, then rotate credentials on restart and reject existing clients while claiming the key was saved. The invariant is that the service either reuses a durable key or fails visibly; it never serves with an accidental ephemeral credential.

## Overlap check

Searched open and closed PR titles/bodies for `privacy shield key persistence` and scanned open PR production-file changes. This search surfaced this existing `tang-vu` PR, so its branch was rebased and revalidated instead of opening a duplicate.

## Validation

- `python -m unittest discover -s ods/extensions/services/privacy-shield/tests -p 'test_key_management.py' -v` — 6 tests pass on Windows, with the POSIX mode-bit assertion correctly skipped
- `python -m py_compile ods/extensions/services/privacy-shield/key_management.py ods/extensions/services/privacy-shield/tests/test_key_management.py`
- `git diff main...HEAD --check`

## Tradeoffs and rollback

A broken key volume now prevents startup instead of silently rotating authentication, matching the repository's fail-visible policy. Atomic replace requires the temporary file to share the destination directory/filesystem. Reverting restores best-effort persistence; existing key files remain compatible.