### PR TITLE
fix(uninstall): add _exec_with_timeout helper for portable systemd service teardown in ods-uninstall.sh

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -20,6 +20,16 @@ log_ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+_exec_with_timeout() {
+    local timeout_spec="$1"
+    shift
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "$timeout_spec" "$@"
+    else
+        "$@"
+    fi
+}
+
 resolve_compose_flags() {
     local flags=""
 
@@ -286,18 +296,10 @@ unset _ods_uninstall_orphan_pids _pid
 # Remove system-mode ods-host-agent unit (migrated from --user mode).
 # Idempotent — no-op if the unit was never installed (e.g. older user-mode installs).
 if systemctl is-enabled ods-host-agent.service >/dev/null 2>&1; then
-    if command -v timeout >/dev/null 2>&1; then
-        if ! timeout 20s sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
-            log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
-            sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true
-            timeout 10s sudo systemctl disable ods-host-agent.service 2>/dev/null || true
-        fi
-    else
-        if ! sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
-            log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
-            sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true
-            sudo systemctl disable ods-host-agent.service 2>/dev/null || true
-        fi
+    if ! _exec_with_timeout 20s sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
+        log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
+        sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true
+        _exec_with_timeout 10s sudo systemctl disable ods-host-agent.service 2>/dev/null || true
     fi
 fi
 sudo rm -f /etc/systemd/system/ods-host-agent.service 2>/dev/null || true

--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -286,10 +286,18 @@ unset _ods_uninstall_orphan_pids _pid
 # Remove system-mode ods-host-agent unit (migrated from --user mode).
 # Idempotent — no-op if the unit was never installed (e.g. older user-mode installs).
 if systemctl is-enabled ods-host-agent.service >/dev/null 2>&1; then
-    if ! timeout 20s sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
-        log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
-        sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true
-        timeout 10s sudo systemctl disable ods-host-agent.service 2>/dev/null || true
+    if command -v timeout >/dev/null 2>&1; then
+        if ! timeout 20s sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
+            log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
+            sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true
+            timeout 10s sudo systemctl disable ods-host-agent.service 2>/dev/null || true
+        fi
+    else
+        if ! sudo systemctl disable --now ods-host-agent.service 2>/dev/null; then
+            log_warn "ods-host-agent did not stop cleanly; forcing service shutdown"
+            sudo systemctl kill -s SIGKILL ods-host-agent.service 2>/dev/null || true
+            sudo systemctl disable ods-host-agent.service 2>/dev/null || true
+        fi
     fi
 fi
 sudo rm -f /etc/systemd/system/ods-host-agent.service 2>/dev/null || true


### PR DESCRIPTION
## Problem

In `ods/ods-uninstall.sh`, the uninstaller attempts to disable system-level systemd units using `timeout 20s sudo systemctl disable --now ods-host-agent.service`. On macOS, BSD systems, or Linux environments where GNU coreutils `timeout` is absent from PATH, calling `timeout 20s ...` fails with `command not found`, skipping service teardown or crashing uninstaller script execution.

## Fix

Add a reusable `_exec_with_timeout()` helper in `ods/ods-uninstall.sh` that checks `command -v timeout` before invocation, delegating to `timeout` when available and falling back to untimed execution on systems lacking coreutils `timeout`.

## Verification

Verified POSIX/Bash syntax with `bash -n ods/ods-uninstall.sh`. `git diff --check` passed cleanly.