### PR TITLE
feat(support): add deep log and trace redaction engine to ods-support-bundle.sh

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -142,6 +142,10 @@ patterns = [
     (re.compile(r"(?i)(Bearer\s+)[A-Za-z0-9._~+/=-]+"), r"\1[REDACTED]"),
     (re.compile(r"(?i)((?:authorization|x-api-key|api-key|apikey)\s*[:=]\s*)([\"']?)[^\"'\s,}]+"), r"\1\2[REDACTED]"),
     (re.compile(r"(?i)(https?://)([^/\s:@]+):([^@\s/]+)@"), r"\1[REDACTED]@"),
+    (re.compile(r"sk-[A-Za-z0-9_-]{20,}"), "[REDACTED_API_KEY]"),
+    (re.compile(r"tskey-auth-[A-Za-z0-9_-]+"), "[REDACTED_TAILSCALE_KEY]"),
+    (re.compile(r"hf_[A-Za-z0-9]{30,}"), "[REDACTED_HF_TOKEN]"),
+    (re.compile(r"-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----[\s\S]*?-----END (?:[A-Z ]+ )?PRIVATE KEY-----"), "[REDACTED_PRIVATE_KEY]"),
     (
         re.compile(rf"(?im)^([ \t]*(?:export[ \t]+)?[A-Za-z_][A-Za-z0-9_]*{secret_word}[A-Za-z0-9_]*[ \t]*=[ \t]*).*$"),
         r"\1[REDACTED]",


### PR DESCRIPTION
## Problem

In `ods/scripts/ods-support-bundle.sh`, support bundles collect system diagnostics and container stdout/stderr logs (`docker logs`). While `.env` variables were sanitized, collected container logs and diagnostic text traces retained raw API tokens (`sk-...`), Tailscale authorization keys (`tskey-auth-...`), Hugging Face access tokens (`hf_...`), and private key blocks if logged by services during startup. When operators attach these support archives to public GitHub issues, sensitive credentials could be accidentally exposed.

## Fix

Expand `redact_file()` in `ods-support-bundle.sh` with dedicated credential scrubbing regex patterns for API keys (`sk-[A-Za-z0-9_-]{20,}`), Tailscale auth keys (`tskey-auth-...`), Hugging Face tokens (`hf_...`), and private key blocks (`-----BEGIN PRIVATE KEY-----`). All collected container logs and diagnostic outputs are automatically scrubbed at the collection boundary before archiving.

## Verification

Ran `bash -n ods/scripts/ods-support-bundle.sh` (passed cleanly). Verified pattern masking against synthetic credential logs. `git diff --check` passed cleanly.