### PR TITLE
fix(token-spy): atomic write for accumulated-turns.json

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -1223,8 +1223,17 @@ def _get_local_accumulated_turns(agent: str) -> int:
     acc = {"total": total, "last_file_turns": current_file_turns}
     try:
         os.makedirs(os.path.dirname(acc_path), exist_ok=True)
-        with open(acc_path, "w") as f:
-            json.dump(acc, f)
+        fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(acc_path), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(acc, f)
+            os.replace(tmp_path, acc_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
     except Exception:
         log.warning(f"[SESSION] Failed to save accumulated turns for {agent}")
 


### PR DESCRIPTION
## Summary
- `_get_local_accumulated_turns` writes the per-agent `accumulated-turns.json` with a plain `open("w") + json.dump` (`ods/extensions/services/token-spy/main.py:1226`).
- A crash/restart mid-write (or two overlapping poll calls) truncates the file; the next read's `JSONDecodeError` is swallowed and the accumulator silently resets to `{"total": 0, ...}` — losing all historically accumulated turn/token counts for that agent.

## Root cause
Non-atomic write with no temp-file swap. The same module's `save_settings()` already does this correctly with `tempfile.mkstemp` + `os.replace`.

## Fix
Write to a `.tmp` file in the same dir and `os.replace()` into place (tempfile is already imported).

## Test plan
- [x] `py_compile` passes.
- [x] Minimal 11-line diff, mirrors existing `save_settings()` pattern.
- CI: python lint + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)