### PR TITLE
fix(worker): improve temp file creation in prune-hermes-slash-workers.sh

### DIFF
--- a/ods/scripts/prune-hermes-slash-workers.sh
+++ b/ods/scripts/prune-hermes-slash-workers.sh
@@ -137,9 +137,9 @@ collect_workers() {
     return 1
 }
 
-WORKERS_FILE="$(mktemp)"
-CANDIDATES_FILE="$(mktemp)"
-OVERAGE_FILE="$(mktemp)"
+WORKERS_FILE="$(mktemp -t hermes-workers.XXXXXX 2>/dev/null || mktemp)"
+CANDIDATES_FILE="$(mktemp -t hermes-candidates.XXXXXX 2>/dev/null || mktemp)"
+OVERAGE_FILE="$(mktemp -t hermes-overage.XXXXXX 2>/dev/null || mktemp)"
 trap 'rm -f "$WORKERS_FILE" "$CANDIDATES_FILE" "$OVERAGE_FILE"' EXIT
 
 collect_workers > "$WORKERS_FILE"


### PR DESCRIPTION
## Problem

In `ods/scripts/prune-hermes-slash-workers.sh`, temporary tracking files were generated using bare `mktemp` calls without a prefix template fallback. In environments with restricted default system temp configurations, bare `mktemp` calls can fail to allocate named paths.

## Fix

Update `mktemp` invocations in `prune-hermes-slash-workers.sh` to use explicit `-t` prefix templates with fallback (`mktemp -t hermes-workers.XXXXXX 2>/dev/null || mktemp`).

## Verification

Ran `bash -n ods/scripts/prune-hermes-slash-workers.sh` (passed cleanly). `git diff --check` passed cleanly.