### PR TITLE
fix(open-interpreter): terminate disconnected stream workers

### DIFF
--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -108,6 +108,55 @@ for chunk in interpreter.chat(config["message"], stream=True):
 """
 
 
+def _terminate_process(proc: subprocess.Popen) -> None:
+    """Stop a streaming child, escalating if it ignores termination."""
+    if proc.poll() is not None:
+        return
+    try:
+        proc.terminate()
+    except ProcessLookupError:
+        proc.wait()
+        return
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def _stream_interpreter(script_path: str, config: str):
+    proc = None
+    try:
+        proc = subprocess.Popen(
+            ["python", script_path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        if proc.stdin is None or proc.stdout is None:
+            raise RuntimeError("Interpreter subprocess pipes were not created")
+
+        proc.stdin.write(config)
+        proc.stdin.close()
+
+        for line in proc.stdout:
+            if line.startswith("SSE: "):
+                payload = line[5:].rstrip("\r\n")
+                yield f"data: {payload}\n\n"
+
+        proc.wait()
+    finally:
+        if proc is not None:
+            _terminate_process(proc)
+            if proc.stdin is not None and not proc.stdin.closed:
+                proc.stdin.close()
+            if proc.stdout is not None:
+                proc.stdout.close()
+        os.unlink(script_path)
+
+
 @app.get("/health")
 def health():
     return {"status": "ok", "llm_url": LLM_API_URL}
@@ -164,29 +213,10 @@ def chat_stream(req: ChatRequest, _auth=Depends(verify_api_key)):
         f.write(_STREAM_RUNNER_SCRIPT)
         script_path = f.name
 
-    def generate():
-        try:
-            proc = subprocess.Popen(
-                ["python", script_path],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-            )
-
-            proc.stdin.write(config)
-            proc.stdin.close()
-
-            for line in proc.stdout:
-                if line.startswith("SSE: "):
-                    yield f"data: {line[5:]}\n\n"
-
-            proc.wait()
-        finally:
-            os.unlink(script_path)
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
+    return StreamingResponse(
+        _stream_interpreter(script_path, config),
+        media_type="text/event-stream",
+    )
 
 
 if __name__ == "__main__":

--- a/ods/extensions/library/services/open-interpreter/tests/test_server.py
+++ b/ods/extensions/library/services/open-interpreter/tests/test_server.py
@@ -1,0 +1,95 @@
+import importlib.util
+import io
+from pathlib import Path
+
+import pytest
+
+
+SERVER_PATH = Path(__file__).resolve().parents[1] / "server.py"
+
+
+@pytest.fixture()
+def server_module(monkeypatch):
+    monkeypatch.setattr(Path, "mkdir", lambda *args, **kwargs: None)
+    spec = importlib.util.spec_from_file_location(
+        "open_interpreter_server", SERVER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeProcess:
+    def __init__(self, lines):
+        self.stdin = io.StringIO()
+        self.stdout = io.StringIO("".join(lines))
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+        self.wait_timeouts = []
+
+    def poll(self):
+        return self.returncode
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = -15
+
+    def kill(self):
+        self.killed = True
+        self.returncode = -9
+
+    def wait(self, timeout=None):
+        self.wait_timeouts.append(timeout)
+        if self.returncode is None:
+            self.returncode = 0
+        return self.returncode
+
+
+def test_stream_disconnect_terminates_child_and_removes_script(
+    server_module, monkeypatch
+):
+    process = FakeProcess(["SSE: first\n", "SSE: second\n"])
+    removed = []
+    monkeypatch.setattr(server_module.subprocess, "Popen", lambda *a, **kw: process)
+    monkeypatch.setattr(server_module.os, "unlink", removed.append)
+
+    stream = server_module._stream_interpreter("runner.py", "{}")
+    assert next(stream) == "data: first\n\n"
+    stream.close()
+
+    assert process.terminated is True
+    assert process.killed is False
+    assert removed == ["runner.py"]
+
+
+def test_completed_stream_does_not_terminate_child(server_module, monkeypatch):
+    process = FakeProcess(["SSE: only\n"])
+    monkeypatch.setattr(server_module.subprocess, "Popen", lambda *a, **kw: process)
+    monkeypatch.setattr(server_module.os, "unlink", lambda _path: None)
+
+    assert list(server_module._stream_interpreter("runner.py", "{}")) == [
+        "data: only\n\n"
+    ]
+
+    assert process.returncode == 0
+    assert process.terminated is False
+
+
+def test_terminate_process_kills_a_child_that_ignores_termination(server_module):
+    class StubbornProcess(FakeProcess):
+        def terminate(self):
+            self.terminated = True
+
+        def wait(self, timeout=None):
+            if timeout is not None and not self.killed:
+                raise server_module.subprocess.TimeoutExpired("python", timeout)
+            self.returncode = -9
+            return self.returncode
+
+    process = StubbornProcess([])
+
+    server_module._terminate_process(process)
+
+    assert process.terminated is True
+    assert process.killed is True


### PR DESCRIPTION
## Summary
- terminate the Open Interpreter streaming subprocess when a client disconnects
- escalate to `kill()` if the child ignores the bounded termination wait
- close subprocess pipes and remove the temporary runner on every exit path
- keep SSE payload framing stable while removing subprocess newlines

## Why this matters
`POST /chat/stream` starts a Python worker for every stream. When a browser, proxy, or client disconnects after receiving a chunk, Starlette closes the generator, but the old implementation only removed the runner file and left the worker alive. Repeated disconnects could accumulate interpreter processes, CPU/memory use, and in-flight model work until the optional service became unhealthy.

## Overlap check
Searched open and closed upstream PRs for `open interpreter stream subprocess cleanup`, `open-interpreter`, `disconnect`, and the changed production file `extensions/library/services/open-interpreter/server.py`. PR #403 hardened authentication and container execution but does not manage streaming child lifecycles. No open or closed PR covers disconnect cleanup.

## Test plan
- `python -m pytest -q ods/extensions/library/services/open-interpreter/tests/test_server.py` (3 passed)
- `python -m py_compile ods/extensions/library/services/open-interpreter/server.py`

The regression tests exercise the stream generator boundary: closing after the first SSE event terminates the live worker and removes the runner; normal completion does not terminate an exited worker; an unresponsive worker is killed.

Generated with Codex.