### PR TITLE
feat(scripts): add --help to check-compatibility.sh

### DIFF
--- a/ods/scripts/check-compatibility.sh
+++ b/ods/scripts/check-compatibility.sh
@@ -3,6 +3,18 @@
 
 set -euo pipefail
 
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'USAGE'
+Usage: check-compatibility.sh
+
+Validate core compatibility contracts declared in manifest.json:
+manifest structure, compose canonical files, workflow catalog path,
+extension schema, ports contract, and OS support-matrix consistency.
+Takes no arguments. Exits non-zero on the first failed contract.
+USAGE
+    exit 0
+fi
+
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST_FILE="${ROOT_DIR}/manifest.json"
 


### PR DESCRIPTION
## Summary
- `check-compatibility.sh` had no `-h`/`--help`, unlike several sibling scripts.
- Adds a short usage message describing what contracts it validates and that it takes no arguments.

## Test plan
- [x] `bash -n scripts/check-compatibility.sh` passes
- [x] `bash scripts/check-compatibility.sh --help` prints usage and exits 0
- [x] Normal invocation (no args) unaffected