### PR TITLE
fix(token-spy): make sessions.json cleanup atomic and race-free

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -16,6 +16,7 @@ import re
 import secrets
 import shlex
 import tempfile
+import threading
 import time
 from pathlib import Path
 from urllib.parse import urlparse
@@ -41,6 +42,11 @@ else:
     from db import init_db, log_usage, query_report, query_session_status, query_summary, query_usage, query_recent_events
 
 # ── Configuration ────────────────────────────────────────────────────────────
+
+
+# Serializes read-modify-write of per-agent sessions.json so concurrent
+# /api/reset-session calls cannot clobber each other's updates.
+_sessions_json_lock = threading.Lock()
 
 AGENT_NAME = os.environ.get("AGENT_NAME", "unknown")
 START_TIME = time.time()
@@ -1406,18 +1412,24 @@ def _kill_session(agent: str, reason: str = "manual") -> dict:
     except FileNotFoundError:
         return {"agent": agent, "action": "none", "reason": "session file already gone"}
 
-    # Clean sessions.json reference (best-effort)
+    # Clean sessions.json reference (best-effort).
+    # Serialize under a lock and write atomically: concurrent /api/reset-session
+    # calls otherwise interleave read-modify-write and silently drop each other's
+    # deletions, or truncate the file mid-write.
     sessions_json = f"{sessions_dir}/sessions.json"
-    try:
-        with open(sessions_json, "r") as f:
-            data = json.load(f)
-        to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get("sessionId") == largest]
-        for k in to_remove:
-            del data[k]
-        with open(sessions_json, "w") as f:
-            json.dump(data, f, indent=2)
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        log.warning(f"[RESET] Failed to clean sessions.json for {agent}")
+    with _sessions_json_lock:
+        try:
+            with open(sessions_json, "r") as f:
+                data = json.load(f)
+            to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get("sessionId") == largest]
+            for k in to_remove:
+                del data[k]
+            tmp_path = f"{sessions_json}.tmp"
+            with open(tmp_path, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp_path, sessions_json)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            log.warning(f"[RESET] Failed to clean sessions.json for {agent}")
 
     log.warning(f"[RESET] Killed session {largest} for {agent} ({size} bytes) — {reason}")
     return {"agent": agent, "action": "killed", "session_id": largest, "size_bytes": size}


### PR DESCRIPTION
## Summary
- `_kill_session` rewrites per-agent `sessions.json` with a non-atomic read-modify-write and **no lock** (`ods/extensions/services/token-spy/main.py:1412`).
- `/api/reset-session` (and the background auto-reset poller) can be invoked concurrently. Two in-flight resets interleave the read and the write, so one deletion is lost, or the file is truncated mid-write and the next `json.load` raises.

## Root cause
The cleanup block does `open(r) → json.load → del → open(w) → json.dump` with no serialization and no temp-file swap.

## Fix
- Wrap the read-modify-write under a module-level `threading.Lock()`.
- Write to a `.tmp` file and `os.replace()` it into place (atomic), matching the existing `save_settings()` pattern in this file.

## Reproduction (on current main)
```python
# Two threads resetting the same agent at once:
import threading, json, os
# seed sessions.json with 2 entries
p = "<agent>/sessions.json"
json.dump({"a": {"sessionId": "X"}, "b": {"sessionId": "Y"}}, open(p, "w"))
def reset():
    # simulate the un-guarded block
    d = json.load(open(p)); del d["a"]; json.dump(d, open(p, "w"))
# run reset("a") and reset("b") concurrently many times -> eventually one key survives
```
The patched version keeps the lock + atomic swap, so both deletions persist.

## Test plan
- [x] `py_compile` passes on main.py.
- [x] Minimal, scoped diff (23 insertions / 11 deletions).
- CI: python lint + type-check + secret-scan pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)