### PR TITLE
fix(privacy-shield): atomic write for SHIELD_API_KEY

### DIFF
--- a/ods/extensions/services/privacy-shield/key_management.py
+++ b/ods/extensions/services/privacy-shield/key_management.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import tempfile
 from typing import Optional
 
 
@@ -25,14 +26,21 @@ def load_persisted_key(path: str) -> Optional[str]:
 
 def persist_key(path: str, key: str) -> None:
     try:
-        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(key)
+        dirname = os.path.dirname(path) or "."
+        os.makedirs(dirname, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(dir=dirname, suffix=".tmp")
         try:
-            os.chmod(path, 0o600)
-        except Exception:
-            # Best-effort only (may fail on some mounts/platforms)
-            pass
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(key)
+            # Restrict permissions before the file becomes live.
+            os.chmod(tmp_path, 0o600)
+            os.replace(tmp_path, path)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
     except Exception:
         logging.exception("Failed to persist generated SHIELD_API_KEY")
 


### PR DESCRIPTION
## Summary
- `persist_key` in `ods/extensions/services/privacy-shield/key_management.py:29` writes `SHIELD_API_KEY` with a plain `open("w") + write()` — no temp-file swap.
- A crash/restart mid-write (or two services generating/rotating the key at first boot) can truncate the key file to 0 bytes. On restart `load_persisted_key` returns `""` → `None`, so a **brand-new key is generated**, invalidating every previously-issued Privacy-Shield client token (fleet-wide re-auth).

## Root cause
Non-atomic write.

## Fix
Write to a temp file in the same directory, `os.chmod(tmp, 0o600)` **before** the swap, then `os.replace()` into place (matching the pattern used elsewhere in this repo). Added `import tempfile`.

## Test plan
- [x] `py_compile` passes.
- [x] Minimal 22-line diff.
- CI: python lint + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)