### PR TITLE
fix(talk): reject empty attachment and audio uploads

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -697,6 +697,12 @@ def _image_content_type(file: UploadFile) -> str:
     return _IMAGE_EXTENSION_MIMES.get(ext, "image/png")
 
 
+def _require_upload_content(data: bytes) -> bytes:
+    if not data:
+        raise HTTPException(status_code=422, detail="Uploaded file is empty.")
+    return data
+
+
 @router.post("/api/talk/attachment")
 async def talk_attachment(
     request: Request,
@@ -727,7 +733,7 @@ async def talk_attachment(
         raise HTTPException(status_code=413, detail="Caption is too long.")
 
     if kind == "image":
-        data = await file.read(MAX_IMAGE_BYTES + 1)
+        data = _require_upload_content(await file.read(MAX_IMAGE_BYTES + 1))
         if len(data) > MAX_IMAGE_BYTES:
             raise HTTPException(status_code=413, detail=f"Image is too large (max {MAX_IMAGE_BYTES // (1024 * 1024)} MB).")
         prompt_text = caption or "Describe what you see in this image."
@@ -743,7 +749,7 @@ async def talk_attachment(
 
     # text-like
     await _require_hermes_talk_compatible()
-    data = await file.read(MAX_DOC_BYTES + 1)
+    data = _require_upload_content(await file.read(MAX_DOC_BYTES + 1))
     if len(data) > MAX_DOC_BYTES:
         raise HTTPException(status_code=413, detail=f"File is too large (max {MAX_DOC_BYTES // (1024 * 1024)} MB).")
     try:
@@ -774,7 +780,7 @@ async def talk_attachment(
 async def talk_audio_message(request: Request, file: UploadFile = File(...)) -> dict[str, Any]:
     session_key, _expires_at = _require_session(request)
     await _require_hermes_talk_compatible()
-    data = await file.read(MAX_AUDIO_BYTES + 1)
+    data = _require_upload_content(await file.read(MAX_AUDIO_BYTES + 1))
     if len(data) > MAX_AUDIO_BYTES:
         raise HTTPException(status_code=413, detail="Audio message is too large.")
     transcript = await _transcribe_bytes(

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -224,6 +224,21 @@ def test_talk_audio_message_transcribes_and_routes(talk_client, monkeypatch):
     assert data["text"] == "answer to what is running locally"
 
 
+def test_talk_audio_message_rejects_empty_upload(talk_client, monkeypatch):
+    async def unexpected_transcribe(*_args):
+        pytest.fail("empty audio must not reach transcription")
+
+    monkeypatch.setattr("routers.talk._transcribe_bytes", unexpected_transcribe)
+
+    resp = talk_client.post(
+        "/api/talk/audio-message",
+        files={"file": ("voice.webm", b"", "audio/webm")},
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Uploaded file is empty."
+
+
 def test_talk_speak_streams_audio(talk_client, monkeypatch):
     """The /api/talk/speak endpoint streams MP3 bytes from Kokoro as they
     arrive (instead of buffering the whole reply into a single Response).
@@ -1039,6 +1054,21 @@ def test_talk_attachment_unknown_filetype_returns_415(talk_client):
         data={"text": ""},
     )
     assert resp.status_code == 415
+
+
+@pytest.mark.parametrize(
+    ("filename", "content_type"),
+    [("empty.md", "text/markdown"), ("empty.png", "image/png")],
+)
+def test_talk_attachment_rejects_empty_upload(talk_client, filename, content_type):
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": (filename, b"", content_type)},
+        data={"text": "inspect this"},
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Uploaded file is empty."
 
 
 def test_talk_attachment_image_routes_to_vision_endpoint_bypassing_hermes(talk_client, monkeypatch):


### PR DESCRIPTION
## Summary
- reject zero-byte Talk image, text, and audio uploads with HTTP 422
- stop empty audio before Whisper transcription
- cover all three upload paths through authenticated Talk endpoints

## Why this matters
The multipart routes currently accept zero-byte files and forward them to vision inference, Hermes, or Whisper. Operators then receive provider-specific failures or meaningless prompts instead of an immediate, actionable validation response at the upload boundary.

## Overlap check
Searched open and closed PRs for empty Talk uploads, attachments, audio messages, and routers/talk.py. Reviewed open PRs #2054, #2705, #2084, and #2342. They address quoted model names, backend-specific vision configuration, compatibility payload shape, and empty SSE choice frames; none validates multipart body content. #2705 touches the image branch but has an independent configuration guard.

## Test plan
- [x] py -3 -m pytest tests/test_talk.py -q (42 passed)

Generated with Codex