### PR TITLE
fix(healthcheck): handle ConnectionResetError in HTTP probes

### DIFF
--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -239,6 +239,9 @@ def check_http(
         except socket.timeout:
             last_err = f"http {m}: timeout"
             continue
+        except ConnectionResetError:
+            last_err = f"http {m}: connection reset by peer"
+            continue
 
     return (False, last_err or "http: request failed", None)
 


### PR DESCRIPTION
## Summary

`check_http()` catches `urllib.error.URLError` and `socket.timeout` but not `ConnectionResetError`. When a service like llama-server is starting up or overloaded, it may accept the TCP connection but then reset it mid-HTTP-exchange. This raises `ConnectionResetError` which propagates uncaught, causing the healthcheck process to crash with exit code 1 and a stack trace instead of a clean "unhealthy" result.

Fix: add `except ConnectionResetError` alongside the existing `socket.timeout` handler, with a descriptive error message and `continue` (to allow HEAD→GET fallback and retry logic).

## Test plan
- [x] `python -m py_compile ods/scripts/healthcheck.py` — compiles cleanly
- [x] Read-through: `ConnectionResetError` is a subclass of `OSError`, not `URLError`, so the existing handlers don't catch it
