### PR TITLE
fix(installer): honor N8N_PORT override in Windows health probe

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2085,7 +2085,10 @@ if ($enableVoice)     {
     $healthWhisperPort = if ($windowsEnvMap.ContainsKey("WHISPER_PORT") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["WHISPER_PORT"])) { $windowsEnvMap["WHISPER_PORT"] } else { "9000" }
     $healthChecks += @{ Name = "Whisper (STT)"; Url = "http://localhost:$healthWhisperPort/health" }
 }
-if ($enableWorkflows) { $healthChecks += @{ Name = "n8n (Workflows)";   Url = "http://localhost:5678/healthz" } }
+if ($enableWorkflows) {
+    $n8nHealthPort = Get-WindowsODSEnvPort -EnvMap $windowsEnvMap -Name "N8N_PORT" -DefaultPort 5678
+    $healthChecks += @{ Name = "n8n (Workflows)"; Url = "http://localhost:$n8nHealthPort/healthz" }
+}
 
 Write-AI "Running health checks..."
 $maxAttempts = 60; $allHealthy = $true

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2087,7 +2087,10 @@ if ($enableVoice)     {
     $healthWhisperPort = if ($windowsEnvMap.ContainsKey("WHISPER_PORT") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["WHISPER_PORT"])) { $windowsEnvMap["WHISPER_PORT"] } else { "9000" }
     $healthChecks += @{ Name = "Whisper (STT)"; Url = "http://localhost:$healthWhisperPort/health" }
 }
-if ($enableWorkflows) { $healthChecks += @{ Name = "n8n (Workflows)";   Url = "http://localhost:5678/healthz" } }
+if ($enableWorkflows) {
+    $n8nHealthPort = Get-WindowsODSEnvPort -EnvMap $windowsEnvMap -Name "N8N_PORT" -DefaultPort 5678
+    $healthChecks += @{ Name = "n8n (Workflows)"; Url = "http://localhost:$n8nHealthPort/healthz" }
+}
 
 Write-AI "Running health checks..."
 $maxAttempts = 60; $allHealthy = $true


### PR DESCRIPTION
## Summary
The Windows installer health check for n8n hardcoded `http://localhost:5678/healthz`, while the readiness block honored an `N8N_PORT` override. A user who sets `N8N_PORT` got a false-failing health check even though n8n was healthy. This change resolves the probe port via `Get-WindowsODSEnvPort` (the same helper the neighboring checks use) so the health check matches the configured port.

## AI Assistance
This change was authored with assistance from an AI coding.

## Release Lane
- [ ] Stable hotfix (semver-patch to next
- [x] Mainline `main` (merged at next release train)
- [ ] Next-minor (non-hotfix)
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [ ] Dashboard API Python
- [ ] Dashboard (React)
- [ ] Backend config
- [ ] CLI / ods-cli
- [x] Installer (Linux / macOS / Windows) — Windows

## Validation
- PowerShell parse check via `[System.Management.Automation.Language.Parser]`