### PR TITLE
feat(release): publish commit-bound deterministic runtime SBOM

### DIFF
--- a/.github/workflows/runtime-sbom.yml
+++ b/.github/workflows/runtime-sbom.yml
@@ -1,0 +1,51 @@
+name: Runtime SBOM
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "ods/docker-compose*.yml"
+      - "ods/docker-compose*.yaml"
+      - "ods/extensions/**/compose.y*ml"
+      - "ods/extensions/**/Dockerfile*"
+      - "ods/installers/**/compose.y*ml"
+      - "ods/installers/**/Dockerfile*"
+      - "ods/config/dependency-lock.json"
+      - "ods/scripts/check-dependency-pins.py"
+      - "ods/scripts/generate-runtime-sbom.py"
+      - "ods/tests/test_runtime_sbom.py"
+      - ".github/workflows/runtime-sbom.yml"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate:
+    name: Generate deterministic CycloneDX inventory
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Validate dependency pins
+        working-directory: ods
+        run: python3 scripts/check-dependency-pins.py
+
+      - name: Generate and verify reproducibility
+        working-directory: ods
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          python3 scripts/generate-runtime-sbom.py --output artifacts/ods-runtime.cdx.json
+          python3 scripts/generate-runtime-sbom.py > artifacts/ods-runtime.second.cdx.json
+          cmp artifacts/ods-runtime.cdx.json artifacts/ods-runtime.second.cdx.json
+          python3 -m pytest -q tests/test_runtime_sbom.py
+
+      - name: Upload runtime inventory
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ods-runtime-cyclonedx
+          path: ods/artifacts/ods-runtime.cdx.json
+          if-no-files-found: error

--- a/.github/workflows/runtime-sbom.yml
+++ b/.github/workflows/runtime-sbom.yml
@@ -41,7 +41,7 @@ jobs:
           python3 scripts/generate-runtime-sbom.py --output artifacts/ods-runtime.cdx.json
           python3 scripts/generate-runtime-sbom.py > artifacts/ods-runtime.second.cdx.json
           cmp artifacts/ods-runtime.cdx.json artifacts/ods-runtime.second.cdx.json
-          python3 -m pytest -q tests/test_runtime_sbom.py
+          python3 tests/test_runtime_sbom.py
 
       - name: Upload runtime inventory
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/runtime-sbom.yml
+++ b/.github/workflows/runtime-sbom.yml
@@ -38,14 +38,17 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          python3 scripts/generate-runtime-sbom.py --output artifacts/ods-runtime.cdx.json
-          python3 scripts/generate-runtime-sbom.py > artifacts/ods-runtime.second.cdx.json
+          python3 scripts/generate-runtime-sbom.py --source-commit "$GITHUB_SHA" --output artifacts/ods-runtime.cdx.json
+          python3 scripts/generate-runtime-sbom.py --source-commit "$GITHUB_SHA" > artifacts/ods-runtime.second.cdx.json
           cmp artifacts/ods-runtime.cdx.json artifacts/ods-runtime.second.cdx.json
+          sha256sum artifacts/ods-runtime.cdx.json > artifacts/ods-runtime.cdx.json.sha256
           python3 tests/test_runtime_sbom.py
 
       - name: Upload runtime inventory
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ods-runtime-cyclonedx
-          path: ods/artifacts/ods-runtime.cdx.json
+          name: ods-runtime-cyclonedx-${{ github.sha }}
+          path: |
+            ods/artifacts/ods-runtime.cdx.json
+            ods/artifacts/ods-runtime.cdx.json.sha256
           if-no-files-found: error

--- a/ods/docs/INSTALLER_TRUST.md
+++ b/ods/docs/INSTALLER_TRUST.md
@@ -217,8 +217,15 @@ Maintainers and downstream forks can reproduce the current source inventory:
 
 ```bash
 cd ods
-python3 scripts/generate-runtime-sbom.py --output artifacts/ods-runtime.cdx.json
+python3 scripts/generate-runtime-sbom.py \
+  --source-commit "$(git rev-parse HEAD)" \
+  --output artifacts/ods-runtime.cdx.json
 ```
+
+Published CI artifacts include that exact commit in CycloneDX metadata, use the
+commit in the artifact name, and ship a SHA-256 receipt beside the inventory.
+Omit `--source-commit` only for source exports where Git metadata is unavailable;
+the image inventory remains deterministic but no longer claims an exact VCS object.
 
 ## Related Validation
 

