### PR TITLE
fix(simulation): specify errors=replace in load_json in simulate-installers.sh

### DIFF
--- a/ods/scripts/simulate-installers.sh
+++ b/ods/scripts/simulate-installers.sh
@@ -98,7 +98,7 @@ def load_json(path):
     if not p.exists():
         return None
     try:
-        return json.loads(p.read_text(encoding="utf-8"))
+        return json.loads(p.read_text(encoding="utf-8", errors="replace"))
     except Exception:
         return None
 


### PR DESCRIPTION
## Problem

In `ods/scripts/simulate-installers.sh`, inline Python helper `load_json()` reads installer dry-run report JSON outputs using `p.read_text(encoding="utf-8")`. On platforms or localized environments producing non-standard byte sequences in dry-run reports, an uncaught `UnicodeDecodeError` previously crashed report aggregation.

## Fix

Pass `errors="replace"` parameter to `p.read_text()` inside `load_json()`.

## Verification

Ran `bash -n ods/scripts/simulate-installers.sh` (passed cleanly). `git diff --check` passed cleanly.