### PR TITLE
fix(renderer): use container-service default for litellm base

### DIFF
--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -173,7 +173,7 @@ litellm_settings:
 def render_litellm_local_native(inputs: RenderInputs) -> RenderedFile:
     # ODS-CONTRACT-WRITER: litellm-local-native
     model = inputs.gguf_file or inputs.model
-    api_base = inputs.llm_base_url.rstrip("/") or "http://host.docker.internal:8080/v1"
+    api_base = inputs.llm_base_url.rstrip("/") or "http://llama-server:8080/v1"
     content = f"""model_list:
   - model_name: default
     litellm_params:


### PR DESCRIPTION
## Summary

host.docker.internal does not resolve on native Linux, so the local-litellm fallback base pointed at a broken address. Use the llama-server container-service default used elsewhere in the file.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Installer
- [ ] Dashboard UI
- [x] Core runtime
- [ ] Tests only

## Validation

- `python -m py_compile` on render-runtime-configs.py - passed.
- `git diff --check` - passed.
