### PR TITLE
feat(auth): revoke individual browser sessions

### DIFF
--- a/ods/docs/HERMES-SSO.md
+++ b/ods/docs/HERMES-SSO.md
@@ -122,15 +122,15 @@ What this catches:
 
 What this does NOT do:
 - Identify which user is behind a request — the cookie is opaque (the random-id is not a username)
-- Track per-cookie revocation. Today's only revocation mechanism is rotating `ODS_SESSION_SECRET`, which invalidates every issued cookie. A future PR could add a revocation list keyed on the random-id; the cookie format reserves space for it.
+- List active sessions. The store records opaque random ids only after they are revoked.
 
-For the ODS trust model (single home, trusted LAN, family-scale users), this gives real signature-based gating without a session store. The proxy explicitly says "**gating**, not identification."
+For the ODS trust model (single home, trusted LAN, family-scale users), this gives real signature-based gating without an identity-bearing session database. The proxy explicitly says "**gating**, not identification."
 
 ## Known limitations
 
 1. **No real multi-user.** All authed users share one Hermes — same memories, skills, persona, sessions. Mom can see Dad's chats and vice-versa. Treat Hermes as "the family's agent."
 
-2. **Stolen cookies are valid until expiry or secret rotation.** The cookie is signed, but if it's exfiltrated (malicious browser extension, leaked screenshot, etc.) the attacker can use it until the 12h expiry passes or the operator rotates `ODS_SESSION_SECRET`. There's no per-cookie revocation today. The signed format reserves the random-id field for a future revocation list.
+2. **A copied cookie stays valid until logout, expiry, or secret rotation.** `POST /api/auth/logout` persists the current random id in the server-side revocation store and immediately blocks replay. An operator who cannot submit the stolen cookie itself can still rotate `ODS_SESSION_SECRET` to invalidate every session.
 
 3. **No per-request user identification.** The proxy doesn't add an `X-ODS-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid signed cookie."
 

--- a/ods/extensions/services/dashboard-api/README.md
+++ b/ods/extensions/services/dashboard-api/README.md
@@ -52,6 +52,8 @@ Environment variables (set in `.env`):
 | `GET` | `/status` | Yes | Full system status (all above combined) |
 | `GET` | `/api/status` | Yes | Dashboard-formatted status with inference metrics |
 | `GET` | `/api/host-agent/diagnostics` | Yes | Host-agent URL, gateway, auth, and live probe diagnostics |
+| `GET` | `/api/auth/verify-session` | Session cookie | Verify a signed, non-revoked browser session |
+| `POST` | `/api/auth/logout` | Session cookie | Revoke the current session and clear its cookie |
 
 ### Preflight
 

--- a/ods/extensions/services/dashboard-api/routers/auth.py
+++ b/ods/extensions/services/dashboard-api/routers/auth.py
@@ -1,143 +1,114 @@
-"""Auth-related dashboard-api endpoints.
+"""Authentication and signed browser-session endpoints.
 
-Two endpoints today:
-
-  * ``GET /api/auth/verify-session`` — validates the HMAC-signed
-    ``ods-session`` cookie. Used by Caddy reverse proxies (e.g., the
-    Hermes auth-proxy) via ``forward_auth`` to gate access on a valid
-    session without each proxy needing to know the signing secret.
-
-  * ``POST /api/auth/admin-session`` — mints a signed ``ods-session``
-    cookie for the install owner (gated by ``DASHBOARD_API_KEY``). Lets
-    the admin reach cookie-gated services (Hermes, etc.) without
-    redeeming their own magic link. Without this, the install owner
-    would be locked out of their own services until they minted +
-    redeemed an invite to themselves, which is absurd UX.
-
-Security:
-  * ``verify-session`` is intentionally NOT gated by the API key — it's
-    reachable from any reverse proxy on the bridge network. The cookie
-    ITSELF is the credential.
-  * ``admin-session`` IS gated by the API key. Only callers that already
-    hold the admin secret (the dashboard, ods-cli, the host agent)
-    can mint a session. The minted cookie is identical in shape to one
-    issued by magic-link redemption; downstream consumers can't tell
-    them apart.
+``verify-session`` is consumed by reverse proxies through ``forward_auth``.
+``admin-session`` exchanges the dashboard API key for a signed browser cookie.
+``logout`` persists a per-cookie revocation before clearing that cookie.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 import session_signer
+from config import DATA_DIR
 from security import verify_api_key
