### PR TITLE
fix(windows): check Docker Desktop disk space, not only INSTALL_DIR

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -53,6 +53,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh
 	@bash tests/contracts/test-windows-strix-tier-map.sh
+	@bash tests/test-windows-docker-disk-preflight.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@bash tests/contracts/test-windows-hermes-config-patching.sh

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -3,7 +3,7 @@
 # ============================================================================
 # Part of: installers/windows/lib/
 # Purpose: GPU detection (NVIDIA via nvidia-smi, AMD via WMI), Docker Desktop
-#          validation, system RAM detection
+#          validation, system RAM detection, and Docker image-disk location.
 #
 # Canonical source: installers/lib/detection.sh (keep tier thresholds in sync)
 #
@@ -596,6 +596,89 @@ function Test-ZipIntegrity {
     }
 }
 
+function Get-WindowsPathDrive {
+    <#
+    .SYNOPSIS
+        Return the drive qualifier (for example 'C:') from a Windows path.
+    #>
+    param([string]$Path)
+
+    if ([string]::IsNullOrWhiteSpace($Path)) { return "" }
+    if ($Path -match '^([A-Za-z]):') {
+        return ($Matches[1].ToUpperInvariant() + ":")
+    }
+    return ""
+}
+
+function Get-WindowsDockerDataPathFromSettings {
+    <#
+    .SYNOPSIS
+        Read Docker Desktop's host data path from a settings JSON object.
+    #>
+    param($Settings)
+
+    if ($null -eq $Settings) { return "" }
+
+    foreach ($name in @(
+        "dataFolder",
+        "DataFolder",
+        "diskPath",
+        "DiskPath",
+        "DiskImageLocation",
+        "CustomWslDir"
+    )) {
+        $value = $Settings.$name
+        if ($value -is [string] -and $value -match '^[A-Za-z]:\\') {
+            return $value
+        }
+    }
+
+    foreach ($prop in $Settings.PSObject.Properties) {
+        if ($prop.Name -notmatch '(?i)disk|dataFolder|DataRoot|vhdx|wslDir') {
+            continue
+        }
+        $value = [string]$prop.Value
+        if ($value -match '^[A-Za-z]:\\') {
+            return $value
+        }
+    }
+    return ""
+}
+
+function Get-WindowsDockerDataPath {
+    <#
+    .SYNOPSIS
+        Resolve Docker Desktop's host data path (VHDX or data folder).
+    .DESCRIPTION
+        Docker images live on this path, which is often C: even when ODS is
+        installed on another drive. Settings JSON is preferred; otherwise the
+        default Docker Desktop WSL VHDX location is used.
+    #>
+    param(
+        [string]$LocalAppData = $env:LOCALAPPDATA,
+        [string]$RoamingAppData = $env:APPDATA
+    )
+
+    foreach ($file in @(
+        (Join-Path $RoamingAppData "Docker\settings.json"),
+        (Join-Path $RoamingAppData "Docker\settings-store.json")
+    )) {
+        if (-not (Test-Path -LiteralPath $file)) { continue }
+        try {
+            $raw = Get-Content -LiteralPath $file -Raw -ErrorAction Stop
+            $settings = $raw | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            # Optional Docker Desktop settings. Unreadable or invalid JSON
+            # must not abort ODS preflight; fall through to the default VHDX.
+            continue
+        }
+        $fromSettings = Get-WindowsDockerDataPathFromSettings -Settings $settings
+        if ($fromSettings) { return $fromSettings }
+    }
+
+    return (Join-Path $LocalAppData "Docker\wsl\disk\docker_data.vhdx")
+}
+
 function Test-DiskSpace {
     <#
     .SYNOPSIS
@@ -637,6 +720,39 @@ function Test-DiskSpace {
         FreeGB     = $freeGB
         RequiredGB = $RequiredGB
         Sufficient = ($freeGB -ge $RequiredGB)
+    }
+}
+
+function Test-WindowsDockerImageDiskSpace {
+    <#
+    .SYNOPSIS
+        Check free space on Docker Desktop's image disk, if it differs from INSTALL_DIR.
+    .DESCRIPTION
+        Models and config are stored under INSTALL_DIR. Compose image pulls go
+        into Docker Desktop's VHDX, which is frequently on C:. Checking only
+        INSTALL_DIR lets a D: install pass preflight and then fail mid-pull.
+        When both paths are on the same drive, this check is a no-op success
+        because Test-DiskSpace on INSTALL_DIR already covered that volume.
+    #>
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallDir,
+        [Parameter(Mandatory = $true)][string]$DockerDataPath,
+        [int]$RequiredGB = 12
+    )
+
+    $installDrive = Get-WindowsPathDrive -Path $InstallDir
+    $dockerDrive = Get-WindowsPathDrive -Path $DockerDataPath
+    $space = Test-DiskSpace -Path $DockerDataPath -RequiredGB $RequiredGB
+    $sameDrive = ($installDrive -ne "" -and $installDrive -eq $dockerDrive)
+
+    return @{
+        DockerDataPath = $DockerDataPath
+        Drive          = $(if ($dockerDrive) { $dockerDrive } else { [string]$space.Drive })
+        InstallDrive   = $installDrive
+        SameAsInstall  = $sameDrive
+        FreeGB         = $space.FreeGB
+        RequiredGB     = $RequiredGB
+        Sufficient     = $(if ($sameDrive) { $true } else { [bool]$space.Sufficient })
     }
 }
 

