### PR TITLE
fix(resources): isolate malformed host-agent stats entries

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -67,7 +67,17 @@ def _fetch_container_stats() -> list[dict]:
     """Fetch container stats from host agent."""
     try:
         data = request_agent_json("GET", "/v1/service/stats", timeout=10)
-        return data.get("containers", [])
+        containers = data.get("containers", [])
+        if not isinstance(containers, list):
+            logger.warning("Host agent container stats must be a list")
+            return []
+        valid = [stat for stat in containers if isinstance(stat, dict)]
+        if len(valid) != len(containers):
+            logger.warning(
+                "Ignored %d malformed host-agent container stats",
+                len(containers) - len(valid),
+            )
+        return valid
     except (AgentClientError, OSError):
         logger.debug("Could not fetch container stats from host agent")
         return []

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -210,6 +210,35 @@ class TestServiceResources:
         assert data["totals"]["cpu_percent"] == 0
         assert data["totals"]["memory_used_mb"] == 0
 
+    def test_malformed_host_agent_entries_do_not_break_resources_endpoint(self, test_client, monkeypatch):
+        """A partial host-agent protocol violation is isolated at the HTTP boundary."""
+        self._clear_resource_cache()
+        monkeypatch.setattr(
+            "routers.resources.SERVICES",
+            {"llama-server": {"name": "Llama Server", "container_name": "ods-llama"}},
+        )
+        monkeypatch.setattr("routers.resources.GPU_BACKEND", "nvidia")
+        stats_payload = {
+            "containers": [
+                {"container_name": "ods-llama", "cpu_percent": 12.5, "memory_used_mb": 256},
+                None,
+                "not-an-object",
+            ]
+        }
+
+        with patch("routers.resources.request_agent_json", return_value=stats_payload), \
+             patch("routers.resources._scan_service_disk", return_value={}):
+            resp = test_client.get(
+                "/api/services/resources",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["totals"]["cpu_percent"] == 12.5
+        assert data["totals"]["memory_used_mb"] == 256
+        assert data["services"][0]["container"]["container_name"] == "ods-llama"
+
     def test_apple_backend_sets_caveat(self, test_client, monkeypatch):
         """GPU_BACKEND=apple sets docker_desktop_memory caveat to True."""
         self._clear_resource_cache()


### PR DESCRIPTION
## Summary
- validate that the host-agent containers field is a list
- retain valid container-stat objects while logging and dropping malformed entries
- prove the public resources endpoint remains available for a mixed payload

## Why this matters
GET /api/services/resources iterates and calls .get() on every host-agent stats entry. A single null or scalar entry currently raises AttributeError, turning the entire dashboard resource panel into a 500 even when the rest of the host-agent response is usable.

## Overlap check
Searched open and closed PRs for malformed container stats, resource contracts, and routers/resources.py. Reviewed open PRs #2007 (null numeric metrics), #2078/#2041 (disk scan I/O errors), and #2716 (service-id validation). None validates the containers collection or its element shape. This change is confined to the host-agent response boundary and does not replace those scopes.

## Test plan
- [x] py -3 -m pytest tests/test_resources.py -q (21 passed)

Generated with Codex