### PR TITLE
test(security): make the network-security suite able to read compose bindings

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Windows Report Command Tests
         run: bash tests/test-windows-report-command.sh
 
+      - name: Network Security Posture Tests
+        run: bash tests/test-network-security.sh
+
       - name: Compose Failure Report Tests
         run: bash tests/test-compose-failure-report.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -101,6 +101,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh
 	@echo ""
+	@echo "=== network security posture ==="
+	@bash tests/test-network-security.sh
+	@echo ""
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
 	@echo ""

--- a/ods/tests/test-network-security.sh
+++ b/ods/tests/test-network-security.sh
@@ -53,6 +53,75 @@ header() {
     echo -e "${CYAN}$(printf '%.0s─' {1..70})${NC}"
 }
 
+# ----------------------------------------------------------------------------
+# Compose binding helpers
+#
+# Every published port in this repo is written as `${VAR:-default}`:
+#
+#     - "${BIND_ADDRESS:-127.0.0.1}:${QDRANT_PORT:-6333}:6333"
+#     - "${ODS_PROXY_BIND:-0.0.0.0}:${ODS_PROXY_PORT:-80}:80"
+#
+# so matching a literal `127.0.0.1:` or `0.0.0.0:` finds nothing — the text is
+# `127.0.0.1}:`. Resolve the defaults first, and strip comments before doing it,
+# because ods-proxy's compose comment mentions BIND_ADDRESS=127.0.0.1 and would
+# otherwise be read as a binding.
+# ----------------------------------------------------------------------------
+
+resolve_compose_defaults() {
+    sed -e 's/#.*$//' -e 's/[$][{][A-Za-z_][A-Za-z0-9_]*:-\([^}]*\)[}]/\1/g' "$1"
+}
+
+# Emit the host bind address of every published port, one per line. Scoped to
+# `ports:` blocks so volume entries, which look the same, are not counted. A
+# mapping with no address ("5432:5432") emits "unspecified".
+published_bind_addresses() {
+    resolve_compose_defaults "$1" | awk '
+        /^[[:space:]]*ports:[[:space:]]*$/ { in_ports = 1; next }
+        in_ports && /^[[:space:]]*-/ {
+            line = $0
+            sub(/^[[:space:]]*-[[:space:]]*/, "", line)
+            gsub(/"/, "", line)
+            sub(/[[:space:]]*$/, "", line)
+            if (line == "") next
+            n = split(line, part, ":")
+            if (n >= 3)      print part[1]
+            else if (n == 2) print "unspecified"
+            next
+        }
+        in_ports && /^[[:space:]]*[^[:space:]-]/ { in_ports = 0 }
+    '
+}
+
+# Name a compose file's service. Root-level stack files live in the repo root,
+# where basename(dirname(...)) is "." — name those after the file instead.
+compose_service_name() {
+    local dir
+    dir="$(basename "$(dirname "$1")")"
+    case "$dir" in
+        .|ods) basename "$1" ;;
+        *)     printf '%s' "$dir" ;;
+    esac
+}
+
+# A service whose manifest declares host_network: true has opted out of port
+# mapping deliberately (tailscale). The extension audit uses the same signal.
+declares_host_network() {
+    local manifest
+    manifest="$(dirname "$1")/manifest.yaml"
+    [[ -f "$manifest" ]] && grep -qE '^[[:space:]]*host_network:[[:space:]]*true' "$manifest"
+}
+
+# network-exposure-policy.json is the source of truth for which services are
+# meant to face the LAN. Keep this list aligned with its lan_exposure values.
+is_intentionally_exposed() {
+    case "$1" in
+        dashboard|dashboard-api|open-webui) return 0 ;;  # operator UI / API
+        ods-proxy)                          return 0 ;;  # the LAN-facing proxy itself
+        tailscale)                          return 0 ;;  # host networking, by design
+        *)                                  return 1 ;;
+    esac
+}
+
 # ============================================
 # TEST 1: Port Binding Security
 # ============================================
@@ -64,27 +133,36 @@ insecure_bindings=()
 secure_bindings=0
 
 for compose_file in "${compose_files[@]}"; do
-    if [[ -f "$compose_file" ]]; then
-        service_name=$(basename "$(dirname "$compose_file")" | sed 's/compose//')
+    [[ -f "$compose_file" ]] || continue
+    file_label="$(basename "$compose_file")"
 
