### PR TITLE
fix(backend): use context manager and errors=replace in load-backend-contract.sh

### DIFF
--- a/ods/scripts/load-backend-contract.sh
+++ b/ods/scripts/load-backend-contract.sh
@@ -47,7 +47,8 @@ if [[ "$ENV_MODE" == "true" ]]; then
 import json
 import sys
 
-contract = json.load(open(sys.argv[1], "r", encoding="utf-8"))
+with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as f:
+    contract = json.load(f)
 
 def out(key, value):
     safe = str(value).replace("\\", "\\\\").replace('"', '\\"')


### PR DESCRIPTION
## Problem

In `ods/scripts/load-backend-contract.sh`, inline Python loaded backend contract JSON files via `json.load(open(sys.argv[1], "r", encoding="utf-8"))`. Opening files without a `with` statement leaves file handles open until garbage collection runs, and missing `errors="replace"` parameter caused `UnicodeDecodeError` on non-standard locale encodings.

## Fix

Wrap file opening in a `with open(sys.argv[1], "r", encoding="utf-8", errors="replace") as f:` context manager inside `load-backend-contract.sh`.

## Verification

Ran `bash -n ods/scripts/load-backend-contract.sh` (passed cleanly). `git diff --check` passed cleanly.