### PR TITLE
fix(opencode): remove stale LaunchAgent plist on reinstall

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2384,6 +2384,7 @@ else
     launchctl bootout "gui/$(id -u)/${HOST_AGENT_BRIDGE_PLIST_LABEL}" 2>/dev/null || true
     rm -f "$HOST_AGENT_BRIDGE_PLIST" 2>/dev/null || true
     launchctl bootout "gui/$(id -u)/${OPENCODE_PLIST_LABEL}" 2>/dev/null || true
+    rm -f "$OPENCODE_PLIST" 2>/dev/null || true
     for _legacy_plist_label in \
         com.ods.llama-server \
         com.ods.full-model-download; do


### PR DESCRIPTION
## Summary

On reinstall the pre-install LaunchAgent sweep removed old agent plists but left a stale `com.ods.opencode-web.plist`, which then carried a previous port/subcommand and could double-start the service. The sweep now also removes the OpenCode plist before installing fresh.

## AI Assistance

AI-assisted review of the macOS stale-agent cleanup surface. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on macOS install scripts - passed.
- macOS pre-existing failure confirmed environmental (Windows FS), not introduced here.
- `git diff --check` - passed.