### PR TITLE
fix(helpers): specify errors=replace and catch UnicodeError in _read_json_file in helpers.py

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -244,8 +244,8 @@ def is_plausible_single_request_tps(value) -> bool:
 def _read_json_file(path: Path, default):
     try:
         if path.exists():
-            return json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as e:
+            return json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except (json.JSONDecodeError, OSError, UnicodeError, ValueError) as e:
         logger.debug("Failed to read JSON file %s: %s", path, e)
     return default
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/helpers.py`, `_read_json_file()` reads performance/metrics JSON data from disk using `path.read_text(encoding="utf-8")` and catches `(json.JSONDecodeError, OSError)`. If JSON files on disk contain non-standard byte sequences or corrupt unicode encodings, `read_text()` raises an uncaught `UnicodeDecodeError` or `ValueError`, crashing calling helper routines.

## Fix

Pass `errors="replace"` to `path.read_text()` and add `UnicodeError` and `ValueError` to the exception handler in `_read_json_file()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/helpers.py`. `git diff --check` passed cleanly.