### PR TITLE
fix(dashboard): keep update banner usable without localStorage

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useVersion.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useVersion.test.js
@@ -93,6 +93,39 @@ describe('useVersion', () => {
     expect(result.current.version.update_available).toBe(true)
   })
 
+  test('still exposes version data when reading localStorage throws', async () => {
+    vi.spyOn(globalThis.Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new globalThis.DOMException('Storage is blocked', 'SecurityError')
+    })
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ current: '1.0.0', latest: '2.0.0', update_available: true })
+    })
+
+    const { result } = renderHook(() => useVersion())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.version.latest).toBe('2.0.0')
+    expect(result.current.version.update_available).toBe(true)
+    expect(result.current.error).toBeNull()
+  })
+
+  test('dismisses the current banner when writing localStorage throws', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ current: '1.0.0', latest: '2.0.0', update_available: true })
+    })
+    const { result } = renderHook(() => useVersion())
+    await waitFor(() => expect(result.current.version).toBeTruthy())
+    vi.spyOn(globalThis.Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new globalThis.DOMException('Storage is blocked', 'SecurityError')
+    })
+
+    act(() => result.current.dismissUpdate())
+
+    expect(result.current.version.update_available).toBe(false)
+  })
+
   test('handles fetch error gracefully', async () => {
     fetch.mockRejectedValue(new Error('network error'))
 

--- a/ods/extensions/services/dashboard/src/hooks/useVersion.js
+++ b/ods/extensions/services/dashboard/src/hooks/useVersion.js
@@ -2,6 +2,22 @@ import { useState, useEffect } from 'react'
 
 // Auth: nginx injects Authorization header for all /api/ requests (see nginx.conf).
 
+function readDismissedVersion() {
+  try {
+    return globalThis.localStorage?.getItem('dismissed-update') ?? null
+  } catch {
+    return null
+  }
+}
+
+function storeDismissedVersion(version) {
+  try {
+    globalThis.localStorage?.setItem('dismissed-update', version)
+  } catch {
+    // Persistence is best-effort when storage is blocked or quota-limited.
+  }
+}
+
 export function useVersion() {
   const [version, setVersion] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -22,7 +38,7 @@ export function useVersion() {
         // the exact version that was dismissed; a genuinely newer `latest` no
         // longer matches and surfaces normally.
         if (data.update_available && data.latest &&
-            localStorage.getItem('dismissed-update') === data.latest) {
+            readDismissedVersion() === data.latest) {
           data.update_available = false
         }
         setVersion(data)
@@ -43,7 +59,7 @@ export function useVersion() {
 
   const dismissUpdate = () => {
     if (version) {
-      localStorage.setItem('dismissed-update', version.latest)
+      storeDismissedVersion(version.latest)
       setVersion({ ...version, update_available: false })
     }
   }


### PR DESCRIPTION
Keep version information and in-page update dismissal usable when browser storage is denied.

## Why this matters
Privacy modes or storage restrictions can throw even when accessing the localStorage property, currently hiding valid version data or crashing dismissal.

Root cause: Version handling treats optional persistence as part of the required API success path and accesses storage outside a narrow boundary.

Behavioral invariant: DOM storage failures cannot prevent displaying a valid version or dismissing the current banner; unrelated programming errors still propagate.

## Implementation and compatibility
Isolate get/set/property access, tolerate DOMException at that browser I/O boundary and retain in-memory dismissal. Persistence across reloads remains best-effort when the browser denies storage.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useVersion.js`.

Relevant same-file results: No public-beta PR touched these production files in the all-state changed-file index.

The earlier canonical #2780 is retained. #3046 concerns failed network observations and is independently useful; the combined version tests preserve both storage availability and last-good snapshot behavior.

## Regression and validation
Candidate commit: `b38578567d70c201972178742a8db129309cd8d9`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useVersion.test.js` — **9 passed**.
- Three baseline failures cover denied storage reads, writes and the property getter itself. All 9 candidate version/dismissal tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `b38578567d70c201972178742a8db129309cd8d9`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #3046, production merges cleanly; resolve the test-file conflict by retaining both storage-denial and last-good-snapshot scenarios.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
