### PR TITLE
fix(hermes): escape model/base_url/api_key and write config.yaml atomically

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -10,7 +10,10 @@ the rest of the user's config.
 from __future__ import annotations
 
 import argparse
+import json
+import os
 import re
+import tempfile
 from pathlib import Path
 
 
@@ -87,12 +90,12 @@ def _ensure_model(
     if block is None:
         insert = ["model:"]
         if model:
-            insert.append(f'  default: "{model}"')
+            insert.append(f'  default: {json.dumps(model)}')
         if base_url:
             insert.append('  provider: "custom"')
-            insert.append(f'  base_url: "{base_url}"')
+            insert.append(f'  base_url: {json.dumps(base_url)}')
         if api_key:
-            insert.append(f'  api_key: "{api_key}"')
+            insert.append(f'  api_key: {json.dumps(api_key)}')
         if context_length:
             insert.append(f"  context_length: {context_length}")
         if max_tokens:
@@ -101,11 +104,11 @@ def _ensure_model(
         return
 
     if model:
-        block = _set_key(lines, block, "default", f'"{model}"', 2)
+        block = _set_key(lines, block, "default", json.dumps(model), 2)
     if base_url:
-        block = _set_key(lines, block, "base_url", f'"{base_url}"', 2)
+        block = _set_key(lines, block, "base_url", json.dumps(base_url), 2)
     if api_key:
-        block = _set_key(lines, block, "api_key", f'"{api_key}"', 2)
+        block = _set_key(lines, block, "api_key", json.dumps(api_key), 2)
     if context_length:
         block = _set_key(lines, block, "context_length", str(context_length), 2)
     # Existing operator values win, but migrate configs that predate ODS's
@@ -290,7 +293,18 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
+    # Atomic write: never leave config.yaml half-written on interruption.
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(updated)
+        os.replace(tmp_path, str(path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
     return True
 
 


### PR DESCRIPTION
## Summary
Two bugs in `ods/scripts/patch-hermes-config.py` (the Hermes config migrator):

1. **YAML injection** — `model`/`base_url`/`api_key` are interpolated into `config.yaml` wrapped in bare double quotes with **no escaping** (`patch-hermes-config.py:90,93,95,104,106,108`). A value containing `"` or `\` (or a newline) yields invalid YAML and corrupts Hermes's config. These values come from install/config env (the api_key is the Litellm/ODS bearer token), so this is reachable.
2. **Non-atomic write** — the file is written with `path.write_text` (`patch-hermes-config.py:293`). An interrupted bootstrap/upgrade migration leaves `config.yaml` half-written; Hermes then fails to parse it on next boot.

## Fix
- Emit the three scalars via `json.dumps(value)` (valid YAML, properly escaped).
- Write to a `.tmp` file in the same dir and `os.replace()` into place.
- Added `json`/`os`/`tempfile` imports.

## Reproduction (bug 1, on current main)
```sh
printf 'model:\n  default: "x"\n' > /tmp/c.yaml
python3 ods/scripts/patch-hermes-config.py /tmp/c.yaml --model 'a"b' --api-key 'c\d'
# BEFORE: model:\n  default: "a"b"   (invalid YAML)
# AFTER : model:\n  default: "a\"b"  (valid)
```

## Test plan
- [x] `py_compile` passes.
- [x] Minimal 28-line diff.
- CI: python lint + type-check pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)