### PR TITLE
feat(extensions): add Docling Serve document intelligence

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:02:03Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -677,6 +677,65 @@
           ]
         }
       ]
+    },
+    {
+      "id": "docling-serve",
+      "name": "Docling Serve",
+      "description": "Local document conversion, OCR, layout analysis, and structured chunking API.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 5001,
+      "external_port_default": 5001,
+      "health_endpoint": "/readyz",
+      "env_vars": [
+        {
+          "key": "DOCLING_SERVE_ENABLE_UI",
+          "required": false,
+          "default": "1",
+          "description": "Enable the browser conversion playground at /ui"
+        }
+      ],
+      "tags": [
+        "document",
+        "ocr",
+        "parsing",
+        "rag",
+        "pdf"
+      ],
+      "features": [
+        {
+          "id": "docling-document-intelligence",
+          "name": "Document Intelligence",
+          "description": "Convert PDFs and office documents into Markdown, JSON, HTML, or chunks locally",
+          "icon": "FileSearch",
+          "category": "productivity",
+          "requirements": {
+            "services": [
+              "docling-serve"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 12
+          },
+          "enabled_services_all": [
+            "docling-serve"
+          ],
+          "setup_time": "~5 minutes",
+          "priority": 30,
+          "launch": {
+            "type": "service",
+            "service": "docling-serve",
+            "path": "/ui"
+          },
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 300
     },
     {
       "id": "flowise",

--- a/ods/extensions/library/services/docling-serve/README.md
+++ b/ods/extensions/library/services/docling-serve/README.md
@@ -1,0 +1,40 @@
+# Docling Serve
+
+Docling Serve runs IBM's Docling document-conversion pipeline as a local API and browser playground. It extracts layout, tables, OCR text, and structured chunks without uploading source documents to a hosted parser.
+
+## Enable and access
+
+```bash
+ods enable docling-serve
+ods start docling-serve
+```
+
+- Playground: `http://localhost:5001/ui`
+- OpenAPI: `http://localhost:5001/docs`
+- Readiness: `http://localhost:5001/readyz`
+
+The first start may take several minutes while the image initializes its document models. The CPU image works on every ODS backend and has a deliberately generous memory limit for OCR-heavy PDFs.
+
+## Convert a document
+
+```bash
+curl -X POST http://localhost:5001/v1/convert/file \
+  -H "accept: application/json" \
+  -F "files=@document.pdf"
+```
+
+Remote URL conversion is also supported through `/v1/convert/source`. Only submit URLs you trust: the service, not your browser, fetches those resources.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `DOCLING_SERVE_PORT` | `5001` | Host port for the API and playground |
+| `DOCLING_SERVE_ENABLE_UI` | `1` | Enables the browser playground |
+
+The service is loopback-bound by default. Standard ODS `BIND_ADDRESS` policy controls intentional LAN exposure.
+
+## Upstream
+
+- Project: <https://github.com/docling-project/docling-serve>
+- API documentation: <https://github.com/docling-project/docling-serve/blob/main/docs/README.md>

--- a/ods/extensions/library/services/docling-serve/compose.yaml
+++ b/ods/extensions/library/services/docling-serve/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  docling-serve:
+    image: quay.io/docling-project/docling-serve-cpu:v1.30.0
+    container_name: ods-docling-serve
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      DOCLING_SERVE_ENABLE_UI: "${DOCLING_SERVE_ENABLE_UI:-1}"
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${DOCLING_SERVE_PORT:-5001}:5001"
+    tmpfs:
+      - /tmp:size=1g,mode=1777
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:5001/readyz', timeout=5)"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 8G
+        reservations:
+          cpus: '1.0'
+          memory: 2G
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/docling-serve/manifest.yaml
+++ b/ods/extensions/library/services/docling-serve/manifest.yaml
@@ -1,0 +1,53 @@
+schema_version: ods.services.v1
+
+service:
+  id: docling-serve
+  name: Docling Serve
+  aliases: [docling, document-parser]
+  container_name: ods-docling-serve
+  host_env: DOCLING_SERVE_HOST
+  default_host: docling-serve
+  port: 5001
+  external_port_env: DOCLING_SERVE_PORT
+  external_port_default: 5001
+  health: /readyz
+  ui_path: /ui
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 300
+  description: "Local document conversion, OCR, layout analysis, and structured chunking API."
+  env_vars:
+    - key: DOCLING_SERVE_ENABLE_UI
+      required: false
+      secret: false
+      default: "1"
+      description: Enable the browser conversion playground at /ui
+
+features:
+  - id: docling-document-intelligence
+    name: Document Intelligence
+    description: Convert PDFs and office documents into Markdown, JSON, HTML, or chunks locally
+    icon: FileSearch
+    category: productivity
+    requirements:
+      services: [docling-serve]
+      vram_gb: 0
+      disk_gb: 12
+    enabled_services_all: [docling-serve]
+    setup_time: ~5 minutes
+    priority: 30
+    launch:
+      type: service
+      service: docling-serve
+      path: /ui
+    gpu_backends: [all]
+
+tags:
+  - document
+  - ocr
+  - parsing
+  - rag
+  - pdf

--- a/ods/tests/test_library_docling_serve.py
+++ b/ods/tests/test_library_docling_serve.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "docling-serve"
+
+
+def test_docling_serve_reaches_the_generated_dashboard_catalog(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "docling-serve")
+    assert entry["health_endpoint"] == "/readyz"
+    assert entry["external_port_default"] == 5001
+    assert entry["features"][0]["launch"]["path"] == "/ui"
+
+
+def test_docling_serve_compose_keeps_the_public_boundary_reproducible() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["docling-serve"]
+
+    assert service["image"] == "quay.io/docling-project/docling-serve-cpu:v1.30.0"
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${DOCLING_SERVE_PORT:-5001}:5001"
+    ]
+    assert "/readyz" in " ".join(service["healthcheck"]["test"])


### PR DESCRIPTION
## Summary

- add Docling Serve v1.30.0 as an opt-in, CPU-portable extension
- expose the local conversion playground and stable readiness contract through the ODS catalog
- ship loopback-safe Compose defaults, bounded resources, documentation, and a catalog-boundary regression test

## Why this matters

ODS has RAG runtimes and vector stores, but no first-class local document-intelligence ingress. Docling turns PDFs and office documents into structured Markdown, JSON, HTML, and chunks without sending source files to a hosted parser. The production path is Dashboard extension catalog -> library install -> host-agent Compose start -> `/readyz` and `/ui`.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `docling` and inspected the extension library plus `ods/config/extensions-catalog.json` on 2026-08-20. No matching PR, existing service directory, or strict superset was found. The scope is independent of current document-Q&A workflow PRs because it adds the parser service boundary rather than an n8n template.

## AI Assistance

Codex assisted with upstream contract research, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [ ] Mainline change targeting `main`
- [x] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in service Compose)
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation

Commands/results:

```text
python -m pytest ods/tests/test_library_docling_serve.py -q       # 2 passed
python ods/extensions/library/validate-manifests.py               # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict docling-serve
                                                                  # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/docling-serve/compose.yaml config --quiet
bash ods/tests/test-bind-address-sweep.sh                          # PASS
docker manifest inspect quay.io/docling-project/docling-serve-cpu:v1.30.0
                                                                  # manifest exists
git diff --check                                                  # clean
```

The regression test runs the production catalog generator and proves that the dashboard-facing entry retains the readiness, port, launch, pinned-image, and loopback-binding contracts.

## Operational Change Check

- [ ] This is not an operational change.
- [ ] This is an operational change and release-grade validation is recorded above.
- [x] This is an operational change and release-grade validation is intentionally deferred: the service is opt-in and isolated from the default stack; a live conversion smoke on representative amd64/arm64 hosts is still required before release promotion.

## Notes For Reviewers

Rollback is `ods disable docling-serve` followed by uninstalling the library extension; no core route or shared data format changes. The image is the upstream CPU multi-architecture build, deliberately chosen over a GPU overlay so every ODS backend gets the same supported baseline.