### PR TITLE
fix(download-hf-artifact): reject directory as destination path

### DIFF
--- a/ods/scripts/download-hf-artifact.py
+++ b/ods/scripts/download-hf-artifact.py
@@ -34,6 +34,10 @@ def parse_huggingface_resolve_url(url: str) -> tuple[str, str, str]:
 
 
 def download_artifact(url: str, destination: Path) -> Path:
+    if destination.is_dir():
+        raise ValueError(
+            f"destination must be a file path, not an existing directory: {destination}"
+        )
     repo_id, revision, filename = parse_huggingface_resolve_url(url)
     try:
         from huggingface_hub import hf_hub_download


### PR DESCRIPTION
## Summary

If the `destination` argument to `download_artifact()` is an existing directory rather than a file path, `tmp_destination.replace(destination)` raises `IsADirectoryError` on Linux or `PermissionError` on Windows — both with unhelpful stack traces that don't indicate the real mistake.

Fix: validate early and raise a clear `ValueError` before attempting the download.

## Test plan
- [x] `python -m py_compile ods/scripts/download-hf-artifact.py` — compiles cleanly
- [x] Read-through: `is_dir()` is called before any network I/O; existing valid-path behavior unchanged
