### PR TITLE
fix(card): handle missing name attribute on ImportError in generate-setup-card.py

### DIFF
--- a/ods/scripts/generate-setup-card.py
+++ b/ods/scripts/generate-setup-card.py
@@ -348,7 +348,8 @@ def main(argv: list[str] | None = None) -> int:
         import PIL  # noqa: F401, PLC0415
         import qrcode  # noqa: F401, PLC0415
     except ImportError as exc:
-        print(f"error: missing dependency: {exc.name}. "
+        mod_name = getattr(exc, "name", None) or str(exc)
+        print(f"error: missing dependency: {mod_name}. "
               "Install with: pip install 'qrcode[pil]'", file=sys.stderr)
         return 2
 


### PR DESCRIPTION
## Problem

In `ods/scripts/generate-setup-card.py`, `main()` checks required image libraries by importing `PIL` and `qrcode`. On certain Python versions or customized exception objects where `exc.name` evaluates to `None`, the error print formatted output as `missing dependency: None`.

## Fix

Use `mod_name = getattr(exc, "name", None) or str(exc)` to ensure a meaningful error message is logged when dependencies are missing.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/generate-setup-card.py`. `git diff --check` passed cleanly.