### PR TITLE
fix(hardware): add safe float parsing for vram_mb and ram_mb in classify-hardware.sh

### DIFF
--- a/ods/scripts/classify-hardware.sh
+++ b/ods/scripts/classify-hardware.sh
@@ -63,11 +63,17 @@ env_mode = sys.argv[2] == "true"
 platform_id = sys.argv[3]
 gpu_vendor = sys.argv[4]
 memory_type = sys.argv[5]
-vram_mb = int(float(sys.argv[6] or 0))
+def safe_int_float(val):
+    try:
+        return int(float(val or 0))
+    except (ValueError, TypeError):
+        return 0
+
+vram_mb = safe_int_float(sys.argv[6])
 device_id = sys.argv[7]
 gpu_name = sys.argv[8]
 cpu_name = sys.argv[9]
-ram_mb = int(float(sys.argv[10] or 0))
+ram_mb = safe_int_float(sys.argv[10])
 
 with open(db_path, "r", encoding="utf-8") as f:
     db = json.load(f)


### PR DESCRIPTION
## Problem

In `ods/scripts/classify-hardware.sh`, inline Python code parsed `vram_mb` and `ram_mb` command line arguments using `int(float(sys.argv[...] or 0))`. If non-numeric values were passed as arguments, Python raised an unhandled `ValueError`.

## Fix

Add a local `safe_int_float()` helper function in `classify-hardware.sh` to parse numeric memory parameters safely, defaulting to `0` on unparseable inputs.

## Verification

Verified syntax with `bash -n ods/scripts/classify-hardware.sh`. `git diff --check` passed cleanly.