### PR TITLE
fix(validate): handle paths outside root in relative_to in validate-models.py

### DIFF
--- a/ods/scripts/validate-models.py
+++ b/ods/scripts/validate-models.py
@@ -198,7 +198,11 @@ def check_hf_model(
     found = hf_model_path(root / cache_dir, repo_id)
     if found is None:
         return False, f"Not found or incomplete: {cache_dir}/ ({repo_id})"
-    return True, f"OK: {found.relative_to(root)}"
+    try:
+        rel_path = found.relative_to(root)
+    except ValueError:
+        rel_path = found
+    return True, f"OK: {rel_path}"
 
 
 def installer_command(platform_name: str | None = None) -> str:


### PR DESCRIPTION
## Problem

In `ods/scripts/validate-models.py`, `check_hf_model()` returns formatted relative model paths using `found.relative_to(root)`. If `data/embeddings` or `data/stt` caches are symlinked to external storage locations outside the installation root, `relative_to()` raises an uncaught `ValueError`.

## Fix

Wrap `found.relative_to(root)` in a `try...except ValueError` block in `check_hf_model()`, falling back cleanly to the absolute `found` path string when models reside outside the root directory.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/validate-models.py`. `git diff --check` passed cleanly.