### PR TITLE
feat(extensions): inspect and gate dependency graphs

### DIFF
--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -53,7 +53,9 @@ python3 scripts/extension-dependency-graph.py \
 
 The command fails on missing dependency definitions, duplicate service IDs, or
 cycles. JSON includes a dependency-first order for automation; DOT output can
-be rendered with Graphviz.
+be rendered with Graphviz. The same full-catalog graph validation runs through
+`ods config validate` / `scripts/validate-manifests.sh`, so install-time and CI
+manifest checks reject dependency topology that cannot be activated safely.
 
 ## What You Can Extend
 

--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -34,6 +34,27 @@ rather than filling existing fields, read
 the supported schema until migration tooling and compatibility policy are in
 place.
 
+## Inspect the Dependency Graph
+
+Before enabling or reviewing a set of extensions, inspect the same
+`service.depends_on` relationships used by the lifecycle API:
+
+```bash
+# Human-readable inventory of bundled and library extensions
+python3 scripts/extension-dependency-graph.py
+
+# Install order for one extension and its prerequisites
+python3 scripts/extension-dependency-graph.py --root hermes --format json
+
+# Reverse blast radius: every extension that transitively depends on llama-server
+python3 scripts/extension-dependency-graph.py \
+  --root llama-server --direction dependents --format dot
+```
+
+The command fails on missing dependency definitions, duplicate service IDs, or
+cycles. JSON includes a dependency-first order for automation; DOT output can
+be rendered with Graphviz.
+
 ## What You Can Extend
 
 - **Docker services** via `extensions/services/<name>/compose.yaml`

