### PR TITLE
fix(opencode): resolve Windows sync libs for installed tree

### DIFF
--- a/ods/scripts/update-windows-opencode-config.ps1
+++ b/ods/scripts/update-windows-opencode-config.ps1
@@ -6,9 +6,23 @@ param(
 $ErrorActionPreference = "Stop"
 
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-$RepoRoot = Split-Path $ScriptDir -Parent
-$WindowsInstallerDir = Join-Path (Join-Path $RepoRoot "installers") "windows"
-$LibDir = Join-Path $WindowsInstallerDir "lib"
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    if ($env:ODS_HOME) {
+        $InstallDir = $env:ODS_HOME
+    } else {
+        $InstallDir = Join-Path $env:USERPROFILE "ods"
+    }
+}
+$inSourceLib = Join-Path (Join-Path (Join-Path (Split-Path $ScriptDir -Parent) "installers") "windows") "lib"
+$installLib = Join-Path (Join-Path (Join-Path $InstallDir "installers") "windows") "lib"
+
+if (Test-Path (Join-Path $inSourceLib "constants.ps1")) {
+    $LibDir = $inSourceLib
+} elseif (Test-Path (Join-Path $installLib "constants.ps1")) {
+    $LibDir = $installLib
+} else {
+    throw "Could not locate ODS Windows installer lib (installers/windows/lib). Looked in source tree: $inSourceLib and installed tree: $installLib"
+}
 
 . (Join-Path $LibDir "constants.ps1")
 . (Join-Path $LibDir "ui.ps1")


### PR DESCRIPTION
## Summary

Windows sync script used a fixed lib path that broke for the installed (non-source) tree; now the lib path is resolved relative to the installed tree.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Windows install/sync scripts
- [ ] macOS
- [ ] Linux
- [ ] renderer
- [ ] config

## Validation

- [x] powershell parse check
- [x] focused diff
