### PR TITLE
fix(dashboard): add aria-label to icon-only buttons in FeatureDiscovery

### DIFF
--- a/ods/extensions/services/dashboard/src/components/FeatureDiscovery.jsx
+++ b/ods/extensions/services/dashboard/src/components/FeatureDiscovery.jsx
@@ -62,6 +62,7 @@ export function FeatureDiscoveryBanner({ onDismiss }) {
           <button
             onClick={() => { setDismissed(true); onDismiss?.() }}
             className="p-2 text-theme-text-muted hover:text-theme-text transition-colors"
+            aria-label="Dismiss suggestion"
           >
             <X size={16} />
           </button>
@@ -261,7 +262,7 @@ function EnableInstructions({ featureId, onClose }) {
         <div className="p-6 border-b border-theme-border">
           <div className="flex items-center justify-between">
             <h2 className="text-xl font-bold text-theme-text">Enable {data.name}</h2>
-            <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text">
+            <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text" aria-label="Close">
               <X size={20} />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- `FeatureDiscovery.jsx` has two icon-only buttons (a dismiss button and a modal close button) with no accessible name — just an `<X />` icon, no text or `aria-label`.
- Screen readers announce these as just "button", giving no indication of what they do.
- Adds `aria-label="Dismiss suggestion"` and `aria-label="Close"`, matching the pattern already used for the close button in `Invites.jsx`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive `aria-label` props, no layout/behavior change