### PR TITLE
fix(catalog): add errors=replace in load_manifest in generate-extensions-catalog.py

### DIFF
--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -56,8 +56,8 @@ def strip_secrets(env_vars: list[dict]) -> list[dict]:
 def load_manifest(manifest_path: Path) -> dict | None:
     """Load and validate a single manifest file. Returns None on failure."""
     try:
-        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-    except (yaml.YAMLError, OSError) as e:
+        data = yaml.safe_load(manifest_path.read_text(encoding="utf-8", errors="replace"))
+    except (yaml.YAMLError, OSError, UnicodeDecodeError, ValueError) as e:
         print(f"WARNING: Failed to read {manifest_path}: {e}", file=sys.stderr)
         return None
 


### PR DESCRIPTION
## Problem

In `ods/scripts/generate-extensions-catalog.py`, `load_manifest()` opens extension manifests using `manifest_path.read_text(encoding="utf-8")`. If non-UTF-8 characters or malformed bytes are encountered in third-party or custom extension manifests, an uncaught `UnicodeDecodeError` or `ValueError` crashed catalog generation.

## Fix

Pass `errors="replace"` parameter to `read_text()` and expand the exception handler tuple to catch `UnicodeDecodeError` and `ValueError` in `load_manifest()`.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/generate-extensions-catalog.py`. `git diff --check` passed cleanly.