### PR TITLE
fix(card): add graceful ImportError handler for PIL and qrcode in generate-setup-card.py

### DIFF
--- a/ods/scripts/generate-setup-card.py
+++ b/ods/scripts/generate-setup-card.py
@@ -82,9 +82,13 @@ def build_wifi_qr_payload(ssid: str, password: str, security: str = "WPA") -> st
 
 def render_qr(text: str, target_px: int):
     """Return a Pillow Image of the QR sized to ~target_px x target_px."""
-    import qrcode  # noqa: PLC0415 — lazy import keeps --help fast
-    from PIL import Image  # noqa: PLC0415
-    from qrcode.constants import ERROR_CORRECT_M
+    try:
+        import qrcode  # noqa: PLC0415 — lazy import keeps --help fast
+        from PIL import Image  # noqa: PLC0415
+        from qrcode.constants import ERROR_CORRECT_M
+    except (ImportError, ModuleNotFoundError) as exc:
+        print(f"error: required image library missing ({exc}). Install with: pip install Pillow qrcode", file=sys.stderr)
+        sys.exit(1)
 
     # ERROR_CORRECT_M handles ~15% damage which is fine for a printed card.
     # box_size is the pixel size of each "module" (QR cell); we scale up.


### PR DESCRIPTION
## Problem

In `ods/scripts/generate-setup-card.py`, `render_qr()` imports `qrcode` and `PIL` lazily. If required image rendering libraries are missing from the execution environment, Python raised a raw `ModuleNotFoundError` traceback instead of a clear CLI user error.

## Fix

Wrap lazy imports in `render_qr()` with a `try...except (ImportError, ModuleNotFoundError)` block that logs a clear error message to stderr and exits cleanly with status code 1.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/generate-setup-card.py`. `git diff --check` passed cleanly.