### PR TITLE
fix(dashboard): clean error when model record lacks gguf_file

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -1960,8 +1960,12 @@ def download_model(model_id: str, api_key: str = Depends(verify_api_key)):
             detail={**bootstrap_conflict, "requestedModelId": model_id},
         )
 
+    gguf_file = model.get("gguf_file")
+    if not gguf_file:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' is missing a GGUF file reference")
+
     payload = {
-        "gguf_file": model["gguf_file"],
+        "gguf_file": gguf_file,
         "gguf_url": model.get("gguf_url", ""),
         "gguf_sha256": model.get("gguf_sha256", ""),
     }
@@ -2065,8 +2069,12 @@ def delete_model(model_id: str, api_key: str = Depends(verify_api_key)):
     if model is None:
         raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found in library or local GGUF files")
 
+    gguf_file = model.get("gguf_file")
+    if not gguf_file:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' is missing a GGUF file reference")
+
     payload = {
-        "gguf_file": model["gguf_file"],
+        "gguf_file": gguf_file,
     }
     if model.get("gguf_parts"):
         payload["gguf_parts"] = model["gguf_parts"]

--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -1961,8 +1961,12 @@ def download_model(model_id: str, api_key: str = Depends(verify_api_key)):
             detail={**bootstrap_conflict, "requestedModelId": model_id},
         )
 
+    gguf_file = model.get("gguf_file")
+    if not gguf_file:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' is missing a GGUF file reference")
+
     payload = {
-        "gguf_file": model["gguf_file"],
+        "gguf_file": gguf_file,
         "gguf_url": model.get("gguf_url", ""),
         "gguf_sha256": model.get("gguf_sha256", ""),
     }
@@ -2066,8 +2070,12 @@ def delete_model(model_id: str, api_key: str = Depends(verify_api_key)):
     if model is None:
         raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found in library or local GGUF files")
 
+    gguf_file = model.get("gguf_file")
+    if not gguf_file:
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' is missing a GGUF file reference")
+
     payload = {
-        "gguf_file": model["gguf_file"],
+        "gguf_file": gguf_file,
     }
     if model.get("gguf_parts"):
         payload["gguf_parts"] = model["gguf_parts"]

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -2645,3 +2645,27 @@ def test_load_model_rejects_local_gguf_path_separators(test_client, monkeypatch,
     )
 
     assert resp.status_code == 404
+
+
+def test_download_and_delete_reject_library_record_missing_gguf_file(test_client, monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [{"id": "legacy-model", "name": "Legacy Model"}])
+    monkeypatch.setattr(
+        models_router,
+        "_call_agent_model",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("host agent reached for record without gguf_file")
+        ),
+    )
+
+    download_response = test_client.post(
+        "/api/models/legacy-model/download",
+        headers=test_client.auth_headers,
+    )
+    delete_response = test_client.delete(
+        "/api/models/legacy-model",
+        headers=test_client.auth_headers,
+    )
+
+    assert download_response.status_code == 404
+    assert delete_response.status_code == 404

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -2655,3 +2655,27 @@ def test_load_model_rejects_local_gguf_path_separators(test_client, monkeypatch,
     )
 
     assert resp.status_code == 404
+
+
+def test_download_and_delete_reject_library_record_missing_gguf_file(test_client, monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [{"id": "legacy-model", "name": "Legacy Model"}])
+    monkeypatch.setattr(
+        models_router,
+        "_call_agent_model",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("host agent reached for record without gguf_file")
+        ),
+    )
+
+    download_response = test_client.post(
+        "/api/models/legacy-model/download",
+        headers=test_client.auth_headers,
+    )
+    delete_response = test_client.delete(
+        "/api/models/legacy-model",
+        headers=test_client.auth_headers,
+    )
+
+    assert download_response.status_code == 404
+    assert delete_response.status_code == 404


### PR DESCRIPTION
## Summary
A persisted model-library record with an id but no gguf_file raised an unhandled KeyError on download/delete (500). These paths now tolerate the missing key and return a clean 404/400, matching the sibling .get()-based access used elsewhere in the same module.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Dashboard API Python
- [ ] Dashboard UI
- [ ] Installer

## Validation
- python -m py_compile models.py
- dashboard-api tests