### PR TITLE
fix(macos): run OpenCode LaunchAgent with serve, not web

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2873,7 +2873,7 @@ for service in (data.get("services") or {}).values():
     <key>ProgramArguments</key>
     <array>
         <string>${OPENCODE_BIN}</string>
-        <string>web</string>
+        <string>serve</string>
         <string>--port</string>
         <string>3003</string>
         <string>--hostname</string>
@@ -2912,7 +2912,7 @@ PLIST_EOF
             ai_ok "OpenCode Web UI service installed (LaunchAgent, port 3003)"
         else
             ai_warn "OpenCode LaunchAgent failed (rc=${_opencode_bootstrap_rc}): ${_opencode_bootstrap_err}"
-            ai_warn "Start manually: ${OPENCODE_BIN} web --port 3003"
+            ai_warn "Start manually: ${OPENCODE_BIN} serve --port 3003"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

The Linux `opencode-web.service` user unit was moved to the headless `serve` subcommand (f7395384) so boot/install never launches a browser or TUI, but the macOS LaunchAgent still ran the legacy `web` subcommand. Because the plist uses `RunAtLoad` + `KeepAlive`, every login spawns `opencode web`, opening a terminal/browser even on headless installs, and diverges from the Linux unit.

This switches the plist `ProgramArguments` and the manual-start hint to `serve`.

## AI Assistance

AI-assisted cross-platform edge-case enumeration. The author reviewed the implementation and is responsible for the final diff.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer (macOS)

## Validation

- `bash -n ods/installers/macos/install-macos.sh` - passed.