### PR TITLE
fix(installer): BSD-compatible mktemp template for opencode install

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -979,7 +979,7 @@ _install_opencode() {
 
     ai "Installing OpenCode with upstream installer..."
     local tmpfile
-    tmpfile=$(mktemp /tmp/opencode-install.XXXXXX.sh)
+    tmpfile=$(mktemp /tmp/opencode-install.sh.XXXXXX)
     if curl -fsSL --max-time 300 https://opencode.ai/install -o "$tmpfile" 2>/dev/null \
        && bash "$tmpfile" >> "$ODS_LOG_FILE" 2>&1; then
         OPENCODE_BIN="$(_find_opencode_bin 2>/dev/null || true)"


### PR DESCRIPTION
## Summary

`ods/installers/macos/install-macos.sh:982` (`_install_opencode`) uses `mktemp /tmp/opencode-install.XXXXXX.sh`. BSD `mktemp` requires the `X` run to be the **trailing** characters of the leaf name, so on macOS this errors out (`template doesn't end with XXXXXX`), `tmpfile` is empty, the `curl -o "$tmpfile"` fails, and the OpenCode install aborts on a clean macOS install. GNU `mktemp` on Linux accepts the suffix, which is why it was never caught there.

This is the same `XXXXXX` class PR #2288 fixed in a test; the product line was missed.

## Root cause

`XXXXXX` is not at the end of the template leaf name.

## Reproduction

On macOS: `mktemp /tmp/opencode-install.XXXXXX.sh` → `mktemp: bad mode (or "template doesn't end with XXXXXX")`. After fix: `mktemp /tmp/opencode-install.sh.XXXXXX` succeeds.

## Changes

- `install-macos.sh:982`: move the suffix before the `XXXXXX` run → `/tmp/opencode-install.sh.XXXXXX`.