### PR TITLE
fix(dashboard-api): handle UnicodeDecodeError in _read_env_map_from_path in settings.py

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -105,7 +105,7 @@ def _strip_env_quotes(value: str) -> str:
 
 def _read_env_map_from_path(path: Path) -> tuple[dict[str, str], list[dict[str, Any]]]:
     try:
-        return _parse_env_text(path.read_text(encoding="utf-8"))
+        return _parse_env_text(path.read_text(encoding="utf-8", errors="replace"))
     except OSError:
         return {}, []
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/settings.py`, `_read_env_map_from_path()` reads environment settings from `.env` files using `path.read_text(encoding="utf-8")`. If the `.env` file contains invalid non-UTF-8 characters or corrupt bytes, a `UnicodeDecodeError` previously crashed key parsing.

## Fix

Pass `errors="replace"` to `path.read_text()` inside `_read_env_map_from_path()`.

## Verification

Ran `pytest ods/extensions/services/dashboard-api/tests/test_routers.py` (54/54 passed). `git diff --check` passed cleanly.