### PR TITLE
fix(cold-storage): create COLD_DIR before archiving models

### DIFF
--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -87,6 +87,13 @@ do_archive() {
     local archived=0
     local skipped=0
 
+    # Ensure the cold-storage target directory exists before moving any model
+    # tree into it.  Without this, `mv` fails when $COLD_DIR has never been
+    # created (first archive run on a fresh host).
+    if [[ "$dry_run" == "false" ]]; then
+        mkdir -p "$COLD_DIR"
+    fi
+
     log "========== LLM cold storage scan started (dry_run=$dry_run) =========="
 
     for model_dir in "$HF_CACHE"/models--*/; do


### PR DESCRIPTION
## Summary

`do_archive()` moves model directories into `` but never creates that directory. On a fresh host where `` (default `~/llm-cold-storage`) has never existed, the `mv` fails. The script uses `set -uo pipefail` (without `-e`), so the failure is silent — the model disappears from the hot cache glob but is never written to cold storage.

Fix: `mkdir -p $COLD_DIR` before the first `mv`, guarded behind the `dry_run=false` check so dry-run mode stays side-effect-free.

## Test plan
- [x] `bash -n ods/scripts/llm-cold-storage.sh` — no syntax errors
- [x] Read-through: `mkdir -p` is idempotent and only runs in execute mode
