### PR TITLE
fix(migration): write migration version state atomically in migrate-config.sh

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -65,7 +65,10 @@ get_last_migrated_version() {
 set_last_migrated_version() {
     local version="$1"
     mkdir -p "$(dirname "$MIGRATION_STATE")"
-    echo "$version" > "$MIGRATION_STATE"
+    local tmp_state
+    tmp_state="$(mktemp "${MIGRATION_STATE}.XXXXXX.tmp")"
+    echo "$version" > "$tmp_state"
+    mv -f "$tmp_state" "$MIGRATION_STATE"
 }
 
 # Compare semantic versions


### PR DESCRIPTION
## Problem

In `ods/scripts/migrate-config.sh`, `set_last_migrated_version()` persisted migration state version numbers using `echo "$version" > "$MIGRATION_STATE"`. Direct output redirection truncates the target version file in place, risking corrupted or truncated migration markers if interrupted.

## Fix

1. Update `set_last_migrated_version()` to write version strings to a temporary file via `mktemp` in `MIGRATION_STATE`'s directory.
2. Use `mv -f` for atomic replacement of the destination migration state file.

## Verification

Verified syntax with `bash -n ods/scripts/migrate-config.sh`. `git diff --check` passed cleanly with zero whitespace issues.