### PR TITLE
fix(ods-uninstall): fix misaligned box drawing in banner

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -86,7 +86,7 @@ done
 
 echo ""
 echo -e "${RED}╔══════════════════════════════════════════════════╗${NC}"
-echo -e "${RED}║         ODS UNINSTALLER                ║${NC}"
+echo -e "${RED}║              ODS UNINSTALLER                     ║${NC}"
 echo -e "${RED}╚══════════════════════════════════════════════════╝${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary

The uninstaller banner has a misaligned right `║` border — the text `ODS UNINSTALLER` has inconsistent padding so the right border doesn't line up with the `╗`/`╝` corners. This makes the banner look broken in the terminal.

Fix: adjust padding so the `║` characters align vertically with the box corners.

## Test plan
- [x] `bash -n ods/ods-uninstall.sh` — no syntax errors
- [x] Visual inspection: column count matches between all lines of the box
