### PR TITLE
fix(uninstall): surgically remove both OpenCode config docs

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -378,11 +378,22 @@ if [[ -d "$HOME/.ods" ]]; then
 fi
 
 # 7. Remove OpenCode config (if we created it)
-OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
-if [[ -f "$OPENCODE_CONFIG" ]] && grep -q "llama-server" "$OPENCODE_CONFIG" 2>/dev/null; then
-    rm -f "$OPENCODE_CONFIG"
+# installers/phases/07-devtools.sh writes opencode.json from a template and
+# then syncs a config.json copy (OpenCode reads config.json, not opencode.json).
+# Uninstall must remove both documents so no stale route survives, but only the
+# ones ODS wrote — the llama-server marker scopes this to our own config.
+OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
+_ods_opencode_config_removed=false
+for _ods_opencode_config in "$OPENCODE_CONFIG_DIR/opencode.json" "$OPENCODE_CONFIG_DIR/config.json"; do
+    if [[ -f "$_ods_opencode_config" ]] && grep -q "llama-server" "$_ods_opencode_config" 2>/dev/null; then
+        rm -f "$_ods_opencode_config"
+        _ods_opencode_config_removed=true
+    fi
+done
+if $_ods_opencode_config_removed; then
     log_ok "OpenCode config removed"
 fi
+unset _ods_opencode_config _ods_opencode_config_removed
 
 echo ""
 echo -e "${GREEN}╔══════════════════════════════════════════════════╗${NC}"

--- a/ods/tests/test-uninstall-compose-flags.sh
+++ b/ods/tests/test-uninstall-compose-flags.sh
@@ -190,6 +190,33 @@ EOF
             || fail "uninstall must not remove unrelated volume $name (got: '$removed_volumes')"
     done
     pass "volume discovery stays on the ods project prefix"
+
+    # 07-devtools.sh writes opencode.json from a template and syncs a config.json
+    # copy (the document OpenCode actually reads). Uninstall must remove both
+    # ODS-authored documents but leave an unrelated user config untouched.
+    local install_oc="$TMP_DIR/install-oc"
+    local home_oc="$TMP_DIR/home-oc"
+    mkdir -p "$home_oc"
+    make_install "$install_oc"
+    mkdir -p "$home_oc/.config/opencode"
+    cat > "$home_oc/.config/opencode/opencode.json" <<'EOF'
+{ "$schema": "https://opencode.ai/config.json",
+  "model": "llama-server/ods/current",
+  "provider": { "llama-server": {} } }
+EOF
+    cp "$home_oc/.config/opencode/opencode.json" "$home_oc/.config/opencode/config.json"
+    cat > "$home_oc/.config/opencode/user.json" <<'EOF'
+{ "theme": "dark" }
+EOF
+    DOCKER_LOG="$TMP_DIR/docker-oc.log" run_uninstall "$install_oc" "$home_oc" "$stub_dir"
+
+    [[ ! -f "$home_oc/.config/opencode/opencode.json" ]] \
+        || fail "uninstall must remove ODS-managed opencode.json"
+    [[ ! -f "$home_oc/.config/opencode/config.json" ]] \
+        || fail "uninstall must remove the synced config.json document"
+    [[ -f "$home_oc/.config/opencode/user.json" ]] \
+        || fail "uninstall must not remove unrelated user opencode config"
+    pass "uninstall surgically removes ODS OpenCode config but keeps user config"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

07-devtools.sh writes opencode.json from a template and syncs a config.json copy (the document OpenCode actually reads). Uninstall only removed opencode.json, so a stale llama-server route survived as config.json. Uninstall now removes both ODS-authored documents, scoped by the llama-server marker so unrelated user config is left untouched, with regression coverage.

## AI Assistance

AI-assisted review of the uninstall config surface. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Change Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on `ods-uninstall.sh` and test - passed.
- `bash ods/tests/test-uninstall-compose-flags.sh` - passed (7 scenarios incl. new OpenCode config scenario).
- `git diff --check` - passed.