### PR TITLE
fix(installer): route RDNA1 and 6GB AMD GPUs to Vulkan and a fitting model

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -493,6 +493,16 @@
       "type": "string",
       "description": "Optional AMD Lemonade container image override. AMD Linux installs default to the image pinned in config/backends/amd.json."
     },
+    "LEMONADE_RUNTIME_IMAGE": {
+      "type": "string",
+      "description": "Image compose uses for llama-server on AMD. ROCm/Strix Halo builds ods-lemonade-server:latest; RDNA1/2 Vulkan installs point at the upstream Lemonade image so the HIP compile is skipped."
+    },
+    "LEMONADE_LLAMACPP_BACKEND": {
+      "type": "string",
+      "description": "Lemonade --llamacpp backend for the Linux container. auto plus LEMONADE_LLAMACPP_ROCM_BIN is the ROCm path; vulkan is required for gfx10 (RX 5600 XT / RDNA1-2). Lemonade accepts only auto|vulkan|cpu.",
+      "enum": ["auto", "vulkan", "cpu"],
+      "default": "auto"
+    },
     "WHISPER_IMAGE": {
       "type": "string",
       "description": "Optional speaches/whisper image override. Windows installers may set this to the CPU image when the NVIDIA driver is too old for the CUDA tag."
@@ -889,7 +899,7 @@
     },
     "AMDGPU_TARGET": {
       "type": "string",
-      "description": "AMD gfx target used as a Docker build arg for the custom llama.cpp ROCm image (e.g. gfx1151, gfx942, gfx90a, gfx1100). Phase 06 auto-detects this from GPU_TOPOLOGY_JSON; override only if the detection is wrong."
+      "description": "AMD gfx target used as a Docker build arg for the custom llama.cpp ROCm image (e.g. gfx1151, gfx942, gfx90a, gfx1100, gfx1010). Phase 06 auto-detects this from GPU_TOPOLOGY_JSON. RDNA1/2 (gfx10*) use Vulkan and do not build this image."
     },
     "LLAMA_CPP_REF": {
       "type": "string",

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -51,6 +51,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
+	@bash tests/test-rx5600xt-compat.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh
 	@bash tests/contracts/test-windows-strix-tier-map.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh

--- a/ods/config/gpu-database.json
+++ b/ods/config/gpu-database.json
@@ -188,6 +188,86 @@
       }
     },
     {
+      "id": "rx_5700_xt",
+      "match": {
+        "device_ids": ["0x731f"],
+        "name_patterns": ["RX 5700 XT", "Navi 10 XT"]
+      },
+      "specs": {
+        "label": "AMD Radeon RX 5700 XT",
+        "vendor": "amd",
+        "architecture": "rdna-1",
+        "memory_type": "discrete",
+        "memory_mb": 8192,
+        "memory_source": "vram",
+        "bandwidth_gbps": 448
+      },
+      "recommended": {
+        "backend": "amd",
+        "tier": "T1"
+      }
+    },
+    {
+      "id": "rx_5700",
+      "match": {
+        "device_ids": ["0x731f"],
+        "name_patterns": ["RX 5700"]
+      },
+      "specs": {
+        "label": "AMD Radeon RX 5700",
+        "vendor": "amd",
+        "architecture": "rdna-1",
+        "memory_type": "discrete",
+        "memory_mb": 8192,
+        "memory_source": "vram",
+        "bandwidth_gbps": 384
+      },
+      "recommended": {
+        "backend": "amd",
+        "tier": "T1"
+      }
+    },
+    {
+      "id": "rx_5600_xt",
+      "match": {
+        "device_ids": ["0x731f"],
+        "name_patterns": ["RX 5600 XT"]
+      },
+      "specs": {
+        "label": "AMD Radeon RX 5600 XT",
+        "vendor": "amd",
+        "architecture": "rdna-1",
+        "memory_type": "discrete",
+        "memory_mb": 6144,
+        "memory_source": "vram",
+        "bandwidth_gbps": 336
+      },
+      "recommended": {
+        "backend": "amd",
+        "tier": "T1"
+      }
+    },
+    {
+      "id": "rx_5600",
+      "match": {
+        "device_ids": ["0x731f"],
+        "name_patterns": ["RX 5600"]
+      },
+      "specs": {
+        "label": "AMD Radeon RX 5600",
+        "vendor": "amd",
+        "architecture": "rdna-1",
+        "memory_type": "discrete",
+        "memory_mb": 6144,
+        "memory_source": "vram",
+        "bandwidth_gbps": 288
+      },
+      "recommended": {
+        "backend": "amd",
+        "tier": "T1"
+      }
+    },
+    {
       "id": "rx_9070_xt",
       "match": {
         "device_ids": [],
@@ -353,6 +433,10 @@
       "RX 7800 XT": 624,
       "RX 7700 XT": 432,
       "RX 7600": 288,
+      "RX 5700 XT": 448,
+      "RX 5700": 384,
+      "RX 5600 XT": 336,
+      "RX 5600": 288,
       "RX 6950 XT": 576,
       "RX 6900 XT": 512,
       "RX 6800 XT": 512,

--- a/ods/docker-compose.amd.yml
+++ b/ods/docker-compose.amd.yml
@@ -5,7 +5,9 @@
 
 services:
   llama-server:
-    # Custom llama.cpp ROCm build + Lemonade server
+    # Custom llama.cpp ROCm build + Lemonade server on RDNA3+/CDNA.
+    # RDNA1/2 (gfx10*, RX 5600 XT) set LEMONADE_RUNTIME_IMAGE to the upstream
+    # Lemonade tag and LEMONADE_LLAMACPP_BACKEND=vulkan, skipping this HIP build.
     # Service name stays "llama-server" for compose dependency compatibility
     build:
       context: ./extensions/services/llama-server
@@ -14,7 +16,7 @@ services:
         AMDGPU_TARGET: ${AMDGPU_TARGET:-gfx1151}
         LLAMA_CPP_REF: ${LLAMA_CPP_REF:-b8763}
         LEMONADE_SERVER_IMAGE: ${LEMONADE_SERVER_IMAGE:-ghcr.io/lemonade-sdk/lemonade-server:v10.2.0}
-    image: ods-lemonade-server:latest
+    image: ${LEMONADE_RUNTIME_IMAGE:-ods-lemonade-server:latest}
     # Wrapper entrypoint syncs ctx_size from LEMONADE_CTX_SIZE env into
     # Lemonade's cached config.json before launch. Without this, Lemonade
     # only reads the env on first-start and ignores subsequent bumps —
@@ -30,7 +32,7 @@ services:
       - "0.0.0.0"
       - --no-tray
       - --llamacpp
-      - auto
+      - ${LEMONADE_LLAMACPP_BACKEND:-auto}
       - --llamacpp-args
       - "--metrics --host 0.0.0.0 -fa on -b 2048 -ub 256"
       - --extra-models-dir
@@ -65,7 +67,7 @@ services:
       # longer a valid value. Setting auto + LEMONADE_LLAMACPP_ROCM_BIN points
       # Lemonade at the custom ROCm-built llama-server binary while keeping the
       # field schema-valid.
-      - LEMONADE_LLAMACPP_BACKEND=auto
+      - LEMONADE_LLAMACPP_BACKEND=${LEMONADE_LLAMACPP_BACKEND:-auto}
       # Custom binary at /opt/llama-custom is gfx1151-only (Strix Halo patches +
       # AMDGPU_TARGET=gfx1151 at build time). Phase 06 sets this env var only
       # when the detected gfx target is gfx1151; on any other AMD architecture

--- a/ods/installers/lib/amd-topo.sh
+++ b/ods/installers/lib/amd-topo.sh
@@ -9,7 +9,8 @@
 #
 # Expects: jq, warn(), log()
 # Provides: detect_amd_topo(), amd_gpu_id(), amd_gfx_version(),
-#           amd_render_node()
+#           amd_render_node(), amd_gfx_fallback(),
+#           amd_lemonade_inference_backend()
 #
 # Modder notes:
 #   Detection fallback chain:
@@ -145,6 +146,46 @@ amd_gfx_version() {
     fi
 
     echo "unknown"
+}
+
+# When topology did not report a gfx target: Strix Halo (unified) still needs
+# the gfx1151 default so the custom ROCm binary path keeps working. Discrete
+# cards must not inherit that default — gfx1151 kernels ISA-fault on Navi 10.
+amd_gfx_fallback() {
+    local gfx="${1:-unknown}"
+    local memory_type="${2:-discrete}"
+    case "$gfx" in
+        ""|null|unknown)
+            if [[ "$memory_type" == "unified" ]]; then
+                echo "gfx1151"
+            else
+                echo "unknown"
+            fi
+            ;;
+        *) echo "$gfx" ;;
+    esac
+}
+
+# Lemonade on Linux: ROCm 7.x supports RDNA3+ / CDNA. RDNA1/2 (gfx10*) need
+# Vulkan. Unknown discrete also uses Vulkan so a missed probe cannot point a
+# 6GB Navi card at the Strix Halo HIP binary.
+# Prints: rocm | vulkan
+amd_lemonade_inference_backend() {
+    local gfx="${1:-unknown}"
+    local memory_type="${2:-discrete}"
+    gfx="$(printf '%s' "$gfx" | tr '[:upper:]' '[:lower:]')"
+    case "$gfx" in
+        gfx10*) echo "vulkan" ;;
+        gfx110*|gfx115*|gfx12*|gfx90*|gfx94*) echo "rocm" ;;
+        unknown|"")
+            if [[ "$memory_type" == "unified" ]]; then
+                echo "rocm"
+            else
+                echo "vulkan"
+            fi
+            ;;
+        *) echo "vulkan" ;;
+    esac
 }
 
 # Get render node for an AMD GPU card by matching PCI device paths

