### PR TITLE
fix(dashboard): add aria-label to icon-only close buttons

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -973,7 +973,7 @@ function DetailModal({ ext, gpuBackend, onClose }) {
               </div>
             </div>
           </div>
-          <button onClick={onClose} autoFocus className="text-theme-text-muted hover:text-theme-text-secondary transition-colors p-1">
+          <button onClick={onClose} autoFocus aria-label="Close" className="text-theme-text-muted hover:text-theme-text-secondary transition-colors p-1">
             <X size={18} />
           </button>
         </div>
@@ -1234,7 +1234,7 @@ function ConsoleModal({ ext, onClose }) {
               <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" title="Live" />
             )}
           </div>
-          <button onClick={onClose} autoFocus className="text-theme-text-muted hover:text-theme-text-secondary transition-colors p-1">
+          <button onClick={onClose} autoFocus aria-label="Close" className="text-theme-text-muted hover:text-theme-text-secondary transition-colors p-1">
             <X size={16} />
           </button>
         </div>

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -231,7 +231,7 @@ function DetailPanel({ node, edges, onClose }) {
           <span className={`h-2.5 w-2.5 rounded-full ${meta.dot}`} />
           <span className="text-sm font-semibold text-theme-text">{node.name}</span>
         </div>
-        <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text"><X size={16} /></button>
+        <button onClick={onClose} aria-label="Close" className="text-theme-text-muted hover:text-theme-text"><X size={16} /></button>
       </div>
       <div className="space-y-3 px-4 py-3 text-xs">
         <div className="flex justify-between"><span className="text-theme-text-muted">Status</span><span className={meta.text}>{node.status}</span></div>


### PR DESCRIPTION
## Summary
- Two modal close buttons in `Extensions.jsx` and one close button in `ServiceMap.jsx` are icon-only (`<X />`), with no accessible name for screen readers.
- Adds `aria-label="Close"` to each, matching the convention already used in `Invites.jsx` and `Models.jsx`.
- Note: `InstallPromptBanner.jsx`'s dismiss button and `Models.jsx`'s icon-only close button already had `aria-label` set, so they're left untouched.

## Test plan
- [x] `npx eslint` on both changed files — no new errors
- [x] Purely additive `aria-label` props, no behavior change