### PR TITLE
fix(cold-storage): guard do_restore_all against missing COLD_DIR

### DIFF
--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -166,6 +166,10 @@ do_restore() {
 
 do_restore_all() {
     log "========== Restoring all archived models =========="
+    if [[ ! -d "$COLD_DIR" ]]; then
+        log "Cold storage directory does not exist: $COLD_DIR (nothing to restore)"
+        return 0
+    fi
     for cold_model in "$COLD_DIR"/models--*/; do
         [[ -d "$cold_model" ]] || continue
         local name


### PR DESCRIPTION
## Summary

`do_restore_all()` iterates over `$COLD_DIR/models--*/` without first checking that `` exists. When the cold-storage directory has never been created (no prior archive run), Bash expands the glob to its literal string and the loop body processes a non-existent path. The `[[ -d $cold_model ]] || continue` guard inside the loop catches this, but the surrounding log messages (`Restoring all archived models` / `All models restored`) still print — giving a misleading success impression.

Fix: early-return with an informative log message when `` does not exist.

## Test plan
- [x] `bash -n ods/scripts/llm-cold-storage.sh` — no syntax errors
- [x] Read-through: early return is safe; `return 0` matches the existing no-op behavior
