### PR TITLE
fix(cold-storage): accumulate status tags in show_status instead of overwriting

### DIFF
--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -200,8 +200,8 @@ show_status() {
             local size idle_days status=""
             size="$(du -sh "$model_dir" 2>/dev/null | cut -f1)"
             idle_days="$(get_last_access_days "$model_dir")"
-            is_protected "$name" && status=" [protected]"
-            is_model_in_use "$name" && status=" [in use]"
+            is_protected "$name" && status+=" [protected]"
+            is_model_in_use "$name" && status+=" [in use]"
             echo "  [HOT] $name ($size, idle ${idle_days}d)${status}"
         fi
     done


### PR DESCRIPTION
## Summary

In `show_status()`, the status tags `[protected]` and `[in use]` are assigned with `=` instead of `+=`. When a model is both protected **and** in use, the second assignment (`status=" [in use]"`) overwrites the first (`status=" [protected]"`), so the output only shows `[in use]` — hiding the fact that the model is also protected.

Fix: use `+=` to accumulate tags so both are displayed when applicable.

## Test plan
- [x] `bash -n ods/scripts/llm-cold-storage.sh` — no syntax errors
- [x] Read-through: `+=` on a string initialized to `""` produces the same single-tag output as `=` when only one condition is true
