### PR TITLE
fix(test): escape quotes in json payload in ods-test-functional.sh

### DIFF
--- a/ods/scripts/ods-test-functional.sh
+++ b/ods/scripts/ods-test-functional.sh
@@ -86,9 +86,11 @@ test_llm_functional() {
         model_id=""
     fi
     model_id="${model_id:-local}"
+    local safe_model_id="${model_id//\\/\\\\}"
+    safe_model_id="${safe_model_id//\"/\\\"}"
 
     local prompt="What is 2+2? Answer with just the number."
-    local payload="{\"model\": \"$model_id\", \"messages\": [{\"role\": \"user\", \"content\": \"$prompt\"}], \"max_tokens\": 10, \"temperature\": 0.1}"
+    local payload="{\"model\": \"$safe_model_id\", \"messages\": [{\"role\": \"user\", \"content\": \"$prompt\"}], \"max_tokens\": 10, \"temperature\": 0.1}"
 
     local response
     response=$(curl -s --max-time 30 \


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-test-functional.sh`, `test_llm_functional()` queries the model list and embeds `$model_id` directly into an inline JSON payload string. If the active model name contains special characters, backslashes, or quotes, the payload string format breaks and returns a 400 bad request.

## Fix

Add string escaping for backslashes and double quotes in `$model_id` before constructing the JSON POST body payload in `ods-test-functional.sh`.

## Verification

Ran `bash -n ods/scripts/ods-test-functional.sh` (passed cleanly). `git diff --check` passed cleanly.