--- a/ods/docs/INSTALLER_TRUST.md
+++ b/ods/docs/INSTALLER_TRUST.md
@@ -195,19 +195,30 @@ ODS currently relies on:
   installs, product behavior, full-model capabilities, and lifecycle recovery.
 
 ODS does not yet publish a complete signed-release or checksum/SBOM chain for
-every installer artifact. Users who need strict provenance should install from
-a reviewed tag or internal fork and record the exact commit or release tag.
+every installer artifact. CI does publish a deterministic CycloneDX inventory
+of the container image references shipped by the source tree; it is an offline
+inventory, not registry-attested build provenance. Users who need strict
+provenance should install from a reviewed tag or internal fork and record the
+exact commit or release tag.
 
 ## Provenance Roadmap
 
 1. Publish checksums for release installer artifacts.
 2. Sign release artifacts and tags with maintainer-controlled signing keys.
-3. Publish SBOMs for release artifacts and core container images.
+3. Expand the source-derived runtime SBOM into signed, registry-attested SBOMs
+   for release artifacts and core container images.
 4. Record build provenance for desktop installer artifacts.
 5. Document the exact validation receipt tied to each release candidate.
 6. Keep inspect-first and manual source install paths available.
 
 These are roadmap items, not current guarantees.
+
+Maintainers and downstream forks can reproduce the current source inventory:
+
+```bash
+cd ods
+python3 scripts/generate-runtime-sbom.py --output artifacts/ods-runtime.cdx.json
+```
 
 ## Related Validation
 

--- a/ods/scripts/generate-runtime-sbom.py
+++ b/ods/scripts/generate-runtime-sbom.py
@@ -13,6 +13,7 @@ import argparse
 import importlib.util
 import json
 import os
+import re
 import sys
 import tempfile
 from collections import defaultdict
@@ -61,7 +62,11 @@ def _component_identity(reference: str) -> tuple[str, str, str]:
     return name, version, purl
 
 
