### PR TITLE
feat(extensions): preview and confirm lifecycle change plans

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -15,7 +15,7 @@ import time
 from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -1369,6 +1369,168 @@ async def extension_detail(
 # --- Mutation endpoints ---
 
 
+ExtensionChangeAction = Literal["install", "enable", "disable", "uninstall"]
+
+
+def _compose_service_names(compose_path: Path) -> list[str]:
+    """Return the concrete Compose services an extension operation affects."""
+    try:
+        data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid compose file: {exc}") from exc
+    if not isinstance(data, dict) or not isinstance(data.get("services"), dict):
+        raise HTTPException(status_code=400, detail="Compose file has no services map")
+    return sorted(str(name) for name in data["services"])
+
+
+def _enabled_dependents(service_id: str) -> list[str]:
+    """Return enabled extensions whose manifests directly require service_id."""
+    dependents: list[str] = []
+    seen_peers: set[str] = set()
+    for base in (USER_EXTENSIONS_DIR, EXTENSIONS_DIR):
+        try:
+            peer_dirs = list(base.iterdir()) if base.is_dir() else []
+        except OSError:
+            continue
+        for peer_dir in peer_dirs:
+            if (not peer_dir.is_dir() or peer_dir.name == service_id
+                    or peer_dir.name in seen_peers):
+                continue
+            seen_peers.add(peer_dir.name)
+            if ((peer_dir / "compose.yaml").is_file()
+                    and service_id in _read_direct_deps(peer_dir.name)):
+                dependents.append(peer_dir.name)
+    return sorted(dependents)
+
+
+def _extension_change_plan(
+    service_id: str,
+    action: ExtensionChangeAction,
+    *,
+    auto_enable_deps: bool,
+) -> dict:
+    """Build a side-effect-free description of an extension mutation."""
+    _validate_service_id(service_id)
+    _assert_not_core(service_id)
+
+    user_dir = USER_EXTENSIONS_DIR / service_id
+    builtin_dir = EXTENSIONS_DIR / service_id
+    library_dir = EXTENSIONS_LIBRARY_DIR / service_id
+    installed_dir = user_dir if user_dir.is_dir() else builtin_dir
+    active = installed_dir / "compose.yaml"
+    inactive = installed_dir / "compose.yaml.disabled"
+    if active.is_file():
+        current_state = "enabled"
+        compose_path = active
+    elif inactive.is_file():
+        current_state = "disabled"
+        compose_path = inactive
+    else:
+        current_state = "not_installed"
+        compose_path = library_dir / "compose.yaml"
+
+    plan = {
+        "id": service_id,
+        "action": action,
+        "current_state": current_state,
+        "target_state": current_state,
+        "can_apply": True,
+        "blocking_reasons": [],
+        "affected_services": [],
+        "dependencies": [],
+        "dependents": [],
+        "preserves_data": True,
+        "steps": [],
+    }
+
+    if action == "install":
+        plan["target_state"] = "enabled"
+        if current_state != "not_installed":
+            plan["blocking_reasons"].append("Extension is already installed")
+        elif not compose_path.is_file():
+            plan["blocking_reasons"].append("Extension has no deployable library definition")
+        else:
+            plan["affected_services"] = _compose_service_names(compose_path)
+            plan["dependencies"] = _parse_manifest_deps(library_dir / "manifest.yaml")
+            plan["steps"] = [
+                {"operation": "copy_definition", "target": f"user-extensions/{service_id}"},
+                {"operation": "validate_compose", "services": plan["affected_services"]},
+                {"operation": "sync_config", "required": (library_dir / "config").is_dir()},
+                {"operation": "pull_and_start", "services": plan["affected_services"]},
+            ]
+    elif action == "enable":
+        plan["target_state"] = "enabled"
+        if current_state == "not_installed":
+            plan["blocking_reasons"].append("Extension is not installed")
+        else:
+            plan["affected_services"] = _compose_service_names(compose_path)
+            missing = _get_missing_deps_transitive(service_id)
+            plan["dependencies"] = missing
+            if missing and not auto_enable_deps:
+                plan["blocking_reasons"].append(
+                    "Missing dependencies require auto_enable_deps=true: " + ", ".join(missing),
+                )
+            if current_state == "disabled":
+                plan["steps"].append({"operation": "activate_definition"})
+            if missing:
+                plan["steps"].append({
+                    "operation": "enable_dependencies",
+                    "services": missing,
+                    "selected": auto_enable_deps,
+                })
+            plan["steps"].append({
+                "operation": "start",
+                "services": plan["affected_services"],
+            })
+    elif action == "disable":
+        plan["target_state"] = "disabled"
+        if current_state != "enabled":
+            plan["blocking_reasons"].append("Extension is not enabled")
+        else:
+            plan["affected_services"] = _compose_service_names(compose_path)
+            plan["dependents"] = _enabled_dependents(service_id)
+            plan["steps"] = [
+                {"operation": "stop", "services": plan["affected_services"]},
+                {"operation": "deactivate_definition"},
+            ]
+    else:
+        plan["target_state"] = "not_installed"
+        if not user_dir.is_dir():
+            plan["blocking_reasons"].append("Only user-installed extensions can be uninstalled")
+        elif current_state != "disabled":
+            plan["blocking_reasons"].append("Extension must be disabled before uninstalling")
+        else:
+            plan["affected_services"] = _compose_service_names(compose_path)
+            plan["steps"] = [
+                {"operation": "remove_definition", "target": f"user-extensions/{service_id}"},
+                {"operation": "remove_update_backup", "if_present": True},
+            ]
+
+    plan["can_apply"] = not plan["blocking_reasons"]
+    data_info = _get_service_data_info(service_id)
+    plan["data"] = data_info or {
+        "path": f"data/{service_id}",
+        "preserved": True,
+        "exists": False,
+    }
+    return plan
+
+
+@router.get("/api/extensions/{service_id}/plan")
+def extension_change_plan(
+    service_id: str,
+    action: ExtensionChangeAction = Query(...),
+    auto_enable_deps: bool = Query(False),
+    api_key: str = Depends(verify_api_key),
+):
+    """Preview an extension mutation without changing files or containers."""
+    return _extension_change_plan(
+        service_id,
+        action,
+        auto_enable_deps=auto_enable_deps,
+    )
+
+
 @router.post("/api/extensions/{service_id}/logs")
 async def extension_logs(
     service_id: str,
@@ -2333,22 +2495,7 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
     # present) are reported: a disabled dependent is unaffected, while an
     # enabled one is left pointing at a service the merged compose project
     # no longer defines, which fails compose config for the whole stack.
-    dependents_warning = []
-    seen_peers: set[str] = set()
-    for base in (USER_EXTENSIONS_DIR, EXTENSIONS_DIR):
-        try:
-            peer_dirs = list(base.iterdir()) if base.is_dir() else []
-        except OSError:
-            continue
-        for peer_dir in peer_dirs:
-            if (not peer_dir.is_dir() or peer_dir.name == service_id
-                    or peer_dir.name in seen_peers):
-                continue
-            seen_peers.add(peer_dir.name)
-            if not (peer_dir / "compose.yaml").exists():
-                continue
-            if service_id in _read_direct_deps(peer_dir.name):
-                dependents_warning.append(peer_dir.name)
+    dependents_warning = _enabled_dependents(service_id)
 
     # Call agent to stop BEFORE renaming (prevents zombie containers)
     agent_ok = _call_agent("stop", service_id)

--- a/ods/extensions/services/dashboard-api/tests/test_extension_change_plan.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_change_plan.py
@@ -1,0 +1,129 @@
+"""Public-boundary tests for extension mutation previews."""
+
+from pathlib import Path
+
+
+def _write_extension(root: Path, service_id: str, *, enabled: bool, deps=()) -> Path:
+    extension = root / service_id
+    extension.mkdir(parents=True)
+    compose_name = "compose.yaml" if enabled else "compose.yaml.disabled"
+    (extension / compose_name).write_text(
+        f"services:\n  {service_id}:\n    image: example/{service_id}:1\n",
+        encoding="utf-8",
+    )
+    dependencies = "\n".join(f"      - {dep}" for dep in deps)
+    manifest = f"service:\n  id: {service_id}\n"
+    if dependencies:
+        manifest += f"  depends_on:\n{dependencies}\n"
+    (extension / "manifest.yaml").write_text(manifest, encoding="utf-8")
+    return extension
+
+
+def _patch_roots(monkeypatch, tmp_path):
+    import routers.extensions as extensions
+
+    roots = {
+        "USER_EXTENSIONS_DIR": tmp_path / "user",
+        "EXTENSIONS_DIR": tmp_path / "built-in",
+        "EXTENSIONS_LIBRARY_DIR": tmp_path / "library",
+    }
+    for name, root in roots.items():
+        root.mkdir()
+        monkeypatch.setattr(extensions, name, root)
+    monkeypatch.setattr(extensions, "DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setattr(extensions, "ALWAYS_ON_SERVICES", {
+        "dashboard", "dashboard-api", "llama-server", "open-webui",
+    })
+    return roots
+
+
+def test_install_plan_describes_services_config_and_preserved_data(
+    test_client, monkeypatch, tmp_path,
+):
+    roots = _patch_roots(monkeypatch, tmp_path)
+    extension = _write_extension(roots["EXTENSIONS_LIBRARY_DIR"], "notes", enabled=True)
+    (extension / "config").mkdir()
+
+    response = test_client.get(
+        "/api/extensions/notes/plan?action=install",
+        headers=test_client.auth_headers,
+    )
+
+    assert response.status_code == 200
+    plan = response.json()
+    assert plan["can_apply"] is True
+    assert plan["current_state"] == "not_installed"
+    assert plan["target_state"] == "enabled"
+    assert plan["affected_services"] == ["notes"]
+    assert plan["steps"][2] == {"operation": "sync_config", "required": True}
+    assert plan["data"]["preserved"] is True
+
+
+def test_enable_plan_surfaces_dependency_choice_without_mutating_files(
+    test_client, monkeypatch, tmp_path,
+):
+    roots = _patch_roots(monkeypatch, tmp_path)
+    extension = _write_extension(
+        roots["USER_EXTENSIONS_DIR"], "workflows", enabled=False, deps=("database",),
+    )
+    _write_extension(roots["EXTENSIONS_DIR"], "database", enabled=False)
+
+    blocked = test_client.get(
+        "/api/extensions/workflows/plan?action=enable",
+        headers=test_client.auth_headers,
+    ).json()
+    selected = test_client.get(
+        "/api/extensions/workflows/plan?action=enable&auto_enable_deps=true",
+        headers=test_client.auth_headers,
+    ).json()
+
+    assert blocked["can_apply"] is False
+    assert blocked["dependencies"] == ["database"]
+    assert selected["can_apply"] is True
+    assert selected["steps"][1] == {
+        "operation": "enable_dependencies",
+        "services": ["database"],
+        "selected": True,
+    }
+    assert (extension / "compose.yaml.disabled").is_file()
+    assert not (extension / "compose.yaml").exists()
+
+
+def test_disable_and_uninstall_plans_report_dependents_and_preconditions(
+    test_client, monkeypatch, tmp_path,
+):
+    roots = _patch_roots(monkeypatch, tmp_path)
+    _write_extension(roots["USER_EXTENSIONS_DIR"], "database", enabled=True)
+    _write_extension(
+        roots["USER_EXTENSIONS_DIR"], "workflows", enabled=True, deps=("database",),
+    )
+
+    disable = test_client.get(
+        "/api/extensions/database/plan?action=disable",
+        headers=test_client.auth_headers,
+    ).json()
+    uninstall = test_client.get(
+        "/api/extensions/database/plan?action=uninstall",
+        headers=test_client.auth_headers,
+    ).json()
+
+    assert disable["can_apply"] is True
+    assert disable["dependents"] == ["workflows"]
+    assert disable["steps"][0] == {"operation": "stop", "services": ["database"]}
+    assert uninstall["can_apply"] is False
+    assert uninstall["blocking_reasons"] == [
+        "Extension must be disabled before uninstalling",
+    ]
+
+
+def test_plan_rejects_unknown_actions_at_the_http_boundary(
+    test_client, monkeypatch, tmp_path,
+):
+    _patch_roots(monkeypatch, tmp_path)
+
+    response = test_client.get(
+        "/api/extensions/notes/plan?action=restart-everything",
+        headers=test_client.auth_headers,
+    )
+
+    assert response.status_code == 422

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -15,6 +15,7 @@ export { getTemplateStatus }
 
 // API/backend services with no user-facing web UI — show badge instead of port link.
 const HEADLESS_EXTENSIONS = new Set(['embeddings', 'tts', 'whisper', 'privacy-shield'])
+const PLANNED_ACTIONS = new Set(['install', 'enable', 'disable', 'uninstall'])
 
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf).  All fetches
@@ -92,6 +93,7 @@ export default function Extensions() {
   const [statusFilter, setStatusFilter] = useState('all')
   const [expanded, setExpanded] = useState(null)
   const [mutating, setMutating] = useState(null)
+  const [planning, setPlanning] = useState(null)
   const [confirm, setConfirm] = useState(null)
   const [toast, setToast] = useState(null)
   const [consoleExt, setConsoleExt] = useState(null)
@@ -102,6 +104,8 @@ export default function Extensions() {
   const [templatesOpen, setTemplatesOpen] = useState(false)
   const [pollingLost, setPollingLost] = useState(false)
   const installProgressRef = useRef(null)
+  const planInFlightRef = useRef(false)
+  const mutationInFlightRef = useRef(false)
   const activePollers = useRef({})
   // Per-service recovery tracker: counts consecutive fetch failures and
   // fires onThresholdReached/onRecovered to drive the polling-lost banner.
@@ -231,6 +235,8 @@ export default function Extensions() {
   }
 
   const handleMutation = async (serviceId, action, { autoEnableDeps = false, force = false } = {}) => {
+    if (mutationInFlightRef.current) return
+    mutationInFlightRef.current = true
     setMutating(serviceId)
     setConfirm(null)
     setDepConfirm(null)
@@ -294,11 +300,13 @@ export default function Extensions() {
       const base = friendlyError(err.message) || `Failed to ${action} extension`
       setToast({ type: 'error', text: base })
     } finally {
+      mutationInFlightRef.current = false
       setMutating(null)
     }
   }
 
-  const requestAction = (ext, action) => {
+  const requestAction = async (ext, action) => {
+    if (mutating || planInFlightRef.current) return
     const messages = {
       install: `Install ${ext.name}? This will download and start the service.`,
       enable: `Enable ${ext.name}? The service will be started.`,
@@ -312,7 +320,32 @@ export default function Extensions() {
         : `Update ${ext.name} from the ODS library? The current definition will be retained for rollback.`,
       rollback: `Restore the previous ${ext.name} extension definition? Current service data and configuration will be preserved.`,
     }
-    setConfirm({ action, ext, message: messages[action] })
+    if (!PLANNED_ACTIONS.has(action)) {
+      setConfirm({ action, ext, message: messages[action] })
+      return
+    }
+
+    planInFlightRef.current = true
+    setPlanning(ext.id)
+    try {
+      const autoDeps = action === 'enable' ? '&auto_enable_deps=true' : ''
+      const res = await fetchJson(`/api/extensions/${ext.id}/plan?action=${action}${autoDeps}`)
+      if (!res.ok) {
+        const errorBody = await res.json().catch(() => ({}))
+        throw new Error(
+          (typeof errorBody.detail === 'string' && errorBody.detail)
+          || `Failed to preview ${action}`,
+        )
+      }
+      const plan = await res.json()
+      setConfirm({ action, ext, message: messages[action], plan })
+    } catch (err) {
+      const base = friendlyError(err.message) || `Failed to preview ${action}`
+      setToast({ type: 'error', text: base })
+    } finally {
+      planInFlightRef.current = false
+      setPlanning(null)
+    }
   }
 
   if (loading && !catalog) {
@@ -511,7 +544,7 @@ export default function Extensions() {
               onDetails={() => setExpanded(ext.id)}
               onConsole={() => setConsoleExt(ext)}
               onAction={requestAction}
-              mutating={mutating}
+              mutating={mutating || planning}
               progressData={progressMap[ext.id]}
             />
           ))}
@@ -535,7 +568,8 @@ export default function Extensions() {
             <h3 className="text-base font-semibold text-theme-text mb-2">
               {confirm.action === 'uninstall' ? 'Remove' : confirm.action === 'purge' ? 'Purge Data' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)} Extension
             </h3>
-            <p className="text-[11px] text-theme-text-muted/70 mb-5 leading-relaxed">{confirm.message}</p>
+            <p className="text-[11px] text-theme-text-muted/70 mb-3 leading-relaxed">{confirm.message}</p>
+            {confirm.plan && <ExtensionChangePlan plan={confirm.plan} />}
             {confirm.action === 'disable' && confirm.ext.dependents?.length > 0 && (
               <DisableDependentWarning dependents={confirm.ext.dependents} />
             )}
@@ -543,11 +577,14 @@ export default function Extensions() {
               <button onClick={() => setConfirm(null)} autoFocus className="px-4 py-2 text-[10px] font-mono uppercase tracking-[0.16em] text-theme-text-muted/65 hover:text-theme-text transition-colors">Cancel</button>
               <button
                 onClick={() => handleMutation(confirm.ext.id, confirm.action, {
+                  autoEnableDeps: confirm.action === 'enable' && confirm.plan?.dependencies?.length > 0,
                   force: confirm.action === 'update' && (
                     confirm.ext.locally_modified || confirm.ext.update_status === 'untracked'
                   ),
                 })}
-                className={`px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg transition-colors ${
+                disabled={confirm.plan && !confirm.plan.can_apply}
+                aria-label={`Confirm ${confirm.action}`}
+                className={`px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
                   confirm.action === 'uninstall' || confirm.action === 'purge' ? 'bg-red-500/15 text-red-400 hover:bg-red-500/25' :
                   'bg-theme-accent/15 text-theme-accent-light hover:bg-theme-accent/25'
                 }`}
@@ -592,6 +629,46 @@ function SummaryItem({ label, value, color }) {
       <span className={`w-1.5 h-1.5 rounded-full ${color}`} />
       <span className="text-[10px] font-semibold uppercase tracking-[0.13em] text-theme-text-muted/55">{label}</span>
       <span className="text-theme-text font-medium font-mono">{value}</span>
+    </div>
+  )
+}
+
+function ExtensionChangePlan({ plan }) {
+  const operationLabel = (operation) => operation.replaceAll('_', ' ')
+
+  return (
+    <div className="mb-5 rounded-lg border border-theme-border bg-theme-bg/50 p-3 text-[10px] text-theme-text-secondary">
+      <h4 className="mb-2 font-semibold uppercase tracking-[0.14em] text-theme-text">Deployment plan</h4>
+      <div className="mb-2 font-mono text-theme-text-muted">
+        {plan.current_state} → {plan.target_state}
+      </div>
+      {plan.affected_services?.length > 0 && (
+        <p className="mb-1"><span className="text-theme-text-muted">Affected services:</span> {plan.affected_services.join(', ')}</p>
+      )}
+      {plan.dependencies?.length > 0 && (
+        <p className="mb-1"><span className="text-theme-text-muted">Dependencies:</span> {plan.dependencies.join(', ')}</p>
+      )}
+      {plan.dependents?.length > 0 && (
+        <p className="mb-1"><span className="text-theme-text-muted">Enabled dependents:</span> {plan.dependents.join(', ')}</p>
+      )}
+      {plan.steps?.length > 0 && (
+        <ol className="my-2 list-decimal space-y-1 pl-4 text-theme-text-muted">
+          {plan.steps.map((step, index) => (
+            <li key={`${step.operation}-${index}`}>
+              {operationLabel(step.operation)}
+              {step.services?.length > 0 ? `: ${step.services.join(', ')}` : ''}
+            </li>
+          ))}
+        </ol>
+      )}
+      {plan.data?.preserved && (
+        <p className="text-green-400/80">Service data is preserved at {plan.data.path}.</p>
+      )}
+      {plan.blocking_reasons?.length > 0 && (
+        <div className="mt-2 rounded border border-red-500/20 bg-red-500/10 p-2 text-red-300">
+          {plan.blocking_reasons.map(reason => <p key={reason}>{reason}</p>)}
+        </div>
+      )}
     </div>
   )
 }

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -234,6 +234,129 @@ describe('Extensions page — unhealthy + install derivations', () => {
     expect(screen.getByText('Install')).toBeInTheDocument()
   })
 
+  it('previews the authoritative lifecycle plan before installing', async () => {
+    vi.spyOn(globalThis.AbortSignal, 'timeout').mockReturnValue(new AbortController().signal)
+    const catalog = {
+      extensions: [{
+        id: 'planned-service',
+        name: 'Planned Service',
+        status: 'not_installed',
+        source: 'library',
+        installable: true,
+        features: [baseFeature],
+        description: 'desc',
+      }],
+      summary: baseSummary({ not_installed: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
+    }
+    const fetchMock = vi.fn(async (url, options) => {
+      const target = String(url)
+      if (target.includes('/api/extensions/catalog')) return makeJsonResponse(catalog)
+      if (target.includes('/api/templates')) return makeJsonResponse({ templates: [] })
+      if (target === '/api/extensions/planned-service/plan?action=install') {
+        return makeJsonResponse({
+          id: 'planned-service',
+          action: 'install',
+          current_state: 'not_installed',
+          target_state: 'enabled',
+          can_apply: true,
+          blocking_reasons: [],
+          affected_services: ['planned-api', 'planned-worker'],
+          dependencies: ['database'],
+          dependents: [],
+          data: { path: 'data/planned-service', preserved: true, exists: false },
+          steps: [
+            { operation: 'copy_definition' },
+            { operation: 'pull_and_start', services: ['planned-api', 'planned-worker'] },
+          ],
+        })
+      }
+      if (target === '/api/extensions/planned-service/install') {
+        return makeJsonResponse({ action: 'installing' })
+      }
+      throw new Error(`Unmocked fetch: ${target} ${options?.method || 'GET'}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Extensions />)
+    await screen.findByText('Planned Service')
+    const installButton = screen.getByRole('button', { name: 'Install' })
+    fireEvent.click(installButton)
+    fireEvent.click(installButton)
+
+    expect(await screen.findByText('Deployment plan')).toBeInTheDocument()
+    expect(screen.getByText('planned-api, planned-worker')).toBeInTheDocument()
+    expect(screen.getByText('database')).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      '/api/extensions/planned-service/install',
+      expect.anything(),
+    )
+    expect(fetchMock.mock.calls.filter(
+      ([url]) => String(url) === '/api/extensions/planned-service/plan?action=install',
+    )).toHaveLength(1)
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirm install' })
+    fireEvent.click(confirmButton)
+    fireEvent.click(confirmButton)
+    await waitFor(() => {
+      expect(fetchMock.mock.calls.filter(
+        ([url, options]) => String(url) === '/api/extensions/planned-service/install'
+          && options?.method === 'POST',
+      )).toHaveLength(1)
+    })
+  })
+
+  it('keeps a blocked lifecycle plan read-only', async () => {
+    const catalog = {
+      extensions: [{
+        id: 'blocked-service',
+        name: 'Blocked Service',
+        status: 'disabled',
+        source: 'user',
+        installable: true,
+        features: [baseFeature],
+        description: 'desc',
+      }],
+      summary: baseSummary({ installed: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
+    }
+    const fetchMock = vi.fn(async (url) => {
+      const target = String(url)
+      if (target.includes('/api/extensions/catalog')) return makeJsonResponse(catalog)
+      if (target.includes('/api/templates')) return makeJsonResponse({ templates: [] })
+      if (target === '/api/extensions/blocked-service/plan?action=uninstall') {
+        return makeJsonResponse({
+          id: 'blocked-service',
+          action: 'uninstall',
+          current_state: 'disabled',
+          target_state: 'not_installed',
+          can_apply: false,
+          blocking_reasons: ['An enabled dependent still requires this extension'],
+          affected_services: ['blocked-service'],
+          dependencies: [],
+          dependents: ['workflow-service'],
+          data: { path: 'data/blocked-service', preserved: true, exists: true },
+          steps: [],
+        })
+      }
+      throw new Error(`Unmocked fetch: ${target}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Extensions />)
+    await screen.findByText('Blocked Service')
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }))
+
+    expect(await screen.findByText('An enabled dependent still requires this extension')).toBeInTheDocument()
+    expect(screen.getByText('workflow-service')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Confirm uninstall' })).toBeDisabled()
+    expect(fetchMock.mock.calls.some(
+      ([url]) => String(url) === '/api/extensions/blocked-service',
+    )).toBe(false)
+  })
+
   it('renders Check Logs CTA for unhealthy user ext', async () => {
     installFetchMock({
       extensions: [
@@ -342,8 +465,7 @@ describe('Extensions page — unhealthy + install derivations', () => {
     await screen.findByText('Tracked Extension')
     fireEvent.click(screen.getByRole('button', { name: 'Update' }))
     expect(screen.getByText(/Local definition changes will be replaced/)).toBeInTheDocument()
-    const updateButtons = screen.getAllByRole('button', { name: 'Update' })
-    fireEvent.click(updateButtons[updateButtons.length - 1])
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm update' }))
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(


### PR DESCRIPTION
**Ready for independent review (2026-09-15).** Candidate `829dd48f53619f881b037ee93bf647ca2838eedb` has a successful GitHub check rollup and no base-branch conflict at this review snapshot. This supersedes earlier draft-status wording only. All validation gaps, migration requirements, live gates and independent human review requirements below remain in force; this is not a merge-ready approval.

## Why this matters

Extension lifecycle actions previously jumped from a static sentence in the dashboard to filesystem and container mutations. Operators could not see affected Compose services, dependency activation, dependent breakage, data retention, or failed preconditions before confirming the action.

This PR now carries the contract end to end: an authenticated backend plan remains side-effect free, and the dashboard fetches and renders that authoritative plan before install, enable, disable, or uninstall. A blocked plan cannot reach the mutation endpoint.

## Overlap check

Searched open and closed upstream PRs for `extension change plan`, `preview extension`, lifecycle confirmation, and the changed production files. PR #2626 previews ODS mode switches, not extension lifecycle operations. PR #2716 hardens service-id validation in another router region. PR #3065 touches the same dashboard page only to serialize progress polling; this PR owns pre-mutation planning/confirmation and has no logical dependency on it. Both heads were merged in that order on the inspectable synthetic branch `tang-vu:validation/batch-20260824-architecture`; the combined dashboard and API suites pass at integration SHA `2c82aaec`.

## Production contract and state machine

1. A card action requests `GET /api/extensions/{id}/plan?action=...` through the existing authenticated dashboard proxy.
2. The backend derives current/target state, affected Compose services, ordered operations, dependencies/dependents, preserved data, and blockers without writing files or calling the host agent.
3. The dashboard renders that receipt in the confirmation dialog. Enable previews explicitly select dependency activation and the confirmed mutation carries the same `auto_enable_deps=true` choice.
4. A synchronous in-flight guard prevents duplicate preview and mutation requests even before React state rerenders; buttons also expose the busy state.
5. Blocked plans disable confirmation. Preview/network failures terminate as an error toast without mutating.
6. Successful mutations retain the existing catalog refresh and install-progress reconciliation. The mutation endpoint revalidates current state, so a plan becoming stale does not bypass backend preconditions.

## Regression coverage

- API boundary tests prove install, enable/dependency choice, disable/dependent impact, uninstall blockers, side-effect freedom, and typed action rejection.
- Dashboard boundary tests prove the plan is fetched before mutation, exact services/dependencies/steps/data are shown, duplicate clicks issue one request, blocked plans remain read-only, and existing update/rollback surfaces remain intact.

Concrete pre-change evidence: clicking Install opened only a static message and never requested `/plan`; the new dashboard regression failed because `Deployment plan` and the plan request were absent.

## Validation

- `python -m pytest -q tests/test_extensions.py tests/test_extension_change_plan.py` — 259 passed, 5 skipped.
- 
pm test -- --run src/pages/Extensions.test.jsx` — 12 passed.
- 
pm test -- --run` — 28 files, 260 tests passed.
- 
pm run lint` — passed.
- 
pm run build` — passed; only the pre-existing stale Browserslist notice was emitted.
- Python compile and `git diff --check` — passed.
- Synthetic integration with #3065 and the rest of this batch at `2c82aaec` — Dashboard 28 files / 262 tests, lint, and build passed; combined API scope 350 passed, 5 skipped.

## Tradeoffs, limitations, and rollback

Install, enable, disable, and uninstall use the authoritative plan. Update, rollback, and destructive data purge keep their existing dedicated confirmations because the backend plan contract does not yet model those different transactions; the UI does not pretend otherwise. Plans are previews, not reservation tokens: backend mutation validation remains the final authority if state changes between preview and confirmation.

No live host-agent lifecycle mutation was performed locally. Synthetic compatibility with #3065 is complete. This PR is Ready for review but still requires a live host-agent lifecycle gate and independent human review of the user-visible mutation state machine before merge. A normal revert restores static confirmations without changing persisted extension state or formats.