### PR TITLE
fix(egress): require a caller key on remote-provider-egress

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -216,6 +216,7 @@ jobs:
           python3 tests/contracts/test-network-exposure-contracts.py
           python3 tests/contracts/test-remote-provider-egress-policy.py
           python3 tests/contracts/test-remote-provider-egress-service.py
+          python3 tests/contracts/test-egress-caller-auth.py
 
       - name: Linux install preflight tests
         run: |

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -86,6 +86,9 @@ test: ## Run unit and contract tests
 	@echo "=== brave-search searxng compat contract ==="
 	@bash tests/test-brave-search-searxng-compat.sh
 	@echo ""
+	@echo "=== remote-provider-egress caller auth ==="
+	@python3 tests/contracts/test-egress-caller-auth.py
+	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
 	@echo ""

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -369,6 +369,10 @@ services:
       - ODS_REMOTE_PROVIDER_UPSTREAM_TIMEOUT=${ODS_REMOTE_PROVIDER_UPSTREAM_TIMEOUT:-600}
       - ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL=${ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL:-http://remote-provider-ssh-tunnel:18090/health}
       - ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT=${ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_TIMEOUT:-2}
+      # Caller credential. Falls back to DASHBOARD_API_KEY so an
+      # existing install needs no new generated secret.
+      - ODS_EGRESS_INTERNAL_KEY=${ODS_EGRESS_INTERNAL_KEY:-}
+      - DASHBOARD_API_KEY=${DASHBOARD_API_KEY:-}
     volumes:
       - ${ODS_DATA_DIR:-./data}:/state:ro
       - ${ODS_CONFIG_DIR:-./config}/remote-provider-egress-policy.json:/config/remote-provider-egress-policy.json:ro

--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -28,6 +28,16 @@ router = APIRouter(tags=["remote-provider"])
 
 ROUTE_STATE_SCHEMA = "ods.remote-routing-state.v1"
 EGRESS_URL = os.environ.get("REMOTE_PROVIDER_EGRESS_URL", "http://remote-provider-egress:8091")
+# The egress service authenticates its callers. Resolution order matches
+# the service's own (ODS_EGRESS_INTERNAL_KEY, then DASHBOARD_API_KEY), so
+# both sides agree without a new generated secret.
+EGRESS_INTERNAL_KEY = os.environ.get("ODS_EGRESS_INTERNAL_KEY", "") or os.environ.get(
+    "DASHBOARD_API_KEY", ""
+)
+
+
+def _egress_auth_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {EGRESS_INTERNAL_KEY}"} if EGRESS_INTERNAL_KEY else {}
 EGRESS_TIMEOUT_SECONDS = 3.0
 PEER_PROXY_TIMEOUT_SECONDS = 30.0
 PEER_PROXY_LOAD_TIMEOUT_SECONDS = 2700.0
@@ -749,7 +759,7 @@ async def _post_egress_probe() -> dict[str, Any]:
     url = f"{EGRESS_URL.rstrip('/')}/probe"
     try:
         async with httpx.AsyncClient(timeout=EGRESS_TIMEOUT_SECONDS) as client:
-            response = await client.post(url)
+            response = await client.post(url, headers=_egress_auth_headers())
     except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as exc:
         logger.debug("remote-provider-egress probe unavailable: %s", exc)
         raise HTTPException(

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -1052,10 +1052,12 @@ def test_remote_provider_probe_posts_to_egress_and_sanitizes_receipt(
         async def __aexit__(self, *_args):
             return False
 
-        async def post(self, url):
+        async def post(self, url, headers=None):
             calls.append(("post", url))
+            posted_headers.append(headers or {})
             return FakeResponse()
 
+    posted_headers: list = []
     monkeypatch.setattr(rps, "EGRESS_URL", "http://egress.internal:8091/")
     monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)
     async def fake_agent_request(method, path, *, payload, timeout):
@@ -1125,6 +1127,11 @@ def test_remote_provider_probe_posts_to_egress_and_sanitizes_receipt(
         ("timeout", 3.0),
         ("post", "http://egress.internal:8091/probe"),
     ]
+    # The egress service authenticates its callers, so the probe must present
+    # the internal key rather than relying on network reachability.
+    assert posted_headers and posted_headers[0].get("Authorization", "").startswith(
+        "Bearer "
+    ), f"probe must send the egress bearer, got {posted_headers}"
     assert agent_calls == [
         (
             "POST",
@@ -1196,7 +1203,7 @@ def test_remote_provider_probe_reports_nonfatal_proof_record_failure(
         async def __aexit__(self, *_args):
             return False
 
-        async def post(self, _url):
+        async def post(self, _url, headers=None):
             return FakeResponse()
 
     async def fake_agent_request(*_args, **_kwargs):
@@ -1255,7 +1262,7 @@ def test_remote_provider_probe_preserves_sanitized_egress_errors(
         async def __aexit__(self, *_args):
             return False
 
-        async def post(self, _url):
+        async def post(self, _url, headers=None):
             return FakeResponse()
 
     monkeypatch.setattr(rps.httpx, "AsyncClient", FakeAsyncClient)

--- a/ods/extensions/services/litellm/compose.yaml
+++ b/ods/extensions/services/litellm/compose.yaml
@@ -16,6 +16,10 @@ services:
       - ODS_MODEL_SWITCHBOARD=${ODS_MODEL_SWITCHBOARD:-observe}
       - TOKEN_SPY_URL=${TOKEN_SPY_URL:-http://token-spy:8080}
       - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
+      # Presented to remote-provider-egress on the cloud route. Mirrors
+      # the egress service's own resolution order so both sides land on
+      # the same value without a new generated secret.
+      - ODS_EGRESS_INTERNAL_KEY=${ODS_EGRESS_INTERNAL_KEY:-${DASHBOARD_API_KEY:-}}
     volumes:
       - ./config/litellm/${ODS_MODE:-local}.yaml:/app/config.yaml:ro,z
       - ./config/litellm/switchboard.yaml:/app/switchboard.yaml:ro,z

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -8,6 +8,7 @@ injects provider credentials from a private file at the final egress boundary.
 from __future__ import annotations
 
 import os
+import secrets
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
@@ -52,6 +53,14 @@ MAX_BODY_BYTES = int(
 )
 UPSTREAM_TIMEOUT_SECONDS = float(
     os.environ.get("ODS_REMOTE_PROVIDER_UPSTREAM_TIMEOUT", "600")
+)
+# Caller credential. Reachability on ods-network is not authorisation: this
+# service holds the private provider key and injects it into every forwarded
+# request, so an unauthenticated peer would be able to spend the victim's
+# provider quota under their account. Resolution order mirrors model-router's
+# INTERNAL_KEY so an existing install needs no new generated secret.
+INTERNAL_KEY = os.environ.get("ODS_EGRESS_INTERNAL_KEY", "") or os.environ.get(
+    "DASHBOARD_API_KEY", ""
 )
 SSH_TUNNEL_HEALTH_URL = os.environ.get(
     "ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL",
@@ -219,6 +228,31 @@ async def _ssh_tunnel_status() -> dict[str, Any]:
     return _safe_tunnel_summary(payload)
 
 
+def _internal_key_authorized(request: Request) -> bool:
+    """Constant-time check of the caller's internal Bearer key.
+
+    Compared as UTF-8 bytes so a non-ASCII presented token is a clean mismatch
+    rather than a TypeError on the pre-auth path — the same shape as
+    dashboard-api's verify_api_key, token-spy and privacy-shield.
+
+    Returns False when no key is configured: this service must not forward a
+    request carrying the provider credential just because the deployment
+    forgot to set one.
+    """
+    if not INTERNAL_KEY:
+        return False
+    provided = request.headers.get("authorization", "")
+    if not provided.startswith("Bearer "):
+        return False
+    return secrets.compare_digest(
+        provided[len("Bearer "):].encode("utf-8"), INTERNAL_KEY.encode("utf-8")
+    )
+
+
+def _unauthorized() -> JSONResponse:
+    return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+
 @app.get("/health")
 async def health() -> dict[str, Any]:
     secret = provider_secret_status(SECRET_PATH)
@@ -286,7 +320,9 @@ async def health() -> dict[str, Any]:
 
 
 @app.get("/v1/models")
-async def list_models() -> Response:
+async def list_models(request: Request) -> Response:
+    if not _internal_key_authorized(request):
+        return _unauthorized()
     try:
         route = _load_route()
     except EgressError as exc:
@@ -305,7 +341,9 @@ async def list_models() -> Response:
 
 
 @app.post("/probe")
-async def probe() -> Response:
+async def probe(request: Request) -> Response:
+    if not _internal_key_authorized(request):
+        return _unauthorized()
     tunnel = None
     try:
         route = _load_route()
@@ -332,6 +370,9 @@ async def probe() -> Response:
     methods=["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT"],
 )
 async def forward(full_path: str, request: Request) -> Response:
+    # Authenticate before touching route state or the provider secret.
+    if not _internal_key_authorized(request):
+        return _unauthorized()
     path = "/" + full_path
     try:
         route = _load_route()

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -221,19 +221,19 @@ def render_litellm_cloud(inputs: RenderInputs) -> RenderedFile:
     litellm_params:
       model: {model_param}
       api_base: {egress_base}
-      api_key: not-needed
+      api_key: os.environ/ODS_EGRESS_INTERNAL_KEY
 
   - model_name: default
     litellm_params:
       model: {model_param}
       api_base: {egress_base}
-      api_key: not-needed
+      api_key: os.environ/ODS_EGRESS_INTERNAL_KEY
 
   - model_name: {yaml_scalar(model)}
     litellm_params:
       model: {model_param}
       api_base: {egress_base}
-      api_key: not-needed
+      api_key: os.environ/ODS_EGRESS_INTERNAL_KEY
 
 router_settings:
   routing_strategy: simple-shuffle

--- a/ods/tests/contracts/test-egress-caller-auth.py
+++ b/ods/tests/contracts/test-egress-caller-auth.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""remote-provider-egress must authenticate its callers.
+
+The service is `expose:`d on the shared ods-network, reads the private
+provider key from disk, and strips the caller's own Authorization before
+injecting the provider bearer. Reachability therefore must not be the only
+thing between a container and the victim's provider quota —
+network-exposure-policy.json has declared `auth_required: true` for this
+service all along.
+
+Two layers, because the CI job that runs this installs only PyYAML and
+jsonschema (the same reason test-remote-provider-egress-service.py imports the
+shared library rather than the app):
+
+  * source contracts, which need no third-party imports and always run;
+  * live request checks against the real app, which run only where fastapi and
+    httpx are importable and are skipped cleanly otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_MAIN = ROOT / "extensions" / "services" / "remote-provider-egress" / "app" / "main.py"
+POLICY = ROOT / "config" / "network-exposure-policy.json"
+
+INTERNAL_KEY = "test-internal-key"
+
+# Every route that can reach route state, the provider secret, or the upstream.
+GUARDED_ROUTES = ('@app.get("/v1/models")', '@app.post("/probe")', "@app.api_route(")
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def read_app_source() -> str:
+    return APP_MAIN.read_text(encoding="utf-8")
+
+
+# --- source contracts (always run) -----------------------------------------
+
+
+def test_policy_declares_auth_required() -> None:
+    entry = json.loads(POLICY.read_text(encoding="utf-8"))["services"]["remote-provider-egress"]
+    assert_true(entry["auth_required"] is True,
+                "remote-provider-egress policy must require auth")
+
+
+def test_every_credentialed_route_checks_the_caller_key() -> None:
+    """Each guarded decorator's handler must call the auth helper first."""
+    source = read_app_source()
+    for decorator in GUARDED_ROUTES:
+        assert_true(decorator in source, f"expected route {decorator} in the egress app")
+        body = source.split(decorator, 1)[1]
+        # Look only as far as the next route decorator.
+        next_route = body.find("\n@app.")
+        if next_route != -1:
+            body = body[:next_route]
+        assert_true(
+            "_internal_key_authorized(request)" in body,
+            f"{decorator} must authenticate the caller before doing any work",
+        )
+
+
+def test_auth_helper_uses_constant_time_comparison() -> None:
+    source = read_app_source()
+    assert_true("secrets.compare_digest" in source,
+                "the caller-key check must be a constant-time comparison")
+    assert_true('encode("utf-8")' in source,
+                "compare as UTF-8 bytes so a non-ASCII token cannot raise pre-auth")
+
+
+def test_missing_key_denies_rather_than_allows() -> None:
+    source = read_app_source()
+    helper = source.split("def _internal_key_authorized", 1)[1].split("\ndef ", 1)[0]
+    assert_true("if not INTERNAL_KEY:\n        return False" in helper,
+                "an unconfigured key must deny, never allow-all")
+
+
+def test_health_is_not_gated() -> None:
+    """The compose healthcheck calls /health with no credential."""
+    source = read_app_source()
+    body = source.split('@app.get("/health")', 1)[1].split("\n@app.", 1)[0]
+    assert_true("_internal_key_authorized" not in body,
+                "/health must stay anonymous for the container healthcheck")
+
+
+# --- live request checks (skipped without fastapi/httpx) --------------------
+
+
+def load_app(temp: Path):
+    import os
+
+    (temp / "secrets").mkdir(parents=True, exist_ok=True)
+    secret = temp / "secrets" / "provider-api-key"
+    secret.write_text("dummy-provider-secret", encoding="utf-8")
+    state = temp / "routing-state.json"
+    state.write_text(json.dumps({"schema": "ods.remote-provider.v1"}), encoding="utf-8")
+
+    os.environ["ODS_REMOTE_PROVIDER_ROUTE_PATH"] = str(state)
+    os.environ["ODS_REMOTE_PROVIDER_API_KEY_FILE"] = str(secret)
+    os.environ["ODS_EGRESS_INTERNAL_KEY"] = INTERNAL_KEY
+    sys.path.insert(0, str(ROOT / "bin"))
+    sys.path.insert(0, str(APP_MAIN.parent.parent))
+
+    spec = importlib.util.spec_from_file_location("egress_app_under_test", APP_MAIN)
+    if spec is None or spec.loader is None:
+        raise AssertionError("could not load the egress app")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_live_checks() -> None:
+    from fastapi.testclient import TestClient
+
+    with tempfile.TemporaryDirectory(prefix="ods-egress-auth-") as temp:
+        module = load_app(Path(temp))
+        client = TestClient(module.app)
+        body = {"model": "remote", "messages": [{"role": "user", "content": "hi"}]}
+
+        for method, path, kwargs in (
+            ("get", "/v1/models", {}),
+            ("post", "/probe", {}),
+            ("post", "/v1/chat/completions", {"json": body}),
+        ):
+            resp = getattr(client, method)(path, **kwargs)
+            assert_true(
+                resp.status_code == 401,
+                f"{method.upper()} {path} must reject an unauthenticated peer, got {resp.status_code}",
+            )
+            assert_true(
+                resp.json() == {"error": "unauthorized"},
+                f"{method.upper()} {path} must fail on auth, not incidentally: {resp.text[:120]}",
+            )
+        print("[PASS] live: unauthenticated calls rejected on every guarded route")
+
+        resp = client.get("/v1/models", headers={"Authorization": "Bearer wrong"})
+        assert_true(resp.status_code == 401, f"a wrong key must be rejected, got {resp.status_code}")
+        print("[PASS] live: wrong key rejected")
+
+        # The disposable route state is not a usable remote route, so anything
+        # other than 401 proves the request was authenticated.
+        resp = client.get("/v1/models", headers={"Authorization": f"Bearer {INTERNAL_KEY}"})
+        assert_true(resp.status_code != 401,
+                    "a correctly keyed caller must get past the auth guard")
+        print("[PASS] live: correct key passes authentication")
+
+        resp = client.get("/health")
+        assert_true(resp.status_code == 200,
+                    f"/health must stay anonymous, got {resp.status_code}")
+        assert_true("dummy-provider-secret" not in resp.text,
+                    "/health must never echo provider key material")
+        print("[PASS] live: /health anonymous and free of key material")
+
+
+def main() -> int:
+    for test in (
+        test_policy_declares_auth_required,
+        test_every_credentialed_route_checks_the_caller_key,
+        test_auth_helper_uses_constant_time_comparison,
+        test_missing_key_denies_rather_than_allows,
+        test_health_is_not_gated,
+    ):
+        test()
+        print(f"[PASS] {test.__name__}")
+
+    try:
+        import fastapi  # noqa: F401
+        import httpx  # noqa: F401
+    except ImportError:
+        print("[SKIP] live request checks (fastapi/httpx not installed here)")
+        return 0
+
+    run_live_checks()
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -134,7 +134,12 @@ def test_remote_cloud_projection_uses_internal_egress_and_state_receipt() -> Non
     assert 'model: "openai/qwen/remote:latest"' in cloud
     assert 'model_name: "qwen/remote:latest"' in cloud
     assert 'api_base: "http://remote-provider-egress:8091/v1"' in cloud
-    assert "api_key: not-needed" in cloud
+    # The egress service authenticates its callers, so the generated cloud
+    # route presents the internal key instead of the old "not-needed"
+    # placeholder. The provider credential still never appears here — it stays
+    # inside remote-provider-egress.
+    assert "api_key: os.environ/ODS_EGRESS_INTERNAL_KEY" in cloud
+    assert "api_key: not-needed" not in cloud
     assert "https://gpu.example.test" not in cloud
     assert "REMOTE_LLM_API_KEY" not in cloud
 


### PR DESCRIPTION
## Summary

Part of #2718.

`config/network-exposure-policy.json` has declared `auth_required: true` for
`remote-provider-egress` all along:

> Internal-only boundary that injects private provider credentials and
> forwards remote LLM traffic.

The app implemented none of it. `extensions/services/remote-provider-egress/app/main.py`
had no `Depends`, no `verify`, and no `Authorization` read on `/v1/models`,
`/probe`, or the wildcard forward.

That service is `expose:`d on the shared `ods-network`, reads the private
provider key from `/state/remote-provider/secrets/provider-api-key`, and
`sanitize_forward_headers()` strips the caller's own `Authorization` before
injecting the provider bearer. So reachability alone let any container spend
the victim's provider quota, under their account, without ever seeing the
credential — the confused-deputy shape.

## What changed

The same check the rest of the stack already uses — `Authorization: Bearer` +
`secrets.compare_digest` over UTF-8 bytes, as in `dashboard-api/security.py`,
`token-spy`, `privacy-shield` and `model-router` — applied to all three
credentialed routes, before route state or the secret file is touched.

`/health` stays anonymous: the compose healthcheck depends on it, and
`provider_secret_status()` reports configured/byte-count only, never key
material. No configured key means deny, rather than forward with the provider
credential attached.

**Both in-stack callers are wired:**

- LiteLLM's generated cloud route (`scripts/render-runtime-configs.py`) sent
  `api_key: not-needed` to the egress base URL; it now sends
  `os.environ/ODS_EGRESS_INTERNAL_KEY`.
- `dashboard-api`'s `/probe` call in `routers/remote_provider_status.py` now
  presents the same bearer. Its `/health` call is unchanged.

**No new secret and no migration.** `ODS_EGRESS_INTERNAL_KEY` falls back to
`DASHBOARD_API_KEY` on every side — service, LiteLLM, and dashboard-api —
and `DASHBOARD_API_KEY` is generated unconditionally by all three installers
with `minLength: 10` in the schema, so an existing install already has a value
both ends agree on. This is the same approach as #2719 and for the same
reason: it avoids pre-empting the key-provenance question in #2718.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Mainline. Reachable only by something already running on ods-network, and
only when a remote provider is configured, so it is not the most urgent of the
set — but it is the one where the consequence is someone else's bill.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High by the change map — an auth boundary on the remote
  inference path. The failure mode that matters is a caller I did not find, so
  the caller survey is in the summary above and I would welcome a second pass
  on it.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
# New contract test, in two layers. The CI job that runs it installs only
# PyYAML and jsonschema, so the source layer carries the protection there and
# the live layer runs wherever fastapi/httpx exist.
$ python3 tests/contracts/test-egress-caller-auth.py
  on origin/main   [FAIL] @app.get("/v1/models") must authenticate the caller
                          before doing any work        <- caught with no deps
  on this branch   [PASS] policy still declares auth_required
                   [PASS] every credentialed route checks the caller key
                   [PASS] auth helper uses constant-time comparison
                   [PASS] missing key denies rather than allows
                   [PASS] /health is not gated
                   [PASS] live: unauthenticated calls rejected on every route
                   [PASS] live: wrong key rejected
                   [PASS] live: correct key passes authentication
                   [PASS] live: /health anonymous and free of key material

  (on origin/main the unauthenticated GET returned 503 — a route error, not a
   401. There was no boundary to fail.)

$ python3 tests/contracts/test-remote-provider-egress-service.py   12 PASS
$ pytest tests/test_remote_provider_status.py                      26 passed
$ pytest tests/                                    full dashboard-api suite

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

An auth boundary on the remote inference path. What is **not** covered: a real
LiteLLM talking to a real egress container against a real provider. The key
agreement is verified by reading both sides' resolution order and by the
compose interpolation, not by observed traffic. A cloud-mode or remote-provider
fleet run is the gate I would want before release, and I could not run it.

## Notes For Reviewers

- Three test doubles in `tests/test_remote_provider_status.py` had
  `async def post(self, url)` and broke on the new `headers=` kwarg. They now
  accept it, and the primary one asserts the probe actually sends a
  `Bearer` — so the caller side is pinned, not just tolerated.
- The two-layer test shape is deliberate. A single TestClient-based test would
  have been silently skipped in CI for want of fastapi, which is the failure
  mode where a security test exists but never runs. The source layer needs no
  imports and fails on `origin/main`.
- Hardening the SSH-tunnel forwards is a separate problem (raw TCP, no HTTP
  layer to authenticate) and is not addressed here.
