### PR TITLE
fix(install-context): write installation context atomically in build-installation-context.py

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import socket
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 # Service-id → (display name, one-line "what it does and how the user
@@ -418,7 +420,16 @@ def build_soul(
     previous = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
     if previous == assembled:
         return False
-    output_path.write_text(assembled, encoding="utf-8")
+    fd, tmp_str = tempfile.mkstemp(dir=str(output_path.parent), prefix=f".{output_path.name}.", suffix=".tmp")
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(assembled)
+        os.replace(tmp_path, output_path)
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise
     return True
 
 


### PR DESCRIPTION
## Problem

In `ods/scripts/build-installation-context.py`, generated SOUL installation context contents were written directly using `output_path.write_text(assembled, encoding="utf-8")`. This exposes live installation context files (`data/persona/SOUL.md`) to in-place truncation during render cycles.

## Fix

1. Update `build_soul()` in `build-installation-context.py` to write assembled context data to a temporary file via `tempfile.mkstemp` in `output_path.parent`.
2. Use `os.replace` for atomic replacement of destination installation context files.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/build-installation-context.py`. `git diff --check` passed cleanly with zero whitespace issues.