### PR TITLE
fix(opencode): fix VBS launcher quote escaping

### DIFF
--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -204,7 +204,7 @@ exit `$LASTEXITCODE
 ' ODS -- OpenCode Web Server (silent launcher)
 ' Run this script to start OpenCode without a visible console window.
 Set WshShell = CreateObject("WScript.Shell")
-WshShell.Run "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File ""$_ocLauncherPath""", 0, False
+WshShell.Run "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File """"$_ocLauncherPath""""", 0, False
 "@
     $_vbsPath = Join-Path $script:OPENCODE_DIR "start-opencode.vbs"
     Write-Utf8NoBom -Path $_vbsPath -Content $_vbsContent


### PR DESCRIPTION
## Summary

The VBS launcher wrote unescaped quotes into the embedded command, breaking paths containing quotes/spaces; now quotes are escaped correctly.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Windows VBS launcher
- [ ] macOS
- [ ] Linux
- [ ] renderer
- [ ] config

## Validation

- [x] powershell parse check
- [x] focused diff
