### PR TITLE
test(extensions): handle unavailable Windows symlink privilege

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from user_extensions import (
@@ -146,7 +147,12 @@ class TestScanUserExtensions:
         _write_manifest(ext_dir, _make_manifest("real-ext"))
         (ext_dir / "compose.yaml").write_text("services: {}\n")
 
-        (user_dir / "link-ext").symlink_to(ext_dir)
+        try:
+            (user_dir / "link-ext").symlink_to(ext_dir, target_is_directory=True)
+        except OSError as exc:
+            if getattr(exc, "winerror", None) == 1314:
+                pytest.skip("Windows symlink privilege is unavailable")
+            raise
 
         result = scan_user_extension_services(user_dir)
         assert "real-ext" in result


### PR DESCRIPTION
## Summary
- mark the user-extension symlink fixture as a directory link on Windows
- skip only Windows privilege error 1314 when the host cannot create symlinks
- keep every other symlink failure visible

## Why this matters
The documented dashboard-api test command failed on a normal non-elevated Windows checkout after 2,103 successful tests because creating a symlink requires Developer Mode or elevated privilege. That is an environment capability, not a product regression. The test also omitted `target_is_directory=True`, which is required for correct directory-link semantics on Windows when the privilege is available. This restores a reliable local validation gate without weakening the production scanner assertion.

## Overlap check
Searched open and closed PRs for `user extensions symlink Windows privilege`, `WinError 1314 symlink pytest`, and `test_scan_symlink_skipped`. No PR covers this platform-specific test failure. Production extension scanning is unchanged.

## Test plan
- [x] `python -m pytest tests/test_user_extensions.py -q` — 13 passed, 1 skipped
- [x] `python -m pytest tests -q --disable-warnings --maxfail=1` — 2103 passed, 15 skipped
- [x] `git diff --check`

Generated with Codex