### PR TITLE
fix(upgrade): use sha256 lock key hash in acquire_upgrade_lock in bootstrap-upgrade.sh

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -210,7 +210,7 @@ release_upgrade_lock() {
 acquire_upgrade_lock() {
     local tmp_root="${TMPDIR:-/tmp}"
     local lock_key
-    lock_key="$(printf '%s\0%s' "$INSTALL_DIR" "$FULL_GGUF_FILE" | (sha256sum 2>/dev/null || shasum -a 256 2>/dev/null || cksum) | awk '{print $1}')"
+    lock_key="$(printf '%s\0%s' "$INSTALL_DIR" "$FULL_GGUF_FILE" | cksum | awk '{print $1}' | tr -dc '0-9')"
     local lock_dir="$tmp_root/ods-bootstrap-upgrade-${lock_key}.lock"
     local pid_file="$lock_dir/pid"
     local existing_pid=""

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -210,7 +210,7 @@ release_upgrade_lock() {
 acquire_upgrade_lock() {
     local tmp_root="${TMPDIR:-/tmp}"
     local lock_key
-    lock_key="$(printf '%s\0%s' "$INSTALL_DIR" "$FULL_GGUF_FILE" | cksum | awk '{print $1}')"
+    lock_key="$(printf '%s\0%s' "$INSTALL_DIR" "$FULL_GGUF_FILE" | (sha256sum 2>/dev/null || shasum -a 256 2>/dev/null || cksum) | awk '{print $1}')"
     local lock_dir="$tmp_root/ods-bootstrap-upgrade-${lock_key}.lock"
     local pid_file="$lock_dir/pid"
     local existing_pid=""


### PR DESCRIPTION
## Problem

In `ods/scripts/bootstrap-upgrade.sh`, `acquire_upgrade_lock()` computes the lock directory name using raw `cksum`. Output formatting and checksum algorithms for `cksum` differ between GNU coreutils on Linux and BSD `cksum` on macOS. If upgrade processes run across mixed host environments, inconsistent lock directory names allowed multiple model upgrade routines to run concurrently, risking corrupted GGUF downloads.

## Fix

Update `acquire_upgrade_lock()` to use standard SHA-256 hashing (`sha256sum 2>/dev/null || shasum -a 256 2>/dev/null || cksum`) for cross-platform lock key generation in `bootstrap-upgrade.sh`.

## Verification

Ran `bash -n ods/scripts/bootstrap-upgrade.sh` (passed cleanly). Verified lock key hashing on Linux and macOS. `git diff --check` passed cleanly.