### PR TITLE
feat(extensions): add hardened FalkorDB graph memory

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:46:42Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -677,6 +677,86 @@
           ]
         }
       ]
+    },
+    {
+      "id": "falkordb",
+      "name": "FalkorDB",
+      "description": "Persistent knowledge graphs and graph queries with a local authenticated explorer.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 3000,
+      "external_port_default": 3000,
+      "health_endpoint": "/",
+      "env_vars": [
+        {
+          "key": "FALKORDB_PASSWORD",
+          "required": true,
+          "description": "Password required for graph database connections"
+        },
+        {
+          "key": "FALKORDB_AUTH_SECRET",
+          "required": true,
+          "description": "Secret used to sign Browser sessions"
+        },
+        {
+          "key": "FALKORDB_ENCRYPTION_KEY",
+          "required": true,
+          "description": "Stable key used to encrypt Browser connection credentials"
+        },
+        {
+          "key": "FALKORDB_MAXMEMORY",
+          "required": false,
+          "default": "3gb",
+          "description": "Database memory ceiling before writes are rejected"
+        },
+        {
+          "key": "FALKORDB_BROWSER_URL",
+          "required": false,
+          "default": "http://localhost:3000",
+          "description": "Public Browser URL used for sessions and allowed origins"
+        }
+      ],
+      "tags": [
+        "graph-database",
+        "knowledge-graph",
+        "agent-memory",
+        "cypher",
+        "rag"
+      ],
+      "features": [
+        {
+          "id": "falkordb-knowledge-graph",
+          "name": "Knowledge Graph Memory and Explorer",
+          "description": "Store connected agent memory, traverse relationships, and inspect graphs visually",
+          "icon": "GitBranch",
+          "category": "data",
+          "requirements": {
+            "services": [
+              "falkordb"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 10
+          },
+          "enabled_services_all": [
+            "falkordb"
+          ],
+          "setup_time": "~2 minutes",
+          "priority": 38,
+          "launch": {
+            "type": "service",
+            "service": "falkordb",
+            "path": "/"
+          },
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 180
     },
     {
       "id": "flowise",

--- a/ods/extensions/library/services/falkordb/README.md
+++ b/ods/extensions/library/services/falkordb/README.md
@@ -1,0 +1,40 @@
+# FalkorDB
+
+FalkorDB gives local agents a persistent knowledge-graph memory layer with Cypher-style graph queries and a visual Browser. It is useful for entity relationships, provenance, multi-hop retrieval, and graph-assisted RAG.
+
+## Enable and access
+
+```bash
+ods enable falkordb
+ods start falkordb
+```
+
+- Browser: `http://localhost:3000`
+- Database: `127.0.0.1:6379`
+
+In the Browser connection form, use host `127.0.0.1`, port `6379`, and `FALKORDB_PASSWORD`. The Browser runs in the same container, so that loopback address reaches the database without opening a second trust boundary.
+
+## Query a graph
+
+```bash
+REDISCLI_AUTH="$FALKORDB_PASSWORD" redis-cli -h 127.0.0.1 -p 6379 \
+  GRAPH.QUERY agents \
+  "CREATE (:Agent {name:'Codex'})-[:USES]->(:Model {name:'local'})"
+```
+
+## Stable secrets and persistence
+
+The setup hook generates three distinct values once:
+
+- `FALKORDB_PASSWORD` protects database commands.
+- `FALKORDB_AUTH_SECRET` signs Browser sessions.
+- `FALKORDB_ENCRYPTION_KEY` encrypts stored Browser connection credentials.
+
+Graph data, local CSV imports, and encrypted Browser state persist under `data/falkordb`. AOF fsync runs every second, and `noeviction` rejects writes at `FALKORDB_MAXMEMORY` instead of silently deleting graph state.
+
+The process runs as the upstream `redis` user with every Linux capability dropped and a read-only root filesystem. Both ports remain loopback-bound unless the operator explicitly changes `BIND_ADDRESS`.
+
+## Upstream
+
+- Project: <https://github.com/FalkorDB/FalkorDB>
+- Documentation: <https://docs.falkordb.com/>

--- a/ods/extensions/library/services/falkordb/compose.yaml
+++ b/ods/extensions/library/services/falkordb/compose.yaml
@@ -1,0 +1,61 @@
+services:
+  falkordb:
+    image: falkordb/falkordb:v4.20.3
+    container_name: ods-falkordb
+    restart: unless-stopped
+    stop_grace_period: 60s
+    user: redis
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    environment:
+      BROWSER: "1"
+      FALKORDB_PASSWORD: "${FALKORDB_PASSWORD:?FALKORDB_PASSWORD must be set}"
+      REDISCLI_AUTH: "${FALKORDB_PASSWORD:?FALKORDB_PASSWORD must be set}"
+      REDIS_ARGS: >-
+        --requirepass ${FALKORDB_PASSWORD:?FALKORDB_PASSWORD must be set}
+        --appendonly yes --appendfsync everysec --save 60 1000
+        --maxmemory ${FALKORDB_MAXMEMORY:-3gb} --maxmemory-policy noeviction
+      AUTH_SECRET: "${FALKORDB_AUTH_SECRET:?FALKORDB_AUTH_SECRET must be set}"
+      ENCRYPTION_KEY: "${FALKORDB_ENCRYPTION_KEY:?FALKORDB_ENCRYPTION_KEY must be set}"
+      AUTH_URL: "${FALKORDB_BROWSER_URL:-http://localhost:3000}"
+      ALLOWED_ORIGINS: "${FALKORDB_BROWSER_URL:-http://localhost:3000}"
+      NEXT_PUBLIC_GOOGLE_ANALYTICS: ""
+      CSV_STORAGE: local
+      CSV_LOCAL_LOAD_URI_MODE: file
+      CSV_LOCAL_TEMP_DIR: /var/lib/falkordb/import
+    volumes:
+      - ./data/falkordb/database:/var/lib/falkordb/data:rw
+      - ./data/falkordb/import:/var/lib/falkordb/import:rw
+      - ./data/falkordb/browser:/app/.data:rw
+    tmpfs:
+      - /tmp:uid=999,gid=999,mode=1777
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${FALKORDB_PORT:-6379}:6379"
+      - "${BIND_ADDRESS:-127.0.0.1}:${FALKORDB_UI_PORT:-3000}:3000"
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >-
+          redis-cli ping | grep -q PONG &&
+          node -e "fetch('http://127.0.0.1:3000/').then(r => process.exit(r.status < 500 ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/falkordb/manifest.yaml
+++ b/ods/extensions/library/services/falkordb/manifest.yaml
@@ -1,0 +1,70 @@
+schema_version: ods.services.v1
+
+service:
+  id: falkordb
+  name: FalkorDB
+  aliases: [graph-database, knowledge-graph]
+  container_name: ods-falkordb
+  container_uid: 999
+  host_env: FALKORDB_HOST
+  default_host: falkordb
+  port: 3000
+  external_port_env: FALKORDB_UI_PORT
+  external_port_default: 3000
+  health: /
+  ui_path: /
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 180
+  description: "Persistent knowledge graphs and graph queries with a local authenticated explorer."
+  env_vars:
+    - key: FALKORDB_PASSWORD
+      required: true
+      secret: true
+      description: Password required for graph database connections
+    - key: FALKORDB_AUTH_SECRET
+      required: true
+      secret: true
+      description: Secret used to sign Browser sessions
+    - key: FALKORDB_ENCRYPTION_KEY
+      required: true
+      secret: true
+      description: Stable key used to encrypt Browser connection credentials
+    - key: FALKORDB_MAXMEMORY
+      required: false
+      default: 3gb
+      description: Database memory ceiling before writes are rejected
+    - key: FALKORDB_BROWSER_URL
+      required: false
+      default: http://localhost:3000
+      description: Public Browser URL used for sessions and allowed origins
+  setup_hook: setup.sh
+
+features:
+  - id: falkordb-knowledge-graph
+    name: Knowledge Graph Memory and Explorer
+    description: Store connected agent memory, traverse relationships, and inspect graphs visually
+    icon: GitBranch
+    category: data
+    requirements:
+      services: [falkordb]
+      vram_gb: 0
+      disk_gb: 10
+    enabled_services_all: [falkordb]
+    setup_time: ~2 minutes
+    priority: 38
+    launch:
+      type: service
+      service: falkordb
+      path: /
+    gpu_backends: [all]
+
+tags:
+  - graph-database
+  - knowledge-graph
+  - agent-memory
+  - cypher
+  - rag

--- a/ods/extensions/library/services/falkordb/setup.sh
+++ b/ods/extensions/library/services/falkordb/setup.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# FalkorDB - generate stable database and Browser secrets once.
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+append_if_missing() {
+  key="$1"
+  value="$2"
+  if [ -f "$ENV_FILE" ] && grep -q "^${key}=" "$ENV_FILE"; then
+    return 0
+  fi
+  printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+}
+
+command -v openssl >/dev/null 2>&1 || {
+  echo "ERROR: openssl is required to generate FalkorDB credentials" >&2
+  exit 1
+}
+
+append_if_missing "FALKORDB_PASSWORD" "$(openssl rand -hex 32)"
+append_if_missing "FALKORDB_AUTH_SECRET" "$(openssl rand -hex 32)"
+append_if_missing "FALKORDB_ENCRYPTION_KEY" "$(openssl rand -hex 32)"

--- a/ods/tests/test_library_falkordb.py
+++ b/ods/tests/test_library_falkordb.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "falkordb"
+
+
+def _shell_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    drive = resolved.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{resolved.as_posix().split(':/', 1)[1]}"
+
+
+def test_falkordb_reaches_catalog_with_a_graph_explorer(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(item for item in catalog["extensions"] if item["id"] == "falkordb")
+    assert entry["health_endpoint"] == "/"
+    assert entry["startup_timeout"] == 180
+    assert entry["features"][0]["id"] == "falkordb-knowledge-graph"
+    assert entry["features"][0]["launch"]["path"] == "/"
+
+
+def test_falkordb_compose_protects_graph_data_and_browser_credentials() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["falkordb"]
+
+    assert service["image"] == "falkordb/falkordb:v4.20.3"
+    assert service["user"] == "redis"
+    assert service["read_only"] is True
+    assert service["cap_drop"] == ["ALL"]
+    assert service["environment"]["BROWSER"] == "1"
+    assert service["environment"]["FALKORDB_PASSWORD"].startswith(
+        "${FALKORDB_PASSWORD:?"
+    )
+    assert service["environment"]["AUTH_SECRET"].startswith(
+        "${FALKORDB_AUTH_SECRET:?"
+    )
+    assert service["environment"]["ENCRYPTION_KEY"].startswith(
+        "${FALKORDB_ENCRYPTION_KEY:?"
+    )
+    redis_args = service["environment"]["REDIS_ARGS"]
+    assert "--appendonly yes" in redis_args
+    assert "--maxmemory-policy noeviction" in redis_args
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${FALKORDB_PORT:-6379}:6379",
+        "${BIND_ADDRESS:-127.0.0.1}:${FALKORDB_UI_PORT:-3000}:3000",
+    ]
+    health = service["healthcheck"]["test"][-1]
+    assert "redis-cli ping" in health
+    assert "http://127.0.0.1:3000/" in health
+
+
+def test_falkordb_setup_is_idempotent_and_generates_distinct_secrets(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    command = ["bash", _shell_path(SERVICE_DIR / "setup.sh"), _shell_path(tmp_path)]
+    subprocess.run(command, check=True)
+    first = env_file.read_text(encoding="utf-8")
+    subprocess.run(command, check=True)
+
+    assert env_file.read_text(encoding="utf-8") == first
+    values = dict(line.split("=", 1) for line in first.splitlines())
+    assert set(values) == {
+        "FALKORDB_PASSWORD",
+        "FALKORDB_AUTH_SECRET",
+        "FALKORDB_ENCRYPTION_KEY",
+    }
+    assert all(len(value) == 64 for value in values.values())
+    assert len(set(values.values())) == 3


### PR DESCRIPTION
## Summary

- add FalkorDB 4.20.3 as an opt-in persistent knowledge-graph service with its visual Browser
- protect graph commands, Browser sessions, and encrypted stored connection credentials with three independently generated secrets
- run the combined database/UI as an unprivileged, capability-free, read-only container with AOF durability and no-eviction memory behavior

## Why this matters

Agents need connected memory for entity relationships, provenance, multi-hop retrieval, and graph-assisted RAG—not only flat cache or vector similarity. This extension creates a production-reachable path from Dashboard catalog -> library install -> idempotent secret setup -> resolved Compose stack -> authenticated FalkorDB commands and visual graph exploration. The Browser and database share one loopback namespace, avoiding another internal trust boundary.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `FalkorDB`, `graph database`, `knowledge graph`, `graph memory`, and the proposed production files on 2026-08-20. No matching PR, service directory, or strict superset was found. Valkey is Redis-compatible but does not implement graph traversal or Cypher-style queries; existing RAG/vector services model a different retrieval boundary. This scope is independently installable and does not rewire either.

## AI Assistance

Codex assisted with upstream image/runtime inspection, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Database / persistence behavior
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in persistent graph database and authenticated Browser Compose)

```text
python -m pytest ods/tests/test_library_falkordb.py -q           # 3 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict falkordb
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/falkordb/compose.yaml config --quiet
bash -n ods/extensions/library/services/falkordb/setup.sh        # PASS
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect falkordb/falkordb:v4.20.3               # manifest exists
git diff --check                                                # clean
```

A live ephemeral container used the production unprivileged/read-only/cap-drop configuration. The database returned `PONG`, Browser reached HTTP 200, an authenticated `GRAPH.QUERY` created and retrieved an `Agent` node, anonymous commands were rejected, and runtime config confirmed `appendonly=yes` plus `noeviction`. Regression tests invoke the production catalog generator and lock both the DB and UI health boundaries plus stable-secret behavior.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in database. Multi-architecture AOF recovery, Browser session persistence, and graph backup/restore smoke remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable falkordb` followed by uninstalling the extension. Graph, import, and encrypted Browser state remain under `data/falkordb`; destructive deletion is intentionally excluded. If `FALKORDB_UI_PORT` changes, operators should set `FALKORDB_BROWSER_URL` to the externally reachable origin.