--- a/ods/scripts/extension-dependency-graph.py
+++ b/ods/scripts/extension-dependency-graph.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Inspect ODS extension dependencies as a table, JSON document, or DOT graph."""
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+
+@dataclass(frozen=True)
+class Extension:
+    id: str
+    name: str
+    source: str
+    dependencies: tuple[str, ...]
+
+
+class GraphValidationError(ValueError):
+    """Raised when manifests cannot form a valid dependency graph."""
+
+
+def load_extensions(project_dir: Path) -> dict[str, Extension]:
+    roots = (
+        (project_dir / "extensions" / "services", "bundled"),
+        (project_dir / "extensions" / "library" / "services", "library"),
+    )
+    extensions: dict[str, Extension] = {}
+    for root, source in roots:
+        if not root.is_dir():
+            continue
+        for manifest_path in sorted(root.glob("*/manifest.yaml")):
+            data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+            service = data.get("service") if isinstance(data, dict) else None
+            if not isinstance(service, dict):
+                raise GraphValidationError(f"{manifest_path}: missing service map")
+            service_id = service.get("id")
+            if not isinstance(service_id, str) or not service_id:
+                raise GraphValidationError(f"{manifest_path}: missing service.id")
+            if service_id in extensions:
+                previous = extensions[service_id]
+                raise GraphValidationError(
+                    f"duplicate service.id {service_id!r} in {previous.source} and {source}",
+                )
+            dependencies = service.get("depends_on", [])
+            if not isinstance(dependencies, list) or not all(
+                isinstance(item, str) and item for item in dependencies
+            ):
+                raise GraphValidationError(f"{manifest_path}: service.depends_on must be a string list")
+            extensions[service_id] = Extension(
+                id=service_id,
+                name=str(service.get("name") or service_id),
+                source=source,
+                dependencies=tuple(sorted(set(dependencies))),
+            )
+    return extensions
+
+
+def validate_graph(extensions: dict[str, Extension]) -> None:
+    missing = sorted(
+        (extension.id, dependency)
+        for extension in extensions.values()
+        for dependency in extension.dependencies
+        if dependency not in extensions
+    )
+    if missing:
+        details = ", ".join(f"{service}->{dependency}" for service, dependency in missing)
+        raise GraphValidationError(f"missing dependency definitions: {details}")
+
+    state: dict[str, str] = {}
+    stack: list[str] = []
+
+    def visit(service_id: str) -> None:
+        if state.get(service_id) == "done":
+            return
+        if state.get(service_id) == "visiting":
+            cycle_start = stack.index(service_id)
+            cycle = stack[cycle_start:] + [service_id]
+            raise GraphValidationError("dependency cycle: " + " -> ".join(cycle))
+        state[service_id] = "visiting"
+        stack.append(service_id)
+        for dependency in extensions[service_id].dependencies:
+            visit(dependency)
+        stack.pop()
+        state[service_id] = "done"
+
+    for service_id in sorted(extensions):
+        visit(service_id)
+
+
+def select_nodes(
+    extensions: dict[str, Extension],
+    root: str | None,
+    direction: str,
+) -> set[str]:
+    if root is None:
+        return set(extensions)
+    if root not in extensions:
+        raise GraphValidationError(f"unknown extension: {root}")
+
+    reverse = {service_id: set() for service_id in extensions}
+    for extension in extensions.values():
+        for dependency in extension.dependencies:
+            reverse[dependency].add(extension.id)
+
+    selected: set[str] = set()
+    pending = [root]
+    while pending:
+        service_id = pending.pop()
+        if service_id in selected:
+            continue
+        selected.add(service_id)
+        neighbors = (
+            extensions[service_id].dependencies
+            if direction == "dependencies"
+            else reverse[service_id]
+        )
+        pending.extend(sorted(neighbors, reverse=True))
+    return selected
+
+
+def dependency_order(extensions: dict[str, Extension], selected: set[str]) -> list[str]:
+    ordered: list[str] = []
+    visited: set[str] = set()
+
+    def visit(service_id: str) -> None:
+        if service_id in visited:
+            return
+        visited.add(service_id)
+        for dependency in extensions[service_id].dependencies:
+            if dependency in selected:
+                visit(dependency)
+        ordered.append(service_id)
+
+    for service_id in sorted(selected):
+        visit(service_id)
+    return ordered
+
+
+def graph_document(extensions: dict[str, Extension], selected: set[str]) -> dict:
+    reverse = {service_id: [] for service_id in selected}
+    edges = []
+    for service_id in sorted(selected):
+        for dependency in extensions[service_id].dependencies:
+            if dependency not in selected:
+                continue
+            edges.append({"service": service_id, "depends_on": dependency})
+            reverse[dependency].append(service_id)
+    nodes = [
+        {
+            "id": service_id,
+            "name": extensions[service_id].name,
+            "source": extensions[service_id].source,
+            "dependencies": [
+                dependency
+                for dependency in extensions[service_id].dependencies
+                if dependency in selected
+            ],
+            "dependents": sorted(reverse[service_id]),
+        }
+        for service_id in sorted(selected)
+    ]
+    return {
+        "nodes": nodes,
+        "edges": edges,
+        "dependency_order": dependency_order(extensions, selected),
+    }
+
+
+def render_table(document: dict) -> str:
+    rows = [
+        (
+            node["id"],
+            node["source"],
+            ", ".join(node["dependencies"]) or "-",
+            ", ".join(node["dependents"]) or "-",
+        )
+        for node in document["nodes"]
+    ]
+    headers = ("Service", "Source", "Dependencies", "Dependents")
+    widths = [max(len(headers[index]), *(len(row[index]) for row in rows)) for index in range(4)]
+    lines = [
+        "  ".join(headers[index].ljust(widths[index]) for index in range(4)),
+        "  ".join("-" * width for width in widths),
+    ]
+    lines.extend("  ".join(row[index].ljust(widths[index]) for index in range(4)) for row in rows)
+    return "\n".join(lines) + "\n"
+
+
+def _dot(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def render_dot(document: dict) -> str:
+    lines = ["digraph ods_extensions {", "  rankdir=LR;"]
+    for node in document["nodes"]:
+        label = f'{_dot(node["name"])}\\n({_dot(node["source"])})'
+        lines.append(f'  "{_dot(node["id"])}" [label="{label}"];')
+    for edge in document["edges"]:
+        lines.append(
+            f'  "{_dot(edge["service"])}" -> "{_dot(edge["depends_on"])}" '
+            '[label="depends on"];',
+        )
+    lines.append("}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--project-dir", type=Path, default=Path(__file__).parents[1])
+    parser.add_argument("--root", help="Limit output to one extension's graph")
+    parser.add_argument(
+        "--direction",
+        choices=("dependencies", "dependents"),
+        default="dependencies",
+        help="Traverse prerequisites or reverse blast radius from --root",
+    )
+    parser.add_argument("--format", choices=("table", "json", "dot"), default="table")
+    args = parser.parse_args()
+
+    try:
+        extensions = load_extensions(args.project_dir)
+        validate_graph(extensions)
+        selected = select_nodes(extensions, args.root, args.direction)
+    except (OSError, yaml.YAMLError, GraphValidationError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    document = graph_document(extensions, selected)
+    if args.format == "json":
+        print(json.dumps(document, indent=2, sort_keys=True))
+    elif args.format == "dot":
+        print(render_dot(document), end="")
+    else:
+        print(render_table(document), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/scripts/validate-manifests.sh
+++ b/ods/scripts/validate-manifests.sh
@@ -267,3 +267,15 @@ if [[ "$py_exit" -eq 0 ]]; then
 else
   fail "Extension manifest validation failed"
 fi
+
+GRAPH_SCRIPT="${ROOT_DIR}/scripts/extension-dependency-graph.py"
+if $PYTHON_OK; then
+  test -f "$GRAPH_SCRIPT" || fail "dependency graph validator not found"
+  if python3 "$GRAPH_SCRIPT" --project-dir "$ROOT_DIR" --format json >/dev/null; then
+    pass "Extension dependency graph validated"
+  else
+    fail "Extension dependency graph validation failed"
+  fi
+else
+  warn "Skipping dependency graph validation because PyYAML is unavailable"
+fi

--- a/ods/tests/test-validate-manifests.sh
+++ b/ods/tests/test-validate-manifests.sh
@@ -71,6 +71,12 @@ else
     fail "Output missing 'Summary:'"
 fi
 
+if echo "$out" | grep -q "Extension dependency graph validated"; then
+    pass "Output confirms dependency graph validation"
+else
+    fail "Output missing dependency graph validation receipt"
+fi
+
 # 6. Should list at least one service (from extensions/services/)
 if echo "$out" | grep -qE "ok-no-metadata|Compatible|ok"; then
     pass "Output contains compatibility status lines"

--- a/ods/tests/test_extension_dependency_graph.py
+++ b/ods/tests/test_extension_dependency_graph.py
@@ -1,0 +1,83 @@
+"""Tests for the extension dependency graph CLI."""
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "extension-dependency-graph.py"
+SPEC = importlib.util.spec_from_file_location("extension_dependency_graph", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def _manifest(project: Path, service_id: str, dependencies=(), *, library=False):
+    base = project / "extensions" / ("library/services" if library else "services")
+    path = base / service_id / "manifest.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    deps = ", ".join(dependencies)
+    path.write_text(
+        f"service:\n  id: {service_id}\n  name: {service_id.title()}\n  depends_on: [{deps}]\n",
+        encoding="utf-8",
+    )
+
+
+def test_cli_json_reports_dependency_order_and_reverse_blast_radius(tmp_path):
+    _manifest(tmp_path, "database")
+    _manifest(tmp_path, "workflows", ("database",))
+    _manifest(tmp_path, "portal", ("workflows",), library=True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--project-dir", str(tmp_path),
+            "--root", "database",
+            "--direction", "dependents",
+            "--format", "json",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    document = json.loads(result.stdout)
+
+    assert document["dependency_order"] == ["database", "workflows", "portal"]
+    assert document["edges"] == [
+        {"depends_on": "workflows", "service": "portal"},
+        {"depends_on": "database", "service": "workflows"},
+    ]
+
+
+def test_validation_reports_missing_dependency(tmp_path):
+    _manifest(tmp_path, "portal", ("missing-api",))
+    extensions = MODULE.load_extensions(tmp_path)
+
+    with pytest.raises(MODULE.GraphValidationError, match="portal->missing-api"):
+        MODULE.validate_graph(extensions)
+
+
+def test_validation_reports_the_cycle_path(tmp_path):
+    _manifest(tmp_path, "alpha", ("beta",))
+    _manifest(tmp_path, "beta", ("alpha",))
+    extensions = MODULE.load_extensions(tmp_path)
+
+    with pytest.raises(MODULE.GraphValidationError, match="alpha -> beta -> alpha"):
+        MODULE.validate_graph(extensions)
+
+
+def test_dot_output_includes_source_and_dependency_edges(tmp_path):
+    _manifest(tmp_path, "api")
+    _manifest(tmp_path, "portal", ("api",), library=True)
+    extensions = MODULE.load_extensions(tmp_path)
+    document = MODULE.graph_document(extensions, set(extensions))
+
+    output = MODULE.render_dot(document)
+
+    assert '"portal" -> "api" [label="depends on"]' in output
+    assert 'Portal\\n(library)' in output


### PR DESCRIPTION
## Why this matters

Extension dependencies determine activation order and the blast radius of disabling a shared service. Reviewers previously had to inspect dozens of manifests by hand, and the lifecycle path could discover a missing node or cycle only when an operator tried to apply it.

This PR provides deterministic human/JSON/DOT inspection and now runs the same complete graph contract through `ods config validate` / `scripts/validate-manifests.sh`. Invalid topology therefore fails in the installed operator command and existing CI manifest lane, not only when somebody remembers to invoke a standalone helper.

## Overlap check

Searched open and closed upstream PRs for extension dependency graphs, Graphviz, `depends_on` validation, and every changed production/test file. No other PR changes the validator or graph script. #2853 adds a FalkorDB graph-memory extension and is unrelated. #2495 corrects one workflow dependency value; this tool validates that manifest contract but does not overlap its implementation. The existing #2909 branch was strengthened instead of opening a separate release-gate PR.

## What changed

- scan bundled and library service manifests as one graph
- reject malformed dependency lists, duplicate IDs, missing nodes, and cycles with an actionable path
- traverse prerequisites or transitive dependents from a selected root
- emit deterministic table, JSON, and Graphviz DOT formats with dependency-first ordering
- invoke full-catalog graph validation from `scripts/validate-manifests.sh`, the path used by `ods config validate` and CI
- emit an explicit validation receipt; preserve the validator's existing documented skip when Python/PyYAML schema dependencies are unavailable
- document both ad-hoc inspection and automatic gate behavior

## Regression coverage

The graph CLI tests exercise dependency ordering, reverse blast radius, missing nodes, exact cycle paths, and DOT edges. The manifest-validator boundary test now requires the production command to print `Extension dependency graph validated`; it failed before wiring because the standalone inspector was never called.

## Validation

- `python -m pytest -q tests/test_extension_dependency_graph.py` — 4 passed.
- `bash tests/test-validate-manifests.sh` — 8 passed.
- `bash tests/test-validate-manifest-schema.sh` — full bundled/library schema source-of-truth suite passed.
- `python scripts/extension-dependency-graph.py --format json` against the real catalog — passed.
- `bash -n scripts/validate-manifests.sh tests/test-validate-manifests.sh` — passed.
- ShellCheck error-level validation — passed.
- `git diff --check` — passed.

## Tradeoffs and rollback

Graph validation is strict only when the existing Python/PyYAML/jsonschema capability gate is available; dependency checks are skipped with an explicit warning in the same reduced environments where schema parsing is already skipped. This avoids making installed validation less portable while making CI/release validation authoritative. Rollback removes the inspector/gate without changing manifests or runtime state.