### PR TITLE
fix(setup): validate completion responses and surface timeouts

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -198,6 +198,25 @@ async def run_setup_diagnostics(api_key: str = Depends(verify_api_key)):
     return StreamingResponse(run_tests(), media_type="text/plain")
 
 
+def _completion_content(data: object) -> str:
+    """Extract content from an OpenAI-compatible completion response."""
+    if not isinstance(data, dict):
+        raise ValueError("completion response must be an object")
+    choices = data.get("choices")
+    if not isinstance(choices, list) or not choices:
+        raise ValueError("completion response must contain choices")
+    choice = choices[0]
+    if not isinstance(choice, dict):
+        raise ValueError("completion choice must be an object")
+    message = choice.get("message")
+    if not isinstance(message, dict):
+        raise ValueError("completion choice must contain a message")
+    content = message.get("content")
+    if not isinstance(content, str):
+        raise ValueError("completion message content must be a string")
+    return content
+
+
 @router.post("/api/chat")
 async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
     """Simple chat endpoint for the setup wizard QuickWin step."""
@@ -218,9 +237,15 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
             _api_path = os.environ.get("LLM_API_BASE_PATH", "/v1")
             async with session.post(f"{llm_url}{_api_path}/chat/completions", json=payload, headers={"Content-Type": "application/json"}) as resp:
                 if resp.status == 200:
-                    data = await resp.json()
-                    choices = data.get("choices") or [{}]
-                    response_text = (choices[0] or {}).get("message", {}).get("content", "")
+                    try:
+                        data = await resp.json()
+                        response_text = _completion_content(data)
+                    except (aiohttp.ContentTypeError, json.JSONDecodeError, ValueError) as exc:
+                        logger.warning("LLM returned an invalid completion response: %s", exc)
+                        raise HTTPException(
+                            status_code=502,
+                            detail="LLM returned an invalid completion response",
+                        ) from exc
                     # Strip thinking model tags — content may contain <think>...</think> blocks
                     response_text = re.sub(r'<think>[\s\S]*?</think>\s*', '', response_text).strip()
                     return {"response": response_text, "success": True}

--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -203,15 +203,19 @@ def _completion_content(data: object) -> str:
     if not isinstance(data, dict):
         raise ValueError("completion response must be an object")
     choices = data.get("choices")
-    if not isinstance(choices, list) or not choices:
-        raise ValueError("completion response must contain choices")
+    if choices is None or choices == []:
+        return ""
+    if not isinstance(choices, list):
+        raise ValueError("completion choices must be a list")
     choice = choices[0]
+    if choice is None:
+        return ""
     if not isinstance(choice, dict):
         raise ValueError("completion choice must be an object")
-    message = choice.get("message")
+    message = choice.get("message", {})
     if not isinstance(message, dict):
         raise ValueError("completion choice must contain a message")
-    content = message.get("content")
+    content = message.get("content", "")
     if not isinstance(content, str):
         raise ValueError("completion message content must be a string")
     return content

--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -256,6 +256,9 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
                 else:
                     error_text = await resp.text()
                     raise HTTPException(status_code=resp.status, detail=f"LLM error: {error_text}")
+    except asyncio.TimeoutError as exc:
+        logger.warning("LLM request timed out")
+        raise HTTPException(status_code=504, detail="LLM request timed out") from exc
     except aiohttp.ClientError:
         logger.exception("Cannot reach LLM backend")
         raise HTTPException(status_code=503, detail="Cannot reach LLM backend")

--- a/ods/extensions/services/dashboard-api/tests/test_routers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_routers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -875,6 +876,25 @@ def test_chat_connection_error(test_client, monkeypatch):
         )
 
     assert resp.status_code == 503
+
+
+def test_chat_timeout_returns_gateway_timeout(test_client):
+    """POST /api/chat maps the configured upstream timeout to HTTP 504."""
+    session_mock = MagicMock()
+    session_mock.post = MagicMock(side_effect=asyncio.TimeoutError)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.setup.aiohttp.ClientSession", return_value=session_ctx):
+        response = test_client.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 504
+    assert response.json()["detail"] == "LLM request timed out"
 
 
 # ---------------------------------------------------------------------------

--- a/ods/extensions/services/dashboard-api/tests/test_routers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_routers.py
@@ -755,16 +755,14 @@ def test_chat_success(test_client, monkeypatch):
     "payload",
     [
         [],
-        {},
-        {"choices": []},
-        {"choices": [None]},
+        {"choices": {}},
+        {"choices": ["invalid-choice"]},
         {"choices": [{"message": None}]},
         {"choices": [{"message": {"content": 123}}]},
     ],
     ids=[
         "non-object-root",
-        "missing-choices",
-        "empty-choices",
+        "non-list-choices",
         "invalid-choice",
         "invalid-message",
         "invalid-content",
@@ -794,6 +792,43 @@ def test_chat_invalid_completion_response_returns_502(test_client, payload):
 
     assert response.status_code == 502
     assert response.json()["detail"] == "LLM returned an invalid completion response"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {},
+        {"choices": []},
+        {"choices": [None]},
+        {"choices": [{}]},
+        {"choices": [{"message": {}}]},
+    ],
+    ids=["missing-choices", "empty-choices", "null-choice", "empty-choice", "empty-message"],
+)
+def test_chat_empty_completion_response_stays_successful(test_client, payload):
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value=payload)
+
+    response_ctx = AsyncMock()
+    response_ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    response_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session_mock = MagicMock()
+    session_mock.post = MagicMock(return_value=response_ctx)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.setup.aiohttp.ClientSession", return_value=session_ctx):
+        response = test_client.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {"response": "", "success": True}
 
 
 def test_chat_llm_error(test_client, monkeypatch):

