### PR TITLE
fix(dashboard): tolerate features missing requirements

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -16,7 +16,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["features"])
 
 
-def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
+def calculate_feature_status(
+    feature: dict, services: list, gpu_info: Optional[GPUInfo]
+) -> dict:
     """Calculate whether a feature can be enabled and its status."""
     gpu_vram_gb = (gpu_info.memory_total_mb / 1024) if gpu_info else 0
     gpu_vram_used_gb = (gpu_info.memory_used_mb / 1024) if gpu_info else 0
@@ -31,7 +33,7 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
             pass
         gpu_vram_free_gb = gpu_vram_gb  # assumes zero current usage; Docker can't measure host memory pressure
 
-    req = feature["requirements"]
+    req = feature.get("requirements", {})
     vram_ok = gpu_vram_gb >= req.get("vram_gb", 0)
     vram_fits = gpu_vram_free_gb >= req.get("vram_gb", 0)
 
@@ -49,16 +51,20 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
             services_missing.append(svc_id)
 
     services_all_ok = all(svc in services_available for svc in required_services)
-    services_any_ok = (not required_services_any) or any(svc in services_available for svc in required_services_any)
+    services_any_ok = (not required_services_any) or any(
+        svc in services_available for svc in required_services_any
+    )
     services_ok = services_all_ok and services_any_ok
 
     enabled_all = feature.get("enabled_services_all", required_services)
     enabled_any = feature.get("enabled_services_any", required_services_any)
     enabled_all_ok = all(
-        any(s.id == svc and s.status == "healthy" for s in services) for svc in enabled_all
+        any(s.id == svc and s.status == "healthy" for s in services)
+        for svc in enabled_all
     )
     enabled_any_ok = (not enabled_any) or any(
-        any(s.id == svc and s.status == "healthy" for s in services) for svc in enabled_any
+        any(s.id == svc and s.status == "healthy" for s in services)
+        for svc in enabled_any
     )
     is_enabled = enabled_all_ok and enabled_any_ok
 
@@ -106,7 +112,7 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
         "enabledServicesAny": enabled_any,
         "launch": launch,
         "setupTime": feature.get("setup_time", "Unknown"),
-        "priority": feature.get("priority", 99)
+        "priority": feature.get("priority", 99),
     }
 
 
@@ -115,12 +121,15 @@ async def api_features(api_key: str = Depends(verify_api_key)):
     """Get feature discovery data."""
     import asyncio
     from helpers import get_all_services, get_cached_services
+
     service_list = get_cached_services()
     if service_list is None:
         service_list = await get_all_services()
     gpu_info = await asyncio.to_thread(get_gpu_info)
 
-    feature_statuses = [calculate_feature_status(f, service_list, gpu_info) for f in FEATURES]
+    feature_statuses = [
+        calculate_feature_status(f, service_list, gpu_info) for f in FEATURES
+    ]
     feature_statuses.sort(key=lambda x: x["priority"])
 
     enabled_count = sum(1 for f in feature_statuses if f["enabled"])
@@ -130,18 +139,27 @@ async def api_features(api_key: str = Depends(verify_api_key)):
     suggestions = []
     for f in feature_statuses:
         if f["status"] == "available":
-            suggestions.append({
-                "featureId": f["id"], "name": f["name"],
-                "message": f"Your hardware can run {f['name']}. Enable it?",
-                "action": f"Enable {f['name']}", "setupTime": f["setupTime"]
-            })
+            suggestions.append(
+                {
+                    "featureId": f["id"],
+                    "name": f["name"],
+                    "message": f"Your hardware can run {f['name']}. Enable it?",
+                    "action": f"Enable {f['name']}",
+                    "setupTime": f["setupTime"],
+                }
+            )
         elif f["status"] == "services_needed":
             missing = ", ".join(f["requirements"]["servicesMissing"])
