### PR TITLE
fix(dashboard-api): handle permission errors during file existence check in gguf_inspector.py

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -182,14 +182,19 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
     p = Path(path)
     result: dict[str, Any] = {
         "path": str(p),
-        "exists": p.exists(),
+        "exists": False,
         "format": "gguf",
         "readable": False,
         "architecture": "unknown",
         "quantization": "unknown",
         "metadata": {},
     }
-    if not p.exists() or not p.is_file():
+    try:
+        exists = p.exists()
+    except OSError:
+        exists = False
+    result["exists"] = exists
+    if not exists or not p.is_file():
         return result
 
     try:


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/gguf_inspector.py`, `inspect_gguf()` evaluated `p.exists()` directly in dictionary initialization. If the target path points to a broken symlink or restricted path, `p.exists()` can raise `OSError` or `PermissionError` outside the parser's error handler block.

## Fix

Wrap `p.exists()` inside a `try...except OSError` block, assigning `exists = False` cleanly on access errors.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/gguf_inspector.py`. `git diff --check` passed cleanly.