### PR TITLE
fix(installer): do not abort macOS install on benign Hermes dir

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -326,8 +326,7 @@ _macos_patch_hermes_persisted_config() {
         done
 
         if [[ -z "$selected_image" ]]; then
-            if [[ ! -e "$(dirname "$persisted_config")" ]] \
-               || { [[ -x "$(dirname "$persisted_config")" ]] && [[ ! -e "$persisted_config" ]]; }; then
+            if [[ ! -e "$persisted_config" ]]; then
                 return 3
             fi
             return 4


### PR DESCRIPTION
## Summary
`_macos_patch_hermes_persisted_config` gated its "benign no-config" path on the Hermes data dir being executable, so a `data/hermes` dir with restrictive permissions and no `config.yaml` fell through to the fatal `return 4` path, aborting the whole macOS install. The change treats a missing `config.yaml` as benign regardless of directory permissions; the fatal path is kept for a config that exists but cannot be patched.

## AI Assistance
This change was authored with assistance from an AI coding assistant.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline `main`
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Installer (macOS)

## Validation
- repo lint (`bash -n` over modified `.sh`)