### PR TITLE
fix(dashboard): tolerate incomplete workflow catalog entries

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -42,7 +42,7 @@ def load_workflow_catalog() -> dict:
             workflows = []
         if not isinstance(categories, dict):
             categories = {}
-        return {"workflows": workflows, "categories": categories}
+        return {"workflows": [wf for wf in workflows if isinstance(wf, dict) and wf.get("id") and wf.get("name") and wf.get("file")], "categories": categories}
     except (json.JSONDecodeError, OSError, KeyError) as e:
         logger.warning("Failed to load workflow catalog from %s: %s", WORKFLOW_CATALOG_FILE, e)
         return DEFAULT_WORKFLOW_CATALOG

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -143,6 +143,29 @@ def test_load_workflow_catalog_invalid_inner_types(tmp_path, monkeypatch):
     assert result["categories"] == {}
 
 
+def test_load_workflow_catalog_skips_incomplete_entries(tmp_path, monkeypatch):
+    """load_workflow_catalog drops entries missing id/name/file instead of crashing."""
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "complete", "name": "Complete", "description": "ok", "file": "c.json"},
+            {"id": "no-name", "description": "missing name", "file": "nn.json"},
+            {"name": "no-id", "description": "missing id", "file": "ni.json"},
+            {"id": "no-file", "name": "No File", "description": "missing file"},
+            "not-a-dict",
+            None,
+        ],
+        "categories": {}
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+
+    result = wf_mod.load_workflow_catalog()
+    assert [wf["id"] for wf in result["workflows"]] == ["complete"]
+
+
 # ---------------------------------------------------------------------------
 # get_n8n_workflows() unit tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The workflow catalog is a user-editable persisted file; entries missing id/name/file crashed list/detail endpoints with an unhandled KeyError (500). The loader now skips incomplete entries so legacy or hand-edited catalogs stay readable.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix (semver-patch to next impact from targeted backports to stable branch)
- [x] Mainline main
- [ ] Next-minor (non-urgent)
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Dashboard API Python
- [ ] Dashboard UI
- [ ] Installer
- [ ] Backup / restore / migrate

## Validation
- python -m py_compile workflows.py
- dashboard-api tests