### PR TITLE
fix(support-bundle): write bundle evidence JSON atomically in ods-support-bundle.sh

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -748,6 +748,7 @@ evidence = {
 
 evidence_path = bundle_dir / "manifest" / "evidence.json"
 import os
+import pathlib
 import tempfile
 fd, tmp_str = tempfile.mkstemp(dir=str(evidence_path.parent), prefix=f".{evidence_path.name}.", suffix=".tmp")
 tmp_path = pathlib.Path(tmp_str)

--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -746,7 +746,20 @@ evidence = {
     "commands": command_statuses(),
 }
 
-(bundle_dir / "manifest" / "evidence.json").write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+evidence_path = bundle_dir / "manifest" / "evidence.json"
+import os
+import tempfile
+fd, tmp_str = tempfile.mkstemp(dir=str(evidence_path.parent), prefix=f".{evidence_path.name}.", suffix=".tmp")
+tmp_path = pathlib.Path(tmp_str)
+content = json.dumps(evidence, indent=2, sort_keys=True) + "\n"
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(content)
+    os.replace(tmp_path, evidence_path)
+except Exception:
+    if tmp_path.exists():
+        tmp_path.unlink(missing_ok=True)
+    raise
 PY
     redact_file "$BUNDLE_DIR/manifest/evidence.json"
 }


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-support-bundle.sh`, `write_evidence()` wrote support bundle evidence JSON records directly using `(bundle_dir / "manifest" / "evidence.json").write_text(json.dumps(...))`. If support bundle generation is interrupted (e.g. process termination or disk error), the target evidence JSON file can be left partially written or truncated in place.

## Fix

1. Update `ods-support-bundle.sh` to write support bundle evidence JSON data to a temporary file via `tempfile.mkstemp` in `bundle_dir / "manifest"`.
2. Use `os.replace` for atomic replacement of destination evidence files.

## Verification

Verified syntax with `bash -n ods/scripts/ods-support-bundle.sh`. `git diff --check` passed cleanly with zero whitespace issues.