### PR TITLE
fix(opencode): require 2xx responses in host-agent opencode health probe

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -11015,7 +11015,7 @@ def _wait_for_opencode_health(attempts: int = 30) -> None:
         try:
             request = urllib_request.Request(url, method="GET")
             with urllib_request.urlopen(request, timeout=3) as response:
-                if 200 <= response.status < 500:
+                if 200 <= response.status < 300:
                     return
         except (OSError, urllib_error.URLError):
             pass


### PR DESCRIPTION
## Summary

The host-agent opencode health probe treated any HTTP response as healthy, so a 4xx/5xx page state still read as ready and the dashboard flagged the coding surface as up. The probe now requires a 200-299 response before marking the host service healthy.

## AI Assistance

AI-assisted regression triage on the homestay probe path. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on `ods/bin/ods-host-agent.py` - passed.
- `git diff --check` - passed.