### PR TITLE
fix(dashboard): add aria-label to close button in HuggingFaceModelBrowser

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
@@ -300,7 +300,7 @@ function ArtifactDialog({ model, details, loading, error, gpu, downloadBusy, imp
             </div>
             <p className="mt-1 text-xs text-theme-text-muted">Select an exact, integrity-qualified GGUF artifact.</p>
           </div>
-          <button type="button" onClick={onClose} disabled={Boolean(importingArtifact)} className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/[0.08] text-theme-text-muted hover:text-theme-text disabled:opacity-40" title="Close">
+          <button type="button" onClick={onClose} disabled={Boolean(importingArtifact)} className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/[0.08] text-theme-text-muted hover:text-theme-text disabled:opacity-40" title="Close" aria-label="Close">
             <X size={15} />
           </button>
         </header>


### PR DESCRIPTION
## Summary
- The modal close button in `HuggingFaceModelBrowser.jsx` only had a `title="Close"` attribute and an icon, no `aria-label`.
- `title` is not consistently exposed as an accessible name by screen readers, so this button had no reliable accessible name.
- Adds `aria-label="Close"` alongside the existing `title`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change