### PR TITLE
feat(dashboard): add registry-driven command palette

### DIFF
--- a/ods/extensions/services/dashboard/src/App.jsx
+++ b/ods/extensions/services/dashboard/src/App.jsx
@@ -8,6 +8,7 @@ import { useFirstRun } from './hooks/useFirstRun'
 import { useSessionBootstrap } from './hooks/useSessionBootstrap'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
+import CommandPalette from './components/CommandPalette'
 
 // Phone-first first-boot wizard. Mounted instead of the normal app shell
 // when useFirstRun() reports firstRun=true. Lazy-loaded so the wizard
@@ -153,6 +154,7 @@ function App() {
           install. No-op on already-installed PWAs and on browsers that
           can't install (e.g. Firefox desktop). See usePwaInstallPrompt. */}
       <InstallPromptBanner />
+      <CommandPalette routes={routes} />
     </div>
   )
 }

--- a/ods/extensions/services/dashboard/src/components/CommandPalette.jsx
+++ b/ods/extensions/services/dashboard/src/components/CommandPalette.jsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { Command, Search } from 'lucide-react'
+import { useNavigate } from 'react-router-dom'
+
+function routeMatches(route, query) {
+  const haystack = `${route.label} ${route.path}`.toLocaleLowerCase()
+  return haystack.includes(query.trim().toLocaleLowerCase())
+}
+
+export default function CommandPalette({ routes }) {
+  const navigate = useNavigate()
+  const inputRef = useRef(null)
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  const results = useMemo(
+    () => routes.filter(route => route.label && routeMatches(route, query)),
+    [query, routes],
+  )
+
+  useEffect(() => {
+    const handleShortcut = event => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === 'k') {
+        event.preventDefault()
+        setOpen(current => !current)
+      }
+    }
+
+    window.addEventListener('keydown', handleShortcut)
+    return () => window.removeEventListener('keydown', handleShortcut)
+  }, [])
+
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  const close = () => {
+    setOpen(false)
+    setQuery('')
+    setSelectedIndex(0)
+  }
+
+  const selectRoute = route => {
+    navigate(route.path)
+    close()
+  }
+
+  const handleKeyDown = event => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      close()
+      return
+    }
+    if (results.length === 0) return
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault()
+      setSelectedIndex(index => (index + 1) % results.length)
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault()
+      setSelectedIndex(index => (index - 1 + results.length) % results.length)
+    } else if (event.key === 'Enter') {
+      event.preventDefault()
+      selectRoute(results[Math.min(selectedIndex, results.length - 1)])
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-5 right-5 z-30 flex items-center gap-2 rounded-xl border border-theme-border bg-theme-card px-3 py-2 text-sm text-theme-text-secondary shadow-lg transition hover:border-theme-accent hover:text-theme-text"
+        aria-label="Open command palette"
+      >
+        <Command size={16} aria-hidden="true" />
+        <span className="hidden sm:inline">Navigate</span>
+        <kbd className="hidden rounded border border-theme-border px-1.5 py-0.5 font-mono text-xs text-theme-text-muted sm:inline">
+          Ctrl K
+        </kbd>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-start justify-center bg-black/60 px-4 pt-[15vh] backdrop-blur-sm"
+          onMouseDown={event => {
+            if (event.target === event.currentTarget) close()
+          }}
+        >
+          <section
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navigate ODS"
+            className="w-full max-w-xl overflow-hidden rounded-2xl border border-theme-border bg-theme-card shadow-2xl"
+            onKeyDown={handleKeyDown}
+          >
+            <div className="flex items-center gap-3 border-b border-theme-border px-4">
+              <Search size={19} className="shrink-0 text-theme-text-muted" aria-hidden="true" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={event => {
+                  setQuery(event.target.value)
+                  setSelectedIndex(0)
+                }}
+                placeholder="Search dashboard pages..."
+                aria-label="Search dashboard pages"
+                aria-controls="ods-command-results"
+                aria-activedescendant={results.length ? `ods-command-${results[Math.min(selectedIndex, results.length - 1)].id}` : undefined}
+                className="min-w-0 flex-1 bg-transparent py-4 text-theme-text outline-none placeholder:text-theme-text-muted"
+              />
+              <kbd className="rounded border border-theme-border px-1.5 py-0.5 font-mono text-xs text-theme-text-muted">
+                Esc
+              </kbd>
+            </div>
+
+            <ul id="ods-command-results" role="listbox" className="max-h-80 overflow-y-auto p-2">
+              {results.map((route, index) => {
+                const Icon = route.icon
+                const selected = index === Math.min(selectedIndex, results.length - 1)
+                return (
+                  <li
+                    id={`ods-command-${route.id}`}
+                    key={route.id || route.path}
+                    role="option"
+                    aria-selected={selected}
+                    onClick={() => selectRoute(route)}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                    className={`flex cursor-pointer items-center gap-3 rounded-xl px-3 py-3 text-left transition ${
+                      selected ? 'bg-theme-accent/15 text-theme-text' : 'text-theme-text-secondary hover:bg-theme-bg'
+                    }`}
+                  >
+                    {Icon && <Icon size={18} className="shrink-0 text-theme-accent" aria-hidden="true" />}
+                    <span className="min-w-0 flex-1 font-medium">{route.label}</span>
+                    <span className="truncate font-mono text-xs text-theme-text-muted">{route.path}</span>
+                  </li>
+                )
+              })}
+              {results.length === 0 && (
+                <li className="px-3 py-8 text-center text-sm text-theme-text-muted">
+                  No dashboard pages match “{query}”.
+                </li>
+              )}
+            </ul>
+          </section>
+        </div>
+      )}
+    </>
+  )
+}

