### PR TITLE
feat(opencode): preserve user-owned model defaults

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10774,6 +10774,7 @@ def _opencode_config_matches(
     base_url: str,
     api_key: str,
     context_length: int,
+    expected_defaults: dict,
 ) -> bool:
     if not isinstance(config, dict):
         return False
@@ -10783,16 +10784,38 @@ def _opencode_config_matches(
     models = llama_provider.get("models") if isinstance(llama_provider, dict) else None
     model = models.get(model_id) if isinstance(models, dict) else None
     limit = model.get("limit") if isinstance(model, dict) else None
-    model_ref = f"{provider_id}/{model_id}"
+    defaults_match = all(
+        (key in config) == (key in expected_defaults)
+        and config.get(key) == expected_defaults.get(key)
+        for key in ("model", "small_model")
+    )
     return bool(
-        config.get("model") == model_ref
-        and config.get("small_model") == model_ref
+        defaults_match
         and isinstance(options, dict)
         and options.get("baseURL") == base_url
         and options.get("apiKey") == api_key
         and isinstance(limit, dict)
         and limit.get("context") == context_length
     )
+
+
+def _opencode_defaults_are_managed(config: dict, provider_id: str) -> bool:
+    """Return whether ODS may update OpenCode's top-level model defaults.
+
+    Existing defaults that point at another provider identify a user-owned
+    native CLI config. In that case ODS may refresh its provider route, but it
+    must not take over the user's selected model. Missing defaults and defaults
+    already using the ODS provider remain ODS-managed for compatibility with
+    configs created by the installer.
+    """
+    prefix = f"{provider_id}/"
+    for key in ("model", "small_model"):
+        if key not in config:
+            continue
+        value = config[key]
+        if not isinstance(value, str) or not value.startswith(prefix):
+            return False
+    return True
 
 
 def _update_opencode_config(
@@ -10814,8 +10837,10 @@ def _update_opencode_config(
         source = previous.get("parsed") or snapshot["source"]
         config = json.loads(json.dumps(source))
         previous_model_ref = config.get("model")
-        config["model"] = model_ref
-        config["small_model"] = model_ref
+        manage_defaults = _opencode_defaults_are_managed(config, provider_id)
+        if manage_defaults:
+            config["model"] = model_ref
+            config["small_model"] = model_ref
         config.setdefault("$schema", "https://opencode.ai/config.json")
 
         providers = config.setdefault("provider", {})
@@ -10841,7 +10866,8 @@ def _update_opencode_config(
             models = {}
             provider["models"] = models
         if (
-            isinstance(previous_model_ref, str)
+            manage_defaults
+            and isinstance(previous_model_ref, str)
             and previous_model_ref.startswith(f"{provider_id}/")
         ):
             previous_model_id = previous_model_ref.split("/", 1)[1]
@@ -10865,7 +10891,13 @@ def _update_opencode_config(
         except (OSError, json.JSONDecodeError) as exc:
             raise RuntimeError(f"Could not verify OpenCode config {path}: {exc}") from exc
         if not _opencode_config_matches(
-            persisted, provider_id, route_model_id, base_url, api_key, context_length
+            persisted,
+            provider_id,
+            route_model_id,
+            base_url,
+            api_key,
+            context_length,
+            config,
         ):
             raise RuntimeError(f"OpenCode persisted model route is stale in {path}")
 

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -5773,6 +5773,62 @@ class TestModelActivateRollback:
         assert primary_config["provider"]["llama-server"]["options"]["timeout"] == 900
         assert compat_config["compat_only"] is True
 
+    def test_activation_preserves_user_owned_opencode_defaults(
+        self, tmp_path, monkeypatch,
+    ):
+        """A native CLI keeps its selected cloud models across ODS swaps."""
+        install_dir, _env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        config_dir = tmp_path / "home" / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        primary = config_dir / "opencode.json"
+        compat = config_dir / "config.json"
+        user_config = {
+            "model": "anthropic/claude-opus",
+            "small_model": "openai/gpt-mini",
+            "theme": "system",
+            "provider": {
+                "anthropic": {"npm": "@ai-sdk/anthropic"},
+                "llama-server": {
+                    "options": {"baseURL": "http://127.0.0.1:9999/v1"},
+                    "models": {"user-kept-model": {"name": "Keep me"}},
+                },
+            },
+        }
+        primary.write_text(json.dumps(user_config), encoding="utf-8")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "_opencode_config_paths", lambda: (primary, compat))
+        monkeypatch.setattr(_mod, "_restart_managed_opencode", lambda _state=None: False)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 200
+        for path in (primary, compat):
+            config = json.loads(path.read_text(encoding="utf-8"))
+            assert config["model"] == "anthropic/claude-opus"
+            assert config["small_model"] == "openai/gpt-mini"
+            assert config["theme"] == "system"
+            assert config["provider"]["anthropic"] == {
+                "npm": "@ai-sdk/anthropic"
+            }
+            ods_provider = config["provider"]["llama-server"]
+            assert ods_provider["options"] == {
+                "baseURL": "http://127.0.0.1:8080/v1",
+                "apiKey": "no-key",
+            }
+            assert ods_provider["models"]["new-model"]["limit"] == {
+                "context": 4096,
+                "output": 4096,
+            }
+            assert ods_provider["models"]["user-kept-model"] == {
+                "name": "Keep me"
+            }
+
     def test_switchboard_activation_routes_opencode_through_stable_alias(
         self, tmp_path, monkeypatch,
     ):


### PR DESCRIPTION
## Summary
- distinguish ODS-managed OpenCode defaults from a user-owned native CLI configuration
- refresh the ODS provider/model route on every activation without overwriting non-ODS `model` or `small_model` selections
- retain user-curated provider entries and verify both route persistence and exact default preservation after the atomic write

## Why this matters
Closes #2823. A model activation currently rewrites the well-known host OpenCode config whenever OpenCode is installed, so operators using a native CLI can unexpectedly be switched away from Anthropic, OpenAI, or another chosen provider. The reachable `POST /v1/model/activate` host-agent path now honors the manifest's `pinning: none` ownership boundary while keeping the newly loaded ODS model selectable.

## Overlap check
Searched open and closed PR titles/bodies for `OpenCode ownership`, `pinning:none`, and `preserve user defaults`, then inspected open PRs touching `ods/bin/ods-host-agent.py`. PRs #2843, #2858, #2806, #2711, #2646, #2611, and #2555 touch that file for MLX, Windows resolution, atomic PID writes, state locking, provider validation, service-state detection, or health probes; none defines config ownership or preserves non-ODS defaults. This scope is independent and retains the existing managed-config behavior.

## Test plan
- [x] `python -m pytest -q tests/test_model_activate.py -k opencode` (14 passed)
- [x] `python -m py_compile ods/bin/ods-host-agent.py`
- [x] `git diff --check`

Generated with Codex