### PR TITLE
feat(extensions): add hardened Meilisearch service

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:17:14Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -1731,6 +1731,59 @@
           "priority": 9
         }
       ]
+    },
+    {
+      "id": "meilisearch",
+      "name": "Meilisearch",
+      "description": "Typo-tolerant full-text and hybrid search API for local apps and agents.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 7700,
+      "external_port_default": 7700,
+      "health_endpoint": "/health",
+      "env_vars": [
+        {
+          "key": "MEILI_MASTER_KEY",
+          "required": true,
+          "description": "Master key for all Meilisearch API access"
+        }
+      ],
+      "tags": [
+        "search",
+        "full-text",
+        "hybrid-search",
+        "typo-tolerance",
+        "agents"
+      ],
+      "features": [
+        {
+          "id": "meilisearch-api",
+          "name": "Typo-Tolerant Search API",
+          "description": "Fast full-text, filtering, faceting, and hybrid search for local datasets",
+          "icon": "Search",
+          "category": "data",
+          "requirements": {
+            "services": [
+              "meilisearch"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 10
+          },
+          "enabled_services_all": [
+            "meilisearch"
+          ],
+          "setup_time": "~1 minute",
+          "priority": 34,
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 90
     },
     {
       "id": "milvus",

--- a/ods/extensions/library/services/meilisearch/README.md
+++ b/ods/extensions/library/services/meilisearch/README.md
@@ -1,0 +1,36 @@
+# Meilisearch
+
+Meilisearch is a low-latency search API with typo tolerance, filtering, faceting, and hybrid-search primitives. This extension provides a reusable ODS search service; it is separate from the private Meilisearch sidecar bundled inside LibreChat.
+
+## Enable and access
+
+```bash
+ods enable meilisearch
+ods start meilisearch
+```
+
+- API: `http://localhost:7700`
+- Health: `http://localhost:7700/health`
+
+The setup hook generates `MEILI_MASTER_KEY` once. Existing values are never replaced.
+
+## Index documents
+
+```bash
+curl -X POST http://localhost:7700/indexes/notes/documents \
+  -H "Authorization: Bearer $MEILI_MASTER_KEY" \
+  -H "Content-Type: application/json" \
+  --data '[{"id":1,"title":"Local AI","body":"Private search on ODS"}]'
+
+curl 'http://localhost:7700/indexes/notes/search?q=private' \
+  -H "Authorization: Bearer $MEILI_MASTER_KEY"
+```
+
+## Isolation defaults
+
+The API is master-key protected, loopback-bound by default, has analytics disabled, drops every Linux capability, and runs with a read-only root filesystem. Only `data/meilisearch` persists indexes; `/tmp` is ephemeral.
+
+## Upstream
+
+- Project: <https://github.com/meilisearch/meilisearch>
+- Documentation: <https://www.meilisearch.com/docs>

--- a/ods/extensions/library/services/meilisearch/compose.yaml
+++ b/ods/extensions/library/services/meilisearch/compose.yaml
@@ -1,0 +1,40 @@
+services:
+  meilisearch:
+    image: getmeili/meilisearch:v1.53.1
+    container_name: ods-meilisearch
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    environment:
+      MEILI_ENV: production
+      MEILI_MASTER_KEY: "${MEILI_MASTER_KEY:?MEILI_MASTER_KEY must be set}"
+      MEILI_NO_ANALYTICS: "true"
+    volumes:
+      - ./data/meilisearch:/meili_data:rw
+    tmpfs:
+      - /tmp:mode=1777
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${MEILISEARCH_PORT:-7700}:7700"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:7700/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/meilisearch/manifest.yaml
+++ b/ods/extensions/library/services/meilisearch/manifest.yaml
@@ -1,0 +1,48 @@
+schema_version: ods.services.v1
+
+service:
+  id: meilisearch
+  name: Meilisearch
+  aliases: [search-engine, full-text-search]
+  container_name: ods-meilisearch
+  host_env: MEILISEARCH_HOST
+  default_host: meilisearch
+  port: 7700
+  external_port_env: MEILISEARCH_PORT
+  external_port_default: 7700
+  health: /health
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 90
+  description: "Typo-tolerant full-text and hybrid search API for local apps and agents."
+  env_vars:
+    - key: MEILI_MASTER_KEY
+      required: true
+      secret: true
+      description: Master key for all Meilisearch API access
+  setup_hook: setup.sh
+
+features:
+  - id: meilisearch-api
+    name: Typo-Tolerant Search API
+    description: Fast full-text, filtering, faceting, and hybrid search for local datasets
+    icon: Search
+    category: data
+    requirements:
+      services: [meilisearch]
+      vram_gb: 0
+      disk_gb: 10
+    enabled_services_all: [meilisearch]
+    setup_time: ~1 minute
+    priority: 34
+    gpu_backends: [all]
+
+tags:
+  - search
+  - full-text
+  - hybrid-search
+  - typo-tolerance
+  - agents

--- a/ods/extensions/library/services/meilisearch/setup.sh
+++ b/ods/extensions/library/services/meilisearch/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Meilisearch - generate a master key without replacing an operator value.
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+if [ -f "$ENV_FILE" ] && grep -q '^MEILI_MASTER_KEY=' "$ENV_FILE"; then
+  exit 0
+fi
+
+command -v openssl >/dev/null 2>&1 || {
+  echo "ERROR: openssl is required to generate the Meilisearch master key" >&2
+  exit 1
+}
+
+printf 'MEILI_MASTER_KEY=%s\n' "$(openssl rand -hex 32)" >> "$ENV_FILE"

--- a/ods/tests/test_library_meilisearch.py
+++ b/ods/tests/test_library_meilisearch.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "meilisearch"
+
+
+def _shell_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    drive = resolved.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{resolved.as_posix().split(':/', 1)[1]}"
+
+
+def test_meilisearch_reaches_the_dashboard_catalog_as_a_standalone_service(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "meilisearch")
+    assert entry["health_endpoint"] == "/health"
+    assert entry["depends_on"] == []
+    assert entry["env_vars"] == [
+        {
+            "key": "MEILI_MASTER_KEY",
+            "required": True,
+            "description": "Master key for all Meilisearch API access",
+        }
+    ]
+    assert entry["features"][0]["id"] == "meilisearch-api"
+
+
+def test_meilisearch_compose_pins_and_constrains_the_public_api() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["meilisearch"]
+
+    assert service["image"] == "getmeili/meilisearch:v1.53.1"
+    assert service["read_only"] is True
+    assert service["cap_drop"] == ["ALL"]
+    assert service["environment"]["MEILI_ENV"] == "production"
+    assert service["environment"]["MEILI_NO_ANALYTICS"] == "true"
+    assert service["environment"]["MEILI_MASTER_KEY"].startswith("${MEILI_MASTER_KEY:?")
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${MEILISEARCH_PORT:-7700}:7700"
+    ]
+    assert service["volumes"] == ["./data/meilisearch:/meili_data:rw"]
+
+
+def test_meilisearch_setup_is_idempotent_and_generates_a_strong_key(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    command = ["bash", _shell_path(SERVICE_DIR / "setup.sh"), _shell_path(tmp_path)]
+    subprocess.run(command, check=True)
+    first = env_file.read_text(encoding="utf-8")
+    subprocess.run(command, check=True)
+
+    assert env_file.read_text(encoding="utf-8") == first
+    key = first.removeprefix("MEILI_MASTER_KEY=").strip()
+    assert len(key) == 64
+    assert all(character in "0123456789abcdef" for character in key)


### PR DESCRIPTION
## Summary

- add Meilisearch 1.53.1 as a reusable, opt-in full-text and hybrid-search API
- generate a strong master key once and require it at the runtime boundary
- disable analytics and harden the container with loopback binding, dropped capabilities, and a read-only root filesystem

## Why this matters

ODS apps, agents, and RAG pipelines need a shared low-latency search engine for typo-tolerant retrieval, filtering, and facets. The reachable path is Dashboard extension catalog -> library install -> idempotent setup hook -> host-agent Compose start -> authenticated Meilisearch API. This creates a reusable service rather than forcing every application to ship its own private search sidecar.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `Meilisearch`, `meili`, `full-text search`, and the proposed production paths on 2026-08-20. No standalone service PR, library directory, or strict superset was found. LibreChat does bundle an older private `librechat-meilisearch` sidecar; this PR deliberately leaves it untouched and adds an independently addressable `ods-meilisearch` service for other ODS workloads.

## AI Assistance

Codex assisted with upstream contract research, implementation, tests, documentation, overlap triage, image inspection, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in persistent search service Compose)

```text
python -m pytest ods/tests/test_library_meilisearch.py -q       # 3 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict meilisearch
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/meilisearch/compose.yaml config --quiet
bash -n ods/extensions/library/services/meilisearch/setup.sh     # PASS
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect getmeili/meilisearch:v1.53.1            # manifest exists
git diff --check                                                # clean
```

A live container smoke used the same read-only, cap-drop, no-new-privileges, analytics-disabled configuration: `/health` returned 200, anonymous `/version` returned 401, and an authenticated request returned 200. The regression tests invoke the production catalog generator, lock the public Compose/auth boundary, and execute the setup hook twice to prove key strength and idempotence.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in service. Multi-architecture persistence and index-recovery smoke remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable meilisearch` followed by uninstalling the extension. Index data remains under `data/meilisearch` for recovery; removing that directory is intentionally outside rollback automation.