### PR TITLE
feat(extensions): add guarded Typesense search

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:20:49Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -2189,6 +2189,59 @@
           ]
         }
       ]
+    },
+    {
+      "id": "typesense",
+      "name": "Typesense",
+      "description": "Fast federated, vector, and typo-tolerant search for local applications.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 8108,
+      "external_port_default": 8108,
+      "health_endpoint": "/health",
+      "env_vars": [
+        {
+          "key": "TYPESENSE_API_KEY",
+          "required": true,
+          "description": "Bootstrap administrator key for the Typesense API"
+        }
+      ],
+      "tags": [
+        "search",
+        "federated-search",
+        "vector-search",
+        "typo-tolerance",
+        "agents"
+      ],
+      "features": [
+        {
+          "id": "typesense-search-api",
+          "name": "Federated and Vector Search",
+          "description": "Query multiple collections with full-text, filters, and vector similarity",
+          "icon": "Search",
+          "category": "data",
+          "requirements": {
+            "services": [
+              "typesense"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 10
+          },
+          "enabled_services_all": [
+            "typesense"
+          ],
+          "setup_time": "~1 minute",
+          "priority": 35,
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 90
     },
     {
       "id": "weaviate",

--- a/ods/extensions/library/services/typesense/README.md
+++ b/ods/extensions/library/services/typesense/README.md
@@ -1,0 +1,35 @@
+# Typesense
+
+Typesense provides low-latency typo-tolerant, federated, and vector search through a compact HTTP API. It is useful when an ODS app needs multi-collection queries or built-in vector/hybrid retrieval without bundling a search process of its own.
+
+## Enable and access
+
+```bash
+ods enable typesense
+ods start typesense
+```
+
+- API: `http://localhost:8108`
+- Health: `http://localhost:8108/health`
+
+The setup hook generates `TYPESENSE_API_KEY` once. Existing values are never replaced.
+
+## Create a collection
+
+```bash
+curl -X POST http://localhost:8108/collections \
+  -H "X-TYPESENSE-API-KEY: $TYPESENSE_API_KEY" \
+  -H "Content-Type: application/json" \
+  --data '{"name":"notes","fields":[{"name":"title","type":"string"}]}'
+```
+
+Applications should create scoped search-only keys through the Typesense key API instead of distributing the bootstrap administrator key.
+
+## Operational defaults
+
+The API is loopback-bound, administrator-key protected, CORS-disabled, capability-free, and read-only outside `data/typesense`. Typesense rejects new writes at 90% disk or memory use rather than exhausting the host.
+
+## Upstream
+
+- Project: <https://github.com/typesense/typesense>
+- Documentation: <https://typesense.org/docs/>

--- a/ods/extensions/library/services/typesense/compose.yaml
+++ b/ods/extensions/library/services/typesense/compose.yaml
@@ -1,0 +1,49 @@
+services:
+  typesense:
+    image: typesense/typesense:30.2
+    container_name: ods-typesense
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    environment:
+      TYPESENSE_DATA_DIR: /data
+      TYPESENSE_API_KEY: "${TYPESENSE_API_KEY:?TYPESENSE_API_KEY must be set}"
+      TYPESENSE_ENABLE_CORS: "false"
+      TYPESENSE_DISK_USED_MAX_PERCENTAGE: "90"
+      TYPESENSE_MEMORY_USED_MAX_PERCENTAGE: "90"
+    volumes:
+      - ./data/typesense:/data:rw
+    tmpfs:
+      - /tmp:mode=1777
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${TYPESENSE_PORT:-8108}:8108"
+    healthcheck:
+      test:
+        - CMD
+        - /usr/bin/bash
+        - -c
+        - >-
+          exec 3<>/dev/tcp/127.0.0.1/8108 &&
+          printf 'GET /health HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n' >&3 &&
+          grep -q true <&3
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/typesense/manifest.yaml
+++ b/ods/extensions/library/services/typesense/manifest.yaml
@@ -1,0 +1,48 @@
+schema_version: ods.services.v1
+
+service:
+  id: typesense
+  name: Typesense
+  aliases: [typesense-search, federated-search]
+  container_name: ods-typesense
+  host_env: TYPESENSE_HOST
+  default_host: typesense
+  port: 8108
+  external_port_env: TYPESENSE_PORT
+  external_port_default: 8108
+  health: /health
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 90
+  description: "Fast federated, vector, and typo-tolerant search for local applications."
+  env_vars:
+    - key: TYPESENSE_API_KEY
+      required: true
+      secret: true
+      description: Bootstrap administrator key for the Typesense API
+  setup_hook: setup.sh
+
+features:
+  - id: typesense-search-api
+    name: Federated and Vector Search
+    description: Query multiple collections with full-text, filters, and vector similarity
+    icon: Search
+    category: data
+    requirements:
+      services: [typesense]
+      vram_gb: 0
+      disk_gb: 10
+    enabled_services_all: [typesense]
+    setup_time: ~1 minute
+    priority: 35
+    gpu_backends: [all]
+
+tags:
+  - search
+  - federated-search
+  - vector-search
+  - typo-tolerance
+  - agents

--- a/ods/extensions/library/services/typesense/setup.sh
+++ b/ods/extensions/library/services/typesense/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Typesense - generate an administrator key without replacing an operator value.
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+if [ -f "$ENV_FILE" ] && grep -q '^TYPESENSE_API_KEY=' "$ENV_FILE"; then
+  exit 0
+fi
+
+command -v openssl >/dev/null 2>&1 || {
+  echo "ERROR: openssl is required to generate the Typesense API key" >&2
+  exit 1
+}
+
+printf 'TYPESENSE_API_KEY=%s\n' "$(openssl rand -hex 32)" >> "$ENV_FILE"

--- a/ods/tests/test_library_typesense.py
+++ b/ods/tests/test_library_typesense.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "typesense"
+
+
+def _shell_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    drive = resolved.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{resolved.as_posix().split(':/', 1)[1]}"
+
+
+def test_typesense_reaches_the_dashboard_catalog_with_health_and_key_contract(
+    tmp_path: Path,
+) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "typesense")
+    assert entry["health_endpoint"] == "/health"
+    assert entry["env_vars"][0]["key"] == "TYPESENSE_API_KEY"
+    assert entry["env_vars"][0]["required"] is True
+    assert entry["features"][0]["id"] == "typesense-search-api"
+
+
+def test_typesense_compose_pins_and_constrains_the_search_boundary() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["typesense"]
+
+    assert service["image"] == "typesense/typesense:30.2"
+    assert service["read_only"] is True
+    assert service["cap_drop"] == ["ALL"]
+    assert service["environment"]["TYPESENSE_DATA_DIR"] == "/data"
+    assert service["environment"]["TYPESENSE_ENABLE_CORS"] == "false"
+    assert service["environment"]["TYPESENSE_DISK_USED_MAX_PERCENTAGE"] == "90"
+    assert service["environment"]["TYPESENSE_MEMORY_USED_MAX_PERCENTAGE"] == "90"
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${TYPESENSE_PORT:-8108}:8108"
+    ]
+    health_command = service["healthcheck"]["test"][-1]
+    assert "GET /health HTTP/1.1" in health_command
+
+
+def test_typesense_setup_is_idempotent_and_generates_a_strong_key(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    command = ["bash", _shell_path(SERVICE_DIR / "setup.sh"), _shell_path(tmp_path)]
+    subprocess.run(command, check=True)
+    first = env_file.read_text(encoding="utf-8")
+    subprocess.run(command, check=True)
+
+    assert env_file.read_text(encoding="utf-8") == first
+    key = first.removeprefix("TYPESENSE_API_KEY=").strip()
+    assert len(key) == 64
+    assert all(character in "0123456789abcdef" for character in key)


### PR DESCRIPTION
## Summary

- add Typesense 30.2 as an opt-in federated, vector, and typo-tolerant search API
- generate the bootstrap administrator key once and document scoped-key use for applications
- harden the runtime and reject writes before disk or memory exhaustion

## Why this matters

ODS applications that need multi-collection federation and hybrid vector/text retrieval currently have no reusable Typesense boundary. The reachable path is Dashboard extension catalog -> library install -> idempotent setup hook -> host-agent Compose start -> key-authenticated Typesense API. The 90% disk and memory guards turn host exhaustion into an explicit write rejection instead of destabilizing the whole local stack.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `Typesense`, `typesense-search`, `federated search`, `vector search`, and the proposed production paths on 2026-08-20. No matching PR, service directory, or strict superset was found. Meilisearch and existing vector databases have adjacent use cases, but this scope is independent: Typesense exposes native federated multi-search plus collection-level vector/text querying and is an operator-selected alternative, not a replacement.

## AI Assistance

Codex assisted with upstream/runtime contract inspection, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in persistent search service Compose)

```text
python -m pytest ods/tests/test_library_typesense.py -q         # 3 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict typesense
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/typesense/compose.yaml config --quiet
bash -n ods/extensions/library/services/typesense/setup.sh       # PASS
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect typesense/typesense:30.2                # manifest exists
git diff --check                                                # clean
```

A live container smoke used the production read-only, cap-drop, no-new-privileges, CORS-disabled, resource-guarded configuration. `/health` returned `{ok:true}`, the exact in-container `/dev/tcp` healthcheck passed, anonymous `/collections` returned 401, and a keyed request returned 200. Regression tests invoke the production catalog generator, validate the public Compose boundary, and run the setup hook twice.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in service. Multi-architecture persistence, snapshot, and restore smoke remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable typesense` followed by uninstalling the extension. Search data remains under `data/typesense`; application-facing search-only keys should be created after bootstrap so the administrator key is never distributed.