### PR TITLE
fix(ods-update): clean up temp version file on jq failure

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -501,8 +501,11 @@ cmd_check() {
     fi
     local tmp_version_file
     tmp_version_file=$(mktemp "${VERSION_FILE}.tmp.XXXXXX")
-    echo "$version_data" | jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_check = $ts' > "$tmp_version_file"
-    mv -f "$tmp_version_file" "$VERSION_FILE"
+    if echo "$version_data" | jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_check = $ts' > "$tmp_version_file"; then
+        mv -f "$tmp_version_file" "$VERSION_FILE"
+    else
+        rm -f "$tmp_version_file"
+    fi
 }
 
 #==============================================================================


### PR DESCRIPTION
## Summary

In `cmd_check()`, the version file update creates a temp file via `mktemp`, pipes JSON through `jq`, then `mv`s the result. If `jq` fails (e.g., corrupted `$version_data` that isn't valid JSON), the temp file is left as an orphan under the ODS directory (e.g., `.version.tmp.XXXXXX`). Under `set -e`, the script exits immediately on the `jq` failure — the temp file is never cleaned up.

Fix: wrap the `jq | mv` in an `if/else` so the temp file is removed on failure.

## Test plan
- [x] `bash -n ods/ods-update.sh` — no syntax errors
- [x] Read-through: the `if` captures the jq exit code, preventing `set -e` from terminating the script, and the `else` branch cleans up
