### PR TITLE
fix(hermes): resolve Hermes/n8n UID/GID to the host user

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -8,6 +8,13 @@
 # ODS version (auto-set by installer, used by ods-cli for compat checks)
 # ODS_VERSION=2.6.0
 
+# Host user/group ids passed to Docker Compose. Non-readonly substitutes for
+# the shell-only UID/GID vars so Hermes and n8n containers run as the host
+# user instead of a fixed default. The installer auto-resolves these to the
+# host user; set them explicitly only to override.
+# ODS_UID=1000
+# ODS_GID=1000
+
 # LiteLLM proxy API key for internal service auth
 # TARGET_API_KEY=not-needed
 
@@ -80,6 +87,16 @@ ODS_MODE=local
 # Model Switchboard rollout: legacy / observe / enabled.
 # enabled routes supported apps through the stable ods/current alias.
 ODS_MODEL_SWITCHBOARD=observe
+
+# ═══════════════════════════════════════════════════════════════════
+# Host user remapping
+# ═══════════════════════════════════════════════════════════════════
+# Non-readonly substitutes for the shell-only UID/GID vars so Docker
+# Compose can run containers (n8n `user:`, Hermes HERMES_UID/GID) as the
+# host user. Set at install time from `id -u` / `id -g`; edit only if the
+# container data owner must differ from the installing user.
+# ODS_UID=1000
+# ODS_GID=1000
 
 # Inference backend engine: llama-server (NVIDIA/CPU), lemonade (AMD),
 # litellm (cloud), or external (installer-validated Ollama/LM Studio)

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -16,6 +16,18 @@
       "type": "string",
       "description": "ODS version for update compatibility checks"
     },
