### PR TITLE
fix(ssh-tunnel): stop serving the route plan on the unauthenticated status port

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -216,6 +216,7 @@ jobs:
           python3 tests/contracts/test-network-exposure-contracts.py
           python3 tests/contracts/test-remote-provider-egress-policy.py
           python3 tests/contracts/test-remote-provider-egress-service.py
+          python3 tests/contracts/test-ssh-tunnel-health-disclosure.py
 
       - name: Linux install preflight tests
         run: |

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -140,6 +140,9 @@ test: ## Run unit and contract tests
 	@echo "=== token-spy session manager active-id extraction ==="
 	@bash tests/test-token-spy-session-manager.sh
 	@echo ""
+	@echo "=== SSH tunnel health disclosure ==="
+	@python3 tests/contracts/test-ssh-tunnel-health-disclosure.py
+	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 	@echo ""

--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -444,6 +444,36 @@ def health_payload(supervisor: SshProcessSupervisor | None = None) -> dict[str, 
     return _health_from_plan(_supervisor_plan())
 
 
+def public_health_payload(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Reduce a health payload to what a caller on the network needs.
+
+    The status server binds 0.0.0.0 and is unauthenticated — the container
+    healthcheck has no credential to present — so whatever it returns is
+    readable by every peer on the network it sits on. The full payload carries
+    the resolved route plan: the remote endpoint and port, and the local
+    forward definitions. None of that is needed by any consumer.
+
+    remote-provider-egress reads only ready/status/reason and the process
+    status and pid (see _safe_tunnel_summary there), and the compose
+    healthcheck reads only the status code. So serve exactly that, and keep
+    the plan for the in-process callers and the contract tests that assert on
+    it via health_payload() directly.
+    """
+    process = payload.get("process")
+    if not isinstance(process, Mapping):
+        process = {}
+    return {
+        "schema": payload.get("schema"),
+        "ready": bool(payload.get("ready")),
+        "status": payload.get("status"),
+        "reason": payload.get("reason"),
+        "process": {
+            "status": process.get("status"),
+            "pid": process.get("pid"),
+        },
+    }
+
+
 class HealthHandler(BaseHTTPRequestHandler):
     server_version = "ODSRemoteProviderSSHTunnel/1"
     sys_version = ""
@@ -453,7 +483,7 @@ class HealthHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "not_found"}, status=404)
             return
         supervisor = getattr(self.server, "supervisor", None)
-        self._write_json(health_payload(supervisor))
+        self._write_json(public_health_payload(health_payload(supervisor)))
 
     def log_message(self, fmt: str, *args: Any) -> None:
         LOGGER.info("%s - %s", self.address_string(), fmt % args)

--- a/ods/tests/contracts/test-ssh-tunnel-health-disclosure.py
+++ b/ods/tests/contracts/test-ssh-tunnel-health-disclosure.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""The tunnel's status server must not hand the route plan to the network.
+
+`main()` binds the status server to 0.0.0.0 and the handler authenticates
+nothing — it cannot, because the compose healthcheck has no credential to
+present. So whatever /health returns is readable by every peer on the network
+the tunnel sits on.
+
+The full payload carries the resolved plan: remote endpoint and port, and the
+local forward definitions. No consumer needs it. remote-provider-egress reads
+only ready/status/reason plus the process status and pid; the healthcheck
+reads only the status code.
+
+These tests pin the reduced shape, and pin that the fields consumers actually
+use survive.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+APP_MAIN = ROOT / "extensions" / "services" / "remote-provider-ssh-tunnel" / "app" / "main.py"
+EGRESS_MAIN = ROOT / "extensions" / "services" / "remote-provider-egress" / "app" / "main.py"
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def load_module():
+    sys.path.insert(0, str(ROOT / "bin"))
+    spec = importlib.util.spec_from_file_location("ssh_tunnel_under_test", APP_MAIN)
+    if spec is None or spec.loader is None:
+        raise AssertionError("could not load the tunnel app")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def sample_full_payload() -> dict:
+    """A health payload shaped like the real one, with route detail in it."""
+    return {
+        "schema": "ods.remote-provider-ssh-tunnel-health.v1",
+        "ready": True,
+        "status": "running",
+        "reason": "ready",
+        "plan": {
+            "schema": "ods.remote-provider-ssh-plan.v1",
+            "remoteHost": "gpu.example.test",
+            "remotePort": 22,
+            "remoteUser": "remote-operator",
+            "forwards": [
+                "0.0.0.0:18091:127.0.0.1:8000",
+                "0.0.0.0:18092:127.0.0.1:8091",
+            ],
+            "identityFile": "/state/remote-provider/secrets/ssh-identity",
+        },
+        "process": {"status": "running", "pid": 4242, "startedAt": 1.0},
+    }
+
+
+def test_plan_is_not_served_to_the_network(module) -> None:
+    public = module.public_health_payload(sample_full_payload())
+    assert_true("plan" not in public,
+                f"the route plan must not be served unauthenticated: {sorted(public)}")
+    dumped = json.dumps(public)
+    # Distinctive values, so a hit is a real leak and not a substring of the
+    # schema string (which legitimately starts "ods.").
+    for leaked in ("gpu.example.test", "18091", "18092", "ssh-identity",
+                   "remote-operator"):
+        assert_true(leaked not in dumped,
+                    f"{leaked!r} must not appear in the public health payload: {dumped}")
+
+
+def test_fields_consumers_use_survive(module) -> None:
+    """remote-provider-egress's _safe_tunnel_summary reads exactly these."""
+    public = module.public_health_payload(sample_full_payload())
+    assert_true(public["ready"] is True, "ready must survive")
+    assert_true(public["status"] == "running", "status must survive")
+    assert_true(public["reason"] == "ready", "reason must survive")
+    assert_true(public["process"]["status"] == "running", "process status must survive")
+    assert_true(public["process"]["pid"] == 4242, "process pid must survive")
+    assert_true(public["schema"], "schema must survive so consumers can version-check")
+
+
+def test_process_internals_beyond_status_are_dropped(module) -> None:
+    public = module.public_health_payload(sample_full_payload())
+    assert_true("startedAt" not in public["process"],
+                "only the process fields consumers read should be exposed")
+
+
+def test_missing_process_is_handled(module) -> None:
+    """A payload without a process block must not raise."""
+    payload = sample_full_payload()
+    del payload["process"]
+    public = module.public_health_payload(payload)
+    assert_true(public["process"] == {"status": None, "pid": None},
+                f"absent process should degrade cleanly, got {public['process']}")
+
+
+def test_handler_uses_the_reduced_payload(module) -> None:
+    """Source contract: the HTTP path must not serve health_payload directly."""
+    source = APP_MAIN.read_text(encoding="utf-8")
+    handler = source.split("class HealthHandler", 1)[1]
+    assert_true("public_health_payload(" in handler,
+                "HealthHandler must serve the reduced payload")
+
+
+def test_egress_consumer_expectations_still_match() -> None:
+    """The egress summariser must not read a field we stopped sending."""
+    egress = EGRESS_MAIN.read_text(encoding="utf-8")
+    summary = egress.split("def _safe_tunnel_summary", 1)[1].split("\nasync def", 1)[0]
+    for forbidden in ('payload.get("plan")', 'payload["plan"]'):
+        assert_true(forbidden not in summary,
+                    f"egress reads {forbidden}, which /health no longer returns")
+
+
+def main() -> int:
+    module = load_module()
+    for test in (
+        test_plan_is_not_served_to_the_network,
+        test_fields_consumers_use_survive,
+        test_process_internals_beyond_status_are_dropped,
+        test_missing_process_is_handled,
+        test_handler_uses_the_reduced_payload,
+    ):
+        test(module)
+        print(f"[PASS] {test.__name__}")
+    test_egress_consumer_expectations_still_match()
+    print("[PASS] test_egress_consumer_expectations_still_match")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

`remote-provider-ssh-tunnel`'s status server binds `0.0.0.0`
(`app/main.py`, `ThreadingHTTPServer(("0.0.0.0", _status_port()), ...)`) and
`HealthHandler` authenticates nothing. It cannot — the compose healthcheck has
no credential to present. So whatever `/health` returns is readable by every
peer on the network the tunnel sits on.

It returned the full health payload, which carries the resolved route plan:

```json
"plan": {
  "remoteHost": "...", "remotePort": 22, "remoteUser": "...",
  "forwards": ["0.0.0.0:18091:...", "0.0.0.0:18092:..."],
  "identityFile": "/state/remote-provider/secrets/ssh-identity"
}
```

No consumer needs any of it:

- `remote-provider-egress` reads only `ready`, `status`, `reason` and the
  process `status` and `pid` — see `_safe_tunnel_summary` there.
- The compose healthcheck reads only the status code.

## What changed

`public_health_payload()` reduces the response to exactly those fields, and
the HTTP handler serves that. `health_payload()` is unchanged, so in-process
callers and the contract tests that assert on the plan through it are
untouched — only the HTTP surface narrows.

No key material was ever in the payload; `ssh_secret_status()` reports
configured/byte counts only. This is inventory reduction, not a leak fix.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. Informational disclosure to something already on the network,
with no credential in the payload.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low. One HTTP response narrows; the internal function and every
  in-process caller are unchanged. The failure mode is dropping a field a
  consumer reads, which the tests check from both directions.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ python3 tests/contracts/test-ssh-tunnel-health-disclosure.py
  on origin/main   exit 1  (public_health_payload does not exist yet)
  on this branch   [PASS] plan is not served to the network
                   [PASS] fields consumers use survive
                   [PASS] process internals beyond status are dropped
                   [PASS] missing process is handled
                   [PASS] handler uses the reduced payload
                   [PASS] egress consumer expectations still match

$ python3 tests/contracts/test-remote-provider-ssh-tunnel-service.py   PASS
$ python3 tests/contracts/test-remote-provider-egress-service.py       PASS

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

No installer, compose, lifecycle or host-mutation code is touched. The
container healthcheck reads the status code, which is unchanged, and the one
service consumer reads fields the tests assert still present.

## Notes For Reviewers

- The existing contract test asserts on `payload["plan"]`, and still passes,
  because it calls `health_payload()` directly rather than going over HTTP.
  That separation is deliberate: the plan stays available in-process and stops
  being published.
- One test asserts the *egress* summariser does not read `plan`, so if a future
  change starts depending on it, that test fails rather than the service
  silently degrading.
- My first draft of the leak assertion used `"ods"` as a canary and failed
  against its own fixture, because the schema string legitimately starts
  `ods.`. The fixture now uses distinctive values so a hit is a real leak.