-            suggestions.append({
-                "featureId": f["id"], "name": f["name"],
-                "message": f"{f['name']} needs {missing} to be running.",
-                "action": f"Start {missing}", "setupTime": f["setupTime"], "blocked": True
-            })
+            suggestions.append(
+                {
+                    "featureId": f["id"],
+                    "name": f["name"],
+                    "message": f"{f['name']} needs {missing} to be running.",
+                    "action": f"Start {missing}",
+                    "setupTime": f["setupTime"],
+                    "blocked": True,
+                }
+            )
 
     gpu_vram_gb = (gpu_info.memory_total_mb / 1024) if gpu_info else 0
     memory_type = gpu_info.memory_type if gpu_info else "discrete"
@@ -162,26 +180,64 @@ async def api_features(api_key: str = Depends(verify_api_key)):
     tier_recommendations = []
     if memory_type == "unified" and gpu_info and gpu_info.gpu_backend == "amd":
         if gpu_vram_gb >= 90:
-            tier_recommendations = ["Strix Halo 90+ — flagship local profile supported", "Plenty of headroom for large local models plus bootstrap simultaneously", "Voice and Documents work alongside the LLM"]
+            tier_recommendations = [
+                "Strix Halo 90+ — flagship local profile supported",
+                "Plenty of headroom for large local models plus bootstrap simultaneously",
+                "Voice and Documents work alongside the LLM",
+            ]
         else:
-            tier_recommendations = ["Strix Halo Compact — balanced local profile supported", "Fast inference with good room for voice, documents, and agents", "Voice and Documents work alongside the LLM"]
+            tier_recommendations = [
+                "Strix Halo Compact — balanced local profile supported",
+                "Fast inference with good room for voice, documents, and agents",
+                "Voice and Documents work alongside the LLM",
+            ]
     elif gpu_vram_gb >= 80:
-        tier_recommendations = ["Your GPU can run all features simultaneously", "Consider enabling Voice + Documents for the full experience", "Image generation is supported at full quality"]
+        tier_recommendations = [
+            "Your GPU can run all features simultaneously",
+            "Consider enabling Voice + Documents for the full experience",
+            "Image generation is supported at full quality",
+        ]
     elif gpu_vram_gb >= 24:
-        tier_recommendations = ["Great GPU for local AI — most features will run well", "Voice and Documents work together", "Image generation may require model unloading"]
+        tier_recommendations = [
+            "Great GPU for local AI — most features will run well",
+            "Voice and Documents work together",
+            "Image generation may require model unloading",
+        ]
     elif gpu_vram_gb >= 16:
-        tier_recommendations = ["Solid GPU for core features", "Voice works well with the default model", "For images, use a smaller chat model"]
+        tier_recommendations = [
+            "Solid GPU for core features",
+            "Voice works well with the default model",
+            "For images, use a smaller chat model",
+        ]
     elif gpu_vram_gb >= 8:
-        tier_recommendations = ["Entry-level GPU — focus on chat first", "Voice is possible with a compact local profile", "Use the smaller local model profile for better speed"]
+        tier_recommendations = [
+            "Entry-level GPU — focus on chat first",
+            "Voice is possible with a compact local profile",
+            "Use the smaller local model profile for better speed",
+        ]
     else:
-        tier_recommendations = ["Limited GPU memory — chat will work with small models", "Consider cloud hybrid mode for better quality"]
+        tier_recommendations = [
+            "Limited GPU memory — chat will work with small models",
+            "Consider cloud hybrid mode for better quality",
+        ]
 
     return {
         "features": feature_statuses,
-        "summary": {"enabled": enabled_count, "available": available_count, "total": total_count, "progress": round(enabled_count / total_count * 100) if total_count > 0 else 0},
+        "summary": {
+            "enabled": enabled_count,
+            "available": available_count,
+            "total": total_count,
+            "progress": round(enabled_count / total_count * 100)
+            if total_count > 0
+            else 0,
+        },
         "suggestions": suggestions[:3],
         "recommendations": tier_recommendations,
-        "gpu": {"name": gpu_info.name if gpu_info else "Unknown", "vramGb": round(gpu_vram_gb, 1), "tier": get_gpu_tier(gpu_vram_gb, memory_type)}
+        "gpu": {
+            "name": gpu_info.name if gpu_info else "Unknown",
+            "vramGb": round(gpu_vram_gb, 1),
+            "tier": get_gpu_tier(gpu_vram_gb, memory_type),
+        },
     }
 
 
