### PR TITLE
fix(installer): honor LITELLM_PORT override in macOS cloud health

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -3057,9 +3057,11 @@ CLOUD_REQUIRED_HEALTHY=true
 # runs natively on macOS via Metal; OpenCode is a LaunchAgent). Docker
 # services wait on `docker inspect ... .State.Health.Status == healthy`;
 # host-native services fall back to an HTTP probe on 127.0.0.1.
+_health_litellm_port="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_PORT")"
+[[ "$_health_litellm_port" =~ ^[0-9]+$ ]] || _health_litellm_port="4000"
 if $CLOUD_MODE; then
     HEALTH_NAMES=("LiteLLM gateway" "Chat UI (Open WebUI)")
-    HEALTH_URLS=("http://127.0.0.1:4000/health/readiness" "http://127.0.0.1:3000")
+    HEALTH_URLS=("http://127.0.0.1:${_health_litellm_port}/health/readiness" "http://127.0.0.1:3000")
     HEALTH_CONTAINERS=("ods-litellm" "ods-webui")
 else
     _health_bind="$(read_env_value "$INSTALL_DIR/.env" "BIND_ADDRESS")"

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -3059,9 +3059,11 @@ CLOUD_REQUIRED_HEALTHY=true
 # runs natively on macOS via Metal; OpenCode is a LaunchAgent). Docker
 # services wait on `docker inspect ... .State.Health.Status == healthy`;
 # host-native services fall back to an HTTP probe on 127.0.0.1.
+_health_litellm_port="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_PORT")"
+[[ "$_health_litellm_port" =~ ^[0-9]+$ ]] || _health_litellm_port="4000"
 if $CLOUD_MODE; then
     HEALTH_NAMES=("LiteLLM gateway" "Chat UI (Open WebUI)")
-    HEALTH_URLS=("http://127.0.0.1:4000/health/readiness" "http://127.0.0.1:3000")
+    HEALTH_URLS=("http://127.0.0.1:${_health_litellm_port}/health/readiness" "http://127.0.0.1:3000")
     HEALTH_CONTAINERS=("ods-litellm" "ods-webui")
 else
     _health_bind="$(read_env_value "$INSTALL_DIR/.env" "BIND_ADDRESS")"


### PR DESCRIPTION
## Summary
The macOS cloud-mode health probe hardcoded LiteLLM on port 4000 while the same file later reads LITELLM_PORT as overridable, so an override made the initial health wait probe the wrong port. The probe now resolves LITELLM_PORT from .env with the 4000 fallback.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Installer (macOS)

## Validation
- repo lint (bash -n)