### PR TITLE
fix(renderer): drop retry loop from atomic write

### DIFF
--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -15,7 +15,6 @@ import re
 import stat
 import sys
 import tempfile
-import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Callable
@@ -59,18 +58,7 @@ def atomic_write_text(target: Path, content: str) -> None:
             os.fsync(handle.fileno())
         os.chmod(tmp_path, mode)
 
-        last_error: PermissionError | None = None
-        for attempt in range(10):
-            try:
-                os.replace(tmp_path, target)
-                last_error = None
-                break
-            except PermissionError as exc:
-                last_error = exc
-                if attempt < 9:
-                    time.sleep(0.05 * (attempt + 1))
-        if last_error is not None:
-            raise last_error
+        os.replace(tmp_path, target)
     finally:
         tmp_path.unlink(missing_ok=True)
 


### PR DESCRIPTION
## Summary

atomic_write_text retried os.replace up to 10 times with backoff, hiding real failures and contradicting the let-it-crash contract. Replaced with a single os.replace that propagates errors immediately.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on render-runtime-configs.py - passed.
- `git diff --check` - passed.
