### PR TITLE
fix(brave-search): require a caller key on the native search route

### DIFF
--- a/ods/extensions/services/brave-search/compose.yaml
+++ b/ods/extensions/services/brave-search/compose.yaml
@@ -10,6 +10,10 @@ services:
       - no-new-privileges:true
     environment:
       - BRAVE_SEARCH_API_KEY=${BRAVE_SEARCH_API_KEY:-}
+      # Caller credential for the native /v1/search route. Falls back to
+      # DASHBOARD_API_KEY so an existing install needs no new secret.
+      - BRAVE_SEARCH_INTERNAL_KEY=${BRAVE_SEARCH_INTERNAL_KEY:-}
+      - DASHBOARD_API_KEY=${DASHBOARD_API_KEY:-}
       - BRAVE_SEARCH_PORT_INTERNAL=8585
       - BRAVE_SEARCH_SEARXNG_COMPAT=${BRAVE_SEARCH_SEARXNG_COMPAT:-0}
       - BRAVE_SEARCH_TIMEOUT_MS=${BRAVE_SEARCH_TIMEOUT_MS:-8000}

--- a/ods/extensions/services/brave-search/proxy.mjs
+++ b/ods/extensions/services/brave-search/proxy.mjs
@@ -26,6 +26,7 @@
 // ods services and scripts. See README.md for design notes and the fidelity
 // limits of the searxng compatibility mode.
 
+import crypto from "node:crypto";
 import http from "node:http";
 
 // Empty env values (e.g. from compose ${VAR:-} interpolation) fall back to
