### PR TITLE
fix(external-services): strip carriage return from env value parsing

### DIFF
--- a/ods/installers/lib/external-services.sh
+++ b/ods/installers/lib/external-services.sh
@@ -170,6 +170,8 @@ external_llm_env_value() {
     local env_file="${1:-}" key="${2:-}" value
     [[ -f "$env_file" ]] || return 1
     value="$(grep -m1 "^${key}=" "$env_file" 2>/dev/null | cut -d= -f2- || true)"
+    # Strip surrounding quotes and trailing carriage return (Windows .env files)
+    value="${value%$'\r'}"
     value="${value%\"}"
     value="${value#\"}"
     value="${value%\'}"


### PR DESCRIPTION
## Summary

`external_llm_env_value()` reads a key from `.env` using `grep | cut`, then strips surrounding quotes. However, it does not strip a trailing carriage return (`\r`), which is present in `.env` files edited on Windows (CRLF line endings).

The hidden `\r` at the end of the value causes `external_llm_validate_url()` to reject an otherwise valid URL (the URL parser sees a trailing `\r` in the hostname/path), and `curl` calls silently fail with connection errors to `http://localhost:11434\r`.

Fix: strip `$'\r'` before stripping quotes, matching the pattern used in `check-compatibility.sh` (which already does `"${value%$'\r'}"` for the same reason).

## Test plan
- [x] `bash -n ods/installers/lib/external-services.sh` — no syntax errors
- [x] Read-through: `${value%$'\r'}` is a no-op on Unix-style files
