### PR TITLE
fix(dashboard-api): add safe float parsing for throughput values in agents.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/agents.py
+++ b/ods/extensions/services/dashboard-api/routers/agents.py
@@ -37,10 +37,16 @@ async def get_agent_metrics_html(api_key: str = Depends(verify_api_key)):
     active_gpus = esc(cluster.get("active_gpus", 0))
     total_gpus = esc(cluster.get("total_gpus", 0))
     failover_safe = esc(failover_text)
+    def safe_float(val, default=0.0):
+        try:
+            return float(val) if val is not None else default
+        except (ValueError, TypeError):
+            return default
+
     sessions = esc(agent.get("session_count", 0))
     last_update_safe = esc(last_update_time)
-    tp_current = esc(f"{tp.get('current', 0):.1f}")
-    tp_average = esc(f"{tp.get('average', 0):.1f}")
+    tp_current = esc(f"{safe_float(tp.get('current')):.1f}")
+    tp_average = esc(f"{safe_float(tp.get('average')):.1f}")
 
     html = f"""
     <div class="grid">


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/agents.py`, `get_agent_metrics_html()` formatted throughput metrics using string formatting `f"{tp.get('current', 0):.1f}"`. If `current` or `average` returns `None` or a non-numeric payload, string format specifiers raise `TypeError` or `ValueError`.

## Fix

Add a local `safe_float()` helper in `get_agent_metrics_html()` that coerces throughput inputs safely to floats, defaulting to `0.0` on non-numeric or missing data.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed). `git diff --check` passed cleanly.