### PR TITLE
fix(ods-cli): write .env atomically in _env_set/_env_unset

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -102,7 +102,7 @@ _env_set() {
         # Use awk to avoid sed delimiter collisions with values containing | / or =
         awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$file" > "${file}.tmp" && cat "${file}.tmp" > "$file" && rm -f "${file}.tmp"
+        }' "$file" > "${file}.tmp" && mv -f "${file}.tmp" "$file"
     else
         echo "${key}=${val}" >> "$file"
     fi
@@ -112,8 +112,7 @@ _env_unset() {
     local key="$1" file="$INSTALL_DIR/.env"
     [[ -f "$file" ]] || return 0
     awk -v k="$key" 'index($0, k "=") != 1 { print }' "$file" > "${file}.tmp" \
-        && cat "${file}.tmp" > "$file" \
-        && rm -f "${file}.tmp"
+        && mv -f "${file}.tmp" "$file"
 }
 
 _env_get_raw() {


### PR DESCRIPTION
## Summary

`ods/ods-cli` `_env_set` and `_env_unset` rewrite `.env` via ``awk ... > "$file.tmp" && cat "$file.tmp" > "$file"``. The `cat` step truncates `.env` and rewrites it in place, so a kill/SIGKILL/OOM (or power loss) mid-copy leaves a **truncated `.env`** — the whole stack then fails to parse env. The bootstrap/upgrade writers already use atomic `mv` (see `replace_env_file` in `bootstrap-upgrade.sh`); `ods-cli` should match.

## Root cause

`cat "${file}.tmp" > "$file"` is not atomic — it overwrites the destination before the copy completes.

## Reproduction

`ods set X Y` (or `ods up`, which calls `_ensure_hermes_dashboard_session_token` → `_env_set`). `kill -9` the process during the `cat` → reopen `.env` → truncated/corrupt → stack fails to load env.

## Changes

- `_env_set` (line 105) and `_env_unset` (lines 114-115): replace `cat "${file}.tmp" > "$file" && rm -f "${file}.tmp"` with `mv -f "${file}.tmp" "$file"` (atomic rename on same filesystem).