### PR TITLE
fix(devtools): use defined installer error handler

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -183,8 +183,7 @@ else
             _opencode_key="no-key"
         fi
         if [[ -z "${_opencode_key:-}" ]]; then
-            ai_err "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
-            exit 1
+            error "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
         fi
 
         # Writes a fresh opencode.json from the template. Used for first-install


### PR DESCRIPTION
## Summary
- replace the undefined `ai_err` call in the OpenCode switchboard failure path with the installer `error` handler
- remove the now-unreachable explicit exit
- restore the installer environment smoke gate to green

## Why this matters
When `ODS_MODEL_SWITCHBOARD=enabled` but `LITELLM_KEY` is empty, production phase 07 reaches this branch. It attempted to call an undefined function, so operators received `ai_err: command not found` instead of the intended actionable installer error. The repository smoke gate independently detects this broken production path and was failing on `main`.

## Overlap check
Searched open and closed PRs for `ai_err phase 07 undefined`, `OpenCode switchboard LITELLM_KEY`, and `07-devtools.sh`. No PR fixes this call site. The change is independent of switchboard routing and OpenCode JSON rendering; it only restores the established installer error boundary.

## Test plan
- [x] `bash -n ods/installers/phases/07-devtools.sh`
- [x] `bash ods/tests/smoke/installer-env-smoke.sh` — 14 passed, 0 failed
- [x] `git diff --check`

Generated with Codex