### PR TITLE
fix(dashboard): add aria-label to Settings Banner dismiss button

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -925,7 +925,7 @@ function Banner({ tone = 'info', children, onClose }) {
   return (
     <div className={`mb-6 flex w-full items-center justify-between rounded-lg border p-4 text-sm ${cls}`}>
       <span>{children}</span>
-      {onClose ? <button onClick={onClose} className="ml-4 opacity-60 hover:opacity-100">x</button> : null}
+      {onClose ? <button onClick={onClose} aria-label="Dismiss" className="ml-4 opacity-60 hover:opacity-100">x</button> : null}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- The `Banner` component's close button renders a bare `x` text character with no `aria-label`.
- Screen readers announce this as the letter "x" rather than a meaningful dismiss action.
- Adds `aria-label="Dismiss"`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior/visual change