### PR TITLE
fix(pin): specify errors=replace in load_lock in check-dependency-pins.py

### DIFF
--- a/ods/scripts/check-dependency-pins.py
+++ b/ods/scripts/check-dependency-pins.py
@@ -336,7 +336,7 @@ def validate_ephemeral_sha_tags(refs: Iterable[ImageRef]) -> list[str]:
 
 
 def load_lock(path: Path = LOCK_PATH) -> dict[str, object]:
-    with path.open(encoding="utf-8") as handle:
+    with path.open(encoding="utf-8", errors="replace") as handle:
         data = json.load(handle)
     if not isinstance(data, dict):
         raise ValueError("dependency-lock.json must contain a JSON object")


### PR DESCRIPTION
## Problem

In `ods/scripts/check-dependency-pins.py`, `load_lock()` opens `dependency-lock.json` via `path.open(encoding="utf-8")`. If non-UTF-8 characters or malformed bytes exist in customized or localized dependency lockfiles, an uncaught `UnicodeDecodeError` previously crashed dependency pin validation.

## Fix

Pass `errors="replace"` parameter to `path.open()` inside `load_lock()`.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/check-dependency-pins.py`. `git diff --check` passed cleanly.