### PR TITLE
fix(opencode): align bootstrap launcher python resolution with installer

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -273,7 +273,7 @@ macos_launch_detached_bootstrap_upgrade() {
     local log_file="${INSTALL_DIR}/logs/model-upgrade.log"
     local python_cmd="${PYTHON_CMD:-/usr/bin/python3}"
     local bash_cmd="${BASH:-bash}"
-    [[ -x "$python_cmd" ]] || python_cmd="$(command -v python3 || command -v python || true)"
+    [[ -x "$python_cmd" ]] || python_cmd="/usr/bin/python3"
     [[ -n "$python_cmd" ]] || {
         ai_warn "Python is unavailable; cannot launch background model-upgrade retry."
         return 1


### PR DESCRIPTION
## Summary

The detached bootstrap launcher function exists in two copies that drifted: install-macos.sh resolved the python interpreter via ${PYTHON_CMD:-/usr/bin/python3}, while ods-macos.sh fell back to $(command -v python3 || command -v python || true). That drift could select a different interpreter between install and run. This aligns the ods-macos.sh copy to the env-var-with-fallback style while keeping its empty-value guard.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] macOS install scripts
- [x] bootstrap launcher
- [ ] Windows
- [ ] Linux
- [ ] renderer
- [ ] config

## Validation

- [x] bash -n on modified script
- [x] focused single-file diff
