### PR TITLE
fix(installer): print the configured OpenCode port in summary

### DIFF
--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -120,6 +120,9 @@ fi
 bootline
 echo -e "${BGRN}ALL SERVICES${NC}"
 bootline
+# Resolve OpenCode's configured port once (OPENCODE_PORT is documented in .env)
+OPENCODE_WEB_PORT="$(grep -m1 '^OPENCODE_PORT=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"')"
+[[ "$OPENCODE_WEB_PORT" =~ ^[0-9]+$ ]] || OPENCODE_WEB_PORT=3003
 # Core services always shown
 echo "  • Chat UI:       http://localhost:${SERVICE_PORTS[open-webui]:-3000}"
 echo "  • Dashboard:     http://localhost:${SERVICE_PORTS[dashboard]:-3001}"
@@ -128,7 +131,7 @@ echo "  • LLM API:       http://localhost:${SERVICE_PORTS[llama-server]:-11434
 [[ "${ENABLE_COMFYUI:-false}" == "true" ]] && echo "  • ComfyUI:       http://localhost:${SERVICE_PORTS[comfyui]:-8188}"
 [[ "$ENABLE_HERMES" == "true" ]] && echo "  • Hermes (auth): http://localhost:${SERVICE_PORTS[hermes-proxy]:-9120}  (magic-link gated; not direct :9119)"
 [[ "$ENABLE_OPENCLAW" == "true" ]] && echo "  • OpenClaw:      http://localhost:${SERVICE_PORTS[openclaw]:-7860}"
-systemctl --user is-active opencode-web &>/dev/null && echo "  • OpenCode:      http://localhost:3003"
+systemctl --user is-active opencode-web &>/dev/null && echo "  • OpenCode:      http://localhost:${OPENCODE_WEB_PORT}"
 [[ "$ENABLE_VOICE" == "true" ]] && echo "  • Whisper STT:   http://localhost:${SERVICE_PORTS[whisper]:-9000}"
 [[ "$ENABLE_VOICE" == "true" ]] && echo "  • TTS (Kokoro):  http://localhost:${SERVICE_PORTS[tts]:-8880}"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && echo "  • n8n:           http://localhost:${SERVICE_PORTS[n8n]:-5678}"
@@ -414,7 +417,7 @@ echo -e "  ${BGRN}Hermes${NC}       ${WHT}http://localhost:${SERVICE_PORTS[herme
 [[ "$ENABLE_OPENCLAW" == "true" ]] && \
 echo -e "  ${BGRN}OpenClaw${NC}     ${WHT}http://localhost:${OPENCLAW_PORT}${NC}"
 systemctl --user is-active opencode-web &>/dev/null && \
-echo -e "  ${BGRN}OpenCode${NC}     ${WHT}http://localhost:3003${NC}"
+echo -e "  ${BGRN}OpenCode${NC}     ${WHT}http://localhost:${OPENCODE_WEB_PORT}${NC}"
 echo ""
 if [[ -n "$LOCAL_IP" ]]; then
     _bind=$(grep "^BIND_ADDRESS=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"' || echo "127.0.0.1")


### PR DESCRIPTION
## Summary
- `13-summary.sh` printed OpenCode's URL at hardcoded port `3003` in both the service list and the access-card.
- `OPENCODE_PORT` is documented in `.env` (default `3003`), so the printed URL was wrong whenever a user configured a different port.
- Resolve `OPENCODE_WEB_PORT` once from `$INSTALL_DIR/.env` (falling back to `3003` when unset/non-numeric) and interpolate it into both lines.
- The `systemctl --user is-active opencode-web` gate is unchanged.

## AI Assistance
This change was implemented with assistance from an AI coding agent.

## Release Lane
- [x] Mainline
- [ ] Other

## Changed Surface
- [ ] Core
- [x] Installer
- [ ] CLI
- [ ] Dashboard
- [ ] Dashboard API
- [ ] Extensions / Services
- [ ] Docs
- [ ] CI

## Validation
- `bash -n ods/installers/phases/13-summary.sh` — passes
- `git diff --check` — clean