### PR TITLE
fix(setup): complete wizard when browser storage is blocked

### DIFF
--- a/ods/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/ods/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -150,7 +150,14 @@ export default function SetupWizard({ onComplete }) {
     // localStorage retains the wizard's *answers* (voice / userName etc.)
     // for the dashboard to consult later, but is no longer the source of
     // truth for "have we onboarded?" — that lives on the server now.
-    localStorage.setItem('ods-config', JSON.stringify(config))
+    try {
+      localStorage.setItem('ods-config', JSON.stringify(config))
+    } catch (err) {
+      // Storage can be unavailable in private browsing, hardened browser
+      // profiles, or quota-constrained webviews. It is only a convenience
+      // cache, so it must not prevent the server-side completion marker.
+      console.warn('Could not persist setup preferences in browser storage:', err)
+    }
     try {
       // The server endpoint writes setup-complete.json which the
       // useFirstRun hook reads. Best-effort: if it fails (e.g. dashboard-api

--- a/ods/extensions/services/dashboard/src/components/__tests__/SetupWizard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/SetupWizard.test.jsx
@@ -182,6 +182,27 @@ describe('SetupWizard diagnostics sentinel parser', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
+  test('completes setup on the server when browser storage is unavailable', async () => {
+    stubFetchWithSetupStream([
+      '__ODS_RESULT__:FAIL:3\n'
+    ])
+    vi.spyOn(globalThis.Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new globalThis.DOMException('Storage is blocked', 'SecurityError')
+    })
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const onComplete = vi.fn()
+    render(<SetupWizard onComplete={onComplete} />)
+    await navigateToStep6()
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: /Start Diagnostics/i })))
+    await waitFor(() => expect(screen.getByText(/Some tests failed/i)).toBeInTheDocument())
+
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: /Continue Anyway/i })))
+
+    expect(fetch).toHaveBeenCalledWith('/api/setup/complete', { method: 'POST' })
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
   test('falls back to "All tests passed!" trailer when sentinel missing (older backend)', async () => {
     stubFetchWithSetupStream([
       'starting...\n',


### PR DESCRIPTION
## Summary
- treat setup preference persistence as best-effort
- continue writing the server-side setup completion marker when localStorage throws
- cover the final wizard action with a blocked-storage regression test

## Why this matters
Private browsing, hardened browser profiles, and quota-constrained webviews can throw from localStorage.setItem(). That exception currently occurs before POST /api/setup/complete and onComplete(), trapping an operator on the last setup step even though browser storage is only a convenience cache.

## Overlap check
Searched open and closed PRs for setup wizard, localStorage, setup completion, and SetupWizard.jsx. Reviewed merged PRs #1157 (server-side first-boot gating) and #1135 (allow completion after diagnostic failure). Neither handles browser-storage exceptions on the final completion path, and there is no open PR with this behavior.

## Test plan
- [x] npm test -- --run src/components/__tests__/SetupWizard.test.jsx
- [x] npm run lint -- --quiet

Generated with Codex