### PR TITLE
fix(extension): add connect-timeout to health check curl probe in extension-runtime-check.sh

### DIFF
--- a/ods/scripts/extension-runtime-check.sh
+++ b/ods/scripts/extension-runtime-check.sh
@@ -111,7 +111,7 @@ for sid in "${SERVICE_IDS[@]}"; do
     fi
 
     url="http://127.0.0.1:${port}${health}"
-    if curl -sf --max-time "$timeout_sec" "$url" >/dev/null; then
+    if curl -sf --connect-timeout 3 --max-time "$timeout_sec" "$url" >/dev/null; then
         ok_line "[$sid] $disp — running, health OK ($url)"
     else
         bad_line "[$sid] $disp — running but health failed ($url) — try: docker compose logs $sid"


### PR DESCRIPTION
## Problem

In `ods/scripts/extension-runtime-check.sh`, health probing for running non-core containers uses `curl -sf --max-time "$timeout_sec"`. If an extension's published port is non-responsive or dropping packets during connection establishment, `curl` blocks for the full `$timeout_sec` duration instead of timing out quickly on the connection attempt.

## Fix

Add `--connect-timeout 3` to the `curl` health probe invocation in `extension-runtime-check.sh`.

## Verification

Ran `bash -n ods/scripts/extension-runtime-check.sh` (passed cleanly). `git diff --check` passed cleanly.