### PR TITLE
fix(preflight): verify required service secrets are actually set

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -169,6 +169,9 @@ jobs:
       - name: Safe Env Loading Tests
         run: bash tests/test-safe-env.sh
 
+      - name: Required Service Secret Tests
+        run: bash tests/test-required-secrets-check.sh
+
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -67,6 +67,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== required service secrets ==="
+	@bash tests/test-required-secrets-check.sh
+	@echo ""
 	@echo "=== QR code helper LAN detection ==="
 	@bash tests/test-qrcode-helper.sh
 	@echo ""

--- a/ods/extensions/services/qdrant/manifest.yaml
+++ b/ods/extensions/services/qdrant/manifest.yaml
@@ -20,3 +20,11 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  env_vars:
+    # Qdrant reads QDRANT__SERVICE__API_KEY and serves every request
+    # unauthenticated when it is empty, while network-exposure-policy.json
+    # marks this service auth_required: true.
+    - key: QDRANT_API_KEY
+      required: true
+      secret: true
+      description: Qdrant vector DB API key

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -309,6 +309,27 @@ if [ "$DASHBOARD_FOUND" = false ]; then
 fi
 log ""
 
+# ── Required service secrets ────────────────────────────────────────────────
+# Service manifests declare which env vars a service cannot run correctly
+# without. An empty value is not a missing one to the services that consume
+# them — Qdrant serves unauthenticated with an empty API key, and an empty
+# LITELLM_MASTER_KEY disables gateway auth — while
+# config/network-exposure-policy.json marks both auth_required: true.
+log "[8/8] Checking required service secrets..."
+if [ -x "$ODS_DIR/scripts/check-required-secrets.sh" ]; then
+    if _secret_output="$(bash "$ODS_DIR/scripts/check-required-secrets.sh" "$ODS_DIR" 2>&1)"; then
+        pass "Required service secrets present"
+    else
+        while IFS= read -r _line; do
+            [ -n "$_line" ] && log "  $_line"
+        done <<< "$_secret_output"
+        fail "One or more enabled services is missing a required secret"
+    fi
+else
+    warn "scripts/check-required-secrets.sh not found — skipping secret check"
+fi
+log ""
+
 # Summary
 log "========================================"
 log "Pre-flight Summary"

