### PR TITLE
fix(config): write .env atomically in mode-switch/phase11/migrate writers

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -257,7 +257,7 @@ else
             index($0, k "=") == 1 { print k "=" v; found = 1; next }
             { print }
             END { if (!found) print k "=" v }
-        ' "$env_file" > "$tmp_file" && cat "$tmp_file" > "$env_file" && rm -f "$tmp_file"
+        ' "$env_file" > "$tmp_file" && mv -f "$tmp_file" "$env_file"
     }
 
     _phase11_env_get() {

--- a/ods/migrations/migrate-v2.4.1.sh
+++ b/ods/migrations/migrate-v2.4.1.sh
@@ -24,7 +24,7 @@ if [[ -z "$existing" ]]; then
         # Update empty value in place. Use awk to dodge sed delimiter pitfalls.
         awk -v v="$new_key" '
             { if (index($0, "SHIELD_API_KEY=") == 1) print "SHIELD_API_KEY=" v; else print }
-        ' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
+        ' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     else
         echo "" >> "$ENV_FILE"
         echo "# Privacy Shield cross-service auth (PR #1069)" >> "$ENV_FILE"

--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -32,7 +32,7 @@ env_set() {
     if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
         awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
+        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     else
         echo "${key}=${val}" >> "$ENV_FILE"
     fi


### PR DESCRIPTION
## Summary

Three more `.env` writers use the non-atomic `awk ... > file.tmp && cat file.tmp > file && rm file.tmp` pattern already fixed in `ods-cli` and the bootstrap/upgrade path. A kill/OOM/power-loss mid-`cat` truncates `.env` and breaks the stack.

Affected writers:
- `ods/scripts/mode-switch.sh` `env_set` (backend of `ods mode <mode>`)
- `ods/installers/phases/11-services.sh` `_phase11_env_set` (CPU fallback path writes `GPU_BACKEND`/`LLM_MODEL`/`GGUF_FILE`/`MAX_CONTEXT` during install)
- `ods/migrations/migrate-v2.4.1.sh` (regenerates `SHIELD_API_KEY` on upgrade)

## Root cause

`cat file.tmp > file` overwrites the destination before the copy completes; it is not an atomic rename.

## Reproduction

Run `ods mode cloud` (or the CPU-fallback install branch / the v2.4.1 migration) and `kill -9` during the `cat`. Reopen `.env` → truncated/corrupt.

## Changes

- Replace `cat "$X.tmp" > "$X" && rm -f "$X.tmp"` with `mv -f "$X.tmp" "$X"` (atomic rename on the same filesystem) in all three writers.