### PR TITLE
fix(devtools): escape |, &, \ in systemd unit sed substitutions

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -14,6 +14,14 @@
 #   Add new developer tools or change installation methods here.
 # ============================================================================
 
+# Escape a value so it can be interpolated as a sed replacement (| delimiter).
+# In sed's replacement text, backslash, pipe, and ampersand are special:
+# backslash must be doubled, and | / & must be escaped so they are not treated
+# as a delimiter or a "whole match" insertion.
+_devtools_esc_sed() {
+    printf '%s' "$1" | sed 's#\\#\\\\#g; s#|#\\|#g; s#&#\\&#g'
+}
+
 ods_progress 42 "devtools" "Installing developer tools"
 if $DRY_RUN; then
     log "[DRY RUN] Would install AI developer tools (Claude Code, Codex CLI, OpenCode)"
@@ -378,17 +386,23 @@ if [[ -f "$INSTALL_DIR/bin/ods-host-agent.py" ]]; then
                     ai_warn "Failed to create secure temp file for ods-host-agent.service; skipping systemd unit install"
                 else
                     cp "$INSTALL_DIR/scripts/systemd/ods-host-agent.service" "$svc_tmp"
-                    # Substitute placeholders — use sed directly with | delimiter
-                    # (paths contain / but never |, so | is a safe delimiter).
+                    # Substitute placeholders — use sed with | delimiter.
+                    # Values are escaped first because | (our delimiter), & (whole
+                    # match), and \ are special in sed's replacement text; an
+                    # INSTALL_DIR/HOME containing any of these would corrupt the unit.
                     # Dual-form for BSD/GNU sed compatibility.
-                    sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
-                    sed -i "s|__HOME__|${HOME}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__HOME__|${HOME}|g" "$svc_tmp"
-                    sed -i "s|__PYTHON3__|${AGENT_PYTHON}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__PYTHON3__|${AGENT_PYTHON}|g" "$svc_tmp"
-                    sed -i "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp" 2>/dev/null || \
-                        sed -i '' "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp"
+                    _inst_esc="$(_devtools_esc_sed "$INSTALL_DIR")"
+                    _home_esc="$(_devtools_esc_sed "$HOME")"
+                    _py_esc="$(_devtools_esc_sed "$AGENT_PYTHON")"
+                    _user_esc="$(_devtools_esc_sed "$_agent_user")"
+                    sed -i "s|__INSTALL_DIR__|${_inst_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__INSTALL_DIR__|${_inst_esc}|g" "$svc_tmp"
+                    sed -i "s|__HOME__|${_home_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__HOME__|${_home_esc}|g" "$svc_tmp"
+                    sed -i "s|__PYTHON3__|${_py_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__PYTHON3__|${_py_esc}|g" "$svc_tmp"
+                    sed -i "s|__INSTALL_USER__|${_user_esc}|g" "$svc_tmp" 2>/dev/null || \
+                        sed -i '' "s|__INSTALL_USER__|${_user_esc}|g" "$svc_tmp"
                     # Verify placeholders were actually rendered
                     if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__\|__INSTALL_USER__' "$svc_tmp"; then
                         ai_warn "Host agent systemd unit has unrendered placeholders — check $svc_tmp"
@@ -506,14 +520,18 @@ if [[ -f "$INSTALL_DIR/bin/ods-mdns.py" ]] && [[ "$(uname -s)" == "Linux" ]]; th
             ai_warn "Failed to create secure temp file for ods-mdns.service; skipping systemd unit install"
         else
             cp "$INSTALL_DIR/scripts/systemd/ods-mdns.service" "$svc_tmp"
-            sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
-            sed -i "s|__HOME__|${HOME}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__HOME__|${HOME}|g" "$svc_tmp"
-            sed -i "s|__PYTHON3__|${MDNS_PYTHON}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__PYTHON3__|${MDNS_PYTHON}|g" "$svc_tmp"
-            sed -i "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp" 2>/dev/null || \
-                sed -i '' "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp"
+            _inst_esc="$(_devtools_esc_sed "$INSTALL_DIR")"
+            _home_esc="$(_devtools_esc_sed "$HOME")"
+            _py_esc="$(_devtools_esc_sed "$MDNS_PYTHON")"
+            _user_esc="$(_devtools_esc_sed "$_agent_user")"
+            sed -i "s|__INSTALL_DIR__|${_inst_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__INSTALL_DIR__|${_inst_esc}|g" "$svc_tmp"
+            sed -i "s|__HOME__|${_home_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__HOME__|${_home_esc}|g" "$svc_tmp"
+            sed -i "s|__PYTHON3__|${_py_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__PYTHON3__|${_py_esc}|g" "$svc_tmp"
+            sed -i "s|__INSTALL_USER__|${_user_esc}|g" "$svc_tmp" 2>/dev/null || \
+                sed -i '' "s|__INSTALL_USER__|${_user_esc}|g" "$svc_tmp"
             if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__\|__INSTALL_USER__' "$svc_tmp"; then
                 ai_warn "ods-mdns systemd unit has unrendered placeholders — check $svc_tmp"
             else


### PR DESCRIPTION
## Summary
`ods/installers/phases/07-devtools.sh` renders the host-agent and mDNS systemd unit templates with sed using `|` as the delimiter:

\`\`\`sh
sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
\`\`\`

The interpolated values (`INSTALL_DIR`, `HOME`, `AGENT_PYTHON`/`MDNS_PYTHON`, `_agent_user`) are passed **unescaped**. In sed's replacement text, `|` is read as the delimiter, `&` as the whole match, and `\` as an escape — so any of those characters in a value corrupts the substitution and yields a broken/corrupt unit file.

Linux filenames may legally contain `|` and `\`, so a non-default `INSTALL_DIR` (e.g. `/opt/ods|a`) silently produces an invalid service unit.

## Fix
Add `_devtools_esc_sed()` and escape each value before substitution (mirrors the existing OpenCode-config escaping already in this file, but also covers `|` since that is our delimiter):

\`\`\`sh
_devtools_esc_sed() {
    printf '%s' "$1" | sed 's#\#\\#g; s#|#\|#g; s#&#\&#g'
}
\`\`\`

Verified: with `INSTALL_DIR='a|b&c\d'`, `HOME='h|o&m\e'`, etc., the rendered unit correctly contains the literal `a|b&c\d` / `h|o&m\e`.

## Scope
- `ods/installers/phases/07-devtools.sh:384-391` (host-agent unit)
- `ods/installers/phases/07-devtools.sh:509-516` (mDNS unit)

No behavior change for values without `|`/`&`/`\`. `bash -n` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)