### PR TITLE
fix(dashboard): add aria-label to refresh-logs button in Extensions

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -1295,7 +1295,7 @@ function ConsoleModal({ ext, onClose }) {
           <span className={`text-[10px] ${disconnected ? 'text-red-400' : 'text-theme-text-muted'}`}>
             {disconnected ? 'Reconnecting...' : 'Auto-refreshing every 2s'}
           </span>
-          <button onClick={fetchLogsOnce} className="text-xs text-theme-text-muted hover:text-theme-text-secondary transition-colors" title="Refresh now">
+          <button onClick={fetchLogsOnce} className="text-xs text-theme-text-muted hover:text-theme-text-secondary transition-colors" title="Refresh now" aria-label="Refresh logs">
             <RefreshCw size={12} />
           </button>
         </div>


### PR DESCRIPTION
## Summary
- The per-extension logs refresh button (`RefreshCw` icon only) had a `title="Refresh now"` attribute but no `aria-label`.
- `title` is not consistently exposed as an accessible name by screen readers.
- Adds `aria-label="Refresh logs"` alongside the existing `title`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change