### PR TITLE
fix(extensions): specify errors=replace when reading extension manifests in user_extensions.py

### DIFF
--- a/ods/extensions/services/dashboard-api/user_extensions.py
+++ b/ods/extensions/services/dashboard-api/user_extensions.py
@@ -50,8 +50,8 @@ def scan_user_extension_services(
             continue
 
         try:
-            manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-        except (yaml.YAMLError, OSError) as e:
+            manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8", errors="replace"))
+        except (yaml.YAMLError, OSError, UnicodeError, ValueError) as e:
             logger.debug("Skipping %s: bad manifest: %s", service_id, e)
             continue
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/user_extensions.py`, `scan_user_extension_services()` reads extension `manifest.yaml` files using `manifest_path.read_text(encoding="utf-8")` and catches `(yaml.YAMLError, OSError)`. If user-installed extension manifests contain non-UTF-8 bytes or non-standard characters, `read_text()` raises an uncaught `UnicodeDecodeError` or `ValueError`, causing the scanner to abort extension discovery.

## Fix

Pass `errors="replace"` to `manifest_path.read_text()` and add `UnicodeError` and `ValueError` to the exception handler in `scan_user_extension_services()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/user_extensions.py`. `git diff --check` passed cleanly.