### PR TITLE
fix(monitor): specify errors=replace and guard proc.kill in ClusterStatus.refresh in agent_monitor.py

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -59,7 +59,7 @@ class ClusterStatus:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
 
             if proc.returncode == 0:
-                data = json.loads(stdout.decode())
+                data = json.loads(stdout.decode("utf-8", errors="replace"))
                 self.nodes = data.get("nodes", [])
                 self.total_gpus = len(self.nodes)
                 self.active_gpus = sum(1 for n in self.nodes if n.get("healthy", False))
@@ -69,8 +69,11 @@ class ClusterStatus:
         except FileNotFoundError:
             logger.debug("Cluster proxy not available: curl command not found")
         except asyncio.TimeoutError:
-            proc.kill()
-            await proc.wait()
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
             logger.debug("Cluster proxy health check timed out after 5s")
         except OSError as e:
             logger.debug("Cluster proxy connection failed: %s", e)


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/agent_monitor.py`, `ClusterStatus.refresh()` decodes `stdout` from the cluster proxy subprocess using un-parameterized `stdout.decode()`. If non-UTF-8 characters are returned by status endpoints, `stdout.decode()` raises an uncaught `UnicodeDecodeError`. Additionally, calling `proc.kill()` when sub-processes have already exited could raise `ProcessLookupError` inside the `asyncio.TimeoutError` handler.

## Fix

Pass `errors="replace"` to `stdout.decode("utf-8", errors="replace")` and wrap `proc.kill()` in a `try...except ProcessLookupError:` block in `ClusterStatus.refresh()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/agent_monitor.py`. `git diff --check` passed cleanly.