### PR TITLE
fix(dashboard-api): use secure mkstemp for atomic JSON writes in helpers.py

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -9,6 +9,7 @@ import platform
 import re
 import shutil
 import socket
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -250,10 +251,12 @@ def _read_json_file(path: Path, default):
 
 
 def _write_json_file(path: Path, data) -> None:
-    temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp")
+    temporary = Path(tmp_str)
     try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        temporary.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(data, indent=2, sort_keys=True))
         # Windows virus scanners and indexers can briefly retain a handle to
         # the destination. Retry only that transient access-denied case; other
         # filesystem failures remain fail-soft as before.


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/helpers.py`, `_write_json_file` constructed temporary file paths using predictable process and thread ID patterns (`path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")`). Predictable temporary file naming in shared directories can expose atomic write operations to temporary file collision or symlink races.

## Fix

1. Update `_write_json_file` in `helpers.py` to use `tempfile.mkstemp` inside `path.parent` with exclusive `O_CREAT \| O_EXCL` file creation.
2. Maintain existing retry semantics for transient Windows `PermissionError` during `os.replace`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_helpers.py`: 106/106 passed. `git diff --check` passed cleanly with zero whitespace issues.