### PR TITLE
fix(client): URL-encode model_id in model() in lemonade_client.py

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional, Sequence
+from urllib.parse import quote
 
 import httpx
 
@@ -189,7 +190,8 @@ class LemonadeClient:
         return data if isinstance(data, list) else []
 
     async def model(self, model_id: str) -> dict[str, Any]:
-        return await self._request_json("GET", f"models/{model_id}")
+        quoted_id = quote(model_id, safe="")
+        return await self._request_json("GET", f"models/{quoted_id}")
 
     async def chat_completion(
         self,


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/lemonade_client.py`, `LemonadeClient.model(model_id)` constructs endpoint paths by interpolating model identifiers directly into `f"models/{model_id}"`. When model identifiers contain slashes (such as `Qwen/Qwen2.5-7B` or `user.Qwen/Qwen2.5-14B`), the resulting raw URL path (`models/Qwen/Qwen2.5-7B`) is malformed, causing Lemonade REST endpoints to reject requests with HTTP 404 Not Found.

## Fix

Use `urllib.parse.quote(model_id, safe="")` to escape slashes and special characters in `LemonadeClient.model()` before constructing request URLs.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/lemonade_client.py`. `git diff --check` passed cleanly.