### PR TITLE
fix(dashboard-api): specify utf-8 encoding and ignore comments in _read_installed_version in main.py

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -147,7 +147,10 @@ def _read_installed_version() -> str:
     env_file = install_root / ".env"
     if env_file.exists():
         try:
-            for line in env_file.read_text().splitlines():
+            for line in env_file.read_text(encoding="utf-8", errors="replace").splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
                 if line.startswith("ODS_VERSION="):
                     env_version = line.split("=", 1)[1].strip().strip("\"'")
                     if env_version:


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/main.py`, `_read_installed_version()` reads version metadata from `.env` using `env_file.read_text().splitlines()`. On systems with non-UTF-8 default locales, this can raise decoding errors. Additionally, lines with leading spaces or commented entries like `# ODS_VERSION=1.0.0` were evaluated without skipping comments first.

## Fix

Update `_read_installed_version()` in `main.py` to specify `encoding="utf-8"` and `errors="replace"`, strip line whitespace, and ignore commented lines.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/main.py`. `git diff --check` passed cleanly.