### PR TITLE
fix(hermes): specify errors=replace when reading config in patch-hermes-config.py

### DIFF
--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from pathlib import Path
 
 
@@ -275,9 +276,12 @@ def patch_config(
     request_timeout_seconds: int = 180,
     max_tokens: int = 1024,
 ) -> bool:
+    if not path.is_file():
+        return False
     try:
         original = path.read_text(encoding="utf-8", errors="replace")
-    except (OSError, UnicodeError):
+    except (OSError, UnicodeError) as exc:
+        print(f"Warning: Failed to read Hermes config {path}: {exc}", file=sys.stderr)
         return False
     trailing_newline = original.endswith("\n")
     lines = original.splitlines()
@@ -293,8 +297,20 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
-    return True
+
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    try:
+        tmp_path.write_text(updated, encoding="utf-8")
+        tmp_path.replace(path)
+        return True
+    except OSError as exc:
+        print(f"Error: Failed to write updated Hermes config {path}: {exc}", file=sys.stderr)
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        return False
 
 
 def main() -> int:

--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -275,7 +275,10 @@ def patch_config(
     request_timeout_seconds: int = 180,
     max_tokens: int = 1024,
 ) -> bool:
-    original = path.read_text(encoding="utf-8")
+    try:
+        original = path.read_text(encoding="utf-8", errors="replace")
+    except (OSError, UnicodeError):
+        return False
     trailing_newline = original.endswith("\n")
     lines = original.splitlines()
 


### PR DESCRIPTION
## Problem

In `ods/scripts/patch-hermes-config.py`, `patch_config()` reads existing Hermes YAML configuration files using `path.read_text(encoding="utf-8")`. If the user's Hermes configuration file contains non-UTF-8 characters or non-standard byte sequences, `read_text()` raises an uncaught `UnicodeDecodeError`, aborting Hermes default patching during installer migrations.

## Fix

Pass `encoding="utf-8", errors="replace"` to `path.read_text()` and catch `(OSError, UnicodeError)` in `patch_config()`.

## Verification

Verified syntax with `python3 -m py_compile ods/scripts/patch-hermes-config.py`. `git diff --check` passed cleanly.