### PR TITLE
fix(persona): catch OSError and UnicodeDecodeError in _running_services in build-installation-context.py

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -141,7 +141,7 @@ def _running_services(repo_root: Path) -> set[str]:
             ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=ods-"],
             capture_output=True, text=True, timeout=10,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError, UnicodeDecodeError):
         return set()
 
     cmap = _container_to_service_map(repo_root)


### PR DESCRIPTION
## Problem

In `ods/scripts/build-installation-context.py`, `_running_services()` checks container status by executing `subprocess.run(["docker", "ps", ...])`. If Docker daemon permissions fail or subprocess text decoding encounters non-UTF-8 bytes, an uncaught `OSError` or `UnicodeDecodeError` previously crashed context generation.

## Fix

Expand the exception handler in `_running_services()` to catch `OSError` and `UnicodeDecodeError` alongside `FileNotFoundError` and `TimeoutExpired`, returning an empty set safely.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/build-installation-context.py`. `git diff --check` passed cleanly.