### PR TITLE
fix(linux): honor OPENCODE_PORT in the OpenCode systemd unit

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -147,6 +147,8 @@ else
             [[ -z "${ODS_MODEL_SWITCHBOARD:-}" ]] && ODS_MODEL_SWITCHBOARD=$(grep -m1 '^ODS_MODEL_SWITCHBOARD=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_PORT:-}" ]] && LITELLM_PORT=$(grep -m1 '^LITELLM_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ -z "${OPENCODE_PORT:-}" ]] && OPENCODE_PORT=$(grep -m1 '^OPENCODE_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ "$OPENCODE_PORT" =~ ^[0-9]+$ ]] || OPENCODE_PORT=3003
         fi
         # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise.
         #
@@ -287,13 +289,16 @@ OPENCODE_EOF
                 _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN__|${_opencode_bin_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN_DIR__|${_opencode_bin_dir_esc}|g" "$svc_tmp"
+                _opencode_port_esc=$(printf '%s\n' "${OPENCODE_PORT:-3003}" | sed 's/[&/\]/\\&/g')
+                _sed_i "s|__OPENCODE_PORT__|${_opencode_port_esc}|g" "$svc_tmp"
+                if grep -q '__OPENCODE_PORT__' "$svc_tmp"; then ai_warn "opencode-web.service has unrendered __OPENCODE_PORT__ placeholder"; fi
                 cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
                 rm -f "$svc_tmp"
             fi
 
             systemctl --user daemon-reload 2>/dev/null || true
             systemctl --user enable --now opencode-web.service >> "$LOG_FILE" 2>&1 && \
-                ai_ok "OpenCode Web UI service installed (user-level, port 3003)" || \
+                ai_ok "OpenCode Web UI service installed (user-level, port ${OPENCODE_PORT:-3003})" || \
                 ai_warn "OpenCode Web UI service failed to start"
 
             # Enable lingering so service survives logout

--- a/ods/opencode/opencode-web.service
+++ b/ods/opencode/opencode-web.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=__HOME__
-ExecStart=__OPENCODE_BIN__ serve --port 3003 --hostname 127.0.0.1
+ExecStart=__OPENCODE_BIN__ serve --port __OPENCODE_PORT__ --hostname 127.0.0.1
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary

`OPENCODE_PORT` is a documented, schema-validated env var (`ods/.env.schema.json`, default 3003) that `ports.json` declares via `env_var: OPENCODE_PORT`, and it is honored on Windows (`installers/windows`). On Linux it was silently ignored: `ods/opencode/opencode-web.service` hardcoded `--port 3003` and the phase that renders the unit (`ods/installers/phases/07-devtools.sh`) substituted `__HOME__`, `__OPENCODE_BIN__`, and `__OPENCODE_BIN_DIR__` but had no port placeholder. A configured `OPENCODE_PORT` therefore never reached the service, which bound 3003 while the dashboard/health reported the configured port.

## AI Assistance

AI-assisted repository search and edge-case enumeration were used to trace where the Linux unit is rendered, cross-check the Windows handling of `OPENCODE_PORT`, and design the placeholder-render guard pattern to mirror the host-agent block.

## Release Lane

- [x] Mainline

## Changed Surface

- [x] Core runtime

## Validation

```
bash -n ods/installers/phases/07-devtools.sh
bash -n ods/opencode/opencode-web.service
git diff --check
```