### PR TITLE
fix(audit): handle decode and parse errors in load_struct_file in audit-extensions.py

### DIFF
--- a/ods/scripts/audit-extensions.py
+++ b/ods/scripts/audit-extensions.py
@@ -115,11 +115,14 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_document(path: Path) -> Any:
-    with path.open("r", encoding="utf-8") as handle:
-        if path.suffix == ".json":
-            return json.load(handle)
-        return yaml.safe_load(handle)
+def load_struct_file(path: Path) -> Any:
+    try:
+        with path.open("r", encoding="utf-8", errors="replace") as handle:
+            if path.suffix == ".json":
+                return json.load(handle)
+            return yaml.safe_load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, yaml.YAMLError, ValueError):
+        return {}
 
 
 def find_manifest(service_dir: Path) -> Path | None:

--- a/ods/scripts/audit-extensions.py
+++ b/ods/scripts/audit-extensions.py
@@ -115,7 +115,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_struct_file(path: Path) -> Any:
+def load_document(path: Path) -> Any:
     try:
         with path.open("r", encoding="utf-8", errors="replace") as handle:
             if path.suffix == ".json":


### PR DESCRIPTION
## Problem

In `ods/scripts/audit-extensions.py`, structured files (JSON/YAML manifests and compose files) were opened and parsed via `path.open("r", encoding="utf-8")`. If a manifest file contained invalid UTF-8 bytes or malformed syntax, uncaught `UnicodeDecodeError` or `YAMLError` exceptions crashed the extension auditor.

## Fix

Add `errors="replace"` parameter and wrap file reading in a `try...except (OSError, UnicodeDecodeError, json.JSONDecodeError, yaml.YAMLError, ValueError)` block returning `{}` on failure.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/audit-extensions.py`. `git diff --check` passed cleanly.