### PR TITLE
fix(installer): strip quotes when reading env values on macOS

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -36,7 +36,7 @@ read_env_value() {
     local env_path="$1"
     local key="$2"
     [[ -f "$env_path" ]] || { echo ""; return 0; }
-    grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r' || true
+    grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r"' || true
 }
 
 env_key_exists() {


### PR DESCRIPTION
## Summary
`read_env_value` in the macOS env-generator left surrounding double-quotes intact while sibling helpers strip them, so downstream `== "cloud"` / `== "true"` gates failed on quoted values in `bridge-manager.sh` and `install-macos.sh`. This strips quotes to match sibling behavior.

## AI Assistance
This change was authored with assistance from an AI coding assistant.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline `main`
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Installer (macOS)

## Validation
- repo lint (`bash -n`); quote-strip behavior verified locally