### PR TITLE
fix(gpu): NVIDIA VRAM already summed — don't multiply by GPU_COUNT

### DIFF
--- a/ods/installers/phases/02-detection.sh
+++ b/ods/installers/phases/02-detection.sh
@@ -381,11 +381,15 @@ if [[ $GPU_COUNT -gt 1 && "$GPU_BACKEND" == "nvidia" ]]; then
             log "Multi-GPU topology: NVLink=$GPU_HAS_NVLINK, Total VRAM=${GPU_TOTAL_VRAM}MB"
         else
             log "topology detection returned empty, using basic GPU info"
-            GPU_TOTAL_VRAM=$((GPU_VRAM * GPU_COUNT))
+            # GPU_VRAM is already the summed total across all GPUs (see
+            # detection.sh:358), so do not multiply by GPU_COUNT again.
+            GPU_TOTAL_VRAM=$GPU_VRAM
         fi
     else
         log "NVIDIA topology detection script not found, skipping detailed topology analysis"
-        GPU_TOTAL_VRAM=$((GPU_VRAM * GPU_COUNT))
+        # GPU_VRAM is already the summed total across all GPUs (see
+        # detection.sh:358), so do not multiply by GPU_COUNT again.
+        GPU_TOTAL_VRAM=$GPU_VRAM
     fi
 fi
 


### PR DESCRIPTION
## Summary

In `ods/installers/phases/02-detection.sh`, when NVIDIA multi-GPU topology detection returns empty or the `nvidia-topo.sh` script is missing, the fallback computes `GPU_TOTAL_VRAM=$((GPU_VRAM * GPU_COUNT))`. But `GPU_VRAM` is **already the summed total across all GPUs** (set in `ods/installers/lib/detection.sh:358` via `awk '{s+=$1} END {print s+0}'` over every `nvidia-smi` line). Multiplying again by `GPU_COUNT` double-counts VRAM.

The AMD fallback (lines 411/415) correctly assigns `GPU_TOTAL_VRAM=$GPU_VRAM` — this fix makes the NVIDIA fallback consistent with it.

## Root cause

`GPU_VRAM` is the cross-GPU sum; the `* GPU_COUNT` term assumes `GPU_VRAM` is per-GPU, which it is not.

## Reproduction

On a host with 2× RTX 4090 (real 48 GB):
- `GPU_VRAM=49128` (summed), `GPU_COUNT=2`.
- Before: `GPU_TOTAL_VRAM=$((49128 * 2)) = 98256`.
- Tier logic (`02-detection.sh:464` NVLink branch `-ge 90000`, `:473` PCIe `-ge 40000`) then selects `NV_ULTRA` / Tier 4 and pulls a 70B+ GGUF that OOMs on 48 GB.
- After: `GPU_TOTAL_VRAM=49128` → correct Tier 3/4 selection for the real 48 GB budget.

## Changes

- `02-detection.sh:384` and `:388`: set `GPU_TOTAL_VRAM=$GPU_VRAM` (drop the spurious `* GPU_COUNT`).