### PR TITLE
fix(compose): select GPU overlay by backend, not tier

### DIFF
--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -146,10 +146,6 @@ elif gpu_backend == "cpu":
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
-elif tier in {"SH_LARGE", "SH_COMPACT"}:
-    if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
-        resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
-        primary = "docker-compose.amd.yml"
 elif gpu_backend == "apple":
     if existing(["docker-compose.base.yml", APPLE_OVERLAY]):
         resolved = ["docker-compose.base.yml", APPLE_OVERLAY]
@@ -161,7 +157,7 @@ elif gpu_backend == "amd":
     if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
         primary = "docker-compose.amd.yml"
-elif gpu_backend in ("intel", "sycl") or tier in ("ARC", "ARC_LITE"):
+elif gpu_backend in ("intel", "sycl"):
     if existing(["docker-compose.base.yml", "docker-compose.arc.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.arc.yml"]
         primary = "docker-compose.arc.yml"

--- a/ods/tests/test-resolve-compose-resilient.sh
+++ b/ods/tests/test-resolve-compose-resilient.sh
@@ -729,6 +729,43 @@ else
     skip "Docker Compose unavailable; real external-LLM render skipped"
 fi
 
+# ============================================================================
+# 27. GPU overlay selection must be driven by gpu_backend, never by tier.
+#
+# Regression for the SH_LARGE/SH_COMPACT tiers forcing the AMD overlay onto
+# non-AMD backends (--gpu-backend nvidia SH_LARGE or --gpu-backend apple
+# SH_COMPACT previously resolved to docker-compose.amd.yml). The tier may pick
+# tier0/base overrides but must never select a GPU-vendor overlay; gpu_backend
+# alone chooses amd/nvidia/arc/intel/cpu/apple.
+# ============================================================================
+# Ensure every vendor overlay exists so selection reflects the resolver's
+# decision rather than a missing-file fallback.
+for f in docker-compose.cpu.yml docker-compose.nvidia.yml docker-compose.amd.yml docker-compose.apple.yml docker-compose.arc.yml; do
+    touch "$TEMP_DIR/$f"
+done
+
+expect_overlay() {
+    local desc="$1" backend="$2" tier="$3" want="$4"
+    local out
+    out=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$TEMP_DIR" --gpu-backend "$backend" --tier "$tier" --skip-broken \
+        2>/dev/null) || true
+    if contains_path "$out" "docker-compose.$want.yml"; then
+        pass "$desc"
+    else
+        fail "$desc (selected: $(tr '\n' ' ' <<<"$out"))"
+    fi
+}
+
+# GPU backend alone must win; the SH_LARGE/SH_COMPACT tier must not force AMD.
+expect_overlay "cpu backend stays on cpu overlay for SH_LARGE tier" "cpu" "SH_LARGE" "cpu"
+expect_overlay "nvidia backend selects nvidia overlay for SH_LARGE tier" "nvidia" "SH_LARGE" "nvidia"
+expect_overlay "amd backend selects amd overlay for SH_LARGE tier" "amd" "SH_LARGE" "amd"
+expect_overlay "apple backend selects apple overlay for SH_COMPACT tier" "apple" "SH_COMPACT" "apple"
+# ARC tier must not force the ARC/intel overlay onto a non-intel backend.
+expect_overlay "nvidia backend selects nvidia overlay for ARC tier" "nvidia" "ARC" "nvidia"
+expect_overlay "intel backend selects arc overlay for ARC tier" "intel" "ARC" "arc"
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

`resolve-compose-stack.sh` forced the AMD overlay for the `SH_LARGE`/`SH_COMPACT` tiers and the ARC overlay for `ARC`/`ARC_LITE` tiers, regardless of `--gpu-backend`. A nvidia-backend SH_LARGE install or an apple-backend SH_COMPACT install got `docker-compose.amd.yml` merged in, and the ARC tier picked the arc overlay even on a non-intel backend — the resolved stack advertised GPU config the installed hardware cannot honor.

Overlay selection is now driven purely by `gpu_backend` (`amd`/`nvidia`/`arc`/`intel`/`cpu`/`apple`). Tier may influence tier0/base overrides but never a GPU-vendor overlay. The ARC overlay is selected by `gpu_backend intel/sycl`.

## AI Assistance

AI-assisted edge-case enumeration of backend/tier combinations. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime

## Validation

- `bash tests/test-resolve-compose-resilient.sh` - passed (43 passed, 0 failed).
- `bash -n ods/scripts/resolve-compose-stack.sh` - passed.
- `git diff --check origin/main...HEAD` - passed.