### PR TITLE
fix(opencode): cap Windows output limit at the model context

### DIFF
--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -50,7 +50,7 @@ function New-WindowsOpenCodeConfigObject {
                         name = $ModelName
                         limit = [pscustomobject]@{
                             context = $ContextLimit
-                            output = 32768
+                            output = [Math]::Min(32768, $ContextLimit)
                         }
                     }
                 }
@@ -118,7 +118,7 @@ function Update-WindowsOpenCodeConfigObject {
         Set-OpenCodeObjectProperty -Target $modelEntry -Name 'limit' -Value ([pscustomobject]@{})
     }
     Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'context' -Value $ContextLimit
-    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value 32768
+    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value ([Math]::Min(32768, $ContextLimit))
 
     return $Config
 }


### PR DESCRIPTION
## Summary

The Windows OpenCode config fixed `output` at 32768 even when the model context was smaller, so the declared output cap could exceed the model's context. The create and update paths now cap output at `[Math]::Min(32768, $ContextLimit)`.

## AI Assistance

AI-assisted review of the Windows config limit derivation. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- Windows opencode config regression tests - passed.
- `git diff --check` - passed.