### PR TITLE
fix(demo): guard read in pause for non-interactive execution in demo-offline.sh

### DIFF
--- a/ods/scripts/demo-offline.sh
+++ b/ods/scripts/demo-offline.sh
@@ -44,9 +44,10 @@ clear_screen() {
 }
 
 pause() {
+    [[ -t 0 ]] || return 0
     echo ""
     echo -e "${DIM}Press Enter to continue...${NC}"
-    read -r
+    read -r || true
 }
 
 print_header() {


### PR DESCRIPTION
## Problem

In `ods/scripts/demo-offline.sh`, helper function `pause()` pauses execution between interactive demo steps by calling `read -r`. When `demo-offline.sh` is executed non-interactively or in automated CI/documentation screenshot pipelines without an interactive TTY, `read -r` encounters an Immediate EOF or non-zero exit code under `set -e`, causing script failure.

## Fix

Add `[[ -t 0 ]] || return 0` TTY check in `pause()` to bypass interactive pauses in headless environments, and append `|| true` to `read -r` in `demo-offline.sh`.

## Verification

Ran `bash -n ods/scripts/demo-offline.sh` (passed cleanly). Verified headless pipe execution via `./scripts/demo-offline.sh < /dev/null`. `git diff --check` passed cleanly.