### PR TITLE
fix(health): do not fail host-network services on port check

### DIFF
--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -167,6 +167,9 @@ test_service() {
     local port="$default_port"
     [[ -n "$port_env" ]] && port="${!port_env:-$default_port}"
 
+    # Host-network services share the host netns; no Docker-mapped port to probe.
+    [[ "${SERVICE_HOST_NETWORK[$sid]:-}" == "1" ]] && return 0
+
     [[ -z "$health" || "$port" == "0" ]] && return 1
 
     # Check container state first (if docker available)


### PR DESCRIPTION
## Summary
health-check.sh always ran the port probe even for host_network services (port 0), so enabling tailscale made `ods health` report DEGRADED for a healthy stack. test_service now skips the port check for host-network services per the service-registry contract.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] CLI / ods-cli / health check
- [ ] Installer

## Validation
- repo lint (bash -n)