### PR TITLE
fix(features): preserve IPv6 hosts in launch links

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -16,6 +16,20 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["features"])
 
 
+def _link_hostname(host_header: str) -> str:
+    """Return a URL-ready hostname without the request port."""
+    host = host_header.split(",", 1)[0].strip()
+    if host.startswith("["):
+        closing_bracket = host.find("]")
+        if closing_bracket >= 0:
+            return host[:closing_bracket + 1]
+    if host.count(":") == 1:
+        return host.split(":", 1)[0]
+    if ":" in host:
+        return f"[{host}]"
+    return host
+
+
 def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
     """Calculate whether a feature can be enabled and its status."""
     gpu_vram_gb = (gpu_info.memory_total_mb / 1024) if gpu_info else 0
@@ -206,7 +220,7 @@ async def feature_enable_instructions(
             return ""
         forwarded_host = request.headers.get("x-forwarded-host")
         host_header = forwarded_host or request.headers.get("host") or "localhost"
-        hostname = host_header.rsplit(":", 1)[0] if ":" in host_header else host_header
+        hostname = _link_hostname(host_header)
         scheme = request.headers.get("x-forwarded-proto") or request.url.scheme or "http"
         return f"{scheme}://{hostname}:{port}"
 

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -351,6 +351,31 @@ class TestFeatureEnableInstructions:
             "url": "http://dashboard.ods.local:3000",
         }
 
+    def test_instruction_links_preserve_bracketed_ipv6_host(self, test_client, monkeypatch):
+        test_features = [
+            {"id": "documents", "name": "Documents", "description": "Document Q&A",
+             "icon": "FileText", "category": "productivity",
+             "setup_time": "2 min", "priority": 3,
+             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+             "enabled_services_all": [], "enabled_services_any": []}
+        ]
+        monkeypatch.setattr("routers.features.FEATURES", test_features)
+        monkeypatch.setattr(
+            "routers.features.SERVICES",
+            {"open-webui": {"external_port": 3000}},
+        )
+
+        resp = test_client.get(
+            "/api/features/documents/enable",
+            headers={**test_client.auth_headers, "host": "[2001:db8::7]:3001"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["instructions"]["links"][0] == {
+            "label": "Open Chat",
+            "url": "http://[2001:db8::7]:3000",
+        }
+
     def test_instruction_links_prefer_public_service_url(self, test_client, monkeypatch):
         test_features = [
             {"id": "documents", "name": "Documents", "description": "Document Q&A",


### PR DESCRIPTION
## Summary
- parse request hosts without treating IPv6 address segments as ports
- retain brackets when composing service launch URLs
- cover the authenticated feature-instructions endpoint with an IPv6 Host header

## Why this matters
Feature cards derive launch links from the dashboard request host. With a request such as [2001:db8::7]:3001, rsplit(':', 1) produces [2001:db8::7] with its closing bracket lost, so the dashboard returns an invalid Open WebUI URL and IPv6-only operators cannot launch the feature.

## Overlap check
Searched open and closed PRs for feature links, IPv6, forwarded hosts, and routers/features.py. Reviewed open PRs #2551, #2401, #2079, and #2026 plus merged link work #1353. Those address memory values, OPENCODE_PORT, feature requirement shapes, service object shapes, and feature contracts; none changes host parsing. The scope is behaviorally independent, including from #2401's port selection in the same helper.

## Test plan
- [x] py -3 -m pytest tests/test_features.py -q (21 passed)

Generated with Codex