### PR TITLE
fix(installers): write GPU topology JSON atomically in 03-features.sh

### DIFF
--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -271,7 +271,8 @@ fi
 # write $GPU_TOPOLOGY_JSON into a tmpfile to use by the commands
 TOPOLOGY_FILE=$(mktemp "${TMPDIR:-/tmp}/ods_gpu_topology.XXXXXX.json")
 trap 'rm -f "$TOPOLOGY_FILE"' EXIT
-echo "$GPU_TOPOLOGY_JSON" > "$TOPOLOGY_FILE"
+_topo_tmp=$(mktemp "${TOPOLOGY_FILE}.XXXXXX.tmp")
+printf '%s\n' "$GPU_TOPOLOGY_JSON" > "$_topo_tmp" && mv -f "$_topo_tmp" "$TOPOLOGY_FILE"
 
 ASSIGN_GPUS_SCRIPT="$SCRIPT_DIR/scripts/assign_gpus.py"
 


### PR DESCRIPTION
## Problem

In `ods/installers/phases/03-features.sh`, GPU topology JSON payloads were written directly using `echo "$GPU_TOPOLOGY_JSON" > "$TOPOLOGY_FILE"`. If the installer execution is interrupted during feature detection, the target topology JSON file can be left partially written or zero-byte truncated.

## Fix

1. Update `03-features.sh` to write GPU topology JSON data to a temporary file created via `mktemp` in the temporary directory.
2. Use `mv -f` for atomic replacement of the final GPU topology file path.

## Verification

Verified syntax with `bash -n ods/installers/phases/03-features.sh`. `git diff --check` passed cleanly with zero whitespace issues.