### PR TITLE
fix(dashboard-api): add safe integer parsing for SHIELD_PORT in privacy.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/privacy.py
+++ b/ods/extensions/services/dashboard-api/routers/privacy.py
@@ -27,7 +27,10 @@ router = APIRouter(tags=["privacy"])
 async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield status and configuration."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    try:
+        shield_port = int(os.environ.get("SHIELD_PORT") or _ps.get("port", 0))
+    except (ValueError, TypeError):
+        shield_port = int(_ps.get("port", 0))
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
 
     # Check health directly — no Docker socket needed


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/privacy.py`, `get_privacy_shield_status()` parsed `SHIELD_PORT` using `int(os.environ.get("SHIELD_PORT", ...))`. If an invalid non-numeric string was passed as an environment override, `int()` raised an unhandled `ValueError`.

## Fix

Wrap `SHIELD_PORT` integer parsing in a `try...except (ValueError, TypeError)` block, defaulting to the service port configuration.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed). `git diff --check` passed cleanly.