### PR TITLE
fix(macos): force-recreate containers on restart

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -834,7 +834,7 @@ cmd_restart() {
     elif [[ -n "$service" ]]; then
         ai "Restarting ${service}..."
         # shellcheck disable=SC2086
-        docker compose $flags up -d "$service"
+        docker compose $flags up -d --force-recreate "$service"
         ai_ok "${service} restarted"
     else
         # Restart native llama-server
@@ -846,7 +846,7 @@ cmd_restart() {
 
         ai "Restarting all services..."
         # shellcheck disable=SC2086
-        docker compose $flags up -d
+        docker compose $flags up -d --force-recreate
         ai_ok "All services restarted"
     fi
 


### PR DESCRIPTION
## Summary

The 'ods-macos.sh restart' command ran 'docker compose up -d', which is a no-op for containers that are already running, so users were told the service restarted when it was never recreated. Add --force-recreate to both the single-service and all-services restart branches so running containers are actually stopped and recreated.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] macos/ods-macos.sh (restart: single-service + all-services branches)

## Validation

Validation: bash -n pass
