### PR TITLE
fix(session-cleanup): trim leading whitespace from wc -l output

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -242,7 +242,7 @@ fi
 # ── Summary ────────────────────────────────────────────────────
 echo "[$(date)] Cleanup complete: removed $REMOVED_INACTIVE inactive, $REMOVED_BLOATED bloated"
 REMAINING_EXIT=0
-REMAINING=$(find "$SESSIONS_DIR" -maxdepth 1 -name '*.jsonl' 2>&1 | wc -l) || REMAINING_EXIT=$?
+REMAINING=$(find "$SESSIONS_DIR" -maxdepth 1 -name '*.jsonl' 2>&1 | wc -l | tr -d ' ') || REMAINING_EXIT=$?
 if [[ $REMAINING_EXIT -ne 0 ]]; then
     REMAINING=0
 fi


### PR DESCRIPTION
## Summary

macOS `wc -l` pads its output with leading spaces (e.g. `       5` instead of `5`). While Bash's `[[ $REMAINING -gt 0 ]]` handles this via arithmetic coercion, the log line `Remaining session files:        5` has ugly leading whitespace.

Fix: pipe `wc -l` through `tr -d ' '` to strip all spaces.

## Test plan
- [x] `bash -n ods/scripts/session-cleanup.sh` — no syntax errors
- [x] Read-through: `tr -d ' '` is a no-op on GNU coreutils where `wc` already trims; on macOS/BSD it strips the leading padding
