### PR TITLE
fix(settings): exclude live-read keys from changed-key status

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -449,7 +449,8 @@ def _compute_env_apply_plan(
 ) -> dict[str, Any]:
     changed_keys = sorted(
         key for key in set(previous_values) | set(next_values)
-        if previous_values.get(key, "") != next_values.get(key, "")
+        if key not in _LIVE_READ_ENV_KEYS
+        and previous_values.get(key, "") != next_values.get(key, "")
     )
     services: set[str] = set()
     inactive_services: set[str] = set()


### PR DESCRIPTION
## Summary

HF_TOKEN stayed in changed_keys after the mapping loop skipped it, so the apply plan reported manual restart with empty manualKeys. Filter live-read keys at changed_keys construction so the status matches the summary.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on settings.py - passed.
- `git diff --check` - passed.
