### PR TITLE
fix(dashboard-api): generate the fallback API key at startup, not at import

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -43,7 +43,7 @@ from models import (
     GPUInfo, ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus,
     FullStatus, PortCheckRequest,
 )
-from security import verify_api_key
+from security import verify_api_key, persist_generated_key
 from gpu import get_gpu_info
 from helpers import (
     get_all_services, get_cached_services, set_services_cache,
@@ -1032,6 +1032,9 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
 
 @asynccontextmanager
 async def _lifespan(app: FastAPI):
+    # Persist a generated API key here rather than at import, so importing the
+    # module (a test, a script) never writes a secret to disk.
+    persist_generated_key()
     background_tasks = [
         asyncio.create_task(collect_metrics()),
         asyncio.create_task(_poll_service_health()),

--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -10,16 +10,38 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 logger = logging.getLogger(__name__)
 
+# The dashboard container's entrypoint reads this file to inject the key into
+# its nginx config, so the path is a contract between the two services.
+# Overridable so tests do not have to write to an absolute path.
+KEY_FILE = Path(os.environ.get("DASHBOARD_API_KEY_PATH", "/data/dashboard-api-key.txt"))
+
 DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY")
+_key_was_generated = False
 if not DASHBOARD_API_KEY:
     DASHBOARD_API_KEY = secrets.token_urlsafe(32)
-    key_file = Path("/data/dashboard-api-key.txt")
-    key_file.parent.mkdir(parents=True, exist_ok=True)
-    key_file.write_text(DASHBOARD_API_KEY)
-    key_file.chmod(0o600)
+    _key_was_generated = True
+
+
+def persist_generated_key() -> None:
+    """Write a generated key to disk. Called from app startup, not at import.
+
+    This used to run at import time, which meant anything that imported this
+    module — a test, a lint pass, a one-off script — created
+    /data/dashboard-api-key.txt as a side effect. Outside a container that
+    path resolves against the filesystem root, so it silently created a
+    directory and a secret file at the root of whatever drive it ran on.
+
+    Doing it from the lifespan keeps the behaviour the service needs (the
+    dashboard entrypoint reads this file) while making an import inert.
+    """
+    if not _key_was_generated:
+        return
+    KEY_FILE.parent.mkdir(parents=True, exist_ok=True)
+    KEY_FILE.write_text(DASHBOARD_API_KEY)
+    KEY_FILE.chmod(0o600)
     logger.warning(
         "DASHBOARD_API_KEY not set. Generated temporary key and wrote to %s (mode 0600). "
-        "Set DASHBOARD_API_KEY in your .env file for production.", key_file
+        "Set DASHBOARD_API_KEY in your .env file for production.", KEY_FILE
     )
 
 security_scheme = HTTPBearer(auto_error=False)

--- a/ods/extensions/services/dashboard-api/tests/test_security_key_persistence.py
+++ b/ods/extensions/services/dashboard-api/tests/test_security_key_persistence.py
@@ -1,0 +1,129 @@
+"""Importing security.py must not write a secret to disk.
+
+The key generation used to run at import time, so anything that imported the
+module — a test, a lint pass, a one-off script — created
+/data/dashboard-api-key.txt as a side effect. Outside a container that path
+resolves against the filesystem root, so it silently created a directory and
+a 0600 secret file at the root of whatever drive it ran on.
+
+The file itself is a real contract: the dashboard container's entrypoint reads
+it to inject the key into nginx. So the write has to still happen when the
+service starts — just not on import.
+"""
+
+import ast
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+SECURITY_PY = Path(__file__).resolve().parent.parent / "security.py"
+
+
+def _reimport_security(monkeypatch, key_path: Path, env_key: str | None):
+    monkeypatch.setenv("DASHBOARD_API_KEY_PATH", str(key_path))
+    if env_key is None:
+        monkeypatch.delenv("DASHBOARD_API_KEY", raising=False)
+    else:
+        monkeypatch.setenv("DASHBOARD_API_KEY", env_key)
+    sys.modules.pop("security", None)
+    return importlib.import_module("security")
+
+
+class TestImportIsInert:
+
+    def test_import_writes_nothing_when_key_is_absent(self, tmp_path, monkeypatch):
+        key_path = tmp_path / "nested" / "dashboard-api-key.txt"
+        security = _reimport_security(monkeypatch, key_path, env_key=None)
+
+        assert security.DASHBOARD_API_KEY, "a key must still be available in memory"
+        assert not key_path.exists(), "import must not write the key file"
+        assert not key_path.parent.exists(), "import must not create the directory either"
+
+    def test_import_writes_nothing_when_key_is_present(self, tmp_path, monkeypatch):
+        key_path = tmp_path / "dashboard-api-key.txt"
+        security = _reimport_security(monkeypatch, key_path, env_key="configured-key")
+
+        assert security.DASHBOARD_API_KEY == "configured-key"
+        assert not key_path.exists()
+
+    def test_no_filesystem_write_runs_at_import(self):
+        """Source guard: no write may execute at module level.
+
+        The behavioural tests above can only observe the path they control,
+        and the original code wrote to a hardcoded one — so they pass against
+        it while the real write still happens. This walks the AST instead:
+        anything not inside a function or class body runs on import, including
+        statements nested in a module-level `if`, which is exactly where the
+        original write lived.
+        """
+        tree = ast.parse(SECURITY_PY.read_text(encoding="utf-8"))
+        offenders = []
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                continue
+            for child in ast.walk(node):
+                if isinstance(child, ast.Call) and isinstance(child.func, ast.Attribute):
+                    if child.func.attr in {"write_text", "write_bytes", "mkdir", "chmod"}:
+                        offenders.append(f"{child.func.attr}() at line {child.lineno}")
+        assert not offenders, (
+            f"these run at import and touch the filesystem: {offenders}"
+        )
+
+
+class TestStartupPersistsTheKey:
+
+    def test_generated_key_is_written_on_startup(self, tmp_path, monkeypatch):
+        key_path = tmp_path / "nested" / "dashboard-api-key.txt"
+        security = _reimport_security(monkeypatch, key_path, env_key=None)
+
+        security.persist_generated_key()
+
+        assert key_path.exists(), "the dashboard entrypoint reads this file"
+        assert key_path.read_text() == security.DASHBOARD_API_KEY
+        if os.name != "nt":
+            assert oct(key_path.stat().st_mode)[-3:] == "600", "key file must stay 0600"
+
+    def test_configured_key_is_not_written(self, tmp_path, monkeypatch):
+        """An operator-supplied key is already persisted in .env."""
+        key_path = tmp_path / "dashboard-api-key.txt"
+        security = _reimport_security(monkeypatch, key_path, env_key="configured-key")
+
+        security.persist_generated_key()
+
+        assert not key_path.exists(), "a configured key must not be rewritten to disk"
+
+    def test_persist_is_idempotent(self, tmp_path, monkeypatch):
+        key_path = tmp_path / "dashboard-api-key.txt"
+        security = _reimport_security(monkeypatch, key_path, env_key=None)
+
+        security.persist_generated_key()
+        first = key_path.read_text()
+        security.persist_generated_key()
+
+        assert key_path.read_text() == first, "repeat calls must not rotate the key"
+
+
+class TestImportInASeparateProcess:
+    """The regression in its original form: a bare import in a clean process."""
+
+    def test_bare_import_creates_no_file(self, tmp_path):
+        key_path = tmp_path / "root-marker" / "dashboard-api-key.txt"
+        env = dict(os.environ)
+        env.pop("DASHBOARD_API_KEY", None)
+        env["DASHBOARD_API_KEY_PATH"] = str(key_path)
+        env["PYTHONPATH"] = str(SECURITY_PY.parent)
+
+        result = subprocess.run(
+            [sys.executable, "-c", "import security; print(bool(security.DASHBOARD_API_KEY))"],
+            env=env, capture_output=True, text=True, timeout=60,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "True", "the module must still expose a key"
+        assert not key_path.exists(), (
+            "importing security.py in a fresh process must not create the key file"
+        )
+        assert not key_path.parent.exists(), "nor its parent directory"


### PR DESCRIPTION
## Summary

`dashboard-api/security.py` generated a fallback API key and wrote
`/data/dashboard-api-key.txt` **at module import** when `DASHBOARD_API_KEY`
was unset:

```python
DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY")
if not DASHBOARD_API_KEY:
    DASHBOARD_API_KEY = secrets.token_urlsafe(32)
    key_file = Path("/data/dashboard-api-key.txt")
    key_file.parent.mkdir(parents=True, exist_ok=True)
    key_file.write_text(DASHBOARD_API_KEY)
    key_file.chmod(0o600)
```

Anything that imports the module does that as a side effect — a test, a lint
pass, a one-off script. Inside the container the path is correct. Outside one
it resolves against the filesystem root, so importing the module silently
creates a directory and a `0600` secret file at the root of whatever drive it
runs on. I hit this while running the dashboard-api tests: it created
`<drive>:\data\dashboard-api-key.txt`.

## What changed

The file is a real contract — the dashboard container's entrypoint reads it to
inject the key into nginx — so the write stays. It moves to the FastAPI
lifespan, where it runs when the service actually starts. Import now only
resolves a value in memory.

The path picks up `DASHBOARD_API_KEY_PATH`, defaulting to the same
`/data/dashboard-api-key.txt`, so tests do not have to write to an absolute
location.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. In the container the behaviour is identical; the stray write
only happens when the module is imported outside one, which is a developer
and CI concern rather than a user-facing failure.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — it touches how the API key is resolved, which every
  authenticated route depends on. The resolution itself is unchanged; only
  *when the file is written* moves.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ pytest tests/test_security_key_persistence.py
  on origin/main   4 failed, 3 passed
      FAILED ...::test_no_filesystem_write_runs_at_import
      FAILED ...::test_generated_key_is_written_on_startup
      FAILED ...::test_configured_key_is_not_written
      FAILED ...::test_persist_is_idempotent
  on this branch   7 passed

$ pytest tests/     2123 passed, 2 skipped     (full dashboard-api suite)

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

The key file is read by the dashboard container's entrypoint, so getting the
write wrong would break nginx's auth injection. The tests assert the file is
still created with the same contents and `0600` mode when a key is generated,
and *not* created when one is configured. What is not covered is a real
container start with `DASHBOARD_API_KEY` unset — worth one fleet check, since
that is the path the file exists for.

## Notes For Reviewers

- The source guard in the new tests walks the AST rather than grepping. The
  original write lived inside a module-level `if`, so a line-based "is this at
  column 0" check misses it — and so did my first behavioural test, which
  watched an overridable path while the unfixed code wrote to the hardcoded
  one and passed anyway. The AST check catches it because anything outside a
  function or class body runs on import.
- Behaviour inside the container is unchanged: same path, same mode, same
  contents, one lifecycle step later.
- Separate observation, not addressed here: if `dashboard-api` restarts with
  `DASHBOARD_API_KEY` still unset it generates a *new* key, while the already
  running dashboard container's nginx still holds the previous one from its
  own start. Reading an existing key file before generating would fix that,
  but it is a behaviour change rather than a relocation, so I left it out.
