### PR TITLE
fix(uninstall): reap brew-installed OpenCode orphans

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -262,6 +262,10 @@ if command -v pgrep >/dev/null 2>&1; then
     while IFS= read -r _pid; do
         [[ -n "$_pid" ]] && _ods_uninstall_orphan_pids+=("$_pid")
     done < <(pgrep -f '\.opencode/bin/opencode (web|serve)' 2>/dev/null || true)
+    # brew-installed opencode also covered (both subcommands; brew prefixes)
+    while IFS= read -r _pid; do
+        [[ -n "$_pid" ]] && _ods_uninstall_orphan_pids+=("$_pid")
+    done < <(pgrep -f '/(opt/homebrew|usr/local)/bin/opencode (web|serve)' 2>/dev/null || true)
     # macOS-native llama-server: only matches this install's shipped binary
     while IFS= read -r _pid; do
         [[ -n "$_pid" ]] && _ods_uninstall_orphan_pids+=("$_pid")


### PR DESCRIPTION
## Summary
The macOS installer installs OpenCode via `brew install opencode`, placing the binary at /opt/homebrew/bin/opencode (Apple Silicon) or /usr/local/bin/opencode (Intel), but the uninstaller's orphan reaper in ods/ods-uninstall.sh only matched the per-user path ~/.opencode/bin/opencode. Consequently a brew-installed opencode still running `web`/`serve` after uninstall was never reaped, kept holding port 3003, and served stale state to the next install. This change adds a second pgrep pass matching both brew prefixes (`/(opt/homebrew|usr/local)/bin/opencode (web|serve)`) so those orphans are terminated alongside the per-user ones, and updates the inline comment to note the brew paths are also covered.

## AI Assistance
AI-assisted cross-platform edge-case enumeration. The author reviewed the implementation and is responsible for the final diff.

## Release Lane
- [x] Mainline change targeting `main`

## Changed Surface
- [x] Core runtime

## Validation
- bash -n ods/ods-uninstall.sh - passed.