### PR TITLE
fix(compat): check docs/SUPPORT-MATRIX.md existence before grep in check-compatibility.sh

### DIFF
--- a/ods/scripts/check-compatibility.sh
+++ b/ods/scripts/check-compatibility.sh
@@ -51,7 +51,9 @@ pass "ports contract"
 
 # Support matrix consistency checks
 if jq -e '.compatibility.os.macos.supported == false' "$MANIFEST_FILE" >/dev/null; then
-  grep -q "macOS.*Tier C" "${ROOT_DIR}/docs/SUPPORT-MATRIX.md" \
-    || warn "manifest says macOS unsupported/preview but docs may be out of sync"
+  if [[ -f "${ROOT_DIR}/docs/SUPPORT-MATRIX.md" ]]; then
+    grep -q "macOS.*Tier C" "${ROOT_DIR}/docs/SUPPORT-MATRIX.md" \
+      || warn "manifest says macOS unsupported/preview but docs may be out of sync"
+  fi
 fi
 pass "compatibility check complete"


### PR DESCRIPTION
## Problem

In `ods/scripts/check-compatibility.sh`, the script checks macOS support matrix consistency by running `grep -q "macOS.*Tier C" "${ROOT_DIR}/docs/SUPPORT-MATRIX.md"`. If `SUPPORT-MATRIX.md` is missing or not present in sparse checkouts, `grep` fails under `set -e`, aborting the compatibility validation suite.

## Fix

Wrap the `grep` check inside a `if [[ -f "${ROOT_DIR}/docs/SUPPORT-MATRIX.md" ]]` guard in `check-compatibility.sh`.

## Verification

Verified syntax with `bash -n ods/scripts/check-compatibility.sh`. `git diff --check` passed cleanly.