### PR TITLE
fix(upgrade-model): write model upgrade state JSON atomically in upgrade-model.sh

### DIFF
--- a/ods/scripts/upgrade-model.sh
+++ b/ods/scripts/upgrade-model.sh
@@ -147,14 +147,20 @@ save_state() {
     # Backup current state
     [[ -f "$STATE_FILE" ]] && cp "$STATE_FILE" "$BACKUP_FILE"
     
-    jq -n         --arg cur "$current"         --arg prev "$previous"         --arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"         '{
+    local tmp_state
+    tmp_state="$(mktemp "${STATE_FILE}.XXXXXX.tmp")"
+    jq -n \
+        --arg cur "$current" \
+        --arg prev "$previous" \
+        --arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+        '{
             current: $cur,
             previous: $prev,
             updatedAt: $ts,
             history: [
                 {model: $cur, activatedAt: $ts}
             ]
-        }' > "$STATE_FILE"
+        }' > "$tmp_state" && mv -f "$tmp_state" "$STATE_FILE"
 }
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

In `ods/scripts/upgrade-model.sh`, model upgrade state JSON files were written directly using `jq -n ... > "$STATE_FILE"`. If the model activation or upgrade process is interrupted, the target state JSON file can be left partially written or corrupted in place.

## Fix

1. Update `upgrade-model.sh` to write model upgrade state JSON payloads to a temporary file via `mktemp` in `STATE_FILE`'s directory.
2. Use `mv -f` for atomic replacement of the destination model upgrade state JSON file.

## Verification

Verified syntax with `bash -n ods/scripts/upgrade-model.sh`. `git diff --check` passed cleanly with zero whitespace issues.