### PR TITLE
feat(extensions): add swap-safe Crawl4AI ingestion

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:12:28Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -491,6 +491,82 @@
           ]
         }
       ]
+    },
+    {
+      "id": "crawl4ai",
+      "name": "Crawl4AI",
+      "description": "Browser-based crawling and clean Markdown extraction for local agents and RAG.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [
+        "litellm"
+      ],
+      "port": 11235,
+      "external_port_default": 11235,
+      "health_endpoint": "/health",
+      "env_vars": [
+        {
+          "key": "CRAWL4AI_API_TOKEN",
+          "required": true,
+          "description": "Token required to issue Crawl4AI API credentials"
+        },
+        {
+          "key": "CRAWL4AI_SECRET_KEY",
+          "required": true,
+          "description": "Secret used to sign Crawl4AI authentication tokens"
+        }
+      ],
+      "tags": [
+        "crawling",
+        "browser",
+        "markdown",
+        "rag",
+        "agents"
+      ],
+      "features": [
+        {
+          "id": "crawl4ai-web-ingestion",
+          "name": "Agent-Ready Web Ingestion",
+          "description": "Crawl dynamic websites into clean Markdown and structured extraction results",
+          "icon": "Globe2",
+          "category": "search",
+          "requirements": {
+            "services": [
+              "crawl4ai",
+              "litellm"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 4
+          },
+          "enabled_services_all": [
+            "crawl4ai"
+          ],
+          "setup_time": "~3 minutes",
+          "priority": 33,
+          "launch": {
+            "type": "service",
+            "service": "crawl4ai",
+            "path": "/playground"
+          },
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "llm": {
+        "consumes": true,
+        "route": "gateway",
+        "pinning": "none",
+        "probe": {
+          "kind": "custom",
+          "path": "/llm/job",
+          "auth": "bearer"
+        }
+      },
+      "startup_timeout": 180
     },
     {
       "id": "crewai",

--- a/ods/extensions/library/services/crawl4ai/README.md
+++ b/ods/extensions/library/services/crawl4ai/README.md
@@ -1,0 +1,39 @@
+# Crawl4AI
+
+Crawl4AI runs a local browser-crawling API that turns dynamic websites into clean Markdown and structured extraction results. Its optional LLM extraction path is prewired to the ODS LiteLLM gateway using the stable `ods/current` alias, so model swaps do not leave a concrete model ID behind.
+
+## Enable and access
+
+```bash
+ods enable crawl4ai
+ods start crawl4ai
+```
+
+- Playground: `http://localhost:11235/playground`
+- API: `http://localhost:11235`
+- Health: `http://localhost:11235/health`
+
+The installation hook generates `CRAWL4AI_API_TOKEN` and `CRAWL4AI_SECRET_KEY` once. Existing values are never replaced.
+
+## Crawl a page
+
+Use the playground for an interactive request, or call the API after obtaining a token with the generated API token. See the upstream API examples for the current request schema.
+
+## ODS model routing
+
+The container receives:
+
+- `LLM_PROVIDER=openai/ods/current`
+- `LLM_BASE_URL=http://litellm:4000/v1`
+- `OPENAI_API_KEY` from `LITELLM_MASTER_KEY`
+
+This keeps LLM-assisted extraction on the authenticated ODS gateway. `litellm` is therefore an explicit extension dependency.
+
+## Isolation defaults
+
+The service runs as upstream's unprivileged `appuser`, drops every Linux capability, has a read-only root filesystem, caps process count, and uses private tmpfs mounts for Chromium and its job state. The host port remains loopback-bound unless the operator opts into ODS LAN exposure.
+
+## Upstream
+
+- Project: <https://github.com/unclecode/crawl4ai>
+- Docker guide: <https://github.com/unclecode/crawl4ai/blob/main/deploy/docker/README.md>

--- a/ods/extensions/library/services/crawl4ai/compose.yaml
+++ b/ods/extensions/library/services/crawl4ai/compose.yaml
@@ -1,0 +1,52 @@
+services:
+  crawl4ai:
+    image: unclecode/crawl4ai:0.9.2
+    container_name: ods-crawl4ai
+    restart: unless-stopped
+    user: appuser
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    pids_limit: 512
+    read_only: true
+    shm_size: 1g
+    environment:
+      CRAWL4AI_API_TOKEN: "${CRAWL4AI_API_TOKEN:?CRAWL4AI_API_TOKEN must be set}"
+      SECRET_KEY: "${CRAWL4AI_SECRET_KEY:?CRAWL4AI_SECRET_KEY must be set}"
+      LLM_PROVIDER: openai/ods/current
+      LLM_BASE_URL: http://litellm:4000/v1
+      OPENAI_API_KEY: "${LITELLM_MASTER_KEY:?LITELLM_MASTER_KEY must be set}"
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${CRAWL4AI_PORT:-11235}:11235"
+    tmpfs:
+      - /tmp:uid=999,gid=999,mode=1777
+      - /var/lib/redis:uid=999,gid=999,mode=0700
+      - /var/lib/crawl4ai/outputs:uid=999,gid=999,mode=0700
+      - /home/appuser/.crawl4ai:uid=999,gid=999,mode=0700
+      - /home/appuser/.cache/url_seeder:uid=999,gid=999,mode=0700
+      - /home/appuser/.gunicorn:uid=999,gid=999,mode=0700
+    depends_on:
+      litellm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "--silent", "http://127.0.0.1:11235/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+          pids: 512
+        reservations:
+          cpus: '1.0'
+          memory: 1G
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/crawl4ai/manifest.yaml
+++ b/ods/extensions/library/services/crawl4ai/manifest.yaml
@@ -1,0 +1,66 @@
+schema_version: ods.services.v1
+
+service:
+  id: crawl4ai
+  name: Crawl4AI
+  aliases: [crawler, web-crawler]
+  container_name: ods-crawl4ai
+  container_uid: 999
+  host_env: CRAWL4AI_HOST
+  default_host: crawl4ai
+  port: 11235
+  external_port_env: CRAWL4AI_PORT
+  external_port_default: 11235
+  health: /health
+  ui_path: /playground
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: [litellm]
+  startup_timeout: 180
+  description: "Browser-based crawling and clean Markdown extraction for local agents and RAG."
+  env_vars:
+    - key: CRAWL4AI_API_TOKEN
+      required: true
+      secret: true
+      description: Token required to issue Crawl4AI API credentials
+    - key: CRAWL4AI_SECRET_KEY
+      required: true
+      secret: true
+      description: Secret used to sign Crawl4AI authentication tokens
+  llm:
+    consumes: true
+    route: gateway
+    pinning: none
+    probe:
+      kind: custom
+      path: /llm/job
+      auth: bearer
+  setup_hook: setup.sh
+
+features:
+  - id: crawl4ai-web-ingestion
+    name: Agent-Ready Web Ingestion
+    description: Crawl dynamic websites into clean Markdown and structured extraction results
+    icon: Globe2
+    category: search
+    requirements:
+      services: [crawl4ai, litellm]
+      vram_gb: 0
+      disk_gb: 4
+    enabled_services_all: [crawl4ai]
+    setup_time: ~3 minutes
+    priority: 33
+    launch:
+      type: service
+      service: crawl4ai
+      path: /playground
+    gpu_backends: [all]
+
+tags:
+  - crawling
+  - browser
+  - markdown
+  - rag
+  - agents

--- a/ods/extensions/library/services/crawl4ai/setup.sh
+++ b/ods/extensions/library/services/crawl4ai/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Crawl4AI - generate authentication material without replacing user values.
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+append_if_missing() {
+  key="$1"
+  value="$2"
+  if [ -f "$ENV_FILE" ] && grep -q "^${key}=" "$ENV_FILE"; then
+    return 0
+  fi
+  printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+}
+
+command -v openssl >/dev/null 2>&1 || {
+  echo "ERROR: openssl is required to generate Crawl4AI credentials" >&2
+  exit 1
+}
+
+append_if_missing "CRAWL4AI_API_TOKEN" "$(openssl rand -hex 32)"
+append_if_missing "CRAWL4AI_SECRET_KEY" "$(openssl rand -hex 32)"

--- a/ods/tests/test_library_crawl4ai.py
+++ b/ods/tests/test_library_crawl4ai.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "crawl4ai"
+
+
+def _shell_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    drive = resolved.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{resolved.as_posix().split(':/', 1)[1]}"
+
+
+def test_crawl4ai_reaches_catalog_with_swap_safe_gateway_metadata(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "crawl4ai")
+    assert entry["depends_on"] == ["litellm"]
+    assert entry["llm"]["route"] == "gateway"
+    assert entry["llm"]["pinning"] == "none"
+    assert entry["llm"]["probe"] == {
+        "kind": "custom",
+        "path": "/llm/job",
+        "auth": "bearer",
+    }
+    assert entry["features"][0]["launch"]["path"] == "/playground"
+
+
+def test_crawl4ai_compose_keeps_browser_and_llm_boundaries_constrained() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["crawl4ai"]
+
+    assert service["image"] == "unclecode/crawl4ai:0.9.2"
+    assert service["read_only"] is True
+    assert service["cap_drop"] == ["ALL"]
+    assert service["pids_limit"] == 512
+    assert service["deploy"]["resources"]["limits"]["pids"] == 512
+    assert service["environment"]["LLM_PROVIDER"] == "openai/ods/current"
+    assert service["environment"]["LLM_BASE_URL"] == "http://litellm:4000/v1"
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${CRAWL4AI_PORT:-11235}:11235"
+    ]
+
+
+def test_crawl4ai_setup_is_idempotent_and_generates_distinct_secrets(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    command = ["bash", _shell_path(SERVICE_DIR / "setup.sh"), _shell_path(tmp_path)]
+    subprocess.run(command, check=True)
+    first = env_file.read_text(encoding="utf-8")
+    subprocess.run(command, check=True)
+
+    assert env_file.read_text(encoding="utf-8") == first
+    values = dict(line.split("=", 1) for line in first.splitlines())
+    assert len(values["CRAWL4AI_API_TOKEN"]) == 64
+    assert len(values["CRAWL4AI_SECRET_KEY"]) == 64
+    assert values["CRAWL4AI_API_TOKEN"] != values["CRAWL4AI_SECRET_KEY"]


### PR DESCRIPTION
## Summary

- add Crawl4AI 0.9.2 as an opt-in browser crawling and Markdown ingestion service
- route LLM-assisted extraction through the authenticated ODS LiteLLM `ods/current` alias
- generate stable API credentials once and constrain Chromium with an unprivileged user, read-only root, dropped capabilities, PID limits, and private tmpfs state

## Why this matters

Local agents and RAG pipelines need a production-reachable way to ingest JavaScript-heavy websites, not only static HTTP text. This extension makes Crawl4AI available through Dashboard catalog -> library install -> setup hook -> resolved Compose stack -> authenticated `/crawl` and `/llm/job` APIs. Gateway routing also means an ODS model swap does not strand Crawl4AI on a stale concrete model ID.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `Crawl4AI`, `crawl4ai`, `web crawler`, and `web ingestion`, then inspected production service manifests, library directories, and `extensions-catalog.json` on 2026-08-20. No matching PR, changed production file set, existing service, or strict superset was found. Existing document parsers consume supplied files; this scope independently renders and extracts live web pages.

## AI Assistance

Codex assisted with upstream contract research, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in browser service Compose and LiteLLM dependency)

```text
python -m pytest ods/tests/test_library_crawl4ai.py -q          # 3 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict crawl4ai
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/services/litellm/compose.yaml \
  -f ods/extensions/library/services/crawl4ai/compose.yaml config --quiet
bash -n ods/extensions/library/services/crawl4ai/setup.sh        # PASS
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect unclecode/crawl4ai:0.9.2                # manifest exists
git diff --check                                                # clean
```

The regression tests invoke the production catalog generator, lock the dashboard-facing gateway metadata and `/llm/job` probe, validate the constrained Compose boundary, and execute the real setup hook twice to prove credentials are distinct and idempotent.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in browser extension. A live authenticated crawl plus LLM extraction smoke on representative amd64/arm64 hosts remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable crawl4ai` followed by uninstalling the extension. The setup hook never replaces existing `CRAWL4AI_API_TOKEN` or `CRAWL4AI_SECRET_KEY` values, and all model traffic stays behind LiteLLM rather than receiving a direct backend credential.