### PR TITLE
fix(validate-compose): use trap to clean up temp file on all exit paths

### DIFF
--- a/ods/scripts/validate-compose-stack.sh
+++ b/ods/scripts/validate-compose-stack.sh
@@ -67,6 +67,7 @@ fi
 # - Circular dependencies
 # - Invalid environment variable references
 validation_output=$(mktemp)
+trap 'rm -f "$validation_output"' EXIT
 if $DOCKER_COMPOSE_CMD $ENV_FILE_FLAG $COMPOSE_FLAGS config > "$validation_output" 2>&1; then
     if ! $QUIET; then
         echo "Compose stack validation passed"
@@ -74,7 +75,6 @@ if $DOCKER_COMPOSE_CMD $ENV_FILE_FLAG $COMPOSE_FLAGS config > "$validation_outpu
         service_count=$(grep -c "^  [a-z]" "$validation_output" || echo "0")
         echo "  Services defined: $service_count"
     fi
-    rm -f "$validation_output"
     exit 0
 else
     echo "Compose stack validation FAILED" >&2
@@ -83,6 +83,5 @@ else
     cat "$validation_output" >&2
     echo "" >&2
     echo "Compose flags: $COMPOSE_FLAGS" >&2
-    rm -f "$validation_output"
     exit 1
 fi


### PR DESCRIPTION
## Summary

`validate-compose-stack.sh` creates a temp file via `mktemp` for capturing `docker compose config` output. It manually calls `rm -f` in both the success and failure branches, but if the script exits early via `set -e` (e.g., an unexpected error between `mktemp` and the `if`), the temp file is leaked.

Fix: add `trap 'rm -f "$validation_output"' EXIT` immediately after `mktemp`, and remove the manual `rm -f` calls (the trap handles all exit paths).

## Test plan
- [x] `bash -n ods/scripts/validate-compose-stack.sh` — no syntax errors
- [x] Read-through: `trap EXIT` fires on normal exit, `set -e` exit, and signals
