### PR TITLE
feat(extensions): add encrypted NATS JetStream bus

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-08-20T03:53:41Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -1748,6 +1748,88 @@
       "env_vars": [],
       "tags": [],
       "features": []
+    },
+    {
+      "id": "nats-jetstream",
+      "name": "NATS JetStream",
+      "description": "Authenticated pub/sub and encrypted durable streams for local agent events.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 8222,
+      "external_port_default": 8222,
+      "health_endpoint": "/healthz?js-enabled-only=true",
+      "env_vars": [
+        {
+          "key": "NATS_PASSWORD",
+          "required": true,
+          "description": "Password required for client connections; must start with a letter"
+        },
+        {
+          "key": "NATS_JETSTREAM_KEY",
+          "required": true,
+          "description": "Stable key used to encrypt JetStream files at rest; must start with a letter"
+        },
+        {
+          "key": "NATS_USER",
+          "required": false,
+          "default": "ods",
+          "description": "Client username"
+        },
+        {
+          "key": "NATS_JETSTREAM_MAX_MEMORY",
+          "required": false,
+          "default": "256MB",
+          "description": "Maximum memory-backed JetStream storage"
+        },
+        {
+          "key": "NATS_JETSTREAM_MAX_FILE",
+          "required": false,
+          "default": "10GB",
+          "description": "Maximum file-backed JetStream storage"
+        },
+        {
+          "key": "NATS_MAX_PAYLOAD",
+          "required": false,
+          "default": "8MB",
+          "description": "Largest accepted message payload"
+        }
+      ],
+      "tags": [
+        "messaging",
+        "event-bus",
+        "pubsub",
+        "jetstream",
+        "agents"
+      ],
+      "features": [
+        {
+          "id": "nats-agent-event-bus",
+          "name": "Durable Agent Event Bus",
+          "description": "Coordinate services with pub/sub, request/reply, persisted streams, and consumers",
+          "icon": "Workflow",
+          "category": "agents",
+          "requirements": {
+            "services": [
+              "nats-jetstream"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 10
+          },
+          "enabled_services_all": [
+            "nats-jetstream"
+          ],
+          "setup_time": "~1 minute",
+          "priority": 39,
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 90
     },
     {
       "id": "ollama",

--- a/ods/extensions/library/services/nats-jetstream/README.md
+++ b/ods/extensions/library/services/nats-jetstream/README.md
@@ -1,0 +1,40 @@
+# NATS JetStream
+
+NATS gives local services a lightweight event backbone for pub/sub and request/reply. JetStream adds durable streams, replay, retention, and pull or push consumers for agent jobs that must survive restarts.
+
+## Enable and connect
+
+```bash
+ods enable nats-jetstream
+ods start nats-jetstream
+
+export NATS_URL=nats://127.0.0.1:4222
+export NATS_USER="${NATS_USER:-ods}"
+export NATS_PASSWORD
+nats server check connection
+```
+
+The setup hook generates `NATS_PASSWORD` and a distinct `NATS_JETSTREAM_KEY` once. Both start with `nats_` because the NATS config parser can interpret digit-leading environment values as numbers. Custom values must likewise begin with a letter. Existing values are never replaced.
+
+## Create a durable event stream
+
+```bash
+nats stream add ODS_EVENTS \
+  --subjects 'ods.events.>' --storage file --retention limits --defaults
+nats publish ods.events.agent.started '{"agent":"researcher"}'
+nats stream info ODS_EVENTS
+```
+
+## Durability and observability
+
+JetStream files persist under `data/nats-jetstream` and are encrypted with ChaCha using `NATS_JETSTREAM_KEY`. Preserve that key with backups: encrypted streams cannot be recovered without it. Memory and file stores are capped at 256 MB and 10 GB by default.
+
+- Readiness: `http://localhost:8222/healthz?js-enabled-only=true`
+- JetStream diagnostics: `http://localhost:8222/jsz`
+
+The monitoring port is unauthenticated by NATS and is therefore loopback-bound by default. Client connections require credentials. The server runs as UID 1000 with every Linux capability dropped and a read-only root filesystem.
+
+## Upstream
+
+- Server: <https://github.com/nats-io/nats-server>
+- JetStream documentation: <https://docs.nats.io/nats-concepts/jetstream>

--- a/ods/extensions/library/services/nats-jetstream/compose.yaml
+++ b/ods/extensions/library/services/nats-jetstream/compose.yaml
@@ -1,0 +1,52 @@
+services:
+  nats-jetstream:
+    image: nats:2.14.5-alpine
+    container_name: ods-nats
+    restart: unless-stopped
+    stop_grace_period: 30s
+    user: "1000:1000"
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    environment:
+      NATS_USER: "${NATS_USER:-ods}"
+      NATS_PASSWORD: "${NATS_PASSWORD:?NATS_PASSWORD must be set}"
+      NATS_JETSTREAM_KEY: "${NATS_JETSTREAM_KEY:?NATS_JETSTREAM_KEY must be set}"
+      NATS_JETSTREAM_MAX_MEMORY: "${NATS_JETSTREAM_MAX_MEMORY:-256MB}"
+      NATS_JETSTREAM_MAX_FILE: "${NATS_JETSTREAM_MAX_FILE:-10GB}"
+      NATS_MAX_PAYLOAD: "${NATS_MAX_PAYLOAD:-8MB}"
+    volumes:
+      - ./data/nats-jetstream:/data:rw
+      - ./config/nats-jetstream/nats-server.conf:/etc/nats/nats-server.conf:ro
+    tmpfs:
+      - /tmp:uid=1000,gid=1000,mode=1777
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${NATS_PORT:-4222}:4222"
+      - "${BIND_ADDRESS:-127.0.0.1}:${NATS_MONITOR_PORT:-8222}:8222"
+    healthcheck:
+      test:
+        - CMD
+        - wget
+        - --spider
+        - -q
+        - "http://127.0.0.1:8222/healthz?js-enabled-only=true"
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    networks:
+      - ods-network
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1G
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+
+networks:
+  ods-network:
+    external: true

--- a/ods/extensions/library/services/nats-jetstream/config/nats-jetstream/nats-server.conf
+++ b/ods/extensions/library/services/nats-jetstream/config/nats-jetstream/nats-server.conf
@@ -1,0 +1,25 @@
+server_name: ods-nats
+port: 4222
+http: 8222
+max_payload: $NATS_MAX_PAYLOAD
+write_deadline: "10s"
+
+authorization {
+  timeout: 2
+  users: [
+    {
+      user: $NATS_USER
+      password: $NATS_PASSWORD
+    }
+  ]
+}
+
+jetstream {
+  store_dir: "/data/jetstream"
+  max_memory_store: $NATS_JETSTREAM_MAX_MEMORY
+  max_file_store: $NATS_JETSTREAM_MAX_FILE
+  encryption_key: $NATS_JETSTREAM_KEY
+  cipher: chacha
+  strict: true
+  sync_interval: "30s"
+}

--- a/ods/extensions/library/services/nats-jetstream/manifest.yaml
+++ b/ods/extensions/library/services/nats-jetstream/manifest.yaml
@@ -1,0 +1,70 @@
+schema_version: ods.services.v1
+
+service:
+  id: nats-jetstream
+  name: NATS JetStream
+  aliases: [nats, event-bus, message-broker]
+  container_name: ods-nats
+  container_uid: 1000
+  host_env: NATS_HOST
+  default_host: nats-jetstream
+  port: 8222
+  external_port_env: NATS_MONITOR_PORT
+  external_port_default: 8222
+  health: "/healthz?js-enabled-only=true"
+  external_link: false
+  type: docker
+  gpu_backends: [all]
+  category: optional
+  compose_file: compose.yaml
+  depends_on: []
+  startup_timeout: 90
+  description: "Authenticated pub/sub and encrypted durable streams for local agent events."
+  env_vars:
+    - key: NATS_PASSWORD
+      required: true
+      secret: true
+      description: Password required for client connections; must start with a letter
+    - key: NATS_JETSTREAM_KEY
+      required: true
+      secret: true
+      description: Stable key used to encrypt JetStream files at rest; must start with a letter
+    - key: NATS_USER
+      required: false
+      default: ods
+      description: Client username
+    - key: NATS_JETSTREAM_MAX_MEMORY
+      required: false
+      default: 256MB
+      description: Maximum memory-backed JetStream storage
+    - key: NATS_JETSTREAM_MAX_FILE
+      required: false
+      default: 10GB
+      description: Maximum file-backed JetStream storage
+    - key: NATS_MAX_PAYLOAD
+      required: false
+      default: 8MB
+      description: Largest accepted message payload
+  setup_hook: setup.sh
+
+features:
+  - id: nats-agent-event-bus
+    name: Durable Agent Event Bus
+    description: Coordinate services with pub/sub, request/reply, persisted streams, and consumers
+    icon: Workflow
+    category: agents
+    requirements:
+      services: [nats-jetstream]
+      vram_gb: 0
+      disk_gb: 10
+    enabled_services_all: [nats-jetstream]
+    setup_time: ~1 minute
+    priority: 39
+    gpu_backends: [all]
+
+tags:
+  - messaging
+  - event-bus
+  - pubsub
+  - jetstream
+  - agents

--- a/ods/extensions/library/services/nats-jetstream/setup.sh
+++ b/ods/extensions/library/services/nats-jetstream/setup.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# NATS JetStream - generate stable authentication and encryption material once.
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+append_if_missing() {
+  key="$1"
+  value="$2"
+  if [ -f "$ENV_FILE" ] && grep -q "^${key}=" "$ENV_FILE"; then
+    return 0
+  fi
+  printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+}
+
+command -v openssl >/dev/null 2>&1 || {
+  echo "ERROR: openssl is required to generate NATS credentials" >&2
+  exit 1
+}
+
+append_if_missing "NATS_PASSWORD" "nats_$(openssl rand -hex 32)"
+append_if_missing "NATS_JETSTREAM_KEY" "nats_$(openssl rand -hex 32)"

--- a/ods/tests/test_library_nats_jetstream.py
+++ b/ods/tests/test_library_nats_jetstream.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVICE_DIR = ROOT / "extensions" / "library" / "services" / "nats-jetstream"
+
+
+def _shell_path(path: Path) -> str:
+    resolved = path.resolve()
+    if os.name != "nt":
+        return str(resolved)
+    drive = resolved.drive.rstrip(":").lower()
+    return f"/mnt/{drive}/{resolved.as_posix().split(':/', 1)[1]}"
+
+
+def test_nats_reaches_catalog_with_jetstream_only_readiness(tmp_path: Path) -> None:
+    output = tmp_path / "catalog.json"
+    subprocess.run(
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "generate-extensions-catalog.py"),
+            "--library-dir",
+            str(ROOT / "extensions" / "library" / "services"),
+            "--output",
+            str(output),
+        ],
+        check=True,
+    )
+
+    catalog = json.loads(output.read_text(encoding="utf-8"))
+    entry = next(
+        item for item in catalog["extensions"] if item["id"] == "nats-jetstream"
+    )
+    assert entry["health_endpoint"] == "/healthz?js-enabled-only=true"
+    assert entry["features"][0]["id"] == "nats-agent-event-bus"
+    assert entry["env_vars"][0]["key"] == "NATS_PASSWORD"
+    assert entry["env_vars"][1]["key"] == "NATS_JETSTREAM_KEY"
+
+
+def test_nats_compose_pins_and_constrains_client_and_monitor_ports() -> None:
+    compose = yaml.safe_load((SERVICE_DIR / "compose.yaml").read_text(encoding="utf-8"))
+    service = compose["services"]["nats-jetstream"]
+
+    assert service["image"] == "nats:2.14.5-alpine"
+    assert service["user"] == "1000:1000"
+    assert service["read_only"] is True
+    assert service["cap_drop"] == ["ALL"]
+    assert service["ports"] == [
+        "${BIND_ADDRESS:-127.0.0.1}:${NATS_PORT:-4222}:4222",
+        "${BIND_ADDRESS:-127.0.0.1}:${NATS_MONITOR_PORT:-8222}:8222",
+    ]
+    assert (
+        "./config/nats-jetstream/nats-server.conf:"
+        "/etc/nats/nats-server.conf:ro"
+    ) in service["volumes"]
+    assert service["healthcheck"]["test"][-1].endswith(
+        "/healthz?js-enabled-only=true"
+    )
+
+
+def test_nats_server_config_requires_auth_and_encrypts_bounded_storage() -> None:
+    config = (
+        SERVICE_DIR / "config" / "nats-jetstream" / "nats-server.conf"
+    ).read_text(encoding="utf-8")
+
+    assert "password: $NATS_PASSWORD" in config
+    assert "max_memory_store: $NATS_JETSTREAM_MAX_MEMORY" in config
+    assert "max_file_store: $NATS_JETSTREAM_MAX_FILE" in config
+    assert "encryption_key: $NATS_JETSTREAM_KEY" in config
+    assert "cipher: chacha" in config
+    assert 'sync_interval: "30s"' in config
+
+
+def test_nats_setup_is_idempotent_and_generates_distinct_secrets(
+    tmp_path: Path,
+) -> None:
+    env_file = tmp_path / ".env"
+    command = ["bash", _shell_path(SERVICE_DIR / "setup.sh"), _shell_path(tmp_path)]
+    subprocess.run(command, check=True)
+    first = env_file.read_text(encoding="utf-8")
+    subprocess.run(command, check=True)
+
+    assert env_file.read_text(encoding="utf-8") == first
+    values = dict(line.split("=", 1) for line in first.splitlines())
+    assert set(values) == {"NATS_PASSWORD", "NATS_JETSTREAM_KEY"}
+    assert all(value.startswith("nats_") for value in values.values())
+    assert all(len(value) == 69 for value in values.values())
+    assert len(set(values.values())) == 2


### PR DESCRIPTION
## Summary

- add NATS 2.14.5 with JetStream as an opt-in local agent event bus
- require client credentials and encrypt file-backed streams at rest with a separately generated ChaCha key
- bound memory, disk, and payload sizes while exposing JetStream-aware readiness and diagnostics

## Why this matters

Multi-service agents need more than synchronous HTTP: they need pub/sub, request/reply, durable jobs, replay, and consumer state that survives process replacement. This extension creates a production-reachable path from Dashboard catalog -> library install -> config sync/setup hook -> resolved Compose stack -> authenticated NATS and encrypted JetStream storage. Explicit quotas protect the local host from unbounded event growth.

## Overlap check

Searched open and closed `Osmantic/ODS` PRs for `NATS`, `nats-server`, `JetStream`, `event bus`, `message broker`, and the proposed production files on 2026-08-20. No matching PR, service directory, or strict superset was found. Valkey streams provide a data-structure primitive, while this scope supplies a purpose-built messaging protocol with request/reply, subjects, durable consumers, retention, and replay; neither PR depends on or replaces the other.

## AI Assistance

Codex assisted with official config/runtime research, implementation, tests, documentation, overlap triage, and local validation. The human author remains responsible for reviewing the final diff and release decision.

## Release Lane

- [x] Next-minor work targeting the next feature/minor release

## Changed Surface

- [x] Docker Compose / service manifests
- [x] Database / persistence behavior
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High (new opt-in persistent message bus, authentication, and encrypted storage config)

```text
python -m pytest ods/tests/test_library_nats_jetstream.py -q    # 4 passed
python ods/extensions/library/validate-manifests.py             # 34/34 passed
python ods/scripts/audit-extensions.py --project-dir <fixture> --strict nats-jetstream
                                                                # 0 errors, 0 warnings
docker compose -f ods/extensions/library/services/nats-jetstream/compose.yaml config --quiet
nats-server -t -c /etc/nats/ods-test.conf                       # configuration valid
bash -n ods/extensions/library/services/nats-jetstream/setup.sh  # PASS
bash ods/tests/test-bind-address-sweep.sh                        # PASS
docker manifest inspect nats:2.14.5-alpine                      # manifest exists
git diff --check                                                # clean
```

A live persistent-volume smoke used the production UID 1000/read-only/cap-drop configuration. It created a file-backed stream, published a message, observed `auth_required:true` in an anonymous protocol handshake, found no plaintext payload in the store, replaced the server container, and recovered the stream with one message using the same encryption key. The exact NATS config was also parsed by the pinned server image; this caught and fixed digit-leading secret coercion before commit.

## Operational Change Check

- [x] Operational change; release-grade validation intentionally deferred because this is an isolated opt-in message service. Multi-architecture load, consumer replay, backup/restore, and encryption-key rotation smoke remains required before release promotion.

## Notes For Reviewers

Rollback is `ods disable nats-jetstream` followed by uninstalling the extension. Stream files remain under `data/nats-jetstream`; destructive removal is intentionally excluded. `NATS_JETSTREAM_KEY` must be preserved with backups. Generated secrets begin with `nats_` because the NATS config parser can coerce digit-leading environment values into numbers.