### PR TITLE
fix(ssh-tunnel): log Warning when ssh plan argv is invalid

### DIFF
--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -301,7 +301,11 @@ class SshProcessSupervisor:
             self._notice_exited_locked(now)
             try:
                 argv = _combined_ssh_argv(plan)
-            except ValueError:
+            except ValueError as exc:
+                LOGGER.warning(
+                    "ssh plan argv invalid: %s", exc,
+                    extra={"route_path": str(self.route_path)},
+                )
                 self._stop_process_locked()
                 self._last_payload = _health_from_plan(
                     _error_plan("ssh_plan_unavailable", secret_dir=self.secret_dir),


### PR DESCRIPTION
## Summary

Closes #2338. `reconcile()` caught `ValueError` from `_combined_ssh_argv()` and transitioned to the `ssh_plan_unavailable` error state without a single log line, so operators diagnosing a broken remote-provider tunnel saw no reason it refused to start.

## Change

Log a WARNING carrying the exception message (e.g. 'SSH tunnel argv is missing a local forward') with the route path before stopping the process.

## Test plan

- Reproduced the failure path and confirmed a WARNING now appears in the tunnel supervisor log.