### PR TITLE
fix(config): split preset diff env values on first equals

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3368,16 +3368,51 @@ META
                 # used (which missed _PASS, _SALT, email admin fields, etc.).
                 _cmd_config_load_secret_schema
 
-                # Parse both env files
+                # Parse both env files. Split on the FIRST '=' only (values
+                # like JWTs/base64 secrets and URLs carry their own '='), strip
+                # a trailing CR so CRLF files from Windows editors compare
+                # cleanly, and remove one matching pair of surrounding quotes
+                # like lib/safe-env.sh does. Mirrors safe-env.sh semantics.
                 declare -A env1 env2
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+                local line key value
+                while IFS= read -r line || [[ -n "$line" ]]; do
+                    line="${line%$'\r'}"
+                    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+                    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+                    [[ "$line" == *=* ]] || continue
+                    key="${line%%=*}"
+                    value="${line#*=}"
+                    key="${key#"${key%%[![:space:]]*}"}"
+                    key="${key%"${key##*[![:space:]]}"}"
                     [[ -z "$key" ]] && continue
+                    value="${value# }"
+                    if [[ "$value" == '"'*'"' ]]; then
+                        value="${value#\"}"
+                        value="${value%\"}"
+                    elif [[ "$value" == "'"*"'" ]]; then
+                        value="${value#\'}"
+                        value="${value%\'}"
+                    fi
                     env1["$key"]="$value"
                 done < "$dir1/env"
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+                while IFS= read -r line || [[ -n "$line" ]]; do
+                    line="${line%$'\r'}"
+                    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+                    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+                    [[ "$line" == *=* ]] || continue
+                    key="${line%%=*}"
+                    value="${line#*=}"
+                    key="${key#"${key%%[![:space:]]*}"}"
+                    key="${key%"${key##*[![:space:]]}"}"
                     [[ -z "$key" ]] && continue
+                    value="${value# }"
+                    if [[ "$value" == '"'*'"' ]]; then
+                        value="${value#\"}"
+                        value="${value%\"}"
+                    elif [[ "$value" == "'"*"'" ]]; then
+                        value="${value#\'}"
+                        value="${value%\'}"
+                    fi
                     env2["$key"]="$value"
                 done < "$dir2/env"
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3385,16 +3385,51 @@ META
                 # used (which missed _PASS, _SALT, email admin fields, etc.).
                 _cmd_config_load_secret_schema
 
-                # Parse both env files
+                # Parse both env files. Split on the FIRST '=' only (values
+                # like JWTs/base64 secrets and URLs carry their own '='), strip
+                # a trailing CR so CRLF files from Windows editors compare
+                # cleanly, and remove one matching pair of surrounding quotes
+                # like lib/safe-env.sh does. Mirrors safe-env.sh semantics.
                 declare -A env1 env2
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+                local line key value
+                while IFS= read -r line || [[ -n "$line" ]]; do
+                    line="${line%$'\r'}"
+                    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+                    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+                    [[ "$line" == *=* ]] || continue
+                    key="${line%%=*}"
+                    value="${line#*=}"
+                    key="${key#"${key%%[![:space:]]*}"}"
+                    key="${key%"${key##*[![:space:]]}"}"
                     [[ -z "$key" ]] && continue
+                    value="${value# }"
+                    if [[ "$value" == '"'*'"' ]]; then
+                        value="${value#\"}"
+                        value="${value%\"}"
+                    elif [[ "$value" == "'"*"'" ]]; then
+                        value="${value#\'}"
+                        value="${value%\'}"
+                    fi
                     env1["$key"]="$value"
                 done < "$dir1/env"
-                while IFS='=' read -r key value; do
-                    [[ "$key" =~ ^[[:space:]]*# ]] && continue
+                while IFS= read -r line || [[ -n "$line" ]]; do
+                    line="${line%$'\r'}"
+                    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+                    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+                    [[ "$line" == *=* ]] || continue
+                    key="${line%%=*}"
+                    value="${line#*=}"
+                    key="${key#"${key%%[![:space:]]*}"}"
+                    key="${key%"${key##*[![:space:]]}"}"
                     [[ -z "$key" ]] && continue
+                    value="${value# }"
+                    if [[ "$value" == '"'*'"' ]]; then
+                        value="${value#\"}"
+                        value="${value%\"}"
+                    elif [[ "$value" == "'"*"'" ]]; then
+                        value="${value#\'}"
+                        value="${value%\'}"
+                    fi
                     env2["$key"]="$value"
                 done < "$dir2/env"
 

--- a/ods/tests/test-preset-diff.sh
+++ b/ods/tests/test-preset-diff.sh
@@ -122,6 +122,56 @@ test_diff_masks_secrets() {
     fi
 }
 
+# Test 7: Diff preserves '=' inside values (JWT/base64 secrets, URLs)
+test_diff_preserves_equals_in_value() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-i" "$presets_dir/test-preset-j"
+    echo "JWT=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhPT1iIn0.signature" > "$presets_dir/test-preset-i/env"
+    echo "LLM_API_URL=http://localhost:8080/v1/?key=a%3Db&x=1" >> "$presets_dir/test-preset-i/env"
+    echo "JWT=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhPT1iIn0.changed" > "$presets_dir/test-preset-j/env"
+    echo "LLM_API_URL=http://localhost:8080/v1/?key=a%3Db&x=2" >> "$presets_dir/test-preset-j/env"
+
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-i test-preset-j 2>&1 || true)
+    if echo "$output" | grep -q "JWT" && echo "$output" | grep -q "LLM_API_URL"; then
+        pass "Diff detects differences in values containing '='"
+    else
+        fail "Diff should detect differences after the first '=' in values"
+    fi
+}
+
+# Test 8: Diff compares quoted values as their unquoted content
+test_diff_unquotes_values() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-k" "$presets_dir/test-preset-l"
+    echo "TOKEN=\"abc=def=ghi\"" > "$presets_dir/test-preset-k/env"
+    echo "TOKEN=\"abc=def=ghi\"" > "$presets_dir/test-preset-l/env"
+
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-k test-preset-l 2>&1 || true)
+    if echo "$output" | grep -q "no differences"; then
+        pass "Diff treats identically quoted values as equal"
+    else
+        fail "Diff should strip matching quotes before comparing"
+    fi
+}
+
+# Test 9: Diff tolerates CRLF env files (Windows editors)
+test_diff_crlf_env() {
+    local presets_dir="$ODS_DIR/presets"
+    mkdir -p "$presets_dir/test-preset-m" "$presets_dir/test-preset-n"
+    printf 'TIER=3\r\nMODEL=llama-3.1-8b\r\n' > "$presets_dir/test-preset-m/env"
+    printf 'TIER=3\r\nMODEL=llama-3.1-8b\r\n' > "$presets_dir/test-preset-n/env"
+
+    local output
+    output=$("$ODS_CLI" preset diff test-preset-m test-preset-n 2>&1 || true)
+    if echo "$output" | grep -q "no differences"; then
+        pass "Diff tolerates CRLF line endings"
+    else
+        fail "Diff should strip CR so identical CRLF env files compare equal"
+    fi
+}
+
 # Run tests
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Preset Diff Tests"
@@ -134,6 +184,9 @@ test_diff_identical
 test_diff_env_changes
 test_diff_service_changes
 test_diff_masks_secrets
+test_diff_preserves_equals_in_value
+test_diff_unquotes_values
+test_diff_crlf_env
 cleanup
 
 # Summary


### PR DESCRIPTION
## Summary

`ods preset diff` parsed each env line with `IFS='=' read -r key value`, which splits on EVERY equals sign. Values containing `=` (JWTs, base64 secrets, URLs with query strings) were truncated on both sides identically, so real differences after the first `=` were reported as "no difference" (a false negative). It also never stripped a trailing CR (unlike `lib/safe-env.sh`) or quotes.

The diff parser now splits on the FIRST `=` only (`${line%%=*}` / `${line#*=}`), strips a trailing CR so CRLF env files from Windows editors compare cleanly, trims key whitespace, and removes one matching pair of surrounding quotes — mirroring `safe-env.sh` semantics so the comparison reflects what the runtime actually loads.

Fixes #2297.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime

## Validation

- `bash tests/test-preset-diff.sh` - passed (9 passed, 0 failed).
- `git diff --check origin/main...HEAD` - passed.