### PR TITLE
feat(ci): publish dashboard API test reports

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -57,4 +57,23 @@ jobs:
           pip install -r tests/requirements-test.txt
 
       - name: Run Unit Tests
-        run: pytest tests/ -v --cov=. --cov-report=term --cov-report=lcov:coverage.lcov
+        run: |
+          mkdir -p test-results
+          pytest tests/ -v --cov=. --cov-report=term --cov-report=lcov:coverage.lcov \
+            --junitxml=test-results/junit.xml
+
+      - name: Publish API test summary
+        if: ${{ always() && hashFiles('ods/extensions/services/dashboard-api/test-results/junit.xml') != '' }}
+        run: >-
+          python ../../../scripts/summarize-junit.py test-results/junit.xml
+          --title "Dashboard API tests" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload API test results
+        if: ${{ always() && hashFiles('ods/extensions/services/dashboard-api/test-results/junit.xml') != '' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dashboard-api-test-results
+          path: |
+            ods/extensions/services/dashboard-api/test-results/junit.xml
+            ods/extensions/services/dashboard-api/coverage.lcov
+          if-no-files-found: warn

--- a/ods/scripts/summarize-junit.py
+++ b/ods/scripts/summarize-junit.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Render a compact, secret-safe Markdown summary from a JUnit XML report."""
+
+import argparse
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+def _test_name(case: ET.Element) -> str:
+    class_name = case.get("classname", "").strip()
+    name = case.get("name", "unnamed test").strip()
+    value = f"{class_name}::{name}" if class_name else name
+    return value.replace("`", "'").replace("\n", " ")
+
+
+def summarize_junit(report: Path, title: str) -> str:
+    """Return a Markdown summary without embedding failure output or logs."""
+    root = ET.parse(report).getroot()
+    cases = root.findall(".//testcase")
+    if root.tag == "testcase":
+        cases = [root]
+
+    failed = [case for case in cases if case.find("failure") is not None]
+    errors = [case for case in cases if case.find("error") is not None]
+    skipped = [case for case in cases if case.find("skipped") is not None]
+    unsuccessful = {id(case) for case in failed + errors + skipped}
+    passed = sum(1 for case in cases if id(case) not in unsuccessful)
+    duration = sum(float(case.get("time", "0")) for case in cases)
+
+    lines = [
+        f"## {title}",
+        "",
+        "| Total | Passed | Failed | Errors | Skipped | Duration |",
+        "| ---: | ---: | ---: | ---: | ---: | ---: |",
+        (
+            f"| {len(cases)} | {passed} | {len(failed)} | {len(errors)} | "
+            f"{len(skipped)} | {duration:.2f}s |"
+        ),
+    ]
+
+    problem_cases = [(case, "failed") for case in failed]
+    problem_cases.extend((case, "error") for case in errors)
+    if problem_cases:
+        lines.extend(["", "### Unsuccessful tests", ""])
+        for case, outcome in problem_cases[:20]:
+            case_duration = float(case.get("time", "0"))
+            lines.append(f"- `{_test_name(case)}` — {outcome} ({case_duration:.2f}s)")
+        if len(problem_cases) > 20:
+            lines.append(f"- …and {len(problem_cases) - 20} more; see the JUnit artifact.")
+
+    lines.extend([
+        "",
+        "Failure messages and captured output are intentionally omitted; use the CI log or JUnit artifact.",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("report", type=Path, help="JUnit XML report")
+    parser.add_argument("--title", default="Test results", help="Markdown heading")
+    args = parser.parse_args()
+    print(summarize_junit(args.report, args.title), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test_summarize_junit.py
+++ b/ods/tests/test_summarize_junit.py
@@ -1,0 +1,65 @@
+"""Tests for the JUnit-to-GitHub-summary formatter."""
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "summarize-junit.py"
+SPEC = importlib.util.spec_from_file_location("summarize_junit", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_summary_counts_cases_and_omits_failure_payload(tmp_path):
+    report = tmp_path / "junit.xml"
+    report.write_text(
+        """<?xml version="1.0"?>
+<testsuites>
+  <testsuite name="api">
+    <testcase classname="tests.test_health" name="test_ok" time="0.1" />
+    <testcase classname="tests.test_auth" name="test_denied" time="0.2">
+      <failure message="token leaked">API_KEY=super-secret</failure>
+    </testcase>
+    <testcase classname="tests.test_optional" name="test_gpu" time="0.3">
+      <skipped />
+    </testcase>
+  </testsuite>
+</testsuites>
+""",
+        encoding="utf-8",
+    )
+
+    summary = MODULE.summarize_junit(report, "Dashboard API tests")
+
+    assert "| 3 | 1 | 1 | 0 | 1 | 0.60s |" in summary
+    assert "`tests.test_auth::test_denied` — failed (0.20s)" in summary
+    assert "super-secret" not in summary
+    assert "token leaked" not in summary
+
+
+def test_summary_caps_failure_names_and_reports_overflow(tmp_path):
+    cases = "\n".join(
+        f'<testcase classname="suite" name="case_{index}" time="0"><error /></testcase>'
+        for index in range(23)
+    )
+    report = tmp_path / "junit.xml"
+    report.write_text(f"<testsuite>{cases}</testsuite>", encoding="utf-8")
+
+    summary = MODULE.summarize_junit(report, "Tests")
+
+    assert summary.count(" — error ") == 20
+    assert "…and 3 more; see the JUnit artifact." in summary
+
+
+def test_summary_escapes_multiline_and_backtick_test_names(tmp_path):
+    report = tmp_path / "junit.xml"
+    report.write_text(
+        '<testsuite><testcase classname="api" name="bad `name&#10;line" time="1">'
+        '<failure /></testcase></testsuite>',
+        encoding="utf-8",
+    )
+
+    summary = MODULE.summarize_junit(report, "Tests")
+
+    assert "`api::bad 'name line`" in summary


### PR DESCRIPTION
## Why this matters
A failed dashboard API CI job currently leaves reviewers searching a long console log, and its structured results disappear with the runner. This publishes a compact GitHub Job Summary and durable JUnit/coverage artifact on both success and failure. The summary intentionally excludes assertion payloads and captured output so credentials or user data cannot be copied into the broadly visible summary surface.

## Overlap check
Searched open and closed upstream PRs for `JUnit`, `test summary`, `dashboard workflow`, and the changed files. No active PR adds structured dashboard test reporting, and no open PR currently changes `.github/workflows/dashboard.yml`.

## What changed
- emit JUnit XML from the real dashboard API pytest invocation
- always publish a compact Markdown count/duration/failing-test summary when the report exists
- always retain JUnit and LCOV files as a pinned v7 Actions artifact
- add a dependency-free JUnit formatter with output caps, Markdown-safe names, and deliberate failure-payload omission

## Regression test
`python -m pytest -q tests/test_summarize_junit.py`

Also validated:
- generated JUnit from pytest and rendered it through `scripts/summarize-junit.py`
- `python tests/test-dependency-pins.py`
- parsed `.github/workflows/dashboard.yml` with PyYAML
- `python -m py_compile scripts/summarize-junit.py tests/test_summarize_junit.py`
- `git diff --check`