### PR TITLE
fix(hermes): pass errors=replace in _fetch_hermes_token in hermes_bridge.py

### DIFF
--- a/ods/extensions/services/dashboard-api/hermes_bridge.py
+++ b/ods/extensions/services/dashboard-api/hermes_bridge.py
@@ -105,7 +105,7 @@ async def _fetch_hermes_token(session: aiohttp.ClientSession) -> str:
         async with session.get(url) as resp:
             if resp.status >= 400:
                 raise HermesUnavailable(f"Hermes dashboard returned HTTP {resp.status}")
-            html = await resp.text()
+            html = await resp.text(errors="replace")
     except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
         raise HermesUnavailable("Hermes dashboard is not reachable") from exc
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/hermes_bridge.py`, `_fetch_hermes_token()` fetches session tokens by reading the internal Hermes HTML dashboard response via `await resp.text()`. If the Hermes response payload contains non-UTF-8 bytes or non-standard characters, `resp.text()` raises an uncaught `UnicodeDecodeError`, failing session token retrieval.

## Fix

Pass `errors="replace"` to `await resp.text(errors="replace")` in `_fetch_hermes_token()`.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/hermes_bridge.py`. `git diff --check` passed cleanly.