### PR TITLE
feat(extensions): add Gotenberg PDF conversion API

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:06:35Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -1146,6 +1146,63 @@
       ],
       "tags": [],
       "features": []
+    },
+    {
+      "id": "gotenberg",
+      "name": "Gotenberg",
+      "description": "Convert web pages and office documents to PDF with Chromium and LibreOffice.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 3000,
+      "external_port_default": 3000,
+      "health_endpoint": "/health",
+      "env_vars": [
+        {
+          "key": "GOTENBERG_DENY_PRIVATE_IPS",
+          "required": false,
+          "default": "true",
+          "description": "Reject remote input URLs that resolve to loopback or private networks"
+        }
+      ],
+      "tags": [
+        "pdf",
+        "document",
+        "chromium",
+        "libreoffice",
+        "conversion"
+      ],
+      "features": [
+        {
+          "id": "gotenberg-pdf-conversion",
+          "name": "Document-to-PDF API",
+          "description": "Render URLs, HTML, Markdown, and office documents to PDF through a local API",
+          "icon": "FileOutput",
+          "category": "productivity",
+          "requirements": {
+            "services": [
+              "gotenberg"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 2
+          },
+          "enabled_services_all": [
+            "gotenberg"
+          ],
+          "setup_time": "~2 minutes",
+          "priority": 32,
+          "launch": {
+            "type": "none"
+          },
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 120
     },
     {
       "id": "immich",

--- a/ods/extensions/library/services/gotenberg/README.md
+++ b/ods/extensions/library/services/gotenberg/README.md
@@ -1,0 +1,46 @@
+# Gotenberg
+
+Gotenberg is a local document-to-PDF API powered by Chromium, LibreOffice, and PDF tooling. It accepts multipart HTTP requests and returns the converted PDF directly.
+
+## Enable and access
+
+```bash
+ods enable gotenberg
+ods start gotenberg
+```
+
+- API: `http://localhost:3000`
+- Health: `http://localhost:3000/health`
+- Version: `http://localhost:3000/version`
+
+## Convert a URL
+
+```bash
+curl -X POST http://localhost:3000/forms/chromium/convert/url \
+  -F url=https://example.com \
+  -o page.pdf
+```
+
+## Convert an office document
+
+```bash
+curl -X POST http://localhost:3000/forms/libreoffice/convert \
+  -F files=@document.docx \
+  -o document.pdf
+```
+
+Private and loopback URL targets are denied by default to keep a conversion request from probing services on the ODS network. Set `GOTENBERG_DENY_PRIVATE_IPS=false` only when conversion of trusted internal URLs is required.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `GOTENBERG_PORT` | `3000` | Host port for the conversion API |
+| `GOTENBERG_DENY_PRIVATE_IPS` | `true` | Blocks private-network sources used by remote-download features |
+
+The service is loopback-bound by default and intentionally has no dashboard launch link because it exposes an API rather than a user interface.
+
+## Upstream
+
+- Project: <https://github.com/gotenberg/gotenberg>
+- API routes: <https://gotenberg.dev/docs/getting-started/routes>

--- a/ods/extensions/library/services/gotenberg/compose.yaml
+++ b/ods/extensions/library/services/gotenberg/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  gotenberg:
+    image: gotenberg/gotenberg:8.36.0
+    container_name: ods-gotenberg
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    command:
+      - gotenberg
+      - "--api-download-from-deny-private-ips=${GOTENBERG_DENY_PRIVATE_IPS:-true}"
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${GOTENBERG_PORT:-3000}:3000"
+    tmpfs:
+      - /tmp:size=2g,mode=1777
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/gotenberg/manifest.yaml
+++ b/ods/extensions/library/services/gotenberg/manifest.yaml
@@ -1,0 +1,51 @@
+schema_version: ods.services.v1
+
+service:
+  id: gotenberg
+  name: Gotenberg
+  aliases: [document-to-pdf, pdf-api]
+  container_name: ods-gotenberg
+  host_env: GOTENBERG_HOST
+  default_host: gotenberg
+  port: 3000
+  external_port_env: GOTENBERG_PORT
+  external_port_default: 3000
+  health: /health
+  external_link: false
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 120
+  description: "Convert web pages and office documents to PDF with Chromium and LibreOffice."
+  env_vars:
+    - key: GOTENBERG_DENY_PRIVATE_IPS
+      required: false
+      secret: false
+      default: "true"
+      description: Reject remote input URLs that resolve to loopback or private networks
+
+features:
+  - id: gotenberg-pdf-conversion
+    name: Document-to-PDF API
+    description: Render URLs, HTML, Markdown, and office documents to PDF through a local API
+    icon: FileOutput
+    category: productivity
+    requirements:
+      services: [gotenberg]
+      vram_gb: 0
+      disk_gb: 2
+    enabled_services_all: [gotenberg]
+    setup_time: ~2 minutes
+    priority: 32
+    launch:
+      type: none
+    gpu_backends: [all]
+
+tags:
+  - pdf
+  - document
+  - chromium
+  - libreoffice
+  - conversion

--- a/ods/tests/test_library_gotenberg.py
+++ b/ods/tests/test_library_gotenberg.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "gotenberg"
+
+
+def test_gotenberg_reaches_the_generated_dashboard_catalog(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "gotenberg")
+    assert entry["health_endpoint"] == "/health"
+    assert entry["external_port_default"] == 3000
+    assert entry["features"][0]["launch"] == {"type": "none"}
+
+
+def test_gotenberg_compose_pins_runtime_and_blocks_private_sources() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["gotenberg"]
+
+    assert service["image"] == "gotenberg/gotenberg:8.36.0"
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${GOTENBERG_PORT:-3000}:3000"
+    ]
+    assert service["cap_drop"] == ["ALL"]
+    assert "--api-download-from-deny-private-ips=${GOTENBERG_DENY_PRIVATE_IPS:-true}" in service["command"]
+    assert "/health" in " ".join(service["healthcheck"]["test"])


### PR DESCRIPTION
## Summary

- add Gotenberg 8.36.0 as an opt-in document-to-PDF API
- support Chromium and LibreOffice conversion with bounded temporary storage and resources
- deny private-network input URLs by default and cover the generated dashboard contract

## Why this matters

Local agents and workflows often need invoices, reports, HTML, Markdown, and office documents rendered reproducibly as PDFs. Gotenberg provides that production-grade conversion boundary without adding browser or LibreOffice dependencies to ODS services. The reachable path is Dashboard extension catalog -> library install -> host-agent Compose start -> `/health` and conversion routes.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `Gotenberg`, `document-to-PDF`, and `pdf-api`, then inspected the extension library and generated catalog on 2026-08-20. No matching PR, service directory, or strict superset was found. Apache Tika and Docling parse documents; this scope produces PDFs and does not duplicate either runtime.

## AI Assistance

Codex assisted with upstream contract research, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in service Compose)

```text
python -m pytest ods/tests/test_library_gotenberg.py -q         # 2 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict gotenberg
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/gotenberg/compose.yaml config --quiet
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect gotenberg/gotenberg:8.36.0              # manifest exists
git diff --check                                                # clean
```

The regression test invokes the production catalog generator and locks the API-only launch contract, health path, pinned runtime, loopback port, capability drop, and private-network source policy.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in extension. A live Chromium and LibreOffice conversion smoke on representative amd64/arm64 hosts remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable gotenberg` followed by uninstalling the extension. `GOTENBERG_DENY_PRIVATE_IPS=true` is intentional SSRF hardening; operators who explicitly need trusted internal URL conversion can opt out in `.env`.