### PR TITLE
fix(opencode): honor OPENCODE_PORT in Linux service render and health checks

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -147,6 +147,7 @@ else
             [[ -z "${ODS_MODEL_SWITCHBOARD:-}" ]] && ODS_MODEL_SWITCHBOARD=$(grep -m1 '^ODS_MODEL_SWITCHBOARD=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_PORT:-}" ]] && LITELLM_PORT=$(grep -m1 '^LITELLM_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ -z "${OPENCODE_PORT:-}" ]] && OPENCODE_PORT=$(grep -m1 '^OPENCODE_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
         fi
         # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise.
         #
@@ -284,9 +285,11 @@ OPENCODE_EOF
                 _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
                 _opencode_bin_esc=$(printf '%s\n' "$OPENCODE_BIN" | sed 's/[&/\]/\\&/g')
                 _opencode_bin_dir_esc=$(printf '%s\n' "$(dirname "$OPENCODE_BIN")" | sed 's/[&/\]/\\&/g')
+                _oc_port=${OPENCODE_PORT:-3003}
                 _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN__|${_opencode_bin_esc}|g" "$svc_tmp"
                 _sed_i "s|__OPENCODE_BIN_DIR__|${_opencode_bin_dir_esc}|g" "$svc_tmp"
+                _sed_i "s|__OPENCODE_PORT__|${_oc_port}|g" "$svc_tmp"
                 cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
                 rm -f "$svc_tmp"
             fi

--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -514,7 +514,7 @@ fi
 # hermes-proxy is the LAN-facing entry and has an anonymous /health endpoint.
 [[ "$ENABLE_HERMES" == "true" ]] && _check_health "Hermes Proxy" "http://127.0.0.1:${SERVICE_PORTS[hermes-proxy]:-9120}${SERVICE_HEALTH[hermes-proxy]:-/health}" 60 5 "$(sr_container hermes-proxy)"
 [[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://127.0.0.1:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 150 10 "$(sr_container openclaw)"
-systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://127.0.0.1:3003/" 10 5
+systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://127.0.0.1:${OPENCODE_PORT:-3003}/" 10 5
 # Whisper: 150 attempts * adaptive backoff = up to ~20 minutes (model download on first start)
 ods_progress 95 "health" "Checking voice services"
 [[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://127.0.0.1:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 150 10 "$(sr_container whisper)"

--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -128,7 +128,7 @@ echo "  • LLM API:       http://localhost:${SERVICE_PORTS[llama-server]:-11434
 [[ "${ENABLE_COMFYUI:-false}" == "true" ]] && echo "  • ComfyUI:       http://localhost:${SERVICE_PORTS[comfyui]:-8188}"
 [[ "$ENABLE_HERMES" == "true" ]] && echo "  • Hermes (auth): http://localhost:${SERVICE_PORTS[hermes-proxy]:-9120}  (magic-link gated; not direct :9119)"
 [[ "$ENABLE_OPENCLAW" == "true" ]] && echo "  • OpenClaw:      http://localhost:${SERVICE_PORTS[openclaw]:-7860}"
-systemctl --user is-active opencode-web &>/dev/null && echo "  • OpenCode:      http://localhost:3003"
+systemctl --user is-active opencode-web &>/dev/null && echo "  • OpenCode:      http://localhost:${OPENCODE_PORT:-3003}"
 [[ "$ENABLE_VOICE" == "true" ]] && echo "  • Whisper STT:   http://localhost:${SERVICE_PORTS[whisper]:-9000}"
 [[ "$ENABLE_VOICE" == "true" ]] && echo "  • TTS (Kokoro):  http://localhost:${SERVICE_PORTS[tts]:-8880}"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && echo "  • n8n:           http://localhost:${SERVICE_PORTS[n8n]:-5678}"
@@ -414,7 +414,7 @@ echo -e "  ${BGRN}Hermes${NC}       ${WHT}http://localhost:${SERVICE_PORTS[herme
 [[ "$ENABLE_OPENCLAW" == "true" ]] && \
 echo -e "  ${BGRN}OpenClaw${NC}     ${WHT}http://localhost:${OPENCLAW_PORT}${NC}"
 systemctl --user is-active opencode-web &>/dev/null && \
-echo -e "  ${BGRN}OpenCode${NC}     ${WHT}http://localhost:3003${NC}"
+echo -e "  ${BGRN}OpenCode${NC}     ${WHT}http://localhost:${OPENCODE_PORT:-3003}${NC}"
 echo ""
 if [[ -n "$LOCAL_IP" ]]; then
     _bind=$(grep "^BIND_ADDRESS=" "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2- | tr -d '"' || echo "127.0.0.1")

--- a/ods/opencode/opencode-web.service
+++ b/ods/opencode/opencode-web.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=__HOME__
-ExecStart=__OPENCODE_BIN__ serve --port 3003 --hostname 127.0.0.1
+ExecStart=__OPENCODE_BIN__ serve --port __OPENCODE_PORT__ --hostname 127.0.0.1
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## Summary

The Linux OpenCode systemd unit, health check, and summary phases drifted on the web port: the unit hardcoded 3003 while the health/summary reads `OPENCODE_PORT`. Changing the variable left health polling the wrong port. The unit render, `12-health.sh`, and `13-summary.sh` now all honor `OPENCODE_PORT` (default 3003) so the service and its health path stay in sync.

## AI Assistance

AI-assisted repository search and cross-file port-wiring enumeration. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on changed phases - passed.
- Linux opencode path regression test - passed.
- `git diff --check` - passed.