### PR TITLE
fix(dashboard-api): honor OPENCODE_PORT for the OpenCode host service

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -22,6 +22,16 @@ from host_agent_client import AgentClientError, async_request_json as request_ag
 from models import ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus
 
 
+def _effective_external_port(service_id: str, config: dict) -> int:
+    """Return the live external port for a host service, honoring OPENCODE_PORT."""
+    candidate = config.get("external_port", config.get("port", 0))
+    if service_id == "opencode":
+        raw = os.environ.get("OPENCODE_PORT", "")
+        if raw.isdigit() and 1 <= int(raw) <= 65535:
+            candidate = int(raw)
+    return int(candidate or 0)
+
+
 class _DirSizeCache:
     """Per-path TTL cache for dir_size_gb to avoid repeated rglob walks."""
 
@@ -157,7 +167,7 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
     open. If the proof is unavailable, fail closed so the dashboard does not
     launch users into a dead localhost URL.
     """
-    port = int(config.get("health_port") or config.get("external_port") or config.get("port") or 0)
+    port = int(config.get("health_port") or _effective_external_port(service_id, config) or 0)
     if port <= 0:
         return _service_status_from_config(service_id, config, "not_deployed")
 

--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -16,6 +16,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["features"])
 
 
+def _svc_external_port(service_id: str, config: dict) -> int:
+    """Return the live external port for a service, honoring OPENCODE_PORT."""
+    candidate = config.get("external_port", config.get("port", 0))
+    if service_id == "opencode":
+        raw = os.environ.get("OPENCODE_PORT", "")
+        if raw.isdigit() and 1 <= int(raw) <= 65535:
+            candidate = int(raw)
+    return int(candidate or 0)
+
+
 def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
     """Calculate whether a feature can be enabled and its status."""
     gpu_vram_gb = (gpu_info.memory_total_mb / 1024) if gpu_info else 0
@@ -201,7 +211,7 @@ async def feature_enable_instructions(
         public_url = cfg.get("public_url")
         if public_url:
             return public_url
-        port = cfg.get("external_port", cfg.get("port", 0))
+        port = _svc_external_port(service_id, cfg)
         if not port:
             return ""
         forwarded_host = request.headers.get("x-forwarded-host")
@@ -212,7 +222,7 @@ async def feature_enable_instructions(
 
     def _svc_port(service_id: str) -> int:
         cfg = SERVICES.get(service_id, {})
-        return cfg.get("external_port", cfg.get("port", 0))
+        return _svc_external_port(service_id, cfg)
 
     webui_url = _svc_url("open-webui")
     n8n_url = _svc_url("n8n")


### PR DESCRIPTION
## Summary
- The dashboard host-systemd probe and the coding-feature link resolved OpenCode's external port from the static manifest (`external_port`, default 3003).
- `OPENCODE_PORT` is a documented env var honored on Windows, but when it differed from 3003 the dashprobe checked port 3003 and reported `not_deployed`, and the "Open OpenCode" link pointed at the wrong port.
- Added `_effective_external_port` (helpers.py) and `_svc_external_port` (routers/features.py) to resolve the live external port for the `opencode` service from `OPENCODE_PORT`, matching existing manifest semantics (`external_port_env: OPENCODE_PORT`).
- Health probing keeps its fail-closed behavior (port <= 0 → `not_deployed`).

## AI Assistance
This change was implemented with the assistance of an AI coding agent (opencode). The agent read the relevant manifests and router/helper code, then applied a minimal, scoped fix. The resulting diff is small (23 insertions, 3 deletions) and confined to the dashboard-api backend; no frontend was touched.

## Release Lane
- [x] Mainline

## Changed Surface
- [ ] Dashboard UI
- [x] Core runtime

## Validation
- `python3 -m py_compile ods/extensions/services/dashboard-api/helpers.py ods/extensions/services/dashboard-api/routers/features.py` passes.
- `git diff --check` passes.
- Minimal diff preserves existing file line endings and formatting.