### PR TITLE
fix(opencode): honor OPENCODE_PORT in macOS LaunchAgent

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2863,6 +2863,8 @@ for service in (data.get("services") or {}).values():
         # always inside xpcproxy's sandbox writable set, so use that instead.
         mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/ODS"
         OPENCODE_LAUNCHD_PATH="$(_compute_launchd_path "$(dirname "$OPENCODE_BIN")")"
+        _oc_web_port="$(read_env_value "$INSTALL_DIR/.env" "OPENCODE_PORT")"
+        [[ "$_oc_web_port" =~ ^[0-9]+$ ]] || _oc_web_port="${OPENCODE_PORT:-3003}"
         cat > "$OPENCODE_PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -2875,7 +2877,7 @@ for service in (data.get("services") or {}).values():
         <string>${OPENCODE_BIN}</string>
         <string>web</string>
         <string>--port</string>
-        <string>3003</string>
+        <string>${_oc_web_port}</string>
         <string>--hostname</string>
         <string>127.0.0.1</string>
     </array>
@@ -2909,10 +2911,10 @@ PLIST_EOF
         launchctl bootout "gui/$(id -u)/${OPENCODE_PLIST_LABEL}" >/dev/null 2>&1 || true
         _opencode_bootstrap_err="$(launchctl bootstrap "gui/$(id -u)" "$OPENCODE_PLIST" 2>&1)" && _opencode_bootstrap_rc=0 || _opencode_bootstrap_rc=$?
         if [[ $_opencode_bootstrap_rc -eq 0 ]]; then
-            ai_ok "OpenCode Web UI service installed (LaunchAgent, port 3003)"
+            ai_ok "OpenCode Web UI service installed (LaunchAgent, port ${_oc_web_port})"
         else
             ai_warn "OpenCode LaunchAgent failed (rc=${_opencode_bootstrap_rc}): ${_opencode_bootstrap_err}"
-            ai_warn "Start manually: ${OPENCODE_BIN} web --port 3003"
+            ai_warn "Start manually: ${OPENCODE_BIN} web --port ${_oc_web_port}"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

The macOS LaunchAgent hardcoded the web port and bypassed the ODS environment, so a custom `OPENCODE_PORT` was ignored and the agent bound a different port than the dashboard expected. The plist writer now resolves the port from the ODS env (`OPENCODE_PORT`, default 3003) for launch and status parity.

## AI Assistance

AI-assisted repository search over the macOS LaunchAgent wiring. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on macOS install scripts - passed.
- macOS plist transition tests - passed.
- `git diff --check` - passed.