### PR TITLE
fix(preflight): reap timed-out Docker probes

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1174,6 +1174,9 @@ async def preflight_docker():
     except FileNotFoundError:
         return {"available": False, "error": "Docker not installed"}
     except asyncio.TimeoutError:
+        if proc.returncode is None:
+            proc.kill()
+        await proc.wait()
         return {"available": False, "error": "Docker check timed out"}
     except OSError:
         logger.exception("Docker preflight check failed")

--- a/ods/extensions/services/dashboard-api/tests/test_routers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_routers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -312,6 +313,33 @@ def test_preflight_docker_authenticated(test_client):
     assert "available" in data
     if data["available"]:
         assert "version" in data
+
+
+def test_preflight_docker_timeout_reaps_subprocess(test_client, monkeypatch):
+    process = MagicMock()
+    process.returncode = None
+    process.communicate = AsyncMock(side_effect=asyncio.TimeoutError)
+
+    async def finish_wait():
+        process.returncode = -9
+        return -9
+
+    process.wait = AsyncMock(side_effect=finish_wait)
+    monkeypatch.setattr("main.os.path.exists", lambda _path: False)
+    create_process = AsyncMock(return_value=process)
+    monkeypatch.setattr("main.asyncio.create_subprocess_exec", create_process)
+
+    resp = test_client.get(
+        "/api/preflight/docker", headers=test_client.auth_headers
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "available": False,
+        "error": "Docker check timed out",
+    }
+    process.kill.assert_called_once_with()
+    process.wait.assert_awaited_once_with()
 
 
 def test_preflight_gpu_authenticated(test_client):


### PR DESCRIPTION
## Summary
- kill a still-running `docker --version` process when the preflight probe times out
- await the terminated child so the service does not accumulate zombies
- cover the authenticated HTTP endpoint with a timeout regression test

## Why this matters
`GET /api/preflight/docker` runs during setup and diagnostics. If the Docker CLI hangs, `asyncio.wait_for` cancels `communicate()` but does not terminate the operating-system process. Repeated preflight requests can therefore leave blocked Docker clients and unreaped children behind in dashboard-api. The endpoint now owns the complete lifecycle of the subprocess it starts.

## Overlap check
Searched open and closed upstream PRs for `preflight docker timeout subprocess kill`, `preflight_docker create_subprocess_exec`, and the changed production path in `extensions/services/dashboard-api/main.py`. No PR covers cleanup of the Docker preflight child. Existing subprocess cleanup changes target different endpoints and services.

## Test plan
- `python -m pytest -q ods/extensions/services/dashboard-api/tests/test_routers.py` (55 passed)
- `python -m py_compile ods/extensions/services/dashboard-api/main.py ods/extensions/services/dashboard-api/tests/test_routers.py`
- `git diff --check`

The regression test calls the authenticated `/api/preflight/docker` boundary, forces the child communication to time out, and verifies both `kill()` and `wait()` occur before the timeout response is returned.

Generated with Codex.