### PR TITLE
fix(cli): wire rollback to the written rollback-point marker

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4694,18 +4694,18 @@ cmd_rollback() {
     cd "$INSTALL_DIR"
     load_env
 
-    if [[ ! -f "$INSTALL_DIR/.last-backup-id" ]]; then
+    if [[ ! -x "$INSTALL_DIR/ods-update.sh" ]]; then
+        error "ods-update.sh not found or not executable"
+    fi
+
+    local rollback_point
+    rollback_point=$(jq -r '.last_rollback_point // empty' "$INSTALL_DIR/.version" 2>/dev/null || true)
+
+    if [[ -z "$rollback_point" ]]; then
         error "No rollback point found. Rollback is only available after a failed update."
     fi
 
-    local backup_id
-    backup_id=$(cat "$INSTALL_DIR/.last-backup-id")
-
-    if [[ -z "$backup_id" ]]; then
-        error "Invalid rollback point (empty backup ID)"
-    fi
-
-    log "Rolling back to pre-update state (backup: $backup_id)..."
+    log "Rolling back to pre-update state (snapshot: $(basename "$rollback_point"))..."
     echo ""
     warn "This will restore configuration from before the last update."
     read -p "Continue with rollback? [y/N] " -n 1 -r
@@ -4716,32 +4716,12 @@ cmd_rollback() {
         return 0
     fi
 
-    # Stop services before rollback
-    log "Stopping services..."
-    local flags_str
-    flags_str=$(get_compose_flags)
-    local -a flags
-    read -ra flags <<< "$flags_str"
-    docker compose "${flags[@]}" down 2>/dev/null || true
-
-    # Restore from backup
-    if "$INSTALL_DIR/ods-restore.sh" "$backup_id"; then
-        success "Configuration restored from backup: $backup_id"
-
-        # Restart services with restored configuration
-        log "Restarting services with restored configuration..."
-        if docker compose "${flags[@]}" up -d; then
-            success "Rollback complete"
-            rm -f "$INSTALL_DIR/.last-backup-id"
-
-            log "Checking service health..."
-            sleep 5
-            cmd_status
-        else
-            error "Failed to restart services after rollback. Check 'docker compose logs' for details."
-        fi
+    # Delegate to ods-update.sh, which resolves the recorded pre-update
+    # snapshot, stops the stack, restores it, and brings services back up.
+    if "$INSTALL_DIR/ods-update.sh" rollback "$(basename "$rollback_point")"; then
+        success "Rollback complete"
     else
-        error "Failed to restore from backup. Your system may be in an inconsistent state."
+        error "Rollback failed. Check 'ods-update.sh rollback' for details."
     fi
 }
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4711,18 +4711,18 @@ cmd_rollback() {
     cd "$INSTALL_DIR"
     load_env
 
-    if [[ ! -f "$INSTALL_DIR/.last-backup-id" ]]; then
+    if [[ ! -x "$INSTALL_DIR/ods-update.sh" ]]; then
+        error "ods-update.sh not found or not executable"
+    fi
+
+    local rollback_point
+    rollback_point=$(jq -r '.last_rollback_point // empty' "$INSTALL_DIR/.version" 2>/dev/null || true)
+
+    if [[ -z "$rollback_point" ]]; then
         error "No rollback point found. Rollback is only available after a failed update."
     fi
 
-    local backup_id
-    backup_id=$(cat "$INSTALL_DIR/.last-backup-id")
-
-    if [[ -z "$backup_id" ]]; then
-        error "Invalid rollback point (empty backup ID)"
-    fi
-
-    log "Rolling back to pre-update state (backup: $backup_id)..."
+    log "Rolling back to pre-update state (snapshot: $(basename "$rollback_point"))..."
     echo ""
     warn "This will restore configuration from before the last update."
     read -p "Continue with rollback? [y/N] " -n 1 -r
@@ -4733,32 +4733,12 @@ cmd_rollback() {
         return 0
     fi
 
-    # Stop services before rollback
-    log "Stopping services..."
-    local flags_str
-    flags_str=$(get_compose_flags)
-    local -a flags
-    read -ra flags <<< "$flags_str"
-    docker compose "${flags[@]}" down 2>/dev/null || true
-
-    # Restore from backup
-    if "$INSTALL_DIR/ods-restore.sh" "$backup_id"; then
-        success "Configuration restored from backup: $backup_id"
-
-        # Restart services with restored configuration
-        log "Restarting services with restored configuration..."
-        if docker compose "${flags[@]}" up -d; then
-            success "Rollback complete"
-            rm -f "$INSTALL_DIR/.last-backup-id"
-
-            log "Checking service health..."
-            sleep 5
-            cmd_status
-        else
-            error "Failed to restart services after rollback. Check 'docker compose logs' for details."
-        fi
+    # Delegate to ods-update.sh, which resolves the recorded pre-update
+    # snapshot, stops the stack, restores it, and brings services back up.
+    if "$INSTALL_DIR/ods-update.sh" rollback "$(basename "$rollback_point")"; then
+        success "Rollback complete"
     else
-        error "Failed to restore from backup. Your system may be in an inconsistent state."
+        error "Rollback failed. Check 'ods-update.sh rollback' for details."
     fi
 }
 


### PR DESCRIPTION
## Summary
`ods rollback` read a .last-backup-id marker that nothing ever writes, so the documented post-update-failure recovery always errored "No rollback point found". Rollback now reads the rollback point from the same source the update snapshot writes, making the documented recovery path functional.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [ ] Dashboard API
- [ ] Installer
- [x] CLI / ods-cli
- [x] Backup / restore / migrate

## Validation
- repo lint (bash -n)