### PR TITLE
fix(restore): estimate tar size portably on macOS

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -54,8 +54,8 @@ estimate_restore_bytes_dir() {
 # Estimate restore size for a tar.gz (uncompressed file sizes)
 estimate_restore_bytes_tar() {
     local tar_path="$1"
-    # tar -tv lists size in column 3
-    tar -tvzf "$tar_path" 2>/dev/null | awk '{sum += $3} END {print sum+0}'
+    # tar -tv lists the byte size as the first pure-numeric field on GNU and BSD
+    tar -tvzf "$tar_path" 2>/dev/null | awk '{ for (i=1; i<=NF; i++) { if ($i ~ /^[0-9]+$/ && $i+0 > 0) { sum += $i+0; break } } } END { print sum+0 }'
 }
 
 ensure_restore_space() {


### PR DESCRIPTION
## Summary
estimate_restore_bytes_tar parsed column 3 of `tar -tvz`, which is the byte size on GNU tar but the group field on BSD tar, so the pre-restore disk-space guard silently became a no-op on macOS. The parser now takes the first numeric byte field, working on both GNU and BSD tar.

## AI Assistance
This change was authored with assistance from an AI coding tool.

## Release Lane
- [ ] Stable hotfix
- [x] Mainline main
- [ ] Next-minor
- [ ] Not sure

Stable hotfix reason: Not targeting the stable release branch directly.

## Changed Surface
- [x] Backup / restore / migrate

## Validation
- repo lint (bash -n)