--- a/ods/extensions/services/dashboard-api/tests/test_routers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_routers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 
 # ---------------------------------------------------------------------------
@@ -748,6 +749,51 @@ def test_chat_success(test_client, monkeypatch):
     assert data["success"] is True
     assert data["response"] == "Hello from the LLM!"
     assert session_mock.post.call_args.kwargs["json"]["model"] == "new-live-model"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"choices": []},
+        {"choices": [None]},
+        {"choices": [{"message": None}]},
+        {"choices": [{"message": {"content": 123}}]},
+    ],
+    ids=[
+        "non-object-root",
+        "missing-choices",
+        "empty-choices",
+        "invalid-choice",
+        "invalid-message",
+        "invalid-content",
+    ],
+)
+def test_chat_invalid_completion_response_returns_502(test_client, payload):
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value=payload)
+
+    response_ctx = AsyncMock()
+    response_ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    response_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session_mock = MagicMock()
+    session_mock.post = MagicMock(return_value=response_ctx)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.setup.aiohttp.ClientSession", return_value=session_ctx):
+        response = test_client.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 502
+    assert response.json()["detail"] == "LLM returned an invalid completion response"
 
 
 def test_chat_llm_error(test_client, monkeypatch):


### PR DESCRIPTION
﻿## Why this matters

`POST /api/chat` is the setup wizard's QuickWin inference boundary. It accepts OpenAI-compatible completion payloads from the configured local backend, whose response shape and latency are outside FastAPI's control.

Two reachable failures were not represented honestly:

- A backend could return HTTP 200 with malformed nested data, causing an internal exception or false success.
- The configured 30-second `aiohttp` total timeout raises `asyncio.TimeoutError`, which was not caught by the existing `aiohttp.ClientError` branch. A cold or stalled local inference therefore escaped the route and became a generic server failure instead of a gateway timeout the UI/operator can understand.

## Root cause and invariant

Root cause: the route dereferenced upstream JSON without validating its OpenAI-compatible shape and assumed every transport failure inherited from `aiohttp.ClientError`.

Invariant: valid empty completion replies remain successful; malformed successful responses return 502; unreachable backends return 503; and expiration of ODS's explicit upstream deadline returns 504. Programmer errors outside those I/O boundaries still propagate.

## What changed

- Add `_completion_content()` to validate the response object, choices list, first choice, message object, and string content.
- Preserve the established empty-reply contract for missing/empty choices and empty messages.
- Map invalid JSON/content shapes from an HTTP 200 backend to a stable 502 response.
- Catch only `asyncio.TimeoutError` for the configured request deadline and return `504 LLM request timed out`.
- Add parameterized HTTP-boundary regressions for malformed and empty payloads plus a timeout regression.

## Overlap check

Searched open and closed PRs semantically for setup chat timeouts, empty choices, completion response validation, and `Cannot reach LLM backend`; scanned every open PR changing `routers/setup.py`.

- Merged #1729 established that empty choices should return an empty successful reply; this PR deliberately preserves that behavior.
- Open #1956, #2437, and #2816 cover atomic setup/persona state files.
- #2042, #2323, and #2572 cover persisted persona/state parsing and file I/O.
- #2967 covers 64-hex Wi-Fi PSKs.
- None covers completion schema validation or the uncaught `asyncio.TimeoutError` boundary.

This existing #2375 remains the canonical `/api/chat` upstream-response PR; the timeout fix was added here instead of opening a same-endpoint variant.

## Focused validation

Red/green timeout evidence:

- Before the timeout handler: `pytest tests/test_routers.py -q -k "chat_timeout"` ? **failed**, with `TimeoutError` escaping through Starlette's TestClient.
- After the handler: the same command ? **1 passed**.

Affected validation:

- `pytest tests/test_routers.py -q` ? **65 passed**
- `python -m compileall -q routers/setup.py` ? passed
- `git diff --check` ? passed (Git emitted only Windows LF/CRLF checkout notices)
- `pytest tests/ -q` ? **2078 passed, 14 skipped, 1 failed**; the sole failure was the unrelated Windows host refusing symlink creation with `WinError 1314` in `test_scan_symlink_skipped`, before its production assertion. No route/setup failures occurred.

Mocked transport proves HTTP classification and payload parsing; no live cold-model inference was run.

## Design, compatibility, and rollback

The timeout remains 30 seconds and no retry/fallback was added. A timeout is distinct from connection failure because it tells the setup UI that the backend was given a bounded window but did not finish. Non-200 backend statuses continue to pass through unchanged, and empty content stays compatible with #1729.

Rollback is a normal revert of the three commits, but restores malformed-response crashes/false success and uncaught inference timeouts.
