### PR TITLE
fix(dashboard): add aria-label to refresh button in Models

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -285,6 +285,7 @@ export default function Models() {
             onClick={refresh}
             className="flex h-9 w-9 items-center justify-center rounded-lg border border-theme-border bg-theme-bg/45 text-theme-text-muted transition-colors hover:border-theme-accent/35 hover:text-theme-text"
             title="Refresh models"
+            aria-label="Refresh models"
           >
             <RefreshCw size={16} />
           </button>


### PR DESCRIPTION
## Summary
- The models-list refresh button (`RefreshCw` icon only) had a `title="Refresh models"` attribute but no `aria-label`.
- `title` is not consistently exposed as an accessible name by screen readers.
- Adds a matching `aria-label`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change