### PR TITLE
fix(installer): strip quotes when reading env values on macOS

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -36,7 +36,7 @@ read_env_value() {
     local env_path="$1"
     local key="$2"
     [[ -f "$env_path" ]] || { echo ""; return 0; }
-    grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r' || true
+    grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r"' || true
 }
 
 env_key_exists() {


### PR DESCRIPTION
## Summary

read_env_value left surrounding double-quotes intact while sibling helpers stripped them, breaking == "cloud" / == "true" gates on quoted values.

## AI Assistance

AI-assisted; reviewed and verified locally before opening.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: narrow change; syntax and diff checks pass locally

Commands/results:

```text
git diff --check clean; bash -n on touched scripts passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

