### PR TITLE
fix(migrations): write migration state file atomically in migrate-config.sh

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -64,8 +64,13 @@ get_last_migrated_version() {
 # Set last migrated version
 set_last_migrated_version() {
     local version="$1"
-    mkdir -p "$(dirname "$MIGRATION_STATE")"
-    echo "$version" > "$MIGRATION_STATE"
+    local target_dir
+    target_dir="$(dirname "$MIGRATION_STATE")"
+    mkdir -p "$target_dir"
+    local tmp_file
+    tmp_file="$(mktemp "$target_dir/.migration-state.XXXXXX.tmp")"
+    echo "$version" > "$tmp_file"
+    mv -f "$tmp_file" "$MIGRATION_STATE"
 }
 
 # Compare semantic versions


### PR DESCRIPTION
## Problem

In `ods/scripts/migrate-config.sh`, `set_last_migrated_version()` updated `.migration-state` directly using `echo "$version" > "$MIGRATION_STATE"`. Direct file output redirection truncates target state files in place, risking corrupted or incomplete migration state tracking if process execution is interrupted.

## Fix

1. Update `set_last_migrated_version()` in `migrate-config.sh` to write updated version strings to a temporary file via `mktemp` in `MIGRATION_STATE`'s directory.
2. Use `mv -f` for atomic replacement of destination migration state files.

## Verification

Verified syntax with `bash -n ods/scripts/migrate-config.sh`. `git diff --check` passed cleanly with zero whitespace issues.