### PR TITLE
fix(backup): verify compressed backups by bare ID

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -548,6 +548,12 @@ verify_backup() {
 
     local target="$BACKUP_ROOT/$backup_id"
 
+    # Compressed backups are .tar.gz files, not directories; also accept the
+    # bare ID for an archive-only backup (mirrors delete_backup).
+    if [[ ! -e "$target" && -f "$target.tar.gz" ]]; then
+        target="$target.tar.gz"
+    fi
+
     if [[ -d "$target" ]]; then
         if [[ ! -f "$target/checksums.sha256" ]]; then
             log_error "checksums.sha256 not found for backup: $backup_id"
@@ -572,9 +578,10 @@ verify_backup() {
         trap 'rm -rf "$tmpdir"' RETURN
 
         # Extract checksums first (fast fail if missing)
-        local archive_name="${backup_id%.tar.gz}"
+        local archive_name
+        archive_name="$(basename "$target" .tar.gz)"
         if ! tar xzf "$target" -C "$tmpdir" "${archive_name}/checksums.sha256" >/dev/null 2>&1; then
-            log_error "checksums.sha256 not found in archive: $backup_id"
+            log_error "checksums.sha256 not found in archive: $archive_name"
             return 1
         fi
 
@@ -589,7 +596,7 @@ verify_backup() {
             fi
         )
 
-        log_success "Backup verified: $backup_id"
+        log_success "Backup verified: $archive_name"
         return 0
     fi
 

--- a/ods/tests/test-backup-integrity.sh
+++ b/ods/tests/test-backup-integrity.sh
@@ -106,3 +106,20 @@ info "Deleting a compressed backup by bare ID"
 echo y | ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$LIFECYCLE_DIR" -d 20260601-120000 >/dev/null
 [[ ! -f "$LIFECYCLE_DIR/20260601-120000.tar.gz" ]] || fail "delete left the compressed backup behind"
 pass "delete removes compressed backups by bare ID"
+
+# Verify by bare ID must also resolve a compressed archive (mirrors delete).
+# Previously verify_backup required the literal .tar.gz suffix, so the
+# documented `verify 20260212-071500` form reported "not found" after a -c
+# backup had removed its directory.
+info "Verifying a compressed backup by bare ID"
+(cd "$LIFECYCLE_DIR" && mkdir -p 20260602-130000 && echo x > 20260602-130000/f \
+  && (cd 20260602-130000 && sha256sum f > checksums.sha256 2>/dev/null || shasum -a 256 f > checksums.sha256) \
+  && tar czf 20260602-130000.tar.gz 20260602-130000 && rm -rf 20260602-130000)
+set +e
+ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$LIFECYCLE_DIR" verify 20260602-130000 >/dev/null 2>&1
+verify_rc=$?
+set -e
+if [[ $verify_rc -ne 0 ]]; then
+  fail "verify by bare ID did not resolve the compressed archive"
+fi
+pass "verify resolves compressed backups by bare ID"


### PR DESCRIPTION
## Summary

`verify_backup` lacked the `.tar.gz` fallback that `delete_backup` already has: after a `-c` compressed backup removes its directory, the documented bare-ID form `ods-backup.sh verify 20260212-071500` reported `Backup not found` even though `20260212-071500.tar.gz` existed. This change mirrors the delete mapping and derives the archive name from the resolved target so the documented verification path works for compressed backups.

## AI Assistance

AI-assisted triage, repository search, edge-case enumeration, regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Core runtime
- [x] Backup tooling

## Validation

- `bash -n ods-backup.sh tests/test-backup-integrity.sh` - passed.
- `bash tests/test-backup-integrity.sh` - passed (15 checks; requires rsync, runs in CI; verify regression confirmed standalone).
- Bare-ID verify: original returns `Backup not found` (rc=1), patched verifies `f: OK` (rc=0).
- `make lint` - passed (all shell syntax OK; make unavailable on host, target replicated).
- `git diff --check` - passed.