### PR TITLE
feat(scripts): add --help to load-backend-contract.sh

### DIFF
--- a/ods/scripts/load-backend-contract.sh
+++ b/ods/scripts/load-backend-contract.sh
@@ -6,6 +6,20 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 BACKEND_ID=""
 ENV_MODE="false"
 
+usage() {
+    cat <<'USAGE'
+Usage: load-backend-contract.sh --backend BACKEND [OPTIONS]
+
+Load the backend contract JSON for a given backend from
+config/backends/<BACKEND>.json.
+
+Options:
+  --backend BACKEND   Backend id (e.g. nvidia, amd, apple, cpu) — required
+  --env                Emit output as shell-sourceable KEY=VALUE pairs
+  -h, --help           Show this help message and exit
+USAGE
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --backend)
@@ -15,6 +29,10 @@ while [[ $# -gt 0 ]]; do
         --env)
             ENV_MODE="true"
             shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
             ;;
         *)
             echo "Unknown argument: $1" >&2


### PR DESCRIPTION
## Summary
- `load-backend-contract.sh` takes a required `--backend` and optional `--env` but had no `-h`/`--help`.
- Running `--help` previously fell through to the `*` case and errored with "Unknown argument: --help".
- Adds a `usage()` function and a `-h|--help` case, matching the convention used in other recently-fixed scripts.

## Test plan
- [x] `bash -n scripts/load-backend-contract.sh` passes
- [x] `bash scripts/load-backend-contract.sh --help` prints usage and exits 0
- [x] Existing `--backend`/`--env` flags unchanged