### PR TITLE
fix(windows): clamp OpenCode config output to context

### DIFF
--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -49,8 +49,8 @@ function New-WindowsOpenCodeConfigObject {
                     $ModelId = [pscustomobject]@{
                         name = $ModelName
                         limit = [pscustomobject]@{
-                            context = $ContextLimit
-                            output = 32768
+context = $ContextLimit
+                            output = [Math]::Min(32768, $ContextLimit)
                         }
                     }
                 }
@@ -117,8 +117,8 @@ function Update-WindowsOpenCodeConfigObject {
     if (-not $modelEntry.PSObject.Properties['limit'] -or $null -eq $modelEntry.limit) {
         Set-OpenCodeObjectProperty -Target $modelEntry -Name 'limit' -Value ([pscustomobject]@{})
     }
-    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'context' -Value $ContextLimit
-    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value 32768
+Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'context' -Value $ContextLimit
+    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value ([Math]::Min(32768, $ContextLimit))
 
     return $Config
 }


### PR DESCRIPTION
## Summary

The Windows OpenCode config writers (`New-WindowsOpenCodeConfigObject` and `Update-WindowsOpenCodeConfigObject`) hardcoded `limit.output = 32768`, which exceeds the model context on smaller-context installs and is rejected by OpenCode/llama.cpp. Both now clamp to `min(32768, context)` to match the Linux/macOS writers and the host-agent.

## AI Assistance

AI-assisted edge-case enumeration. The author reviewed the implementation and is responsible for the final diff.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Installer

## Validation

- PowerShell parse check on `ods/installers/windows/lib/opencode-config.ps1` - passed.
- `git diff --check` - passed.