### PR TITLE
fix(hermes): use atomic write and errors=replace in patch-hermes-config.py

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -275,7 +275,7 @@ def patch_config(
     request_timeout_seconds: int = 180,
     max_tokens: int = 1024,
 ) -> bool:
-    original = path.read_text(encoding="utf-8")
+    original = path.read_text(encoding="utf-8", errors="replace")
     trailing_newline = original.endswith("\n")
     lines = original.splitlines()
 
@@ -290,7 +290,14 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
+
+    import os
+    import tempfile
+
+    fd, tmp_file = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(updated)
+    os.replace(tmp_file, str(path))
     return True
 
 


### PR DESCRIPTION
## Problem

In `ods/scripts/patch-hermes-config.py`, `patch_config()` reads target YAML files using `path.read_text(encoding="utf-8")` and overwrites configuration files directly using `path.write_text()`. If patching is interrupted mid-write by process signals, Hermes configuration files are left corrupted or zero-byte truncated.

## Fix

Pass `errors="replace"` parameter to `read_text()` and write updated YAML content to a temporary file via `tempfile.mkstemp` followed by an atomic `os.replace` swap.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/patch-hermes-config.py`. `git diff --check` passed cleanly.