--- a/ods/installers/windows/phases/01-preflight.ps1
+++ b/ods/installers/windows/phases/01-preflight.ps1
@@ -3,7 +3,8 @@
 # ============================================================================
 # Part of: installers/windows/phases/
 # Purpose: Admin check, PowerShell version, Windows version, Docker Desktop,
-#          initial disk space, Ollama conflict, compose file presence.
+#          install-dir and Docker image-disk space, Ollama conflict, compose
+#          file presence.
 #
 # Reads (set by install-windows.ps1 before dot-sourcing):
 #   $installDir    -- target install path (for disk check)
@@ -80,8 +81,8 @@ if ($sourceRoot -match "^([A-Za-z]):") { $_sourceDrive = $Matches[1].ToUpperInva
 if ($installDir -match "^([A-Za-z]):") { $_installDrive = $Matches[1].ToUpperInvariant() }
 if ($_sourceDrive -and $_installDrive -and $_sourceDrive -ne $_installDrive) {
     Write-AIWarn "Source checkout is on ${_sourceDrive}: but the runtime install target is on ${_installDrive}:."
-    Write-AI "  To install the runtime on another drive, rerun with:"
-    Write-AI "  .\install.ps1 -InstallDir ${_sourceDrive}:\ods"
+    Write-AI "  Models and config will be stored on ${_installDrive}:."
+    Write-AI "  Docker images still use Docker Desktop's data disk (often C:), not ${_installDrive}:."
 }
 
 # ── Docker Desktop ───────────────────────────────────────────────────────────
@@ -272,21 +273,37 @@ if (-not $_shareOk) {
 Write-AISuccess "Docker Desktop file sharing OK"
 
 # ── Initial disk space check ─────────────────────────────────────────────────
-# 20 GB minimum before model size is known (tier-aware check happens in phase 04).
+# 20 GB minimum on INSTALL_DIR before model size is known (tier-aware check
+# happens in phase 04). Compose image pulls do not use this drive when Docker
+# Desktop's VHDX lives elsewhere (typically C:).
 $_disk = Test-DiskSpace -Path $installDir -RequiredGB 20
 Write-InfoBox "Disk free:" "$($_disk.FreeGB) GB on $($_disk.Drive)"
 if (-not $_disk.Sufficient) {
     Write-AIError "At least 20 GB free space is required. Found $($_disk.FreeGB) GB."
     Write-AI "  Install target checked: $installDir"
-    $_installDirHint = "<path-with-enough-space>\ods"
-    if ($sourceRoot -match "^([A-Za-z]):") {
-        $_installDirHint = "$($Matches[1].ToUpperInvariant()):\ods"
-    }
-    Write-AI "  Free up space on $($_disk.Drive), or rerun from the source checkout with:"
-    Write-AI "  .\install.ps1 -InstallDir $_installDirHint"
+    Write-AI "  Free space on $($_disk.Drive), or rerun with -InstallDir on a drive that has at least 20 GB free."
     throw "ODS_INSTALL_ABORTED"
 }
-Write-AISuccess "Disk space OK ($($_disk.FreeGB) GB free)"
+Write-AISuccess "Disk space OK ($($_disk.FreeGB) GB free on $($_disk.Drive))"
+
+$_dockerDataPath = Get-WindowsDockerDataPath
+$_dockerDisk = Test-WindowsDockerImageDiskSpace `
+    -InstallDir $installDir `
+    -DockerDataPath $_dockerDataPath `
+    -RequiredGB 12
+if ($_dockerDisk.SameAsInstall) {
+    Write-AI "Docker images share $($_disk.Drive) with the install target."
+} else {
+    Write-InfoBox "Docker disk:" "$($_dockerDisk.FreeGB) GB free on $($_dockerDisk.Drive) (images)"
+    if (-not $_dockerDisk.Sufficient) {
+        Write-AIError "Docker Desktop stores images on $($_dockerDisk.Drive), not at $installDir."
+        Write-AIError "At least $($_dockerDisk.RequiredGB) GB free is required there. Found $($_dockerDisk.FreeGB) GB."
+        Write-AI "  Docker data: $($_dockerDisk.DockerDataPath)"
+        Write-AI "  Free space on $($_dockerDisk.Drive), prune unused images, or move Docker Desktop's disk image."
+        throw "ODS_INSTALL_ABORTED"
+    }
+    Write-AISuccess "Docker disk OK ($($_dockerDisk.FreeGB) GB free on $($_dockerDisk.Drive))"
+}
 
 # ── Source file existence check ──────────────────────────────────────────────
 # Verify the compose base file is present in the source tree.

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -252,15 +252,22 @@ $_diskCheck = Test-DiskSpace -Path $installDir -RequiredGB $_minDiskGB
 if (-not $_diskCheck.Sufficient) {
     Write-AIWarn "Disk: $($_diskCheck.FreeGB) GB free, ${_minDiskGB} GB required for Tier $selectedTier."
     Write-AI "  Install target checked: $installDir"
-    $_installDirHint = "<path-with-enough-space>\ods"
-    if ($sourceRoot -match "^([A-Za-z]):") {
-        $_installDirHint = "$($Matches[1].ToUpperInvariant()):\ods"
-    }
-    Write-AI "  To use a different drive, rerun from the source checkout with:"
-    Write-AI "  .\install.ps1 -InstallDir $_installDirHint"
+    Write-AI "  Free space on $($_diskCheck.Drive), or rerun with -InstallDir on a drive that has at least ${_minDiskGB} GB free."
     $requirementsMet = $false
 } else {
     Write-AISuccess "Disk: $($_diskCheck.FreeGB) GB free OK (>= ${_minDiskGB} GB for Tier $selectedTier)"
+}
+
+$_dockerDataPath = Get-WindowsDockerDataPath
+$_dockerDisk = Test-WindowsDockerImageDiskSpace `
+    -InstallDir $installDir `
+    -DockerDataPath $_dockerDataPath `
+    -RequiredGB 12
+if (-not $_dockerDisk.SameAsInstall -and -not $_dockerDisk.Sufficient) {
+    Write-AIWarn "Docker disk: $($_dockerDisk.FreeGB) GB free on $($_dockerDisk.Drive), 12 GB required for image pulls."
+    Write-AI "  Docker data: $($_dockerDisk.DockerDataPath)"
+    Write-AI "  Image layers do not use $installDir. Free space on $($_dockerDisk.Drive) or move Docker Desktop's disk image."
+    $requirementsMet = $false
 }
 
 # ── GPU requirement check ─────────────────────────────────────────────────────

--- a/ods/tests/test-windows-docker-disk-preflight.ps1
+++ b/ods/tests/test-windows-docker-disk-preflight.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+. (Join-Path $root "installers\windows\lib\detection.ps1")
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Label)
+    if ($Actual -ne $Expected) {
+        throw "$Label expected '$Expected', got '$Actual'"
+    }
+}
+
+Assert-Equal (Get-WindowsPathDrive "d:\ods") "D:" "Drive from D: path"
+Assert-Equal (Get-WindowsPathDrive "C:\Users\me\ods") "C:" "Drive from C: path"
+Assert-Equal (Get-WindowsPathDrive "") "" "Empty path has no drive"
+
+Assert-Equal (Get-WindowsDockerDataPathFromSettings ([pscustomobject]@{
+    dataFolder = "E:\DockerDesktop"
+})) "E:\DockerDesktop" "settings.json dataFolder"
+Assert-Equal (Get-WindowsDockerDataPathFromSettings ([pscustomobject]@{
+    DiskImageLocation = "F:\Docker\wsl"
+})) "F:\Docker\wsl" "DiskImageLocation"
+Assert-Equal (Get-WindowsDockerDataPathFromSettings ([pscustomobject]@{
+    "DesktopSettings.Disk.DiskPath" = "G:\DockerData"
+})) "G:\DockerData" "Flattened settings-store disk path"
+Assert-Equal (Get-WindowsDockerDataPathFromSettings ([pscustomobject]@{
+    AutoStart = $true
+    SettingsVersion = 43
+})) "" "Settings without a disk path"
+
+$defaultPath = Get-WindowsDockerDataPath -LocalAppData "C:\ods-test-localappdata" -RoamingAppData "C:\ods-test-roaming"
+Assert-Equal $defaultPath "C:\ods-test-localappdata\Docker\wsl\disk\docker_data.vhdx" "Default VHDX path"
+
+$corruptRoot = Join-Path $env:TEMP "ods-docker-settings-test"
+$corruptDocker = Join-Path $corruptRoot "Docker"
+New-Item -ItemType Directory -Path $corruptDocker -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $corruptDocker "settings-store.json") -Value "{not-json"
+$corruptFallback = Get-WindowsDockerDataPath -LocalAppData "C:\ods-test-localappdata" -RoamingAppData $corruptRoot
+Remove-Item -LiteralPath $corruptRoot -Recurse -Force
+Assert-Equal $corruptFallback "C:\ods-test-localappdata\Docker\wsl\disk\docker_data.vhdx" "Corrupt settings fall back to default VHDX"
+
+$same = Test-WindowsDockerImageDiskSpace `
+    -InstallDir "C:\ods" `
+    -DockerDataPath "C:\Users\example\Docker\wsl\disk\docker_data.vhdx" `
+    -RequiredGB 99999
+Assert-Equal $same.SameAsInstall $true "Same-drive Docker disk"
+Assert-Equal $same.Sufficient $true "Same-drive check must not double-fail C:"
+
+$split = Test-WindowsDockerImageDiskSpace `
+    -InstallDir "D:\ods" `
+    -DockerDataPath "C:\Users\example\Docker\wsl\disk\docker_data.vhdx" `
+    -RequiredGB 99999
+Assert-Equal $split.SameAsInstall $false "Split-drive Docker disk"
+Assert-Equal $split.Drive "C:" "Split-drive reports Docker drive"
+Assert-Equal $split.Sufficient $false "Split-drive must fail when Docker disk is short"
+
+$preflight = Get-Content -LiteralPath (Join-Path $root "installers\windows\phases\01-preflight.ps1") -Raw
+if ($preflight -match 'InstallDir \$\{_sourceDrive\}:\\ods') {
+    throw "Phase 01 still tells users to install on the source drive"
+}
+if ($preflight -notmatch 'Test-WindowsDockerImageDiskSpace') {
+    throw "Phase 01 does not check Docker image disk space"
+}
+if ($preflight -notmatch 'Docker images still use Docker Desktop') {
+    throw "Phase 01 lost the cross-drive Docker disk explanation"
+}
+
+$requirements = Get-Content -LiteralPath (Join-Path $root "installers\windows\phases\04-requirements.ps1") -Raw
+if ($requirements -notmatch 'Test-WindowsDockerImageDiskSpace') {
+    throw "Phase 04 does not check Docker image disk space"
+}
+
+Write-Host "test-windows-docker-disk-preflight: ok"

