### PR TITLE
fix(dashboard-api): specify utf-8 encoding and catch ValueError in get_active_persona_prompt in setup.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -33,10 +33,11 @@ def get_active_persona_prompt() -> str:
     persona_file = SETUP_CONFIG_DIR / "persona.json"
     if persona_file.exists():
         try:
-            with open(persona_file) as f:
+            with open(persona_file, encoding="utf-8") as f:
                 data = json.load(f)
-                return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
+                if isinstance(data, dict):
+                    return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
+        except (FileNotFoundError, PermissionError, OSError, ValueError, json.JSONDecodeError):
             logger.debug("Failed to read persona.json, using default prompt")
     return PERSONAS["general"]["system_prompt"]
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/setup.py`, `get_active_persona_prompt()` opens `persona.json` using default system encoding without explicit `encoding="utf-8"`. Additionally, if decoding raises `ValueError` or `OSError` on malformed JSON, an unhandled exception could occur.

## Fix

Specify `encoding="utf-8"` when opening `persona.json` and catch `OSError` and `ValueError` in `get_active_persona_prompt()`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed). `git diff --check` passed cleanly.