### PR TITLE
fix(preflight): write preflight summary JSON atomically in linux-install-preflight.sh

### DIFF
--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -454,7 +454,10 @@ else
 fi
 
 if [[ -n "$JSON_FILE" ]]; then
-    printf '%s\n' "$REPORT_JSON" >"$JSON_FILE"
+    mkdir -p "$(dirname "$JSON_FILE")"
+    tmp_json="$(mktemp "${JSON_FILE}.tmp.XXXXXX")"
+    printf '%s\n' "$REPORT_JSON" >"$tmp_json"
+    mv -f "$tmp_json" "$JSON_FILE"
     echo "JSON written to: $JSON_FILE"
 fi
 


### PR DESCRIPTION
## Problem

In `ods/scripts/linux-install-preflight.sh`, structured JSON preflight report files specified via `JSON_FILE` were written directly using `printf '%s\n' "$REPORT_JSON" >"$JSON_FILE"`. If execution is interrupted, the target preflight JSON report file can be left truncated or partially written.

## Fix

1. Update `linux-install-preflight.sh` to route JSON report file output through a temporary file created via `mktemp` inside `JSON_FILE`'s directory.
2. Use `mv -f` for atomic replacement of the destination JSON preflight report file path.

## Verification

Verified syntax with `bash -n ods/scripts/linux-install-preflight.sh`. `git diff --check` passed cleanly with zero whitespace issues.