--- a/ods/installers/lib/tier-map.sh
+++ b/ods/installers/lib/tier-map.sh
@@ -162,6 +162,16 @@ set_qwen_tier_config() {
             GGUF_SHA256="03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
             MAX_CONTEXT=16384
             LLM_MODEL_SIZE_MB=5760    # Qwen3.5-9B-Q4_K_M (5.68 GB)
+            # 6GB cards (RX 5600 XT, Arc A380-class) cannot hold 9B Q4 plus KV.
+            # Reuse the Arc Lite 4B assignment when VRAM is known and under 8GB.
+            if [[ "${GPU_VRAM:-0}" -gt 0 && "${GPU_VRAM:-0}" -lt 8192 ]]; then
+                TIER_NAME="Entry Level (6GB)"
+                LLM_MODEL="qwen3.5-4b"
+                GGUF_FILE="Qwen3.5-4B-Q4_K_M.gguf"
+                GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf"
+                GGUF_SHA256="00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4"
+                LLM_MODEL_SIZE_MB=2870    # Qwen3.5-4B-Q4_K_M (2.74 GB)
+            fi
             ;;
         2)
             TIER_NAME="Prosumer"
@@ -374,7 +384,13 @@ tier_to_model() {
                 ARC)            model="qwen3.5-9b" ;;
                 ARC_LITE)       model="qwen3.5-4b" ;;
                 0|T0)           model="qwen3.5-2b" ;;
-                1|T1)           model="qwen3.5-9b" ;;
+                1|T1)
+                    if [[ "${GPU_VRAM:-0}" -gt 0 && "${GPU_VRAM:-0}" -lt 8192 ]]; then
+                        model="qwen3.5-4b"
+                    else
+                        model="qwen3.5-9b"
+                    fi
+                    ;;
                 2|T2)           model="qwen3.5-9b" ;;
                 3|T3)           model="qwen3-30b-a3b" ;;
                 4|T4)           model="qwen3-30b-a3b" ;;

