### PR TITLE
fix(dashboard-api): use mkstemp for collision-free _atomic_write_0600 helper

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -71,6 +71,7 @@ import logging
 import os
 import re
 import secrets
+import tempfile
 import time
 from pathlib import Path
 from typing import Optional
@@ -261,18 +262,22 @@ def _prune_expired_nonces(nonce_dir: Path) -> None:
 
 
 def _atomic_write_0600(target: Path, data: str) -> None:
-    """Write ``data`` to ``target`` atomically with mode 0600 on POSIX.
-    The chmod is best-effort on filesystems that don't honour it
-    (Windows dev boxes, some overlayfs setups). Uses ``with_name`` rather
-    than ``with_suffix`` because Path.with_suffix rejects suffixes that
-    contain embedded dots on some Python versions."""
-    tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(data, encoding="utf-8")
+    """Write ``data`` to ``target`` atomically with mode 0600 on POSIX."""
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp")
+    tmp = Path(tmp_str)
     try:
-        tmp.chmod(0o600)
-    except OSError:
-        logger.debug("could not chmod %s to 0600", tmp, exc_info=True)
-    tmp.replace(target)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(data)
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            logger.debug("could not chmod %s to 0600", tmp, exc_info=True)
+        os.replace(tmp, target)
+    except Exception:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
 
 
 def _success_page(skill: str, return_url: Optional[str] = None) -> str:


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/oauth_passthrough.py`, `_atomic_write_0600` constructed temporary paths using static `target.with_name(target.name + ".tmp")`. Concurrent OAuth token init calls collide on the same temporary path and risk permission window exposure before `chmod(0o600)`.

## Fix

1. Update `_atomic_write_0600` in `oauth_passthrough.py` to generate temporary files via `tempfile.mkstemp` in `target.parent`.
2. Pre-apply restricted mode (`0o600`) to the temporary file before calling `os.replace`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py`: 48/48 passed. `git diff --check` passed cleanly with zero whitespace issues.