### PR TITLE
fix(installer): use the Linux fatal helper for the OpenCode key check

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Validate Env Tests
         run: bash tests/test-validate-env.sh
 
+      - name: Installer Env Generation Smoke
+        run: bash tests/smoke/installer-env-smoke.sh
+
       - name: Safe Env Loading Tests
         run: bash tests/test-safe-env.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -165,6 +165,7 @@ smoke: ## Run platform smoke tests
 	@bash tests/smoke/linux-nvidia.sh
 	@bash tests/smoke/wsl-logic.sh
 	@bash tests/smoke/macos-dispatch.sh
+	@bash tests/smoke/installer-env-smoke.sh
 	@echo "All smoke tests passed."
 
 simulate: ## Run installer simulation harness

--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -183,8 +183,12 @@ else
             _opencode_key="no-key"
         fi
         if [[ -z "${_opencode_key:-}" ]]; then
-            ai_err "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
-            exit 1
+            # `error` is the Linux installer's fatal helper (lib/logging.sh)
+            # and exits 1 itself, so no separate exit is needed. This used to
+            # call the macOS-only error helper from installers/macos/lib/ui.sh,
+            # which is never sourced on this path — so the line died with
+            # "command not found" instead of printing the message.
+            error "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
         fi
 
         # Writes a fresh opencode.json from the template. Used for first-install


### PR DESCRIPTION
## Summary

`installers/phases/07-devtools.sh` called `ai_err` when the OpenCode
switchboard config finds `LITELLM_KEY` empty:

```bash
if [[ -z "${_opencode_key:-}" ]]; then
    ai_err "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
    exit 1
fi
```

That helper is **macOS-only**. It is defined in
`installers/macos/lib/ui.sh:31`, which the Linux install path never sources.
The Linux side provides `log`, `warn`, `error` (`lib/logging.sh`) and
`ai_ok`, `ai_warn`, `ai_bad` (`lib/ui.sh`) — no `ai_err`.

So instead of printing the intended message and exiting 1, the line dies with
`ai_err: command not found` (exit 127). Under `set -euo pipefail` the phase
aborts either way, but the operator sees a bare shell error rather than being
told their `LITELLM_KEY` is empty, and the `exit 1` on the next line never
runs.

Switched to `error`, which is the established fatal helper across the phases
(12 uses in `01-preflight.sh`, 15 in `05-docker.sh`, and so on) and exits 1
itself — so the separate `exit 1` is no longer needed.

## The test that already knew

`tests/smoke/installer-env-smoke.sh` has two assertions for exactly this class:
that no `installers/phases/*.sh` calls `ai_err`, and that every `ai_*` call
resolves to a definition. Both have been failing on `main`.

Nothing ran it. It is referenced by neither the `Makefile` nor any workflow, so
the check existed and reported to no one. This wires it into `make smoke` and
into the `integration-smoke` job, taking it from **11/13 to 13/13**.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Mainline. The branch only fires when LITELLM_KEY is empty at that point in the
install, which is already a failing install — this changes a confusing failure
into a clear one. Reasonable backport if triage wants it, but not urgent.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low. One call site on an error path that is currently broken, plus
  wiring an existing test into the suites. No behaviour changes on a healthy
  install.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/smoke/installer-env-smoke.sh
  on origin/main    ✗ Found calls to undefined function 'ai_err'
                    ✗ Undefined functions called: ai_err
                    Results: 11 passed, 2 failed / 13 total
  on this branch    Results: 13 passed, 0 failed / 13 total

$ shellcheck --exclude=SC1091,SC2034 --severity=warning \
      installers/phases/07-devtools.sh                        clean
$ bash -n installers/phases/07-devtools.sh                    clean

$ bash tests/test-validate-env.sh                             PASS
$ bash tests/contracts/test-installer-contracts.sh            PASS
$ bash tests/test-linux-cloud-mode.sh                         PASS
$ bash tests/contracts/test-preflight-fixtures.sh             PASS

# Full make lint + make test + make smoke, run in a fresh Linux clone inside
# ubuntu:24.04 as a non-root user, which reproduces what actions/checkout
# gives the runner
$ make lint && make test && make smoke     ALL_TARGETS_PASSED
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

An installer phase, so operational. Release-grade validation is not proposed:
the changed line only executes on an install that is already failing, and the
new suite membership is an existing test that now runs rather than new
coverage. What is not covered is an actual install reaching that branch — I
have no environment where `LITELLM_KEY` is empty at phase 07.

## Notes For Reviewers

- One wrinkle worth knowing before editing the comment I left there: the
  smoke test's second assertion greps `\b(ai_\w+)\b` across the whole file,
  **comments included**. My first draft explained the fix by naming the old
  helper, and that re-triggered the failure. The comment now describes it
  without the literal token. A stricter parser that ignores comments would be
  a reasonable follow-up; I did not want to change the checker in the same PR
  that fixes what it caught.
- I put the CI step next to `Validate Env Tests` and the Makefile entry at the
  end of `smoke`, both away from the entries my other open PRs add, so these
  do not conflict textually in whichever order they merge.
