### PR TITLE
fix(backup): handle missing rsync gracefully with cp fallback

### DIFF
--- a/ods/lib/rsync.sh
+++ b/ods/lib/rsync.sh
@@ -33,6 +33,12 @@ rsync_with_progress() {
         echo "[INFO] $label..."
     fi
 
+    # If rsync is not installed, fall back to cp -a (no incremental/delta)
+    if ! command -v rsync >/dev/null 2>&1; then
+        cp -a "$src" "$dest"
+        return
+    fi
+
     # Use --info=progress2 for compact single-line progress updates
     # Fallback to basic rsync if progress2 not supported
     if rsync --help 2>/dev/null | grep -q "info=progress2"; then

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -19,7 +19,10 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Prerequisites check
-command -v rsync >/dev/null 2>&1 || { echo -e "${RED}Error: rsync is required but not installed.${NC}" >&2; echo "Install with: apt install rsync (Debian/Ubuntu) or brew install rsync (macOS)" >&2; exit 1; }
+if ! command -v rsync >/dev/null 2>&1; then
+    echo -e "${YELLOW}[WARN]${NC} rsync is not installed; backup will use cp (no incremental/delta support)." >&2
+    echo "For faster incremental backups, install rsync: apt install rsync (Debian/Ubuntu) or brew install rsync (macOS)" >&2
+fi
 command -v jq >/dev/null 2>&1 || { echo -e "${RED}Error: jq is required but not installed.${NC}" >&2; echo "Install with: apt install jq (Debian/Ubuntu) or brew install jq (macOS)" >&2; exit 1; }
 
 # Logging functions


### PR DESCRIPTION
## Summary

`ods-backup.sh` hard-exits on line 22 if `rsync` is not installed. On minimal Docker images or fresh Alpine/scratch containers where users need an emergency backup, this prevents any backup at all — even though `cp -a` is always available and sufficient for a one-off full copy.

Changes:
1. **`ods-backup.sh`**: downgrade the rsync check from a hard exit to a warning
2. **`lib/rsync.sh`**: add a `cp -a` fallback inside `rsync_with_progress()` when `rsync` is not on `$PATH`

Incremental/delta behavior is lost without rsync, but a full `cp -a` backup is strictly better than refusing to run.

## Test plan
- [x] `bash -n ods/ods-backup.sh` — no syntax errors
- [x] `bash -n ods/lib/rsync.sh` — no syntax errors
- [x] Read-through: `cp -a` preserves timestamps and permissions; `--delete` semantics are not replicated (acceptable for backup, not restore)