-def build_bom(root: Path = ROOT, checker: ModuleType | None = None) -> dict:
+def build_bom(
+    root: Path = ROOT,
+    checker: ModuleType | None = None,
+    source_commit: str | None = None,
+) -> dict:
     checker = checker or _load_pin_checker(root / "scripts" / "check-dependency-pins.py")
     scoped_refs = [
         ("runtime", ref) for ref in checker.discover_image_refs(root)
@@ -102,24 +107,35 @@ def build_bom(root: Path = ROOT, checker: ModuleType | None = None) -> dict:
 
     ods_version = _ods_version(root)
     root_ref = f"pkg:github/Osmantic/ODS@{quote(ods_version, safe='')}"
+    root_component = {
+        "type": "application",
+        "bom-ref": root_ref,
+        "name": "ODS",
+        "version": ods_version,
+        "purl": root_ref,
+    }
+    metadata_properties = [
+        {
+            "name": "ods:generation-mode",
+            "value": "offline-source-inventory",
+        }
+    ]
+    if source_commit is not None:
+        root_component["externalReferences"] = [{
+            "type": "vcs",
+            "url": f"https://github.com/Osmantic/ODS/tree/{source_commit}",
+        }]
+        metadata_properties.append({
+            "name": "ods:source-commit",
+            "value": source_commit,
+        })
     return {
         "bomFormat": "CycloneDX",
         "specVersion": "1.5",
         "version": 1,
         "metadata": {
-            "component": {
-                "type": "application",
-                "bom-ref": root_ref,
-                "name": "ODS",
-                "version": ods_version,
-                "purl": root_ref,
-            },
-            "properties": [
-                {
-                    "name": "ods:generation-mode",
-                    "value": "offline-source-inventory",
-                }
-            ],
+            "component": root_component,
+            "properties": metadata_properties,
         },
         "components": components,
         "dependencies": [
@@ -158,12 +174,26 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="write atomically to this path (default: stdout)",
     )
+    parser.add_argument(
+        "--source-commit",
+        type=_source_commit,
+        help="embed the exact 40- or 64-character Git commit in the inventory",
+    )
     return parser.parse_args()
+
+
+def _source_commit(value: str) -> str:
+    normalized = value.strip().lower()
+    if re.fullmatch(r"(?:[0-9a-f]{40}|[0-9a-f]{64})", normalized) is None:
+        raise argparse.ArgumentTypeError(
+            "source commit must be a full 40- or 64-character hexadecimal object id"
+        )
+    return normalized
 
 
 def main() -> int:
     args = parse_args()
-    content = _serialized(build_bom())
+    content = _serialized(build_bom(source_commit=args.source_commit))
     if args.output is None:
         # Write bytes so stdout is byte-for-byte reproducible on Windows too;
         # TextIO otherwise translates LF to CRLF.

--- a/ods/scripts/generate-runtime-sbom.py
+++ b/ods/scripts/generate-runtime-sbom.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Generate a deterministic CycloneDX inventory of shipped container images.
+
+The inventory is intentionally source-derived: it records every image used by
+the core Compose stack, bundled services, and the optional extension library.
+It does not contact registries, so maintainers and downstream forks can produce
+the same document offline from the same commit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+from collections import defaultdict
+from pathlib import Path
+from types import ModuleType
+from urllib.parse import quote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PIN_CHECKER = ROOT / "scripts" / "check-dependency-pins.py"
+
+
+def _load_pin_checker(path: Path = PIN_CHECKER) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("ods_dependency_pins", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load dependency scanner: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ods_version(root: Path) -> str:
+    with (root / "manifest.json").open(encoding="utf-8") as handle:
+        manifest = json.load(handle)
+    version = manifest.get("ods_version")
+    if not isinstance(version, str) or not version:
+        raise ValueError("manifest.json must define a non-empty ods_version")
+    return version
+
+
+def _component_identity(reference: str) -> tuple[str, str, str]:
+    """Return (name, version, purl) for a Docker/OCI reference."""
+    without_digest, separator, digest = reference.partition("@sha256:")
+    last_slash = without_digest.rfind("/")
+    last_colon = without_digest.rfind(":")
+    if last_colon > last_slash:
+        name = without_digest[:last_colon]
+        version = without_digest[last_colon + 1 :]
+    else:
+        name = without_digest
+        version = "latest"
+
+    qualifiers = f"?digest=sha256%3A{digest}" if separator else ""
+    purl = f"pkg:docker/{quote(name, safe='/')}@{quote(version, safe='')}{qualifiers}"
+    return name, version, purl
+
+
+def build_bom(root: Path = ROOT, checker: ModuleType | None = None) -> dict:
+    checker = checker or _load_pin_checker(root / "scripts" / "check-dependency-pins.py")
+    scoped_refs = [
+        ("runtime", ref) for ref in checker.discover_image_refs(root)
+    ] + [
+        ("extension-library", ref)
+        for ref in checker.discover_extension_library_image_refs(root)
+    ]
+
+    by_reference: dict[str, list[tuple[str, object]]] = defaultdict(list)
+    for scope, ref in scoped_refs:
+        by_reference[ref.value].append((scope, ref))
+
+    components = []
+    for reference in sorted(by_reference):
+        entries = by_reference[reference]
+        name, version, purl = _component_identity(reference)
+        paths = sorted({entry.path for _, entry in entries})
+        scopes = sorted({scope for scope, _ in entries})
+        raw_refs = sorted({entry.raw for _, entry in entries})
+        component = {
+            "type": "container",
+            "bom-ref": purl,
+            "name": name,
+            "version": version,
+            "purl": purl,
+            "properties": [
+                {"name": "ods:image-reference", "value": reference},
+                {"name": "ods:source-paths", "value": ",".join(paths)},
+                {"name": "ods:scopes", "value": ",".join(scopes)},
+                {"name": "ods:raw-references", "value": ",".join(raw_refs)},
+            ],
+        }
+        if "@sha256:" in reference:
+            component["hashes"] = [
+                {"alg": "SHA-256", "content": reference.rsplit("@sha256:", 1)[1]}
+            ]
+        components.append(component)
+
+    ods_version = _ods_version(root)
+    root_ref = f"pkg:github/Osmantic/ODS@{quote(ods_version, safe='')}"
+    return {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "version": 1,
+        "metadata": {
+            "component": {
+                "type": "application",
+                "bom-ref": root_ref,
+                "name": "ODS",
+                "version": ods_version,
+                "purl": root_ref,
+            },
+            "properties": [
+                {
+                    "name": "ods:generation-mode",
+                    "value": "offline-source-inventory",
+                }
+            ],
+        },
+        "components": components,
+        "dependencies": [
+            {"ref": root_ref, "dependsOn": [item["bom-ref"] for item in components]}
+        ],
+    }
+
+
+def _serialized(bom: dict) -> str:
+    return json.dumps(bom, indent=2, sort_keys=True) + "\n"
+
+
+def _write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate the ODS runtime image inventory as CycloneDX JSON."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="write atomically to this path (default: stdout)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    content = _serialized(build_bom())
+    if args.output is None:
+        # Write bytes so stdout is byte-for-byte reproducible on Windows too;
+        # TextIO otherwise translates LF to CRLF.
+        sys.stdout.buffer.write(content.encode("utf-8"))
+    else:
+        _write_atomic(args.output, content)
+        print(f"Wrote CycloneDX runtime inventory: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test_runtime_sbom.py
+++ b/ods/tests/test_runtime_sbom.py
@@ -13,9 +13,9 @@ ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "generate-runtime-sbom.py"
 
 
-def _generate() -> tuple[bytes, dict]:
+def _generate(*args: str) -> tuple[bytes, dict]:
     result = subprocess.run(
-        [sys.executable, str(SCRIPT)],
+        [sys.executable, str(SCRIPT), *args],
         cwd=ROOT,
         check=True,
         capture_output=True,
@@ -72,9 +72,54 @@ def test_output_path_is_parseable_and_matches_stdout(tmp_path):
     assert json.loads(output.read_text(encoding="utf-8")) == expected
 
 
+def test_source_commit_ties_the_inventory_to_an_exact_candidate():
+    commit = "a" * 40
+
+    first_bytes, bom = _generate("--source-commit", commit)
+    second_bytes, _ = _generate("--source-commit", commit)
+
+    assert first_bytes == second_bytes
+    assert {
+        prop["name"]: prop["value"]
+        for prop in bom["metadata"]["properties"]
+    }["ods:source-commit"] == commit
+    assert bom["metadata"]["component"]["externalReferences"] == [{
+        "type": "vcs",
+        "url": f"https://github.com/Osmantic/ODS/tree/{commit}",
+    }]
+    with tempfile.TemporaryDirectory() as temporary:
+        output = Path(temporary) / "candidate.cdx.json"
+        subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--source-commit", commit,
+                "--output", str(output),
+            ],
+            cwd=ROOT,
+            check=True,
+            capture_output=True,
+        )
+        assert output.read_bytes() == first_bytes
+
+
+def test_source_commit_rejects_moving_or_abbreviated_refs():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--source-commit", "main"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    assert "full 40- or 64-character hexadecimal object id" in result.stderr
+
+
 if __name__ == "__main__":
     test_cli_emits_deterministic_cyclonedx_inventory()
     test_every_source_image_is_represented_once()
     with tempfile.TemporaryDirectory() as temporary:
         test_output_path_is_parseable_and_matches_stdout(Path(temporary))
-    print("PASS: 3 runtime SBOM tests")
+    test_source_commit_ties_the_inventory_to_an_exact_candidate()
+    test_source_commit_rejects_moving_or_abbreviated_refs()
+    print("PASS: 5 runtime SBOM tests")

--- a/ods/tests/test_runtime_sbom.py
+++ b/ods/tests/test_runtime_sbom.py
@@ -1,0 +1,71 @@
+"""Public-boundary tests for scripts/generate-runtime-sbom.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "generate-runtime-sbom.py"
+
+
+def _generate() -> tuple[bytes, dict]:
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return result.stdout, json.loads(result.stdout)
+
+
+def test_cli_emits_deterministic_cyclonedx_inventory():
+    first_bytes, first = _generate()
+    second_bytes, second = _generate()
+
+    assert first_bytes == second_bytes
+    assert first == second
+    assert first["bomFormat"] == "CycloneDX"
+    assert first["specVersion"] == "1.5"
+    assert first["metadata"]["component"]["name"] == "ODS"
+    assert first["components"]
+
+
+def test_every_source_image_is_represented_once():
+    _, bom = _generate()
+    references = [
+        next(
+            prop["value"]
+            for prop in component["properties"]
+            if prop["name"] == "ods:image-reference"
+        )
+        for component in bom["components"]
+    ]
+
+    assert references == sorted(set(references))
+    assert any("extension-library" in prop["value"]
+               for component in bom["components"]
+               for prop in component["properties"]
+               if prop["name"] == "ods:scopes")
+    root_dependency = bom["dependencies"][0]
+    assert root_dependency["dependsOn"] == [
+        component["bom-ref"] for component in bom["components"]
+    ]
+
+
+def test_output_path_is_parseable_and_matches_stdout(tmp_path):
+    expected_bytes, expected = _generate()
+    output = tmp_path / "artifacts" / "ods-runtime.cdx.json"
+
+    subprocess.run(
+        [sys.executable, str(SCRIPT), "--output", str(output)],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+
+    assert output.read_bytes() == expected_bytes
+    assert json.loads(output.read_text(encoding="utf-8")) == expected

--- a/ods/tests/test_runtime_sbom.py
+++ b/ods/tests/test_runtime_sbom.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -69,3 +70,11 @@ def test_output_path_is_parseable_and_matches_stdout(tmp_path):
 
     assert output.read_bytes() == expected_bytes
     assert json.loads(output.read_text(encoding="utf-8")) == expected
+
+
+if __name__ == "__main__":
+    test_cli_emits_deterministic_cyclonedx_inventory()
+    test_every_source_image_is_represented_once()
+    with tempfile.TemporaryDirectory() as temporary:
+        test_output_path_is_parseable_and_matches_stdout(Path(temporary))
+    print("PASS: 3 runtime SBOM tests")


### PR DESCRIPTION
## Why this matters

ODS ships a large composable container surface, but operators and downstream forks lacked a machine-readable inventory tying runtime image references to source. The original branch generated a reproducible CycloneDX inventory, yet two commits sharing the same ODS version and image set produced indistinguishable published artifacts. A release receipt must identify the exact candidate it describes.

The published workflow now embeds the full Git object ID in CycloneDX metadata, names the artifact with that SHA, and ships a SHA-256 receipt beside it. This remains an offline source inventory; it does not claim registry attestation, image signing, or build provenance it did not perform.

## Overlap check

Searched open and closed upstream PRs for SBOMs, CycloneDX, source-commit binding, checksums, runtime inventory, and provenance, plus all changed files. The only open PR changing the workflow, generator, or regression file is this canonical PR. Merged #1449 is documentation/roadmap only. No competing implementation or file owner was found.

## Production and release contract

- discover every shipped Compose/Dockerfile image through the repository's existing dependency scanner
- deduplicate by resolved reference while retaining raw expressions, source paths, and runtime/library scopes
- emit byte-stable CycloneDX 1.5 JSON and write output atomically
- accept only a full 40- or 64-character hexadecimal `--source-commit`; reject moving names and abbreviated refs
- record `ods:source-commit` and an exact GitHub VCS reference in metadata
- generate twice in CI for byte comparison, then publish the inventory plus SHA-256 receipt in an artifact named with `${{ github.sha }}`

## Regression coverage

Public CLI tests prove deterministic stdout, one component per source image, root dependency coverage, atomic output parity, exact source-commit metadata/VCS linkage, and rejection of `main` or abbreviated references.

Concrete pre-change evidence: `--source-commit <sha>` exited with argparse status 2 because no source identity contract existed.

## Validation

- `python -m pytest -q tests/test_runtime_sbom.py` — 5 passed.
- `python tests/test_runtime_sbom.py` — standalone CI path passed all 5 contracts.
- `python scripts/check-dependency-pins.py` — passed.
- Python compile and workflow YAML parse — passed.
- `git diff --check` — passed.

An attempt to reproduce the workflow's Bash wrapper locally used WSL against `/mnt/c` and was stopped after the source scans exceeded 90 seconds due that filesystem boundary. The regression suite compares stdout and atomic file bytes directly with native Python; the Ubuntu GitHub Actions run remains the authoritative check for the literal `cmp`/`sha256sum` wrapper.

## Tradeoffs and rollback

`--source-commit` is optional for exported source trees without Git metadata, but CI always supplies the exact candidate SHA. The checksum proves transport/content equality for this generated inventory only; it is not a signature. Rollback removes the artifact/metadata contract without changing runtime images, installation behavior, or release state.