### PR TITLE
fix(opencode): fail closed when systemd unit placeholders remain unrendered

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -287,7 +287,12 @@ OPENCODE_EOF
                 _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN__|${_opencode_bin_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN_DIR__|${_opencode_bin_dir_esc}|g" "$svc_tmp"
-                cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
+                # Verify placeholders were actually rendered
+                if grep -q '__HOME__\|__OPENCODE_BIN__\|__OPENCODE_BIN_DIR__' "$svc_tmp"; then
+                    ai_warn "OpenCode systemd unit has unrendered placeholders — not installing; check $svc_tmp"
+                else
+                    cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
+                fi
                 rm -f "$svc_tmp"
             fi
 


### PR DESCRIPTION
## Summary

A failed substitution silently installed a broken `opencode-web.service` with literal `__HOME__`/`__OPENCODE_BIN__` tokens. This change aborts the install of the unit when any placeholder remains, matching the host-agent guard style already used later in the same phase.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer

## Validation

- `bash -n ods/installers/phases/07-devtools.sh` - passed.
- `git diff --check origin/main...HEAD` - passed.