### PR TITLE
fix(installer): do not abort macOS install on benign Hermes dir

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -326,8 +326,7 @@ _macos_patch_hermes_persisted_config() {
         done
 
         if [[ -z "$selected_image" ]]; then
-            if [[ ! -e "$(dirname "$persisted_config")" ]] \
-               || { [[ -x "$(dirname "$persisted_config")" ]] && [[ ! -e "$persisted_config" ]]; }; then
+            if [[ ! -e "$persisted_config" ]]; then
                 return 3
             fi
             return 4


### PR DESCRIPTION
## Summary

fix(installer): do not abort macOS install on benign Hermes dir.

## AI Assistance

Drafted with an AI coding assistant; reviewed by hand and validated locally.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: narrow change; syntax and diff checks pass locally

Commands/results:

```text
git diff --check clean; bash -n on touched scripts passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

