### PR TITLE
fix(installers): write setup complete JSON atomically in 13-summary.sh

### DIFF
--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -56,10 +56,16 @@ if ! $DRY_RUN; then
     _setup_config_dir="${INSTALL_DIR}/data/config"
     _setup_complete_file="${_setup_config_dir}/setup-complete.json"
     _completed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-    if mkdir -p "${_setup_config_dir}" 2>/dev/null \
-        && printf '{"completed_at": "%s", "version": "1.0.0"}\n' "${_completed_at}" > "${_setup_complete_file}" 2>/dev/null \
-        && chmod 644 "${_setup_complete_file}" 2>/dev/null; then
-        log "Setup wizard pre-marked complete at ${_setup_complete_file}"
+    if mkdir -p "${_setup_config_dir}" 2>/dev/null; then
+        _setup_tmp=$(mktemp "${_setup_complete_file}.XXXXXX.tmp" 2>/dev/null)
+        if printf '{"completed_at": "%s", "version": "1.0.0"}\n' "${_completed_at}" > "${_setup_tmp}" 2>/dev/null \
+            && chmod 644 "${_setup_tmp}" 2>/dev/null \
+            && mv -f "${_setup_tmp}" "${_setup_complete_file}" 2>/dev/null; then
+            log "Setup wizard pre-marked complete at ${_setup_complete_file}"
+        else
+            rm -f "${_setup_tmp}" 2>/dev/null
+            ai_warn "Could not write ${_setup_complete_file} (non-fatal)"
+        fi
     else
         ai_warn "Could not write ${_setup_complete_file} (non-fatal)"
     fi


### PR DESCRIPTION
## Problem

In `ods/installers/phases/13-summary.sh`, setup wizard completion state files (`setup-complete.json`) were written directly using `printf '{"completed_at": ...}' > "${_setup_complete_file}"`. If execution is interrupted during phase 13 summary rendering, the target `setup-complete.json` file can be left partially written or corrupted in place.

## Fix

1. Update `13-summary.sh` to write setup completion JSON payloads to a temporary file via `mktemp` inside `_setup_config_dir`.
2. Apply mode `644` on the temporary file before using `mv -f` for atomic replacement.

## Verification

Verified syntax with `bash -n ods/installers/phases/13-summary.sh`. `git diff --check` passed cleanly with zero whitespace issues.