### PR TITLE
fix(dashboard): add aria-label to sidebar collapse/expand toggle

### DIFF
--- a/ods/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/ods/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -244,6 +244,7 @@ export default function Sidebar({ status, collapsed, onToggle }) {
           onClick={onToggle}
           className={`${collapsed ? '' : 'ml-auto'} hidden items-center justify-center rounded-lg p-2 text-theme-text-muted transition-colors hover:text-theme-text sm:flex`}
           title={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
           style={{ background: 'var(--sidebar-hover-bg)' }}
         >
           {collapsed ? <ChevronRight size={18} /> : <ChevronLeft size={18} />}


### PR DESCRIPTION
## Summary
- The sidebar collapse/expand toggle button only had a `title` attribute (`"Expand sidebar"`/`"Collapse sidebar"`), no `aria-label`.
- `title` is not consistently exposed as an accessible name by screen readers.
- Adds a matching `aria-label` alongside the existing `title`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change