### PR TITLE
fix(opencode): stop sed escape mangling slashes in systemd unit render

### DIFF
--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -217,7 +217,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
 
         # Replace model and provider placeholders to match what the inference backend actually serves
         # Escape sed special chars in variable values to prevent injection
-        _sed_escape() { printf '%s\n' "$1" | sed 's/[&/\|]/\\&/g'; }
+        _sed_escape() { printf '%s\n' "$1" | sed 's/[&\\]/\\&/g'; }
         _oc_model_esc=$(_sed_escape "$OPENCLAW_MODEL")
         _oc_prov_esc=$(_sed_escape "$OPENCLAW_PROVIDER_NAME")
         _sed_i "s|__LLM_MODEL__|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"

--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -281,9 +281,9 @@ OPENCODE_EOF
             else
                 cp "$INSTALL_DIR/opencode/opencode-web.service" "$svc_tmp"
                 # Escape sed special chars to prevent injection from path values
-                _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
-                _opencode_bin_esc=$(printf '%s\n' "$OPENCODE_BIN" | sed 's/[&/\]/\\&/g')
-                _opencode_bin_dir_esc=$(printf '%s\n' "$(dirname "$OPENCODE_BIN")" | sed 's/[&/\]/\\&/g')
+                _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&\\]/\\&/g')
+                _opencode_bin_esc=$(printf '%s\n' "$OPENCODE_BIN" | sed 's/[&\\]/\\&/g')
+                _opencode_bin_dir_esc=$(printf '%s\n' "$(dirname "$OPENCODE_BIN")" | sed 's/[&\\]/\\&/g')
                 _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN__|${_opencode_bin_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN_DIR__|${_opencode_bin_dir_esc}|g" "$svc_tmp"


### PR DESCRIPTION
## Summary

The systemd unit render mangled the `__HOME__` and `__OPENCODE_BIN__` substitutions under the broken `[&/\]` escape, which rendered as a literal `&` on GNU/BSD sed and corrupted the rendered unit. This change escapes only `&` and backslash; `/` is safe since the substitution delimiter is `|`.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer

## Validation

- `bash -n ods/installers/phases/06-directories.sh ods/installers/phases/07-devtools.sh` - passed.
- `git diff --check origin/main...HEAD` - passed.