### PR TITLE
fix(macos): pre-apply restricted permissions on daemon PID temp file in ods-macos.sh

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -307,10 +307,21 @@ with log_path.open("ab", buffering=0) as log_handle:
         close_fds=True,
         start_new_session=True,
     )
-tmp = pid_path.with_name(f"{pid_path.name}.{os.getpid()}.tmp")
-tmp.write_text(f"{proc.pid}\n", encoding="ascii")
-os.chmod(tmp, 0o600)
-os.replace(tmp, pid_path)
+import tempfile
+fd, tmp_str = tempfile.mkstemp(dir=str(pid_path.parent), prefix=f".{pid_path.name}.", suffix=".tmp")
+tmp = Path(tmp_str)
+try:
+    with os.fdopen(fd, "w", encoding="ascii") as f:
+        f.write(f"{proc.pid}\n")
+    try:
+        tmp.chmod(0o600)
+    except OSError:
+        pass
+    os.replace(tmp, pid_path)
+except Exception:
+    if tmp.exists():
+        tmp.unlink(missing_ok=True)
+    raise
 BOOTSTRAP_LAUNCH_PY
 }
 


### PR DESCRIPTION
## Problem

In `ods/installers/macos/ods-macos.sh`, daemon process PID files were written to temporary paths created with default umask (`0644`) prior to calling `os.chmod(tmp, 0o600)` after `tmp.write_text()`. This exposed daemon PID files under loose permissions during the temporary write window.

## Fix

1. Update `ods-macos.sh` to generate temporary PID files via `tempfile.mkstemp` in `pid_path.parent`.
2. Pre-apply restricted file mode (`0o600`) to the temporary file before calling `os.replace`.

## Verification

Verified syntax with `bash -n ods/installers/macos/ods-macos.sh`. `git diff --check` passed cleanly with zero whitespace issues.