+from session_revocations import RevocationStore
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["auth"])
 
 SESSION_COOKIE_NAME = "ods-session"
-# Same TTL the magic-link router uses for redeemed sessions; keeping
-# them aligned means an admin and a guest share the same expiry model
-# and the dashboard's "session expires in N hours" surface is uniform.
 SESSION_TTL_SECONDS = 12 * 3600
+_REVOCATIONS = RevocationStore(Path(DATA_DIR) / "auth" / "session-revocations.json")
 
 
 def _cookie_domain() -> Optional[str]:
-    """Cookie ``Domain`` attribute. Empty/None = host-only cookie.
-
-    ODS_COOKIE_DOMAIN is set by the installer to ``<ODS_DEVICE_NAME>.local``
-    when ods-proxy + mDNS are wired so a single redemption authenticates
-    across chat.<name>.local, hermes.<name>.local, and the rest. With it
-    empty, the cookie is host-only — functional for single-host setups
-    but breaks subdomain SSO. Same logic as routers/magic_link.py;
-    duplicated here intentionally so the two cookie-issuing paths stay
-    coupled without one depending on the other.
-    """
+    """Return the shared cookie domain, or None for a host-only cookie."""
     raw = (os.environ.get("ODS_COOKIE_DOMAIN") or "").strip()
     return raw or None
 
 
+def _validated_session(cookie_value: str) -> tuple[str, int]:
+    """Return signed session claims, rejecting revoked cookies identically."""
+    ok, reason = session_signer.verify(cookie_value)
+    if ok:
+        session_id, expiry_str, _signature = cookie_value.split(".")
+        expiry = int(expiry_str)
+        try:
+            revoked = _REVOCATIONS.is_revoked(session_id)
+        except (OSError, ValueError) as exc:
+            logger.error("session revocation store unavailable: %s", exc)
+            raise HTTPException(
+                status_code=503,
+                detail="Session verification is temporarily unavailable",
+            ) from exc
+        if revoked:
+            ok, reason = False, "revoked"
+    if not ok:
+        logger.info("session denied: reason=%s", reason)
+        # All credential failures intentionally share one response so callers
+        # cannot distinguish expiry, revocation, or signature failures.
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return session_id, expiry
+
+
+def _set_session_cookie(response: Response, request: Request, token: str) -> None:
+    cookie_kwargs: dict = {
+        "max_age": SESSION_TTL_SECONDS,
+        "httponly": True,
+        "samesite": "lax",
+        "secure": request.url.scheme == "https",
+        "path": "/",
+    }
+    cookie_domain = _cookie_domain()
+    if cookie_domain:
+        cookie_kwargs["domain"] = cookie_domain
+    response.set_cookie(key=SESSION_COOKIE_NAME, value=token, **cookie_kwargs)
+
+
 @router.get("/api/auth/verify-session")
 def verify_session(request: Request) -> dict:
-    """Validate the ods-session cookie. Returns 200 if valid, 401 if not.
-
-    Caddy reverse proxies use this via ``forward_auth``:
-
-        forward_auth dashboard-api:3002 {
-            uri /api/auth/verify-session
-            copy_headers Cookie
-        }
-
-    Caddy forwards the original request's Cookie header here; we read
-    the ods-session cookie, hand it to session_signer.verify(), and
-    return 200/401 based on the result. The proxy honors the status
-    code: 2xx → forward the original request to the upstream; non-2xx
-    → return the forward_auth response to the client.
-
-    Response body on success is intentionally minimal — proxies just
-    care about the status code. We do return the cookie's expiry so
-    callers that ALSO want to read it (e.g., the dashboard UI showing
-    "session expires in N minutes") can do so without re-implementing
-    the parser.
-    """
+    """Validate the signed, non-revoked ``ods-session`` cookie."""
     cookie_value = request.cookies.get(SESSION_COOKIE_NAME, "")