+    "ODS_UID": {
+      "type": "integer",
+      "minimum": 0,
+      "default": "1000",
+      "description": "Host user ID used by Docker Compose for n8n `user:` and Hermes HERMES_UID so container data is owned by the host user. Set at install time from `id -u`; empty falls back to 1000/10000."
+    },
+    "ODS_GID": {
+      "type": "integer",
+      "minimum": 0,
+      "default": "1000",
+      "description": "Host group ID used by Docker Compose for n8n `user:` and Hermes HERMES_GID so container data is owned by the host group. Set at install time from `id -g`; empty falls back to 1000/10000."
+    },
     "ODS_MODE": {
       "type": "string",
       "description": "LLM backend mode: local, cloud, hybrid, or lemonade (AMD)",
@@ -380,6 +392,14 @@
     "HOST_LAN_IP": {
       "type": "string",
       "description": "Host machine's LAN IP, written by the installer when BIND_ADDRESS=0.0.0.0 so containers can announce the LAN address (e.g., openclaw allowedOrigins). Empty when binding only to localhost."
+    },
+    "ODS_UID": {
+      "type": "integer",
+      "description": "Host user id exported to Docker Compose. Non-readonly substitute for the shell-only UID var; resolves Hermes/ n8n containers to the host user instead of the fixed default. Falls back to $(id -u) when absent."
+    },
+    "ODS_GID": {
+      "type": "integer",
+      "description": "Host group id exported to Docker Compose. Non-readonly substitute for the shell-only GID var; resolves Hermes/ n8n containers to the host group instead of a fixed default. Falls back to $(id -g) when absent."
     },
     "GGUF_FILE": {
       "type": "string",

--- a/ods/extensions/services/hermes/compose.yaml
+++ b/ods/extensions/services/hermes/compose.yaml
@@ -15,8 +15,8 @@ services:
     environment:
       # User remapping: match the host user so files written into the volume
       # are owned by the user, not container-root. Same pattern as n8n.
-      - HERMES_UID=${UID:-10000}
-      - HERMES_GID=${GID:-10000}
+      - HERMES_UID=${ODS_UID:-10000}
+      - HERMES_GID=${ODS_GID:-10000}
       # Point Hermes at the local LLM. provider=custom is the documented
       # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
       # The actual provider/model wiring lives in cli-config.yaml (mounted below).

--- a/ods/extensions/services/n8n/compose.yaml
+++ b/ods/extensions/services/n8n/compose.yaml
@@ -3,7 +3,7 @@ services:
     image: n8nio/n8n:2.6.4
     container_name: ods-n8n
     restart: unless-stopped
-    user: "${UID:-1000}:${GID:-1000}"
+    user: "${ODS_UID:-1000}:${ODS_GID:-1000}"
     security_opt:
       - no-new-privileges:true
     entrypoint: ["tini", "--", "/bin/sh", "/opt/ods/n8n-entrypoint.sh"]

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -60,6 +60,17 @@ else
         esac
     fi
 
+    # Export the host user's uid/gid under non-readonly names. Bash exposes
+    # UID/GID as readonly shell variables that are never exported into the
+    # process environment, so Docker Compose (which interpolates ${...} from
+    # the environment, not shell state) always saw them empty and fell back to
+    # the compose defaults — leaving ./data/hermes and ./data/n8n owned by
+    # 10000/1000 instead of the host user. ODS_UID/ODS_GID are real exported
+    # vars (override-able) that both the generated .env and every `user:`
+    # / HERMES_UID/GID interpolation below agree on.
+    export ODS_UID="${ODS_UID:-$(id -u)}"
+    export ODS_GID="${ODS_GID:-$(id -g)}"
+
     # Create directories
     _phase06_step "create-directories"
     ods_progress 38 "directories" "Creating directory structure"
@@ -69,15 +80,16 @@ else
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
-    # Hermes runs its gateway/dashboard as the in-container `hermes` user
-    # (uid 10000) and keeps HERMES_HOME at data/hermes mounted as /opt/data.
-    # Upstream intentionally makes that directory 0700. A reinstall running
-    # as the host user must not "repair" it back to uid 1000, or Hermes's web
-    # status and ODS Talk JSON-RPC paths fail with PermissionError.
+    # Hermes runs its gateway/dashboard as the resolved host user (ODS_UID)
+    # and keeps HERMES_HOME at data/hermes mounted as /opt/data. Matches the
+    # host user (same remap as n8n's `user:`) so files written into the volume
+    # are owned by the host user rather than a hardcoded uid 10000. A reinstall
+    # must not leave stale ownership from an earlier uid-10000 install behind,
+    # or Hermes's web status and ODS Talk JSON-RPC paths fail with PermissionError.
     if ! $_phase06_rootless \
         && [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
-        sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
-            warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
+        sudo chown -R "${ODS_UID:-10000}:${ODS_GID:-10000}" "$INSTALL_DIR/data/hermes" 2>/dev/null || \
+            warn "Failed to restore data/hermes ownership to Hermes uid ${ODS_UID:-10000} (Hermes dashboard may be unhealthy)"
         sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
     fi
 
@@ -740,11 +752,17 @@ raise SystemExit(1)' 2>/dev/null && return 0
     # Generate .env file
     # Subshell-scope a tighter umask so the file is created 0600 from the start
     # (closes a brief window on systems where $HOME is world-readable, e.g.
-    # Ubuntu defaults). The umask MUST NOT leak to the rest of phase 06 or
-    # subsequent phases — later mkdirs create container-bind-mount dirs that
-    # need world-traverse (e.g. SearXNG runs as uid 977, OpenClaw as 1000).
-    # The chmod 600 below is belt-and-braces.
-    (
+# Ubuntu defaults). The umask MUST NOT leak to the rest of phase 06 or
+     # subsequent phases — later mkdirs create container-bind-mount dirs that
+     # need world-traverse (e.g. SearXNG runs as uid 977, OpenClaw as 1000).
+     # The chmod 600 below is belt-and-braces.
+     # Resolve the host UID/GID before writing .env. ODS_UID/ODS_GID below are
+     # read by Docker Compose (n8n `user:`, Hermes HERMES_UID/HERMES_GID); these
+     # must hold real numeric values, so fall back to the effective host ids
+     # (ID_UID/ID_GID are shell read-only vars that never reach Compose's env).
+     ODS_UID="${ODS_UID:-$(id -u)}"
+     ODS_GID="${ODS_GID:-$(id -g)}"
+     (
         umask 077
         cat > "$INSTALL_DIR/.env" << ENV_EOF
 # ODS Configuration — ${TIER_NAME} Edition
@@ -753,6 +771,13 @@ raise SystemExit(1)' 2>/dev/null && return 0
 
 #=== ODS Version (used by ods-cli update for version-compat checks) ===
 ODS_VERSION=${VERSION:-2.6.0}
+
+#=== Host user remapping (used by Docker Compose) ===
+# Non-readonly substitutes for the shell-only UID/GID vars. Compose honors
+# these in `user:` (n8n) and HERMES_UID/HERMES_GID so containers run as the
+# host user instead of silently dropping to a fixed default uid/gid.
+ODS_UID=${ODS_UID}
+ODS_GID=${ODS_GID}
 
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -63,6 +63,17 @@ else
         esac
     fi
 
+    # Export the host user's uid/gid under non-readonly names. Bash exposes
+    # UID/GID as readonly shell variables that are never exported into the
+    # process environment, so Docker Compose (which interpolates ${...} from
+    # the environment, not shell state) always saw them empty and fell back to
+    # the compose defaults — leaving ./data/hermes and ./data/n8n owned by
+    # 10000/1000 instead of the host user. ODS_UID/ODS_GID are real exported
+    # vars (override-able) that both the generated .env and every `user:`
+    # / HERMES_UID/GID interpolation below agree on.
+    export ODS_UID="${ODS_UID:-$(id -u)}"
+    export ODS_GID="${ODS_GID:-$(id -g)}"
+
     # Create directories
     _phase06_step "create-directories"
     ods_progress 38 "directories" "Creating directory structure"
@@ -72,15 +83,16 @@ else
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
-    # Hermes runs its gateway/dashboard as the in-container `hermes` user
-    # (uid 10000) and keeps HERMES_HOME at data/hermes mounted as /opt/data.
-    # Upstream intentionally makes that directory 0700. A reinstall running
-    # as the host user must not "repair" it back to uid 1000, or Hermes's web
-    # status and ODS Talk JSON-RPC paths fail with PermissionError.
+    # Hermes runs its gateway/dashboard as the resolved host user (ODS_UID)
+    # and keeps HERMES_HOME at data/hermes mounted as /opt/data. Matches the
+    # host user (same remap as n8n's `user:`) so files written into the volume
+    # are owned by the host user rather than a hardcoded uid 10000. A reinstall
+    # must not leave stale ownership from an earlier uid-10000 install behind,
+    # or Hermes's web status and ODS Talk JSON-RPC paths fail with PermissionError.
     if ! $_phase06_rootless \
         && [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
-        sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
-            warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
+        sudo chown -R "${ODS_UID:-10000}:${ODS_GID:-10000}" "$INSTALL_DIR/data/hermes" 2>/dev/null || \
+            warn "Failed to restore data/hermes ownership to Hermes uid ${ODS_UID:-10000} (Hermes dashboard may be unhealthy)"
         sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
     fi
 
@@ -758,11 +770,17 @@ raise SystemExit(1)' 2>/dev/null && return 0
     # Generate .env file
     # Subshell-scope a tighter umask so the file is created 0600 from the start
     # (closes a brief window on systems where $HOME is world-readable, e.g.
-    # Ubuntu defaults). The umask MUST NOT leak to the rest of phase 06 or
-    # subsequent phases — later mkdirs create container-bind-mount dirs that
-    # need world-traverse (e.g. SearXNG runs as uid 977, OpenClaw as 1000).
-    # The chmod 600 below is belt-and-braces.
-    (
+# Ubuntu defaults). The umask MUST NOT leak to the rest of phase 06 or
+     # subsequent phases — later mkdirs create container-bind-mount dirs that
+     # need world-traverse (e.g. SearXNG runs as uid 977, OpenClaw as 1000).
+     # The chmod 600 below is belt-and-braces.
+     # Resolve the host UID/GID before writing .env. ODS_UID/ODS_GID below are
+     # read by Docker Compose (n8n `user:`, Hermes HERMES_UID/HERMES_GID); these
+     # must hold real numeric values, so fall back to the effective host ids
+     # (ID_UID/ID_GID are shell read-only vars that never reach Compose's env).
+     ODS_UID="${ODS_UID:-$(id -u)}"
+     ODS_GID="${ODS_GID:-$(id -g)}"
+     (
         umask 077
         cat > "$INSTALL_DIR/.env" << ENV_EOF
 # ODS Configuration — ${TIER_NAME} Edition
@@ -771,6 +789,13 @@ raise SystemExit(1)' 2>/dev/null && return 0
 
 #=== ODS Version (used by ods-cli update for version-compat checks) ===
 ODS_VERSION=${VERSION:-2.6.0}
+
+#=== Host user remapping (used by Docker Compose) ===
+# Non-readonly substitutes for the shell-only UID/GID vars. Compose honors
+# these in `user:` (n8n) and HERMES_UID/HERMES_GID so containers run as the
+# host user instead of silently dropping to a fixed default uid/gid.
+ODS_UID=${ODS_UID}
+ODS_GID=${ODS_GID}
 
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)

--- a/ods/tests/test-hermes-data-ownership.sh
+++ b/ods/tests/test-hermes-data-ownership.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Regression guard: Linux reinstall must not chown Hermes HERMES_HOME back to
-# the host user. Hermes's dashboard/Talk path runs as uid 10000 and needs
-# data/hermes mounted as /opt/data with that owner.
+# Regression guard: Hermes HERMES_HOME must be owned by the resolved host
+# user (ODS_UID), never a hardcoded uid 10000 nor a reinstall left-over from
+# an older uid-10000 install. Hermes's dashboard/Talk path runs as ODS_UID
+# with /opt/data mounted from data/hermes.
 
 set -euo pipefail
 
@@ -13,8 +14,8 @@ fail() {
     exit 1
 }
 
-grep -Fq 'sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes"' "$PHASE06" \
-    || fail "phase 06 must restore data/hermes to Hermes uid 10000"
+grep -Fq 'sudo chown -R "${ODS_UID:-10000}:${ODS_GID:-10000}" "$INSTALL_DIR/data/hermes"' "$PHASE06" \
+    || fail "phase 06 must restore data/hermes to the resolved Hermes host uid (ODS_UID)"
 
 grep -Fq 'sudo chmod 700 "$INSTALL_DIR/data/hermes"' "$PHASE06" \
     || fail "phase 06 must preserve Hermes private HERMES_HOME mode"


### PR DESCRIPTION
## Summary

Hermes and n8n compose files interpolated `${UID:-...}` / `${GID:-...}`. Bash exposes `UID`/`GID` as **readonly shell variables that are never exported into the process environment**, so Docker Compose always saw them empty and fell back to the hardcoded defaults (10000 for Hermes, 1000 for n8n). Containers ran as the wrong user and `./data/hermes` stayed owned by uid 10000.

Phase 06 now exports non-readonly `ODS_UID`/`ODS_GID` (defaulting to `$(id -u)` / `$(id -g)`), writes them into the generated `.env`, registers them in `.env.schema.json` and `.env.example`, and both Hermes and n8n compose interpolations switch to `${ODS_UID:-...}` / `${ODS_GID:-...}` so container data is owned by the host user.

Fixes #2303.

## AI Assistance

AI-assisted root-cause analysis (readonly vs exported shell variables) and edge-case enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime

## Validation

- `bash tests/test-hermes-data-ownership.sh` - passed.
- `bash tests/test-validate-env.sh` - passed (43 passed, 0 failed).
- `.env.schema.json` parses as valid JSON.
- `git diff --check origin/main...HEAD` - passed.