### PR TITLE
fix(windows): honor override ports in preflight scan, health probe, and dashboard shortcut

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2087,7 +2087,8 @@ if ($enableVoice)     {
     $healthWhisperPort = if ($windowsEnvMap.ContainsKey("WHISPER_PORT") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["WHISPER_PORT"])) { $windowsEnvMap["WHISPER_PORT"] } else { "9000" }
     $healthChecks += @{ Name = "Whisper (STT)"; Url = "http://localhost:$healthWhisperPort/health" }
 }
-if ($enableWorkflows) { $healthChecks += @{ Name = "n8n (Workflows)";   Url = "http://localhost:5678/healthz" } }
+$n8nHealthPort = if ($windowsEnvMap.ContainsKey("N8N_PORT") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["N8N_PORT"])) { $windowsEnvMap["N8N_PORT"] } else { "5678" }
+if ($enableWorkflows) { $healthChecks += @{ Name = "n8n (Workflows)";   Url = "http://localhost:$n8nHealthPort/healthz" } }
 
 Write-AI "Running health checks..."
 $maxAttempts = 60; $allHealthy = $true
@@ -2438,7 +2439,7 @@ if ($installReadiness -and $installReadiness.AllReady -and $llmModelReady -and $
 
 # ── Desktop & Start Menu shortcuts ───────────────────────────────────────────
 try {
-    $dashboardUrl  = "http://localhost:3001"
+    $dashboardUrl  = "http://localhost:$dashboardPort"
     $shortcutName  = "ODS"
     $iconPath      = Join-Path $installDir "extensions\services\dashboard\public\osmantic-os.ico"
     $iconContent   = if (Test-Path -LiteralPath $iconPath) { "IconFile=$iconPath`nIconIndex=0" } else { "IconIndex=0" }

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -286,8 +286,8 @@ Stop-WindowsODSLemonadePortConflicts `
 $_portsToCheck = [ordered]@{
     "Open WebUI (chat)"   = Resolve-WindowsODSPort `
         -Name "WEBUI_PORT" -DefaultPort 3000 -InstallDir $installDir
-    "Dashboard"           = 3001
-    "Dashboard API"       = 3002
+    "Dashboard"           = (Resolve-WindowsODSPort -Name "DASHBOARD_PORT" -DefaultPort 3001 -InstallDir $installDir)
+    "Dashboard API"       = (Resolve-WindowsODSPort -Name "DASHBOARD_API_PORT" -DefaultPort 3002 -InstallDir $installDir)
 }
 $_llmPortToCheck = Resolve-WindowsLlmPreflightPort `
     -GpuBackend ([string]$gpuInfo.Backend) `
@@ -304,7 +304,7 @@ if ($enableRecommended) {
     $_portsToCheck["Token Spy (usage monitor)"] = 3005
 }
 if ($enableVoice) {
-    $_whisperPortToCheck = $(if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 })
+    $_whisperPortToCheck = Resolve-WindowsODSPort -Name "WHISPER_PORT" -DefaultPort $(if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 }) -InstallDir $installDir
     $_portsToCheck["Whisper (STT)"] = $_whisperPortToCheck
     $_portsToCheck["Kokoro (TTS)"]  = 8880
 }


### PR DESCRIPTION
## Summary

The Windows installer hardcodes several service ports in places that should respect operator overrides, producing false-negative port-conflict reports and broken shortcuts/health probes on a re-install with custom ports.

- `04-requirements.ps1` preflight conflict scan hardcodes Dashboard `3001`, Dashboard API `3002`, and Whisper `9000/9100` instead of the override-aware `DASHBOARD_PORT`/`DASHBOARD_API_PORT`/`WHISPER_PORT` (every other port in the scan already uses `Resolve-WindowsODSPort`/`Resolve-WindowsLlmPreflightPort`).
- `install-windows.ps1` health probe hardcodes n8n `5678` (the Whisper probe just above correctly uses `$windowsEnvMap["WHISPER_PORT"]`).
- `install-windows.ps1` desktop/Start-Menu `.url` shortcut hardcodes `http://localhost:3001` while `$dashboardPort` (resolved from `DASHBOARD_PORT`) is already in scope and used for readiness + the success card.

## Root cause

Ports were copied as literals instead of the resolved override values.

## Reproduction

Set `DASHBOARD_PORT=3101` (or `N8N_PORT`/`WHISPER_PORT`) on a re-install:
- Before: preflight reports "No port conflicts" even if 3101 is occupied (false negative); the installed Dashboard shortcut opens the dead `:3001`; n8n health probe reports an unhealthy/missing `:5678`.
- After: conflict scan, health probe, and shortcut all use the resolved ports.

## Changes

- `04-requirements.ps1`: Dashboard/Dashboard API use `Resolve-WindowsODSPort`; Whisper uses `Resolve-WindowsODSPort -Name WHISPER_PORT` with the same amd/cloud default.
- `install-windows.ps1`: n8n health probe reads `N8N_PORT` from `$windowsEnvMap` (fallback 5678); dashboard shortcut uses `$dashboardPort`.