### PR TITLE
fix(dashboard): tolerate invalid SHIELD_PORT env value

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/privacy.py
+++ b/ods/extensions/services/dashboard-api/routers/privacy.py
@@ -20,6 +20,17 @@ from security import verify_api_key
 
 logger = logging.getLogger(__name__)
 
+
+def _env_int(name: str, default: int = 0) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
 router = APIRouter(tags=["privacy"])
 
 
@@ -27,7 +38,7 @@ router = APIRouter(tags=["privacy"])
 async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield status and configuration."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _env_int("SHIELD_PORT", _ps.get("port", 0))
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
 
     # Check health directly — no Docker socket needed
@@ -94,7 +105,7 @@ async def toggle_privacy_shield(request: PrivacyShieldToggle, api_key: str = Dep
 async def get_privacy_shield_stats(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield usage statistics."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _env_int("SHIELD_PORT", _ps.get("port", 0))
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
     shield_api_key = os.environ.get("SHIELD_API_KEY", "")
     if not shield_api_key:

--- a/ods/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy.py
@@ -79,6 +79,23 @@ def test_privacy_shield_status_not_running(test_client):
     assert data["container_running"] is False
 
 
+def test_privacy_shield_status_invalid_shield_port_env(test_client, monkeypatch):
+    """GET /api/privacy-shield/status with non-numeric SHIELD_PORT does not 500."""
+    monkeypatch.setenv("SHIELD_PORT", "abc")
+    session_mock = MagicMock()
+    session_mock.get = MagicMock(side_effect=aiohttp.ClientError("refused"))
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.privacy.aiohttp.ClientSession", return_value=session_ctx):
+        resp = test_client.get("/api/privacy-shield/status", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["enabled"] is False
+
+
 # ---------------------------------------------------------------------------
 # /api/privacy-shield/toggle — host agent API
 # ---------------------------------------------------------------------------
@@ -291,3 +308,20 @@ def test_privacy_shield_stats_empty_shield_api_key(test_client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"error": "SHIELD_API_KEY not configured", "enabled": False}
     session_factory.assert_not_called()
+
+
+def test_privacy_shield_stats_invalid_shield_port_env(test_client, monkeypatch):
+    """GET /api/privacy-shield/stats with non-numeric SHIELD_PORT does not 500."""
+    monkeypatch.setenv("SHIELD_PORT", "abc")
+    session_mock = MagicMock()
+    session_mock.get = MagicMock(side_effect=aiohttp.ClientError("refused"))
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.privacy.aiohttp.ClientSession", return_value=session_ctx):
+        resp = test_client.get("/api/privacy-shield/stats", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["enabled"] is False


### PR DESCRIPTION
## Summary
A SHIELD_PORT env value that is empty or non-numeric made the privacy-shield status/stats endpoints crash with an unhandled ValueError (500). Port resolution now falls back safely to the default, reusing the existing safe env-int helper.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Dashboard API Python
- [ ] Dashboard UI
- [ ] Installer

## Validation
- python -m py_compile privacy.py
- dashboard-api tests