### PR TITLE
fix(auth): persist fallback dashboard API key across restarts

### DIFF
--- a/ods/extensions/services/dashboard-api/README.md
+++ b/ods/extensions/services/dashboard-api/README.md
@@ -29,7 +29,7 @@ Environment variables (set in `.env`):
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DASHBOARD_API_PORT` | `3002` | External + internal port |
-| `DASHBOARD_API_KEY` | *(auto-generated)* | API key for all protected endpoints. If unset, a random key is generated and written to `/data/dashboard-api-key.txt` |
+| `DASHBOARD_API_KEY` | *(auto-generated)* | API key for all protected endpoints. If unset, a random key is generated once in `/data/dashboard-api-key.txt` and reused across restarts |
 | `GPU_BACKEND` | `nvidia` | GPU backend: `nvidia` or `amd` |
 | `OLLAMA_URL` | `http://llama-server:8080` | LLM backend URL |
 | `LLM_MODEL` | `qwen3:30b-a3b` | Active model name shown in dashboard |
@@ -148,7 +148,7 @@ curl http://localhost:3002/api/status \
   -H "Authorization: Bearer YOUR_KEY"
 ```
 
-When `DASHBOARD_API_KEY` is empty, dashboard-api generates a random key at startup, writes it to `/data/dashboard-api-key.txt` with mode `0600`, and still requires Bearer authentication for protected endpoints.
+When `DASHBOARD_API_KEY` is empty, dashboard-api reuses `/data/dashboard-api-key.txt` or generates it once with mode `0600`, and still requires Bearer authentication for protected endpoints.
 
 ## Architecture
 

--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import secrets
+import tempfile
 from pathlib import Path
 
 from fastapi import HTTPException, Security
@@ -10,17 +11,50 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 logger = logging.getLogger(__name__)
 
+
+def _load_or_create_api_key(key_file: Path) -> tuple[str, bool]:
+    """Return a stable fallback key and whether this call created it."""
+    try:
+        api_key = key_file.read_text(encoding="utf-8").strip()
+    except FileNotFoundError:
+        api_key = ""
+    else:
+        if not api_key:
+            raise RuntimeError(f"Dashboard API key file is empty: {key_file}")
+        key_file.chmod(0o600)
+        return api_key, False
+
+    key_file.parent.mkdir(parents=True, exist_ok=True)
+    api_key = secrets.token_urlsafe(32)
+    fd, temporary_name = tempfile.mkstemp(
+        dir=key_file.parent,
+        prefix=f".{key_file.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(api_key)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, key_file)
+        key_file.chmod(0o600)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return api_key, True
+
+
 DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY")
 if not DASHBOARD_API_KEY:
-    DASHBOARD_API_KEY = secrets.token_urlsafe(32)
     key_file = Path("/data/dashboard-api-key.txt")
-    key_file.parent.mkdir(parents=True, exist_ok=True)
-    key_file.write_text(DASHBOARD_API_KEY)
-    key_file.chmod(0o600)
-    logger.warning(
-        "DASHBOARD_API_KEY not set. Generated temporary key and wrote to %s (mode 0600). "
-        "Set DASHBOARD_API_KEY in your .env file for production.", key_file
-    )
+    DASHBOARD_API_KEY, key_created = _load_or_create_api_key(key_file)
+    if key_created:
+        logger.warning(
+            "DASHBOARD_API_KEY not set. Generated fallback key at %s (mode 0600). "
+            "Set DASHBOARD_API_KEY in your .env file for production.", key_file
+        )
+    else:
+        logger.info("DASHBOARD_API_KEY not set. Reusing fallback key from %s.", key_file)
 
 security_scheme = HTTPBearer(auto_error=False)
 

--- a/ods/extensions/services/dashboard-api/tests/test_security.py
+++ b/ods/extensions/services/dashboard-api/tests/test_security.py
@@ -1,11 +1,34 @@
 """Tests for security.py — API key authentication."""
 
+import os
+
 import pytest
 
 from fastapi import HTTPException
 from fastapi.security import HTTPAuthorizationCredentials
 
 import security
+
+
+def test_fallback_key_survives_process_restart(tmp_path):
+    key_file = tmp_path / "dashboard-api-key.txt"
+
+    first_key, first_created = security._load_or_create_api_key(key_file)
+    second_key, second_created = security._load_or_create_api_key(key_file)
+
+    assert first_created is True
+    assert second_created is False
+    assert second_key == first_key
+    if os.name != "nt":
+        assert key_file.stat().st_mode & 0o777 == 0o600
+
+
+def test_empty_fallback_key_fails_closed(tmp_path):
+    key_file = tmp_path / "dashboard-api-key.txt"
+    key_file.write_text("", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="key file is empty"):
+        security._load_or_create_api_key(key_file)
 
 
 class TestVerifyApiKey:


### PR DESCRIPTION
## Summary
- reuse the documented fallback dashboard API key across dashboard-api restarts
- generate a missing key through a durable mode-0600 temporary file and atomic replacement
- fail closed on an empty persisted key instead of silently rotating credentials
- document and test the restart-stability contract

## Why this matters
When `DASHBOARD_API_KEY` is unset, dashboard-api and the dashboard nginx container coordinate through `/data/dashboard-api-key.txt`. Dashboard-api previously generated and overwrote that file on every process start. Restarting only dashboard-api therefore changed its accepted credential while nginx kept injecting the old key, causing every dashboard API request to return 403 until the dashboard container also restarted. Reusing the persisted key keeps independently restarted services synchronized.

## Overlap check
Searched open and closed PRs for `dashboard API key restart reuse file`, `temporary dashboard key restart`, and `dashboard-api-key.txt`. No PR covers fallback-key restart stability. Recent nginx escaping and auth-gate PRs do not change credential lifecycle.

## Test plan
- [x] `python -m pytest tests/test_security.py -q` — 8 passed
- [x] `python -m py_compile security.py tests/test_security.py`
- [x] `git diff --check`

Generated with Codex