@@ -61,6 +62,14 @@ function booleanFromEnv(name, fallback = false) {
 
 const PORT = Number(process.env.BRAVE_SEARCH_PORT_INTERNAL ?? 8585);
 const API_KEY = process.env.BRAVE_SEARCH_API_KEY;
+// Caller credential for the native /v1/search route. This service holds a paid
+// subscription token and attaches it to every upstream call, so reachability on
+// ods-network must not be the only thing between a container and the victim's
+// search quota — network-exposure-policy.json marks this a paid-api-proxy with
+// auth_required: true. Resolution order matches the other internal services so
+// an existing install needs no new generated secret.
+const INTERNAL_KEY =
+  process.env.BRAVE_SEARCH_INTERNAL_KEY || process.env.DASHBOARD_API_KEY || "";
 const BRAVE_URL =
   process.env.BRAVE_SEARCH_UPSTREAM_URL || "https://api.search.brave.com/res/v1/web/search";
 const REQUEST_TIMEOUT_MS = timeoutMsFromEnv();
@@ -333,6 +342,22 @@ async function handleSearxngSearch(res, params) {
   send(res, 200, searxngEnvelope(query, toSearxngResults(outcome.data), []));
 }
 
+// ── caller authentication ───────────────────────────────────────────────────
+
+/** Constant-time compare of the presented bearer against INTERNAL_KEY. */
+function callerAuthorized(req) {
+  if (!INTERNAL_KEY) return false;
+  const header = req.headers.authorization ?? "";
+  if (!header.startsWith("Bearer ")) return false;
+  const presented = Buffer.from(header.slice("Bearer ".length), "utf8");
+  const expected = Buffer.from(INTERNAL_KEY, "utf8");
+  // timingSafeEqual throws on a length mismatch, which would itself leak the
+  // length, so compare a fixed-size digest of each side instead.
+  const a = crypto.createHash("sha256").update(presented).digest();
+  const b = crypto.createHash("sha256").update(expected).digest();
+  return crypto.timingSafeEqual(a, b);
+}
+
 // ── router ──────────────────────────────────────────────────────────────────
 
 const server = http.createServer(async (req, res) => {
@@ -351,6 +376,11 @@ const server = http.createServer(async (req, res) => {
 
     if (req.method !== "GET" || parsed.pathname !== "/v1/search") {
       send(res, 404, { error: "not_found" });
+      return;
+    }
+
+    if (!callerAuthorized(req)) {
+      send(res, 401, { error: "unauthorized" });
       return;
     }
 

--- a/ods/tests/test-brave-search-searxng-compat.mjs
+++ b/ods/tests/test-brave-search-searxng-compat.mjs
@@ -16,6 +16,7 @@ import { fileURLToPath } from "node:url";
 const ROOT = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const PROXY_SCRIPT = path.join(ROOT, "extensions", "services", "brave-search", "proxy.mjs");
 const STUB_API_KEY = "test-subscription-token";
+const STUB_INTERNAL_KEY = "stub-internal-caller-key";
 const PROXY_TIMEOUT_MS = 1000;
 const SLOW_UPSTREAM_DELAY_MS = 3000;
 
@@ -123,6 +124,7 @@ async function startProxy(port, stubPort, extraEnv) {
       BRAVE_SEARCH_PORT_INTERNAL: String(port),
       BRAVE_SEARCH_UPSTREAM_URL: `http://127.0.0.1:${stubPort}/res/v1/web/search`,
       BRAVE_SEARCH_TIMEOUT_MS: String(PROXY_TIMEOUT_MS),
+      BRAVE_SEARCH_INTERNAL_KEY: STUB_INTERNAL_KEY,
       ...extraEnv,
     },
     stdio: ["ignore", "inherit", "inherit"],
@@ -142,8 +144,13 @@ async function startProxy(port, stubPort, extraEnv) {
   throw new Error(`proxy on :${port} did not become healthy`);
 }
 
-async function getJson(base, pathAndQuery) {
-  const res = await fetch(`${base}${pathAndQuery}`);
+async function getJson(base, pathAndQuery, { authenticated = true } = {}) {
+  // /v1/search authenticates its caller; the searxng-compat /search route
+  // deliberately does not, because its consumers are third-party images.
+  const headers = authenticated
+    ? { Authorization: `Bearer ${STUB_INTERNAL_KEY}` }
+    : {};
+  const res = await fetch(`${base}${pathAndQuery}`, { headers });
   return { status: res.status, body: await res.json() };
 }
 
@@ -241,6 +248,21 @@ function checkEnvelope(body) {
 
 async function testCompatEnabled(base) {
   console.log("searxng compat enabled:");
+
+  // The two routes authenticate differently, on purpose. /v1/search is the
+  // native ODS route and spends a paid subscription token, so it requires the
+  // caller key. /search exists so third-party images (Perplexica, per the
+  // README) can use this service as a drop-in SearXNG, and those cannot
+  // present an ODS bearer — so it must keep working without one.
+  const compatAnon = await getJson(base, "/search?format=json&q=ok", { authenticated: false });
+  check("searxng-compat /search stays open to unauthenticated consumers",
+    compatAnon.status === 200, `got ${compatAnon.status}`);
+
+  const nativeAnon = await getJson(base, "/v1/search?q=ok", { authenticated: false });
+  check("native /v1/search rejects an unauthenticated caller",
+    nativeAnon.status === 401, `got ${nativeAnon.status}`);
+  check("native /v1/search rejection does not leak the subscription token",
+    !JSON.stringify(nativeAnon.body).includes(STUB_API_KEY));
 
   const ok = await getJson(base, "/search?format=json&q=ok");
   check("200 on success", ok.status === 200, `got ${ok.status}`);


### PR DESCRIPTION
## Summary

Part of #2718.

`config/network-exposure-policy.json` marks `brave-search` a `paid-api-proxy`
with `auth_required: true` and says why:

> Bridges to a paid upstream API key; exposure risks quota/key abuse.

`proxy.mjs` had no caller check. It attaches the private
`X-Subscription-Token` to every upstream call, so reachability on
`ods-network` was the only thing between any container and the victim's paid
search quota. The loopback host binding does not help — container peers share
the compose bridge regardless.

## What changed, and what deliberately did not

`/v1/search` — the native ODS route — now requires
`Authorization: Bearer`, compared in constant time.
`BRAVE_SEARCH_INTERNAL_KEY` falls back to `DASHBOARD_API_KEY`, so an existing
install needs no new generated secret, and no configured key means deny.

`/search` — the searxng-compat route — is **left open on purpose.** It exists
so third-party images can use this service as a drop-in SearXNG; the README
documents Perplexica doing exactly that, and those consumers cannot present an
ODS bearer. Requiring one there would break a documented feature.

That carve-out costs less than it sounds. `/search` only exists when the
operator sets `BRAVE_SEARCH_SEARXNG_COMPAT=1`, which is off by default. In the
default configuration `/v1/search` is the entire surface, and it is now shut.

I would rather surface that trade than quietly ship a change that breaks
Perplexica. If you would prefer the compat route gated too — with the
documented drop-in flow moving to a dedicated network instead, which is the
structural answer #2718 is circling — say so and I will switch it.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Mainline. Needs the optional extension enabled and a configured paid key, so
the affected population is small — but for them the consequence is billing.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium. One optional service, and the failure mode to watch is
  breaking the compat consumers — which the tests now pin explicitly.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ node --check extensions/services/brave-search/proxy.mjs     OK

# The existing compat contract test caught the change immediately — it drives
# /v1/search directly and started returning 401:
$ bash tests/test-brave-search-searxng-compat.sh
  before updating the harness   FAIL: 200 on success — got 401
  after                          brave-search searxng compat tests passed

# New assertions pinning that the two routes differ, so neither can drift:
  ok: searxng-compat /search stays open to unauthenticated consumers
  ok: native /v1/search rejects an unauthenticated caller
  ok: native /v1/search rejection does not leak the subscription token

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

An auth boundary on an optional service. Not covered: a real Perplexica
container against a real brave-search with compat on. The compat route is
untouched by this diff and the test asserts it answers anonymously, but that is
a stub upstream rather than the real image.

## Notes For Reviewers

- `timingSafeEqual` throws on a length mismatch, which would leak the key
  length, so both sides are SHA-256'd to a fixed width before comparison
  rather than compared raw.
- No in-stack service points at brave-search by default — `SEARXNG_URL`
  defaults to the bundled `searxng`. So there is no ODS-side caller to update;
  the consumers are whatever the operator points at it. That is also why the
  compat carve-out matters: those consumers are exactly the ones that cannot
  authenticate.