-        # Check for 0.0.0.0 bindings (insecure)
-        if grep -q "0\.0\.0\.0:" "$compose_file"; then
-            insecure_bindings+=("$compose_file")
-            fail "Insecure port binding in $compose_file" "Uses 0.0.0.0 (exposes to all interfaces)"
-        fi
+    mapfile -t binds < <(published_bind_addresses "$compose_file")
+    [[ ${#binds[@]} -gt 0 ]] || continue
 
-        # Check for 127.0.0.1 bindings (secure)
-        if grep -q "127\.0\.0\.1:" "$compose_file"; then
-            secure_bindings=$((secure_bindings + 1))
-            pass "Secure port binding in $(basename "$compose_file")"
-        fi
-
-        # Check for port mappings without explicit IP (potentially insecure)
-        if grep -E "^\s*-\s*[\"']?[0-9]+:[0-9]+" "$compose_file" | grep -v "127.0.0.1\|0.0.0.0"; then
-            skip "Port binding without explicit IP in $(basename "$compose_file")" "Consider using 127.0.0.1"
-        fi
-    fi
+    for bind in "${binds[@]}"; do
+        case "$bind" in
+            127.0.0.1|localhost|::1|"[::1]")
+                secure_bindings=$((secure_bindings + 1))
+                ;;
+            0.0.0.0|::|"[::]")
+                svc="$(compose_service_name "$compose_file")"
+                if is_intentionally_exposed "$svc"; then
+                    skip "$file_label binds $bind" "Intentional: $svc is a LAN-facing surface"
+                else
+                    insecure_bindings+=("$compose_file")
+                    fail "Insecure port binding in $file_label" "Binds $bind (all interfaces)"
+                fi
+                ;;
+            unspecified)
+                skip "Port mapping without an explicit address in $file_label" "Prefer a bound address"
+                ;;
+        esac
+    done
 done
+
+if [[ $secure_bindings -gt 0 ]]; then
+    pass "$secure_bindings loopback-bound port mapping(s)"
+fi
 
 echo ""
 echo -e "    ${BOLD}Summary:${NC} $secure_bindings secure bindings, ${#insecure_bindings[@]} insecure bindings"
@@ -99,28 +177,37 @@ external_services=()
 internal_services=0
 
 for compose_file in "${compose_files[@]}"; do
-    if [[ -f "$compose_file" ]]; then
-        service_name=$(basename "$(dirname "$compose_file")")
+    [[ -f "$compose_file" ]] || continue
+    service_name="$(compose_service_name "$compose_file")"
 
