### PR TITLE
fix(models): handle file and decode errors in load_catalog in select-model.py

### DIFF
--- a/ods/scripts/select-model.py
+++ b/ods/scripts/select-model.py
@@ -119,8 +119,12 @@ def curated_source_allowed(model: dict[str, Any]) -> bool:
 
 
 def load_catalog(path: Path) -> list[dict[str, Any]]:
-    with path.open("r", encoding="utf-8") as fh:
-        data = json.load(fh)
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"error: failed to load catalog from {path}: {exc}", file=sys.stderr)
+        return []
     return [
         model for model in (
             normalize_model(raw)


### PR DESCRIPTION
## Problem

In `ods/scripts/select-model.py`, `load_catalog()` opens and decodes the model catalog JSON file directly using `with path.open("r", encoding="utf-8") as fh: data = json.load(fh)`. If the specified catalog path is unreadable, missing, or corrupt, an uncaught exception previously crashed process execution.

## Fix

Wrap catalog loading inside a `try...except (OSError, json.JSONDecodeError, ValueError)` block in `load_catalog()`, logging an error message to stderr and returning `[]` safely.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/select-model.py`. `git diff --check` passed cleanly.