### PR TITLE
fix(inspector): catch RecursionError and TypeError in inspect_gguf in gguf_inspector.py

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -229,7 +229,7 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
             "model_name": _first_value(metadata, ("general.name",)),
             "metadata": metadata,
         })
-    except (OSError, UnicodeDecodeError, ValueError, struct.error) as exc:
+    except (OSError, UnicodeDecodeError, ValueError, struct.error, RecursionError, TypeError) as exc:
         logger.debug("Failed to inspect GGUF %s: %s", p, exc)
         result["error"] = str(exc)
     return result


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/gguf_inspector.py`, `inspect_gguf()` parses lightweight GGUF metadata headers and catches `(OSError, UnicodeDecodeError, ValueError, struct.error)`. When parsing deeply nested arrays or malformed metadata types in user-uploaded model files, `_read_array()` and `_skip_value()` can raise `RecursionError` or `TypeError`, leaking uncaught exceptions and crashing the inspector process.

## Fix

Add `RecursionError` and `TypeError` to the exception handling tuple in `inspect_gguf()`, ensuring all corrupt GGUF metadata read failures degrade gracefully to `{"error": ...}`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/gguf_inspector.py`. `git diff --check` passed cleanly.