### PR TITLE
fix(uninstall): keep resolver and overlay GPU backend in lockstep

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -22,6 +22,7 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 resolve_compose_flags() {
     local flags=""
+    local _gpu="${GPU_BACKEND:-nvidia}"
 
     if [[ -f "$INSTALL_DIR/.compose-flags" ]]; then
         flags="$(tr '\n' ' ' < "$INSTALL_DIR/.compose-flags" | xargs 2>/dev/null || true)"
@@ -31,16 +32,16 @@ resolve_compose_flags() {
         flags="$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" \
             --tier "${TIER:-1}" \
-            --gpu-backend "${GPU_BACKEND:-nvidia}" \
+            --gpu-backend "$_gpu" \
             --gpu-count "${GPU_COUNT:-1}" \
             --ods-mode "${ODS_MODE:-local}" 2>/dev/null || true)"
     fi
 
     if [[ -z "$flags" && -f "$INSTALL_DIR/docker-compose.base.yml" ]]; then
         flags="-f docker-compose.base.yml"
-        case "${GPU_BACKEND:-}" in
+        case "$_gpu" in
             amd|nvidia|intel|apple|arc|cpu)
-                [[ -f "$INSTALL_DIR/docker-compose.${GPU_BACKEND}.yml" ]] && flags="$flags -f docker-compose.${GPU_BACKEND}.yml"
+                [[ -f "$INSTALL_DIR/docker-compose.${_gpu}.yml" ]] && flags="$flags -f docker-compose.${_gpu}.yml"
                 ;;
         esac
     fi


### PR DESCRIPTION
## Summary

resolve_compose_flags defaulted GPU_BACKEND to nvidia for the resolver but used the unset variable for the overlay selection, so docker compose down ran base-only and leftovers survived on AMD/Apple hosts. Capture the defaulted value once and reuse it for both.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Dashboard UI
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n` on ods-uninstall.sh - passed.
- `git diff --check` - passed.
