### PR TITLE
fix(support): write support bundle archive atomically in ods-support-bundle.sh

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -779,7 +779,7 @@ collect_docker
 write_evidence
 write_manifest
 
-tar -czf "$ARCHIVE_PATH" -C "$OUTPUT_DIR" "$BUNDLE_NAME"
+tar -czf "${ARCHIVE_PATH}.tmp" -C "$OUTPUT_DIR" "$BUNDLE_NAME" && mv -f "${ARCHIVE_PATH}.tmp" "$ARCHIVE_PATH"
 
 if [[ "$JSON_OUTPUT" == "true" ]]; then
     write_summary_json


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-support-bundle.sh`, `tar -czf "$ARCHIVE_PATH"` outputs tar archives directly to the destination path. If compression fails or is aborted by a process signal, partially created archive files are left on disk.

## Fix

Write the tar archive to a temporary file (`"${ARCHIVE_PATH}.tmp"`) and perform an atomic `mv -f` swap upon successful exit.

## Verification

Ran `bash -n ods/scripts/ods-support-bundle.sh` (passed cleanly). `git diff --check` passed cleanly.