--- a/ods/installers/phases/02-detection.sh
+++ b/ods/installers/phases/02-detection.sh
@@ -390,22 +390,26 @@ if [[ $GPU_COUNT -gt 1 && "$GPU_BACKEND" == "nvidia" ]]; then
 fi
 
 # -----------------------------------------------------------------------------
-# AMD Multi-GPU Topology Detection
+# AMD Topology Detection (single GPU included — gfx target drives Vulkan vs ROCm)
 # -----------------------------------------------------------------------------
-if [[ $GPU_COUNT -gt 1 && "$GPU_BACKEND" == "amd" ]]; then
-    ai "Detecting AMD multi-GPU topology..."
+if [[ $GPU_COUNT -ge 1 && "$GPU_BACKEND" == "amd" ]]; then
+    if [[ $GPU_COUNT -gt 1 ]]; then
+        ai "Detecting AMD multi-GPU topology..."
+    else
+        log "Detecting AMD GPU gfx target..."
+    fi
     if [[ -f "$SCRIPT_DIR/installers/lib/amd-topo.sh" ]]; then
         source "$SCRIPT_DIR/installers/lib/amd-topo.sh"
 
         GPU_TOPOLOGY_JSON=$(detect_amd_topo 2>>"$LOG_FILE") || {
-            warn "AMD multi-GPU topology detection failed — using fallback"
-            ai_warn "Could not detect AMD GPU topology. Using default PCIe configuration."
+            warn "AMD topology detection failed — using fallback"
+            ai_warn "Could not detect AMD GPU topology. Using conservative backend defaults."
             GPU_TOPOLOGY_JSON="{}"
         }
 
         if [[ -n "$GPU_TOPOLOGY_JSON" && "$GPU_TOPOLOGY_JSON" != "{}" ]]; then
             GPU_TOTAL_VRAM=$(echo "$GPU_TOPOLOGY_JSON" | jq -r '[.gpus[].memory_gb] | add * 1024 | floor')
-            log "AMD multi-GPU topology: Total VRAM=${GPU_TOTAL_VRAM}MB"
+            log "AMD topology: GPUs=$GPU_COUNT, Total VRAM=${GPU_TOTAL_VRAM}MB, gfx=$(echo "$GPU_TOPOLOGY_JSON" | jq -r '[.gpus[]?.gfx_version] | unique | join(",")')"
         else
             log "AMD topology detection returned empty, using basic GPU info"
             GPU_TOTAL_VRAM=$GPU_VRAM

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -755,6 +755,43 @@ raise SystemExit(1)' 2>/dev/null && return 0
         GPU_ASSIGNMENT_JSON_B64=""
     fi
 
+    # AMD gfx / Lemonade backend: Vulkan for RDNA1/2 (gfx10*, RX 5600 XT),
+    # ROCm for RDNA3+ / CDNA. Compute before .env write so inference metadata
+    # and the gfx block stay in lockstep.
+    _amd_gfx_detected=""
+    _amd_inference_backend=""
+    _amd_lemonade_llamacpp=""
+    _amd_hsa_override=""
+    _amd_custom_bin=""
+    _amd_runtime_image=""
+    if [[ "$GPU_BACKEND" == "amd" ]]; then
+        if ! declare -F amd_lemonade_inference_backend >/dev/null 2>&1; then
+            # shellcheck source=/dev/null
+            source "$SCRIPT_DIR/installers/lib/amd-topo.sh"
+        fi
+        _amd_gfx_detected=$(echo "${GPU_TOPOLOGY_JSON:-{\}}" | jq -r '[.gpus[]?.gfx_version] | unique | .[0] // "unknown"' 2>/dev/null || echo "unknown")
+        _amd_gfx_detected="$(amd_gfx_fallback "$_amd_gfx_detected" "${GPU_MEMORY_TYPE:-discrete}")"
+        _amd_inference_backend="$(amd_lemonade_inference_backend "$_amd_gfx_detected" "${GPU_MEMORY_TYPE:-discrete}")"
+        if [[ "$_amd_inference_backend" == "vulkan" ]]; then
+            _amd_lemonade_llamacpp="vulkan"
+            _amd_runtime_image="${LEMONADE_SERVER_IMAGE:-${BACKEND_LEMONADE_CONTAINER_IMAGE:-ghcr.io/lemonade-sdk/lemonade-server:v10.2.0}}"
+            _amd_hsa_override="# HSA_OVERRIDE_GFX_VERSION unset — $_amd_gfx_detected uses Vulkan, not ROCm"
+            _amd_custom_bin="# LEMONADE_LLAMACPP_ROCM_BIN unset — Vulkan path uses Lemonade bundled binary"
+        else
+            _amd_lemonade_llamacpp="auto"
+            _amd_runtime_image="ods-lemonade-server:latest"
+            case "$_amd_gfx_detected" in
+                gfx1151) _amd_hsa_override="HSA_OVERRIDE_GFX_VERSION=11.5.1" ;;
+                *)       _amd_hsa_override="# HSA_OVERRIDE_GFX_VERSION unset — $_amd_gfx_detected is natively supported" ;;
+            esac
+            if [[ "$_amd_gfx_detected" == "gfx1151" ]]; then
+                _amd_custom_bin="LEMONADE_LLAMACPP_ROCM_BIN=/opt/llama-custom/llama-server"
+            else
+                _amd_custom_bin="# LEMONADE_LLAMACPP_ROCM_BIN unset — custom binary is gfx1151-only; Lemonade uses bundled binary on $_amd_gfx_detected"
+            fi
+        fi
+    fi
+
     # Generate .env file
     # Subshell-scope a tighter umask so the file is created 0600 from the start
     # (closes a brief window on systems where $HOME is world-readable, e.g.
