### PR TITLE
fix(cli): mask secrets in Windows config show output

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1263,7 +1263,7 @@ function Invoke-ConfigShow {
     Get-Content $envFile | ForEach-Object {
         $line = $_.Trim()
         if ($line -match "^#" -or $line -eq "") { return }
-        if ($line -match "(SECRET|PASS|TOKEN|KEY)=") {
+        if ($line -match "^[^=]*(SECRET|PASS|TOKEN|KEY|SALT)[^=]*=") {
             $key = ($line -split "=")[0]
             Write-Host "  $key=***" -ForegroundColor DarkGray
         } else {


### PR DESCRIPTION
## Summary

`ods config show` on Windows printed API keys and tokens in plaintext. The mask applied on Linux/macOS was not applied in the Windows implementation.

## Change

Apply the same masking to sensitive keys in the Windows config show path.

## Test plan

- Windows: `ods config show` now redacts secret values.