### PR TITLE
fix(oracle): specify errors=replace in read_env_file_value in performance_oracle.py

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -141,10 +141,10 @@ def read_env_value(key: str, install_dir: str | Path) -> str:
 def read_env_file_value(key: str, install_dir: str | Path) -> str:
     env_path = Path(install_dir) / ".env"
     try:
-        for line in env_path.read_text(encoding="utf-8").splitlines():
+        for line in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
             if line.startswith(f"{key}="):
                 return strip_matching_quotes(line.split("=", 1)[1])
-    except OSError:
+    except (OSError, UnicodeDecodeError, ValueError):
         pass
     return ""
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/performance_oracle.py`, `read_env_file_value()` parses `.env` values by reading the file with `env_path.read_text(encoding="utf-8")`. If non-UTF-8 characters or non-standard byte sequences exist in local or localized `.env` files, an uncaught `UnicodeDecodeError` or `ValueError` previously escaped the `except OSError:` block and crashed dashboard API performance oracle evaluations.

## Fix

Pass `errors="replace"` to `env_path.read_text()` and expand the exception handling tuple to catch `(OSError, UnicodeDecodeError, ValueError)` in `read_env_file_value()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/performance_oracle.py`. `git diff --check` passed cleanly.