### PR TITLE
fix(detection): add sysctl hw.ncpu lookup on macOS in detection.sh

### DIFF
--- a/ods/installers/lib/detection.sh
+++ b/ods/installers/lib/detection.sh
@@ -91,7 +91,7 @@ load_backend_contract() {
 
 get_host_logical_cpus() {
     local cores
-    cores=$(nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null || echo "1")
+    cores=$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo 2>/dev/null || echo "1")
     if [[ "$cores" =~ ^[0-9]+$ ]] && [[ "$cores" -gt 0 ]]; then
         echo "$cores"
     else


### PR DESCRIPTION
## Problem

In `ods/installers/lib/detection.sh`, `get_host_logical_cpus()` resolves system CPU core count using `nproc 2>/dev/null || grep -c ^processor /proc/cpuinfo`. On macOS (Darwin), neither `nproc` nor `/proc/cpuinfo` exist by default, causing `get_host_logical_cpus()` to fall back to `1` core. This led to under-allocated thread counts (`--threads 1`) during `llama-server` CPU thread budget calculation on Apple Silicon Macs.

## Fix

Add `sysctl -n hw.ncpu 2>/dev/null` as the primary hardware query in `get_host_logical_cpus()` in `detection.sh`.

## Verification

Ran `bash -n ods/installers/lib/detection.sh` (passed cleanly). Verified CPU core count resolution on macOS. `git diff --check` passed cleanly.