### PR TITLE
fix(backup): make rsync --delete opt-in

### DIFF
--- a/ods/lib/rsync.sh
+++ b/ods/lib/rsync.sh
@@ -11,6 +11,7 @@
 # Usage:
 #   . "$ODS_DIR/lib/rsync.sh"
 #   rsync_with_progress "$src" "$dest" "Optional label"
+#   rsync_with_progress "$src" "$dest" "Optional label" "--delete"  # mirror-sync ONLY
 # ============================================================================
 
 # Rsync with progress indicator
@@ -18,10 +19,19 @@
 #   $1 - source path
 #   $2 - destination path
 #   $3 - optional label (default: "Copying")
+#   $4 - optional "--delete"; ONLY for a true mirror-sync into a dedicated
+#        destination. --delete removes every file the source does not contain,
+#        so it must never be used when the destination already holds unrelated
+#        content: a backup dir receives one rsync per service/config/cache path
+#        (--delete would wipe the previously backed-up entries), and restore
+#        writes into the live data tree (--delete would delete the other live
+#        service dirs). The flag is deliberately opt-in and unused by the
+#        current backup/restore callers.
 rsync_with_progress() {
     local src="$1"
     local dest="$2"
     local label="${3:-Copying}"
+    local delete_flag="${4:-}"
 
     # Prefer the caller's styled logger when it exists. log_info is a *function*
     # in the scripts that source this lib (ods-backup.sh, ods-restore.sh), so it
@@ -33,12 +43,15 @@ rsync_with_progress() {
         echo "[INFO] $label..."
     fi
 
+    local rsync_args=(-a)
+    [[ "$delete_flag" == "--delete" ]] && rsync_args+=(--delete)
+
     # Use --info=progress2 for compact single-line progress updates
     # Fallback to basic rsync if progress2 not supported
     if rsync --help 2>/dev/null | grep -q "info=progress2"; then
-        rsync -a --delete --info=progress2 "$src" "$dest"
+        rsync "${rsync_args[@]}" --info=progress2 "$src" "$dest"
     else
         # Fallback: use --progress for older rsync versions
-        rsync -a --delete --progress "$src" "$dest" 2>/dev/null || rsync -a --delete "$src" "$dest"
+        rsync "${rsync_args[@]}" --progress "$src" "$dest" 2>/dev/null || rsync "${rsync_args[@]}" "$src" "$dest"
     fi
 }

--- a/ods/tests/test-rsync-delete-optin.sh
+++ b/ods/tests/test-rsync-delete-optin.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# ============================================================================
+# rsync_with_progress --delete opt-in contract test
+# ============================================================================
+# Regression for issue #2304: rsync_with_progress baked --delete into every
+# rsync call. In the backup flow that meant each service/config/cache rsync
+# into the SAME backup dir deleted the entries the previous call had just
+# written (only the last path survived), and on restore the --delete against
+# the live data tree wiped the other service directories.
+#
+# Strategy: install an rsync shim that records the exact argv so we can assert
+# --delete is ABSENT by default and only present when the caller opts in.
+#
+# Usage: ./tests/test-rsync-delete-optin.sh
+# ============================================================================
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RSYNC_LIB="$ROOT_DIR/lib/rsync.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+[[ -f "$RSYNC_LIB" ]] || { echo "rsync.sh not found at $RSYNC_LIB"; exit 1; }
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/rsync-delete.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+CALL_LOG="$TMP/rsync-args.log"
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/rsync" <<SH
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$CALL_LOG"
+# Fail unless --help: this test asserts argv, not copy behavior.
+exit 0
+SH
+chmod +x "$TMP/bin/rsync"
+
+export PATH="$TMP/bin:$PATH"
+
+# ---- helper: source the lib inside a subshell that stubs log_info ---------
+run_rsync() {
+    local out="$1"; shift
+    ( log_info() { :; }; . "$RSYNC_LIB"; rsync_with_progress "$@" ) > "$out" 2>&1
+}
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   rsync_with_progress --delete opt-in test    ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. default call (backup/restore callers) must NOT pass --delete
+# ---------------------------------------------------------------------------
+: > "$CALL_LOG"
+run_rsync "$TMP/default.log" /src/data /backup/data/ "label"
+if grep -q -- "--delete" "$CALL_LOG"; then
+    fail "default rsync_with_progress must not pass --delete"
+else
+    pass "default rsync_with_progress omits --delete"
+fi
+if grep -q -- "-a" "$CALL_LOG"; then
+    pass "default rsync_with_progress keeps -a archive mode"
+else
+    fail "default rsync_with_progress lost -a archive mode"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. explicit opt-in must pass --delete (mirror-sync caller)
+# ---------------------------------------------------------------------------
+: > "$CALL_LOG"
+run_rsync "$TMP/optin.log" /src/data /mirror/data/ "label" "--delete"
+if grep -q -- "--delete" "$CALL_LOG"; then
+    pass "rsync_with_progress forwards --delete when explicitly opted in"
+else
+    fail "rsync_with_progress dropped the --delete opt-in flag"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. a non---delete 4th arg must not inject --delete (defensive)
+# ---------------------------------------------------------------------------
+: > "$CALL_LOG"
+run_rsync "$TMP/junk.log" /src/data /mirror/data/ "label" "junk"
+if grep -q -- "--delete" "$CALL_LOG"; then
+    fail "unrecognized 4th arg must not be treated as --delete"
+else
+    pass "unrecognized 4th arg is ignored (no --delete)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

`rsync_with_progress` unconditionally passed `--delete` on every call, which made full backups self-destructive and wiped live data on restore:

- **Backup flow** (`ods-backup.sh`): each user-data/config/models rsync writes into the SAME backup dir, so every subsequent `--delete` removed what the previous call had just written. Only the last path survived (`do_backup full` produced a backup containing only `models/`; even `manifest.json` was gone).
- **Restore flow** (`ods-restore.sh`): restoring `data/open-webui` with `--delete` against `$ODS_DIR/data/` deleted the live n8n/qdrant/openclaw directories that were created after the backup — directly contradicting the `-a without --delete` comment already in the code.

`--delete` is now an explicit opt-in 4th argument and is removed from every backup and restore caller. Nothing in the current flow is a true mirror-sync, so no caller opts in; the flag remains available only for future code that genuinely needs a mirror destination.

Fixes #2304.

## AI Assistance

AI-assisted trace of every rsync invocation across the backup/restore flows. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime

## Validation

- `bash tests/test-rsync-delete-optin.sh` - passed (4 passed, 0 failed).
- `bash tests/test-update-rollback-contract.sh` - passed (5 checks, backup/restore/rollback round-trip intact).
- `git diff --check origin/main...HEAD` - passed.