### PR TITLE
fix(dashboard-api): guard against None memory values in calculate_feature_status in features.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -18,8 +18,8 @@ router = APIRouter(tags=["features"])
 
 def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
     """Calculate whether a feature can be enabled and its status."""
-    gpu_vram_gb = (gpu_info.memory_total_mb / 1024) if gpu_info else 0
-    gpu_vram_used_gb = (gpu_info.memory_used_mb / 1024) if gpu_info else 0
+    gpu_vram_gb = ((gpu_info.memory_total_mb or 0) / 1024) if gpu_info else 0
+    gpu_vram_used_gb = ((gpu_info.memory_used_mb or 0) / 1024) if gpu_info else 0
     gpu_vram_free_gb = gpu_vram_gb - gpu_vram_used_gb
 
     # On Apple Silicon, when HOST_CHIP is missing (get_gpu_info_apple returned None),


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/features.py`, `calculate_feature_status()` divides `gpu_info.memory_total_mb` and `gpu_info.memory_used_mb` by `1024` to calculate VRAM capacity. If a GPU driver probe returns `None` for memory attributes on uninitialized GPU devices, a `TypeError` was raised.

## Fix

Guard memory attributes using `((gpu_info.memory_total_mb or 0) / 1024)` and `((gpu_info.memory_used_mb or 0) / 1024)` in `calculate_feature_status()`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed). `git diff --check` passed cleanly.