### PR TITLE
fix(opencode): use serve subcommand in macOS LaunchAgent

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2873,7 +2873,7 @@ for service in (data.get("services") or {}).values():
     <key>ProgramArguments</key>
     <array>
         <string>${OPENCODE_BIN}</string>
-        <string>web</string>
+        <string>serve</string>
         <string>--port</string>
         <string>3003</string>
         <string>--hostname</string>
@@ -2912,7 +2912,7 @@ PLIST_EOF
             ai_ok "OpenCode Web UI service installed (LaunchAgent, port 3003)"
         else
             ai_warn "OpenCode LaunchAgent failed (rc=${_opencode_bootstrap_rc}): ${_opencode_bootstrap_err}"
-            ai_warn "Start manually: ${OPENCODE_BIN} web --port 3003"
+            ai_warn "Start manually: ${OPENCODE_BIN} serve --port 3003"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

The macOS LaunchAgent called `opencode web`, a legacy subcommand that current OpenCode builds no longer ship. The plist writer now uses `opencode serve`, matching the Linux systemd unit's ExecStart.

## AI Assistance

AI-assisted cross-platform subcommand comparison. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on macOS install scripts - passed.
- macOS plist transition tests - passed.
- `git diff --check` - passed.