### PR TITLE
fix(ods-update): remove duplicate jq prerequisite check

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -12,8 +12,6 @@
 
 set -euo pipefail
 
-# Prerequisites
-command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed." >&2; echo "Install with: apt install jq (Debian/Ubuntu) or brew install jq (macOS)" >&2; exit 1; }
 
 #==============================================================================
 # CONFIGURATION


### PR DESCRIPTION
## Summary

`ods-update.sh` checks for `jq` twice — once at line 16 (plain text, before color variables are defined) and again at line 40 (with color-coded output). The first check is redundant and prints an unformatted error message that is inconsistent with the rest of the script's output style.

Fix: remove the early duplicate. The second check (after color variables are set) already covers the same guard with proper formatting.

## Test plan
- [x] `bash -n ods/ods-update.sh` — no syntax errors
- [x] Verified the remaining `jq` check at line 40 still guards against missing `jq` with colored output
