### PR TITLE
fix(validate): guard against lines missing equals sign in split_kv in validate-env.sh

### DIFF
--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -122,6 +122,10 @@ unquote() {
 # Split KEY=VALUE where VALUE may contain '='
 split_kv() {
   local line="$1"
+  if [[ "$line" != *"="* ]]; then
+    printf '%s\n' "" ""
+    return 0
+  fi
   local key="${line%%=*}"
   local value="${line#*=}"
   key="$(trim "$key")"


### PR DESCRIPTION
## Problem

In `ods/scripts/validate-env.sh`, `split_kv()` splits input lines into key-value pairs using parameter expansions `line%%=*` and `line#*=`. If a line without an equals sign is passed directly to `split_kv()`, `line#*=` evaluates to the full input string, returning a false key-value mapping.

## Fix

Add an explicit check in `split_kv()` for missing equals signs, returning empty key and value strings safely when no equals sign is present.

## Verification

Ran `bash -n ods/scripts/validate-env.sh` (passed cleanly). `git diff --check` passed cleanly.