### PR TITLE
fix(opencode): read Windows config with UTF-8 encoding

### DIFF
--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -163,7 +163,7 @@ function Sync-WindowsOpenCodeConfig {
 
     if ($_existingConfigFile) {
         try {
-            $_configObject = Get-Content $_existingConfigFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            $_configObject = Get-Content $_existingConfigFile -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
             $_configStatus = "updated"
         } catch {
             $_configStatus = "regenerated"


### PR DESCRIPTION
## Summary

Windows config was read with the default (non-UTF8) PowerShell encoding, corrupting non-ASCII keys; now uses UTF-8.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Windows install scripts
- [x] config encoding
- [ ] macOS
- [ ] Linux
- [ ] renderer

## Validation

- [x] Powershell parse check
- [x] focused diff
