### PR TITLE
fix(opencode): add small_model to flat render config

### DIFF
--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -454,6 +454,7 @@ def render_opencode(inputs: RenderInputs) -> RenderedFile:
         "baseURL": base_url,
         "apiKey": opencode_key(inputs),
         "model": model,
+        "small_model": model,
         "port": inputs.opencode_port,
     }
     return RenderedFile(


### PR DESCRIPTION
## Summary

The flat OpenCode config rendered by `render-runtime-configs.py` omitted `small_model`, drifting from the Linux/Windows/macOS writers. The payload now mirrors `small_model` so runtime feature gating is consistent across surfaces.

## AI Assistance

AI-assisted review of the cross-surface config parity. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on `render-runtime-configs.py` - passed.
- `git diff --check` - passed.