### PR TITLE
fix(opencode): resolve port from env and gate status on binary

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -713,8 +713,15 @@ cmd_status() {
     echo -e "  ${DGRN}$(printf -- '-%.0s' {1..40})${NC}"
 
     # Parallel arrays (Bash 3.2 compatible)
-    local ep_names=("$CLI_LLM_NAME" "Chat UI" "Dashboard" "OpenCode (IDE)")
-    local ep_urls=("$CLI_LLM_HEALTH_URL" "http://127.0.0.1:3000" "http://127.0.0.1:3001" "http://127.0.0.1:3003")
+    local ep_names=("$CLI_LLM_NAME" "Chat UI" "Dashboard")
+    local ep_urls=("$CLI_LLM_HEALTH_URL" "http://127.0.0.1:3000" "http://127.0.0.1:3001")
+    local _oc_web_port
+    _oc_web_port="$(read_env_value "${INSTALL_DIR}/.env" "OPENCODE_PORT")"
+    [[ "$_oc_web_port" =~ ^[0-9]+$ ]] || _oc_web_port="${OPENCODE_PORT:-3003}"
+    if [[ -x "$HOME/.opencode/bin/opencode" ]]; then
+        ep_names+=("OpenCode (IDE)")
+        ep_urls+=("http://127.0.0.1:${_oc_web_port}")
+    fi
 
     for ((i=0; i<${#ep_names[@]}; i++)); do
         local name="${ep_names[$i]}"


### PR DESCRIPTION
## Summary

`ods-macos.sh status` reported OpenCode state using a hardcoded port and did not check whether the binary exists, so it could claim "running" or "installed" incorrectly. Status now resolves `OPENCODE_PORT` from env (default 3003) and gates on the per-user binary path.

## AI Assistance

AI-assisted enumeration of the macOS status surface. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on `ods-macos.sh` - passed.
- macOS transition tests - passed.
- `git diff --check` - passed.