@@ -794,10 +831,10 @@ EXTERNAL_LLM_PROVIDER=${EXTERNAL_LLM_PROVIDER_VALUE}
 EXTERNAL_LLM_MODEL=${EXTERNAL_SELECTED_MODEL}
 SKIP_MODEL_DOWNLOAD=${EXTERNAL_LLM_ACTIVE}
 AMD_INFERENCE_RUNTIME=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" || ( "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ) ]]; then echo "lemonade"; else echo ""; fi)
-AMD_INFERENCE_BACKEND=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_BACKEND:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
+AMD_INFERENCE_BACKEND=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_BACKEND:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${_amd_inference_backend:-${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}}"; else echo ""; fi)
 AMD_INFERENCE_LOCATION=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "host"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "container"; else echo ""; fi)
 AMD_INFERENCE_PORT=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_PORT_VALUE}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_API_PORT:-8080}"; else echo ""; fi)
-AMD_INFERENCE_SUPPORTED_BACKENDS=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_SUPPORTED_BACKENDS:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
+AMD_INFERENCE_SUPPORTED_BACKENDS=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_SUPPORTED_BACKENDS:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${_amd_inference_backend:-${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}}"; else echo ""; fi)
 AMD_INFERENCE_RUNTIME_MODE=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "external-lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "linux-container"; else echo ""; fi)
 AMD_INFERENCE_MANAGED=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "false"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "true"; else echo ""; fi)
 LEMONADE_EXTERNAL=${LEMONADE_EXTERNAL_VALUE}
@@ -865,42 +902,15 @@ COMFYUI_CPU_LIMIT=${COMFYUI_CPU_LIMIT}
 COMFYUI_CPU_RESERVATION=${COMFYUI_CPU_RESERVATION}
 
 $(if [[ "$GPU_BACKEND" == "amd" ]]; then
-    # Read gfx target from topology detection. Falls back to gfx1151 (Strix Halo)
-    # if the topology probe failed — preserves prior behavior for the OG target.
-    _amd_gfx_detected=$(echo "${GPU_TOPOLOGY_JSON:-{\}}" | jq -r '[.gpus[]?.gfx_version] | unique | .[0] // "gfx1151"' 2>/dev/null || echo "gfx1151")
-    [[ -z "$_amd_gfx_detected" || "$_amd_gfx_detected" == "null" || "$_amd_gfx_detected" == "unknown" ]] && _amd_gfx_detected="gfx1151"
-
-    # HSA_OVERRIDE_GFX_VERSION is a Strix Halo (gfx1151) workaround — that target
-    # is not in ROCm 7.x's official support list, so we coerce HSA to load
-    # gfx1151 kernels by reporting "11.5.1". For natively-supported parts
-    # (gfx942 / MI300X, gfx90a / MI250, gfx1100 / RX 7900, etc.) we MUST NOT set
-    # this — doing so reports the wrong ISA and triggers
-    # HSA_STATUS_ERROR_INVALID_ISA at model-load.
-    case "$_amd_gfx_detected" in
-        gfx1151) _amd_hsa_override="HSA_OVERRIDE_GFX_VERSION=11.5.1" ;;
-        *)       _amd_hsa_override="# HSA_OVERRIDE_GFX_VERSION unset — $_amd_gfx_detected is natively supported" ;;
-    esac
-
-    # The custom llama-server binary at /opt/llama-custom is built with Strix
-    # Halo-specific patches (MMQ tile size reduced from 64 to 48 for gfx1151's
-    # register file). Pointing Lemonade at it from any other architecture either
-    # ISA-faults (kernels compiled for gfx1151) or runs a perf-regressed binary.
-    # Only opt-in when the host is actually Strix Halo; otherwise leave unset so
-    # docker-compose.amd.yml's empty default lets Lemonade use its bundled
-    # ROCm-aware binary.
-    if [[ "$_amd_gfx_detected" == "gfx1151" ]]; then
-        _amd_custom_bin="LEMONADE_LLAMACPP_ROCM_BIN=/opt/llama-custom/llama-server"
-    else
-        _amd_custom_bin="# LEMONADE_LLAMACPP_ROCM_BIN unset — custom binary is gfx1151-only; Lemonade uses bundled binary on $_amd_gfx_detected"
-    fi
-
     cat << AMD_ENV
 #=== GPU Group IDs (for container device access) ===
 VIDEO_GID=$(getent group video 2>/dev/null | cut -d: -f3 || echo 44)
 RENDER_GID=$(getent group render 2>/dev/null | cut -d: -f3 || echo 992)
 
-#=== AMD ROCm Settings (gfx target detected from topology) ===
+#=== AMD GPU Settings (gfx target detected from topology) ===
 LEMONADE_SERVER_IMAGE=${LEMONADE_SERVER_IMAGE:-${BACKEND_LEMONADE_CONTAINER_IMAGE:-ghcr.io/lemonade-sdk/lemonade-server:v10.2.0}}
+LEMONADE_RUNTIME_IMAGE=${_amd_runtime_image}
+LEMONADE_LLAMACPP_BACKEND=${_amd_lemonade_llamacpp}
 ${_amd_hsa_override}
 HSA_XNACK=1
 ROCBLAS_USE_HIPBLASLT=1
@@ -911,7 +921,7 @@ ${_amd_custom_bin}
 #=== LiteLLM → Lemonade outbound key (AMD only) ===
 LITELLM_LEMONADE_API_KEY=${LITELLM_LEMONADE_API_KEY}
 AMD_ENV
-    unset _amd_gfx_detected _amd_hsa_override _amd_custom_bin
+    unset _amd_gfx_detected _amd_hsa_override _amd_custom_bin _amd_inference_backend _amd_lemonade_llamacpp _amd_runtime_image
 fi)
 $(if [[ "$GPU_BACKEND" == "sycl" ]]; then cat << INTEL_ENV
 #=== GPU Group IDs (for container device access) ===
@@ -1050,6 +1060,10 @@ fi)
 
 ENV_EOF
     )
