### PR TITLE
fix(embeddings): make platform arch configurable

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -448,6 +448,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # RAG_OPENAI_API_KEY=              # only for authenticated external providers
 # Larger models such as BAAI/bge-m3 may need a higher container memory limit.
 # EMBEDDINGS_MEMORY_LIMIT=4G
+# TEI ships x86_64-only images by default. Override the Docker platform on native
+# arm64 hosts (Apple Silicon, Raspberry Pi, AWS Graviton).
+# EMBEDDINGS_PLATFORM=linux/amd64
 
 # Image generation (ComfyUI + SDXL Lightning)
 # ENABLE_IMAGE_GENERATION=true

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -454,6 +454,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # RAG_OPENAI_API_KEY=              # only for authenticated external providers
 # Larger models such as BAAI/bge-m3 may need a higher container memory limit.
 # EMBEDDINGS_MEMORY_LIMIT=4G
+# TEI ships x86_64-only images by default. Override the Docker platform on native
+# arm64 hosts (Apple Silicon, Raspberry Pi, AWS Graviton).
+# EMBEDDINGS_PLATFORM=linux/amd64
 
 # Image generation (ComfyUI + SDXL Lightning)
 # ENABLE_IMAGE_GENERATION=true

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -860,6 +860,11 @@
       "default": "4G",
       "pattern": "^[1-9][0-9]*([bBkKmMgG]|[kKmMgG][bB])?$"
     },
+    "EMBEDDINGS_PLATFORM": {
+      "type": "string",
+      "description": "Docker platform for the bundled TEI embeddings service. TEI ships x86-only images, so the default is linux/amd64. On native arm64 hosts (Apple Silicon, Raspberry Pi, AWS Graviton) set this to linux/arm64 or use an image tag that publishes an arm64 build.",
+      "default": "linux/amd64"
+    },
     "EMBEDDING_URL": {
       "type": "string",
       "description": "Embedding service URL used by dashboard-api functional diagnostics. Leave empty for the bundled embeddings service."

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -861,6 +861,11 @@
       "default": "4G",
       "pattern": "^[1-9][0-9]*([bBkKmMgG]|[kKmMgG][bB])?$"
     },
