### PR TITLE
fix(cli): write background runner PID file atomically in ods-macos.sh

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -286,6 +286,7 @@ macos_launch_detached_bootstrap_upgrade() {
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 pid_path = Path(sys.argv[1])
@@ -307,10 +308,17 @@ with log_path.open("ab", buffering=0) as log_handle:
         close_fds=True,
         start_new_session=True,
     )
-tmp = pid_path.with_name(f"{pid_path.name}.{os.getpid()}.tmp")
-tmp.write_text(f"{proc.pid}\n", encoding="ascii")
-os.chmod(tmp, 0o600)
-os.replace(tmp, pid_path)
+fd, tmp_str = tempfile.mkstemp(dir=str(pid_path.parent), prefix=f".{pid_path.name}.", suffix=".tmp")
+tmp = Path(tmp_str)
+try:
+    os.chmod(tmp_str, 0o600)
+    with os.fdopen(fd, "w", encoding="ascii") as f:
+        f.write(f"{proc.pid}\n")
+    os.replace(tmp, pid_path)
+except Exception:
+    if tmp.exists():
+        tmp.unlink(missing_ok=True)
+    raise
 BOOTSTRAP_LAUNCH_PY
 }
 


### PR DESCRIPTION
## Problem

In `ods/installers/macos/ods-macos.sh`, `BOOTSTRAP_LAUNCH_PY` wrote background process PID files using predictable PID-suffixed names (`pid_path.with_name(f"{pid_path.name}.{os.getpid()}.tmp")`) and process default umask before calling `os.chmod(tmp, 0o600)`. Predictable temporary file naming in runtime directories can expose PID file updates to collision or permission race conditions.

## Fix

1. Update `BOOTSTRAP_LAUNCH_PY` in `ods-macos.sh` to write background runner PIDs to a temporary file via `tempfile.mkstemp` in `pid_path.parent`.
2. Pre-apply mode `0o600` on the temporary file before writing process IDs and calling `os.replace`.

## Verification

Verified syntax with `bash -n ods/installers/macos/ods-macos.sh`. `git diff --check` passed cleanly with zero whitespace issues.