### PR TITLE
fix(model): specify errors=replace in load_catalog in select-model.py

### DIFF
--- a/ods/scripts/select-model.py
+++ b/ods/scripts/select-model.py
@@ -119,7 +119,7 @@ def curated_source_allowed(model: dict[str, Any]) -> bool:
 
 
 def load_catalog(path: Path) -> list[dict[str, Any]]:
-    with path.open("r", encoding="utf-8") as fh:
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
         data = json.load(fh)
     return [
         model for model in (


### PR DESCRIPTION
## Problem

In `ods/scripts/select-model.py`, `load_catalog()` opens `model-library.json` using `path.open("r", encoding="utf-8")`. If non-UTF-8 characters or malformed bytes are encountered in customized or local model catalogs, an uncaught `UnicodeDecodeError` previously crashed model selection during setup.

## Fix

Pass `errors="replace"` parameter to `path.open()` inside `load_catalog()`.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/select-model.py`. `git diff --check` passed cleanly.