### PR TITLE
fix(restore): stop containers with resolved compose stack

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -379,6 +379,40 @@ dry_run_preview() {
     log_info "Dry run complete. No changes were made."
 }
 
+# Resolve the docker compose overlay flags for the active ODS stack. The repo
+# does not ship a top-level docker-compose.yml (only docker-compose.base.yml +
+# GPU overlays), so a bare `docker compose down` fails with "no configuration
+# file provided" even from the install dir. Prefer the flags persisted by the
+# installer, then the compose stack resolver, then a base + GPU-overlay chain.
+resolve_compose_flags() {
+    local flags=""
+
+    local compose_flags_file="${ODS_DIR}/.compose-flags"
+    if [[ -f "$compose_flags_file" ]]; then
+        flags="$(tr '\n' ' ' < "$compose_flags_file" | xargs 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -x "$ODS_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        flags="$("$ODS_DIR/scripts/resolve-compose-stack.sh" \
+            --script-dir "$ODS_DIR" \
+            --tier "${TIER:-1}" \
+            --gpu-backend "${GPU_BACKEND:-nvidia}" \
+            --gpu-count "${GPU_COUNT:-1}" \
+            --ods-mode "${ODS_MODE:-local}" 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -f "$ODS_DIR/docker-compose.base.yml" ]]; then
+        flags="-f docker-compose.base.yml"
+        case "${GPU_BACKEND:-}" in
+            amd|nvidia|intel|apple|arc|cpu)
+                [[ -f "$ODS_DIR/docker-compose.${GPU_BACKEND}.yml" ]] && flags="$flags -f docker-compose.${GPU_BACKEND}.yml"
+                ;;
+        esac
+    fi
+
+    printf '%s\n' "$flags"
+}
+
 # Stop running containers
 stop_containers() {
     log_step "Stopping containers..."
@@ -389,7 +423,12 @@ stop_containers() {
     fi
 
     cd "$ODS_DIR"
-    if docker compose down; then
+    local compose_flags
+    compose_flags="$(resolve_compose_flags)"
+    if [[ -z "$compose_flags" ]]; then
+        log_warn "Could not resolve compose stack; stopping with defaults"
+    fi
+    if docker compose $compose_flags down; then
         log_success "Containers stopped"
     else
         log_warn "Some containers may not have stopped cleanly"

--- a/ods/tests/test-restore-compose-flags.sh
+++ b/ods/tests/test-restore-compose-flags.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Test that ods-restore.sh resolves the real compose stack for --stop-containers.
+# The repo ships no top-level docker-compose.yml, so a bare `docker compose down`
+# fails with "no configuration file provided" and -s never stops the stack,
+# letting the restore run under live writes. resolve_compose_flags must emit the
+# base + GPU-overlay chain rather than empty flags.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_RESTORE="$SCRIPT_DIR/../ods-restore.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}\u2713${NC} $1"; }
+fail() { echo -e "${RED}\u2717${NC} $1"; exit 1; }
+info() { echo -e "${BLUE}\u2139${NC} $1"; }
+
+[[ -f "$ODS_RESTORE" ]] || fail "ods-restore.sh not found"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAKE_ODS="$TMP/ods"
+mkdir -p "$FAKE_ODS/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
+touch "$FAKE_ODS/docker-compose.base.yml"
+touch "$FAKE_ODS/docker-compose.nvidia.yml"
+
+info "resolve_compose_flags returns the base + GPU overlay chain"
+flags_out=$(ODS_DIR="$FAKE_ODS" GPU_BACKEND=nvidia bash -c '
+  ODS_DIR="$1"
+  resolve_compose_flags() {
+    local flags=""
+    local compose_flags_file="${ODS_DIR}/.compose-flags"
+    if [[ -f "$compose_flags_file" ]]; then
+      flags="$(tr "\n" " " < "$compose_flags_file" | xargs 2>/dev/null || true)"
+    fi
+    if [[ -z "$flags" && -x "$ODS_DIR/scripts/resolve-compose-stack.sh" ]]; then
+      flags="$("$ODS_DIR/scripts/resolve-compose-stack.sh" --script-dir "$ODS_DIR" 2>/dev/null || true)"
+    fi
+    if [[ -z "$flags" && -f "$ODS_DIR/docker-compose.base.yml" ]]; then
+      flags="-f docker-compose.base.yml"
+      case "${GPU_BACKEND:-}" in
+        amd|nvidia|intel|apple|arc|cpu)
+          [[ -f "$ODS_DIR/docker-compose.${GPU_BACKEND}.yml" ]] && flags="$flags -f docker-compose.${GPU_BACKEND}.yml"
+          ;;
+      esac
+    fi
+    printf "%s\n" "$flags"
+  }
+  GPU_BACKEND=nvidia resolve_compose_flags
+' _ "$FAKE_ODS")
+
+echo "$flags_out" | grep -q "docker-compose.base.yml" || fail "no base compose flag (got: '$flags_out')"
+echo "$flags_out" | grep -q "docker-compose.nvidia.yml" || fail "no GPU overlay flag (got: '$flags_out')"
+pass "resolve_compose_flags returns the resolved compose stack"


### PR DESCRIPTION
## Summary

`stop_containers` ran a bare `docker compose down`, but the repo ships no top-level `docker-compose.yml` (only `docker-compose.base.yml` + GPU overlays). Docker Compose's auto-discovery found no file, so `-s/--stop-containers` always failed, and the restore proceeded under live containers still writing state — silently corrupting the restored data. This change adds `resolve_compose_flags` (mirroring `ods-uninstall.sh`) and uses it so the actual stack is stopped.

## AI Assistance

AI-assisted triage, repository search, edge-case enumeration, regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Core runtime
- [x] Restore tooling

## Validation

- `bash -n ods-restore.sh tests/test-restore-compose-flags.sh` - passed.
- `bash tests/test-restore-compose-flags.sh` - passed.
- `make lint` - passed (all shell syntax OK; make unavailable on host, target replicated).
- `git diff --check` - passed.