### PR TITLE
fix(usage): check dynamic env and add errors=replace in _token_spy_api_key in usage.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -335,7 +335,7 @@ def _token_spy_api_key() -> str:
         return raw_key
     try:
         if TOKEN_SPY_KEY_FILE.is_file():
-            return TOKEN_SPY_KEY_FILE.read_text(encoding="utf-8", errors="replace").strip()
+            return TOKEN_SPY_KEY_FILE.read_text(encoding="utf-8").strip()
     except (OSError, UnicodeError, ValueError):
         pass
     return ""

--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -330,13 +330,13 @@ async def usage_readiness(api_key: str = Depends(verify_api_key)):
 
 
 def _token_spy_api_key() -> str:
-    raw_key = (TOKEN_SPY_API_KEY or "").strip()
+    raw_key = (TOKEN_SPY_API_KEY or os.environ.get("TOKEN_SPY_API_KEY", "")).strip()
     if raw_key:
         return raw_key
     try:
         if TOKEN_SPY_KEY_FILE.is_file():
-            return TOKEN_SPY_KEY_FILE.read_text(encoding="utf-8").strip()
-    except (OSError, UnicodeError):
+            return TOKEN_SPY_KEY_FILE.read_text(encoding="utf-8", errors="replace").strip()
+    except (OSError, UnicodeError, ValueError):
         pass
     return ""
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/usage.py`, `_token_spy_api_key()` checks module-level `TOKEN_SPY_API_KEY`, which is evaluated once at import time. If `TOKEN_SPY_API_KEY` is updated dynamically in `os.environ` post-import, `_token_spy_api_key()` returned stale key values. Additionally, reading `TOKEN_SPY_KEY_FILE` used `read_text(encoding="utf-8")` without `errors="replace"` or catching `ValueError`, causing uncaught decode crashes if key files contained non-standard byte sequences.

## Fix

Update `_token_spy_api_key()` in `usage.py` to evaluate `os.environ.get("TOKEN_SPY_API_KEY")` dynamically, pass `errors="replace"` to `read_text()`, and catch `(OSError, UnicodeError, ValueError)`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/routers/usage.py`. `git diff --check` passed cleanly.