### PR TITLE
fix(renderer): fall back to active model for LEMONADE_MODEL

### DIFF
--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -467,7 +467,7 @@ def render_env(inputs: RenderInputs) -> RenderedFile:
     lemonade_model = (
         lemonade_model_id(inputs)
         if inputs.ods_mode == "lemonade"
-        else inputs.lemonade_model_id
+        else inputs.lemonade_model_id or (inputs.gguf_file or inputs.model)
     )
     lines = [
         f"ODS_MODE={inputs.ods_mode}",


### PR DESCRIPTION
## Summary

For non-lemonade modes lemonade_model_id defaults to empty, emitting LEMONADE_MODEL= with no value in the generated env. Fall back to the active model identity so consumers never see an empty variable.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on render-runtime-configs.py - passed.
- `git diff --check` - passed.
