### PR TITLE
fix(installer): point Windows dashboard shortcut and success card at resolved ports

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2438,7 +2438,7 @@ if ($installReadiness -and $installReadiness.AllReady -and $llmModelReady -and $
 
 # ── Desktop & Start Menu shortcuts ───────────────────────────────────────────
 try {
-    $dashboardUrl  = "http://localhost:3001"
+    $dashboardUrl  = "http://localhost:$dashboardPort"
     $shortcutName  = "ODS"
     $iconPath      = Join-Path $installDir "extensions\services\dashboard\public\osmantic-os.ico"
     $iconContent   = if (Test-Path -LiteralPath $iconPath) { "IconFile=$iconPath`nIconIndex=0" } else { "IconIndex=0" }
@@ -2468,7 +2468,7 @@ try {
 
 # ── Success card ──────────────────────────────────────────────────────────────
 if ($allHealthy) {
-    Write-SuccessCard
+    Write-SuccessCard -WebUIPort $webuiPort -DashboardPort $dashboardPort
 } else {
     Write-Host ""
     Write-AIWarn "Install finished, but one or more services are not ready yet. Check status with:"


### PR DESCRIPTION
## Summary

On Windows, the dashboard `.url` desktop shortcut hardcoded port `3001`, and the success card defaulted its displayed URLs to `WebUIPort=3000` / `DashboardPort=3001`. Anyone installing with `DASHBOARD_PORT` / `WEBUI_PORT` overrides got a shortcut and a success screen pointing at dead ports even though the stack itself came up correctly on the overridden ports.

Both spots now reuse the already-resolved port variables, so the shortcut and the success card always match where the services actually listen. Found while testing custom-port installs on a real Windows 11 box.

## AI Assistance

Drafted with an AI coding assistant; verified against a local Windows install with non-default ports.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: two-variable substitution; behavior verified by running the Windows installer with DASHBOARD_PORT/WEBUI_PORT set

Commands/results:

```text
./install.ps1 -DryRun   # renders shortcut + success card with resolved
                        # ports instead of 3000/3001 literals
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

Windows installer surface only; no default-install behavior change (resolved ports equal the old constants when no overrides are set).
