### PR TITLE
fix(dashboard-api): ignore whitespace and comments in _find_env_file_value in config.py

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -96,6 +96,9 @@ def _find_env_file_value(key: str) -> tuple[bool, str]:
     value = ""
     try:
         for line in env_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
             if line.startswith(f"{key}="):
                 found = True
                 value = line.split("=", 1)[1].strip().strip("\"'")


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/config.py`, `_find_env_file_value()` parses `.env` file lines to extract configuration values. Lines with leading whitespace or commented entries like `# ODS_MODE=local` were previously evaluated without skipping comments first.

## Fix

Update `_find_env_file_value()` in `config.py` to strip line whitespace and ignore blank lines or lines starting with `#`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_config.py` (53/53 passed). `git diff --check` passed cleanly.