### PR TITLE
fix(version): specify errors=replace in read_text in check-version-consistency.py

### DIFF
--- a/ods/scripts/check-version-consistency.py
+++ b/ods/scripts/check-version-consistency.py
@@ -14,7 +14,7 @@ SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
 
 
 def read_text(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
+    return path.read_text(encoding="utf-8", errors="replace")
 
 
 def first_match(path: Path, pattern: str, label: str) -> str:


### PR DESCRIPTION
## Problem

In `ods/scripts/check-version-consistency.py`, `read_text()` reads version files using `path.read_text(encoding="utf-8")`. If non-UTF-8 characters or corrupt bytes are encountered in documentation files or version manifests, a `UnicodeDecodeError` previously crashed release verification.

## Fix

Pass `errors="replace"` parameter to `path.read_text()` inside `read_text()`.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/check-version-consistency.py`. `git diff --check` passed cleanly.