### PR TITLE
fix(dashboard): add aria-label to toast dismiss button in Extensions

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -578,7 +578,7 @@ export default function Extensions() {
         }`}>
           <div className="flex items-center justify-between gap-3">
             <span className="leading-relaxed">{toast.text}</span>
-            <button onClick={() => setToast(null)} className="text-theme-text-muted/45 hover:text-theme-text-secondary transition-colors">×</button>
+            <button onClick={() => setToast(null)} aria-label="Dismiss notification" className="text-theme-text-muted/45 hover:text-theme-text-secondary transition-colors">×</button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- The extensions-page toast notification's close button renders a bare `×` character with no `aria-label`.
- Screen readers announce this ambiguously rather than as a meaningful dismiss action.
- Adds `aria-label="Dismiss notification"`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior/visual change