-    ok, reason = session_signer.verify(cookie_value)
-    if not ok:
-        logger.info("verify-session denied: reason=%s", reason)
-        # We don't echo the reason back to the caller — that would help
-        # an attacker probe (is it expired? bad signature? no secret?).
-        # Caddy only needs the status code.
-        raise HTTPException(status_code=401, detail="Invalid or expired session")
-
-    # On success, return the expiry so the dashboard can surface "session
-    # ends at X" without each consumer re-parsing the cookie. The format is
-    # `<id>.<expiry>.<sig>`; we already validated the signature in verify().
-    try:
-        _, expiry_str, _ = cookie_value.split(".")
-        expiry = int(expiry_str)
-    except (ValueError, TypeError):
-        # Validated above, but be defensive.
-        expiry = 0
-
+    _session_id, expiry = _validated_session(cookie_value)
     return {"valid": True, "expires_at": expiry}
+
+
+@router.post("/api/auth/logout")
+def logout(response: Response, request: Request) -> dict:
+    """Revoke the current signed session and expire its browser cookie."""
+    cookie_value = request.cookies.get(SESSION_COOKIE_NAME, "")
+    session_id, expiry = _validated_session(cookie_value)
+    try:
+        _REVOCATIONS.revoke(session_id, expiry)
+    except (OSError, ValueError) as exc:
+        logger.error("session revocation write failed: %s", exc)
+        raise HTTPException(
+            status_code=503,
+            detail="Session revocation is temporarily unavailable",
+        ) from exc
+
+    response.delete_cookie(
+        key=SESSION_COOKIE_NAME,
+        path="/",
+        domain=_cookie_domain(),
+        secure=request.url.scheme == "https",
+        httponly=True,
+        samesite="lax",
+    )
+    logger.info("session revoked; expires_at=%d", expiry)
+    return {"revoked": True, "expires_at": expiry}
 
 
 @router.post("/api/auth/admin-session", dependencies=[Depends(verify_api_key)])
 def admin_session(response: Response, request: Request) -> dict:
-    """Mint a signed ``ods-session`` cookie for the install owner.
-
-    The install owner already holds ``DASHBOARD_API_KEY`` (the admin
-    credential). Requiring them to ALSO redeem a magic link to access
-    cookie-gated services (Hermes, future ones) is bad UX — they own
-    the box. This endpoint trades the admin API key in for a signed
-    ``ods-session`` cookie identical to one a magic-link redemption
-    would issue.
-
-    Used by:
-      * The dashboard UI on load — when ``verify-session`` returns 401
-        and the caller has the API key, the dashboard POSTs here to
-        mint a session quietly. From the user's POV, the sidebar
-        "Hermes" link just works.
-      * The first-boot wizard — after Finish, before showing the
-        success screen, so a fresh install lands with a session.
-      * The host agent / ods-cli — when running setup flows that
-        need to leave a cookie in a browser session for follow-up.
-
-    The cookie is identical in shape to a magic-link-issued one:
-    HMAC-SHA256 signed against ``ODS_SESSION_SECRET``, ``HttpOnly``,
-    ``SameSite=Lax``, ``Secure`` when reached over HTTPS, with the
-    operator's ``ODS_COOKIE_DOMAIN`` (if set) so it travels across
-    proxy subdomains.
-
-    Returns 503 if ``ODS_SESSION_SECRET`` is not configured — same
-    behaviour as the redemption path. Issue must fail loudly, not
-    silently mint unverifiable cookies.
-    """
+    """Mint a signed browser session for a caller holding the admin API key."""
     if not session_signer.is_configured():
         logger.error(
             "admin-session refused: ODS_SESSION_SECRET is not configured. "
@@ -149,32 +120,9 @@ def admin_session(response: Response, request: Request) -> dict:
         )
 
     session_token = session_signer.issue(ttl_seconds=SESSION_TTL_SECONDS)