--- a/ods/tests/test-windows-docker-disk-preflight.sh
+++ b/ods/tests/test-windows-docker-disk-preflight.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+preflight="$ROOT_DIR/installers/windows/phases/01-preflight.ps1"
+requirements="$ROOT_DIR/installers/windows/phases/04-requirements.ps1"
+detection="$ROOT_DIR/installers/windows/lib/detection.ps1"
+
+grep -q 'function Get-WindowsDockerDataPath' "$detection"
+grep -q 'function Test-WindowsDockerImageDiskSpace' "$detection"
+grep -q 'Test-WindowsDockerImageDiskSpace' "$preflight"
+grep -q 'Test-WindowsDockerImageDiskSpace' "$requirements"
+grep -q 'Docker images still use Docker Desktop' "$preflight"
+if grep -q 'InstallDir \${_sourceDrive}:\\ods' "$preflight"; then
+    echo "[FAIL] phase 01 still suggests -InstallDir on the source drive"
+    exit 1
+fi
+
+if command -v powershell.exe >/dev/null 2>&1; then
+    PS_BIN="powershell.exe"
+elif command -v pwsh >/dev/null 2>&1; then
+    PS_BIN="pwsh"
+else
+    echo "[SKIP] PowerShell unavailable (bash wiring checks passed)"
+    exit 0
+fi
+
+if command -v cygpath >/dev/null 2>&1; then
+    TEST_PATH="$(cygpath -w "$ROOT_DIR/tests/test-windows-docker-disk-preflight.ps1")"
+elif [[ "$PS_BIN" == "powershell.exe" ]] && command -v wslpath >/dev/null 2>&1; then
+    TEST_PATH="$(wslpath -w "$ROOT_DIR/tests/test-windows-docker-disk-preflight.ps1")"
+else
+    TEST_PATH="$ROOT_DIR/tests/test-windows-docker-disk-preflight.ps1"
+fi
+
+"$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$TEST_PATH"


