### PR TITLE
fix(dashboard-api): parse LEMONADE_TIMEOUT environment variable in lemonade_client.py

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -58,10 +58,17 @@ class LemonadeSettings:
             or env.get("LITELLM_LEMONADE_API_KEY")
             or ""
         )
+        timeout_raw = env.get("LEMONADE_TIMEOUT") or env.get("LLM_API_TIMEOUT") or "20.0"
+        try:
+            timeout_val = float(timeout_raw)
+        except (ValueError, TypeError):
+            timeout_val = 20.0
+
         return cls(
             base_url=normalize_base_url(base_url, api_base_path),
             api_base_path=_clean_path(api_base_path),
             api_key=api_key,
+            timeout=timeout_val,
         )
 
     @property

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -1,3 +1,4 @@
+import json
 import httpx
 import pytest
 

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -88,8 +88,9 @@ async def test_chat_completion_posts_openai_shape():
 
     assert payload["choices"][0]["message"]["content"] == "ok"
     assert seen["url"] == "http://lemonade:13305/api/v1/chat/completions"
-    assert b'"model":"Qwen3-0.6B-GGUF"' in seen["body"]
-    assert b'"temperature":0' in seen["body"]
+    body_data = json.loads(seen["body"])
+    assert body_data["model"] == "Qwen3-0.6B-GGUF"
+    assert body_data["temperature"] == 0
     await client.aclose()
 
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/lemonade_client.py`, `LemonadeSettings.from_env()` populated connection attributes from environment variables (`LEMONADE_BASE_URL`, `LEMONADE_API_KEY`, etc.), but omitted parsing timeout configuration, defaulting unconditionally to `20.0` seconds.

## Fix

Update `LemonadeSettings.from_env()` in `lemonade_client.py` to parse `LEMONADE_TIMEOUT` or `LLM_API_TIMEOUT` from the process environment, falling back safely to `20.0` if unparseable.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_lemonade_client.py` (9/9 passed). `git diff --check` passed cleanly.