### PR TITLE
fix(opencode): drop erroneous VRAM gate on the coding feature

### DIFF
--- a/ods/extensions/services/opencode/manifest.yaml
+++ b/ods/extensions/services/opencode/manifest.yaml
@@ -36,7 +36,7 @@ features:
     category: development
     requirements:
       services: [opencode]
-      vram_gb: 8
+      vram_gb: 0
     enabled_services_all: [opencode]
     setup_time: Ready
     priority: 6


### PR DESCRIPTION
## Summary

The OpenCode coding feature declared `vram_gb: 8` while OpenCode itself runs on the host against any active model route and does not reserve GPU VRAM; the gate hid the feature on lower-VRAM systems. The feature now requires `vram_gb: 0`, matching its host-managed deployment.

## AI Assistance

AI-assisted review of the feature VRAM gating. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Installer
- [x] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `ods/scripts/validate-manifests.sh` - passed (opencode ok).
- Manifest schema tests - passed.
- `git diff --check` - passed.