### PR TITLE
fix(dashboard): add aria-label to copy-command button in TroubleshootingAssistant

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
+++ b/ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
@@ -231,6 +231,7 @@ export function TroubleshootingAssistant({ serviceStatus }) {
                           <button
                             onClick={() => copyToClipboard(solution.command, `${issue.id}-${i}`)}
                             className="absolute top-1 right-1 p-1 bg-theme-card hover:bg-theme-surface-hover rounded text-theme-text-muted hover:text-theme-text transition-colors"
+                            aria-label={copied === `${issue.id}-${i}` ? 'Copied' : 'Copy command'}
                           >
                             {copied === `${issue.id}-${i}` ? (
                               <Check className="w-3 h-3 text-emerald-400" />


### PR DESCRIPTION
## Summary
- The copy-to-clipboard button next to each troubleshooting command is icon-only (`Copy`/`Check` from lucide-react), with no text, `title`, or `aria-label`.
- Screen readers announce it as just "button", with no indication of what it does or whether the copy succeeded.
- Adds `aria-label` that reflects the current state ("Copy command" / "Copied").

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change