### PR TITLE
fix(host-agent): ensure parent directory exists and write pid file atomically in ods-host-agent.py

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -12532,7 +12532,10 @@ def main():
 
     if args.pid_file:
         pid_path = Path(args.pid_file)
-        pid_path.write_text(str(os.getpid()), encoding="utf-8")
+        pid_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_pid = pid_path.with_name(f"{pid_path.name}.tmp.{os.getpid()}")
+        tmp_pid.write_text(str(os.getpid()), encoding="utf-8")
+        tmp_pid.replace(pid_path)
         atexit.register(lambda: pid_path.unlink(missing_ok=True))
 
     # Determine bind address: explicit env override, or a platform-aware safe


### PR DESCRIPTION
## Problem

In `ods/bin/ods-host-agent.py`, when `--pid-file` is passed to the host agent daemon, `pid_path.write_text(str(os.getpid()))` wrote the process ID directly to the specified file path. If the parent directory of the PID file did not exist on fresh or custom installations, an uncaught `FileNotFoundError` crashed daemon initialization. Furthermore, writing directly to the target file path could result in zero-byte truncation if process startup was interrupted by a signal.

## Fix

Update `main()` in `ods/bin/ods-host-agent.py` to create the parent directory via `pid_path.parent.mkdir(parents=True, exist_ok=True)`, write the PID to a unique process temporary file, and execute an atomic `tmp_pid.replace(pid_path)` operation.

## Verification

Verified syntax with `python3 -m py_compile ods/bin/ods-host-agent.py`. `git diff --check` passed cleanly.