### PR TITLE
fix(installer): specify errors=replace in python image lookup in 11-services.sh

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -56,7 +56,8 @@ _phase11_build_local_images() {
                     | python3 -c "
 import json, sys
 try:
-    d = json.load(sys.stdin)
+    raw = sys.stdin.buffer.read().decode('utf-8', errors='replace')
+    d = json.loads(raw)
     svc_name = '$svc'
     svc_config = d.get('services', {}).get(svc_name, {})
     image = svc_config.get('image', '') or ''


### PR DESCRIPTION
## Problem

In `ods/installers/phases/11-services.sh`, the installer verifies local Docker container image builds by piping `docker compose config --format json` output into an inline Python helper using `json.load(sys.stdin)`. If the environment output contains non-UTF-8 characters or localized system bytes, `sys.stdin` decoding raised an uncaught `UnicodeDecodeError`, causing image build cross-checks to fail prematurely.

## Fix

Read raw stdin bytes via `sys.stdin.buffer.read()`, decode with `errors="replace"`, and parse the JSON string in `11-services.sh`.

## Verification

Ran `bash -n ods/installers/phases/11-services.sh` (passed cleanly). `git diff --check` passed cleanly.