### PR TITLE
fix(token-spy): pass session paths NUL-delimited to avoid remote shell re-parse

### DIFF
--- a/ods/extensions/services/token-spy/session-manager.sh
+++ b/ods/extensions/services/token-spy/session-manager.sh
@@ -286,11 +286,17 @@ REMOTESCRIPT
   log "  Sessions: $session_count total, ${#to_remove[@]} to remove"
 
   if [ "${#to_remove[@]}" -gt 0 ]; then
-    local rm_args=""
+    local -a rm_paths=()
     for sid in "${to_remove[@]}"; do
-      rm_args="${rm_args} ${remote_dir}/${sid}.jsonl"
+      rm_paths+=("${remote_dir}/${sid}.jsonl")
     done
-    ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "rm -f ${rm_args}" 2>/dev/null || true
+    # Pass paths NUL-delimited so the remote login shell never re-parses the
+    # filenames. Session ids are raw .jsonl basenames; an id containing a space
+    # previously split the rm into bogus args (file left behind), and an id
+    # containing shell metacharacters (e.g. `a; touch /tmp/PWNED`) executed
+    # arbitrary commands on the agent host.
+    printf '%s\0' "${rm_paths[@]}" \
+      | ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "xargs -0 -I{} rm -f -- {}" 2>/dev/null || true
     log "  [DONE] Removed ${#to_remove[@]} sessions on $host"
   else
     log "  [OK] No cleanup needed"


### PR DESCRIPTION
## Summary

`ods/extensions/services/token-spy/session-manager.sh` builds a space-separated string of remote session-file paths and interpolates it **unquoted** into an `ssh` command. The remote login shell re-parses that string, so a session id with a space or shell metacharacter breaks cleanup or enables command injection on the agent host.

## Root cause

Session ids are the raw basenames of `*.jsonl` files in the remote `$SESSIONS_DIR` (`sid=$(basename "$f" .jsonl)`). Concatenating them into `rm -f ${rm_args}` and sending through `ssh "..."` lets the remote shell word-split and interpret them.

## Reproduction

On the remote agent host, drop a session file named `a; touch /tmp/PWNED.jsonl`:
- Before: remote command becomes `rm -f /dir/a; touch /tmp/PWNED.jsonl` → arbitrary command runs on the agent host. A name with a space leaves the intended file un-removed (silent cleanup failure).
- After: paths are streamed NUL-delimited into `xargs -0 -I{} rm -f -- {}` on the remote, so filename content is never re-parsed by a shell.

## Changes

- `session-manager.sh:288-296`: collect paths into an array and pipe them NUL-delimited to `ssh ... "xargs -0 -I{} rm -f -- {}"`, removing the unquoted interpolation.