### PR TITLE
ci: scope GITHUB_TOKEN permissions across 10 workflows

### DIFF
--- a/.github/workflows/ai-issue-triage.yml
+++ b/.github/workflows/ai-issue-triage.yml
@@ -8,6 +8,12 @@ on:
   issues:
     types: [opened]
 
+# Least privilege by default. The triage job escalates to issues: write for
+# label application.
+permissions:
+  contents: read
+  issues: read
+
 concurrency:
   group: issue-triage-${{ github.event.issue.number }}
   cancel-in-progress: false

--- a/.github/workflows/autonomous-code-scanner.yml
+++ b/.github/workflows/autonomous-code-scanner.yml
@@ -19,6 +19,11 @@ on:
         type: boolean
         default: false
 
+# Least privilege by default: read-only contents for every job. The
+# create-prs job escalates to the write scopes it needs.
+permissions:
+  contents: read
+
 concurrency:
   group: autonomous-code-scanner
   cancel-in-progress: false
@@ -759,6 +764,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: read
     needs:
       - security-check
       - scan-formatting

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -8,6 +8,11 @@ on:
   issues:
     types: [labeled]
 
+# Least privilege by default: read-only contents for every job. Jobs that
+# create PRs or comment on issues escalate explicitly below.
+permissions:
+  contents: read
+
 concurrency:
   group: issue-to-pr-${{ github.event.issue.number }}
   cancel-in-progress: true
@@ -20,6 +25,9 @@ jobs:
     name: Validate Issue
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     if: >-
       github.event.label.name == 'ai-implement' &&
       github.event.issue.user.login != 'claude[bot]' &&
@@ -322,6 +330,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
     outputs:
       pr_number: ${{ steps.create.outputs.pull-request-number }}
       pr_url: ${{ steps.create.outputs.pull-request-url }}

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   powershell-lint:
     strategy:

--- a/.github/workflows/nightly-code-review.yml
+++ b/.github/workflows/nightly-code-review.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         default: false
 
+# Least privilege by default: read-only contents for every job. The PR
+# creation job escalates to write scopes explicitly.
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-code-review
   cancel-in-progress: false
@@ -27,6 +32,9 @@ jobs:
     name: Pre-flight Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_changes: ${{ steps.detect.outputs.has_changes }}
       skip: ${{ steps.dedup.outputs.skip }}
@@ -77,6 +85,8 @@ jobs:
     if: needs.preflight.outputs.has_changes == 'true' && needs.preflight.outputs.skip != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     outputs:
       has_improvements: ${{ steps.check-changes.outputs.has_improvements }}
 

--- a/.github/workflows/nightly-docs-update.yml
+++ b/.github/workflows/nightly-docs-update.yml
@@ -18,6 +18,11 @@ on:
         type: boolean
         default: false
 
+# Least privilege by default: read-only contents for every job. The PR
+# creation job escalates to write scopes explicitly.
+permissions:
+  contents: read
+
 concurrency:
   group: nightly-docs-update
   cancel-in-progress: false
@@ -27,6 +32,9 @@ jobs:
     name: Detect Doc-Affecting Changes
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       has_changes: ${{ steps.check.outputs.has_changes }}
       affected_docs: ${{ steps.check.outputs.affected_docs }}
@@ -162,6 +170,9 @@ jobs:
     if: needs.detect-changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -14,6 +14,11 @@ on:
         required: true
         type: string
 
+# Least privilege by default. The generate job escalates to contents: write
+# for `gh release edit` on the release body.
+permissions:
+  contents: read
+
 concurrency:
   group: release-notes
   cancel-in-progress: false

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   token-spy-postgres:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   env-schema:
     runs-on: ubuntu-latest

--- a/ods/tests/test-workflow-permissions.sh
+++ b/ods/tests/test-workflow-permissions.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# ============================================================================
+# Workflow least-privilege permissions test
+# ============================================================================
+# Regression for issue #2300: several .github/workflows/*.yml had no top-level
+# `permissions:` block, so GITHUB_TOKEN ran with repo-default (full write)
+# privileges on every job. This test enforces the least-privilege contract:
+#   - every workflow declares a top-level `permissions:` block, and
+#   - no workflow grants `write-all` (the "everything write" shorthand).
+#
+# Any job that needs write access must declare it at job level explicitly;
+# a blanket top-level write-all is never acceptable.
+#
+# Usage: ./tests/test-workflow-permissions.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOWS_DIR="$ROOT_DIR/../.github/workflows"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   Workflow least-privilege permissions test   ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+if [[ ! -d "$WORKFLOWS_DIR" ]]; then
+    fail ".github/workflows directory not found at $WORKFLOWS_DIR"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+
+shopt -s nullglob
+workflow_files=("$WORKFLOWS_DIR"/*.yml)
+shopt -u nullglob
+
+if [[ ${#workflow_files[@]} -eq 0 ]]; then
+    fail "no workflow YAML files found in $WORKFLOWS_DIR"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+pass "found ${#workflow_files[@]} workflow YAML files"
+
+for wf in "${workflow_files[@]}"; do
+    name="$(basename "$wf")"
+    if grep -q '^permissions:' "$wf"; then
+        pass "$name declares a top-level permissions block"
+    else
+        fail "$name is missing a top-level permissions block (GITHUB_TOKEN runs with default privileges)"
+    fi
+
+    if grep -q '^permissions: *write-all' "$wf"; then
+        fail "$name grants write-all at the top level"
+    else
+        pass "$name does not grant write-all at the top level"
+    fi
+done
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Ten workflows (dashboard, issue-to-pr, lint-powershell, nightly-docs-update, nightly-code-review, ai-issue-triage, autonomous-code-scanner, release-notes, test-linux, validate-env) had no `permissions:` block, so `GITHUB_TOKEN` ran with repo-default privileges on every job. The workflows that genuinely need write access (issue-to-pr's create-pr, nightly-docs-update's update-and-create-pr) were doing so without declaring it, and everything else carried needless write power.

Each workflow now gets a least-privilege top-level default of `contents: read`, with explicit per-job escalation only where a step actually needs it: `pull-requests: read` for `gh pr list` dedup checks, and `contents`/`pull-requests` write (plus `issues: write` and `actions: read` for the scanner's issue-creation and workflow-run queries) on the PR-creation jobs. Jobs that already had a job-level `permissions:` block are behaviorally unchanged — the diff only narrows the token for everything else.

Fixes #2300.

## AI Assistance

AI-assisted permissions audit of all ten workflows against their step-level GITHUB_TOKEN usage. The author reviewed the scoping, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [x] CI

## Validation

- All 10 workflow files parse as valid YAML (PyYAML safe_load) - passed.
- Every workflow now declares a top-level `permissions:` block with least-privilege scopes.
- `bash tests/test-workflow-permissions.sh` - passed (39 passed, 0 failed). Enforces that all 19 workflows carry a top-level `permissions:` block and that none grants `write-all`.
- `git diff --check origin/main...HEAD` - passed.