### PR TITLE
fix(bootstrap): replace un-fsynced heredoc mv with atomic Python fsync+replace for bootstrap-status.json

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -89,6 +89,17 @@ MODELS_INI="$INSTALL_DIR/config/llama-server/models.ini"
 STATUS_FILE="$INSTALL_DIR/data/bootstrap-status.json"
 UPGRADE_LOCK_DIR=""
 
+# Resolve a usable Python interpreter for atomic status writes. (#2728)
+# python3 is preferred; fall back to python. If neither is available the
+# write_status function degrades gracefully and skips the fsync write with
+# a warning rather than aborting the download.
+PYTHON_CMD=""
+if command -v python3 >/dev/null 2>&1; then
+    PYTHON_CMD="python3"
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+fi
+
 # Cross-platform file size (GNU stat on Linux/WSL2, BSD stat on macOS)
 # IMPORTANT: Try GNU stat -c %s FIRST (Linux). stat -f on Linux returns filesystem
 # block count (not file size). BSD stat -f %z is the macOS fallback.
@@ -106,24 +117,81 @@ get_remote_size() {
         | grep -i '^content-length:' | tail -1 | tr -dc '0-9'
 }
 
-# Write status JSON (atomic via mv)
+# Write status JSON atomically with fsync.
+#
+# The original implementation used a shell heredoc redirect (cat > .tmp) and
+# then `mv`. Shell redirection never calls fsync(), so the kernel may not flush
+# buffered bytes to disk before the process is killed. Additionally, `mv` across
+# filesystem boundaries (e.g. /tmp vs a Docker volume mount) falls back to
+# cp + unlink, breaking atomicity. (#2728)
+#
+# Fix: delegate the write to Python, which flushes + fsyncs the temp file before
+# os.replace(), matching the proven pattern in session-cleanup.sh.
 write_status() {
     local status="$1" percent="${2:-}" downloaded="${3:-0}" total="${4:-0}" speed="${5:-0}" eta="${6:-}"
     local _safe_model="${FULL_GGUF_FILE//\"/\\\"}"
-    cat > "$STATUS_FILE.tmp" << STATUSEOF
-{
-  "status": "$status",
-  "model": "$_safe_model",
-  "percent": ${percent:-null},
-  "bytesDownloaded": $downloaded,
-  "bytesTotal": $total,
-  "speedBytesPerSec": $speed,
-  "eta": "${eta:-}",
-  "updatedAt": "$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')"
+    local _updated_at
+    _updated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date '+%Y-%m-%dT%H:%M:%SZ')"
+    local _percent_json="${percent:-null}"
+
+    if [[ -z "${PYTHON_CMD:-}" ]]; then
+        log "WARNING: no Python interpreter found; skipping fsync'd status write for $STATUS_FILE"
+        return 0
+    fi
+
+    "$PYTHON_CMD" - \
+        "$STATUS_FILE" \
+        "$status" \
+        "$_safe_model" \
+        "$_percent_json" \
+        "$downloaded" \
+        "$total" \
+        "$speed" \
+        "${eta:-}" \
+        "$_updated_at" \
+        <<'PY'
+import json
+import os
+import sys
+import tempfile
+
+status_file = sys.argv[1]
+payload = {
+    "status":           sys.argv[2],
+    "model":            sys.argv[3],
+    "percent":          None if sys.argv[4] == "null" else float(sys.argv[4]),
+    "bytesDownloaded":  int(sys.argv[5]),
+    "bytesTotal":       int(sys.argv[6]),
+    "speedBytesPerSec": int(sys.argv[7]),
+    "eta":              sys.argv[8],
+    "updatedAt":        sys.argv[9],
 }
-STATUSEOF
-    mv "$STATUS_FILE.tmp" "$STATUS_FILE"
+parent = os.path.dirname(os.path.abspath(status_file))
+os.makedirs(parent, exist_ok=True)
+tmp_path = None
+try:
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".bootstrap-status.",
+        suffix=".tmp",
+        dir=parent,
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2)
+        fh.write("\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp_path, status_file)
+    tmp_path = None
+finally:
+    if tmp_path is not None:
+        try:
+            os.unlink(tmp_path)
+        except FileNotFoundError:
+            pass
+PY
 }
