### PR TITLE
fix(gpu): specify errors=replace in run_command and _read_sysfs in gpu.py

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def run_command(cmd: list[str], timeout: int = 5) -> tuple[bool, str]:
     """Run a shell command and return (success, output)."""
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        result = subprocess.run(cmd, capture_output=True, text=True, errors="replace", timeout=timeout)
         return result.returncode == 0, result.stdout.strip()
     except subprocess.TimeoutExpired:
         return False, "timeout"
@@ -30,7 +30,7 @@ def run_command(cmd: list[str], timeout: int = 5) -> tuple[bool, str]:
 def _read_sysfs(path: str) -> Optional[str]:
     """Read a sysfs file, returning None on failure."""
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8", errors="replace") as f:
             return f.read().strip()
     except (OSError, IOError):
         return None


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/gpu.py`, `run_command()` executes hardware detection commands (`nvidia-smi`, `rocm-smi`, `lspci`) using `text=True` without specifying `errors="replace"`. If hardware query sub-processes output non-UTF-8 vendor data or binary status strings, `subprocess.run()` raises an uncaught `UnicodeDecodeError`. Similarly, `_read_sysfs()` reads sysfs attributes without `errors="replace"`.

## Fix

Pass `errors="replace"` to `subprocess.run()` in `run_command()` and `open()` in `_read_sysfs()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/gpu.py`. `git diff --check` passed cleanly.