### PR TITLE
fix(restore): preserve files created after backup

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -113,6 +113,10 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@echo ""
+	@echo "=== backup integrity and restore round-trip ==="
+	@bash tests/test-backup-integrity.sh
+	@bash tests/test-backup-restore-roundtrip.sh
+	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
 	@echo ""

--- a/ods/lib/rsync.sh
+++ b/ods/lib/rsync.sh
@@ -36,9 +36,9 @@ rsync_with_progress() {
     # Use --info=progress2 for compact single-line progress updates
     # Fallback to basic rsync if progress2 not supported
     if rsync --help 2>/dev/null | grep -q "info=progress2"; then
-        rsync -a --delete --info=progress2 "$src" "$dest"
+        rsync -a --info=progress2 "$src" "$dest"
     else
         # Fallback: use --progress for older rsync versions
-        rsync -a --delete --progress "$src" "$dest" 2>/dev/null || rsync -a --delete "$src" "$dest"
+        rsync -a --progress "$src" "$dest" 2>/dev/null || rsync -a "$src" "$dest"
     fi
 }

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -25,13 +25,15 @@ trap 'rm -rf "$TMP"' EXIT
 
 # Create source ODS directory with minimal data
 SRC="$TMP/src"
-mkdir -p "$SRC/data/open-webui"
+mkdir -p "$SRC/data/open-webui" "$SRC/data/n8n" "$SRC/models"
 mkdir -p "$SRC/config"
 echo "1.0.0" > "$SRC/.version"
 echo "test-env-value" > "$SRC/.env"
 echo "compose-content" > "$SRC/docker-compose.yml"
 echo "config-data" > "$SRC/config/settings.json"
 echo "user-data-file" > "$SRC/data/open-webui/data.txt"
+echo "workflow-data-file" > "$SRC/data/n8n/workflows.txt"
+echo "model-cache-file" > "$SRC/models/model.gguf"
 
 # Both scripts source lib/rsync.sh relative to ODS_DIR
 mkdir -p "$SRC/lib"
@@ -45,11 +47,23 @@ BACKUP_ID=$(ls -1 "$SRC/.backups" | head -n 1)
 [[ -n "$BACKUP_ID" ]] || fail "No backup created"
 pass "Backup created: $BACKUP_ID"
 
+# A full backup merges several source trees into one destination. Earlier
+# sources must survive later copies.
+BACKUP_DIR="$SRC/.backups/$BACKUP_ID"
+[[ -f "$BACKUP_DIR/manifest.json" ]] || fail "Full backup lost manifest.json"
+[[ -f "$BACKUP_DIR/.env" ]] || fail "Full backup lost .env"
+[[ -f "$BACKUP_DIR/config/settings.json" ]] || fail "Full backup lost config data"
+[[ -f "$BACKUP_DIR/data/open-webui/data.txt" ]] || fail "Full backup lost open-webui data"
+[[ -f "$BACKUP_DIR/data/n8n/workflows.txt" ]] || fail "Full backup lost n8n data"
+[[ -f "$BACKUP_DIR/models/model.gguf" ]] || fail "Full backup lost model cache"
+
 # Create destination ODS directory (empty)
 DST="$TMP/dst"
 mkdir -p "$DST/data"
 mkdir -p "$DST/.backups"
 mkdir -p "$DST/lib"
+mkdir -p "$DST/data/n8n"
+echo "created-after-backup" > "$DST/data/n8n/live-only.txt"
 cp "$SCRIPT_DIR/../lib/rsync.sh" "$DST/lib/"
 
 info "Restoring backup to destination"
@@ -70,6 +84,8 @@ info "Validating restored contents"
 [[ -f "$DST/config/settings.json" ]] || fail "Missing config/settings.json after restore"
 [[ -d "$DST/data/open-webui" ]] || fail "Missing data/open-webui after restore"
 [[ -f "$DST/data/open-webui/data.txt" ]] || fail "Missing data/open-webui/data.txt after restore"
+[[ -f "$DST/data/n8n/workflows.txt" ]] || fail "Missing data/n8n/workflows.txt after restore"
+[[ -f "$DST/data/n8n/live-only.txt" ]] || fail "Restore deleted live data created after backup"
 
 pass "All expected files/dirs present after restore"
 


### PR DESCRIPTION
## Summary

- stop the shared backup/restore copy helper from deleting destination files that are absent from the source
- preserve files created after a backup when restoring the matching service data directory
- expand the full backup/restore round-trip across multiple service directories, config, and model cache
- add the existing backup integrity and round-trip suites to `make test`

Closes #2304

## AI Assistance

Codex reproduced the destructive restore behavior, narrowed the issue to the behavior actually observable with rsync directory semantics, implemented the fix, expanded regression coverage, and ran validation. The human author remains responsible for the final diff and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High — changes backup/restore filesystem copy semantics
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
bash tests/test-backup-restore-roundtrip.sh
passed; verifies multiple data trees, config, model cache, and preservation of a live-only file

bash tests/test-backup-integrity.sh
passed

bash -n lib/rsync.sh tests/test-backup-restore-roundtrip.sh ods-backup.sh ods-restore.sh
passed

git diff --check
passed
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [x] This is an operational change and release-grade fleet validation is intentionally deferred for: the focused round-trip executes the changed filesystem copy path end to end without requiring a running stack; CI will run the broader matrix.

## Notes For Reviewers

The reported destructive behavior is reproducible when restoring into a service directory that contains files created after the backup. Multiple backup source directories do not delete one another under the current directory-copy layout, but the expanded test keeps that invariant explicit. Rollback is a one-commit revert.