### PR TITLE
fix(bootstrap): write upgrade lock PID file atomically in bootstrap-upgrade.sh

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -235,7 +235,8 @@ acquire_upgrade_lock() {
     done
 
     UPGRADE_LOCK_DIR="$lock_dir"
-    printf '%s\n' "$$" > "$pid_file"
+    _pid_tmp=$(mktemp "${pid_file}.XXXXXX.tmp")
+    printf '%s\n' "$$" > "$_pid_tmp" && mv -f "$_pid_tmp" "$pid_file"
     trap 'release_model_lifecycle_lock; release_upgrade_lock' EXIT
 }
 


### PR DESCRIPTION
## Problem

In `ods/scripts/bootstrap-upgrade.sh`, model upgrade lock PID files were written directly using `printf '%s\n' "$$" > "$pid_file"`. If process execution is interrupted while acquiring the lock directory, the target PID file inside the lock directory can be left truncated or empty.

## Fix

1. Update `bootstrap-upgrade.sh` to write lock PID values to a temporary file via `mktemp` inside the lock directory.
2. Use `mv -f` for atomic replacement of the destination lock PID file path.

## Verification

Verified syntax with `bash -n ods/scripts/bootstrap-upgrade.sh`. `git diff --check` passed cleanly with zero whitespace issues.