### PR TITLE
fix(dashboard): tolerate magic links missing created_at

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -294,6 +294,7 @@ def _normalize_record(record: dict) -> dict:
         record["redemptions"] = []
     record.setdefault("note", None)
     record.setdefault("revoked_at", None)
+    record.setdefault("created_at", _now_iso())  # legacy records may lack created_at
     return record
 
 


### PR DESCRIPTION
## Summary
Legacy or revoked magic-link records can be persisted without a `created_at` field. `_normalize_record()` fills defaults for other fields but not `created_at`, so `_prune()` (`keep.sort(key=lambda r: r["created_at"])`) and `list_magic_links()` raise `KeyError` and return HTTP 500 on the list / generate / redeem magic-link endpoints. This change defaults `created_at` during record normalization so pruning and listing remain stable.

## AI Assistance
This change was developed with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix (semver-patch to next impact from targeted backports to stable branch)
- [x] Mainline `main` (merged at next release train)
- [ ] Next-minor (non-urgent)
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Dashboard API Python
- [ ] Dashboard UI (React)
- [ ] Backend config
- [ ] CLI / ods-cli
- [ ] Installer (Linux / macOS / Windows)
- [ ] Backup / restore / migrate
- [ ] CI
- [ ] Documentation

## Validation
- `python -m py_compile .../routers/magic_link.py`
- Existing dashboard-api test suite
- Manual reproduction of a legacy record missing `created_at` no longer raises