### PR TITLE
fix(backup): recognize multi-segment user-named backup IDs

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -148,7 +148,7 @@ collect_backups() {
     local entry base
     while IFS= read -r -d '' entry; do
         base=$(basename "$entry")
-        [[ "$base" =~ ^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
+        [[ "$base" =~ ^([A-Za-z0-9_-]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
         COLLECTED_BACKUPS+=("$entry")
     done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
 }


### PR DESCRIPTION
## Summary

Closes #2299. `collect_backups()` allowed at most one hyphenated prefix segment, while `ods-host-agent.py BACKUP_ID_RE` permits `[A-Za-z0-9_-]{0,63}`. A backup named `dashboard-my-name-20260715-143022` was invisible to `list_backups` and `apply_retention`.

## Change

Align the shell regex with the host-agent: allow multiple hyphen-separated segments while keeping the prefix optional.

## Test plan

- Ran `ods-backup.sh list` against a fixture dir containing multi-segment names; all now resolve.