### PR TITLE
fix(bootstrap): trim whitespace from media_type in verify-hosted-bootstrap.sh

### DIFF
--- a/ods/scripts/verify-hosted-bootstrap.sh
+++ b/ods/scripts/verify-hosted-bootstrap.sh
@@ -119,7 +119,7 @@ for endpoint in "$@"; do
     [[ "$presentation" == "script" ]] \
         || fail "$endpoint reports presentation '${presentation:-missing}'; expected script."
 
-    media_type="$(printf '%s' "${content_type%%;*}" | tr '[:upper:]' '[:lower:]')"
+    media_type="$(printf '%s' "${content_type%%;*}" | tr '[:upper:]' '[:lower:]' | xargs)"
     case "$media_type" in
         text/plain) ;;
         *) fail "$endpoint returned content type '${content_type:-missing}'; expected text/plain." ;;


### PR DESCRIPTION
## Problem

In `ods/scripts/verify-hosted-bootstrap.sh`, `media_type` is extracted using `printf '%s' "${content_type%%;*}" | tr '[:upper:]' '[:lower:]'`. If the HTTP `Content-Type` header contains trailing spaces before the semicolon (e.g. `text/plain ; charset=utf-8`), the parameter expansion leaves trailing whitespace (`"text/plain "`), causing the `case "$media_type" in text/plain)` check to fail unexpectedly.

## Fix

Pipe `media_type` through `xargs` in `verify-hosted-bootstrap.sh` to trim surrounding whitespace before running header format checks.

## Verification

Ran `bash -n ods/scripts/verify-hosted-bootstrap.sh` (passed cleanly). `git diff --check` passed cleanly.