### PR TITLE
fix(opencode): prune stale model entries in Windows config upsert

### DIFF
--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -108,6 +108,11 @@ function Update-WindowsOpenCodeConfigObject {
     }
     $models = $llamaProvider.models
 
+    $staleModelIds = @($models.PSObject.Properties.Name | Where-Object { $_ -ne $ModelId })
+    foreach ($staleModelId in $staleModelIds) {
+        $models.PSObject.Properties.Remove($staleModelId)
+    }
+
     if (-not $models.PSObject.Properties[$ModelId] -or $null -eq $models.PSObject.Properties[$ModelId].Value) {
         Set-OpenCodeObjectProperty -Target $models -Name $ModelId -Value ([pscustomobject]@{})
     }


### PR DESCRIPTION
## Summary

The Windows OpenCode config upsert appended model entries on every update without pruning, so switching models left stale `models` entries under the llama-server provider. The upsert now prunes obsolete model ids before writing the current route.

## AI Assistance

AI-assisted review of the Windows config upsert path. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- Windows opencode config regression tests - passed (24/24).
- `git diff --check` - passed.