### PR TITLE
fix(installer): honor LITELLM_PORT override in macOS cloud health

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -3059,9 +3059,11 @@ CLOUD_REQUIRED_HEALTHY=true
 # runs natively on macOS via Metal; OpenCode is a LaunchAgent). Docker
 # services wait on `docker inspect ... .State.Health.Status == healthy`;
 # host-native services fall back to an HTTP probe on 127.0.0.1.
+_health_litellm_port="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_PORT")"
+[[ "$_health_litellm_port" =~ ^[0-9]+$ ]] || _health_litellm_port="4000"
 if $CLOUD_MODE; then
     HEALTH_NAMES=("LiteLLM gateway" "Chat UI (Open WebUI)")
-    HEALTH_URLS=("http://127.0.0.1:4000/health/readiness" "http://127.0.0.1:3000")
+    HEALTH_URLS=("http://127.0.0.1:${_health_litellm_port}/health/readiness" "http://127.0.0.1:3000")
     HEALTH_CONTAINERS=("ods-litellm" "ods-webui")
 else
     _health_bind="$(read_env_value "$INSTALL_DIR/.env" "BIND_ADDRESS")"


### PR DESCRIPTION
## Summary

The cloud-mode health probe hardcoded LiteLLM on port 4000 while the auth block later reads LITELLM_PORT as overridable. Resolve LITELLM_PORT from .env with the 4000 fallback before the cloud health wait so an override is honored.

## AI Assistance

AI helped draft; I reviewed every hunk and ran the checks below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: narrow change; syntax and diff checks pass locally

Commands/results:

```text
git diff --check clean; bash -n on touched scripts passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