-    secure_cookie = request.url.scheme == "https"
-    cookie_domain = _cookie_domain()
-
-    cookie_kwargs: dict = dict(
-        max_age=SESSION_TTL_SECONDS,
-        httponly=True,
-        samesite="lax",
-        secure=secure_cookie,
-        path="/",
-    )
-    if cookie_domain:
-        cookie_kwargs["domain"] = cookie_domain
-
-    response.set_cookie(
-        key=SESSION_COOKIE_NAME,
-        value=session_token,
-        **cookie_kwargs,
-    )
-
-    # Pull the expiry out for the dashboard's "session ends at X" surface.
-    # We know the format because we just minted it; defensive parse anyway.
-    try:
-        _, expiry_str, _ = session_token.split(".")
-        expiry = int(expiry_str)
-    except (ValueError, TypeError):
-        expiry = 0
+    _set_session_cookie(response, request, session_token)
+    _session_id, expiry_str, _signature = session_token.split(".")
+    expiry = int(expiry_str)
 
     logger.info("admin-session minted; expires_at=%d", expiry)
     return {"ok": True, "expires_at": expiry}

--- a/ods/extensions/services/dashboard-api/session_revocations.py
+++ b/ods/extensions/services/dashboard-api/session_revocations.py
@@ -1,0 +1,101 @@
+"""Persistent per-cookie revocation for signed ODS sessions."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+
+_SESSION_ID_RE = re.compile(r"^[A-Za-z0-9_-]{16,128}$")
+
+
+class RevocationStore:
+    """Thread-safe, process-local cache backed by an atomic JSON record."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._lock = threading.Lock()
+        self._revoked: dict[str, int] | None = None
+
+    def _load_locked(self) -> dict[str, int]:
+        if self._revoked is not None:
+            return self._revoked
+        if not self.path.exists():
+            self._revoked = {}
+            return self._revoked
+
+        data = json.loads(self.path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict) or data.get("schema_version") != 1:
+            raise ValueError("session revocation store has an unsupported schema")
+        entries = data.get("revoked")
+        if not isinstance(entries, dict):
+            raise ValueError("session revocation store must contain a revoked object")
+
+        revoked: dict[str, int] = {}
+        for session_id, expiry in entries.items():
+            if not isinstance(session_id, str) or not _SESSION_ID_RE.fullmatch(session_id):
+                raise ValueError("session revocation store contains an invalid session id")
+            if isinstance(expiry, bool) or not isinstance(expiry, int):
+                raise ValueError("session revocation store contains an invalid expiry")
+            revoked[session_id] = expiry
+        self._revoked = revoked
+        return revoked
+
+    def _write_locked(self, revoked: dict[str, int]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=f".{self.path.name}.",
+            dir=self.path.parent,
+        )
+        try:
+            os.chmod(temporary, 0o600)
+            payload = {"schema_version": 1, "revoked": revoked}
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
+                json.dump(payload, handle, indent=2, sort_keys=True)
+                handle.write("\n")
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, self.path)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            Path(temporary).unlink(missing_ok=True)
+
+    def is_revoked(self, session_id: str, *, now: int | None = None) -> bool:
+        if not _SESSION_ID_RE.fullmatch(session_id):
+            raise ValueError("invalid session id")
+        current_time = int(time.time()) if now is None else now
+        with self._lock:
+            expiry = self._load_locked().get(session_id)
+            return expiry is not None and expiry > current_time
+
+    def revoke(
+        self,
+        session_id: str,
+        expires_at: int,
+        *,
+        now: int | None = None,
+    ) -> None:
+        if not _SESSION_ID_RE.fullmatch(session_id):
+            raise ValueError("invalid session id")
+        if isinstance(expires_at, bool) or not isinstance(expires_at, int):
+            raise ValueError("expires_at must be an integer")
+        current_time = int(time.time()) if now is None else now
+        if expires_at <= current_time:
+            raise ValueError("cannot revoke an expired session")
+
+        with self._lock:
+            current = self._load_locked()
+            active = {
+                key: expiry for key, expiry in current.items()
+                if expiry > current_time
+            }
+            active[session_id] = max(expires_at, active.get(session_id, 0))
+            self._write_locked(active)
+            self._revoked = active

