### PR TITLE
feat(extensions): add Apache Tika content extraction

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:04:25Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -136,6 +136,58 @@
           ]
         }
       ]
+    },
+    {
+      "id": "apache-tika",
+      "name": "Apache Tika",
+      "description": "Extract text and metadata from PDFs, office files, images, and 1,000+ formats.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 9998,
+      "external_port_default": 9998,
+      "health_endpoint": "/tika",
+      "env_vars": [],
+      "tags": [
+        "document",
+        "extraction",
+        "ocr",
+        "metadata",
+        "rag"
+      ],
+      "features": [
+        {
+          "id": "tika-content-extraction",
+          "name": "Universal Content Extraction",
+          "description": "Extract text, metadata, and OCR output from more than a thousand document formats",
+          "icon": "ScanText",
+          "category": "productivity",
+          "requirements": {
+            "services": [
+              "apache-tika"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 4
+          },
+          "enabled_services_all": [
+            "apache-tika"
+          ],
+          "setup_time": "~2 minutes",
+          "priority": 31,
+          "launch": {
+            "type": "service",
+            "service": "apache-tika",
+            "path": "/"
+          },
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 120
     },
     {
       "id": "audiocraft",

--- a/ods/extensions/library/services/apache-tika/README.md
+++ b/ods/extensions/library/services/apache-tika/README.md
@@ -1,0 +1,44 @@
+# Apache Tika
+
+Apache Tika provides a local HTTP API for extracting text and metadata from PDFs, office documents, archives, email, images, audio, and more than a thousand other formats. The `full` image includes Tesseract OCR and common native parsers.
+
+## Enable and access
+
+```bash
+ods enable apache-tika
+ods start apache-tika
+```
+
+- API: `http://localhost:9998`
+- Health/version endpoint: `http://localhost:9998/tika`
+
+## Extract text
+
+```bash
+curl -T document.pdf \
+  -H "Accept: text/plain" \
+  http://localhost:9998/tika
+```
+
+## Extract metadata
+
+```bash
+curl -T document.pdf \
+  -H "Accept: application/json" \
+  http://localhost:9998/meta
+```
+
+Optional parser JARs can be placed under `data/apache-tika/extras`; the directory is mounted read-only at `/tika-extras` inside the container.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `APACHE_TIKA_PORT` | `9998` | Host port for the Tika API |
+
+The service is loopback-bound by default. Standard ODS `BIND_ADDRESS` policy controls intentional LAN exposure.
+
+## Upstream
+
+- Project: <https://github.com/apache/tika>
+- Container image: <https://github.com/apache/tika-docker>

--- a/ods/extensions/library/services/apache-tika/compose.yaml
+++ b/ods/extensions/library/services/apache-tika/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  apache-tika:
+    image: apache/tika:3.2.3.0-full
+    container_name: ods-apache-tika
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${APACHE_TIKA_PORT:-9998}:9998"
+    volumes:
+      - ./data/apache-tika/extras:/tika-extras:ro
+    tmpfs:
+      - /tmp:size=1g,mode=1777
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:9998/tika"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/apache-tika/manifest.yaml
+++ b/ods/extensions/library/services/apache-tika/manifest.yaml
@@ -1,0 +1,48 @@
+schema_version: ods.services.v1
+
+service:
+  id: apache-tika
+  name: Apache Tika
+  aliases: [tika, document-extractor]
+  container_name: ods-apache-tika
+  host_env: APACHE_TIKA_HOST
+  default_host: apache-tika
+  port: 9998
+  external_port_env: APACHE_TIKA_PORT
+  external_port_default: 9998
+  health: /tika
+  ui_path: /
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 120
+  description: "Extract text and metadata from PDFs, office files, images, and 1,000+ formats."
+  env_vars: []
+
+features:
+  - id: tika-content-extraction
+    name: Universal Content Extraction
+    description: Extract text, metadata, and OCR output from more than a thousand document formats
+    icon: ScanText
+    category: productivity
+    requirements:
+      services: [apache-tika]
+      vram_gb: 0
+      disk_gb: 4
+    enabled_services_all: [apache-tika]
+    setup_time: ~2 minutes
+    priority: 31
+    launch:
+      type: service
+      service: apache-tika
+      path: /
+    gpu_backends: [all]
+
+tags:
+  - document
+  - extraction
+  - ocr
+  - metadata
+  - rag

--- a/ods/tests/test_library_apache_tika.py
+++ b/ods/tests/test_library_apache_tika.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "apache-tika"
+
+
+def test_apache_tika_reaches_the_generated_dashboard_catalog(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "apache-tika")
+    assert entry["health_endpoint"] == "/tika"
+    assert entry["external_port_default"] == 9998
+    assert entry["features"][0]["launch"]["service"] == "apache-tika"
+
+
+def test_apache_tika_compose_is_pinned_and_loopback_safe() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["apache-tika"]
+
+    assert service["image"] == "apache/tika:3.2.3.0-full"
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${APACHE_TIKA_PORT:-9998}:9998"
+    ]
+    assert service["cap_drop"] == ["ALL"]
+    assert "/tika" in " ".join(service["healthcheck"]["test"])


### PR DESCRIPTION
## Summary

- add Apache Tika 3.2.3.0 Full as an opt-in universal extraction service
- expose text, metadata, and OCR APIs through the ODS extension catalog
- ship a loopback-safe, capability-dropped Compose contract plus public-catalog regression coverage

## Why this matters

Local RAG pipelines routinely receive formats that application-specific parsers cannot open. Tika provides one stable local boundary for PDFs, office documents, archives, email, images, and metadata extraction. The reachable production path is Dashboard extension catalog -> library install -> host-agent Compose start -> `/tika`, `/meta`, and parser endpoints.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `Apache Tika` and `tika`, then inspected the extension library and generated catalog on 2026-08-20. No matching PR, service directory, or strict superset was found. This is independent of Docling: Tika is a broad Java content-detection/extraction API with optional parser JARs, while Docling is a layout-aware document-intelligence pipeline.

## AI Assistance

Codex assisted with upstream contract research, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [ ] Mainline change targeting `main`
- [x] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in service Compose)
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation

Commands/results:

```text
python -m pytest ods/tests/test_library_apache_tika.py -q       # 2 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict apache-tika
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/apache-tika/compose.yaml config --quiet
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect apache/tika:3.2.3.0-full                # manifest exists
git diff --check                                                # clean
```

The regression test invokes the production catalog generator and locks the dashboard health/port/launch entry together with the pinned image, loopback binding, capability drop, and container health probe.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because the service is opt-in and isolated from the default stack. A live OCR/extraction smoke on representative amd64/arm64 hosts remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable apache-tika` followed by uninstalling the library extension. Optional parser JARs are mounted read-only from `data/apache-tika/extras`; user documents are request-scoped and no core data format changes.