### PR TITLE
fix(opencode): grant linger to the real install user

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -296,10 +296,15 @@ OPENCODE_EOF
                 ai_ok "OpenCode Web UI service installed (user-level, port 3003)" || \
                 ai_warn "OpenCode Web UI service failed to start"
 
-            # Enable lingering so service survives logout
-            loginctl enable-linger "$(whoami)" 2>/dev/null || \
-                sudo -n loginctl enable-linger "$(whoami)" 2>/dev/null || \
-                ai_warn "Could not enable linger. OpenCode may stop after logout. Run: loginctl enable-linger $(whoami)"
+            # Enable lingering so service survives logout. Under `sudo bash
+            # install.sh`, $(whoami) is root — grant linger to the real user via
+            # the same heuristic the host-agent block uses (INSTALL_USER/SUDO_USER/whoami).
+            _linger_user="${INSTALL_USER:-}"
+            [[ -n "$_linger_user" ]] || _linger_user="${SUDO_USER:-}"
+            [[ -n "$_linger_user" ]] || _linger_user="$(whoami)"
+            loginctl enable-linger "$_linger_user" 2>/dev/null || \
+                sudo -n loginctl enable-linger "$_linger_user" 2>/dev/null || \
+                ai_warn "Could not enable linger. OpenCode may stop after logout. Run: loginctl enable-linger $_linger_user"
         fi
     fi
 fi


### PR DESCRIPTION
## Summary

The Linux installer enabled loginctl linger for a hard-coded user instead of the actual install user, so the opencode service died at logout on systems where the two differ. Linger is now granted to the resolved install user, keeping the service alive.

## AI Assistance

AI-assisted repository exploration and regression triage. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Linux install scripts
- [x] linger/systemd setup
- [ ] macOS
- [ ] Windows
- [ ] renderer
- [ ] config

## Validation

- [x] bash -n on modified scripts
- [x] focused single-file diff
