### PR TITLE
fix(installer): escape env values in macOS upsert_env_value sed

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -71,7 +71,9 @@ upsert_env_value() {
     local key="$2"
     local value="$3"
     if grep -qE "^${key}=" "$env_path" 2>/dev/null; then
-        sed -i '' "s|^${key}=.*|${key}=${value}|" "$env_path"
+        local esc_value
+        esc_value=$(printf '%s' "$value" | sed -e 's/\\/\\\\/g' -e 's/&/\\&/g' -e 's/|/\\|/g' -e 's/"/\\"/g')
+        sed -i '' "s|^${key}=.*|${key}=${esc_value}|" "$env_path"
     else
         printf '%s=%s\n' "$key" "$value" >> "$env_path"
     fi

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -396,7 +396,9 @@ upsert_env_value() {
     local key="$2"
     local value="$3"
     if grep -qE "^${key}=" "$env_file" 2>/dev/null; then
-        sed -i '' "s|^${key}=.*|${key}=${value}|" "$env_file"
+        local esc_value
+        esc_value=$(printf '%s' "$value" | sed -e 's/\\/\\\\/g' -e 's/&/\\&/g' -e 's/|/\\|/g' -e 's/"/\\"/g')
+        sed -i '' "s|^${key}=.*|${key}=${esc_value}|" "$env_file"
     else
         printf '%s=%s\n' "$key" "$value" >> "$env_file"
     fi


### PR DESCRIPTION
## Summary

`upsert_env_value` in `ods/installers/macos/lib/env-generator.sh:74` and `ods/installers/macos/ods-macos.sh:399` interpolate `${value}` unescaped into a `sed` replacement (`s|^${key}=.*|${key}=${value}|`). A value containing `&`, `|`, `\`, or `"` corrupts the `.env` line or (for `"`) breaks the shell double-quoted `sed` program. This mirrors the already-fixed `bootstrap-upgrade.sh` (`sed_replacement_escape`) and `11-services.sh` paths — the macOS env writer was simply never given the same treatment.

## Root cause

`sed` replacement treats `&` as "whole match" and `\` as its escape char; `|` is the delimiter; `"` closes the shell double-quote. None are escaped.

## Reproduction

macOS install: set `RAG_OPENAI_API_KEY` (written via `upsert_env_value ... "${RAG_OPENAI_API_KEY:-}"`) to a value containing `&`, e.g. `sk-abc&tok`.
- Before: `sed -i '' "s|^RAG_OPENAI_API_KEY=.*|RAG_OPENAI_API_KEY=sk-abc&tok|"` writes `RAG_OPENAI_API_KEY=sk-abc<entire matched line>tok`, corrupting the secret and breaking the install.
- After: `sk-abc&tok` is written verbatim.

## Changes

- Both `upsert_env_value` copies: escape the value with `sed -e 's/\/\\/g' -e 's/&/\&/g' -e 's/|/\|/g' -e 's/"/\\"/g'` before substitution. The `printf '%s=%s' >>` append path needs no escaping (it writes the value verbatim, outside any sed context).