### PR TITLE
feat(config): explain effective value provenance

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -2289,8 +2289,20 @@ cmd_config() {
                 warn "validate-manifests.sh not found at $INSTALL_DIR/scripts/validate-manifests.sh"
             fi
             ;;
+        explain)
+            shift
+            local _explain_script="$INSTALL_DIR/scripts/explain-config.py"
+            [[ -f "$_explain_script" ]] \
+                || error "explain-config.py not found at $_explain_script"
+            command -v python3 >/dev/null 2>&1 \
+                || error "python3 is required for configuration provenance"
+            python3 "$_explain_script" \
+                --env-file "$INSTALL_DIR/.env" \
+                --schema "$INSTALL_DIR/.env.schema.json" \
+                "$@"
+            ;;
         *)
-            log "Usage: ods config [show|edit|validate]"
+            log "Usage: ods config [show|edit|validate|explain]"
             ;;
     esac
 }
@@ -6377,8 +6389,8 @@ ${CYAN}Commands:${NC}
                       Pull latest images and restart (--force skips version-compat confirmation;
                       --rebuild-images rebuilds locally-built images so contributor edits deploy)
   shell <service>     Open shell in container
-  config [show|edit|validate]
-                      View, edit, or validate configuration
+  config [show|edit|validate|explain]
+                      View, edit, validate, or explain configuration provenance
   chat "<message>"    Quick chat with the LLM
   benchmark           Run a quick performance test
   doctor [report|--json]   Run diagnostics (--json writes JSON to stdout)
@@ -6482,6 +6494,8 @@ ${CYAN}Examples:${NC}
   ods restart stt               # Restart Whisper (via alias)
   ods chat "What is 2+2?"      # Quick LLM test
   ods config edit               # Edit .env file
+  ods config explain --key ODS_MODE
+                                  # Show effective value and source (secrets stay masked)
   ods template list              # List available templates
   ods template preview creative-studio
                                   # Preview what a template will change

