### PR TITLE
fix(hermes): write patched Hermes configuration atomically in patch-hermes-config.py

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -10,7 +10,9 @@ the rest of the user's config.
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import tempfile
 from pathlib import Path
 
 
@@ -290,7 +292,17 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(updated)
+        os.replace(tmp_path, path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
     return True
 
 


### PR DESCRIPTION
## Problem

In `ods/scripts/patch-hermes-config.py`, `patch_config()` updated Hermes CLI configuration templates and live configs directly using `path.write_text(updated, encoding="utf-8")`. If process execution is interrupted during installer migration patching, Hermes's `config.yaml` file can be left truncated or corrupted in place.

## Fix

1. Update `patch_config()` in `patch-hermes-config.py` to write updated YAML configuration contents to a temporary file via `tempfile.mkstemp` inside `path.parent`.
2. Use `os.replace` for atomic replacement of the final destination Hermes configuration path.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/patch-hermes-config.py`. `git diff --check` passed cleanly with zero whitespace issues.