### PR TITLE
fix(dashboard): add aria-label to pagination buttons in Models

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -1400,6 +1400,7 @@ function Pagination({ page, pageCount, onChange }) {
         disabled={page <= 1}
         className="flex h-7 w-7 items-center justify-center rounded-md border border-theme-border text-theme-text-muted transition-colors hover:text-theme-text disabled:opacity-35"
         title="Previous page"
+        aria-label="Previous page"
       >
         <ChevronLeft size={14} />
       </button>
@@ -1426,6 +1427,7 @@ function Pagination({ page, pageCount, onChange }) {
         disabled={page >= pageCount}
         className="flex h-7 w-7 items-center justify-center rounded-md border border-theme-border text-theme-text-muted transition-colors hover:text-theme-text disabled:opacity-35"
         title="Next page"
+        aria-label="Next page"
       >
         <ChevronRight size={14} />
       </button>


### PR DESCRIPTION
## Summary
- The Previous/Next pagination buttons (`ChevronLeft`/`ChevronRight` icon only) in the Models page pagination component had `title` attributes but no `aria-label`.
- `title` is not consistently exposed as an accessible name by screen readers.
- Adds matching `aria-label="Previous page"` / `aria-label="Next page"`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive props, no behavior change