### PR TITLE
fix(installer): honor dashboard port overrides in Windows conflict scan

### DIFF
--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -286,8 +286,10 @@ Stop-WindowsODSLemonadePortConflicts `
 $_portsToCheck = [ordered]@{
     "Open WebUI (chat)"   = Resolve-WindowsODSPort `
         -Name "WEBUI_PORT" -DefaultPort 3000 -InstallDir $installDir
-    "Dashboard"           = 3001
-    "Dashboard API"       = 3002
+    "Dashboard"           = Resolve-WindowsODSPort `
+        -Name "DASHBOARD_PORT" -DefaultPort 3001 -InstallDir $installDir
+    "Dashboard API"       = Resolve-WindowsODSPort `
+        -Name "DASHBOARD_API_PORT" -DefaultPort 3002 -InstallDir $installDir
 }
 $_llmPortToCheck = Resolve-WindowsLlmPreflightPort `
     -GpuBackend ([string]$gpuInfo.Backend) `


### PR DESCRIPTION
## Summary
The Windows preflight port-conflict scan hardcoded Dashboard=3001 and Dashboard API=3002, ignoring the `DASHBOARD_PORT` / `DASHBOARD_API_PORT` overrides the rest of the installer honors, so a real conflict on an overridden port was missed. This change resolves those ports via `Resolve-WindowsODSPort`, matching the Open WebUI entry.

## AI Assistance
This change was authored with assistance from an AI coding assistant.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline `main`
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Installer (Windows)

## Validation
- PowerShell parse check via `[System.Management.Automation.Language.Parser]`