### PR TITLE
fix(showcase): fix misaligned box drawing in print_header

### DIFF
--- a/ods/scripts/showcase.sh
+++ b/ods/scripts/showcase.sh
@@ -43,7 +43,7 @@ clear_screen() {
 print_header() {
     echo ""
     echo -e "${BOLD}${CYAN}╔══════════════════════════════════════════════════════════════╗${NC}"
-    echo -e "${BOLD}${CYAN}║               ODS Interactive Showcase              ║${NC}"
+    echo -e "${BOLD}${CYAN}║                ODS Interactive Showcase                     ║${NC}"
     echo -e "${BOLD}${CYAN}╚══════════════════════════════════════════════════════════════╝${NC}"
     echo ""
 }


### PR DESCRIPTION
## Summary

The `print_header()` banner in `showcase.sh` has a misaligned right `║` border — the title text has inconsistent padding so the right border doesn't line up with the `╗`/`╝` corners.

Fix: adjust padding so the `║` characters align vertically with the box corners.

## Test plan
- [x] `bash -n ods/scripts/showcase.sh` — no syntax errors
- [x] Visual inspection: column count matches between all lines of the box