--- a/ods/scripts/check-required-secrets.sh
+++ b/ods/scripts/check-required-secrets.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Verify every enabled service has the secrets its manifest marks required.
+#
+# Service manifests declare which env vars a service cannot run correctly
+# without (`required: true`), but nothing checked that at runtime. An empty
+# value is not the same as a missing one to the services that consume them:
+# Qdrant treats an empty QDRANT__SERVICE__API_KEY as "no API key configured"
+# and serves every request unauthenticated, and an empty LITELLM_MASTER_KEY
+# disables gateway auth. config/network-exposure-policy.json marks both
+# auth_required: true, so an empty value is a silent disagreement between the
+# declared posture and the running one.
+#
+# The installers generate these keys, so this only fires on a hand-edited or
+# hand-migrated .env — which is exactly the case nothing else catches.
+#
+# usage: check-required-secrets.sh [ODS_DIR]
+# exit 0 = all present, 1 = at least one enabled service is missing one.
+
+set -uo pipefail
+
+ODS_DIR="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ENV_FILE="$ODS_DIR/.env"
+SERVICES_DIR="$ODS_DIR/extensions/services"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+problems=0
+checked=0
+
+# Emit the keys a manifest marks required, one per line.
+#
+# A small awk pass rather than a YAML dependency on purpose: this runs from
+# preflight, before any Python environment is guaranteed to exist.
+manifest_required_secrets() {
+    awk '
+        /^[[:space:]]*env_vars:/ { in_env = 1; next }
+        in_env && /^[[:space:]]*-[[:space:]]*key:[[:space:]]*/ {
+            key = $0
+            sub(/^[[:space:]]*-[[:space:]]*key:[[:space:]]*/, "", key)
+            gsub(/[[:space:]]|"|'"'"'/, "", key)
+            pending = key
+            required = 0
+            next
+        }
+        in_env && /^[[:space:]]*required:[[:space:]]*true/ { required = 1 }
+        in_env && /^[[:space:]]*(secret|description):/ {
+            if (pending != "" && required) { print pending; pending = ""; required = 0 }
+        }
+        /^[a-zA-Z]/ && !/^[[:space:]]/ { in_env = 0 }
+    ' "$1" | sort -u
+}
+
+# Read one key out of .env without sourcing it. The file is user-editable, so
+# it is never eval'd here.
+env_value() {
+    local key="$1"
+    [[ -f "$ENV_FILE" ]] || return 0
+    sed -n "s/^[[:space:]]*${key}[[:space:]]*=//p" "$ENV_FILE" \
+        | tail -n 1 \
+        | tr -d '\r' \
+        | sed -e 's/^["'"'"']//' -e 's/["'"'"']$//'
+}
+
+for manifest in "$SERVICES_DIR"/*/manifest.yaml; do
+    [[ -f "$manifest" ]] || continue
+    svc_dir="$(dirname "$manifest")"
+    svc="$(basename "$svc_dir")"
+
+    # Only enabled services matter. Enablement is on-disk state: compose.yaml
+    # present versus compose.yaml.disabled, which the installer's
+    # _sync_extension_compose and the dashboard's enable/disable routes both
+    # maintain.
+    [[ -f "$svc_dir/compose.yaml" ]] || continue
+
+    while IFS= read -r key; do
+        [[ -n "$key" ]] || continue
+        checked=$((checked + 1))
+        value="$(env_value "$key")"
+        if [[ -z "$value" ]]; then
+            echo -e "${RED}✗${NC} $svc is enabled but $key is empty or missing in .env"
+            problems=$((problems + 1))
+        elif [[ "$value" == "CHANGEME" ]]; then
+            echo -e "${RED}✗${NC} $svc is enabled but $key is still the CHANGEME placeholder"
+            problems=$((problems + 1))
+        fi
+    done < <(manifest_required_secrets "$manifest")
+done
+
+if [[ "$problems" -gt 0 ]]; then
+    echo -e "${RED}✗${NC} $problems required secret(s) missing — the installer normally generates these."
+    echo "  Re-run the installer, or set them in $ENV_FILE, then restart the stack."
+    exit 1
+fi
+
+if [[ "$checked" -eq 0 ]]; then
+    echo -e "${YELLOW}⚠${NC} No enabled service declares a required secret"
+else
+    echo -e "${GREEN}✓${NC} Required secrets present for all enabled services ($checked checked)"
+fi
+exit 0

--- a/ods/tests/test-required-secrets-check.sh
+++ b/ods/tests/test-required-secrets-check.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# scripts/check-required-secrets.sh must catch an enabled service whose
+# manifest-declared required secret is empty, and must stay quiet about
+# services that are disabled or whose secret is set.
+#
+# The services that consume these do not treat empty as missing: Qdrant serves
+# every request unauthenticated with an empty QDRANT__SERVICE__API_KEY, and an
+# empty LITELLM_MASTER_KEY disables gateway auth — while
+# config/network-exposure-policy.json marks both auth_required: true.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/../scripts/check-required-secrets.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; exit 1; }
+
+[[ -f "$CHECKER" ]] || fail "check-required-secrets.sh not found"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Build a disposable ODS root with one service that declares a required
+# secret, mirroring the shape of a real manifest.
+make_root() {
+    local root="$1" enabled="$2" env_line="$3"
+    local svc="$root/extensions/services/faux"
+    mkdir -p "$svc"
+    cat > "$svc/manifest.yaml" <<'YAML'
+schema_version: ods.services.v1
+service:
+  id: faux
+  name: Faux Service
+  env_vars:
+    - key: FAUX_API_KEY
+      required: true
+      secret: true
+      description: Faux service API key
+YAML
+    if [[ "$enabled" == "enabled" ]]; then
+        echo "services: {}" > "$svc/compose.yaml"
+    else
+        echo "services: {}" > "$svc/compose.yaml.disabled"
+    fi
+    printf '%s\n' "$env_line" > "$root/.env"
+}
+
+run_checker() {
+    bash "$CHECKER" "$1" > "$TMP/out.txt" 2>&1
+    echo $?
+}
+
+# --- an enabled service with an empty secret must fail ----------------------
+
+R="$TMP/empty"; make_root "$R" enabled "FAUX_API_KEY="
+rc="$(run_checker "$R")"
+[[ "$rc" -ne 0 ]] || fail "Expected nonzero exit for an empty required secret, got $rc"
+grep -q "FAUX_API_KEY" "$TMP/out.txt" || fail "Error must name the missing key: $(cat "$TMP/out.txt")"
+pass "Enabled service with an empty required secret fails"
+
+# --- entirely absent from .env is the same problem --------------------------
+
+R="$TMP/absent"; make_root "$R" enabled "SOMETHING_ELSE=x"
+rc="$(run_checker "$R")"
+[[ "$rc" -ne 0 ]] || fail "Expected nonzero exit for a missing required secret, got $rc"
+pass "Enabled service with the secret absent from .env fails"
+
+# --- the CHANGEME placeholder is not a real value ---------------------------
+
+R="$TMP/changeme"; make_root "$R" enabled "FAUX_API_KEY=CHANGEME"
+rc="$(run_checker "$R")"
+[[ "$rc" -ne 0 ]] || fail "Expected nonzero exit for a CHANGEME placeholder, got $rc"
+grep -qi "changeme" "$TMP/out.txt" || fail "Error should mention the placeholder"
+pass "CHANGEME placeholder is rejected"
+
+# --- a set secret passes ----------------------------------------------------
+
+R="$TMP/ok"; make_root "$R" enabled "FAUX_API_KEY=a-real-looking-secret"
+rc="$(run_checker "$R")"
+[[ "$rc" -eq 0 ]] || fail "Expected exit 0 when the secret is set, got $rc: $(cat "$TMP/out.txt")"
+pass "Enabled service with the secret set passes"
+
+# --- a DISABLED service is not checked --------------------------------------
+# Guards against over-blocking: an operator who never enabled qdrant must not
+# be told to set QDRANT_API_KEY.
+
+R="$TMP/disabled"; make_root "$R" disabled "SOMETHING_ELSE=x"
+rc="$(run_checker "$R")"
+[[ "$rc" -eq 0 ]] || fail "A disabled service must not be checked, got $rc: $(cat "$TMP/out.txt")"
+pass "Disabled service is not checked"
+
+# --- quoted values are read correctly ---------------------------------------
+
+R="$TMP/quoted"; make_root "$R" enabled 'FAUX_API_KEY="quoted-secret"'
+rc="$(run_checker "$R")"
+[[ "$rc" -eq 0 ]] || fail "A quoted value must count as set, got $rc: $(cat "$TMP/out.txt")"
+pass "Quoted .env values are read correctly"
+
+# --- the shipped manifests are actually covered -----------------------------
+# qdrant and litellm are the two this exists for; if either stops declaring
+# its secret the check silently stops protecting it.
+
+for svc in qdrant litellm; do
+    m="$SCRIPT_DIR/../extensions/services/$svc/manifest.yaml"
+    grep -q "required: true" "$m" \
+        || fail "$svc/manifest.yaml must declare a required secret for the check to cover it"
+done
+pass "qdrant and litellm declare their required secrets"
+
+echo "All required-secret checks passed"


### PR DESCRIPTION
## Summary

Service manifests declare which env vars a service cannot run correctly
without (`required: true`), but nothing verified that at runtime.

An empty value is not a missing one to the services that consume these. Qdrant
treats an empty `QDRANT__SERVICE__API_KEY` as "no API key configured" and
serves every request unauthenticated; an empty `LITELLM_MASTER_KEY` disables
gateway auth. `config/network-exposure-policy.json` marks both
`auth_required: true`, so an empty value is a silent disagreement between the
declared posture and the running one — with no error anywhere.

The installers generate both keys unconditionally on all three platforms, so
this only bites a hand-edited or hand-migrated `.env`. That is precisely the
case nothing else catches: `validate-env.sh` runs at install time, not on
`ods restart`.

## What this adds

`scripts/check-required-secrets.sh` walks the **enabled** services and fails
when a manifest-declared required secret is empty, absent, or still `CHANGEME`.
Enablement is read from disk — `compose.yaml` versus `compose.yaml.disabled`,
the state `03-features.sh:_sync_extension_compose` and the dashboard's
enable/disable routes both maintain — so an operator who never enabled Qdrant
is never told to set `QDRANT_API_KEY`.

`ods-preflight.sh` delegates to it as check `[8/8]`.

`qdrant/manifest.yaml` declared no `env_vars` at all, so it now declares
`QDRANT_API_KEY` the way `litellm/manifest.yaml` declares `LITELLM_KEY`. That
also gives the existing `required: true` metadata something that enforces it.

## Why not `${VAR:?}` in compose

That was the first version of this PR, and it reads stricter — Compose refuses
to render at all. But `:?` aborts the **whole** compose invocation, not just
the one service, and ten CI tests render a stack with `docker compose config`.
Each would need its fixtures extended with both keys. I got three of them
(`.env.example`, `test-resolve-compose-resilient.sh`,
`test-windows-amd-local-compose.sh`) before concluding the churn was out of
proportion to the risk, given the installers already generate these.

This version catches the same hand-edited-`.env` case at the point where an
operator can read the message, and touches no compose file and no fixture.

Happy to revisit the stricter form if you would rather have it — it is a real
trade, not a dodge, and the fixture work is mechanical.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. An install produced by any supported installer already has
both keys, so there is no user-visible failure on stable to hot-fix.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

One manifest gains an `env_vars` declaration; no compose file is touched.

## Risk And Validation

- Risk level: Low. Additive — a new preflight check and a new script. Nothing
  existing changes behaviour, and the check only ever reports.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/test-required-secrets-check.sh
  ✓ Enabled service with an empty required secret fails
  ✓ Enabled service with the secret absent from .env fails
  ✓ CHANGEME placeholder is rejected
  ✓ Enabled service with the secret set passes
  ✓ Disabled service is not checked          <- guards against over-blocking
  ✓ Quoted .env values are read correctly
  ✓ qdrant and litellm declare their required secrets

$ bash tests/test-validate-manifests.sh              PASS
$ bash tests/test-validate-manifest-schema.sh        PASS
$ python3 scripts/audit-extensions.py --project-dir . PASS
$ bash tests/test-extension-audit.sh                 PASS
$ bash tests/contracts/test-installer-contracts.sh   PASS
$ python3 tests/contracts/test-network-exposure-contracts.py  PASS
$ shellcheck --severity=warning  (both new/changed scripts)   clean

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

It adds a preflight check that can fail the run, so it is operational. Not
covered: preflight against a real installed stack. The check is exercised
against disposable ODS roots with synthetic manifests, plus an assertion that
the two shipped manifests still declare their secrets — but a real
`./ods-preflight.sh` on an installed host is the thing I could not run.

## Notes For Reviewers

- The manifest parser is a small `awk` pass rather than a YAML dependency
  on purpose: preflight runs before any Python environment is guaranteed. It
  is verified against all five shipped manifests that declare required
  secrets — brave-search, litellm, n8n (two keys), openclaw, qdrant.
- `.env` is read with `sed`, never sourced, since it is user-editable.
- `CHANGEME` is treated as unset because that is the placeholder
  `.env.example` ships and `validate-env.sh` already rejects it.
