### PR TITLE
fix(dashboard-api): bound limit param on workflow_executions

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -6,7 +6,7 @@ import logging
 import re
 
 import aiohttp
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from config import (
     SERVICES, WORKFLOW_DIR, WORKFLOW_CATALOG_FILE,
@@ -273,7 +273,11 @@ async def disable_workflow(workflow_id: str, api_key: str = Depends(verify_api_k
 
 
 @router.get("/api/workflows/{workflow_id}/executions")
-async def workflow_executions(workflow_id: str, limit: int = 20, api_key: str = Depends(verify_api_key)):
+async def workflow_executions(
+    workflow_id: str,
+    limit: int = Query(default=20, ge=1, le=100),
+    api_key: str = Depends(verify_api_key),
+):
     """Get recent executions for a workflow."""
     _validate_workflow_id(workflow_id)
     n8n_workflows = await get_n8n_workflows()


### PR DESCRIPTION
## Summary
- `workflow_executions` accepted `limit: int = 20` with no upper bound, unlike `list_available_models` in `models.py` which already uses `Query(default=20, ge=1, le=30)` for the same kind of parameter.
- A caller could pass an arbitrarily large `limit`, forcing an unbounded fetch of execution history from n8n.
- Adds `Query(default=20, ge=1, le=100)`, matching the repo's existing bounding convention.

## Test plan
- [x] `python -m py_compile routers/workflows.py` passes
- [x] Change is a signature-only edit; behavior for valid limits (1-100) unchanged