### PR TITLE
fix(ap-mode): write AP mode state configuration atomically in ap-mode.sh

### DIFF
--- a/ods/scripts/ap-mode.sh
+++ b/ods/scripts/ap-mode.sh
@@ -273,7 +273,9 @@ bring_up_interface() {
 
 write_state() {
   local status="$1"
-  cat > "${STATE_FILE}" <<HEREDOC
+  local tmp_state
+  tmp_state="$(mktemp "${STATE_FILE}.XXXXXX.tmp")"
+  cat > "${tmp_state}" <<HEREDOC
 {
   "status": "${status}",
   "ssid": "${ODS_AP_SSID}",
@@ -282,7 +284,8 @@ write_state() {
   "since": "$(date -Iseconds)"
 }
 HEREDOC
-  chmod 0644 "${STATE_FILE}"
+  chmod 0644 "${tmp_state}"
+  mv -f "${tmp_state}" "${STATE_FILE}"
 }
 
 cmd_up() {


### PR DESCRIPTION
## Problem

In `ods/scripts/ap-mode.sh`, `write_state()` wrote Access Point mode status JSON files directly using `cat > "${STATE_FILE}" <<HEREDOC`. Direct file redirection truncates the target state JSON file in place, risking corrupted or partial status files if interrupted during Wi-Fi AP provisioning.

## Fix

1. Update `write_state()` in `ap-mode.sh` to write AP status JSON contents to a temporary file via `mktemp` inside `STATE_FILE`'s directory.
2. Apply mode `0644` on the temporary file before using `mv -f` for atomic replacement.

## Verification

Verified syntax with `bash -n ods/scripts/ap-mode.sh`. `git diff --check` passed cleanly with zero whitespace issues.