+    "EMBEDDINGS_PLATFORM": {
+      "type": "string",
+      "description": "Docker platform for the bundled TEI embeddings service. TEI ships x86-only images, so the default is linux/amd64. On native arm64 hosts (Apple Silicon, Raspberry Pi, AWS Graviton) set this to linux/arm64 or use an image tag that publishes an arm64 build.",
+      "default": "linux/amd64"
+    },
     "EMBEDDING_URL": {
       "type": "string",
       "description": "Embedding service URL used by dashboard-api functional diagnostics. Leave empty for the bundled embeddings service."

--- a/ods/extensions/services/embeddings/compose.yaml
+++ b/ods/extensions/services/embeddings/compose.yaml
@@ -1,7 +1,7 @@
 services:
   embeddings:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1
-    platform: linux/amd64  # TEI has no arm64 image -- Rosetta 2 on Apple Silicon
+    platform: ${EMBEDDINGS_PLATFORM:-linux/amd64}  # TEI ships x86-only images; on native arm64 hosts (Apple Silicon, Raspberry Pi, Graviton) set EMBEDDINGS_PLATFORM=linux/arm64 or use an image with an arm64 tag
     container_name: ods-embeddings
     restart: unless-stopped
     security_opt:

--- a/ods/tests/test-embeddings-platform.sh
+++ b/ods/tests/test-embeddings-platform.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# ============================================================================
+# Embeddings platform configurability test
+# ============================================================================
+# Regression for issue #2302: the bundled TEI embeddings service pinned
+# `platform: linux/amd64`, forcing native arm64 hosts (Apple Silicon,
+# Raspberry Pi, AWS Graviton) through slow QEMU emulation. The platform is now
+# driven by EMBEDDINGS_PLATFORM (default linux/amd64) and registered in
+# .env.schema.json + .env.example so validate-env CI stays green.
+#
+# Checks:
+#   - compose.yaml reads platform from ${EMBEDDINGS_PLATFORM:-linux/amd64}
+#   - .env.schema.json declares EMBEDDINGS_PLATFORM with the same default
+#   - .env.example documents the variable
+#   - (optional) docker compose config honors EMBEDDINGS_PLATFORM override
+#
+# Usage: ./tests/test-embeddings-platform.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE="$ROOT_DIR/extensions/services/embeddings/compose.yaml"
+SCHEMA="$ROOT_DIR/.env.schema.json"
+ENV_EXAMPLE="$ROOT_DIR/.env.example"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+skip() { echo -e "  ${YELLOW}⊘ SKIP${NC} $1"; }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   Embeddings platform configurability test    ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+for f in "$COMPOSE" "$SCHEMA" "$ENV_EXAMPLE"; do
+    if [[ ! -f "$f" ]]; then
+        fail "missing file: $f"
+        echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+    fi
+done
+pass "compose.yaml, .env.schema.json and .env.example all exist"
+
+# --- 1. compose.yaml reads platform from EMBEDDINGS_PLATFORM -----------------
+if grep -q 'platform: ${EMBEDDINGS_PLATFORM:-linux/amd64}' "$COMPOSE"; then
+    pass "compose.yaml platform is driven by \${EMBEDDINGS_PLATFORM:-linux/amd64}"
+else
+    fail "compose.yaml must interpolate platform from \${EMBEDDINGS_PLATFORM:-linux/amd64}"
+fi
+
+if grep -q 'platform: linux/amd64  #' "$COMPOSE"; then
+    fail "compose.yaml still hardcodes platform: linux/amd64"
+else
+    pass "compose.yaml no longer hardcodes the x86 platform"
+fi
+
+# --- 2. .env.schema.json declares EMBEDDINGS_PLATFORM ------------------------
+if python3 -c '
+import json, sys
+schema = json.load(open(sys.argv[1]))
+prop = schema.get("properties", {}).get("EMBEDDINGS_PLATFORM")
+if not prop:
+    sys.exit(1)
+assert prop.get("type") == "string", "type must be string"
+assert prop.get("default") == "linux/amd64", "default must be linux/amd64"
+print(prop.get("description", ""))
+' "$SCHEMA" > /dev/null 2>&1; then
+    pass ".env.schema.json declares EMBEDDINGS_PLATFORM (string, default linux/amd64)"
+else
+    fail ".env.schema.json must declare EMBEDDINGS_PLATFORM with type string and default linux/amd64"
+fi
+
+# --- 3. .env.example documents the variable ----------------------------------
+if grep -q 'EMBEDDINGS_PLATFORM=linux/amd64' "$ENV_EXAMPLE"; then
+    pass ".env.example documents EMBEDDINGS_PLATFORM with its default"
+else
+    fail ".env.example should document EMBEDDINGS_PLATFORM=linux/amd64"
+fi
+
+# --- 4. Behavioral (optional): docker compose config honors the override -----
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    cd "$ROOT_DIR"
+    rendered="$(EMBEDDINGS_PLATFORM=linux/arm64 docker compose \
+        -f extensions/services/embeddings/compose.yaml config 2>/dev/null)"
+    platform_line="$(printf '%s\n' "$rendered" | grep 'platform:')"
+    if [[ "$platform_line" == *"linux/arm64"* ]]; then
+        pass "docker compose config renders EMBEDDINGS_PLATFORM=linux/arm64"
+    elif [[ "$platform_line" == *"linux/amd64"* ]]; then
+        fail "docker compose config ignored the EMBEDDINGS_PLATFORM override"
+    else
+        skip "docker compose config output did not include a platform line"
+    fi
+else
+    skip "Docker Compose unavailable; behavioral render skipped"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

The bundled TEI embeddings service pinned `platform: linux/amd64`, so native arm64 hosts (Apple Silicon, Raspberry Pi, AWS Graviton) were forced through slow QEMU emulation — embeddings stayed on an x86 image even when the model files were arm64-native.

The platform is now driven by `EMBEDDINGS_PLATFORM` (default `linux/amd64`), so arm64 hosts can opt out of emulation with `EMBEDDINGS_PLATFORM=linux/arm64`. The variable is registered in `.env.schema.json` and `.env.example` so `validate-env` CI keeps passing.

Fixes #2302.

## AI Assistance

AI-assisted root-cause analysis and env-key registration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime

## Validation

- `bash tests/test-validate-env.sh` - passed (43 passed, 0 failed).
- `.env.schema.json` parses as valid JSON.
- `bash tests/test-embeddings-platform.sh` - passed (6 passed, 0 failed). Verifies the compose platform reads from `EMBEDDINGS_PLATFORM` (default `linux/amd64`), the schema/default registration, and that `docker compose config` honors a `linux/arm64` override.
- `git diff --check origin/main...HEAD` - passed.