### PR TITLE
test(backup): give the disk-space preflight fixture the library it needs

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -139,6 +139,9 @@ jobs:
       - name: Uninstall Compose Flags Tests
         run: bash tests/test-uninstall-compose-flags.sh
 
+      - name: Disk Space Preflight Tests
+        run: bash tests/test-disk-space-preflight.sh
+
       - name: Windows Compose Failure Report Tests
         run: bash tests/test-windows-compose-failure-report.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -116,6 +116,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@echo ""
+	@echo "=== backup/restore disk-space preflight ==="
+	@bash tests/test-disk-space-preflight.sh
+	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
 	@echo ""

--- a/ods/tests/test-disk-space-preflight.sh
+++ b/ods/tests/test-disk-space-preflight.sh
@@ -40,6 +40,12 @@ mkdir -p "$FAKE_ODS/data/open-webui"
 mkdir -p "$FAKE_ODS/.backups"
 echo test > "$FAKE_ODS/.version"
 echo hello > "$FAKE_ODS/data/open-webui/file.txt"
+# Both scripts source lib/rsync.sh relative to ODS_DIR, before either reaches
+# its disk-space preflight. Without it they exit 1 at the source line — which
+# still looks like "the command failed", so the assertions below passed over
+# untested code.
+mkdir -p "$FAKE_ODS/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
 
 info "Backup should fail preflight when disk is low"
 set +e


### PR DESCRIPTION
## Summary

`tests/test-disk-space-preflight.sh` stubs `df` to report 1KB free and asserts
that `ods-backup.sh` and `ods-restore.sh` refuse to proceed. Its fake ODS root
contains only `data/`, `.backups/` and `.version`.

Both scripts source `$ODS_DIR/lib/rsync.sh` near the top — `ods-backup.sh:32`,
`ods-restore.sh:29` — before either reaches its disk-space check. So both exit
1 at the source line:

```text
ods-backup.sh: line 32: /tmp/.../ods/lib/rsync.sh: No such file or directory
```

That still looks like "the command failed", which is exactly what the first
assertion checks, so the test proceeds to look for the message and reports:

```text
✗ Expected 'Not enough disk space' message
```

The preflight it exists to verify has never run.

Copying the library into the fixture — the way
`tests/test-backup-restore-roundtrip.sh` already does, for the same reason —
makes both assertions pass. **The preflight itself was correct all along.**

## Confirming the repaired test actually guards it

A test that starts passing is not automatically a test that checks something.
I made the low-space branch in `ods-backup.sh` unreachable and ran both
fixtures against it:

```text
old fixture + broken check    ✗ Expected 'Not enough disk space' message
old fixture + correct check   ✗ Expected 'Not enough disk space' message
new fixture + broken check    ✗ Expected backup to fail due to low disk space
new fixture + correct check   ✓ ✓ both assertions pass
```

The old fixture produced the *same* failure whether the check worked or was
gone entirely, so it carried no signal either way. The mutation was reverted —
`ods-backup.sh` is unchanged in this PR.

## Same class as #2717

That PR fixed the identical omission in `tests/test-restore-safety-ux.sh`.
This is a second instance in a different test. Both were invisible because
neither file is referenced by the `Makefile` or any workflow, so this one is
wired into `make test` and the `integration-smoke` job as well.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. No shipped behaviour changes; this repairs a test fixture and
puts the test into the suites.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

Plus one CI workflow step and one `make test` line. No product code is
modified — `ods-backup.sh` and `ods-restore.sh` are untouched.

## Risk And Validation

- Risk level: Low — test fixture and test wiring only.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/test-disk-space-preflight.sh
  on origin/main    ✗ Expected 'Not enough disk space' message      exit 1
  on this branch    ✓ Backup preflight blocks low-space backup
                    ✓ Restore preflight blocks low-space restore    exit 0

  (mutation table above)

# Neighbouring backup/restore coverage on this branch
$ bash tests/test-backup-restore-cli.sh       PASS
$ bash tests/test-update-script-backup.sh     PASS
$ bash tests/test-backup-integrity.sh         PASS

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

No installer, compose, lifecycle, API or host-mutation code is touched.

## Notes For Reviewers

- The Makefile and CI entries are placed away from the ones my other open PRs
  add, so these do not conflict textually in whichever order they merge.
- Worth noting what this implies: the disk-space preflight in `ods-backup.sh`
  and `ods-restore.sh` has been shipping unverified. It turned out to be
  correct, but nothing was checking.
