### PR TITLE
fix(download-hf-snapshot): expand tilde in cache_dir path

### DIFF
--- a/ods/scripts/download-hf-snapshot.py
+++ b/ods/scripts/download-hf-snapshot.py
@@ -15,6 +15,10 @@ def download_snapshot(
     revision: str | None = None,
     allow_patterns: list[str] | None = None,
 ) -> Path:
+    # Expand ~ to the user's home directory.  Python's Path("~/…") treats the
+    # tilde literally, so a shell caller passing ~/models without quoting would
+    # create a directory literally named "~" instead of expanding to $HOME.
+    cache_dir = cache_dir.expanduser()
     try:
         from huggingface_hub import snapshot_download
     except ImportError as exc:


### PR DESCRIPTION
## Summary

`download_snapshot()` receives `cache_dir` as a `Path` argument. Python's `Path("~/models")` does **not** expand `~` to the user's home directory — it treats the tilde literally. When a shell caller passes `~/my-cache` to the CLI without quoting, argparse creates `Path("~/my-cache")`, and `cache_dir.mkdir(parents=True)` creates a directory literally named `~` in the current working directory instead of `$HOME/my-cache`.

Fix: call `cache_dir.expanduser()` at the top of `download_snapshot()` before any filesystem operations.

## Test plan
- [x] `python -m py_compile ods/scripts/download-hf-snapshot.py` — compiles cleanly
- [x] Read-through: `expanduser()` is a no-op when the path does not start with `~`, so existing absolute-path callers are unaffected
