### PR TITLE
fix(updates): handle OSError and JSONDecodeError when reading update manifests in updates.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -39,7 +39,7 @@ _version_refresh_task: Optional[asyncio.Task] = None
 
 def _read_utf8(path: Path) -> str:
     """Read repository text files consistently across Windows and Linux."""
-    return path.read_text(encoding="utf-8")
+    return path.read_text(encoding="utf-8", errors="replace")
 
 
 def _read_current_version() -> str:
@@ -50,7 +50,7 @@ def _read_current_version() -> str:
             for line in _read_utf8(env_file).splitlines():
                 if line.startswith("ODS_VERSION="):
                     return strip_matching_quotes(line.split("=", 1)[1])
-        except OSError:
+        except (OSError, UnicodeDecodeError, ValueError):
             pass
     version_file = Path(INSTALL_DIR) / ".version"
     if version_file.exists():


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/updates.py`, `_read_utf8()` reads `.env` and version files via `path.read_text(encoding="utf-8")`. If non-UTF-8 characters exist in installed version files or local environment overrides, `read_text()` raised an uncaught `UnicodeDecodeError` or `ValueError`.

## Fix

Pass `errors="replace"` parameter to `path.read_text()` inside `_read_utf8()` and expand exception handling to catch `(OSError, UnicodeDecodeError, ValueError)` in `_read_current_version()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/routers/updates.py`. `git diff --check` passed cleanly.