### PR TITLE
fix(opencode): map OPENCODE_ keys to the opencode service on apply

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -419,6 +419,8 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "perplexica"
     if key.startswith("APE_"):
         return "ape"
+    if key.startswith("OPENCODE_"):
+        return "opencode"
     return None
 
 


### PR DESCRIPTION
## Summary

When applying settings, `OPENCODE_*` env keys fell through the service matcher, so OpenCode settings applied to the wrong service or were dropped. The matcher now maps the `OPENCODE_` prefix to the `opencode` service.

## AI Assistance

AI-assisted review of the settings apply service mapping. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Installer
- [x] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on `settings.py` - passed.
- `git diff --check` - passed.