@@ -207,7 +263,9 @@ async def feature_enable_instructions(
         forwarded_host = request.headers.get("x-forwarded-host")
         host_header = forwarded_host or request.headers.get("host") or "localhost"
         hostname = host_header.rsplit(":", 1)[0] if ":" in host_header else host_header
-        scheme = request.headers.get("x-forwarded-proto") or request.url.scheme or "http"
+        scheme = (
+            request.headers.get("x-forwarded-proto") or request.url.scheme or "http"
+        )
         return f"{scheme}://{hostname}:{port}"
 
     def _svc_port(service_id: str) -> int:
@@ -228,15 +286,60 @@ async def feature_enable_instructions(
                 "Start or restart ODS so ods-proxy listens on port 80",
                 "Use the LAN hostnames such as dashboard.<device>.local, chat.<device>.local, and talk.<device>.local",
             ],
-            "links": [{"label": "Open LAN entry", "url": ods_proxy_url}] if ods_proxy_url else [],
+            "links": [{"label": "Open LAN entry", "url": ods_proxy_url}]
+            if ods_proxy_url
+            else [],
         },
-        "chat": {"steps": ["Chat is already enabled if llama-server is running", "Open the Dashboard and click 'Chat' to start"], "links": [{"label": "Open Chat", "url": webui_url}]},
-        "voice": {"steps": [f"Ensure Whisper (STT) is running on port {_svc_port('whisper')}", f"Ensure Kokoro (TTS) is running on port {_svc_port('tts')}", "Open Open WebUI and use its voice controls"], "links": [{"label": "Open Chat", "url": webui_url}]},
-        "documents": {"steps": ["Ensure Qdrant vector database is running", "Open Open WebUI and use its document/RAG controls"], "links": [{"label": "Open Chat", "url": webui_url}]},
-        "workflows": {"steps": [f"Ensure n8n is running on port {_svc_port('n8n')}", "Open n8n to see and manage available automations"], "links": [{"label": "n8n Dashboard", "url": n8n_url}]},
-        "images": {"steps": [f"Ensure ComfyUI is running on port {_svc_port('comfyui')}", "Open ComfyUI to build and run image workflows"], "links": [{"label": "Open ComfyUI", "url": comfyui_url}]},
-        "coding": {"steps": [f"Ensure OpenCode is running on port {_svc_port('opencode')}", "Open OpenCode for the browser-based coding assistant"], "links": [{"label": "Open OpenCode", "url": opencode_url}]},
-        "hermes-agent": {"steps": [f"Ensure Hermes proxy is running on port {_svc_port('hermes-proxy')}", "Open Hermes for advanced agent access"], "links": [{"label": "Open Hermes", "url": hermes_url}]},
+        "chat": {
+            "steps": [
+                "Chat is already enabled if llama-server is running",
+                "Open the Dashboard and click 'Chat' to start",
+            ],
+            "links": [{"label": "Open Chat", "url": webui_url}],
+        },
+        "voice": {
+            "steps": [
+                f"Ensure Whisper (STT) is running on port {_svc_port('whisper')}",
+                f"Ensure Kokoro (TTS) is running on port {_svc_port('tts')}",
+                "Open Open WebUI and use its voice controls",
+            ],
+            "links": [{"label": "Open Chat", "url": webui_url}],
+        },
+        "documents": {
+            "steps": [
+                "Ensure Qdrant vector database is running",
+                "Open Open WebUI and use its document/RAG controls",
+            ],
+            "links": [{"label": "Open Chat", "url": webui_url}],
+        },
+        "workflows": {
+            "steps": [
+                f"Ensure n8n is running on port {_svc_port('n8n')}",
+                "Open n8n to see and manage available automations",
+            ],
+            "links": [{"label": "n8n Dashboard", "url": n8n_url}],
+        },
+        "images": {
+            "steps": [
+                f"Ensure ComfyUI is running on port {_svc_port('comfyui')}",
+                "Open ComfyUI to build and run image workflows",
+            ],
+            "links": [{"label": "Open ComfyUI", "url": comfyui_url}],
+        },
+        "coding": {
+            "steps": [
+                f"Ensure OpenCode is running on port {_svc_port('opencode')}",
+                "Open OpenCode for the browser-based coding assistant",
+            ],
+            "links": [{"label": "Open OpenCode", "url": opencode_url}],
+        },
+        "hermes-agent": {
+            "steps": [
+                f"Ensure Hermes proxy is running on port {_svc_port('hermes-proxy')}",
+                "Open Hermes for advanced agent access",
+            ],
+            "links": [{"label": "Open Hermes", "url": hermes_url}],
+        },
         "hermes-sso": {
             "steps": [
                 "Ensure Hermes, Hermes proxy, and Dashboard API are running",
@@ -244,7 +347,18 @@ async def feature_enable_instructions(
             ],
             "links": [{"label": "Manage Hermes access", "url": "/invites"}],
         },
-        "observability": {"steps": [f"Langfuse is running on port {_svc_port('langfuse')}", "Open Langfuse to view LLM traces and evaluations", "LiteLLM automatically sends traces — no additional configuration needed"], "links": [{"label": "Open Langfuse", "url": _svc_url("langfuse")}]},
+        "observability": {
+            "steps": [
+                f"Langfuse is running on port {_svc_port('langfuse')}",
+                "Open Langfuse to view LLM traces and evaluations",
+                "LiteLLM automatically sends traces — no additional configuration needed",
+            ],
+            "links": [{"label": "Open Langfuse", "url": _svc_url("langfuse")}],
+        },
     }
 
