### PR TITLE
fix(opencode): use detected interpreter in macOS config writer

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -431,7 +431,7 @@ _write_macos_opencode_config() {
     ODS_OPENCODE_BASE_URL="$base_url" \
     ODS_OPENCODE_API_KEY="$api_key" \
     ODS_OPENCODE_CONTEXT="$context_length" \
-        /usr/bin/python3 - "$config_path" "$compat_path" <<'OPENCODE_CONFIG_PY'
+        ${ODS_PYTHON_CMD:-/usr/bin/python3} - "$config_path" "$compat_path" <<'OPENCODE_CONFIG_PY'
 import json
 import os
 import sys


### PR DESCRIPTION
## Summary

The macOS config writer hardcoded the Python interpreter, breaking on systems where `python3` resolves differently than the interpreter the installer validated. It now uses the detected `ODS_PYTHON_CMD` (defaulting to `/usr/bin/python3`) for writing OpenCode config.

## AI Assistance

AI-assisted review of the macOS config writer interpreter wiring. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on macOS install scripts - passed.
- `git diff --check` - passed.