### PR TITLE
fix(opencode): wait for bootstrap compose stack on update

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -988,6 +988,7 @@ cmd_update() {
     compose_pull_with_retry "$flags"
 
     ai "Recreating containers..."
+    macos_wait_for_bootstrap_compose_safe "update" || return 1
     # shellcheck disable=SC2086
     docker compose $flags up -d --force-recreate
     ai_ok "Update complete"


### PR DESCRIPTION
## Summary

cmd_update recreated the compose stack without the readiness wait that cmd_start and cmd_restart already perform, so an update could race the bootstrap compose stack coming up. This adds macos_wait_for_bootstrap_compose_safe "update" || return 1 ahead of the force-recreate, mirroring the existing guard pattern.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] macOS update flow
- [x] bootstrap compose wait
- [ ] Windows
- [ ] Linux
- [ ] renderer
- [ ] config

## Validation

- [x] bash -n on modified script
- [x] focused single-file diff