-    return {"featureId": feature_id, "name": feature["name"], "instructions": instructions.get(feature_id, {"steps": [], "links": []})}
+    return {
+        "featureId": feature_id,
+        "name": feature["name"],
+        "instructions": instructions.get(feature_id, {"steps": [], "links": []}),
+    }

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -26,9 +26,19 @@ class TestCalculateFeatureStatusDefaults:
         assert result["setupTime"] == "Unknown"
         assert result["priority"] == 99
 
+    def test_missing_requirements_block_does_not_keyerror(self):
+        """A feature with no requirements block is computed, not a KeyError 500."""
+        feature = {"id": "no-req", "name": "Missing Requirements"}
+        result = calculate_feature_status(feature, [], None)
+
+        assert result["id"] == "no-req"
+        assert result["requirements"]["vramGb"] == 0
+        assert result["requirements"]["vramOk"] is True
+        assert result["requirements"]["services"] == []
+        assert result["requirements"]["servicesOk"] is True
+
 
 class TestCalculateFeatureStatusAppleFallback:
-
     def _make_feature(self, vram_gb=0):
         return {
             "id": "test-feat",
@@ -50,6 +60,7 @@ class TestCalculateFeatureStatusAppleFallback:
     def test_apple_fallback_uses_host_ram_when_gpu_info_none(self):
         """When GPU_BACKEND=apple and gpu_info is None, HOST_RAM_GB gates VRAM."""
         from routers.features import calculate_feature_status
+
         feature = self._make_feature(vram_gb=16)
         with patch.dict(os.environ, {"HOST_RAM_GB": "24", "GPU_BACKEND": "apple"}):
             with patch("routers.features.GPU_BACKEND", "apple"):
@@ -60,6 +71,7 @@ class TestCalculateFeatureStatusAppleFallback:
     def test_apple_fallback_insufficient_when_ram_too_low(self):
         """When HOST_RAM_GB < feature vram_gb, feature is insufficient_vram."""
         from routers.features import calculate_feature_status
+
         feature = self._make_feature(vram_gb=32)
         with patch.dict(os.environ, {"HOST_RAM_GB": "16", "GPU_BACKEND": "apple"}):
             with patch("routers.features.GPU_BACKEND", "apple"):
@@ -70,6 +82,7 @@ class TestCalculateFeatureStatusAppleFallback:
     def test_apple_fallback_not_triggered_on_linux(self):
         """HOST_RAM fallback does NOT apply on non-apple backends."""
         from routers.features import calculate_feature_status
+
         feature = self._make_feature(vram_gb=8)
         with patch.dict(os.environ, {"HOST_RAM_GB": "64", "GPU_BACKEND": "nvidia"}):
             with patch("routers.features.GPU_BACKEND", "nvidia"):
@@ -86,7 +99,11 @@ class TestApiFeaturesAppleFallback:
         with patch.dict(os.environ, {"HOST_RAM_GB": "16", "GPU_BACKEND": "apple"}):
             with patch("routers.features.GPU_BACKEND", "apple"):
                 with patch("routers.features.get_gpu_info", return_value=None):
-                    with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
+                    with patch(
+                        "helpers.get_all_services",
+                        new_callable=AsyncMock,
+                        return_value=[],
+                    ):
                         response = test_client.get(
                             "/api/features",
                             headers=test_client.auth_headers,
@@ -100,9 +117,14 @@ class TestApiFeaturesAppleFallback:
 
 
 class TestCalculateFeatureStatusGeneral:
-
-    def _make_feature(self, vram_gb=0, services=None, services_any=None,
-                      enabled_all=None, enabled_any=None):
+    def _make_feature(
+        self,
+        vram_gb=0,
+        services=None,
+        services_any=None,
+        enabled_all=None,
+        enabled_any=None,
+    ):
         return {
             "id": "test-feat",
             "name": "Test Feature",
@@ -116,14 +138,23 @@ class TestCalculateFeatureStatusGeneral:
                 "services": services or [],
                 "services_any": services_any or [],
             },
-            "enabled_services_all": enabled_all if enabled_all is not None else (services or []),
-            "enabled_services_any": enabled_any if enabled_any is not None else (services_any or []),
+            "enabled_services_all": enabled_all
+            if enabled_all is not None
+            else (services or []),
+            "enabled_services_any": enabled_any
+            if enabled_any is not None
+            else (services_any or []),
         }
 
     def _make_service_status(self, sid, status="healthy"):
         from models import ServiceStatus
+
         return ServiceStatus(
-            id=sid, name=sid, port=8080, external_port=8080, status=status,
+            id=sid,
+            name=sid,
+            port=8080,
+            external_port=8080,
+            status=status,
         )
 
     def test_enabled_when_all_services_healthy(self):
@@ -131,12 +162,17 @@ class TestCalculateFeatureStatusGeneral:
         from models import GPUInfo
 
         gpu = GPUInfo(
-            name="RTX 4090", memory_used_mb=2048, memory_total_mb=24576,
-            memory_percent=8.3, utilization_percent=35, temperature_c=62,
+            name="RTX 4090",
+            memory_used_mb=2048,
+            memory_total_mb=24576,
+            memory_percent=8.3,
+            utilization_percent=35,
+            temperature_c=62,
             gpu_backend="nvidia",
         )
-        feature = self._make_feature(vram_gb=8, services=["llama-server"],
-                                     enabled_all=["llama-server"])
+        feature = self._make_feature(
+            vram_gb=8, services=["llama-server"], enabled_all=["llama-server"]
+        )
         services = [self._make_service_status("llama-server", "healthy")]
 
         with patch("routers.features.GPU_BACKEND", "nvidia"):
@@ -149,8 +185,12 @@ class TestCalculateFeatureStatusGeneral:
         from models import GPUInfo
 
         gpu = GPUInfo(
-            name="RTX 4090", memory_used_mb=2048, memory_total_mb=24576,
-            memory_percent=8.3, utilization_percent=35, temperature_c=62,
+            name="RTX 4090",
+            memory_used_mb=2048,
+            memory_total_mb=24576,
+            memory_percent=8.3,
+            utilization_percent=35,
+            temperature_c=62,
             gpu_backend="nvidia",
         )
         feature = self._make_feature(
@@ -173,14 +213,19 @@ class TestCalculateFeatureStatusGeneral:
         from models import GPUInfo
 
         gpu = GPUInfo(
-            name="GTX 1050", memory_used_mb=1024, memory_total_mb=4096,
-            memory_percent=25.0, utilization_percent=10, temperature_c=50,
+            name="GTX 1050",
+            memory_used_mb=1024,
+            memory_total_mb=4096,
+            memory_percent=25.0,
+            utilization_percent=10,
+            temperature_c=50,
             gpu_backend="nvidia",
         )
         # enabled_all must reference a service not in the service list so
         # is_enabled is False, allowing the vram check to be reached.
-        feature = self._make_feature(vram_gb=16, services=[],
-                                     enabled_all=["llama-server"])
+        feature = self._make_feature(
+            vram_gb=16, services=[], enabled_all=["llama-server"]
+        )
 
         with patch("routers.features.GPU_BACKEND", "nvidia"):
             result = calculate_feature_status(feature, [], gpu)
@@ -192,12 +237,17 @@ class TestCalculateFeatureStatusGeneral:
         from models import GPUInfo
 
         gpu = GPUInfo(
-            name="RTX 4090", memory_used_mb=2048, memory_total_mb=24576,
-            memory_percent=8.3, utilization_percent=35, temperature_c=62,
+            name="RTX 4090",
+            memory_used_mb=2048,
+            memory_total_mb=24576,
+            memory_percent=8.3,
+            utilization_percent=35,
+            temperature_c=62,
             gpu_backend="nvidia",
         )
-        feature = self._make_feature(vram_gb=8, services=["whisper", "tts"],
-                                     enabled_all=["whisper", "tts"])
+        feature = self._make_feature(
+            vram_gb=8, services=["whisper", "tts"], enabled_all=["whisper", "tts"]
+        )
         services = [self._make_service_status("whisper", "healthy")]
 
         with patch("routers.features.GPU_BACKEND", "nvidia"):
@@ -210,12 +260,17 @@ class TestCalculateFeatureStatusGeneral:
         from models import GPUInfo
 
         gpu = GPUInfo(
-            name="RTX 4090", memory_used_mb=2048, memory_total_mb=24576,
-            memory_percent=8.3, utilization_percent=35, temperature_c=62,
+            name="RTX 4090",
+            memory_used_mb=2048,
+            memory_total_mb=24576,
+            memory_percent=8.3,
+            utilization_percent=35,
+            temperature_c=62,
             gpu_backend="nvidia",
         )
-        feature = self._make_feature(vram_gb=8, services=[],
-                                     enabled_all=["some-service"])
+        feature = self._make_feature(
+            vram_gb=8, services=[], enabled_all=["some-service"]
+        )
         services = []
 
         with patch("routers.features.GPU_BACKEND", "nvidia"):
@@ -227,6 +282,7 @@ class TestHermesFeatureContracts:
     @staticmethod
     def _service(service_id, status="healthy"):
         from models import ServiceStatus
+
         return ServiceStatus(
             id=service_id,
             name=service_id,
@@ -243,8 +299,12 @@ class TestHermesFeatureContracts:
 
         services_dir = Path(__file__).resolve().parents[2]
         manifest_name = "hermes-proxy" if feature_id == "hermes-sso" else "hermes"
-        manifest = yaml.safe_load((services_dir / manifest_name / "manifest.yaml").read_text())
-        return next(feature for feature in manifest["features"] if feature["id"] == feature_id)
+        manifest = yaml.safe_load(
+            (services_dir / manifest_name / "manifest.yaml").read_text()
+        )
+        return next(
+            feature for feature in manifest["features"] if feature["id"] == feature_id
+        )
 
     def test_agent_uses_authenticated_proxy_and_accepts_local_provider(self):
         services = [
@@ -297,21 +357,31 @@ class TestHermesFeatureContracts:
 
         assert result["status"] == "enabled"
         assert result["launch"] == {"type": "internal", "path": "/invites"}
-        assert result["enabledServicesAll"] == ["hermes", "hermes-proxy", "dashboard-api"]
+        assert result["enabledServicesAll"] == [
+            "hermes",
+            "hermes-proxy",
+            "dashboard-api",
+        ]
 
 
 # --- /api/features/{feature_id}/enable ---
 
 
 class TestFeatureEnableInstructions:
-
     def test_returns_instructions_for_known_feature(self, test_client, monkeypatch):
         test_features = [
-            {"id": "chat", "name": "Chat", "description": "AI Chat",
-             "icon": "MessageSquare", "category": "inference",
-             "setup_time": "1 min", "priority": 1,
-             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
-             "enabled_services_all": [], "enabled_services_any": []}
+            {
+                "id": "chat",
+                "name": "Chat",
+                "description": "AI Chat",
+                "icon": "MessageSquare",
+                "category": "inference",
+                "setup_time": "1 min",
+                "priority": 1,
+                "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+                "enabled_services_all": [],
+                "enabled_services_any": [],
+            }
         ]
         monkeypatch.setattr("routers.features.FEATURES", test_features)
 
@@ -327,11 +397,18 @@ class TestFeatureEnableInstructions:
 
     def test_instruction_links_use_request_host(self, test_client, monkeypatch):
         test_features = [
-            {"id": "documents", "name": "Documents", "description": "Document Q&A",
-             "icon": "FileText", "category": "productivity",
-             "setup_time": "2 min", "priority": 3,
-             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
-             "enabled_services_all": [], "enabled_services_any": []}
+            {
+                "id": "documents",
+                "name": "Documents",
+                "description": "Document Q&A",
+                "icon": "FileText",
+                "category": "productivity",
+                "setup_time": "2 min",
+                "priority": 3,
+                "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+                "enabled_services_all": [],
+                "enabled_services_any": [],
+            }
         ]
         monkeypatch.setattr("routers.features.FEATURES", test_features)
         monkeypatch.setattr(
@@ -351,18 +428,32 @@ class TestFeatureEnableInstructions:
             "url": "http://dashboard.ods.local:3000",
         }
 
-    def test_instruction_links_prefer_public_service_url(self, test_client, monkeypatch):
+    def test_instruction_links_prefer_public_service_url(
+        self, test_client, monkeypatch
+    ):
         test_features = [
-            {"id": "documents", "name": "Documents", "description": "Document Q&A",
-             "icon": "FileText", "category": "productivity",
-             "setup_time": "2 min", "priority": 3,
-             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
-             "enabled_services_all": [], "enabled_services_any": []}
+            {
+                "id": "documents",
+                "name": "Documents",
+                "description": "Document Q&A",
+                "icon": "FileText",
+                "category": "productivity",
+                "setup_time": "2 min",
+                "priority": 3,
+                "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+                "enabled_services_all": [],
+                "enabled_services_any": [],
+            }
         ]
         monkeypatch.setattr("routers.features.FEATURES", test_features)
         monkeypatch.setattr(
             "routers.features.SERVICES",
-            {"open-webui": {"external_port": 3000, "public_url": "https://chat.example.test"}},
+            {
+                "open-webui": {
+                    "external_port": 3000,
+                    "public_url": "https://chat.example.test",
+                }
+            },
         )
 
         resp = test_client.get(
@@ -376,13 +467,22 @@ class TestFeatureEnableInstructions:
             "url": "https://chat.example.test",
         }
 
-    def test_lan_web_instructions_are_explicit_about_ods_proxy(self, test_client, monkeypatch):
+    def test_lan_web_instructions_are_explicit_about_ods_proxy(
+        self, test_client, monkeypatch
+    ):
         test_features = [
-            {"id": "lan-web", "name": "LAN web entry", "description": "LAN entry",
-             "icon": "Globe", "category": "networking",
-             "setup_time": "Ready", "priority": 1,
-             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
-             "enabled_services_all": ["ods-proxy"], "enabled_services_any": []}
+            {
+                "id": "lan-web",
+                "name": "LAN web entry",
+                "description": "LAN entry",
+                "icon": "Globe",
+                "category": "networking",
+                "setup_time": "Ready",
+                "priority": 1,
+                "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+                "enabled_services_all": ["ods-proxy"],
+                "enabled_services_any": [],
+            }
         ]
         monkeypatch.setattr("routers.features.FEATURES", test_features)
         monkeypatch.setattr(
@@ -405,13 +505,24 @@ class TestFeatureEnableInstructions:
             "url": "http://dashboard.ods.local:80",
         }
 
-    def test_hermes_sso_instructions_open_access_management(self, test_client, monkeypatch):
+    def test_hermes_sso_instructions_open_access_management(
+        self, test_client, monkeypatch
+    ):
         test_features = [
-            {"id": "hermes-sso", "name": "Hermes Single Sign-On",
-             "description": "Manage Hermes access", "icon": "Shield",
-             "category": "privacy", "setup_time": "Ready", "priority": 5,
-             "requirements": {"vram_gb": 0, "services": ["hermes", "hermes-proxy", "dashboard-api"]},
-             "enabled_services_all": ["hermes", "hermes-proxy", "dashboard-api"]}
+            {
+                "id": "hermes-sso",
+                "name": "Hermes Single Sign-On",
+                "description": "Manage Hermes access",
+                "icon": "Shield",
+                "category": "privacy",
+                "setup_time": "Ready",
+                "priority": 5,
+                "requirements": {
+                    "vram_gb": 0,
+                    "services": ["hermes", "hermes-proxy", "dashboard-api"],
+                },
+                "enabled_services_all": ["hermes", "hermes-proxy", "dashboard-api"],
+            }
         ]
         monkeypatch.setattr("routers.features.FEATURES", test_features)
 
@@ -422,7 +533,9 @@ class TestFeatureEnableInstructions:
 
         assert resp.status_code == 200
         instructions = resp.json()["instructions"]
-        assert instructions["links"] == [{"label": "Manage Hermes access", "url": "/invites"}]
+        assert instructions["links"] == [
+            {"label": "Manage Hermes access", "url": "/invites"}
+        ]
         assert "owner cards" in " ".join(instructions["steps"]).lower()
 
     def test_404_for_unknown_feature(self, test_client, monkeypatch):


### PR DESCRIPTION
## Summary

`config.py` warns when a feature manifest is missing optional metadata but never validates the `requirements` block. A third-party feature entry without `requirements` raised a `KeyError` that 500'd the entire `/api/features` endpoint. This change defaults the block to `{}` in `calculate_feature_status`, so such entries are served with empty requirements instead of crashing the response.

## AI Assistance

AI-assisted triage, repository search, edge-case enumeration, regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Core runtime

## Validation

- `python3 -m py_compile routers/features.py` - passed.
- `python3 -m pytest tests/test_features.py` - passed (21 passed).
- `git diff --check` - passed.