### PR TITLE
feat(scripts): add --help to preflight-engine.sh

### DIFF
--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -14,6 +14,29 @@ SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 STRICT="false"
 ENV_MODE="false"
 
+usage() {
+    cat <<'USAGE'
+Usage: preflight-engine.sh [OPTIONS]
+
+Simulate a preflight hardware/tier check and write a JSON report.
+
+Options:
+  --report FILE          Output path for the JSON report (default: /tmp/ods-preflight-report.json)
+  --tier TIER            Hardware tier (e.g. T1, T2)
+  --ram-gb GB            System RAM in gigabytes
+  --disk-gb GB           Free disk space in gigabytes
+  --gpu-backend BACKEND  GPU backend (nvidia, amd, apple, cpu)
+  --gpu-vram-mb MB       GPU VRAM in megabytes
+  --gpu-name NAME        GPU model name
+  --platform-id ID       Platform identifier (linux, macos, windows)
+  --compose-overlays LIST  Comma-separated compose overlay files
+  --script-dir DIR       Root directory to resolve relative paths against
+  --strict               Fail on warnings, not just blockers
+  --env                  Emit output as shell-sourceable KEY=VALUE pairs
+  -h, --help             Show this help message and exit
+USAGE
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --report)
@@ -63,6 +86,10 @@ while [[ $# -gt 0 ]]; do
         --env)
             ENV_MODE="true"
             shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
             ;;
         *)
             echo "Unknown argument: $1" >&2


### PR DESCRIPTION
## Summary
- `preflight-engine.sh` accepts 12 flags (`--report`, `--tier`, `--ram-gb`, etc.) but had no `-h`/`--help`.
- Running `--help` previously fell through to the `*` case and errored with "Unknown argument: --help".
- Adds a `usage()` function and a `-h|--help` case, matching the convention used in other recently-fixed scripts (`classify-hardware.sh`, `check-compatibility.sh`, `build-capability-profile.sh`).

## Test plan
- [x] `bash -n scripts/preflight-engine.sh` passes
- [x] `bash scripts/preflight-engine.sh --help` prints usage and exits 0
- [x] All existing flags unchanged