### PR TITLE
fix(sessions): skip sessions created after snapshot in cleanup

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -140,6 +140,12 @@ WIPE_FILES=()
 REMOVED_INACTIVE=0
 REMOVED_BLOATED=0
 
+# Snapshot timestamp: sessions whose .jsonl is created after this point were
+# not present when we read the active set above, so the live gateway may have
+# just added them. Treating them as inactive would delete a live session and
+# leave a dangling index entry after the rewrite below — skip them.
+SNAP_TS=$(date +%s)
+
 for f in "$SESSIONS_DIR"/*.jsonl; do
     [ -f "$f" ] || continue
     BASENAME=$(basename "$f" .jsonl)
@@ -154,6 +160,11 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
     done
 
     if [ "$IS_ACTIVE" = false ]; then
+        f_mtime=$(stat -c%Y "$f" 2>/dev/null || stat -f%Y "$f" 2>/dev/null || echo 0)
+        if [[ "$f_mtime" -gt "$SNAP_TS" ]]; then
+            echo "[$(date)] Skipping session created during cleanup: $BASENAME"
+            continue
+        fi
         SIZE=$(du -h "$f" | cut -f1)
         echo "[$(date)] Removing inactive session: $BASENAME ($SIZE)"
         rm -f "$f"


### PR DESCRIPTION
## Summary

`ods/scripts/session-cleanup.sh` snapshots the active session set once at startup (lines 76-113), then later loops over `*.jsonl` files and `rm -f`s any not in that snapshot. PR #2272 fixed the *ordering* crash (commit index before deleting files), but the stale-snapshot race against the live gateway remains: if a session `Z` is created while cleanup runs, `Z.jsonl` is not in the start-of-run snapshot, so cleanup deletes it — losing an active session and leaving a dangling `sessions.json` entry (index says `Z` is active, file gone) that makes the gateway fail to load it.

## Root cause

The active-id set is captured once; files added to `$SESSIONS_DIR` after that capture are misclassified as inactive.

## Reproduction

Run cleanup (e.g. via `openclaw-session-cleanup.timer`) while a chat is starting. Force a new session `Z` to be written mid-run (or slow the loop). Result: `Z.jsonl` is removed and `sessions.json` still references `Z`. Gateway then cannot open `Z`.

## Changes

- Capture `SNAP_TS=$(date +%s)` just before the file loop.
- In the inactive branch, read the file mtime (`stat -c%Y` / `stat -f%Y`) and `continue` (skip deletion) for any `.jsonl` newer than `SNAP_TS`, so sessions created during the run survive.