### PR TITLE
fix(updates): validate GitHub release payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -142,6 +142,42 @@ def _normalize_version(value: Optional[str]) -> str:
     return (value or "").strip().lstrip("v")
 
 
+def _release_object(value: object) -> dict:
+    """Validate one object returned by the GitHub releases API."""
+    if not isinstance(value, dict):
+        raise ValueError(f"unexpected GitHub release response: {type(value).__name__}")
+    return value
+
+
+def _release_string(release: dict, key: str) -> str:
+    """Read an optional string field from a GitHub release object."""
+    value = release.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"unexpected GitHub release field {key}: {type(value).__name__}")
+    return value
+
+
+def _format_release(value: object) -> dict:
+    """Convert a validated GitHub release object to the dashboard schema."""
+    release = _release_object(value)
+    prerelease = release.get("prerelease", False)
+    if not isinstance(prerelease, bool):
+        raise ValueError(
+            f"unexpected GitHub release field prerelease: {type(prerelease).__name__}"
+        )
+    changelog = _release_string(release, "body")
+    return {
+        "version": _release_string(release, "tag_name").lstrip("v"),
+        "date": _release_string(release, "published_at"),
+        "title": _release_string(release, "name"),
+        "changelog": changelog[:500] + "..." if len(changelog) > 500 else changelog,
+        "url": _release_string(release, "html_url"),
+        "prerelease": prerelease,
+    }
+
+
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     current = _normalize_version(current)
     result = {
@@ -178,10 +214,10 @@ async def _refresh_release_cache() -> Optional[dict]:
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
-        data = response.json()
+        data = _release_object(response.json())
         payload = {
-            "latest": data.get("tag_name", "").lstrip("v"),
-            "changelog_url": data.get("html_url"),
+            "latest": _release_string(data, "tag_name").lstrip("v"),
+            "changelog_url": _release_string(data, "html_url") or None,
             "checked_at": datetime.now(timezone.utc).isoformat(),
         }
         _version_cache = {
@@ -233,15 +269,12 @@ async def get_release_manifest():
             )
         releases = resp.json()
         if not isinstance(releases, list):
-            raise httpx.HTTPError(f"unexpected releases response: {type(releases).__name__}")
+            raise ValueError(f"unexpected releases response: {type(releases).__name__}")
         return {
-            "releases": [
-                {"version": r.get("tag_name", "").lstrip("v"), "date": r.get("published_at", ""), "title": r.get("name", ""), "changelog": r.get("body", "")[:500] + "..." if len(r.get("body", "")) > 500 else r.get("body", ""), "url": r.get("html_url", ""), "prerelease": r.get("prerelease", False)}
-                for r in releases
-            ],
+            "releases": [_format_release(release) for release in releases],
             "checked_at": datetime.now(timezone.utc).isoformat()
         }
-    except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError, OSError):
+    except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError, OSError, ValueError):
         current = await asyncio.to_thread(_read_current_version)
         return {
             "releases": [{"version": current, "date": datetime.now(timezone.utc).isoformat(), "title": f"ODS {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": _GITHUB_RELEASES_PAGE, "prerelease": False}],
@@ -303,9 +336,9 @@ async def get_update_dry_run():
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
-        data = resp.json()
-        latest = _normalize_version(data.get("tag_name")) or None
-        changelog_url = data.get("html_url") or None
+        data = _release_object(resp.json())
+        latest = _normalize_version(_release_string(data, "tag_name")) or None
+        changelog_url = _release_string(data, "html_url") or None
         if latest:
             def _parts(v: str) -> list[int]:
                 return ([int(x) for x in v.split(".") if x.isdigit()][:3] + [0, 0, 0])[:3]

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -72,6 +72,28 @@ def test_get_version_with_mock_github(test_client, monkeypatch):
     assert data["changelog_url"] == "https://github.com/test"
 
 
+def test_get_version_rejects_non_object_github_payload(test_client, monkeypatch):
+    """Valid JSON with the wrong shape must not crash the refresh task."""
+    import routers.updates as updates_mod
+
+    monkeypatch.setattr(updates_mod, "_version_cache", {"expires_at": 0.0, "payload": None})
+    monkeypatch.setattr(updates_mod, "_version_refresh_task", None)
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = []
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["latest"] is None
+    assert updates_mod._version_cache["payload"] is None
+
+
 def test_build_version_result_strips_v_prefix_from_current():
     """Current versions stored with a 'v' prefix (matching the release tag
     convention, e.g. a .version file of 'v2.6.0') must normalize before
@@ -142,6 +164,22 @@ def test_get_releases_manifest_authenticated(test_client):
     assert isinstance(data["releases"], list)
     assert len(data["releases"]) == 1
     assert data["releases"][0]["version"] == "1.0.0"
+
+
+def test_get_releases_manifest_rejects_malformed_release(test_client):
+    """A malformed item falls back to local release data instead of returning 500."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = [None]
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/releases/manifest", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["error"] == "Could not fetch release information"
 
 
 def test_trigger_update_requires_auth(test_client):
@@ -334,6 +372,30 @@ def test_update_dry_run_with_env_and_version(test_client, tmp_path, monkeypatch)
     assert "GPU_BACKEND" in data["env_keys"]
     assert "LLM_MODEL" in data["env_keys"]
     assert "SOME_OTHER_KEY" not in data["env_keys"]
+
+
+def test_update_dry_run_rejects_non_object_github_payload(test_client, tmp_path, monkeypatch):
+    """A valid non-object JSON response is reported as a version-check error."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "ods"
+    install_dir.mkdir()
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = []
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_resp)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/update/dry-run", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["latest_version"] is None
+    assert "unexpected GitHub release response: list" in data["version_check_error"]
 
 
 def test_update_dry_run_parses_quoted_ods_version(test_client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- validate GitHub release responses before accessing object fields
- normalize optional string and prerelease fields at the HTTP boundary
- fall back cleanly when valid JSON has an unexpected schema instead of returning 500 or crashing the refresh task

## Tests
- `pytest tests/test_updates.py -q` (30 passed)
- `python -m py_compile ods/extensions/services/dashboard-api/routers/updates.py ods/extensions/services/dashboard-api/tests/test_updates.py`
- `git diff --check`