### PR TITLE
fix(catalog): write generated extensions catalog JSON atomically in generate-extensions-catalog.py

### DIFF
--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -163,7 +165,16 @@ def main() -> None:
     }
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(catalog, indent=2, ensure_ascii=False) + "\n")
+        os.replace(tmp_path, output_path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
 
     print(f"Generated catalog with {len(entries)} extensions at {output_path}")
 


### PR DESCRIPTION
## Problem

In `ods/scripts/generate-extensions-catalog.py`, catalog generator tools wrote static catalog outputs directly using `output_path.write_text(json.dumps(...))`. If execution is interrupted during extension catalog generation, the target `extensions-catalog.json` file can be left partially written or corrupted in place.

## Fix

1. Update `generate-extensions-catalog.py` to write catalog JSON payloads to a temporary file via `tempfile.mkstemp` inside `output_path.parent`.
2. Use `os.replace` for atomic replacement of the final destination catalog JSON path.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/generate-extensions-catalog.py`. `git diff --check` passed cleanly with zero whitespace issues.