### PR TITLE
fix(opencode): use llama-server host port default in Linux route

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -179,7 +179,7 @@ else
             _opencode_url="http://127.0.0.1:${LITELLM_PORT:-4000}/v1"
             _opencode_key="${LITELLM_KEY:-no-key}"
         else
-            _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
+            _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-11434}/v1"
             _opencode_key="no-key"
         fi
         if [[ -z "${_opencode_key:-}" ]]; then


### PR DESCRIPTION
## Summary

The OpenCode route fell back to OLLAMA_PORT :8080, the container-internal port, while llama-server is exposed on the host at 11434 — so OpenCode probed a dead port and the model list was empty. Default the host port to 11434.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on 07-devtools.sh - passed.
- `git diff --check` - passed.
