### PR TITLE
fix(token-spy): atomic sessions.json write in _kill_session

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -1414,8 +1414,14 @@ def _kill_session(agent: str, reason: str = "manual") -> dict:
         to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get("sessionId") == largest]
         for k in to_remove:
             del data[k]
-        with open(sessions_json, "w") as f:
+        # Atomic write: a crash mid-flush would otherwise truncate/corrupt the
+        # index and silently lose every session reference for this agent.
+        _tmp = f"{sessions_json}.{os.getpid()}.tmp"
+        with open(_tmp, "w") as f:
             json.dump(data, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(_tmp, sessions_json)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         log.warning(f"[RESET] Failed to clean sessions.json for {agent}")
 


### PR DESCRIPTION
## Summary
`_kill_session()` in `ods/extensions/services/token-spy/main.py` rewrites `sessions.json` with `open(..., "w")`, which **truncates the file first and then streams `json.dump`**:

\`\`\`python
with open(sessions_json, "w") as f:
    json.dump(data, f, indent=2)
\`\`\`

If the process is killed / OOMs / hits a disk error mid-write, `sessions.json` is left truncated or corrupt. Because `sessions.json` is the **index for every tracked session of that agent**, a single interrupted kill wipes the agent's entire session metadata — not just the one session being killed.

## Fix
Write to a per-pid temp file, `flush()` + `os.fsync()`, then `os.replace()` (atomic rename) onto the target, same safe-write pattern used by the persistence path:

\`\`\`python
_tmp = f"{sessions_json}.{os.getpid()}.tmp"
with open(_tmp, "w") as f:
    json.dump(data, f, indent=2)
    f.flush()
    os.fsync(f.fileno())
os.replace(_tmp, sessions_json)
\`\`\`

No behavior change on the success path. `py_compile` passes.

## Scope
- `ods/extensions/services/token-spy/main.py:1417` (the `_kill_session` write; distinct from the websocket-persist path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)