### PR TITLE
fix(preflight): write report JSON atomically in preflight-engine.sh

### DIFF
--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -342,9 +342,15 @@ report = {
     "checks": checks,
 }
 
+import os
+import tempfile
+
 report_path = pathlib.Path(report_file)
 report_path.parent.mkdir(parents=True, exist_ok=True)
-report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+fd, tmp_name = tempfile.mkstemp(dir=str(report_path.parent), suffix=".tmp")
+with os.fdopen(fd, "w", encoding="utf-8") as f:
+    f.write(json.dumps(report, indent=2) + "\n")
+os.replace(tmp_name, str(report_path))
 
 if env_mode:
     def out(key, value):


### PR DESCRIPTION
## Problem

In `ods/scripts/preflight-engine.sh`, inline Python evaluation writes preflight report JSON outputs directly using `report_path.write_text(...)`. Writing directly truncates target report files in place, risking incomplete or corrupted JSON outputs if preflight evaluation is interrupted by process signals.

## Fix

Update `preflight-engine.sh` inline Python to create temporary output files via `tempfile.mkstemp` in `report_path`'s parent directory and perform an atomic `os.replace` swap.

## Verification

Ran `bash -n ods/scripts/preflight-engine.sh` (passed cleanly). `git diff --check` passed cleanly.