### PR TITLE
fix(installer): clamp fresh OpenCode config output to context

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -191,6 +191,8 @@ else
         # and as deterministic recovery when the jq rewrite path finds an
         # existing malformed file it cannot parse (issue #332).
         _opencode_write_fresh() {
+            local _opencode_output=32768
+            if (( ${MAX_CONTEXT:-65536} < 32768 )); then _opencode_output=$(( ${MAX_CONTEXT:-65536} )); fi
             cat > "$1" <<OPENCODE_EOF
 {
   "\$schema": "https://opencode.ai/config.json",
@@ -209,7 +211,7 @@ else
           "name": "${_opencode_model_name}",
           "limit": {
             "context": ${MAX_CONTEXT:-65536},
-            "output": 32768
+            "output": ${_opencode_output}
           }
         }
       }


### PR DESCRIPTION
## Summary

`_opencode_write_fresh` in `ods/installers/phases/07-devtools.sh` wrote a hardcoded model `limit.output` of `32768` even when `MAX_CONTEXT` was smaller, while the jq rewrite path, the macOS writer, and the host-agent all clamp to `min(32768, context)`. An output limit above the model context is rejected by OpenCode/llama.cpp. The fresh-template writer now clamps to the configured context.

## AI Assistance

AI-assisted edge-case enumeration. The author reviewed the implementation and is responsible for the final diff.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer

## Validation

- `bash -n ods/installers/phases/07-devtools.sh` - passed.
- `git diff --check` - passed.