### PR TITLE
fix(opencode): add small_model and unify provider name in macOS config

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -454,7 +454,7 @@ provider_id = "llama-server"
 provider = data.setdefault("provider", {}).setdefault(provider_id, {})
 provider.update({
     "npm": "@ai-sdk/openai-compatible",
-    "name": "ODS inference",
+    "name": "llama-server (local)",
     "options": {"baseURL": base_url, "apiKey": api_key},
     "models": {
         model_name: {
@@ -464,6 +464,7 @@ provider.update({
     },
 })
 data["model"] = f"{provider_id}/{model_name}"
+data["small_model"] = f"{provider_id}/{model_name}"
 data.setdefault("$schema", "https://opencode.ai/config.json")
 
 payload = json.dumps(data, indent=2) + "\n"


### PR DESCRIPTION
## Summary

The macOS OpenCode config omitted `small_model` and used a different provider name than Linux/Windows, so agility features and dashboard labels diverged per platform. The writer now sets `small_model` and uses the shared provider name `llama-server (local)` for parity.

## AI Assistance

AI-assisted cross-platform config comparison. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on macOS install scripts - passed.
- macOS transition tests - passed.
- `git diff --check` - passed.