### PR TITLE
fix(dashboard-api): prefer exact name match in _remove_workflow

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -235,9 +235,14 @@ async def _remove_workflow(workflow_id: str):
     n8n_wf = None
     wf_name_lower = wf_info["name"].lower()
     for wf in n8n_workflows:
-        if wf_name_lower in wf.get("name", "").lower():
+        if wf.get("name", "").lower() == wf_name_lower:
             n8n_wf = wf
             break
+    if not n8n_wf:
+        for wf in n8n_workflows:
+            if wf_name_lower in wf.get("name", "").lower():
+                n8n_wf = wf
+                break
     if not n8n_wf:
         raise HTTPException(status_code=404, detail="Workflow not installed in n8n")
 


### PR DESCRIPTION
## Summary
- `_remove_workflow` matched a catalog workflow to its n8n counterpart using first-hit substring containment (`wf_name_lower in wf.get("name","").lower()`), with no exact-match preference.
- If n8n has two workflows where one name is a substring of another (e.g. "Slack" and "Slack Notify Extended"), disabling/removing "Slack" could hit the wrong workflow depending on n8n's list order.
- Now tries an exact case-insensitive match first, falling back to substring matching only when no exact match is found.

## Test plan
- [x] `python -m py_compile routers/workflows.py` passes
- [x] Existing substring-match behavior preserved as fallback, so workflows relying on it still work