### PR TITLE
fix(capability): use int float conversion for ram_mb calculation in build-capability-profile.sh

### DIFF
--- a/ods/scripts/build-capability-profile.sh
+++ b/ods/scripts/build-capability-profile.sh
@@ -52,7 +52,7 @@ CLASS_ENV="$("${SCRIPT_DIR}/classify-hardware.sh" \
     --device-id "$("$PYTHON_CMD" -c "import json,sys; print(json.loads(sys.argv[1]).get('gpu',{}).get('device_id',''))" "$HARDWARE_JSON")" \
     --gpu-name "$("$PYTHON_CMD" -c "import json,sys; print(json.loads(sys.argv[1]).get('gpu',{}).get('name',''))" "$HARDWARE_JSON")" \
     --cpu-name "$("$PYTHON_CMD" -c "import json,sys; print(json.loads(sys.argv[1]).get('cpu',''))" "$HARDWARE_JSON")" \
-    --ram-mb "$("$PYTHON_CMD" -c "import json,sys; print(json.loads(sys.argv[1]).get('ram_gb',0) * 1024)" "$HARDWARE_JSON")" \
+    --ram-mb "$("$PYTHON_CMD" -c "import json,sys; print(int(float(json.loads(sys.argv[1]).get('ram_gb',0) or 0) * 1024))" "$HARDWARE_JSON")" \
     --env)"
 load_env_from_output <<< "$CLASS_ENV"
 


### PR DESCRIPTION
## Problem

In `ods/scripts/build-capability-profile.sh`, `classify-hardware.sh` is invoked with `--ram-mb` using inline Python multiplication `json.loads(sys.argv[1]).get('ram_gb',0) * 1024`. If `ram_gb` is reported as a float (e.g. `15.8`), Python outputs a floating point string (`16179.2`), causing downstream integer regex validation checks to reject the parameter.

## Fix

Wrap `ram_gb` multiplication in `int(float(... or 0) * 1024)` inside the inline Python string parser in `build-capability-profile.sh`.

## Verification

Ran `bash -n ods/scripts/build-capability-profile.sh` (passed cleanly). `git diff --check` passed cleanly.