--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -19,11 +19,9 @@ Why this shape:
     request session-store lookup.
   * Tamper-evident — a leaked cookie can't have its expiry extended;
     that would invalidate the signature.
-  * Revocation is bounded by expiry — if a cookie leaks, the operator
-    rotates ODS_SESSION_SECRET (which invalidates every issued cookie)
-    or waits for natural expiry. Adding a per-cookie revocation list is
-    a follow-up if needed; the cookie format reserves room (the random-
-    id field is what a revocation list would key on).
+  * Revocation is checked by the API boundary against a persistent store keyed
+    by the random-id. The signer stays responsible only for cookie integrity
+    and expiry, so it remains reusable by tests and non-HTTP callers.
   * No identity in the cookie — the random-id is opaque. The magic-link
     redemption records the target user separately (via the
     `ods-target-user` cookie or server-side audit log). Putting the

--- a/ods/extensions/services/dashboard-api/tests/test_auth_router.py
+++ b/ods/extensions/services/dashboard-api/tests/test_auth_router.py
@@ -8,12 +8,19 @@ It validates the ods-session cookie via session_signer and returns
 import pytest
 
 import session_signer
+from routers import auth as auth_router
+from session_revocations import RevocationStore
 
 
 @pytest.fixture(autouse=True)
-def _set_secret():
+def _set_secret(monkeypatch, tmp_path):
     """Install a known signing secret for each test."""
     session_signer._set_secret_for_tests("test-secret-for-verify-endpoint")
+    monkeypatch.setattr(
+        auth_router,
+        "_REVOCATIONS",
+        RevocationStore(tmp_path / "session-revocations.json"),
+    )
     yield
     session_signer._set_secret_for_tests("")
 
@@ -202,3 +209,51 @@ class TestAdminSession:
             v for k, v in resp.headers.raw if k.lower() == b"set-cookie"
         ).lower()
         assert b"domain=kitchen.local" in cookie_blob
+
+
+class TestLogout:
+
+    def test_revokes_current_cookie_at_server_boundary(self, test_client):
+        cookie = session_signer.issue(ttl_seconds=60)
+        test_client.cookies.set("ods-session", cookie)
+
+        response = test_client.post("/api/auth/logout")
+
+        assert response.status_code == 200
+        assert response.json()["revoked"] is True
+        assert "ods-session=" in response.headers["set-cookie"]
+        assert "Max-Age=0" in response.headers["set-cookie"]
+
+        # Replay the copied cookie after the browser deletion. Server-side
+        # revocation, rather than cookie clearing alone, must reject it.
+        test_client.cookies.set("ods-session", cookie)
+        replay = test_client.get("/api/auth/verify-session")
+        assert replay.status_code == 401
+
+    def test_revocation_survives_store_reload(self, test_client, tmp_path, monkeypatch):
+        path = tmp_path / "persisted-revocations.json"
+        monkeypatch.setattr(auth_router, "_REVOCATIONS", RevocationStore(path))
+        cookie = session_signer.issue(ttl_seconds=60)
+        test_client.cookies.set("ods-session", cookie)
+        assert test_client.post("/api/auth/logout").status_code == 200
+
+        monkeypatch.setattr(auth_router, "_REVOCATIONS", RevocationStore(path))
+        test_client.cookies.set("ods-session", cookie)
+        assert test_client.get("/api/auth/verify-session").status_code == 401
+
+    def test_invalid_cookie_cannot_create_revocation(self, test_client, tmp_path):
+        test_client.cookies.set("ods-session", "not.a.valid-cookie")
+        response = test_client.post("/api/auth/logout")
+        assert response.status_code == 401
+        assert not list(tmp_path.rglob("session-revocations.json"))
+
+    def test_corrupt_revocation_store_fails_closed(self, test_client, tmp_path, monkeypatch):
+        path = tmp_path / "corrupt.json"
+        path.write_text("not-json", encoding="utf-8")
+        monkeypatch.setattr(auth_router, "_REVOCATIONS", RevocationStore(path))
+        test_client.cookies.set("ods-session", session_signer.issue(ttl_seconds=60))
+
+        response = test_client.get("/api/auth/verify-session")
+
+        assert response.status_code == 503
+        assert "temporarily unavailable" in response.json()["detail"]

