### PR TITLE
fix(dashboard): add aria-label to close button in TemplatePicker

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -195,7 +195,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
               <p className="text-xs text-theme-text-muted">{template.description}</p>
             </div>
           </div>
-          <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text transition-colors">
+          <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text transition-colors" aria-label="Close">
             <X size={18} />
           </button>
         </div>


### PR DESCRIPTION
## Summary
- The preview-modal close button in `TemplatePicker.jsx` is icon-only (`<X size={18} />`), with no text, no `title`, and no `aria-label` — zero accessible name for screen readers.
- Adds `aria-label="Close"`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change