### PR TITLE
feat: native MLX runtime family (Apple Silicon)

### DIFF
--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -13,7 +13,8 @@ failure; adapters must not raise for expected runtime failures.
 PR 2A ships the shared contract, the transaction fake used by the boundary
 test matrix, and the container llama.cpp adapter. Native Windows/macOS and
 Lemonade/HipFire adapters land in PR 2B/2C and must pass the same contract
-suite.
+suite. The native MLX runtime (Apple Silicon) is a fourth family and passes
+the same suite.
 """
 
 from __future__ import annotations
@@ -63,6 +64,22 @@ class ReadinessProbe(Protocol):
         gguf_file: str,
         context_length: int,
         lemonade_model_id: str = "",
+    ) -> dict[str, Any]: ...
+
+
+class ModelReadinessProbe(Protocol):
+    """Return runtime-carried identity, context, and proof time for a model ref.
+
+    Distinct from ``ReadinessProbe``: runtimes that serve a directory of
+    weights rather than a single GGUF file identify themselves by a model
+    reference, and have no Lemonade concrete-ID concept.
+    """
+
+    def __call__(
+        self,
+        env: dict[str, str],
+        model_ref: str,
+        context_length: int,
     ) -> dict[str, Any]: ...
 
 
@@ -317,6 +334,131 @@ class LemonadeAdapter:
 
     def publish_native_alias(self, env: dict[str, str]) -> dict[str, Any]:
         return result(True, "native Lemonade alias is deferred to the route adapter")
+
+    def unload(self, env: dict[str, str]) -> dict[str, Any]:
+        return ContainerLlamaAdapter._optional_operation("unload", self._unload, env)
+
+    def delete(self, env: dict[str, str]) -> dict[str, Any]:
+        return ContainerLlamaAdapter._optional_operation("delete", self._delete, env)
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        return ContainerLlamaAdapter._optional_operation(
+            "rollback", self._rollback, env
+        )
+
+
+class NativeMLXAdapter:
+    """Native MLX runtime on Apple Silicon (mlx-vlm / mlx-lm server).
+
+    MLX always runs as a host process: Docker on macOS has no Metal
+    passthrough, so containers reach it over ``host.docker.internal``. The
+    runtime family therefore has no compose path and ``stage`` drives an
+    injected native process restart, mirroring ``NativeLlamaAdapter``.
+
+    Two contract differences from llama.cpp are structural, not incidental:
+    - The runtime serves a directory of weights, so identity is a model
+      reference (a local path or repo id), never a GGUF filename.
+    - There is no ``/props`` endpoint, so the served context length cannot
+      be read back from the runtime. The injected probe reports whether it
+      could confirm the context; an unconfirmed context is proof-carried as
+      ``contextVerified: False`` rather than silently asserted.
+    """
+
+    kind = "mlx"
+
+    def __init__(
+        self,
+        *,
+        restart: Callable[[dict[str, str]], None],
+        wait_ready: ModelReadinessProbe,
+        expected_model: str,
+        context_length: int,
+        capabilities: dict[str, bool] | None = None,
+        unload: Callable[[dict[str, str]], None] | None = None,
+        delete: Callable[[dict[str, str]], None] | None = None,
+        rollback: Callable[[dict[str, str]], None] | None = None,
+    ) -> None:
+        self._restart = restart
+        self._wait_ready = wait_ready
+        self._expected_model = expected_model
+        self._context_length = int(context_length)
+        supplied_capabilities = capabilities or {}
+        self._capabilities = {
+            "chat": bool(supplied_capabilities.get("chat", True)),
+            "tools": bool(supplied_capabilities.get("tools", False)),
+            "vision": bool(supplied_capabilities.get("vision", False)),
+            "agentViable": bool(supplied_capabilities.get("agentViable", False)),
+        }
+        self._unload = unload
+        self._delete = delete
+        self._rollback = rollback
+        self._verified_identity = ""
+        self._verified_context = 0
+        self._context_verified = False
+        self._verified_at = ""
+
+    def _verification_result(self, detail: str) -> dict[str, Any]:
+        return result(
+            True,
+            detail,
+            identity=self._verified_identity,
+            contextLength=self._verified_context,
+            contextVerified=self._context_verified,
+            capabilities=dict(self._capabilities),
+            verifiedAt=self._verified_at,
+        )
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        try:
+            self._restart(env)
+        except Exception as exc:  # expected runtime failures become results
+            return result(False, str(exc))
+        return result(True, "native MLX server restart issued")
+
+    def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
+        try:
+            runtime_proof = self._wait_ready(
+                env,
+                self._expected_model,
+                self._context_length,
+            )
+        except Exception as exc:
+            return result(False, f"MLX readiness wait failed: {exc}")
+        if not isinstance(runtime_proof, dict):
+            return result(False, "MLX runtime did not return a proof record")
+        runtime_identity = runtime_proof.get("identity")
+        runtime_context = runtime_proof.get("contextLength")
+        context_verified = runtime_proof.get("contextVerified")
+        verified_at = runtime_proof.get("verifiedAt")
+        if not isinstance(runtime_identity, str) or not runtime_identity.strip():
+            return result(False, "MLX runtime did not report the staged model")
+        if (
+            not isinstance(runtime_context, int)
+            or isinstance(runtime_context, bool)
+            or runtime_context <= 0
+        ):
+            return result(False, "MLX runtime did not report a valid context length")
+        if not isinstance(context_verified, bool):
+            return result(False, "MLX runtime proof has no context-verification status")
+        if not isinstance(verified_at, str) or not verified_at.strip():
+            return result(False, "MLX runtime proof has no timestamp")
+        self._verified_identity = runtime_identity.strip()
+        self._verified_context = runtime_context
+        self._context_verified = context_verified
+        self._verified_at = verified_at.strip()
+        return self._verification_result("MLX runtime reports staged model")
+
+    def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
+        # The probe returns an identity only after a meaningful completion
+        # reports the same concrete model; do not echo configuration.
+        if not self._verified_identity:
+            return result(False, "completion proof has no runtime identity")
+        return self._verification_result(
+            "completion proven during MLX readiness wait"
+        )
+
+    def publish_native_alias(self, env: dict[str, str]) -> dict[str, Any]:
+        return result(True, "native alias not required for MLX")
 
     def unload(self, env: dict[str, str]) -> dict[str, Any]:
         return ContainerLlamaAdapter._optional_operation("unload", self._unload, env)

--- a/ods/bin/model_switchboard/state.py
+++ b/ods/bin/model_switchboard/state.py
@@ -33,7 +33,7 @@ HISTORY_LIMIT = 10
 PUBLIC_MODEL_DEFAULT = "ods/current"
 STATE_FILE_MODE = 0o644
 
-_BACKEND_KINDS = {"llama-server", "lemonade", "hipfire", "unknown"}
+_BACKEND_KINDS = {"llama-server", "lemonade", "hipfire", "mlx", "unknown"}
 _OPERATION_PHASES = {
     "requested", "staging", "verifying", "publishing",
     "flipping", "serving", "failed", "rolling_back",

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -7469,6 +7469,20 @@ class AgentHandler(BaseHTTPRequestHandler):
                 json_response(self, 404, {"error": f"Model '{model_id}' not found in library or local GGUF files"})
                 return
 
+        # MLX models are served by a native host process, not llama.cpp, and
+        # carry no GGUF artifact. Dispatch before the GGUF-shaped transaction
+        # rather than threading a second runtime family through it.
+        if str(model.get("runtime") or "").lower() == "mlx":
+            if _switchboard_adapters is None or _switchboard_reconciler is None:
+                json_response(self, 500, {
+                    "error": "MLX activation requires the model switchboard",
+                })
+                return
+            _do_mlx_model_activate(
+                self, model, model_id, env_path, requested_context_length
+            )
+            return
+
         gguf_file = model.get("gguf_file", "")
         llm_model_name = model.get("llm_model_name", model_id)
         if not _valid_gguf_filename(gguf_file):
@@ -11749,6 +11763,422 @@ def _stop_macos_native_llama_server(pid_file: Path) -> None:
         pass
     finally:
         pid_file.unlink(missing_ok=True)
+
+
+# --- Native MLX runtime (Apple Silicon) -------------------------------------
+#
+# MLX is always a host process: Docker on macOS has no Metal passthrough, so
+# containers reach it over host.docker.internal. The runtime is managed here
+# with the same PID-file discipline as the native llama-server path.
+
+_MLX_DEFAULT_PORT = "8081"
+# Large MLX repos are tens of GB; the llama GGUF path uses a comparable ceiling.
+_MLX_DOWNLOAD_TIMEOUT = 14400
+
+
+def _mlx_runtime_paths(env: dict) -> dict[str, Path]:
+    """Resolve the interpreter, weights root, PID file, and log for MLX."""
+    data_dir = Path(env.get("ODS_DATA_DIR") or (INSTALL_DIR / "data"))
+    configured = str(env.get("MLX_PYTHON") or "").strip()
+    python_bin = Path(configured) if configured else data_dir / "mlx" / "venv" / "bin" / "python"
+    return {
+        "python": python_bin,
+        "models_root": data_dir / "models" / "mlx",
+        "pid_file": data_dir / "mlx-server.pid",
+        "log": data_dir / "mlx-server.log",
+    }
+
+
+def _mlx_runtime_address(env: dict) -> tuple[str, str]:
+    port = str(env.get("ODS_MLX_PORT") or _MLX_DEFAULT_PORT)
+    return "127.0.0.1", port
+
+
+def _stop_native_mlx_server(pid_file: Path) -> None:
+    """Stop only the PID-file-owned native MLX server process."""
+    if not pid_file.exists():
+        return
+    try:
+        old_pid = int(pid_file.read_text(encoding="utf-8").strip())
+        if old_pid <= 1:
+            raise OSError("invalid MLX server PID")
+        try:
+            ps_result = subprocess.run(
+                ["ps", "-p", str(old_pid), "-o", "command="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if ps_result.returncode != 0 or "mlx" not in ps_result.stdout.lower():
+                raise OSError("PID is not an MLX server")
+        except (subprocess.TimeoutExpired, OSError) as exc:
+            raise OSError("stale MLX server PID") from exc
+
+        os.kill(old_pid, signal.SIGTERM)
+        for _ in range(20):
+            try:
+                os.kill(old_pid, 0)
+                time.sleep(0.5)
+            except OSError:
+                break
+        else:
+            os.kill(old_pid, signal.SIGKILL)
+    except (ValueError, OSError):
+        pass
+
+
+def _launch_native_mlx_server(env_path: Path, model_dir: Path) -> None:
+    """Launch mlx_vlm.server for the staged weights and write its PID file.
+
+    Reads the current .env so the caller only needs .env to be up to date.
+    Raises so the adapter's stage phase reports a real failure instead of
+    leaving the reconciler to time out in verification.
+    """
+    env = load_env(env_path)
+    paths = _mlx_runtime_paths(env)
+    python_bin = paths["python"]
+    if not python_bin.is_file():
+        raise RuntimeError(f"MLX runtime interpreter is missing: {python_bin}")
+    if not (model_dir / "config.json").is_file():
+        raise RuntimeError(f"MLX weights are missing config.json: {model_dir}")
+
+    bind_addr = str(env.get("BIND_ADDRESS") or "").strip() or "127.0.0.1"
+    _, port = _mlx_runtime_address(env)
+    ctx_size = str(env.get("CTX_SIZE") or "65536")
+    args = [
+        str(python_bin), "-m", "mlx_vlm.server",
+        "--model", str(model_dir),
+        "--host", bind_addr,
+        "--port", str(port),
+        "--max-tokens", str(env.get("MLX_MAX_TOKENS") or "8192"),
+    ]
+    # KV quantization keeps the long-context footprint affordable; it is only
+    # engaged past the configured start so short prompts stay full precision.
+    kv_bits = str(env.get("MLX_KV_BITS") or "8").strip()
+    if kv_bits:
+        args.extend(["--kv-bits", kv_bits,
+                     "--quantized-kv-start", str(env.get("MLX_KV_START") or "4096")])
+
+    log_path = paths["log"]
+    pid_file = paths["pid_file"]
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a") as log_f:
+        proc = subprocess.Popen(
+            args, stdout=log_f, stderr=log_f, cwd=str(INSTALL_DIR),
+        )
+    pid_file.write_text(str(proc.pid), encoding="utf-8")
+    logger.info(
+        "Native MLX server launched (pid %d, model %s, ctx %s)",
+        proc.pid, model_dir.name, ctx_size,
+    )
+
+
+def _restart_native_mlx_server(env_path: Path, model_dir: Path) -> None:
+    env = load_env(env_path)
+    _stop_native_mlx_server(_mlx_runtime_paths(env)["pid_file"])
+    _launch_native_mlx_server(env_path, model_dir)
+
+
+def _mlx_reported_identity(body: str, expected_model: str) -> str:
+    """Return the runtime-reported id matching the staged weights, else ''.
+
+    mlx_vlm.server lists every model it has resolved, so an exact match on
+    the staged path is required: a substring match would accept a different
+    model that merely shares a prefix.
+    """
+    try:
+        payload = json.loads(body or "{}")
+    except json.JSONDecodeError:
+        return ""
+    entries = payload.get("data")
+    if not isinstance(entries, list):
+        return ""
+    wanted = str(expected_model).rstrip("/")
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        served = str(entry.get("id") or "").rstrip("/")
+        if served and served == wanted:
+            return served
+    return ""
+
+
+def _wait_for_mlx_readiness(
+    env: dict,
+    model_ref: str,
+    context_length: int,
+    *,
+    attempts: int = 60,
+    initial_delay: float = 3,
+    interval: float = 5,
+) -> dict[str, object]:
+    """Prove the MLX runtime serves the staged weights and completes a request.
+
+    MLX exposes no /props endpoint, so the served context cannot be read back
+    from the runtime. The configured length is reported with
+    ``contextVerified`` False rather than asserted as proven.
+    """
+    host, port = _mlx_runtime_address(env)
+    identity_url = f"http://{host}:{port}/v1/models"
+    logger.info("Waiting for MLX model identity %s at %s", model_ref, identity_url)
+    if initial_delay > 0:
+        time.sleep(initial_delay)
+    for attempt in range(max(1, attempts)):
+        try:
+            probe = subprocess.run(
+                ["curl", "-s", "--max-time", "5", identity_url],
+                capture_output=True, text=True, timeout=10,
+            )
+            runtime_identity = _mlx_reported_identity(probe.stdout.strip(), model_ref)
+            if runtime_identity and _chat_completion_ready(
+                host, port, runtime_identity, "/v1",
+                expected_model_id=runtime_identity,
+            ):
+                logger.info("MLX model %s ready after %d attempts", model_ref, attempt + 1)
+                return {
+                    "identity": runtime_identity,
+                    "contextLength": int(context_length),
+                    "contextVerified": False,
+                    "verifiedAt": _iso_now(),
+                }
+            if attempt % 6 == 0:
+                logger.info(
+                    "MLX model %s readiness incomplete (attempt %d, identity=%s)",
+                    model_ref, attempt + 1, bool(runtime_identity),
+                )
+        except subprocess.TimeoutExpired:
+            if attempt % 6 == 0:
+                logger.info("MLX readiness attempt %d timed out", attempt + 1)
+        if attempt + 1 < attempts and interval > 0:
+            time.sleep(interval)
+    return {}
+
+
+def _update_env_file(env_path: Path, updates: dict[str, str]) -> None:
+    """Rewrite .env in place, replacing known keys and appending new ones."""
+    lines = env_path.read_text(encoding="utf-8").splitlines()
+    new_lines: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        key = line.split("=", 1)[0] if "=" in line and not line.startswith("#") else None
+        if key and key in updates:
+            new_lines.append(f"{key}={updates[key]}")
+            seen.add(key)
+        else:
+            new_lines.append(line)
+    for key, value in updates.items():
+        if key not in seen:
+            new_lines.append(f"{key}={value}")
+    _atomic_write_text(env_path, "\n".join(new_lines) + "\n")
+
+
+def _mlx_catalog_files(model: dict) -> list[dict]:
+    entries = model.get("mlx_files")
+    return [e for e in entries if isinstance(e, dict)] if isinstance(entries, list) else []
+
+
+def _verify_mlx_weights(model: dict, model_dir: Path) -> list[str]:
+    """Return the catalogued files that are missing or fail their sha256."""
+    bad: list[str] = []
+    for entry in _mlx_catalog_files(model):
+        rel = str(entry.get("file") or "")
+        expected = str(entry.get("sha256") or "")
+        if not rel or not expected:
+            continue
+        # Catalog paths include the quant subdir; the weights live directly in
+        # model_dir, so compare against the basename.
+        target = model_dir / Path(rel).name
+        if not target.is_file():
+            bad.append(f"{target.name}: missing")
+            continue
+        digest = hashlib.sha256()
+        with open(target, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        if digest.hexdigest() != expected:
+            bad.append(f"{target.name}: sha256 mismatch")
+    return bad
+
+
+def _ensure_mlx_weights(model: dict, model_dir: Path) -> None:
+    """Download the staged MLX weights when absent, then verify every shard.
+
+    Verification is not optional: the catalog pins a per-shard sha256 against
+    a repo revision, and a truncated or tampered shard would otherwise only
+    surface as an opaque runtime load failure.
+    """
+    repo = str(model.get("mlx_repo") or "")
+    if not repo:
+        raise RuntimeError("catalog entry has no mlx_repo")
+    if not _mlx_catalog_files(model):
+        raise RuntimeError("catalog entry has no mlx_files to verify")
+
+    if not (model_dir / "config.json").is_file():
+        _download_mlx_weights(model, model_dir)
+
+    failures = _verify_mlx_weights(model, model_dir)
+    if failures:
+        raise RuntimeError("; ".join(failures))
+
+
+def _download_mlx_weights(model: dict, model_dir: Path) -> None:
+    """Fetch one quant subdirectory of an MLX repo into model_dir.
+
+    Runs inside the MLX runtime venv, which is where huggingface_hub lives;
+    the agent's own interpreter is not required to carry that dependency.
+    """
+    env = load_env(INSTALL_DIR / ".env")
+    python_bin = _mlx_runtime_paths(env)["python"]
+    if not python_bin.is_file():
+        raise RuntimeError(f"MLX runtime interpreter is missing: {python_bin}")
+
+    repo = str(model.get("mlx_repo"))
+    revision = str(model.get("mlx_revision") or "") or None
+    subdir = str(model.get("mlx_subdir") or "").strip("/")
+    model_dir.mkdir(parents=True, exist_ok=True)
+    script = (
+        "import sys\n"
+        "from huggingface_hub import snapshot_download\n"
+        "repo, revision, subdir, dest = sys.argv[1:5]\n"
+        "snapshot_download(\n"
+        "    repo_id=repo,\n"
+        "    revision=revision or None,\n"
+        "    allow_patterns=[f'{subdir}/*'] if subdir else None,\n"
+        "    local_dir=dest,\n"
+        ")\n"
+    )
+    logger.info("Downloading MLX weights %s (%s) -> %s", repo, subdir or "root", model_dir)
+    # The staging parent receives <subdir>/, which is then the served dir.
+    staging = model_dir.parent
+    result = subprocess.run(
+        [str(python_bin), "-c", script, repo, revision or "", subdir, str(staging)],
+        capture_output=True, text=True, timeout=_MLX_DOWNLOAD_TIMEOUT,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"MLX weight download failed: {(result.stderr or '').strip()[:400]}"
+        )
+
+
+def _do_mlx_model_activate(
+    handler,
+    model: dict,
+    model_id: str,
+    env_path: Path,
+    requested_context_length: int | None,
+) -> None:
+    """Activate a native-MLX catalog model.
+
+    MLX needs a far smaller transaction than the llama.cpp path: there is
+    no models.ini, no LLAMA_ARG_* runtime profile, no Lemonade concrete ID
+    and no compose service. Keeping it a separate sequence avoids threading
+    a second runtime family through the GGUF transaction's ~50 GGUF-shaped
+    call sites, where a mistake would regress llama.cpp activation.
+    """
+    env_pre = load_env(env_path)
+    gpu_backend = str(env_pre.get("GPU_BACKEND") or "").lower()
+    if gpu_backend != "apple":
+        json_response(handler, 400, {
+            "error": "MLX models require the apple GPU backend, "
+                     f"not {gpu_backend or 'unset'}",
+        })
+        return
+
+    try:
+        context_length = int(model.get("context_length") or 65536)
+    except (TypeError, ValueError):
+        context_length = 65536
+    if requested_context_length is not None:
+        context_length = requested_context_length
+
+    paths = _mlx_runtime_paths(env_pre)
+    model_dir = (paths["models_root"] / str(model_id) / str(
+        model.get("mlx_subdir") or ""
+    )).resolve()
+    models_root = paths["models_root"].resolve()
+    if not model_dir.is_relative_to(models_root):
+        json_response(handler, 400, {"error": "Invalid MLX model path"})
+        return
+
+    try:
+        _ensure_mlx_weights(model, model_dir)
+    except (RuntimeError, OSError) as exc:
+        json_response(handler, 400, {"error": f"MLX weights unavailable: {exc}"})
+        return
+
+    env_snapshot = env_path.read_text(encoding="utf-8")
+    capabilities = {
+        "chat": True,
+        "tools": bool(model.get("tools")),
+        "vision": bool(model.get("vision")),
+        "agentViable": False,
+    }
+    llm_model_name = str(model.get("llm_model_name") or model_id)
+
+    _update_env_file(env_path, {
+        "LLM_MODEL": llm_model_name,
+        "MLX_MODEL_PATH": str(model_dir),
+        "MLX_MODEL_ID": str(model_id),
+        "CTX_SIZE": str(context_length),
+        "MAX_CONTEXT": str(context_length),
+        "ODS_MLX_PORT": _mlx_runtime_address(env_pre)[1],
+    })
+
+    adapter = _switchboard_adapters.NativeMLXAdapter(
+        restart=lambda _e: _restart_native_mlx_server(env_path, model_dir),
+        wait_ready=_wait_for_mlx_readiness,
+        expected_model=str(model_dir),
+        context_length=context_length,
+        capabilities=capabilities,
+    )
+    run = _switchboard_reconciler.run_runtime_activation(
+        adapter, load_env(env_path)
+    )
+
+    if not run["ok"]:
+        logger.error(
+            "MLX activation failed at %s: %s", run.get("phase"), run.get("detail")
+        )
+        _atomic_write_text(env_path, env_snapshot)
+        _stop_native_mlx_server(paths["pid_file"])
+        json_response(handler, 500, {
+            "error": f"MLX activation failed: {run.get('detail')}",
+            "failure_phase": run.get("phase"),
+            "failure_detail": run.get("detail"),
+        })
+        return
+
+    # Identity and completion are proven; only the served context could not
+    # be read back, because MLX exposes no /props equivalent. That is a
+    # property of the runtime family, not a failed probe, so the route is
+    # published with contextVerified already recorded as False by the
+    # adapter rather than withheld the way an unproven llama route is.
+    if _switchboard_state is not None:
+        try:
+            _switchboard_state.record_verified_route(
+                INSTALL_DIR / "data" / "model-state.json",
+                catalog_id=str(model_id),
+                runtime_model_id=str(run["identity"]),
+                backend_kind="mlx",
+                endpoint_id="mlx-host",
+                native_route=None,
+                context_length=int(run["contextLength"]),
+                capabilities=run["capabilities"],
+                proof_identity=str(run["identity"]),
+            )
+        except Exception as exc:
+            logger.warning("switchboard state record failed: %s", exc)
+
+    json_response(handler, 200, {
+        "status": "activated",
+        "model_id": model_id,
+        "llm_model": llm_model_name,
+        "runtime": "mlx",
+        "mlx_model_path": str(model_dir),
+        "context_length": int(context_length),
+        "context_verified": False,
+    })
 
 
 def _restart_macos_native_llama_server(

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -2016,6 +2016,74 @@
       "tokens_per_sec_estimate": 15,
       "llm_model_name": "qwen3.5-122b-a10b",
       "llama_server_image": null
+    },
+    {
+      "id": "qwen3.8-27b-uncensored-mlx-8bit",
+      "name": "Qwen 3.8 27B Uncensored (MLX 8-bit)",
+      "family": "qwen",
+      "runtime": "mlx",
+      "mlx_repo": "orcarouter/Qwen3.8-27B-Uncensored-MLX",
+      "mlx_revision": "ef682bdbb5c28d8869ecbf615459b8d15eb24799",
+      "mlx_subdir": "8-bit",
+      "mlx_files": [
+        {
+          "file": "8-bit/model-00001-of-00006.safetensors",
+          "url": "https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX/resolve/ef682bdbb5c28d8869ecbf615459b8d15eb24799/8-bit/model-00001-of-00006.safetensors",
+          "sha256": "d8f01eded64ecd012b90a8e1375433a5ec49cd1acadb77c2ed5f8ce833af528e",
+          "size_bytes": 5317707349
+        },
+        {
+          "file": "8-bit/model-00002-of-00006.safetensors",
+          "url": "https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX/resolve/ef682bdbb5c28d8869ecbf615459b8d15eb24799/8-bit/model-00002-of-00006.safetensors",
+          "sha256": "e90b3f8eadb473ce46d60f231d7a50f0386d4e6dcb92907cd7c99f1e75e33573",
+          "size_bytes": 5354102528
+        },
+        {
+          "file": "8-bit/model-00003-of-00006.safetensors",
+          "url": "https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX/resolve/ef682bdbb5c28d8869ecbf615459b8d15eb24799/8-bit/model-00003-of-00006.safetensors",
+          "sha256": "1fc349c8f9411680471dd5c0f6e586958feb9cc67d7c020ed459423b7b6ea050",
+          "size_bytes": 5354184654
+        },
+        {
+          "file": "8-bit/model-00004-of-00006.safetensors",
+          "url": "https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX/resolve/ef682bdbb5c28d8869ecbf615459b8d15eb24799/8-bit/model-00004-of-00006.safetensors",
+          "sha256": "86b4fe4b4a85620254875b52575f5a459f83f0ead952c362b9800937a2e9dba9",
+          "size_bytes": 5337309675
+        },
+        {
+          "file": "8-bit/model-00005-of-00006.safetensors",
+          "url": "https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX/resolve/ef682bdbb5c28d8869ecbf615459b8d15eb24799/8-bit/model-00005-of-00006.safetensors",
+          "sha256": "215aa22dc0d42e96283ae624b48c6ae82173999a6ff137c575f07f825ee53975",
+          "size_bytes": 5292848520
+        },
+        {
+          "file": "8-bit/model-00006-of-00006.safetensors",
+          "url": "https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX/resolve/ef682bdbb5c28d8869ecbf615459b8d15eb24799/8-bit/model-00006-of-00006.safetensors",
+          "sha256": "0c7e1d9fb971cf6eaea638ee8d48661abc85ed822e34f405e334b8c1ef910ff6",
+          "size_bytes": 2845065535
+        }
+      ],
+      "gated": true,
+      "size_bytes": 29501218261,
+      "size_mb": 28135,
+      "vram_required_gb": 32,
+      "context_length": 65536,
+      "max_context_length": 262144,
+      "quantization": "MLX-8bit",
+      "specialty": "Uncensored / Red-Team",
+      "description": "Abliterated Qwen 3.8 27B in MLX 8-bit for Apple Silicon. Vision tower preserved, 256K native context, served by the native MLX runtime rather than llama.cpp. Refusal behavior has been removed, so it carries no model-side guardrails and is intended for red-team and evaluation work behind your own filtering.",
+      "tokens_per_sec_estimate": 14,
+      "llm_model_name": "qwen3.8-27b-uncensored-mlx",
+      "llama_server_image": null,
+      "gpu_backend_scope": ["apple"],
+      "app_compatibility": {
+        "openai_chat": {
+          "status": "unvalidated",
+          "label": "Not fleet-validated",
+          "reason": "Added alongside the native MLX runtime adapter. No fleet validation run has covered the MLX runtime family yet.",
+          "globalScope": true
+        }
+      }
     }
   ]
 }

--- a/ods/config/model-state.schema.v1.json
+++ b/ods/config/model-state.schema.v1.json
@@ -56,7 +56,7 @@
               "required": ["kind", "endpointId"],
               "additionalProperties": false,
               "properties": {
-                "kind": { "enum": ["llama-server", "lemonade", "hipfire", "unknown"] },
+                "kind": { "enum": ["llama-server", "lemonade", "hipfire", "mlx", "unknown"] },
                 "endpointId": { "type": "string", "minLength": 1 },
                 "nativeRoute": { "type": ["string", "null"] }
               }

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -6656,3 +6656,191 @@ class TestNvidiaHealthUnchanged:
         assert '"ok"' in body
         # But Lemonade check would fail (no model_loaded key)
         assert _check_lemonade_health(body) is False
+
+
+def _write_mlx_activation_fixture(tmp_path, *, gpu_backend="apple"):
+    """Install tree whose catalog holds one MLX model with real shard hashes."""
+    install_dir = tmp_path / "install"
+    config_dir = install_dir / "config"
+    data_dir = install_dir / "data"
+    weights = data_dir / "models" / "mlx" / "target-mlx" / "8-bit"
+    weights.mkdir(parents=True)
+    config_dir.mkdir(parents=True)
+
+    shard = b"mlx-weights"
+    (weights / "model-00001-of-00001.safetensors").write_bytes(shard)
+    (weights / "config.json").write_text("{}", encoding="utf-8")
+
+    (config_dir / "model-library.json").write_text(
+        json.dumps({"models": [{
+            "id": "target-mlx",
+            "runtime": "mlx",
+            "mlx_repo": "example/Target-MLX",
+            "mlx_revision": "0" * 40,
+            "mlx_subdir": "8-bit",
+            "mlx_files": [{
+                "file": "8-bit/model-00001-of-00001.safetensors",
+                "url": "https://huggingface.co/example/Target-MLX/resolve/main/8-bit/x",
+                "sha256": hashlib.sha256(shard).hexdigest(),
+                "size_bytes": len(shard),
+            }],
+            "llm_model_name": "target-mlx",
+            "context_length": 65536,
+        }]}),
+        encoding="utf-8",
+    )
+
+    # A real interpreter path so the launcher's preflight passes.
+    venv_bin = data_dir / "mlx" / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    python_stub = venv_bin / "python"
+    python_stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_stub.chmod(0o755)
+
+    (install_dir / ".env").write_text(
+        f"GPU_BACKEND={gpu_backend}\n"
+        "LLM_MODEL=old-model\n"
+        "CTX_SIZE=2048\n"
+        "OLLAMA_PORT=8080\n",
+        encoding="utf-8",
+    )
+    return install_dir
+
+
+class TestMLXActivation:
+    def _prepare(self, tmp_path, monkeypatch, *, gpu_backend="apple"):
+        install_dir = _write_mlx_activation_fixture(tmp_path, gpu_backend=gpu_backend)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _s: None)
+        return install_dir
+
+    def test_activates_and_publishes_an_mlx_route(self, tmp_path, monkeypatch):
+        install_dir = self._prepare(tmp_path, monkeypatch)
+        weights = install_dir / "data" / "models" / "mlx" / "target-mlx" / "8-bit"
+        order = []
+
+        monkeypatch.setattr(
+            _mod, "_restart_native_mlx_server",
+            lambda _env_path, model_dir: order.append(("restart", str(model_dir))),
+        )
+        monkeypatch.setattr(
+            _mod, "_wait_for_mlx_readiness",
+            lambda env, model_ref, ctx: (
+                order.append(("wait", model_ref)) or {
+                    "identity": model_ref,
+                    "contextLength": ctx,
+                    "contextVerified": False,
+                    "verifiedAt": "2026-07-20T00:00:00+00:00",
+                }
+            ),
+        )
+
+        handler = _ResponseHandler()
+        _mod.AgentHandler._do_model_activate(handler, "target-mlx")
+
+        assert handler.response_code == 200, handler.parse_response()
+        payload = handler.parse_response()
+        assert payload["runtime"] == "mlx"
+        assert payload["context_verified"] is False
+        assert order == [("restart", str(weights)), ("wait", str(weights))]
+
+        state = json.loads(
+            (install_dir / "data" / "model-state.json").read_text(encoding="utf-8")
+        )
+        # The route must publish as a real mlx backend, not be downgraded to
+        # "unknown" and not be withheld for lacking a context readback.
+        assert state["active"]["backend"]["kind"] == "mlx"
+        assert state["active"]["backend"]["endpointId"] == "mlx-host"
+        assert state["active"]["runtimeModelId"] == str(weights)
+
+        env_text = (install_dir / ".env").read_text(encoding="utf-8")
+        assert f"MLX_MODEL_PATH={weights}" in env_text
+        assert "CTX_SIZE=65536" in env_text
+
+    def test_non_apple_backend_is_refused(self, tmp_path, monkeypatch):
+        self._prepare(tmp_path, monkeypatch, gpu_backend="nvidia")
+        handler = _ResponseHandler()
+        _mod.AgentHandler._do_model_activate(handler, "target-mlx")
+        assert handler.response_code == 400
+        assert "apple GPU backend" in handler.parse_response()["error"]
+
+    def test_corrupt_shard_blocks_activation_before_any_restart(
+        self, tmp_path, monkeypatch
+    ):
+        install_dir = self._prepare(tmp_path, monkeypatch)
+        shard = (install_dir / "data" / "models" / "mlx" / "target-mlx" / "8-bit"
+                 / "model-00001-of-00001.safetensors")
+        shard.write_bytes(b"tampered")
+        restarted = []
+        monkeypatch.setattr(
+            _mod, "_restart_native_mlx_server",
+            lambda *a: restarted.append(a),
+        )
+
+        handler = _ResponseHandler()
+        _mod.AgentHandler._do_model_activate(handler, "target-mlx")
+        assert handler.response_code == 400
+        assert "sha256 mismatch" in handler.parse_response()["error"]
+        assert restarted == []
+
+    def test_failed_verification_restores_env_and_stops_the_process(
+        self, tmp_path, monkeypatch
+    ):
+        install_dir = self._prepare(tmp_path, monkeypatch)
+        env_path = install_dir / ".env"
+        before = env_path.read_text(encoding="utf-8")
+        stopped = []
+
+        monkeypatch.setattr(_mod, "_restart_native_mlx_server", lambda *a: None)
+        monkeypatch.setattr(_mod, "_wait_for_mlx_readiness", lambda *a: {})
+        monkeypatch.setattr(
+            _mod, "_stop_native_mlx_server", lambda pid: stopped.append(pid)
+        )
+
+        handler = _ResponseHandler()
+        _mod.AgentHandler._do_model_activate(handler, "target-mlx")
+
+        assert handler.response_code == 500
+        assert handler.parse_response()["failure_phase"] == "verify_identity"
+        assert env_path.read_text(encoding="utf-8") == before
+        assert stopped, "a failed activation must not leave the process running"
+        assert not (install_dir / "data" / "model-state.json").exists()
+
+    def test_stage_failure_is_reported_as_stage(self, tmp_path, monkeypatch):
+        self._prepare(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            _mod, "_restart_native_mlx_server",
+            lambda *a: (_ for _ in ()).throw(RuntimeError("interpreter missing")),
+        )
+        monkeypatch.setattr(_mod, "_stop_native_mlx_server", lambda pid: None)
+
+        handler = _ResponseHandler()
+        _mod.AgentHandler._do_model_activate(handler, "target-mlx")
+        assert handler.response_code == 500
+        payload = handler.parse_response()
+        assert payload["failure_phase"] == "stage"
+        assert "interpreter missing" in payload["failure_detail"]
+
+
+class TestMLXIdentityMatching:
+    def test_exact_path_match_is_required(self):
+        body = json.dumps({"data": [
+            {"id": "/models/mlx/Other-8bit"},
+            {"id": "/models/mlx/Target-8bit"},
+        ]})
+        assert _mod._mlx_reported_identity(body, "/models/mlx/Target-8bit") == \
+            "/models/mlx/Target-8bit"
+
+    def test_prefix_of_a_served_model_is_not_accepted(self):
+        # "/models/mlx/Target" must not match "/models/mlx/Target-8bit".
+        body = json.dumps({"data": [{"id": "/models/mlx/Target-8bit"}]})
+        assert _mod._mlx_reported_identity(body, "/models/mlx/Target") == ""
+
+    def test_trailing_slash_is_tolerated(self):
+        body = json.dumps({"data": [{"id": "/models/mlx/Target-8bit"}]})
+        assert _mod._mlx_reported_identity(body, "/models/mlx/Target-8bit/") == \
+            "/models/mlx/Target-8bit"
+
+    def test_malformed_body_yields_no_identity(self):
+        assert _mod._mlx_reported_identity("not json", "/x") == ""
+        assert _mod._mlx_reported_identity('{"data": {}}', "/x") == ""

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -281,6 +281,167 @@ class TestNativeLlamaAdapter:
         assert required.issubset(set(dir(ad.FakeAdapter)))
 
 
+class TestNativeMLXAdapter:
+    """MLX is a host process reached over host.docker.internal, and reports a
+    model reference rather than a GGUF filename."""
+
+    def _proof(self, identity="/models/mlx/Q-8bit", context_length=65536,
+               context_verified=True):
+        return {
+            "identity": identity,
+            "contextLength": context_length,
+            "contextVerified": context_verified,
+            "verifiedAt": "2026-07-20T00:00:00+00:00",
+        }
+
+    def test_kind_is_a_distinct_runtime_family(self):
+        assert ad.NativeMLXAdapter.kind == "mlx"
+
+    def test_delegates_with_model_ref_and_no_lemonade_argument(self):
+        seen = {}
+
+        def restart(env):
+            seen["restart_env"] = env
+
+        def wait_ready(env, model_ref, context_length):
+            seen["wait"] = (model_ref, context_length)
+            return self._proof("/models/mlx/Q-8bit", 65536)
+
+        adapter = ad.NativeMLXAdapter(
+            restart=restart,
+            wait_ready=wait_ready,
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+            capabilities={"chat": True, "vision": True, "tools": True},
+        )
+        env = {"GPU_BACKEND": "apple"}
+        run = rc.run_runtime_activation(adapter, env)
+        assert run["ok"] is True
+        assert run["identity"] == "/models/mlx/Q-8bit"
+        assert run["contextLength"] == 65536
+        assert run["capabilities"] == {
+            "chat": True,
+            "tools": True,
+            "vision": True,
+            "agentViable": False,
+        }
+        assert seen["restart_env"] is env
+        assert seen["wait"] == ("/models/mlx/Q-8bit", 65536)
+
+    def test_unconfirmed_context_is_carried_as_unverified_not_asserted(self):
+        # MLX has no /props endpoint, so a probe that cannot read the served
+        # context must still succeed while reporting contextVerified False.
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: self._proof(context_verified=False),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is True
+        assert run["contextVerified"] is False
+
+    def test_restart_exception_becomes_stage_failure(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: (_ for _ in ()).throw(OSError("port busy")),
+            wait_ready=lambda *a: self._proof(),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "stage"
+        assert "port busy" in run["detail"]
+
+    def test_not_ready_is_identity_failure(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: {},
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert "did not report the staged model" in run["detail"]
+
+    def test_non_dict_probe_return_is_identity_failure(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: None,
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert "did not return a proof record" in run["detail"]
+
+    def test_probe_exception_is_identity_failure_not_a_raise(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: (_ for _ in ()).throw(OSError("connection refused")),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert "connection refused" in run["detail"]
+
+    def test_blank_identity_is_rejected(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: self._proof(identity="   "),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert "did not report the staged model" in run["detail"]
+
+    def test_nonpositive_context_is_rejected(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: self._proof(context_length=0),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert "valid context length" in run["detail"]
+
+    def test_publish_native_alias_is_a_proven_noop(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: self._proof(),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        assert adapter.publish_native_alias({})["ok"] is True
+
+    def test_optional_operations_report_unconfigured(self):
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: self._proof(),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+        )
+        for op in ("unload", "delete", "rollback"):
+            outcome = getattr(adapter, op)({})
+            assert outcome["ok"] is False
+            assert "is not configured" in outcome["detail"]
+
+    def test_configured_rollback_runs(self):
+        seen = {}
+        adapter = ad.NativeMLXAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a: self._proof(),
+            expected_model="/models/mlx/Q-8bit",
+            context_length=65536,
+            rollback=lambda env: seen.setdefault("rolled_back", env),
+        )
+        outcome = adapter.rollback({"K": "V"})
+        assert outcome["ok"] is True
+        assert seen["rolled_back"] == {"K": "V"}
+
+
 class TestLemonadeAdapter:
     def test_verify_uses_resolved_lemonade_id(self):
         seen = {}

--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -437,7 +437,9 @@ def _validate_state_schema(doc: Any) -> bool:
             backend, {"kind", "endpointId"}, {"kind", "endpointId", "nativeRoute"}
         ):
             return False
-        if backend["kind"] not in {"llama-server", "lemonade", "hipfire", "unknown"}:
+        if backend["kind"] not in {
+            "llama-server", "lemonade", "hipfire", "mlx", "unknown"
+        }:
             return False
         if not isinstance(backend["endpointId"], str) or not backend["endpointId"]:
             return False

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -381,6 +381,29 @@ class TestForwarding:
 
 
 class TestStateTrust:
+    def test_mlx_backend_kind_is_routable(self, router):
+        """MLX is a first-class runtime family, not an "unknown" backend."""
+        mod, client, write_state, calls = router
+        write_state(
+            mutate=lambda doc: doc["active"]["backend"].update({"kind": "mlx"})
+        )
+        resp = client.post("/v1/chat/completions", json={
+            "model": "ods/current", "messages": [],
+        })
+        assert resp.status_code == 200
+        assert len(calls) == 1
+
+    def test_unknown_backend_kind_is_not_routable(self, router):
+        mod, client, write_state, calls = router
+        write_state(
+            mutate=lambda doc: doc["active"]["backend"].update({"kind": "torch"})
+        )
+        resp = client.post("/v1/chat/completions", json={
+            "model": "ods/current", "messages": [],
+        })
+        assert resp.status_code == 503
+        assert calls == []
+
     def test_schema_invalid_state_is_not_routable(self, router):
         mod, client, write_state, calls = router
         write_state(mutate=lambda doc: doc.update({"unexpected": True}))

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -91,6 +91,9 @@ class RenderInputs:
     remote_llm_transport: str = ""
     remote_llm_base_url: str = ""
     remote_llm_model: str = ""
+    # Native MLX runtime base URL (Apple Silicon). Empty when no MLX runtime
+    # is configured, which keeps the endpoint out of the router allowlist.
+    mlx_api_base: str = ""
     # Switchboard rollout mode: legacy | observe | enabled (plan section 8)
     switchboard_mode: str = "observe"
 
@@ -574,6 +577,16 @@ def render_model_router_endpoints(inputs: RenderInputs) -> RenderedFile:
             "id": "lemonade-default",
             "baseUrl": _origin_base(inputs.lemonade_api_base, "http://lemonade:8000/api"),
         })
+    # MLX is always a host process (Docker on macOS has no Metal passthrough),
+    # so it is only reachable over host.docker.internal and only exists when
+    # an MLX base URL was configured.
+    if inputs.mlx_api_base.strip():
+        endpoints.append({
+            "id": "mlx-host",
+            "baseUrl": _origin_base(
+                inputs.mlx_api_base, "http://host.docker.internal:8081"
+            ),
+        })
     content = json.dumps({"endpoints": endpoints}, indent=2) + "\n"
     return RenderedFile(
         "model-router-endpoints", "config/model-router/endpoints.json", content
@@ -645,6 +658,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--gguf-file", default=DEFAULT_GGUF)
     parser.add_argument("--lemonade-model-id", default="")
     parser.add_argument("--lemonade-api-base", default="http://llama-server:8080/api/v1")
+    parser.add_argument(
+        "--mlx-api-base",
+        default="",
+        help="Native MLX server base URL; empty disables the mlx-host endpoint",
+    )
     parser.add_argument("--gpu-backend", choices=["amd", "apple", "cpu", "nvidia"], default="nvidia")
     parser.add_argument("--ods-mode", choices=["local", "cloud", "hybrid", "lemonade"], default="local")
     parser.add_argument("--llm-base-url", default="http://llama-server:8080/v1")
@@ -735,6 +753,7 @@ def render(args: argparse.Namespace) -> dict[str, object]:
         gguf_file=args.gguf_file,
         lemonade_model_id=args.lemonade_model_id,
         lemonade_api_base=args.lemonade_api_base,
+        mlx_api_base=args.mlx_api_base,
         gpu_backend=args.gpu_backend,
         ods_mode=args.ods_mode,
         llm_base_url=args.llm_base_url,

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -362,6 +362,27 @@ def test_router_endpoints_strip_trailing_v1() -> None:
     assert by_id["lemonade-default"] == "http://lemonade:8000/api"
 
 
+def test_router_endpoints_omit_mlx_when_unconfigured() -> None:
+    payload = run_renderer("--surface", "model-router-endpoints")
+    import json as _json
+    content = _json.loads(payload["files"][0]["content"])
+    assert [e["id"] for e in content["endpoints"]] == ["llama-server-default"]
+
+
+def test_router_endpoints_add_mlx_host_when_configured() -> None:
+    payload = run_renderer(
+        "--surface", "model-router-endpoints",
+        "--gpu-backend", "apple",
+        "--mlx-api-base", "http://host.docker.internal:8081/v1",
+    )
+    import json as _json
+    content = _json.loads(payload["files"][0]["content"])
+    by_id = {e["id"]: e["baseUrl"] for e in content["endpoints"]}
+    # MLX only ever runs as a host process, and the /v1 suffix is stripped
+    # because the router appends the full OpenAI path itself.
+    assert by_id["mlx-host"] == "http://host.docker.internal:8081"
+
+
 def test_lemonade_disables_thinking_and_uses_extra_alias() -> None:
     payload = run_renderer(
         "--surface",


### PR DESCRIPTION
## Why

MLX models could not be activated or routed. The switchboard's adapter registry covered llama.cpp (container + native) and Lemonade only, and `model-router` rejected any `backend.kind` outside that set — the sole way to express an MLX route was `"unknown"`, indistinguishable from a genuinely unrecognized backend.

This matters specifically on Apple Silicon: Docker on macOS has no Metal passthrough, so an MLX runtime can only ever be a **host process** reached over `host.docker.internal`.

## What

**Commit 1 — the runtime family**

- `NativeMLXAdapter` implements the PR 2A adapter contract and passes the same boundary suite. Two contract differences are structural, and modeled explicitly rather than papered over:
  - identity is a **model reference** (a weights directory), not a GGUF filename → takes a new `ModelReadinessProbe` instead of the GGUF/Lemonade-shaped `ReadinessProbe`;
  - MLX has **no `/props` endpoint**, so a served context the probe cannot read back is proof-carried as `contextVerified: false` rather than asserted from configuration.
- `"mlx"` becomes a first-class `backend.kind` in the router, the v1 state schema, and `state.py`.
- `render-runtime-configs` emits an `mlx-host` endpoint under `--mlx-api-base`. **Without this the allowlist is regenerated on every install and update**, so a hand-added MLX endpoint disappears silently and the route stops resolving.
- Catalog gains a `runtime` discriminator and the Qwen3.8 27B Uncensored MLX 8-bit entry, per-shard sha256 pinned to a repo revision.

**Commit 2 — activation**

Dispatches MLX models to their own sequence at **one** branch point after catalog lookup, instead of threading a second runtime family through the GGUF transaction's ~50 GGUF-shaped call sites. The llama.cpp path is byte-for-byte unchanged — deliberately, since a retrofit mistake there would regress the runtime every existing install uses.

- PID-file lifecycle mirroring the native llama-server path; the stop probe matches the process command line so a recycled PID is never signalled.
- Readiness probe proving identity **and** a real completion. Identity requires an exact path match — `mlx_vlm.server` lists every model it has resolved, so a substring match would accept a different model sharing a prefix.
- Weight staging that downloads the pinned revision when absent, then verifies every shard's sha256 unconditionally — a truncated shard would otherwise surface only as an opaque load failure.
- On failure: `.env` restored, and the process it started is stopped.

## Deliberate divergence worth reviewing

The llama path publishes a verified route only when `contextVerified is true`. That is correct for llama.cpp, where a missing readback means the `/props` probe failed. MLX exposes no `/props` at all, so the same gate would mean **an MLX route could never publish, however healthy**. The MLX path publishes on proven identity + completion and records `contextVerified: false` — honest about what was proven rather than asserting a context it cannot read.

## Verification

Against the **live 27B server**, not only fixtures:
- probe matches the served path exactly and rejects a prefix of it;
- full reconciler sequence returns `"runtime activation proven"` with a real completion.

Also:
- catalog sha256 values match the downloaded weights byte-for-byte;
- `select-model` output byte-identical across apple/nvidia/cpu profiles (a GGUF-less entry is inert to the tier selector);
- renderer output unchanged when `--mlx-api-base` is unset;
- `make lint` and CI's exact ruff ruleset pass;
- dashboard-api shows the **identical 118 pre-existing failures** before and after (they also fail on clean `main` — a BSD-sed/dependency issue local to macOS), plus **21 new passing tests**.

## Known gaps

- Consumer configs (LiteLLM, Hermes, Open WebUI) are not repointed at the MLX endpoint on activation; the route publishes but downstream surfaces still target `llama-server-default`. Worth a follow-up.
- `NativeMLXAdapter`, `ContainerLlamaAdapter`, and `LemonadeAdapter` now share duplicated proof-record validation. I matched the existing house style rather than refactor two working adapters in this PR; extraction is a clean follow-up.
- The catalogued model is abliterated (refusal behavior removed) and carries no model-side guardrails. It is marked `unvalidated` / not agent-viable and scoped to `apple`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)