### PR TITLE
fix(setup): guard rm -rf against unvalidated install dir

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -65,8 +65,59 @@ format_git_clone_error() {
 }
 
 
+_ods_install_has_marker() {
+    local dir="$1"
+    local marker=""
+
+    for marker in .env docker-compose.base.yml ods-cli install.sh .ods-install; do
+        [[ -e "$dir/$marker" ]] && return 0
+    done
+    return 1
+}
+
+# Hard refusal before any `rm -rf -- "$target_dir"`. ODS_INSTALL_DIR comes from
+# the environment verbatim; a typo like `ODS_INSTALL_DIR=~` or `/` must never be
+# passed to rm -rf. Removal is only allowed for a genuine ODS marker directory
+# that resolves strictly inside $HOME (the default is $HOME/ods). Exits on any
+# violation, so it cannot be bypassed by --force.
+assert_safe_install_dir() {
+    local target_dir="$1"
+    local resolved=""
+    local home_real=""
+    local home_parent=""
+    local base=""
+
+    resolved="$(cd "$target_dir" && pwd -P 2>/dev/null)" || {
+        error "Refusing to remove $target_dir: cannot resolve its absolute path."
+    }
+    home_real="$(cd "$HOME" && pwd -P 2>/dev/null)" || {
+        error "Refusing to remove $target_dir: cannot resolve \$HOME ($HOME)."
+    }
+    home_real="${home_real%/}"
+    home_parent="${home_real%/*}"
+
+    [[ "$resolved" != "/" ]] \
+        || error "Refusing to remove / — refusing to run rm -rf on the filesystem root."
+    [[ "$resolved" != "$home_real" ]] \
+        || error "Refusing to remove $home_real — that is \$HOME itself."
+    [[ -z "$home_parent" || "$resolved" != "$home_parent" ]] \
+        || error "Refusing to remove $home_parent — that is the parent of \$HOME."
+    [[ "$resolved" == "$home_real"/* ]] \
+        || error "Refusing to remove $target_dir — resolved path $resolved is not inside \$HOME ($home_real)."
+
+    base="${resolved##*/}"
+    [[ "$base" == *ods* ]] \
+        || error "Refusing to remove $target_dir — '$base' does not look like an ODS install directory."
+
+    _ods_install_has_marker "$resolved" \
+        || error "Refusing to remove $target_dir — no ODS marker files found (.env, docker-compose.base.yml, ods-cli, install.sh, or .ods-install); this is not an incomplete ODS install."
+}
+
 remove_install_dir() {
     local target_dir="$1"
+
+    [[ -d "$target_dir" ]] || return 0
+    assert_safe_install_dir "$target_dir"
 
     if rm -rf -- "$target_dir" 2>/dev/null; then
         return 0
@@ -376,6 +427,7 @@ if [[ -d "$INSTALL_DIR" ]]; then
         echo ""
         if [[ "$BOOTSTRAP_FORCE" == "true" ]]; then
             echo "  Removing incomplete install because --force was provided."
+            assert_safe_install_dir "$INSTALL_DIR"
             remove_install_dir "$INSTALL_DIR" || error "Failed to remove incomplete install at $INSTALL_DIR. Try: sudo rm -rf \"$INSTALL_DIR\""
         elif [[ "$BOOTSTRAP_NON_INTERACTIVE" == "true" ]]; then
             echo "  Aborting. Re-run with --force to remove it automatically, or remove manually with: rm -rf $INSTALL_DIR"

--- a/ods/tests/test-get-ods-install-guard.sh
+++ b/ods/tests/test-get-ods-install-guard.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# ============================================================================
+# get-ods.sh install-dir removal guard test
+# ============================================================================
+# Regression for issue #2301: get-ods.sh removed an incomplete install with
+# `rm -rf -- "$INSTALL_DIR"` where INSTALL_DIR comes from the environment
+# verbatim. A typo like ODS_INSTALL_DIR=/ or an empty value resolved to the
+# filesystem root or $HOME, and --force would destroy it unvalidated.
+#
+# assert_safe_install_dir must refuse:
+#   - the filesystem root (/)
+#   - $HOME itself
+#   - the parent of $HOME
+#   - any path that resolves outside $HOME
+#   - a directory whose basename does not contain "ods"
+#   - an *ods*-named directory with no ODS marker files
+# and must accept a genuine ODS install dir (marker file present) inside $HOME.
+#
+# Strategy: extract the two guard functions verbatim from get-ods.sh so the
+# test always reflects the shipped logic, then exercise them against a fake
+# HOME with error() stubbed to record the refusal message.
+#
+# Usage: ./tests/test-get-ods-install-guard.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+GET_ODS="$ROOT_DIR/get-ods.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   get-ods.sh install-dir removal guard test   ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+if [[ ! -f "$GET_ODS" ]]; then
+    fail "get-ods.sh not found at $GET_ODS"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+
+# Extract _ods_install_has_marker and assert_safe_install_dir verbatim (from
+# the _ods_install_has_marker definition up to, but not including,
+# remove_install_dir).
+FUNCS="$(
+    awk '
+        /^_ods_install_has_marker\(\) \{/ { in_funcs=1 }
+        in_funcs && /^remove_install_dir\(\) \{/ { exit }
+        in_funcs { print }
+    ' "$GET_ODS"
+)"
+if [[ -z "$FUNCS" ]]; then
+    fail "could not extract guard functions from get-ods.sh"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+pass "extracted guard functions from get-ods.sh"
+
+# Stub error() to record the refusal and abort, then exercise the guard.
+run_guard() {
+    local target="$1"
+    local home="$2"
+    HOME="$home" TARGET="$target" LAST_ERROR="" bash -c '
+        set -euo pipefail
+        error() { LAST_ERROR="$1"; echo "REFUSED: $1"; exit 1; }
+        '"$FUNCS"'
+        if assert_safe_install_dir "$TARGET" 2>/dev/null; then
+            echo "ACCEPTED"
+        else
+            echo "REFUSED"
+        fi
+    ' || true
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+FAKE_HOME="$TMP/home/user"
+mkdir -p "$FAKE_HOME"
+
+# A genuine ODS install dir: *ods* basename + a marker file.
+GOOD_ODS="$FAKE_HOME/ods"
+mkdir -p "$GOOD_ODS"
+touch "$GOOD_ODS/.env"
+
+# An *ods*-named dir with no markers (incomplete/foreign install).
+EMPTY_ODS="$FAKE_HOME/someods"
+mkdir -p "$EMPTY_ODS"
+
+# An ods-looking dir that is actually a file (marker check requires -e, which
+# matches files too, but assert_safe_install_dir resolves with pwd -P; keep a
+# real dir without markers for the marker-negative case above and test a file
+# only for the basename check separately).
+NON_ODS_DIR="$FAKE_HOME/sandbox"
+mkdir -p "$NON_ODS_DIR"
+
+OUTSIDE="$TMP/outside"
+mkdir -p "$OUTSIDE"
+
+# --- 1. Accept a genuine ODS install dir inside HOME ------------------------
+out="$(run_guard "$GOOD_ODS" "$FAKE_HOME")"
+if [[ "$out" == "ACCEPTED" ]]; then
+    pass "accepts a genuine ODS install dir inside HOME"
+else
+    fail "should accept a genuine ODS install dir (got: $out)"
+fi
+
+# --- 2. Refuse the filesystem root ------------------------------------------
+out="$(run_guard "/" "$FAKE_HOME")"
+if [[ "$out" == "REFUSED"* ]]; then
+    pass "refuses the filesystem root (/)"
+else
+    fail "must refuse the filesystem root (got: $out)"
+fi
+
+# --- 3. Refuse $HOME itself ---------------------------------------------------
+out="$(run_guard "$FAKE_HOME" "$FAKE_HOME")"
+if [[ "$out" == "REFUSED"* ]]; then
+    pass "refuses \$HOME itself"
+else
+    fail "must refuse \$HOME itself (got: $out)"
+fi
+
+# --- 4. Refuse the parent of $HOME -------------------------------------------
+out="$(run_guard "$TMP/home" "$FAKE_HOME")"
+if [[ "$out" == "REFUSED"* ]]; then
+    pass "refuses the parent of \$HOME"
+else
+    fail "must refuse the parent of \$HOME (got: $out)"
+fi
+
+# --- 5. Refuse a path outside $HOME -------------------------------------------
+out="$(run_guard "$OUTSIDE" "$FAKE_HOME")"
+if [[ "$out" == "REFUSED"* ]]; then
+    pass "refuses a resolved path outside \$HOME"
+else
+    fail "must refuse a path outside \$HOME (got: $out)"
+fi
+
+# --- 6. Refuse an *ods* dir with no marker files ------------------------------
+out="$(run_guard "$EMPTY_ODS" "$FAKE_HOME")"
+if [[ "$out" == "REFUSED"* ]]; then
+    pass "refuses an *ods* directory with no ODS marker files"
+else
+    fail "must refuse a marker-less *ods* directory (got: $out)"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

`get-ods.sh` removed an incomplete install with `rm -rf -- "$INSTALL_DIR"`, where `INSTALL_DIR` comes from the environment (`ODS_INSTALL_DIR`) verbatim. A typo like `ODS_INSTALL_DIR=/` or an empty value resolved to the filesystem root or `$HOME`, and `--force` would destroy it with no validation whatsoever.

Removal is now gated by `assert_safe_install_dir`, which runs before any `rm -rf` (both inside `remove_install_dir` and on the explicit `--force` path): it resolves the absolute path, refuses `/`, `$HOME`, and `$HOME`'s parent, requires the target to resolve strictly inside `$HOME`, requires an `*ods*` basename, and requires an ODS marker file (`.env`, `docker-compose.base.yml`, `ods-cli`, `install.sh`, or `.ods-install`). Any violation aborts the script rather than being bypassable by `--force`.

Fixes #2301.

## AI Assistance

AI-assisted edge-case enumeration of resolvable paths (/, $HOME, $HOME parent, symlinks, marker files). The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [ ] Core runtime

## Validation

- `bash -n ods/get-ods.sh` - passed.
- Manual trace of `assert_safe_install_dir` against `/`, `$HOME`, `$HOME/*`, and marker-less directories - all abort as expected.
- `bash tests/test-get-ods-install-guard.sh` - passed (7 passed, 0 failed). Sources the guard verbatim from get-ods.sh and verifies it accepts a genuine ODS install dir while refusing `/`, `$HOME`, `$HOME`'s parent, outside-`$HOME` paths, and marker-less `*ods*` directories.
- `git diff --check origin/main...HEAD` - passed.