-        # Services with external port mappings
-        if grep -q "ports:" "$compose_file"; then
-            # Check if ports are bound to localhost only
-            if grep -A10 "ports:" "$compose_file" | grep -q "127\.0\.0\.1:"; then
-                internal_services=$((internal_services + 1))
-                pass "Service '$service_name' exposed only to localhost"
-            else
-                external_services+=("$service_name")
-                # Check if this is intentional (dashboard, API endpoints)
-                case "$service_name" in
-                    dashboard|dashboard-api|open-webui)
-                        skip "Service '$service_name' externally exposed (expected for UI/API)"
-                        ;;
-                    *)
-                        fail "Service '$service_name' may be externally exposed" "Review port binding configuration"
-                        ;;
-                esac
-            fi
+    mapfile -t binds < <(published_bind_addresses "$compose_file")
+
+    if [[ ${#binds[@]} -eq 0 ]]; then
+        if declares_host_network "$compose_file"; then
+            skip "Service '$service_name' uses host networking" "Declared host_network: true"
+        else
+            internal_services=$((internal_services + 1))
+            pass "Service '$service_name' publishes no host ports"
         fi
+        continue
+    fi
+
+    exposed=false
+    for bind in "${binds[@]}"; do
+        case "$bind" in
+            127.0.0.1|localhost|::1|"[::1]") ;;
+            *) exposed=true ;;
+        esac
+    done
+
+    if [[ "$exposed" == "false" ]]; then
+        internal_services=$((internal_services + 1))
+        pass "Service '$service_name' exposed only to localhost"
+    elif is_intentionally_exposed "$service_name"; then
+        skip "Service '$service_name' externally exposed" "Declared in network-exposure-policy.json"
+    else
+        external_services+=("$service_name")
+        fail "Service '$service_name' may be externally exposed" "Review port binding configuration"
     fi
 done
 
@@ -150,8 +237,15 @@ host_network_count=0
 for compose_file in "${compose_files[@]}"; do
     if [[ -f "$compose_file" ]]; then
         if grep -q "network_mode.*host" "$compose_file"; then
-            host_network_count=$((host_network_count + 1))
-            fail "Service uses host networking in $(basename "$compose_file")" "Breaks container isolation"
+            # Declared host networking is a design decision, not a defect:
+            # tailscale needs the host stack, says so in its manifest, and
+            # network-exposure-policy.json records it as intentional.
+            if declares_host_network "$compose_file"; then
+                skip "Service uses host networking in $(basename "$compose_file")" "Declared host_network: true"
+            else
+                host_network_count=$((host_network_count + 1))
+                fail "Service uses host networking in $(basename "$compose_file")" "Breaks container isolation"
+            fi
         fi
     fi
 done


### PR DESCRIPTION
## Summary

`tests/test-network-security.sh` classifies port bindings by grepping for the
literal strings `127.0.0.1:` and `0.0.0.0:`. Every published port in this repo
is written with a default expansion:

```yaml
- "${BIND_ADDRESS:-127.0.0.1}:${QDRANT_PORT:-6333}:6333"
- "${ODS_PROXY_BIND:-0.0.0.0}:${ODS_PROXY_PORT:-80}:80"
```

Neither pattern ever matches — the text is `127.0.0.1}:`, with a brace in the
way. **The suite is blind in both directions.**

### False positives — 17

Thirteen loopback-bound services reported as "may be externally exposed", plus
two entries literally named `Service '.'`, because `basename(dirname())` of a
root-level compose file is `.`.

### False negative — the one that matters

`ods-proxy` genuinely binds `0.0.0.0`, and the insecure-binding check does not
see it. **A security test meant to catch `0.0.0.0` bindings cannot catch the
only one in the repo**, or any new one written in house style.

The secure/insecure counters never increment either, so the summary always
reads `0 secure bindings, 0 insecure bindings`.

## What changed

Resolve `${VAR:-default}` before classifying, and strip comments first —
`ods-proxy`'s compose comment contains `BIND_ADDRESS=127.0.0.1` and would
otherwise be read as a binding. Extraction is scoped to `ports:` blocks, since
`volumes:` entries have the same list shape.

Two exposures are intentional and documented, so they are **skipped** rather
than failed:

- `ods-proxy` is the LAN-facing surface by design — its own comment says "this
  is an explicit exception to `BIND_ADDRESS=127.0.0.1` — every other ODS
  service stays loopback so the proxy is the only thing the LAN can reach".
- `tailscale` declares `host_network: true` in its manifest, which
  `network-exposure-policy.json` records as "intentional and must stay
  explicit". The host-networking check now consults that same signal instead
  of failing on it.

**45 passed / 18 failed** becomes **70 passed / 0 failed / 4 skipped**.

## Verifying it now catches what it exists to catch

A suite that goes green because it stopped looking is worse than one that
fails. I pointed `qdrant` at `0.0.0.0` and ran both versions:

```text
old suite + genuinely 0.0.0.0-bound qdrant   ->  0 detections
new suite + genuinely 0.0.0.0-bound qdrant   ->  3 detections
    ✗ Insecure port binding in compose.yaml       (x2, one per mapping)
    ✗ Service 'qdrant' may be externally exposed
```

The mutation was reverted; no compose file is modified by this PR.

## AI Assistance

Used Claude Code.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. No shipped behaviour changes; this repairs a test and puts it
into the suites.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

Plus one CI step and one `make test` line. No product code and no compose file
is modified.

## Risk And Validation

- Risk level: Low as a diff — test-only. Worth review attention anyway, because
  a check that is wrong in the *permissive* direction is how a real exposure
  ships unnoticed, and the allowlist is the part that could hide one.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`

Commands/results:

```text
$ bash tests/test-network-security.sh
  on origin/main    45 passed, 18 failed, 0 skipped   (63 total)
  on this branch    70 passed,  0 failed, 4 skipped   (74 total)

  (mutation table above)

$ shellcheck --exclude=SC1091,SC2034 --severity=warning
      tests/test-network-security.sh                        clean
$ bash -n tests/test-network-security.sh                    clean
$ bash tests/test-secret-security.sh                        PASS
$ python3 tests/contracts/test-network-exposure-contracts.py PASS

# Full make lint + make test in a fresh Linux clone inside ubuntu:24.04 as a
# non-root user, reproducing what actions/checkout gives the runner
$ make lint && make test    ALL_TARGETS_PASSED
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

No installer, compose, lifecycle, API or host-mutation code is touched.

## Notes For Reviewers

- **The allowlist is the part to scrutinise.** `is_intentionally_exposed()`
  currently hardcodes `dashboard`, `dashboard-api`, `open-webui`, `ods-proxy`
  and `tailscale`. `network-exposure-policy.json` already records
  `lan_exposure` per service and would be the better source of truth; I kept
  the hardcoded list because reading JSON here would add a `jq` dependency to
  a suite that currently has none. Happy to switch if you would rather have it
  driven by the policy file.
- I checked every one of the 17 flagged services before deciding they were
  false positives — thirteen bind `${BIND_ADDRESS:-127.0.0.1}`, the ComfyUI
  and Hermes hits come from GPU overlays that are also loopback, and the two
  `Service '.'` entries are root-level stack files. No real exposure was hiding
  among them.
- The suite is referenced by neither the Makefile nor any workflow, which is
  how it drifted this far. Same pattern as #2717, #2745 and #2746.
