### PR TITLE
fix(installer): probe OpenCode health on the configured port

### DIFF
--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -514,7 +514,9 @@ fi
 # hermes-proxy is the LAN-facing entry and has an anonymous /health endpoint.
 [[ "$ENABLE_HERMES" == "true" ]] && _check_health "Hermes Proxy" "http://127.0.0.1:${SERVICE_PORTS[hermes-proxy]:-9120}${SERVICE_HEALTH[hermes-proxy]:-/health}" 60 5 "$(sr_container hermes-proxy)"
 [[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://127.0.0.1:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 150 10 "$(sr_container openclaw)"
-systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://127.0.0.1:3003/" 10 5
+_opencode_health_port="$(grep -m1 '^OPENCODE_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"' )"
+[[ "$_opencode_health_port" =~ ^[0-9]+$ ]] || _opencode_health_port=3003
+systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://127.0.0.1:${_opencode_health_port}/" 10 5
 # Whisper: 150 attempts * adaptive backoff = up to ~20 minutes (model download on first start)
 ods_progress 95 "health" "Checking voice services"
 [[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://127.0.0.1:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 150 10 "$(sr_container whisper)"


### PR DESCRIPTION
## Summary

`ods/installers/phases/12-health.sh` hardcoded `127.0.0.1:3003` for the OpenCode health probe even though `OPENCODE_PORT` is a documented env var (default 3003) that is honored on Windows. The probe now resolves the port from `.env` with numeric validation so the health check tracks the actual binding.

## AI Assistance

AI-assisted repository search and edge-case enumeration. The author reviewed the implementation and is responsible for the final diff.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer

## Validation

- `bash -n ods/installers/phases/12-health.sh` - passed.
- `git diff --check` - passed.