### PR TITLE
fix(installer): honor WHISPER_PORT override in Windows conflict scan

### DIFF
--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -304,7 +304,8 @@ if ($enableRecommended) {
     $_portsToCheck["Token Spy (usage monitor)"] = 3005
 }
 if ($enableVoice) {
-    $_whisperPortToCheck = $(if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 })
+    $_whisperDefaultPort = if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 }
+    $_whisperPortToCheck = Resolve-WindowsODSPort -Name "WHISPER_PORT" -DefaultPort $_whisperDefaultPort -InstallDir $installDir
     $_portsToCheck["Whisper (STT)"] = $_whisperPortToCheck
     $_portsToCheck["Kokoro (TTS)"]  = 8880
 }


### PR DESCRIPTION
## Summary
The Windows Whisper port-conflict scan hardcoded 9100/9000 and ignored a persisted WHISPER_PORT override, so a re-install with a custom port could miss a real conflict. It now resolves the port via Resolve-WindowsODSPort, matching the WEBUI entry in the same block.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Installer (Windows)

## Validation
- PowerShell parse check