### PR TITLE
fix(ods-update): redirect health-check timeout output to stderr

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -386,7 +386,7 @@ wait_for_healthy() {
     done
 
     log_error "Health-check timeout after ${HEALTH_TIMEOUT}s. Final status:"
-    cat "$health_log"
+    cat "$health_log" >&2
     rm -f "$health_log"
     return 1
 }


### PR DESCRIPTION
## Summary

In `wait_for_healthy()`, when the health-check times out, `log_error` writes the error message to stderr but `cat "$health_log"` writes the full health-check output to **stdout**. This mixes output streams — callers that capture stdout (e.g., `result=$(cmd_update ...)`) would silently swallow the diagnostic output instead of seeing it in the terminal.

Fix: redirect `cat "$health_log"` to stderr (`>&2`) to match `log_error`.

## Test plan
- [x] `bash -n ods/ods-update.sh` — no syntax errors
- [x] Read-through: all other diagnostic output in the file already uses `>&2` or `log_error` (which sends to stderr)
