### PR TITLE
fix(storage): force symlink creation in do_archive in llm-cold-storage.sh

### DIFF
--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -124,7 +124,8 @@ do_archive() {
                 # Move to cold storage
                 mv "$model_dir" "$COLD_DIR/$name"
                 # Create symlink so HF cache still resolves
-                ln -s "$COLD_DIR/$name" "${model_dir%/}"
+                rm -f "${model_dir%/}"
+                ln -sf "$COLD_DIR/$name" "${model_dir%/}"
                 log "ARCHIVED: $name -> $COLD_DIR/$name"
             fi
             ((archived++))


### PR DESCRIPTION
## Problem

In `ods/scripts/llm-cold-storage.sh`, `do_archive()` moves idle model directories to cold storage and attempts to create a replacement symlink via `ln -s "$COLD_DIR/$name" "${model_dir%/}"`. If a stale or dangling symlink already exists at the target location, bare `ln -s` fails with a target exists error.

## Fix

Add `rm -f "${model_dir%/}"` and use `ln -sf` when creating the replacement symlink in `do_archive()`.

## Verification

Ran `bash -n ods/scripts/llm-cold-storage.sh` (passed cleanly). `git diff --check` passed cleanly.