### PR TITLE
fix(golden): catch OSError and UnicodeDecodeError in validate-golden-paths.py

### DIFF
--- a/ods/scripts/validate-golden-paths.py
+++ b/ods/scripts/validate-golden-paths.py
@@ -184,9 +184,9 @@ def main(argv: list[str]) -> int:
         print(f"[FAIL] golden path file not found: {path}")
         return 1
     try:
-        data = json.loads(path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        print(f"[FAIL] invalid JSON in {path}: {exc}")
+        data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError) as exc:
+        print(f"[FAIL] invalid or unreadable JSON in {path}: {exc}")
         return 1
 
     issues = Issues()


### PR DESCRIPTION
## Problem

In `ods/scripts/validate-golden-paths.py`, `main()` loads `golden-paths.json` using `path.read_text(encoding="utf-8")` inside a `try...except json.JSONDecodeError` block. If non-UTF-8 characters or file reading errors occur, an uncaught `UnicodeDecodeError` or `OSError` previously crashed contract validation.

## Fix

Pass `errors="replace"` parameter to `read_text()` and expand the exception block to catch `UnicodeDecodeError` and `OSError` in `validate-golden-paths.py`.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/validate-golden-paths.py`. `git diff --check` passed cleanly.