### PR TITLE
fix(installers): write compose flags cache atomically in 11-services.sh

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -456,7 +456,8 @@ else
     mkdir -p "$INSTALL_DIR/logs"
 
     # Persist compose flags so ods-cli can reuse them without re-resolving
-    echo "$COMPOSE_FLAGS" > "$INSTALL_DIR/.compose-flags" || warn "Could not cache compose flags (non-fatal)"
+    _flags_tmp=$(mktemp "$INSTALL_DIR/.compose-flags.XXXXXX.tmp")
+    printf '%s\n' "$COMPOSE_FLAGS" > "$_flags_tmp" && mv -f "$_flags_tmp" "$INSTALL_DIR/.compose-flags" || warn "Could not cache compose flags (non-fatal)"
     log "Saved compose flags to $INSTALL_DIR/.compose-flags"
 
     _phase11_compose_command_text() {


### PR DESCRIPTION
## Problem

In `ods/installers/phases/11-services.sh`, cached compose flags were written directly using `echo "$COMPOSE_FLAGS" > "$INSTALL_DIR/.compose-flags"`. If installer execution is interrupted during service resolution, the target `.compose-flags` file can be left partially written or zero-byte truncated.

## Fix

1. Update `11-services.sh` to route cached compose flags output through a temporary file created via `mktemp` inside `INSTALL_DIR`.
2. Use `mv -f` for atomic replacement of the destination `.compose-flags` file path.

## Verification

Verified syntax with `bash -n ods/installers/phases/11-services.sh`. `git diff --check` passed cleanly with zero whitespace issues.