### PR TITLE
fix(opencode): drop empty container_name and correct unit path

### DIFF
--- a/ods/extensions/services/opencode/README.md
+++ b/ods/extensions/services/opencode/README.md
@@ -81,4 +81,4 @@ another process, stop that process before reinstalling.
 ## Files
 
 - `manifest.yaml`: service metadata, health route, and dashboard feature
-- `opencode-web.service`: Linux user service template
+- `ods/opencode/opencode-web.service`: Linux user service template (shared by installer phases, tracked outside this extension dir)

--- a/ods/extensions/services/opencode/manifest.yaml
+++ b/ods/extensions/services/opencode/manifest.yaml
@@ -7,7 +7,6 @@ service:
   id: opencode
   name: OpenCode (IDE)
   aliases: [opencode-web]
-  container_name: ""
   default_host: localhost
   port: 3003
   external_port_env: OPENCODE_PORT


### PR DESCRIPTION
## Summary

The OpenCode manifest carried an empty `container_name` placeholder even though the host-service has no Docker container, and the README Files section listed `opencode-web.service` inside the extension dir when the unit actually lives at `ods/opencode/`. Removed the empty field and corrected the documented unit path. `container_name` is optional in `service-manifest.v1.json`.

## AI Assistance

AI-assisted review of the manifest and its documentation. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [x] Docs only
- [ ] Tests only

## Validation

- `ods/scripts/validate-manifests.sh` - passed (opencode ok).
- `ods/tests/test-validate-manifest-schema.sh` - passed.
- `git diff --check` - passed.