--- a/ods/scripts/explain-config.py
+++ b/ods/scripts/explain-config.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Explain effective ODS configuration values and their provenance."""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+
+_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_SECRET_WORDS = ("secret", "password", "pass", "token", "key", "salt", "bearer", "user", "email")
+
+
+def _strip_matching_quotes(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        return value[1:-1]
+    return value
+
+
+def parse_env(path: Path) -> tuple[dict[str, str], dict[str, int], dict[str, list[int]], list[int]]:
+    """Parse assignments without evaluating shell syntax or expansions."""
+    values: dict[str, str] = {}
+    lines: dict[str, int] = {}
+    occurrences: dict[str, list[int]] = {}
+    malformed: list[int] = []
+    for line_number, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[7:].lstrip()
+        if "=" not in line:
+            malformed.append(line_number)
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not _KEY_RE.fullmatch(key):
+            malformed.append(line_number)
+            continue
+        occurrences.setdefault(key, []).append(line_number)
+        values[key] = _strip_matching_quotes(value.strip())
+        lines[key] = line_number
+    duplicates = {key: value for key, value in occurrences.items() if len(value) > 1}
+    return values, lines, duplicates, malformed
+
+
+def _is_secret(key: str, specification: dict) -> bool:
+    if specification.get("secret") is True:
+        return True
+    lowered = key.lower()
+    return any(word in lowered for word in _SECRET_WORDS)
+
+
+def build_report(
+    env_file: Path,
+    schema_file: Path,
+    *,
+    include_all: bool,
+    selected_keys: list[str],
+) -> dict:
+    schema = json.loads(schema_file.read_text(encoding="utf-8"))
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        raise ValueError("schema properties must be an object")
+    required = set(schema.get("required", []))
+    values, lines, duplicates, malformed = parse_env(env_file)
+
+    if selected_keys:
+        keys = set(selected_keys)
+    elif include_all:
+        keys = set(properties) | set(values)
+    else:
+        keys = set(values)
+        keys.update(key for key in required if key not in values or values[key] == "")
+
+    entries = []
+    for key in sorted(keys):
+        specification = properties.get(key)
+        known = isinstance(specification, dict)
+        specification = specification if known else {}
+        secret = _is_secret(key, specification)
+
+        if key in values:
+            source = "env"
+            raw_value = values[key]
+            value = "***" if secret else raw_value
+        elif "default" in specification:
+            source = "schema_default"
+            raw_value = specification["default"]
+            value = "***" if secret else raw_value
+        else:
+            source = "unset"
+            raw_value = None
+            value = None
+
+        if not known:
+            status = "unknown"
+        elif key in required and (source == "unset" or raw_value == ""):
+            status = "missing_required"
+        elif source == "env":
+            status = "configured"
+        elif source == "schema_default":
+            status = "default"
+        else:
+            status = "unset"
+
+        entries.append({
+            "key": key,
+            "value": value,
+            "source": source,
+            "status": status,
+            "secret": secret,
+            "required": key in required,
+            "is_empty": source == "env" and raw_value == "",
+            "line": lines.get(key),
+            "duplicate_lines": duplicates.get(key, []),
+            "type": specification.get("type"),
+            "description": specification.get("description", ""),
+        })
+
+    summary = {
+        "total": len(entries),
+        "configured": sum(entry["status"] == "configured" for entry in entries),
+        "defaults": sum(entry["status"] == "default" for entry in entries),
+        "unset": sum(entry["status"] == "unset" for entry in entries),
+        "missing_required": sum(entry["status"] == "missing_required" for entry in entries),
+        "unknown": sum(entry["status"] == "unknown" for entry in entries),
+        "duplicate_keys": len(duplicates),
+        "malformed_lines": len(malformed),
+    }
+    return {
+        "env_file": str(env_file),
+        "schema_file": str(schema_file),
+        "entries": entries,
+        "duplicates": duplicates,
+        "malformed_lines": malformed,
+        "summary": summary,
+    }
+
+
+def _display_value(value) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, str):
+        return value or "(empty)"
+    return json.dumps(value, separators=(",", ":"))
+
+
+def render_table(report: dict) -> str:
+    headers = ("Key", "Source", "Status", "Value")
+    rows = [
+        (
+            entry["key"],
+            entry["source"],
+            entry["status"],
+            _display_value(entry["value"]),
+        )
+        for entry in report["entries"]
+    ]
+    widths = [max(len(headers[index]), *(len(row[index]) for row in rows)) for index in range(4)]
+    lines = [
+        "  ".join(headers[index].ljust(widths[index]) for index in range(4)),
+        "  ".join("-" * width for width in widths),
+    ]
+    lines.extend("  ".join(row[index].ljust(widths[index]) for index in range(4)) for row in rows)
+    summary = report["summary"]
+    lines.extend([
+        "",
+        (
+            f"Configured: {summary['configured']}  Defaults: {summary['defaults']}  "
+            f"Missing required: {summary['missing_required']}  Unknown: {summary['unknown']}  "
+            f"Duplicates: {summary['duplicate_keys']}  Malformed lines: {summary['malformed_lines']}"
+        ),
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    project_dir = Path(__file__).parents[1]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--env-file", type=Path, default=project_dir / ".env")
+    parser.add_argument("--schema", type=Path, default=project_dir / ".env.schema.json")
+    parser.add_argument("--key", action="append", default=[], help="Explain one key (repeatable)")
+    parser.add_argument("--all", action="store_true", help="Include unset optional schema keys")
+    parser.add_argument("--format", choices=("table", "json"), default="table")
+    parser.add_argument("--check", action="store_true", help="Exit 2 for missing, unknown, duplicate, or malformed input")
+    args = parser.parse_args()
+
+    try:
+        report = build_report(
+            args.env_file,
+            args.schema,
+            include_all=args.all,
+            selected_keys=args.key,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_table(report), end="")
+
+    issue_fields = ("missing_required", "unknown", "duplicate_keys", "malformed_lines")
+    if args.check and any(report["summary"][field] for field in issue_fields):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -503,6 +503,15 @@ else
 ' ' ')"
 fi
 
+# 22. The read-only provenance view consumes the same schema contract but must
+# never expose secret values while reporting defaults, unknown keys, and
+# duplicate assignments.
+if python3 "$ROOT_DIR/tests/test_explain_config.py"; then
+    pass "Configuration provenance inspector honors schema and redaction contracts"
+else
+    fail "Configuration provenance inspector contract failed"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]

--- a/ods/tests/test_explain_config.py
+++ b/ods/tests/test_explain_config.py
@@ -1,0 +1,147 @@
+"""Tests for configuration provenance and the public ods CLI delegation."""
+
+import importlib.util
+import json
+import os
+import shlex
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[1]
+SCRIPT = ROOT / "scripts" / "explain-config.py"
+SPEC = importlib.util.spec_from_file_location("explain_config", SCRIPT)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def _bash_path(path: Path) -> str:
+    if os.name != "nt":
+        return str(path)
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    tail = resolved.as_posix().split(":/", 1)[1]
+    return f"/mnt/{drive}/{tail}"
+
+
+def _fixture(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text(
+        "# fixture\nODS_MODE=cloud\nAPI_TOKEN=do-not-leak\n"
+        "export ENDPOINT='https://example.test/v1?a=b'\nUNKNOWN_EMAIL=person@example.test\n"
+        "ODS_MODE=hybrid\nBROKEN LINE\n",
+        encoding="utf-8",
+    )
+    schema_file = tmp_path / ".env.schema.json"
+    schema_file.write_text(json.dumps({
+        "required": ["ODS_MODE", "WEBUI_SECRET"],
+        "properties": {
+            "ODS_MODE": {"type": "string", "default": "local"},
+            "API_TOKEN": {"type": "string", "secret": True},
+            "ENDPOINT": {"type": "string"},
+            "WEBUI_SECRET": {"type": "string", "secret": True},
+            "PORT": {"type": "integer", "default": 3002},
+        },
+    }), encoding="utf-8")
+    return env_file, schema_file
+
+
+def test_report_tracks_sources_duplicates_unknowns_and_redacts_secrets(tmp_path):
+    env_file, schema_file = _fixture(tmp_path)
+
+    report = MODULE.build_report(
+        env_file,
+        schema_file,
+        include_all=True,
+        selected_keys=[],
+    )
+    entries = {entry["key"]: entry for entry in report["entries"]}
+
+    assert entries["ODS_MODE"]["value"] == "hybrid"
+    assert entries["ODS_MODE"]["duplicate_lines"] == [2, 6]
+    assert entries["PORT"]["source"] == "schema_default"
+    assert entries["PORT"]["value"] == 3002
+    assert entries["WEBUI_SECRET"]["status"] == "missing_required"
+    assert entries["API_TOKEN"]["value"] == "***"
+    assert entries["UNKNOWN_EMAIL"]["value"] == "***"
+    assert entries["UNKNOWN_EMAIL"]["status"] == "unknown"
+    assert entries["ENDPOINT"]["value"].endswith("?a=b")
+    assert report["malformed_lines"] == [7]
+
+
+def test_check_mode_returns_two_without_printing_secret(tmp_path):
+    env_file, schema_file = _fixture(tmp_path)
+    result = subprocess.run(
+        [
+            os.fspath(shutil.which("python3") or shutil.which("python")),
+            str(SCRIPT),
+            "--env-file", str(env_file),
+            "--schema", str(schema_file),
+            "--format", "json",
+            "--check",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "do-not-leak" not in result.stdout
+    assert "person@example.test" not in result.stdout
+    assert json.loads(result.stdout)["summary"]["unknown"] == 1
+
+
+def test_ods_config_explain_delegates_at_the_installed_cli_boundary(tmp_path):
+    install = tmp_path / "install"
+    (install / "scripts").mkdir(parents=True)
+    (install / "docker-compose.base.yml").touch()
+    shutil.copy2(SCRIPT, install / "scripts" / SCRIPT.name)
+    (install / ".env").write_text("API_TOKEN=cli-secret\nODS_VERSION=test\n", encoding="utf-8")
+    (install / ".env.schema.json").write_text(json.dumps({
+        "properties": {
+            "API_TOKEN": {"type": "string", "secret": True},
+            "ODS_VERSION": {"type": "string"},
+        },
+    }), encoding="utf-8")
+    if os.name == "nt":
+        command = [
+            "bash", "-lc",
+            (
+                f"ODS_HOME={shlex.quote(_bash_path(install))} NO_COLOR=1 "
+                f"bash {shlex.quote(_bash_path(ROOT / 'ods-cli'))} "
+                "config explain --format json"
+            ),
+        ]
+        environment = None
+    else:
+        command = ["bash", str(ROOT / "ods-cli"), "config", "explain", "--format", "json"]
+        environment = {**os.environ, "ODS_HOME": str(install), "NO_COLOR": "1"}
+
+    result = subprocess.run(
+        command,
+        env=environment,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    entries = {entry["key"]: entry for entry in report["entries"]}
+    assert entries["API_TOKEN"]["value"] == "***"
+    assert "cli-secret" not in result.stdout
+
+
+if __name__ == "__main__":
+    tests = (
+        test_report_tracks_sources_duplicates_unknowns_and_redacts_secrets,
+        test_check_mode_returns_two_without_printing_secret,
+        test_ods_config_explain_delegates_at_the_installed_cli_boundary,
+    )
+    for test in tests:
+        with tempfile.TemporaryDirectory() as temporary:
+            test(Path(temporary))
+    print(f"PASS: {len(tests)} configuration provenance tests")


### PR DESCRIPTION
## Why this matters
`ods config show` displays persisted assignments and `ods config validate` checks legality, but neither explains the effective source of a setting. Operators troubleshooting routing, ports, or model behavior need to distinguish explicit `.env` values from schema defaults and missing configuration without risking secret disclosure. This adds a read-only provenance view with a machine-readable contract.

## Overlap check
Searched open and closed upstream PRs for `config explain`, `configuration provenance`, and the changed files. No PR implements this command. Open PR #2889 fixes preset-diff splitting, #2787 makes `_env_set` atomic, and #2804 changes rootless Podman setup; all touch `ods-cli` but operate in separate functions and do not add provenance reporting. The new Python implementation and regression files have no overlap.

## What changed
- add `ods config explain` with table/JSON output, repeatable `--key`, `--all`, and CI-friendly `--check`
- report env/schema-default/unset provenance, required state, original line, duplicates, malformed lines, and unknown keys
- parse values without sourcing or evaluating shell syntax; split on the first equals and honor matching quotes
- always redact schema secrets plus a defensive keyword fallback in every output format
- run the standalone and installed-CLI boundary tests from the existing validate-env CI contract

## Regression test
`python3 tests/test_explain_config.py`

Also validated:
- `bash tests/test-validate-env.sh` (46 passed)
- `python -m pytest -q tests/test_explain_config.py` (3 passed)
- exercised real `.env.example` + `.env.schema.json` output with secret redaction
- `bash -n ods-cli tests/test-validate-env.sh`
- `python -m py_compile scripts/explain-config.py tests/test_explain_config.py`
- `git diff --check`