### PR TITLE
fix(upgrade-model): remove dead else branch in detect_inference_service

### DIFF
--- a/ods/scripts/upgrade-model.sh
+++ b/ods/scripts/upgrade-model.sh
@@ -50,16 +50,10 @@ detect_compose_file() {
 }
 
 detect_inference_service() {
-    if [[ ${#COMPOSE_FILE_ARGS[@]} -eq 0 ]]; then
-        echo "llama-server"
-        return
-    fi
-
-    if docker compose "${COMPOSE_FILE_ARGS[@]}" config --services 2>/dev/null | grep -q '^llama-server$'; then
-        echo "llama-server"
-    else
-        echo "llama-server"
-    fi
+    # Currently ODS only ships llama-server as the inference backend.
+    # When additional backends are added, this function should inspect the
+    # compose config to pick the right one.
+    echo "llama-server"
 }
 
 resolve_inference_runtime() {


### PR DESCRIPTION
## Summary

`detect_inference_service()` in `upgrade-model.sh` has an `if/else` block where both branches return the same value (`"llama-server"`). The `docker compose config --services | grep` check is dead code — its result is never used to differentiate behavior.

Fix: replace the entire function body with a single `echo "llama-server"` and a comment explaining where to add backend differentiation when new inference backends are introduced.

## Test plan
- [x] `bash -n ods/scripts/upgrade-model.sh` — no syntax errors
- [x] Read-through: the function return value is identical before and after this change