--- a/ods/extensions/services/dashboard-api/tests/test_session_revocations.py
+++ b/ods/extensions/services/dashboard-api/tests/test_session_revocations.py
@@ -1,0 +1,60 @@
+"""Tests for the persistent per-session revocation store."""
+
+import json
+import os
+
+import pytest
+
+from session_revocations import RevocationStore
+
+
+def test_revoke_prunes_expired_entries_and_persists_owner_only(tmp_path):
+    path = tmp_path / "auth" / "revocations.json"
+    old_id = "expired_session_identifier"
+    active_id = "active_session_identifier"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({
+            "schema_version": 1,
+            "revoked": {old_id: 99, active_id: 300},
+        }),
+        encoding="utf-8",
+    )
+    store = RevocationStore(path)
+
+    new_id = "new_session_identifier"
+    store.revoke(new_id, 400, now=100)
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["revoked"] == {active_id: 300, new_id: 400}
+    if os.name != "nt":
+        assert path.stat().st_mode & 0o077 == 0
+
+
+def test_revoke_is_idempotent_and_never_shortens_expiry(tmp_path):
+    path = tmp_path / "revocations.json"
+    store = RevocationStore(path)
+    session_id = "idempotent_session_identifier"
+
+    store.revoke(session_id, 400, now=100)
+    store.revoke(session_id, 300, now=100)
+
+    assert RevocationStore(path).is_revoked(session_id, now=350) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {"schema_version": 2, "revoked": {}},
+        {"schema_version": 1, "revoked": []},
+        {"schema_version": 1, "revoked": {"bad id": 200}},
+        {"schema_version": 1, "revoked": {"valid_session_identifier": "200"}},
+    ],
+)
+def test_invalid_persisted_shape_is_rejected(tmp_path, payload):
+    path = tmp_path / "revocations.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        RevocationStore(path).is_revoked("valid_session_identifier", now=100)


### PR DESCRIPTION
## Summary
- add a persistent, owner-only revocation store keyed by the signed cookie's opaque random id
- expose `POST /api/auth/logout`, which atomically persists revocation before clearing the browser cookie
- make the reverse-proxy verification boundary reject replayed cookies and fail closed when revocation state is unreadable
- prune expired entries on writes and document the remaining identity/admin limitations

## Why this matters
A copied `ods-session` cookie currently remains usable for up to 12 hours unless the operator rotates `ODS_SESSION_SECRET` and logs out every device. The production `GET /api/auth/verify-session` forward-auth path now enforces per-cookie logout across Hermes and future cookie-gated services, while secret rotation remains the recovery path when the stolen cookie is unavailable.

## Overlap check
Searched open and closed PR titles for `session revocation`, `logout session`, and `revoke cookie`, and inspected open PRs touching `session_signer.py` and the auth router. PR #2824 adds secret lookup fallback and #2529 tightens TTL types; neither adds server-side state, logout, or replay rejection. No open PR touches `routers/auth.py`, the new revocation module, or its public-boundary tests.

## Test plan
- [x] `python -m pytest -q tests/test_session_revocations.py tests/test_auth_router.py tests/test_session_signer.py` (44 passed)
- [x] `python -m py_compile session_revocations.py routers/auth.py`
- [x] `git diff --check`

Generated with Codex