### PR TITLE
feat(extensions): add durable observable Valkey

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:38:39Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -2189,6 +2189,65 @@
           ]
         }
       ]
+    },
+    {
+      "id": "valkey",
+      "name": "Valkey",
+      "description": "Authenticated Valkey state, cache, streams, and queues with Prometheus metrics.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 6379,
+      "external_port_default": 6379,
+      "health_endpoint": "/metrics",
+      "env_vars": [
+        {
+          "key": "VALKEY_PASSWORD",
+          "required": true,
+          "description": "Password required by Valkey clients and the metrics sidecar"
+        },
+        {
+          "key": "VALKEY_MAXMEMORY",
+          "required": false,
+          "default": "768mb",
+          "description": "Memory ceiling before Valkey rejects writes"
+        }
+      ],
+      "tags": [
+        "cache",
+        "queues",
+        "streams",
+        "pubsub",
+        "agent-state"
+      ],
+      "features": [
+        {
+          "id": "valkey-agent-state",
+          "name": "Durable Agent State and Queues",
+          "description": "Persist cache entries, streams, pub/sub state, and work queues with AOF",
+          "icon": "Database",
+          "category": "data",
+          "requirements": {
+            "services": [
+              "valkey"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 5
+          },
+          "enabled_services_all": [
+            "valkey"
+          ],
+          "setup_time": "~1 minute",
+          "priority": 37,
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 90
     },
     {
       "id": "weaviate",

--- a/ods/extensions/library/services/valkey/README.md
+++ b/ods/extensions/library/services/valkey/README.md
@@ -1,0 +1,31 @@
+# Valkey
+
+Valkey provides a Redis-compatible data plane for low-latency cache entries, streams, pub/sub, rate limits, sessions, and agent work queues. This extension enables AOF persistence so durable state survives a clean restart.
+
+## Enable and connect
+
+```bash
+ods enable valkey
+ods start valkey
+
+VALKEYCLI_AUTH="$VALKEY_PASSWORD" valkey-cli \
+  --host 127.0.0.1 --port 6379 ping
+```
+
+The setup hook generates `VALKEY_PASSWORD` once. Existing values are never replaced.
+
+Prometheus metrics are available at `http://localhost:9121/metrics`. The sidecar shares Valkey's network namespace and becomes healthy only when the authenticated `redis_up` metric is 1.
+
+## Durability and memory behavior
+
+- AOF fsync runs every second, balancing durability and write throughput.
+- A snapshot is also created after 1,000 changes within 60 seconds.
+- `VALKEY_MAXMEMORY` defaults to `768mb` inside a 1 GiB container limit.
+- `noeviction` rejects writes at the ceiling instead of silently deleting queue or session data.
+
+The service runs as the upstream `valkey` user with every Linux capability dropped. Its root filesystem is read-only; only `data/valkey` persists.
+
+## Upstream
+
+- Valkey: <https://github.com/valkey-io/valkey>
+- Metrics exporter: <https://github.com/oliver006/redis_exporter>

--- a/ods/extensions/library/services/valkey/compose.yaml
+++ b/ods/extensions/library/services/valkey/compose.yaml
@@ -1,0 +1,89 @@
+services:
+  valkey:
+    image: valkey/valkey:9.1.1-alpine
+    container_name: ods-valkey
+    restart: unless-stopped
+    stop_grace_period: 30s
+    user: valkey
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    environment:
+      VALKEYCLI_AUTH: "${VALKEY_PASSWORD:?VALKEY_PASSWORD must be set}"
+    command:
+      - valkey-server
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --save
+      - "60"
+      - "1000"
+      - --requirepass
+      - "${VALKEY_PASSWORD:?VALKEY_PASSWORD must be set}"
+      - --maxmemory
+      - "${VALKEY_MAXMEMORY:-768mb}"
+      - --maxmemory-policy
+      - noeviction
+    volumes:
+      - ./data/valkey:/data:rw
+    tmpfs:
+      - /tmp:uid=999,gid=1000,mode=1777
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${VALKEY_PORT:-6379}:6379"
+      - "${BIND_ADDRESS:-127.0.0.1}:9121:9121"
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+
+  valkey-metrics:
+    image: oliver006/redis_exporter:v1.89.0-alpine
+    container_name: ods-valkey-metrics
+    restart: unless-stopped
+    network_mode: service:valkey
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    environment:
+      REDIS_ADDR: redis://127.0.0.1:6379
+      REDIS_PASSWORD: "${VALKEY_PASSWORD:?VALKEY_PASSWORD must be set}"
+    depends_on:
+      valkey:
+        condition: service_healthy
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - wget -qO- http://127.0.0.1:9121/metrics | grep -q '^redis_up 1$'
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+        reservations:
+          cpus: '0.05'
+          memory: 32M
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/valkey/manifest.yaml
+++ b/ods/extensions/library/services/valkey/manifest.yaml
@@ -1,0 +1,55 @@
+schema_version: ods.services.v1
+
+service:
+  id: valkey
+  name: Valkey
+  aliases: [redis-compatible, durable-cache]
+  container_name: ods-valkey
+  container_uid: 999
+  host_env: VALKEY_HOST
+  default_host: valkey
+  port: 6379
+  external_port_env: VALKEY_PORT
+  external_port_default: 6379
+  health: /metrics
+  health_port: 9121
+  external_link: false
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 90
+  description: "Authenticated Valkey state, cache, streams, and queues with Prometheus metrics."
+  env_vars:
+    - key: VALKEY_PASSWORD
+      required: true
+      secret: true
+      description: Password required by Valkey clients and the metrics sidecar
+    - key: VALKEY_MAXMEMORY
+      required: false
+      default: 768mb
+      description: Memory ceiling before Valkey rejects writes
+  setup_hook: setup.sh
+
+features:
+  - id: valkey-agent-state
+    name: Durable Agent State and Queues
+    description: Persist cache entries, streams, pub/sub state, and work queues with AOF
+    icon: Database
+    category: data
+    requirements:
+      services: [valkey]
+      vram_gb: 0
+      disk_gb: 5
+    enabled_services_all: [valkey]
+    setup_time: ~1 minute
+    priority: 37
+    gpu_backends: [all]
+
+tags:
+  - cache
+  - queues
+  - streams
+  - pubsub
+  - agent-state

--- a/ods/extensions/library/services/valkey/setup.sh
+++ b/ods/extensions/library/services/valkey/setup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Valkey - generate a password without replacing an operator value.
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+if [ -f "$ENV_FILE" ] && grep -q '^VALKEY_PASSWORD=' "$ENV_FILE"; then
+  exit 0
+fi
+
+command -v openssl >/dev/null 2>&1 || {
+  echo "ERROR: openssl is required to generate the Valkey password" >&2
+  exit 1
+}
+
+printf 'VALKEY_PASSWORD=%s\n' "$(openssl rand -hex 32)" >> "$ENV_FILE"

--- a/ods/tests/test_library_valkey.py
+++ b/ods/tests/test_library_valkey.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "valkey"
+
+
+def _shell_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    drive = resolved.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{resolved.as_posix().split(':/', 1)[1]}"
+
+
+def test_valkey_reaches_catalog_with_durable_state_and_metrics(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "valkey")
+    assert entry["port"] == 6379
+    assert entry["health_endpoint"] == "/metrics"
+    assert entry["env_vars"][0]["key"] == "VALKEY_PASSWORD"
+    assert entry["features"][0]["id"] == "valkey-agent-state"
+
+
+def test_valkey_compose_locks_auth_durability_and_no_eviction() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["valkey"]
+
+    assert service["image"] == "valkey/valkey:9.1.1-alpine"
+    assert service["user"] == "valkey"
+    assert service["read_only"] is True
+    assert service["cap_drop"] == ["ALL"]
+    assert service["environment"]["VALKEYCLI_AUTH"].startswith("${VALKEY_PASSWORD:?")
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${VALKEY_PORT:-6379}:6379",
+        "${BIND_ADDRESS:-127.0.0.1}:9121:9121",
+    ]
+    command = service["command"]
+    assert command[command.index("--appendonly") + 1] == "yes"
+    assert command[command.index("--appendfsync") + 1] == "everysec"
+    assert command[command.index("--maxmemory-policy") + 1] == "noeviction"
+
+    metrics = compose["services"]["valkey-metrics"]
+    assert metrics["image"] == "oliver006/redis_exporter:v1.89.0-alpine"
+    assert metrics["network_mode"] == "service:valkey"
+    assert metrics["read_only"] is True
+    assert metrics["cap_drop"] == ["ALL"]
+    assert "redis_up 1" in metrics["healthcheck"]["test"][-1]
+
+
+def test_valkey_setup_is_idempotent_and_generates_a_strong_password(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    command = ["bash", _shell_path(SERVICE_DIR / "setup.sh"), _shell_path(tmp_path)]
+    subprocess.run(command, check=True)
+    first = env_file.read_text(encoding="utf-8")
+    subprocess.run(command, check=True)
+
+    assert env_file.read_text(encoding="utf-8") == first
+    password = first.removeprefix("VALKEY_PASSWORD=").strip()
+    assert len(password) == 64
+    assert all(character in "0123456789abcdef" for character in password)


### PR DESCRIPTION
## Summary

- add Valkey 9.1.1 as an authenticated, persistent cache/stream/queue service
- enable AOF + periodic snapshots and reject writes at a bounded memory ceiling instead of evicting state
- add an isolated Valkey-aware metrics sidecar whose health requires `redis_up 1`

## Why this matters

Local agents and workflows need shared low-latency state for queues, streams, rate limits, sessions, and coordination. ODS currently only carries private Redis sidecars owned by individual applications. This extension creates a reusable path from Dashboard catalog -> library install -> idempotent credential setup -> resolved Compose stack -> password-authenticated Valkey, with explicit durability and host-protection behavior.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `Valkey`, `redis-compatible`, `durable cache`, `redis-exporter`, and the proposed production paths on 2026-08-20. No matching standalone service PR, library directory, exporter integration, or strict superset was found. Paperless and other applications keep their private Redis-compatible sidecars; this scope does not rewire them. Generic non-HTTP health PRs #1343, #1692, and #1934 are also untouched because this extension supplies a merge-independent `/metrics` surface.

## AI Assistance

Codex assisted with upstream/runtime contract inspection, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Database / persistence behavior
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in persistent state service and metrics sidecar Compose)

```text
python -m pytest ods/tests/test_library_valkey.py -q             # 3 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict valkey
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/valkey/compose.yaml config --quiet
bash -n ods/extensions/library/services/valkey/setup.sh          # PASS
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect valkey/valkey:9.1.1-alpine              # manifest exists
docker manifest inspect oliver006/redis_exporter:v1.89.0-alpine # manifest exists
git diff --check                                                # clean
```

A live ephemeral stack used the production unprivileged/read-only/cap-drop configuration. It returned `PONG`, completed an authenticated SET/GET, rejected anonymous access with `NOAUTH`, reported `redis_up 1`, and confirmed `appendonly=yes` plus `maxmemory-policy=noeviction`. Regression tests invoke the production catalog generator and lock authentication, durability, resource, metrics, and setup-hook contracts.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in state service. Multi-architecture AOF recovery, snapshot restore, and sustained memory-pressure smoke remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable valkey` followed by uninstalling the extension. State remains under `data/valkey`; destructive deletion is intentionally excluded. `VALKEY_MAXMEMORY` defaults to 768 MiB under a 1 GiB container limit to retain exporter and allocator headroom.