### PR TITLE
fix(installer): write OpenCode configuration atomically with restricted permissions in install-macos.sh

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -435,6 +435,7 @@ _write_macos_opencode_config() {
 import json
 import os
 import sys
+import tempfile
 from pathlib import Path
 
 path = Path(sys.argv[1])
@@ -470,10 +471,17 @@ payload = json.dumps(data, indent=2) + "\n"
 
 
 def write_atomic(target):
-    tmp = target.with_name(f"{target.name}.{os.getpid()}.tmp")
-    tmp.write_text(payload, encoding="utf-8")
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, target)
+    fd, tmp_str = tempfile.mkstemp(dir=str(target.parent), prefix=f".{target.name}.", suffix=".tmp")
+    tmp = Path(tmp_str)
+    try:
+        os.chmod(tmp_str, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(payload)
+        os.replace(tmp, target)
+    except Exception:
+        if tmp.exists():
+            tmp.unlink(missing_ok=True)
+        raise
 
 
 for target in (path, compat_path):


### PR DESCRIPTION
## Problem

In `ods/installers/macos/install-macos.sh`, `write_atomic()` wrote OpenCode configuration payloads containing API keys directly using `tmp.write_text(...)` under process default umask before calling `os.chmod(tmp, 0o600)`. This exposes API key configurations to a brief window of permissive mode before restrictive permissions take effect.

## Fix

1. Update `write_atomic()` in `install-macos.sh` to write OpenCode JSON configuration data to a temporary file via `tempfile.mkstemp` in `target.parent`.
2. Pre-apply mode `0o600` on the temporary file before writing data and calling `os.replace`.

## Verification

Verified syntax with `bash -n ods/installers/macos/install-macos.sh`. `git diff --check` passed cleanly with zero whitespace issues.