--- a/ods/extensions/services/dashboard/src/components/__tests__/CommandPalette.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/CommandPalette.test.jsx
@@ -1,0 +1,64 @@
+import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useLocation } from 'react-router-dom'
+import { render } from '../../test/test-utils'
+import CommandPalette from '../CommandPalette' // eslint-disable-line no-unused-vars
+
+const routes = [
+  { id: 'dashboard', path: '/', label: 'Dashboard' },
+  { id: 'models', path: '/models', label: 'Models' },
+  { id: 'settings', path: '/settings', label: 'Settings' },
+]
+
+function Location() { // eslint-disable-line no-unused-vars
+  return <output aria-label="Current route">{useLocation().pathname}</output>
+}
+
+function renderPalette() {
+  return render(
+    <>
+      <CommandPalette routes={routes} />
+      <Location />
+    </>,
+  )
+}
+
+describe('CommandPalette', () => {
+  test('opens with the platform shortcut and filters registry routes', async () => {
+    const user = userEvent.setup()
+    renderPalette()
+
+    fireEvent.keyDown(window, { key: 'k', ctrlKey: true })
+    const search = screen.getByRole('textbox', { name: 'Search dashboard pages' })
+    expect(search).toHaveFocus()
+
+    await user.type(search, 'model')
+    expect(screen.getByRole('option', { name: /Models/ })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: /Settings/ })).not.toBeInTheDocument()
+  })
+
+  test('navigates the selected result with the keyboard', () => {
+    renderPalette()
+
+    fireEvent.keyDown(window, { key: 'k', metaKey: true })
+    const search = screen.getByRole('textbox', { name: 'Search dashboard pages' })
+    fireEvent.keyDown(search, { key: 'ArrowDown' })
+    fireEvent.keyDown(search, { key: 'Enter' })
+
+    expect(screen.getByRole('status', { name: 'Current route' })).toHaveTextContent('/models')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  test('supports pointer navigation and escape dismissal', async () => {
+    const user = userEvent.setup()
+    renderPalette()
+
+    await user.click(screen.getByRole('button', { name: 'Open command palette' }))
+    await user.click(screen.getByRole('option', { name: /Settings/ }))
+    expect(screen.getByRole('status', { name: 'Current route' })).toHaveTextContent('/settings')
+
+    await user.click(screen.getByRole('button', { name: 'Open command palette' }))
+    await user.keyboard('{Escape}')
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Why this matters
Operators currently have to scan the sidebar or remember a URL to move between dashboard surfaces. This adds a fast, discoverable command palette with Ctrl/Cmd+K, fuzzy substring filtering, pointer support, and complete Arrow/Enter/Escape keyboard navigation. Entries come from the same enabled route registry as the router, so extensions and context-gated pages stay in sync automatically.

## Overlap check
Searched open and closed upstream PRs for `command palette`, `dashboard keyboard navigation`, and the changed production files (`App.jsx`, `CommandPalette.jsx`). No active PR implements this workflow. Closed PR #2194 appeared in the broad keyword search but only refines the splash animation and changes unrelated files.

## What changed
- add a registry-driven navigation palette available from a floating launcher or Ctrl/Cmd+K
- provide filtering, wraparound selection, direct navigation, backdrop dismissal, and an explicit empty state
- expose dialog/listbox semantics and active-option state for assistive technology
- mount the palette only in the normal dashboard shell, outside first-boot and ODS Talk

## Regression test
`npm test -- --run src/components/__tests__/CommandPalette.test.jsx`

Also validated:
- `npm run lint`
- `npm run build`
- `git diff --check`