+
+    if [[ -n "${_amd_inference_backend:-}" ]]; then
+        export AMD_INFERENCE_BACKEND="$_amd_inference_backend"
+    fi
 
     chmod 600 "$INSTALL_DIR/.env"  # Secure secrets file
     ai_ok "Created $INSTALL_DIR"

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -1162,7 +1162,7 @@ MODELS_INI_EOF
     # installer refuses to launch any potentially stale image.
     _candidate_build_services=(dashboard dashboard-api model-router remote-provider-egress remote-provider-ssh-tunnel ape token-spy privacy-shield brave-search)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _candidate_build_services+=(comfyui)
-    [[ "$GPU_BACKEND" == "amd" ]] && _candidate_build_services+=(llama-server)
+    [[ "$GPU_BACKEND" == "amd" && "${AMD_INFERENCE_BACKEND:-rocm}" != "vulkan" ]] && _candidate_build_services+=(llama-server)
     if ! _enabled_compose_services="$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --services 2>>"$LOG_FILE")"; then
         ai_bad "Could not resolve compose services before local image builds."
         ai "Inspect compose config with: $(_phase11_compose_command_text) config --services"

--- a/ods/installers/windows/lib/tier-map.ps1
+++ b/ods/installers/windows/lib/tier-map.ps1
@@ -94,7 +94,10 @@ function Resolve-EffectiveModelProfile {
 }
 
 function Resolve-QwenTierConfig {
-    param([string]$Tier)
+    param(
+        [string]$Tier,
+        [int]$VramMB = 0
+    )
 
     switch ($Tier) {
         "CLOUD" {
@@ -172,6 +175,22 @@ function Resolve-QwenTierConfig {
             }
         }
         "1" {
+            $useLite = $VramMB -gt 0 -and $VramMB -lt 8192
+            if ($useLite) {
+                return @{
+                    TierName   = "Entry Level (6GB)"
+                    LlmModel   = "qwen3.5-4b"
+                    GgufFile   = "Qwen3.5-4B-Q4_K_M.gguf"
+                    GgufUrl    = "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf"
+                    GgufSha256 = "00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4"
+                    MaxContext = 16384
+                    ModelSizeMB = 2870
+                    ModelProfileRequested = "qwen"
+                    ModelProfileEffective = "qwen"
+                    LlamaServerImage = ""
+                    LlamaCppReleaseTag = ""
+                }
+            }
             return @{
                 TierName   = "Entry Level"
                 LlmModel   = "qwen3.5-9b"
@@ -380,7 +399,8 @@ function Resolve-GemmaTierConfig {
 function Resolve-TierConfig {
     param(
         [string]$Tier,
-        [string]$ModelProfile = $env:MODEL_PROFILE
+        [string]$ModelProfile = $env:MODEL_PROFILE,
+        [int]$VramMB = 0
     )
 
     $requestedProfile = Normalize-ModelProfile -ModelProfile $ModelProfile
@@ -388,7 +408,7 @@ function Resolve-TierConfig {
 
     switch ($effectiveProfile) {
         "gemma4" { return Resolve-GemmaTierConfig -Tier $Tier -RequestedProfile $requestedProfile }
-        default { return Resolve-QwenTierConfig -Tier $Tier }
+        default { return Resolve-QwenTierConfig -Tier $Tier -VramMB $VramMB }
     }
 }
 

--- a/ods/installers/windows/lib/ui.ps1
+++ b/ods/installers/windows/lib/ui.ps1
@@ -205,8 +205,18 @@ function Invoke-ODSHuggingFaceDownloadFallback {
 
     Write-AI "Retrying with Hugging Face client..."
     $downloadArgs = @($python.PrefixArgs) + @($helper, $Url, $Destination)
-    & $python.FilePath @downloadArgs
-    if ($LASTEXITCODE -eq 0 -and (Test-Path $Destination) -and ((Get-Item $Destination).Length -gt 0)) {
+    $prevEAP = $ErrorActionPreference
+    $hfExit = 1
+    try {
+        # huggingface_hub prints progress and warnings on stderr; PS 5.1
+        # promotes that to a terminating NativeCommandError under Stop.
+        $ErrorActionPreference = "Continue"
+        & $python.FilePath @downloadArgs
+        $hfExit = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+    if ($hfExit -eq 0 -and (Test-Path $Destination) -and ((Get-Item $Destination).Length -gt 0)) {
         return $true
     }
     return $false
@@ -235,8 +245,17 @@ function Show-ProgressDownload {
     )
     $curlArgs += Get-ODSCurlDownloadHttpArgs
     $curlArgs += @("-o", $partFile, $Url)
-    & curl.exe @curlArgs
-    $curlExit = $LASTEXITCODE
+    # Windows PowerShell 5.1 promotes native stderr (curl's progress bar) to
+    # NativeCommandError when ErrorActionPreference is Stop.
+    $prevEAP = $ErrorActionPreference
+    $curlExit = 1
+    try {
+        $ErrorActionPreference = "Continue"
+        & curl.exe @curlArgs
+        $curlExit = $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
     if ($curlExit -eq 0 -and (Test-Path $partFile)) {
         Move-Item -Path $partFile -Destination $Destination -Force
         Write-AISuccess "$Label complete"

--- a/ods/installers/windows/phases/02-detection.ps1
+++ b/ods/installers/windows/phases/02-detection.ps1
@@ -111,7 +111,7 @@ if (-not $env:MODEL_PROFILE) {
     }
 }
 
-$tierConfig = Resolve-TierConfig -Tier $selectedTier
+$tierConfig = Resolve-TierConfig -Tier $selectedTier -VramMB ([int]$gpuInfo.VramMB)
 $tierConfig = Resolve-CatalogModelRecommendation `
     -TierConfig $tierConfig `
     -Tier $selectedTier `

--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -246,7 +246,15 @@ if (-not $_npmCmd -or -not $_nodeCmd) {
 }
 
 if ($_npmCmd) {
-    $_npmVer = & npm --version 2>$null
+    $prevEAP = $ErrorActionPreference
+    try {
+        # npm prints config warnings on stderr; PS 5.1 treats that as a
+        # terminating NativeCommandError when ErrorActionPreference is Stop.
+        $ErrorActionPreference = "SilentlyContinue"
+        $_npmVer = (& npm --version 2>$null | Select-Object -First 1)
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
     Write-AISuccess "Node.js / npm $_npmVer available"
 
     # Install Claude Code (Anthropic's terminal agent)

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -35,10 +35,20 @@ python3 tests/test-install-footprint-contract.py
 bash tests/contracts/test-install-footprint-macos.sh
 
 echo "[contract] AMD phase-06 env keys exist in schema"
-for key in HSA_XNACK AMDGPU_TARGET LLAMA_CPP_REF; do
+for key in HSA_XNACK AMDGPU_TARGET LLAMA_CPP_REF LEMONADE_LLAMACPP_BACKEND LEMONADE_RUNTIME_IMAGE; do
   jq -e --arg key "$key" '.properties[$key]' .env.schema.json >/dev/null \
     || { echo "[FAIL] .env.schema.json missing AMD installer key: $key"; exit 1; }
 done
+
+echo "[contract] RDNA1/2 Vulkan path is wired"
+grep -q 'GPU_COUNT -ge 1 && "$GPU_BACKEND" == "amd"' installers/phases/02-detection.sh \
+  || { echo "[FAIL] AMD topology must run for single-GPU gfx detection"; exit 1; }
+grep -q 'amd_lemonade_inference_backend' installers/phases/06-directories.sh \
+  || { echo "[FAIL] phase 06 must select Lemonade backend from gfx"; exit 1; }
+grep -q 'LEMONADE_LLAMACPP_BACKEND=\${LEMONADE_LLAMACPP_BACKEND:-auto}' docker-compose.amd.yml \
+  || { echo "[FAIL] docker-compose.amd.yml must honor LEMONADE_LLAMACPP_BACKEND"; exit 1; }
+grep -q 'AMD_INFERENCE_BACKEND:-rocm}" != "vulkan"' installers/phases/11-services.sh \
+  || { echo "[FAIL] phase 11 must skip HIP llama-server build on Vulkan AMD"; exit 1; }
 
 echo "[contract] canonical port contract parity"
 test -x tests/contracts/test-port-contracts.sh || { echo "[FAIL] script not executable: tests/contracts/test-port-contracts.sh"; exit 1; }
@@ -720,6 +730,25 @@ _classify_bw()   { _classify "$@" | jq -r '.bandwidth_gbps'; }
   || { echo "[FAIL] 0x7480 empty name + 16GB → 7800 XT"; exit 1; }
 [[ "$(_classify_id 0x7480 "" amd 12288)" == "rx_7700_xt" ]] \
   || { echo "[FAIL] 0x7480 empty name + 12GB → 7700 XT"; exit 1; }
+
+# --- 0x731f: Navi 10 XL (RX 5600 XT / 5700 XT share the die) ---
+
+[[ "$(_classify_id 0x731f "AMD Radeon RX 5600 XT" amd 6144)" == "rx_5600_xt" ]] \
+  || { echo "[FAIL] 5600 XT with name"; exit 1; }
+[[ "$(_classify_id 0x731f "AMD Radeon RX 5700 XT" amd 8192)" == "rx_5700_xt" ]] \
+  || { echo "[FAIL] 5700 XT with name"; exit 1; }
+[[ "$(_classify_id 0x731f "AMD Radeon RX 5700" amd 8192)" == "rx_5700" ]] \
+  || { echo "[FAIL] 5700 with name must not match 5700 XT"; exit 1; }
+[[ "$(_classify_id 0x731f "AMD Radeon RX 5600" amd 6144)" == "rx_5600" ]] \
+  || { echo "[FAIL] 5600 with name must not match 5600 XT"; exit 1; }
+[[ "$(_classify_tier 0x731f "AMD Radeon RX 5600 XT" amd 6144)" == "T1" ]] \
+  || { echo "[FAIL] 5600 XT tier"; exit 1; }
+[[ "$(_classify_bw 0x731f "AMD Radeon RX 5600 XT" amd 6144)" == "336" ]] \
+  || { echo "[FAIL] 5600 XT bandwidth"; exit 1; }
+[[ "$(_classify_id 0x731f "" amd 6144)" == "rx_5600_xt" ]] \
+  || { echo "[FAIL] empty name + 6GB → 5600 XT"; exit 1; }
+[[ "$(_classify_id 0x731f "" amd 8192)" == "rx_5700_xt" ]] \
+  || { echo "[FAIL] empty name + 8GB → 5700 XT"; exit 1; }
 
 # --- Name-only match (no device_id) ---
 

--- a/ods/tests/test-amd-topo.sh
+++ b/ods/tests/test-amd-topo.sh
@@ -283,6 +283,27 @@ test_gfx_version_mixed() {
     assert_eq "GPU[1] gfx1101" "gfx1101" "$gfx1"
 }
 
+# ── Test: gfx fallback + Lemonade backend selection ────────────────────────
+
+test_amd_lemonade_backend_selection() {
+    echo -e "${BLU}Testing: amd_gfx_fallback and amd_lemonade_inference_backend${NC}"
+
+    source "$TOPO_SCRIPT"
+
+    assert_eq "unknown discrete gfx stays unknown" "unknown" "$(amd_gfx_fallback unknown discrete)"
+    assert_eq "unknown unified gfx falls back to gfx1151" "gfx1151" "$(amd_gfx_fallback unknown unified)"
+    assert_eq "empty discrete gfx stays unknown" "unknown" "$(amd_gfx_fallback "" discrete)"
+    assert_eq "detected gfx1010 is preserved" "gfx1010" "$(amd_gfx_fallback gfx1010 discrete)"
+
+    assert_eq "gfx1010 → vulkan" "vulkan" "$(amd_lemonade_inference_backend gfx1010 discrete)"
+    assert_eq "gfx1030 → vulkan" "vulkan" "$(amd_lemonade_inference_backend gfx1030 discrete)"
+    assert_eq "gfx1100 → rocm" "rocm" "$(amd_lemonade_inference_backend gfx1100 discrete)"
+    assert_eq "gfx1151 → rocm" "rocm" "$(amd_lemonade_inference_backend gfx1151 unified)"
+    assert_eq "gfx942 → rocm" "rocm" "$(amd_lemonade_inference_backend gfx942 discrete)"
+    assert_eq "unknown discrete → vulkan" "vulkan" "$(amd_lemonade_inference_backend unknown discrete)"
+    assert_eq "unknown unified → rocm" "rocm" "$(amd_lemonade_inference_backend unknown unified)"
+}
+
 # ── Main test runner ───────────────────────────────────────────────────────
 
 echo -e "${MAG}=== AMD Topology Detection Tests ===${NC}\n"
@@ -302,6 +323,8 @@ echo
 test_gfx_version_parsing
 echo
 test_gfx_version_mixed
+echo
+test_amd_lemonade_backend_selection
 
 echo -e "\n${MAG}=== Test Summary ===${NC}"
 echo -e "Tests run:    $TESTS_RUN"

--- a/ods/tests/test-rx5600xt-compat.sh
+++ b/ods/tests/test-rx5600xt-compat.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# RX 5600 XT / Navi 10 compatibility checks (classify + Vulkan backend).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+PASS=0
+FAIL=0
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+json_field() {
+    local py="python3"
+    command -v python3 >/dev/null 2>&1 || py="python"
+    "$py" -c "import json,sys; d=json.load(sys.stdin); print($1)"
+}
+
+_classify() {
+    bash scripts/classify-hardware.sh --device-id "$1" --gpu-name "$2" --gpu-vendor "${3:-amd}" --vram-mb "${4:-0}" --memory-type "${5:-discrete}"
+}
+
+echo "=== RX 5600 XT classify-hardware ==="
+assert_eq "5600 XT name" "rx_5600_xt" "$(_classify 0x731f "AMD Radeon RX 5600 XT" amd 6144 | json_field 'd["id"]')"
+assert_eq "5700 XT name" "rx_5700_xt" "$(_classify 0x731f "AMD Radeon RX 5700 XT" amd 8192 | json_field 'd["id"]')"
+assert_eq "5700 name" "rx_5700" "$(_classify 0x731f "AMD Radeon RX 5700" amd 8192 | json_field 'd["id"]')"
+assert_eq "5600 name" "rx_5600" "$(_classify 0x731f "AMD Radeon RX 5600" amd 6144 | json_field 'd["id"]')"
+assert_eq "5600 XT tier" "T1" "$(_classify 0x731f "AMD Radeon RX 5600 XT" amd 6144 | json_field 'd["recommended"]["tier"]')"
+assert_eq "5600 XT bandwidth" "336" "$(_classify 0x731f "AMD Radeon RX 5600 XT" amd 6144 | json_field 'd["bandwidth_gbps"]')"
+assert_eq "empty 6GB" "rx_5600_xt" "$(_classify 0x731f "" amd 6144 | json_field 'd["id"]')"
+assert_eq "empty 8GB" "rx_5700_xt" "$(_classify 0x731f "" amd 8192 | json_field 'd["id"]')"
+
+echo "=== gfx / Lemonade backend ==="
+# shellcheck source=/dev/null
+source installers/lib/amd-topo.sh
+assert_eq "unknown discrete gfx" "unknown" "$(amd_gfx_fallback unknown discrete)"
+assert_eq "unknown unified gfx" "gfx1151" "$(amd_gfx_fallback unknown unified)"
+assert_eq "gfx1010 preserved" "gfx1010" "$(amd_gfx_fallback gfx1010 discrete)"
+assert_eq "gfx1010 vulkan" "vulkan" "$(amd_lemonade_inference_backend gfx1010 discrete)"
+assert_eq "gfx1030 vulkan" "vulkan" "$(amd_lemonade_inference_backend gfx1030 discrete)"
+assert_eq "gfx1100 rocm" "rocm" "$(amd_lemonade_inference_backend gfx1100 discrete)"
+assert_eq "gfx1151 rocm" "rocm" "$(amd_lemonade_inference_backend gfx1151 unified)"
+assert_eq "unknown discrete vulkan" "vulkan" "$(amd_lemonade_inference_backend unknown discrete)"
+assert_eq "unknown unified rocm" "rocm" "$(amd_lemonade_inference_backend unknown unified)"
+
+echo "=== wiring ==="
+grep -q 'GPU_COUNT -ge 1 && "$GPU_BACKEND" == "amd"' installers/phases/02-detection.sh \
+    && { echo "  PASS: single-GPU AMD topology"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL: single-GPU AMD topology"; FAIL=$((FAIL + 1)); }
+grep -q 'amd_lemonade_inference_backend' installers/phases/06-directories.sh \
+    && { echo "  PASS: phase 06 backend select"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL: phase 06 backend select"; FAIL=$((FAIL + 1)); }
+grep -q 'LEMONADE_LLAMACPP_BACKEND=${LEMONADE_LLAMACPP_BACKEND:-auto}' docker-compose.amd.yml \
+    && { echo "  PASS: compose Vulkan env"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL: compose Vulkan env"; FAIL=$((FAIL + 1)); }
+grep -q 'AMD_INFERENCE_BACKEND:-rocm}" != "vulkan"' installers/phases/11-services.sh \
+    && { echo "  PASS: skip HIP build on Vulkan"; PASS=$((PASS + 1)); } \
+    || { echo "  FAIL: skip HIP build on Vulkan"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/ods/tests/test-tier-map.sh
+++ b/ods/tests/test-tier-map.sh
@@ -66,6 +66,16 @@ assert_eq "GGUF_FILE"   "Qwen3.5-9B-Q4_K_M.gguf"             "$GGUF_FILE"
 assert_eq "MAX_CONTEXT"  "16384"                                "$MAX_CONTEXT"
 echo ""
 
+echo "Tier 1 with 6GB VRAM (RX 5600 XT / qwen must not select 9B):"
+GPU_VRAM=6144
+run_tier 1
+assert_eq "TIER_NAME"   "Entry Level (6GB)"                    "$TIER_NAME"
+assert_eq "LLM_MODEL"   "qwen3.5-4b"                           "$LLM_MODEL"
+assert_eq "GGUF_FILE"   "Qwen3.5-4B-Q4_K_M.gguf"              "$GGUF_FILE"
+assert_eq "LLM_MODEL_SIZE_MB" "2870"                           "$LLM_MODEL_SIZE_MB"
+unset GPU_VRAM
+echo ""
+
 # --- Tier 2: Prosumer ---
 echo "Tier 2 (Prosumer):"
 run_tier 2
@@ -438,6 +448,37 @@ assert_eq "SELECTOR_RUNTIME_PROFILE" "" "$MODEL_RUNTIME_PROFILE"
 assert_eq "SELECTOR_N_CPU_MOE" "" "$LLAMA_ARG_N_CPU_MOE"
 assert_eq "SELECTOR_CACHE_V" "" "$LLAMA_ARG_CACHE_TYPE_V"
 assert_eq "SELECTOR_CHECKPOINTS" "" "$LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS"
+echo ""
+
+echo "Catalog selector (6GB AMD qwen stays under the 4B size ceiling, not 9B):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend amd \
+    --memory-type discrete \
+    --vram-mb 6144 \
+    --ram-gb 16 \
+    --profile qwen \
+    --tier 1 \
+    --max-size-mb 2870 \
+    --host-arch amd64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE="" LLM_MODEL_SIZE_MB=""
+load_selector_env "$_selector_env"
+if [[ "$LLM_MODEL" == "qwen3.5-9b" || "$GGUF_FILE" == "Qwen3.5-9B-Q4_K_M.gguf" ]]; then
+    echo "  FAIL: 6GB AMD selected 9B ($LLM_MODEL / $GGUF_FILE)"
+    ((FAIL++))
+else
+    echo "  PASS: SELECTOR_LLM_MODEL is not 9B ($LLM_MODEL)"
+    ((PASS++))
+fi
+if [[ "${LLM_MODEL_SIZE_MB:-0}" -gt 0 && "${LLM_MODEL_SIZE_MB:-0}" -le 2870 ]]; then
+    echo "  PASS: SELECTOR_SIZE_MB=$LLM_MODEL_SIZE_MB <= 2870"
+    ((PASS++))
+else
+    echo "  FAIL: SELECTOR_SIZE_MB=$LLM_MODEL_SIZE_MB exceeded 6GB ceiling"
+    ((FAIL++))
+fi
 echo ""
 
 echo "Catalog selector (8GB NVIDIA gemma uses upstream catalog fit):"


### PR DESCRIPTION
## Summary
- Stop treating unknown discrete AMD GPUs as Strix Halo `gfx1151` / ROCm 7. Navi 10 (RX 5600 XT, `gfx1010`, PCI `0x731f`) is not ROCm 7-capable, so Linux now selects Lemonade **Vulkan** and skips the HIP `llama-server` build.
- Run AMD topology on a **single** GPU (not only 2+), add Navi 10 entries to the GPU database, and for known VRAM under 8 GB pick a 6 GB-safe GGUF (Qwen 4B static / catalog fit such as Phi-4 Mini) instead of Qwen 9B.
- Windows installer: pass VRAM into tier mapping, and stop PowerShell 5.1 from treating curl/npm stderr as a fatal `NativeCommandError` so AMD installs can finish.

## AI Assistance
Cursor Agent drafted the installer/GPU routing changes, contract tests, and this PR text. I reviewed the diff, ran the focused tests, and validated inference on local hardware.

## Release Lane
- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline hardware-reach fix.
```

## Changed Surface
- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation
- Risk level: **High** (installer phases, Windows installer, AMD compose overlay, model selector)
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [x] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
bash tests/test-rx5600xt-compat.sh
  21/21 passed

Live Windows (AMD Radeon RX 5600 XT, ~6128 MB, discrete):
  classify: rx_5600_xt, T1, 336 GB/s
  installer: Tier 1 Entry Level (6GB), catalog pick phi-4-mini
  Lemonade 10.0.0: --llamacpp vulkan, device=gpu
  chat completions: HTTP 200; first load ~90s; follow-up ~216 ms / ~48 tok/s
  Full Windows AMD stack later completed (dashboard :3001, Open WebUI :3000, Lemonade :8080).

Deferred:
  Linux ROCm-vs-Vulkan compose path not exercised on this host (Windows uses native Lemonade).
  Fleet / make gate not run.
```

## Operational Change Check
- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers
- Rollback: revert this PR. Existing installs keep their `.env` until re-run; new AMD gfx10 installs will stop defaulting to ROCm 7 / gfx1151.
- Known pre-existing: Windows PnP can report `HasNpu=True` on this desktop (false positive). Not changed here.
- Windows-only NativeCommandError guards in `ui.ps1` / `07-devtools.ps1` were required to get past OpenCode/npm downloads on PowerShell 5.1 during the live install. They are bundled because that path blocked the hardware validation; happy to split if review prefers.
- Out of scope: Docker image disk vs INSTALL_DIR preflight (follow-up PR); SearXNG not started with `-NoRecommended` while Open WebUI still enables web search.