### PR TITLE
feat(scripts): add --help to build-capability-profile.sh

### DIFF
--- a/ods/scripts/build-capability-profile.sh
+++ b/ods/scripts/build-capability-profile.sh
@@ -6,6 +6,19 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 OUTPUT_FILE=""
 ENV_MODE="false"
 
+usage() {
+    cat <<'USAGE'
+Usage: build-capability-profile.sh [OPTIONS]
+
+Build the host capability profile (OS, GPU, memory, disk, etc.).
+
+Options:
+  --output FILE   Write the profile as JSON to FILE
+  --env           Emit output as shell-sourceable KEY=VALUE pairs
+  -h, --help      Show this help message and exit
+USAGE
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --output)
@@ -15,6 +28,10 @@ while [[ $# -gt 0 ]]; do
         --env)
             ENV_MODE="true"
             shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
             ;;
         *)
             echo "Unknown argument: $1" >&2


### PR DESCRIPTION
## Summary
- `build-capability-profile.sh` takes `--output` and `--env` but had no `-h`/`--help`; running `--help` fell through to the `*` case and errored with "Unknown argument: --help".
- Adds a `usage()` function and a `-h|--help` case, matching the convention used elsewhere in `scripts/`.

## Test plan
- [x] `bash -n scripts/build-capability-profile.sh` passes
- [x] `bash scripts/build-capability-profile.sh --help` prints usage and exits 0
- [x] Existing `--output`/`--env` flags unchanged