### PR TITLE
fix(upgrade): include docker-compose.override.yml in compose stack resolution in upgrade-model.sh

### DIFF
--- a/ods/scripts/upgrade-model.sh
+++ b/ods/scripts/upgrade-model.sh
@@ -47,6 +47,9 @@ detect_compose_file() {
     elif [[ -f "$ODS_DIR/docker-compose.yml" ]]; then
         COMPOSE_FILE_ARGS=(-f "$ODS_DIR/docker-compose.yml")
     fi
+    if [[ -f "$ODS_DIR/docker-compose.override.yml" ]]; then
+        COMPOSE_FILE_ARGS+=(-f "$ODS_DIR/docker-compose.override.yml")
+    fi
 }
 
 detect_inference_service() {


### PR DESCRIPTION
## Problem

In `ods/scripts/upgrade-model.sh`, `detect_compose_file()` detects base and GPU-specific docker compose files (`docker-compose.base.yml`, `docker-compose.nvidia.yml`, etc.). If an operator has created local overrides in `docker-compose.override.yml`, the script previously omitted appending `-f docker-compose.override.yml` to `COMPOSE_FILE_ARGS`.

## Fix

Update `detect_compose_file()` in `upgrade-model.sh` to check for `docker-compose.override.yml` in `ODS_DIR` and append it to `COMPOSE_FILE_ARGS` when present.

## Verification

Verified syntax with `bash -n ods/scripts/upgrade-model.sh`. `git diff --check` passed cleanly.