### PR TITLE
fix(installer): use resolved WHISPER_PORT in macOS Whisper health probe

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -3072,7 +3072,7 @@ else
     HEALTH_URLS=("http://${_health_llama_host}:${_health_llama_port}/health" "http://127.0.0.1:3000")
     HEALTH_CONTAINERS=("" "ods-webui")
 fi
-$ENABLE_VOICE && HEALTH_NAMES+=("Whisper (STT)") && HEALTH_URLS+=("http://127.0.0.1:9000/health") && HEALTH_CONTAINERS+=("ods-whisper")
+$ENABLE_VOICE && HEALTH_NAMES+=("Whisper (STT)") && HEALTH_URLS+=("http://127.0.0.1:${WHISPER_PORT:-9000}/health") && HEALTH_CONTAINERS+=("ods-whisper")
 $ENABLE_WORKFLOWS && HEALTH_NAMES+=("n8n (Workflows)") && HEALTH_URLS+=("http://127.0.0.1:5678/healthz") && HEALTH_CONTAINERS+=("ods-n8n")
 [[ -x "$OPENCODE_BIN" ]] && HEALTH_NAMES+=("OpenCode (IDE)") && HEALTH_URLS+=("http://127.0.0.1:${OPENCODE_PORT}") && HEALTH_CONTAINERS+=("")
 


### PR DESCRIPTION
## Summary

`ods/installers/macos/install-macos.sh:3075` hardcodes the Whisper health URL to `http://127.0.0.1:9000/health`, but the macOS installer reassigns Whisper to port `9100` when AirPlay owns `9000` (`export WHISPER_PORT=9100`, line 1327) and `WHISPER_PORT` is already used for the readiness URL elsewhere (lines 3174/3311 use `${WHISPER_PORT:-9000}`). The health probe ignores that, so on affected Macs the installer reports Whisper unhealthy even though it is running on `9100`.

## Root cause

Health URL port was a literal `9000` instead of the resolved `${WHISPER_PORT:-9000}`.

## Reproduction

On macOS where AirPlay owns port 9000, the installer moves Whisper to 9100. The health probe still hits `:9000` → Whisper reports as unhealthy / install aborts the healthy path. After fix: probe uses `${WHISPER_PORT:-9000}` (9100 in that case).

## Changes

- `install-macos.sh:3075`: `http://127.0.0.1:9000/health` → `http://127.0.0.1:${WHISPER_PORT:-9000}/health`.