### PR TITLE
fix(context): preserve nonempty SOUL output directories

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -29,6 +29,7 @@ test: ## Run unit and contract tests
 	@echo "=== Hermes slash worker prune ==="
 	@bash tests/test-hermes-slash-worker-prune.sh
 	@python3 tests/contracts/test-hermes-worker-guardrails.py
+	@python3 tests/test-installation-context-output.py
 	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -1107,7 +1107,7 @@ MODELS_INI_EOF
         _soul_template="$INSTALL_DIR/extensions/services/hermes/SOUL.md.template"
         mkdir -p "$(dirname "$_soul_output")"
         if [[ -e "$_soul_output" && ! -f "$_soul_output" ]]; then
-            rm -rf "$_soul_output" || \
+            rmdir "$_soul_output" || \
                 warn "Could not replace invalid Hermes SOUL.md path at $_soul_output"
         fi
         if [[ -n "$_python_cmd" && -f "$_soul_builder" ]]; then

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -545,7 +545,12 @@ function Invoke-HermesSoulRefresh {
 
     if (-not $_rendered) {
         if (Test-Path -LiteralPath $_output -PathType Container) {
-            Remove-Item -LiteralPath $_output -Recurse -Force
+            try {
+                Remove-Item -LiteralPath $_output -Force -ErrorAction Stop
+            } catch {
+                Write-AIWarn "Hermes SOUL.md output path is a non-empty directory; preserving its contents"
+                return
+            }
         }
         if (-not (Test-Path -LiteralPath $_output -PathType Leaf)) {
             $_content = Get-Content -LiteralPath $_template -Raw

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -109,8 +109,12 @@ $_expectedRegularFiles = @(
 foreach ($_expectedFileName in $_expectedRegularFiles) {
     $_expectedFilePath = Join-Path $installDir $_expectedFileName
     if (Test-Path -LiteralPath $_expectedFilePath -PathType Container) {
-        Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force
-        Write-AIWarn "Removed malformed $_expectedFileName directory from a previous partial install."
+        try {
+            Remove-Item -LiteralPath $_expectedFilePath -Force -ErrorAction Stop
+            Write-AIWarn "Removed empty malformed $_expectedFileName directory from a previous partial install."
+        } catch {
+            throw "Expected regular file path is a non-empty directory; preserving it: $_expectedFilePath"
+        }
     }
 }
 

--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -404,17 +404,12 @@ def build_soul(
         assembled = build_compact_soul(env_path)
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    # Self-heal a pathological state: Docker's bind-mount engine auto-creates
-    # the source path as a *directory* when the path doesn't exist at
-    # compose-up time. If a previous install ran compose-up before this
-    # script generated the file, ``data/persona/SOUL.md`` is now an empty
-    # directory, and the next compose-up keeps failing with "not a directory:
-    # Are you trying to mount a directory onto a file." Remove that directory
-    # so we can write the real file in its place. Caught when re-running
-    # /ods-fleet-test on mac-mini after a prior failed install.
+    # Self-heal the empty directory Docker creates when a bind-mount source is
+    # missing at compose-up time. Use rmdir rather than recursive deletion: a
+    # non-empty path is operator data or an unexpected state and must fail
+    # visibly without deleting its contents.
     if output_path.exists() and not output_path.is_file():
-        import shutil
-        shutil.rmtree(output_path)
+        output_path.rmdir()
     previous = output_path.read_text(encoding="utf-8") if output_path.is_file() else ""
     if previous == assembled:
         return False

--- a/ods/tests/test-installation-context-output.py
+++ b/ods/tests/test-installation-context-output.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Public-boundary checks for installation-context output recovery."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "build-installation-context.py"
+
+
+def run_builder(template: Path, env_file: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--template",
+            str(template),
+            "--env",
+            str(env_file),
+            "--output",
+            str(output),
+        ],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        template = work / "SOUL.md.template"
+        env_file = work / ".env"
+        template.write_text("# Persona\n\n<!-- INSTALLATION_CONTEXT -->\n", encoding="utf-8")
+        env_file.write_text("ODS_DEVICE_NAME=test-node\n", encoding="utf-8")
+
+        empty_output = work / "empty" / "SOUL.md"
+        empty_output.mkdir(parents=True)
+        result = run_builder(template, env_file, empty_output)
+        assert result.returncode == 0, result.stderr
+        assert empty_output.is_file()
+        assert "test-node" in empty_output.read_text(encoding="utf-8")
+
+        nonempty_output = work / "nonempty" / "SOUL.md"
+        nonempty_output.mkdir(parents=True)
+        sentinel = nonempty_output / "operator-data.txt"
+        sentinel.write_text("preserve me", encoding="utf-8")
+        result = run_builder(template, env_file, nonempty_output)
+        assert result.returncode != 0
+        assert sentinel.read_text(encoding="utf-8") == "preserve me"
+
+    print("[PASS] installation-context replaces only empty output directories")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test-installation-context-output.py
+++ b/ods/tests/test-installation-context-output.py
@@ -11,6 +11,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "build-installation-context.py"
+LINUX_PHASE = ROOT / "installers" / "phases" / "11-services.sh"
+WINDOWS_PHASE = ROOT / "installers" / "windows" / "phases" / "06-directories.ps1"
 
 
 def run_builder(template: Path, env_file: Path, output: Path) -> subprocess.CompletedProcess[str]:
@@ -53,6 +55,16 @@ def main() -> int:
         result = run_builder(template, env_file, nonempty_output)
         assert result.returncode != 0
         assert sentinel.read_text(encoding="utf-8") == "preserve me"
+
+    linux_source = LINUX_PHASE.read_text(encoding="utf-8")
+    assert 'rmdir "$_soul_output"' in linux_source
+    assert 'rm -rf "$_soul_output"' not in linux_source
+
+    windows_source = WINDOWS_PHASE.read_text(encoding="utf-8")
+    soul_refresh = windows_source.split("function Invoke-HermesSoulRefresh", 1)[1]
+    soul_refresh = soul_refresh.split("if ($enableHermes)", 1)[0]
+    assert "Remove-Item -LiteralPath $_output -Force -ErrorAction Stop" in soul_refresh
+    assert "Remove-Item -LiteralPath $_output -Recurse" not in soul_refresh
 
     print("[PASS] installation-context replaces only empty output directories")
     return 0

--- a/ods/tests/test-installation-context-output.py
+++ b/ods/tests/test-installation-context-output.py
@@ -61,6 +61,8 @@ def main() -> int:
     assert 'rm -rf "$_soul_output"' not in linux_source
 
     windows_source = WINDOWS_PHASE.read_text(encoding="utf-8")
+    assert "Remove-Item -LiteralPath $_expectedFilePath -Force -ErrorAction Stop" in windows_source
+    assert "Remove-Item -LiteralPath $_expectedFilePath -Recurse" not in windows_source
     soul_refresh = windows_source.split("function Invoke-HermesSoulRefresh", 1)[1]
     soul_refresh = soul_refresh.split("if ($enableHermes)", 1)[0]
     assert "Remove-Item -LiteralPath $_output -Force -ErrorAction Stop" in soul_refresh


### PR DESCRIPTION
## Summary
- replace recursive deletion of unexpected SOUL output directories with empty-only removal
- cover the Python builder plus Linux and Windows installer call sites
- preserve Docker bind-mount self-healing when the auto-created directory is empty
- add CLI-boundary and integration-contract regression coverage for empty and non-empty output paths

## Why this matters
The installers invoke `scripts/build-installation-context.py` to render `data/persona/SOUL.md` before Hermes starts. Docker can legitimately auto-create that file path as an empty directory, which ODS should repair. The builder, Linux phase 11, and the Windows fallback all used recursive deletion, so an unexpected non-empty directory at the same path—including operator files—could be deleted. The new behavior repairs only the known empty-directory state and preserves any non-empty state while reporting the failure.

## Overlap check
Searched open and closed PRs for `SOUL output directory rmtree`, `build-installation-context directory`, `persona SOUL.md directory`, and all callers touching `data/persona/SOUL.md`. No PR covers this deletion boundary. Existing context PRs concern payload validation and snapshot content, not output-path recovery.

## Test plan
- [x] `python ods/tests/test-installation-context-output.py`
- [x] `python -m py_compile ods/scripts/build-installation-context.py ods/tests/test-installation-context-output.py`
- [x] `bash -n ods/installers/phases/11-services.sh`
- [x] PowerShell parser accepts `ods/installers/windows/phases/06-directories.ps1`
- [x] `git diff --check`

Generated with Codex