### PR TITLE
fix(doctor): strip leading key whitespace in load_env_safe in ods-doctor.sh

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -46,6 +46,7 @@ load_env_safe() {
     local env_file="${1:-$ROOT_DIR/.env}"
     [[ -f "$env_file" ]] || return 0
     while IFS='=' read -r key value; do
+        key="${key#"${key%%[![:space:]]*}"}"
         value="${value%$'\r'}"
         [[ "$key" =~ ^[[:space:]]*# ]] && continue
         [[ -z "$key" ]] && continue


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-doctor.sh`, `load_env_safe()` parses environment variables from `.env` using `while IFS='=' read -r key value`. If a variable key contains leading whitespace (e.g., `  ODS_PORT=3000`), the key validation regex `^[A-Za-z_][A-Za-z0-9_]*$` fails and ignores valid configuration entries.

## Fix

Strip leading whitespace from `key` using `key="${key#"${key%%[![:space:]]*}"}"` prior to running key name validation regexes in `load_env_safe()`.

## Verification

Ran `bash -n ods/scripts/ods-doctor.sh` (passed cleanly). `git diff --check` passed cleanly.