### PR TITLE
fix(pre-download): capture python exit code instead of relying on dead error path

### DIFF
--- a/ods/scripts/pre-download.sh
+++ b/ods/scripts/pre-download.sh
@@ -159,7 +159,8 @@ download_model() {
     
     log "Downloading $label: $model"
     
-    "${ODS_PYTHON_CMD:-python3}" << EOF
+    local dl_exit=0
+    "${ODS_PYTHON_CMD:-python3}" <<EOF || dl_exit=$?
 from huggingface_hub import snapshot_download
 import sys
 
@@ -174,8 +175,8 @@ except Exception as e:
     print(f"Error: {e}", file=sys.stderr)
     sys.exit(1)
 EOF
-    
-    if [[ $? -eq 0 ]]; then
+
+    if [[ $dl_exit -eq 0 ]]; then
         success "Downloaded $label"
         return 0
     else


### PR DESCRIPTION
## Summary

`download_model()` runs a Python heredoc to download a HuggingFace model, then checks `True` in an `if` block to print success or failure. However, the script runs under `set -euo pipefail` — if the Python heredoc exits non-zero, `set -e` terminates the script immediately **before** reaching `if [[ $? -eq 0 ]]`. The entire `else` branch (error log + `return 1`) is dead code.

Fix: capture the exit code with `|| dl_exit=$?` so the Python failure does not trigger `set -e`, and then branch on the captured variable.

## Test plan
- [x] `bash -n ods/scripts/pre-download.sh` — no syntax errors
- [x] Read-through: `|| dl_exit=$?` is the idiomatic pattern used elsewhere in the repo (e.g. `session-cleanup.sh` line 103)
