### PR TITLE
fix(tts): bound temp storage and worker memory

### DIFF
--- a/ods/extensions/services/tts/README.md
+++ b/ods/extensions/services/tts/README.md
@@ -10,7 +10,7 @@ The TTS service provides high-quality neural text-to-speech synthesis using [Kok
 
 - **OpenAI-compatible API**: Drop-in replacement for `POST /v1/audio/speech`
 - **Multiple voices**: Multiple voice presets available; default is `af_heart`
-- **Concurrent requests**: 2 Uvicorn workers for parallel synthesis
+- **Concurrent requests**: Async request handling in one memory-safe Uvicorn worker by default
 - **Low latency**: CPU-based inference with fast Kokoro neural TTS model
 - **OpenAI format**: Compatible with any client that uses `openai.audio.speech.create()`
 
@@ -22,7 +22,8 @@ Environment variables (set in `.env`):
 |----------|---------|-------------|
 | `TTS_PORT` | `8880` | External port (maps to internal 8880) |
 | `DEFAULT_VOICE` | `af_heart` | Default voice preset |
-| `UVICORN_WORKERS` | `2` | Number of worker processes |
+| `TTS_WORKERS` | `1` | Uvicorn worker processes. Each worker loads its own CPU model; increase only with a larger memory limit. |
+| `TTS_TMPFS_SIZE` | `512m` | Maximum RAM-backed `/tmp` size. Prevents transient synthesis files from growing Docker.raw without bound. The mount permits execution because phonemizer loads its private eSpeak library copy from `/tmp`. |
 
 ## API Endpoints
 
@@ -31,7 +32,7 @@ Environment variables (set in `.env`):
 | `GET` | `/health` | Health check |
 | `POST` | `/v1/audio/speech` | Synthesize speech from text (OpenAI format) |
 | `GET` | `/v1/models` | List available TTS models |
-| `GET` | `/v1/voices` | List available voice presets |
+| `GET` | `/v1/audio/voices` | List available voice presets |
 
 ### Example
 
@@ -94,8 +95,14 @@ docker compose logs tts
 - The CPU image processes speech on CPU; synthesis takes 1–5 seconds depending on text length
 - Ensure the container has sufficient CPU allocation (`TTS_CPU_LIMIT` in `.env`; the installer auto-caps it to Docker's visible CPU count)
 
+**Growing Docker disk usage:**
+- `/tmp` is RAM-backed and capped by `TTS_TMPFS_SIZE`, so transient Kokoro,
+  PyTorch, and espeak files are discarded when the container is recreated.
+- Keep `TTS_WORKERS=1` under the default 4 GiB memory limit. Extra workers each
+  load another model and can enter a crash/restart loop under memory pressure.
+
 **Wrong voice:**
-- List available voices: `curl http://localhost:8880/v1/voices`
+- List available voices: `curl http://localhost:8880/v1/audio/voices`
 - Change `DEFAULT_VOICE` in `.env` or specify `voice` per-request
 
 ## License

--- a/ods/extensions/services/tts/compose.yaml
+++ b/ods/extensions/services/tts/compose.yaml
@@ -1,6 +1,6 @@
 services:
   tts:
-    image: ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4
+    image: ghcr.io/remsky/kokoro-fastapi-cpu:v0.8.0
     container_name: ods-tts
     restart: unless-stopped
     security_opt:
@@ -8,7 +8,15 @@ services:
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - DEFAULT_VOICE=af_heart
-      - UVICORN_WORKERS=2
+      # One worker avoids loading multiple CPU model copies inside the 4 GiB
+      # container limit. Kokoro's async API still accepts concurrent requests.
+      - UVICORN_WORKERS=${TTS_WORKERS:-1}
+    # Kokoro, PyTorch, and the espeak phonemizer use /tmp during model warmup
+    # and synthesis. Keep those files off Docker.raw and bound their growth.
+    tmpfs:
+      # exec is required because phonemizer loads a private libespeak-ng.so
+      # copy from /tmp for each isolated espeak wrapper.
+      - /tmp:exec,size=${TTS_TMPFS_SIZE:-512m},mode=1777
     ports:
       - "${BIND_ADDRESS:-127.0.0.1}:${TTS_PORT:-8880}:8880"
     deploy:

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -371,6 +371,12 @@ grep -A16 -F 'location ~ ^/api/models/.+/load$ {' "$dashboard_nginx" | grep -qF 
 echo "[contract] bundled service CPU limits are env-driven"
 grep -qF "cpus: '\${TTS_CPU_LIMIT:-1.0}'" extensions/services/tts/compose.yaml \
   || { echo "[FAIL] Kokoro TTS CPU limit must be env-driven with safe fallback"; exit 1; }
+grep -qF 'ghcr.io/remsky/kokoro-fastapi-cpu:v0.8.0' extensions/services/tts/compose.yaml \
+  || { echo "[FAIL] Kokoro TTS must use the memory-leak-fixed v0.8.0 image"; exit 1; }
+grep -qF 'UVICORN_WORKERS=${TTS_WORKERS:-1}' extensions/services/tts/compose.yaml \
+  || { echo "[FAIL] Kokoro TTS must default to one memory-safe worker"; exit 1; }
+grep -qF '/tmp:exec,size=${TTS_TMPFS_SIZE:-512m},mode=1777' extensions/services/tts/compose.yaml \
+  || { echo "[FAIL] Kokoro TTS must bound transient /tmp growth with tmpfs"; exit 1; }
 grep -qF "cpus: '\${WHISPER_CPU_LIMIT:-1.0}'" extensions/services/whisper/compose.yaml \
   || { echo "[FAIL] Whisper CPU limit must be env-driven with safe fallback"; exit 1; }
 grep -qF "cpus: '\${WHISPER_CPU_LIMIT:-1.0}'" extensions/services/whisper/compose.nvidia.yaml \


### PR DESCRIPTION
## Summary
- upgrade Kokoro FastAPI CPU from v0.2.4 to v0.8.0, which includes the upstream voice-tensor memory-leak fix
- default to one Uvicorn worker under the existing 4 GiB limit
- mount `/tmp` as a bounded 512 MiB tmpfs so transient Kokoro/PyTorch/espeak files cannot grow Docker.raw indefinitely
- retain `exec` on `/tmp` because phonemizer loads its private `libespeak-ng.so` copy there
- document the operational controls and correct the voices endpoint

## Runtime evidence
Observed on Apple Silicon with the existing v0.2.4 service:
- 3,941 `Child process died` events and 3,617 pipeline recreations
- 75,134 stale `/tmp/tmp*` entries consumed 27.20 GiB in the container writable layer

Validated the patched v0.8.0 service:
- container healthy with one worker, 4 GiB memory limit, and `/tmp` mounted as `exec,size=512m,mode=1777`
- real WAV synthesis passed (`24 kHz`, mono PCM)
- 20 concurrent synthesis requests: 20 successes, 0 failures
- `/tmp` remained effectively flat (2,892 KiB to 2,908 KiB by `du`)
- restart count remained 0; no OOM or unhealthy state

## Tests
- `docker compose ... config --quiet`
- focused YAML contract assertions passed
- `bash -n ods/tests/contracts/test-installer-contracts.sh`
- full installer contract suite reached and passed the new TTS assertions, then failed later in the pre-existing bootstrap hot-swap test with `sed: -e: No such file or directory` / `Hermes live patch helper rejected metacharacters` on macOS.