+
+
 
 status_percent() {
     local downloaded="${1:-0}" total="${2:-0}"

--- a/ods/tests/test-bootstrap-status-fsync.py
+++ b/ods/tests/test-bootstrap-status-fsync.py
@@ -6,7 +6,6 @@ atomically with fsync so the file is never left truncated or corrupted on crash.
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 import sys
 import tempfile
@@ -40,8 +39,6 @@ def test_no_heredoc_mv_in_write_status() -> None:
     start = source.find("\nwrite_status() {")
     assert start != -1, "write_status function not found in bootstrap-upgrade.sh"
 
-    # Find the closing brace of write_status — search for next top-level '}'
-    body_start = start + len("\nwrite_status() {")
     # Extract roughly 150 lines worth of the function body
     body = source[start : start + 4000]
 

--- a/ods/tests/test-bootstrap-status-fsync.py
+++ b/ods/tests/test-bootstrap-status-fsync.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""Regression tests for #2728 — write_status must write bootstrap-status.json
+atomically with fsync so the file is never left truncated or corrupted on crash.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "bootstrap-upgrade.sh"
+
+
+def _have_bash() -> bool:
+    import shutil
+    return shutil.which("bash") is not None
+
+
+def _have_python() -> bool:
+    import shutil
+    return shutil.which("python3") is not None or shutil.which("python") is not None
+
+
+# ---------------------------------------------------------------------------
+# Source-level contract tests (no bash required)
+# ---------------------------------------------------------------------------
+
+def test_no_heredoc_mv_in_write_status() -> None:
+    """Regression #2728: the old un-fsynced pattern must be absent from write_status."""
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    # Locate write_status function body
+    start = source.find("\nwrite_status() {")
+    assert start != -1, "write_status function not found in bootstrap-upgrade.sh"
+
+    # Find the closing brace of write_status — search for next top-level '}'
+    body_start = start + len("\nwrite_status() {")
+    # Extract roughly 150 lines worth of the function body
+    body = source[start : start + 4000]
+
+    assert "cat > " not in body or "cat >" not in body.split("PY")[0], (
+        "write_status must not use 'cat >' shell redirection — use Python os.fsync + os.replace (#2728)"
+    )
+    assert "mv \"$STATUS_FILE.tmp\"" not in body, (
+        "write_status must not use plain 'mv' for atomic replace — use Python os.replace (#2728)"
+    )
+
+
+def test_write_status_uses_python_fsync_pattern() -> None:
+    """Regression #2728: write_status must delegate to Python with os.fsync and os.replace."""
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    # The Python heredoc must be present inside the function
+    assert "os.fsync" in source, (
+        "write_status must call os.fsync() on the temp file before atomic replace (#2728)"
+    )
+    assert "os.replace" in source, (
+        "write_status must use os.replace() for atomic rename (#2728)"
+    )
+    assert "tempfile.mkstemp" in source, (
+        "write_status must use tempfile.mkstemp() so the temp file is in the same directory (#2728)"
+    )
+
+
+def test_python_cmd_resolved_before_write_status() -> None:
+    """Regression #2728: PYTHON_CMD must be set before write_status is defined."""
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    python_cmd_pos = source.find("PYTHON_CMD=")
+    write_status_pos = source.find("\nwrite_status() {")
+
+    assert python_cmd_pos != -1, "PYTHON_CMD must be defined in bootstrap-upgrade.sh (#2728)"
+    assert write_status_pos != -1, "write_status function must exist in bootstrap-upgrade.sh"
+    assert python_cmd_pos < write_status_pos, (
+        "PYTHON_CMD must be resolved before write_status is defined (#2728)"
+    )
+
+
+def test_write_status_has_no_python_cmd_guard_removed() -> None:
+    """Regression #2728: write_status must have a PYTHON_CMD guard for graceful degradation."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    start = source.find("\nwrite_status() {")
+    body = source[start: start + 4000]
+    assert "PYTHON_CMD" in body, (
+        "write_status must guard on PYTHON_CMD so it degrades gracefully when Python is absent (#2728)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Functional tests (requires bash + python3)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    not _have_bash() or sys.platform == "win32",
+    reason="Functional test requires bash on a POSIX system",
+)
+def test_write_status_produces_valid_json() -> None:
+    """Regression #2728: write_status must produce valid, complete JSON."""
+    with tempfile.TemporaryDirectory(prefix="ods-bootstrap-test-") as tmp:
+        status_file = Path(tmp) / "data" / "bootstrap-status.json"
+
+        # Minimal environment to exercise write_status directly
+        script = f"""
+set -euo pipefail
+INSTALL_DIR="{tmp}"
+FULL_GGUF_FILE="test-model.gguf"
+STATUS_FILE="{status_file}"
+PYTHON_CMD="$(command -v python3 || command -v python)"
+
+source "{SCRIPT}"
+
+mkdir -p "{status_file.parent}"
+write_status "downloading" "42.5" "1073741824" "2147483648" "52428800" "20s"
+"""
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"write_status failed:\n{result.stderr}"
+        assert status_file.exists(), "bootstrap-status.json was not created"
+
+        data = json.loads(status_file.read_text(encoding="utf-8"))
+        assert data["status"] == "downloading"
+        assert data["model"] == "test-model.gguf"
+        assert abs(data["percent"] - 42.5) < 0.01
+        assert data["bytesDownloaded"] == 1073741824
+        assert data["bytesTotal"] == 2147483648
+        assert data["speedBytesPerSec"] == 52428800
+        assert data["eta"] == "20s"
+        assert "updatedAt" in data
+
+
+@pytest.mark.skipif(
+    not _have_bash() or sys.platform == "win32",
+    reason="Functional test requires bash on a POSIX system",
+)
+def test_write_status_null_percent_produces_valid_json() -> None:
+    """Regression #2728: write_status with empty percent must produce JSON null (not empty string)."""
+    with tempfile.TemporaryDirectory(prefix="ods-bootstrap-null-test-") as tmp:
+        status_file = Path(tmp) / "data" / "bootstrap-status.json"
+
+        script = f"""
+set -euo pipefail
+INSTALL_DIR="{tmp}"
+FULL_GGUF_FILE="model.gguf"
+STATUS_FILE="{status_file}"
+PYTHON_CMD="$(command -v python3 || command -v python)"
+
+source "{SCRIPT}"
+
+mkdir -p "{status_file.parent}"
+write_status "downloading" "" "0" "0" "0" ""
+"""
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"write_status failed:\n{result.stderr}"
+        data = json.loads(status_file.read_text(encoding="utf-8"))
+        assert data["percent"] is None, (
+            "percent must be JSON null when not provided, not an empty string"
+        )
+
+
+@pytest.mark.skipif(
+    not _have_bash() or sys.platform == "win32",
+    reason="Functional test requires bash on a POSIX system",
+)
+def test_write_status_no_temp_file_left_on_success() -> None:
+    """Regression #2728: no .bootstrap-status.*.tmp files must remain after a successful write."""
+    with tempfile.TemporaryDirectory(prefix="ods-bootstrap-cleanup-test-") as tmp:
+        status_file = Path(tmp) / "data" / "bootstrap-status.json"
+        data_dir = status_file.parent
+
+        script = f"""
+set -euo pipefail
+INSTALL_DIR="{tmp}"
+FULL_GGUF_FILE="model.gguf"
+STATUS_FILE="{status_file}"
+PYTHON_CMD="$(command -v python3 || command -v python)"
+
+source "{SCRIPT}"
+
+mkdir -p "{data_dir}"
+write_status "complete" "100" "4294967296" "4294967296" "0" ""
+"""
+        result = subprocess.run(
+            ["bash", "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, f"write_status failed:\n{result.stderr}"
+
+        leftover = list(data_dir.glob(".bootstrap-status.*.tmp"))
+        assert leftover == [], (
+            f"Temporary file(s) leaked after successful write: {leftover}"
+        )


### PR DESCRIPTION
### Summary

Fixes **#2728** — `write_status()` in `ods/scripts/bootstrap-upgrade.sh` was writing `bootstrap-status.json` using a shell heredoc redirect (`cat > .tmp`) followed by `mv`. Shell redirection never calls `fsync()`, leaving buffered data in kernel page cache. On a crash, container kill, or hard system interruption during a multi-gigabyte GGUF download, the status file could be left 0-byte or corrupted — causing the dashboard to crash parsing the JSON progress report. The `mv` pattern also breaks atomicity when `$STATUS_FILE` and the temp file are on different filesystem mounts (e.g. Docker volume paths vs system `/tmp`).

### Problem

```bash
# Before — NOT fsync-safe, NOT cross-filesystem atomic

write_status() {
    cat > "$STATUS_FILE.tmp" << STATUSEOF
    { "status": "$status", ... }
STATUSEOF

    mv "$STATUS_FILE.tmp" "$STATUS_FILE"   # ← no fsync; non-atomic across mounts
}
```

* `cat >` does **not** call `fsync()` — buffered bytes can be lost on process kill.
* `mv` across filesystem boundaries falls back to `cp` + `unlink`, breaking atomicity.
* The `.tmp` suffix is hardcoded, meaning it could collide with concurrent readers.

The codebase already uses the correct pattern in `session-cleanup.sh` (`tempfile.mkstemp` → `fh.flush()` → `os.fsync()` → `os.replace()`), but this was never applied to the background model downloader.

### Solution

Delegate `write_status()` to Python using the same proven fsync-safe pattern:

1. **`PYTHON_CMD` resolver** — added once after `STATUS_FILE` is defined, detects `python3` → `python` at startup.
2. **`write_status()` rewritten**:

   * `tempfile.mkstemp(dir=parent)` — temp file is always in the **same directory** as `STATUS_FILE`, guaranteeing `os.replace()` is always a same-filesystem rename, never a cross-mount copy.
   * `fh.flush()` + `os.fsync(fh.fileno())` — kernel page cache is drained to disk before the rename.
   * `os.replace()` — POSIX-atomic on Linux/macOS; Win32-atomic (`MoveFileEx`) on WSL2.
   * `try/finally` cleanup — the `.tmp` file is always deleted on any Python exception.
   * **Graceful degradation** — if no Python interpreter is available, `write_status` logs a warning and returns without aborting the download.

### Changes

* **`ods/scripts/bootstrap-upgrade.sh`**:

  * Added `PYTHON_CMD` detection block (prefers `python3`, falls back to `python`).
  * Replaced `write_status()` heredoc + `mv` with Python `os.fsync` + `os.replace` pattern with a graceful fallback.

* **`ods/tests/test-bootstrap-status-fsync.py`** *(new)* — 7 regression tests across two tiers:

  * **Source-level (4 tests, platform-independent)**: assert `os.fsync`, `os.replace`, and `tempfile.mkstemp` are present; assert `PYTHON_CMD` is defined before `write_status`; assert the old `cat >` + `mv` pattern is absent; assert the `PYTHON_CMD` guard exists.
  * **Functional bash (3 tests, Linux CI)**: assert produced JSON is valid and complete; assert `percent` serialises as JSON `null` when not provided; assert no `.bootstrap-status.*.tmp` files are leaked after a successful write.
