### PR TITLE
fix(mdns): stop advertising endpoints that cannot answer

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Offline Model Validation Tests
         run: python3 tests/test-offline-model-validation.py
 
+      - name: mDNS Record Gating Tests
+        run: python3 tests/test-mdns-record-gating.py
+
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -92,6 +92,9 @@ test: ## Run unit and contract tests
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
 	@echo ""
+	@echo "=== mDNS record gating ==="
+	@python3 tests/test-mdns-record-gating.py
+	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh
 	@echo ""

--- a/ods/bin/ods-mdns.py
+++ b/ods/bin/ods-mdns.py
@@ -170,6 +170,19 @@ def _direct_ports_lan_reachable(env: dict[str, str]) -> bool:
     return bind not in {"", "127.0.0.1", "localhost", "::1"}
 
 
+def _extension_enabled(service_id: str) -> bool:
+    """Whether an optional service is currently enabled.
+
+    Enablement is on-disk state, not an .env flag: 03-features.sh's
+    `_sync_extension_compose` (and the dashboard's enable/disable routes)
+    move `compose.yaml` to `compose.yaml.disabled` and back. ENABLE_ODS_PROXY
+    exists only as an installer shell variable and is never written to .env,
+    so the compose file is the only thing the announcer can consult.
+    """
+    compose = INSTALL_DIR / "extensions" / "services" / service_id / "compose.yaml"
+    return compose.is_file()
+
+
 def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[ServiceInfo]:
     """Build the ServiceInfo records to publish.
 
@@ -204,11 +217,14 @@ def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[Serv
             ("dashboard",     _safe_port(env, "DASHBOARD_PORT", 3001),     "ODS Dashboard", {"path": "/"}),
             ("chat",          _safe_port(env, "WEBUI_PORT", 3000),         "ODS Chat",      {"path": "/"}),
             ("dashboard-api", _safe_port(env, "DASHBOARD_API_PORT", 3002), "ODS API",       {"path": "/health"}),
-            # Announce unconditionally when direct ports are LAN-reachable:
-            # the Hermes extension is opt-in via `ods enable hermes`, but
-            # the failure mode when disabled is the same as any optional
-            # service that is not running.
-            ("hermes",        _safe_port(env, "HERMES_PORT", 9119),        "Hermes Agent",    {"path": "/api/health"}),
+            # Hermes is deliberately absent here. Its compose declares only
+            # `expose: 9119` and binds no host port — "By NOT binding a host
+            # port on the Hermes container itself, we close the door on
+            # direct LAN access that would bypass the magic-link gate."
+            # A direct SRV on 9119 therefore points every LAN client at a
+            # closed port, whether or not the extension is enabled. The
+            # supported LAN path is the hermes.<device>.local proxy record
+            # below, which Caddy forward_auths before reaching Hermes.
         ]
         for suffix, port, label, txt in direct:
             infos.append(ServiceInfo(
@@ -245,6 +261,16 @@ def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[Serv
         # owner experience stalls on a white screen.
         ("talk",      "ODS Talk (mobile owner portal)"),
     )
+    # Every record below resolves to the proxy's listen port and depends on
+    # Caddy being there to route by Host header. With ods-proxy disabled the
+    # port is closed, so publishing them hands LAN clients — and the phones
+    # following magic-link QR codes — a set of hostnames that resolve but
+    # never connect. Same principle as the direct-port gate above: do not
+    # advertise an endpoint that cannot answer.
+    if not _extension_enabled("ods-proxy"):
+        logger.info("Skipping proxy subdomain records because ods-proxy is not enabled")
+        return infos
+
     for suffix, label in subdomain_routes:
         server = f"{device_name}.local." if suffix == "root" else f"{suffix}.{device_name}.local."
         infos.append(ServiceInfo(

--- a/ods/tests/test-mdns-record-gating.py
+++ b/ods/tests/test-mdns-record-gating.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""The announcer must not publish records that cannot answer.
+
+bin/ods-mdns.py already refuses to publish direct-port SRV records when
+BIND_ADDRESS is loopback-only, on the grounds that they "would point LAN
+clients at unreachable endpoints". These tests hold the rest of the record set
+to the same standard:
+
+  * the ods-proxy subdomain records depend on Caddy listening, so they must
+    not be published when the ods-proxy extension is disabled;
+  * Hermes publishes no host port at all (its compose declares only
+    `expose: 9119`), so a direct SRV on 9119 can never connect.
+
+zeroconf is imported lazily inside main(), so these run without it installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+MDNS_SCRIPT = ROOT / "bin" / "ods-mdns.py"
+
+
+def load_mdns():
+    spec = importlib.util.spec_from_file_location("ods_mdns_under_test", MDNS_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError(f"could not load {MDNS_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    # ServiceInfo is None until the lazy zeroconf import in main(); stub it so
+    # record construction is observable without the package present.
+    module.ServiceInfo = type(
+        "ServiceInfoStub", (), {"__init__": lambda self, **kw: self.__dict__.update(kw)}
+    )
+    return module
+
+
+def build(module, *, bind: str, proxy_enabled: bool):
+    """Run _build_services against a disposable install root."""
+    with tempfile.TemporaryDirectory() as temp:
+        root = Path(temp)
+        proxy_dir = root / "extensions" / "services" / "ods-proxy"
+        proxy_dir.mkdir(parents=True)
+        # Enablement is on-disk: compose.yaml present vs .disabled.
+        name = "compose.yaml" if proxy_enabled else "compose.yaml.disabled"
+        (proxy_dir / name).write_text("services: {}\n", encoding="utf-8")
+        module.INSTALL_DIR = root
+        env = {"BIND_ADDRESS": bind, "HERMES_PORT": "9119", "ODS_PROXY_PORT": "80",
+               "DASHBOARD_PORT": "3001", "WEBUI_PORT": "3000",
+               "DASHBOARD_API_PORT": "3002"}
+        return module._build_services(env, "ods", "192.0.2.10")
+
+
+def names(infos) -> list[str]:
+    return [i.name.split("._http")[0] for i in infos]
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def test_proxy_records_are_skipped_when_proxy_is_disabled(module) -> None:
+    infos = build(module, bind="0.0.0.0", proxy_enabled=False)
+    proxy = [n for n in names(infos) if n.startswith("ods-proxy-")]
+    assert_true(proxy == [], f"proxy records published while ods-proxy is disabled: {proxy}")
+
+
+def test_proxy_records_are_published_when_proxy_is_enabled(module) -> None:
+    infos = build(module, bind="0.0.0.0", proxy_enabled=True)
+    proxy = [n for n in names(infos) if n.startswith("ods-proxy-")]
+    assert_true(len(proxy) == 7, f"expected the full proxy subdomain set, got {proxy}")
+
+
+def test_nothing_is_published_when_nothing_is_reachable(module) -> None:
+    """Loopback bind plus no proxy means no LAN endpoint exists at all."""
+    infos = build(module, bind="127.0.0.1", proxy_enabled=False)
+    assert_true(infos == [], f"records published with no reachable endpoint: {names(infos)}")
+
+
+def test_no_direct_hermes_record_is_ever_published(module) -> None:
+    """Hermes binds no host port, so a direct SRV points at a closed port."""
+    for bind in ("0.0.0.0", "127.0.0.1"):
+        for proxy_enabled in (True, False):
+            infos = build(module, bind=bind, proxy_enabled=proxy_enabled)
+            direct_hermes = [n for n in names(infos) if n == "ods-hermes"]
+            assert_true(
+                direct_hermes == [],
+                f"direct Hermes SRV published (bind={bind}, proxy={proxy_enabled})",
+            )
+
+
+def test_hermes_is_still_reachable_through_the_proxy_record(module) -> None:
+    """Removing the direct record must not remove the supported LAN path."""
+    infos = build(module, bind="0.0.0.0", proxy_enabled=True)
+    assert_true("ods-proxy-hermes" in names(infos),
+                "hermes.<device>.local must still be announced via the proxy")
+
+
+def main() -> int:
+    module = load_mdns()
+    tests = [
+        test_proxy_records_are_skipped_when_proxy_is_disabled,
+        test_proxy_records_are_published_when_proxy_is_enabled,
+        test_nothing_is_published_when_nothing_is_reachable,
+        test_no_direct_hermes_record_is_ever_published,
+        test_hermes_is_still_reachable_through_the_proxy_record,
+    ]
+    for test in tests:
+        test(module)
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

`bin/ods-mdns.py` already refuses to publish direct-port SRV records when
`BIND_ADDRESS` is loopback-only, and says why:

> In that default, advertise the proxy hostnames but do not publish
> direct-port SRV records that would point LAN clients at unreachable
> endpoints.

Two records in the same function do not follow that rule.

**The seven `ods-proxy-*` subdomain records** all resolve to the proxy's listen
port and depend on Caddy being there to route by `Host`. They were emitted with
no regard for whether `ods-proxy` is enabled, so with the proxy off a LAN
client — and a phone following a magic-link QR code — resolves
`dashboard.<device>.local` and then never connects.

**The direct Hermes SRV on 9119** never had a listener to reach. Hermes's
compose declares only `expose: 9119` and binds no host port, deliberately:

> By NOT binding a host port on the Hermes container itself, we close the door
> on direct LAN access that would bypass the magic-link gate.

So that record pointed every LAN client at a closed port, whether or not the
extension was enabled.

## What changed

Proxy records are gated on the extension's resolved state, and the direct
Hermes entry is removed.

Enablement is read from disk rather than from `.env`. `ENABLE_ODS_PROXY` exists
only as an installer shell variable — it is not written to `.env`, not in
`.env.example`, and not in `.env.schema.json`, so `_read_env()` can never see
it. The actual signal is the one `03-features.sh:_sync_extension_compose` and
the dashboard's enable/disable routes both maintain: `compose.yaml` present
means enabled, `compose.yaml.disabled` means not.

Behaviour across the four states:

```text
                                 records   proxy   direct-hermes
BIND=0.0.0.0, proxy enabled         10       7          0
BIND=0.0.0.0, proxy disabled         3       0          0      (was 10, 7, 1)
BIND=127.0.0.1, proxy enabled        7       7          0
BIND=127.0.0.1, proxy disabled       0       0          0      (was  7, 7, 0)
```

Publishing nothing in the last case is the correct answer: with a loopback bind
and no proxy, no ODS endpoint is LAN-reachable at all.

`hermes.<device>.local` is still announced through the proxy record, which is
the supported path and still goes through Caddy's `forward_auth`.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. The symptom is a stale discovery record, not a broken install.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium. It only ever removes advertisements, so the failure mode
  to check is removing one that was doing useful work — which the tests cover
  directly.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 tests/test-mdns-record-gating.py
  on origin/main   [FAIL] proxy records published while ods-proxy is disabled:
                     ['ods-proxy-root', 'ods-proxy-chat', 'ods-proxy-dashboard',
                      'ods-proxy-auth', 'ods-proxy-api', 'ods-proxy-hermes',
                      'ods-proxy-talk']
  on this branch   [PASS] test_proxy_records_are_skipped_when_proxy_is_disabled
                   [PASS] test_proxy_records_are_published_when_proxy_is_enabled
                   [PASS] test_nothing_is_published_when_nothing_is_reachable
                   [PASS] test_no_direct_hermes_record_is_ever_published
                   [PASS] test_hermes_is_still_reachable_through_the_proxy_record

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, matching what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

The announcer is installed as a systemd unit by phase 07, so this is
operational. Not covered here: a real Bonjour/avahi client resolving the
records on a LAN. The tests exercise `_build_services` directly with a stubbed
`ServiceInfo`, which pins which records are constructed but not what a phone
sees. A magic-link QR redemption on a real LAN, with the proxy both enabled and
disabled, is the check I would want before release.

## Notes For Reviewers

- Removing the direct Hermes record is the part worth a second opinion. If an
  operator has re-added a `ports:` binding to the Hermes compose — which the
  file's own comment suggests as the escape hatch when the proxy is off — they
  lose an advertisement. My reading is that they were the rare case and
  everyone else was being pointed at a closed port, but say the word and I will
  gate it on the extension state instead of removing it.
- `tests/test_mdns_subdomains.py` still passes: it asserts the
  `subdomain_routes` tuple statically, and the tuple is unchanged — only
  whether it is emitted.
- The new test is wired into `make test` and `test-linux.yml`, placed away from
  the entries other open PRs add so the branches do not conflict textually.
- Neither `test_mdns_subdomains.py` nor the new test's neighbours were running
  anywhere before; this is the same orphaned-test problem noted in #2717.
