### PR TITLE
fix(backup): accept multi-segment backup IDs in retention

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -138,17 +138,19 @@ ensure_backup_space() {
 # Collect backup entries (dirs or .tar.gz archives) under BACKUP_ROOT into
 # the global COLLECTED_BACKUPS array, newest first.
 #
-# Backup IDs are YYYYMMDD-HHMMSS (this script) or <prefix>-YYYYMMDD-HHMMSS
-# (dashboard/host-agent). Match that shape explicitly: retention deletes
-# whatever this collects, so an operator's unrelated files in the backup
-# directory must never qualify.
+# Backup IDs are YYYYMMDD-HHMMSS (this script) or <label>-YYYYMMDD-HHMMSS
+# where <label> may span multiple hyphen/underscore segments (dashboard/host
+# agent, e.g. dashboard-my-name-20260715-143022). The host-agent's
+# BACKUP_ID_RE allows [A-Za-z0-9_-]{0,63} labels, so match that shape while
+# still requiring the trailing timestamp so an operator's unrelated files in
+# the backup directory never qualify for retention deletes.
 COLLECTED_BACKUPS=()
 collect_backups() {
     COLLECTED_BACKUPS=()
     local entry base
     while IFS= read -r -d '' entry; do
         base=$(basename "$entry")
-        [[ "$base" =~ ^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
+        [[ "$base" =~ ^(([A-Za-z0-9_]+-)+)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
         COLLECTED_BACKUPS+=("$entry")
     done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
 }

--- a/ods/tests/test-backup-id-regex.sh
+++ b/ods/tests/test-backup-id-regex.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# ============================================================================
+# collect_backups backup-ID regex test
+# ============================================================================
+# Regression for issue #2299: collect_backups only accepted at most one
+# hyphenated prefix segment, so a user-named backup like
+# dashboard-my-name-20260715-143022 was invisible to list_backups and
+# apply_retention (though still deletable). The host-agent's BACKUP_ID_RE
+# permits [A-Za-z0-9_-]{0,63} labels, so the two sides disagreed.
+#
+# Strategy: extract the regex literal from ods-backup.sh (the script itself
+# needs rsync, so we don't source it) and assert it matches multi-segment
+# backup IDs while still rejecting operator files that don't carry the
+# trailing YYYYMMDD-HHMMSS timestamp.
+#
+# Usage: ./tests/test-backup-id-regex.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+# Pull the regex literal out of collect_backups so the test always reflects
+# the shipped pattern (no copy-paste drift).
+backup_id_re=$(sed -n 's/.*\[\[ "\$base" =~ \(.*\) \]\] || continue/\1/p' "$ROOT_DIR/ods-backup.sh")
+
+if [[ -z "$backup_id_re" ]]; then
+    echo -e "  ${RED}✗ FAIL${NC} could not extract backup-ID regex from ods-backup.sh"
+    exit 1
+fi
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   collect_backups backup-ID regex test        ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo "  regex: $backup_id_re"
+echo ""
+
+# Names that must match (backup dirs / archives this tool should manage).
+should_match=(
+    "20260715-143022"
+    "20260715-143022.tar.gz"
+    "dashboard-20260715-143022"
+    "dashboard-my-name-20260715-143022"
+    "dashboard-my-name-20260715-143022.tar.gz"
+    "my_name-backup-20260715-143022"
+    "a-b-c-20260715-143022"
+)
+
+# Names that must NOT match (operator files must never qualify for retention).
+should_reject=(
+    "notes.txt"
+    "my-file.txt"
+    "20260715"
+    "20260715-143022.zip"
+    "dashboard-my-name"
+    "dashboard-my-name-20260715"
+    ".bashrc"
+    "backup"
+    "readme"
+)
+
+for name in "${should_match[@]}"; do
+    if [[ "$name" =~ $backup_id_re ]]; then
+        pass "accepts multi-segment backup ID: $name"
+    else
+        fail "REJECTED backup ID that must match: $name"
+    fi
+done
+
+for name in "${should_reject[@]}"; do
+    if [[ "$name" =~ $backup_id_re ]]; then
+        fail "MATCHED operator file that must be excluded: $name"
+    else
+        pass "rejects non-backup file: $name"
+    fi
+done
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

`collect_backups` matched `^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}` which permits at most ONE hyphenated prefix segment, while the host-agent's `BACKUP_ID_RE` accepts `[A-Za-z0-9_-]{0,63}` labels. A user-named backup like `dashboard-my-name-20260715-143022` therefore landed in `BACKUP_ROOT` but was invisible to `list_backups`/`apply_retention` (though still deletable) — the two sides disagreed about which backups exist.

The label is now one or more hyphen/underscore segments before the required trailing `YYYYMMDD-HHMMSS` timestamp. The timestamp anchor is preserved so unrelated operator files in the backup directory still never qualify for retention deletes.

Fixes #2299.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime

## Validation

- `bash tests/test-backup-id-regex.sh` - passed (16 passed, 0 failed).
- `git diff --check origin/main...HEAD` - passed.