### PR TITLE
fix(installers): pre-apply restricted permissions on env generator temp file

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -756,10 +756,21 @@ def load(path):
 
 def save(path, value):
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
-    tmp.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, path)
+    import tempfile
+    fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(value, indent=2) + "\n")
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            pass
+        os.replace(tmp, path)
+    except Exception:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
 
 home_path = Path(os.environ["ODS_OPENCLAW_HOME_CONFIG"])
 home = load(home_path)


### PR DESCRIPTION
## Problem

In `ods/installers/macos/lib/env-generator.sh`, `save()` created temporary config files using default umask (`0644`) prior to calling `os.chmod(tmp, 0o600)` after `tmp.write_text()`. This exposed sensitive model provider API keys under permissive mode during the write window.

## Fix

1. Update `save()` in `env-generator.sh` to generate temporary files via `tempfile.mkstemp` in `path.parent`.
2. Pre-apply restricted file mode (`0o600`) to the temporary file before calling `os.replace`.

## Verification

Verified syntax with `bash -n ods/installers/macos/lib/env-generator.sh`. `git diff --check` passed cleanly with zero whitespace issues.