### PR TITLE
fix(auth): add fallback secret lookup from .env in session_signer.py

### DIFF
--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -63,11 +63,15 @@ logger = logging.getLogger(__name__)
 # This prevents an unconfigured ODS from silently issuing
 # unsignable cookies that look valid because they pass an empty-key
 # HMAC check.
-_SECRET: bytes = (os.environ.get("ODS_SESSION_SECRET", "")).encode("utf-8")
+_SECRET: bytes | None = (
+    os.environ["ODS_SESSION_SECRET"].encode("utf-8")
+    if "ODS_SESSION_SECRET" in os.environ
+    else None
+)
 
 
 def _get_secret() -> bytes:
-    if _SECRET:
+    if _SECRET is not None:
         return _SECRET
     try:
         from config import INSTALL_DIR

--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -66,6 +66,18 @@ logger = logging.getLogger(__name__)
 _SECRET: bytes = (os.environ.get("ODS_SESSION_SECRET", "")).encode("utf-8")
 
 
+def _get_secret() -> bytes:
+    if _SECRET:
+        return _SECRET
+    try:
+        from config import INSTALL_DIR
+        from performance_oracle import read_env_value
+        val = read_env_value("ODS_SESSION_SECRET", INSTALL_DIR)
+        return val.encode("utf-8")
+    except Exception:
+        return b""
+
+
 def is_configured() -> bool:
     """Return True iff ODS_SESSION_SECRET was provided.
 
@@ -73,7 +85,7 @@ def is_configured() -> bool:
     state (e.g., marking a single-use magic-link as redeemed) so the
     operation fails BEFORE the side effect lands, not after.
     """
-    return bool(_SECRET)
+    return bool(_get_secret())
 
 
 def _set_secret_for_tests(value: str) -> None:
@@ -96,7 +108,7 @@ def _b64u_decode(text: str) -> bytes:
 
 def _sign(payload: str) -> str:
     """HMAC-SHA256 of ``payload`` with ``_SECRET``. Returns base64-url."""
-    mac = hmac.new(_SECRET, payload.encode("utf-8"), hashlib.sha256).digest()
+    mac = hmac.new(_get_secret(), payload.encode("utf-8"), hashlib.sha256).digest()
     return _b64u(mac)
 
 
@@ -106,7 +118,7 @@ def issue(ttl_seconds: int = 12 * 3600) -> str:
     Raises ``RuntimeError`` if ODS_SESSION_SECRET is not configured —
     we refuse to issue cookies that can't be verified.
     """
-    if not _SECRET:
+    if not _get_secret():
         raise RuntimeError(
             "ODS_SESSION_SECRET is not configured; refusing to issue an "
             "unsignable session cookie. Set it in .env (32+ random bytes) "


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/session_signer.py`, module-level `_SECRET` is evaluated once at import time via `os.environ.get("ODS_SESSION_SECRET", "")`. If the `.env` file is loaded dynamically after initial module import (e.g. during FastAPI lifespan startup or settings initialization), `_SECRET` remains empty (`b""`), causing `issue()` to raise a `RuntimeError` and `is_configured()` to return `False` even when `ODS_SESSION_SECRET` is valid in `.env`.

## Fix

Add a fallback helper `_get_secret()` in `session_signer.py` that queries `.env` via `read_env_value("ODS_SESSION_SECRET", INSTALL_DIR)` when `_SECRET` is empty at import time.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/session_signer.py`. `git diff --check` passed cleanly.