### PR TITLE
fix(download): cleanup temporary file on download failure in download-hf-artifact.py

### DIFF
--- a/ods/scripts/download-hf-artifact.py
+++ b/ods/scripts/download-hf-artifact.py
@@ -48,11 +48,14 @@ def download_artifact(url: str, destination: Path) -> Path:
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
     tmp_destination = destination.with_name(f"{destination.name}.hf-tmp")
-    shutil.copyfile(downloaded, tmp_destination)
-    if tmp_destination.stat().st_size <= 0:
+    try:
+        shutil.copyfile(downloaded, tmp_destination)
+        if tmp_destination.stat().st_size <= 0:
+            raise RuntimeError("downloaded artifact is empty")
+        tmp_destination.replace(destination)
+    except Exception:
         tmp_destination.unlink(missing_ok=True)
-        raise RuntimeError("downloaded artifact is empty")
-    tmp_destination.replace(destination)
+        raise
     return destination
 
 


### PR DESCRIPTION
## Problem

In `ods/scripts/download-hf-artifact.py`, `download_artifact()` copies downloaded Hugging Face files to a temporary destination (`${destination.name}.hf-tmp`). If `shutil.copyfile()` or atomic replacement fails due to disk errors, partially written `.hf-tmp` files are left behind on disk.

## Fix

Wrap file copying and replacement in a `try...except Exception` block in `download_artifact()`, calling `tmp_destination.unlink(missing_ok=True)` before re-raising exceptions.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/download-hf-artifact.py`. `git diff --check` passed cleanly.