### PR TITLE
fix(ods-restore): redirect log_error output to stderr

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -22,7 +22,7 @@ NC='\033[0m' # No Color
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
 log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 log_step() { echo -e "${CYAN}[STEP]${NC} $*"; }
 
 # Source shared rsync utilities


### PR DESCRIPTION
## Summary

`log_error()` in `ods-restore.sh` writes to **stdout** instead of stderr — unlike the same function in `ods-update.sh`, `ods-backup.sh`, `ods-uninstall.sh`, and other scripts in the repo which all use `>&2`.

This causes error messages to be swallowed by callers that capture stdout (e.g., `backup_dir=$(extract_backup ...)` in the restore flow), and mixes error output with data output in pipelines.

Fix: add `>&2` to match the convention used across all other ODS scripts.

## Test plan
- [x] `bash -n ods/ods-restore.sh` — no syntax errors
- [x] Read-through: `log_error` in `ods-update.sh` (line 50), `ods-backup.sh` (line 29), and `ods-uninstall.sh` (line 21) all use `>&2`
