### PR TITLE
test(installer): make exact-line contracts CRLF-safe

### DIFF
--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -110,9 +110,9 @@ assert_grep "installers/windows/install-windows.ps1" 'CTX_SIZE=\$\(\$tierConfig\
 
 echo ""
 echo "Hermes config patch paths:"
-assert_grep "extensions/services/hermes/cli-config.yaml.template" '^  max_tokens: 1024$' \
+assert_grep "extensions/services/hermes/cli-config.yaml.template" '^  max_tokens: 1024[[:space:]]*$' \
     "Hermes template bounds each model turn"
-assert_grep "scripts/render-runtime-configs.py" '^DEFAULT_HERMES_MAX_TOKENS = 1024$' \
+assert_grep "scripts/render-runtime-configs.py" '^DEFAULT_HERMES_MAX_TOKENS = 1024[[:space:]]*$' \
     "runtime renderer uses the bounded Hermes output default"
 assert_grep "bin/ods-host-agent.py" 'max_tokens: int = 1024' \
     "runtime model switch patcher migrates an uncapped Hermes config"

--- a/ods/tests/test-linux-host-agent-stop.sh
+++ b/ods/tests/test-linux-host-agent-stop.sh
@@ -17,7 +17,7 @@ SERVICE="scripts/systemd/ods-host-agent.service"
 UNINSTALL="ods-uninstall.sh"
 AGENT="bin/ods-host-agent.py"
 
-grep -q '^TimeoutStopSec=15$' "$SERVICE" \
+grep -q '^TimeoutStopSec=15[[:space:]]*$' "$SERVICE" \
   || fail "ods-host-agent systemd unit must bound service stop time"
 pass "systemd unit has bounded stop timeout"
 


### PR DESCRIPTION
## Summary
- make exact-line installer and systemd contract assertions tolerate CRLF checkout endings
- retain strict value and logical line-boundary matching
- restore context-parity and host-agent stop gates on Windows/WSL worktrees

## Why this matters
`bash tests/test-installer-context-parity.sh` and `bash tests/test-linux-host-agent-stop.sh` are part of the documented `make test` gate. On a Windows checkout with Git CRLF conversion, they rejected valid tracked configuration because `$` matched before LF but not before the retained carriage return. That prevented contributors from completing local validation even though the runtime contracts were correct. `[[:space:]]*$` accepts CRLF while still requiring each expected value at the end of its logical line.

## Overlap check
Searched open and closed PRs for `installer context parity CRLF`, `host agent TimeoutStopSec CRLF`, and the exact failing contract messages. No PR covers these checkout-portability failures. Production configuration is unchanged.

## Test plan
- [x] `bash tests/test-installer-context-parity.sh` — 76 passed
- [x] `bash tests/test-linux-host-agent-stop.sh`
- [x] `git diff --check`

Generated with Codex