### PR TITLE
fix(schema): handle decode errors in resolve_schema_path in validate-manifest-schema.sh

### DIFF
--- a/ods/scripts/validate-manifest-schema.sh
+++ b/ods/scripts/validate-manifest-schema.sh
@@ -95,7 +95,7 @@ root_dir = Path(sys.argv[2])
 try:
     manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
     schema_rel = manifest["contracts"]["extensions"]["serviceManifestSchema"]
-except (OSError, KeyError, TypeError, json.JSONDecodeError) as exc:
+except (OSError, KeyError, TypeError, json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
     print(
         "Cannot resolve contracts.extensions.serviceManifestSchema "
         f"from {manifest_file}: {exc}",


### PR DESCRIPTION
## Problem

In `ods/scripts/validate-manifest-schema.sh`, `resolve_schema_path()` loads `manifest.json` via `manifest_file.read_text(encoding="utf-8")`. If non-UTF-8 characters or malformed bytes are encountered in the manifest file, an uncaught `UnicodeDecodeError` or `ValueError` previously escaped the error handler block.

## Fix

Include `UnicodeDecodeError` and `ValueError` in the exception handling tuple in `resolve_schema_path()` in `validate-manifest-schema.sh`.

## Verification

Ran `bash -n ods/scripts/validate-manifest-schema.sh` (passed cleanly). `git diff --check` passed cleanly.