### PR DESCRIPTION
## Summary
- Windows preflight measured free space only on `-InstallDir`. Compose image pulls still go into Docker Desktop's WSL VHDX, which is usually on C:. A D: install can pass `25 GB free on D:` and then stall or fail while pulling Open WebUI.
- Fail (phase 01) / warn (phase 04) when that Docker data drive is different from the install drive and has under 12 GB free. Keep the existing INSTALL_DIR check for models and config.
- Stop telling users to rerun with `-InstallDir C:\ods` when they already chose another drive. Explain that models go to the install drive and images stay on Docker's disk.

## AI Assistance
Cursor Agent drafted the disk-path helpers, preflight/requirements wiring, tests, and this PR text. I reviewed the diff and ran the focused Windows tests on the machine that hit the failure.

## Release Lane
- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline Windows preflight fix.
```

## Changed Surface
- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation
- Risk level: **High** (Windows installer preflight / host mutation gate)
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [x] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
powershell.exe -File ods/tests/test-windows-docker-disk-preflight.ps1
  test-windows-docker-disk-preflight: ok

bash tests/test-windows-docker-disk-preflight.sh
  test-windows-docker-disk-preflight: ok

Live Windows (INSTALL_DIR=D:\ods, Docker VHDX on C:):
  Get-WindowsDockerDataPath -> C:\Users\<user>\AppData\Local\Docker\wsl\disk\docker_data.vhdx
  Test-WindowsDockerImageDiskSpace -RequiredGB 12 -> SameAsInstall=False, FreeGB=2, Sufficient=False
  This is the split-drive failure that previously passed preflight and then hung on Open WebUI pull.
```

## Operational Change Check
- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers
- Rollback: revert this PR. Existing installs are unaffected until the Windows installer is re-run.
- Same-drive installs do not add a second quota; the existing INSTALL_DIR 20 GB check still applies.
- Corrupt Docker `settings.json` / `settings-store.json` falls back to the default VHDX path instead of aborting preflight.
- Out of scope: SearXNG missing when `-NoRecommended` still leaves Open WebUI web search enabled. That is a separate installer/service-plan bug.

Made with [Cursor](https://cursor.com)