### PR TITLE
fix(dashboard-api): ignore whitespace and comments in _read_current_version in updates.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -47,6 +47,9 @@ def _read_current_version() -> str:
     if env_file.exists():
         try:
             for line in _read_utf8(env_file).splitlines():
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
                 if line.startswith("ODS_VERSION="):
                     return line.split("=", 1)[1].strip().strip("\"'")
         except OSError:


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/updates.py`, `_read_current_version()` reads the current installed version string from `.env`. If a commented line like `# ODS_VERSION=1.0.0` or a line with leading whitespace preceded active assignments, it was matched incorrectly.

## Fix

Update `_read_current_version()` in `updates.py` to strip line whitespace and ignore blank lines or lines starting with `#`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed). `git diff --check` passed cleanly.