### PR TITLE
fix(mode): update .env atomically via mv -f in mode-switch.sh

### DIFF
--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -32,7 +32,7 @@ env_set() {
     if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
         awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
+        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     else
         echo "${key}=${val}" >> "$ENV_FILE"
     fi


### PR DESCRIPTION
## Problem

In `ods/scripts/mode-switch.sh`, `env_set()` updates `.env` values by redirecting `awk` output to `"${ENV_FILE}.tmp"` and overwriting `$ENV_FILE` via `cat "${ENV_FILE}.tmp" > "$ENV_FILE"`. Overwriting directly via redirection is non-atomic and risks zero-byte truncation if process execution is interrupted.

## Fix

Replace `cat ... > ... && rm -f ...` with a direct atomic `mv -f "${ENV_FILE}.tmp" "$ENV_FILE"` operation in `mode-switch.sh`.

## Verification

Ran `bash -n ods/scripts/mode-switch.sh` (passed cleanly). `git diff --check` passed cleanly.