### PR TITLE
fix(opencode): mark loopback-managed coding surface as unauthenticated

### DIFF
--- a/ods/config/network-exposure-policy.json
+++ b/ods/config/network-exposure-policy.json
@@ -95,7 +95,7 @@
     "opencode": {
       "risk": "code-execution-ui",
       "lan_exposure": "operator-controlled",
-      "auth_required": true,
+      "auth_required": false,
       "notes": "Browser IDE/coding assistant surface."
     },
     "perplexica": {


### PR DESCRIPTION
## Summary

The network-exposure policy marked the OpenCode surface `auth_required: true`, but ODS runs OpenCode on loopback without a login, so the auth flag mismatched the actual surface and misclassified it in the dashboard policy summary. The flag is now `false` for the local managed surface.

## AI Assistance

AI-assisted review of the exposure policy classification. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- Config policy regression test - passed.
- `git diff --check` - passed.