### PR TITLE
fix(installer): honor WHISPER_PORT override in Windows conflict scan

### DIFF
--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -304,7 +304,8 @@ if ($enableRecommended) {
     $_portsToCheck["Token Spy (usage monitor)"] = 3005
 }
 if ($enableVoice) {
-    $_whisperPortToCheck = $(if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 })
+    $_whisperDefaultPort = if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 }
+    $_whisperPortToCheck = Resolve-WindowsODSPort -Name "WHISPER_PORT" -DefaultPort $_whisperDefaultPort -InstallDir $installDir
     $_portsToCheck["Whisper (STT)"] = $_whisperPortToCheck
     $_portsToCheck["Kokoro (TTS)"]  = 8880
 }


### PR DESCRIPTION
## Summary

The Whisper port-conflict scan hardcoded 9100/9000 and ignored a persisted
WHISPER_PORT value from .env, so a re-install with a custom port could scan
the wrong port and miss a real conflict. Resolve it via Resolve-WindowsODSPort
like the WEBUI entry in the same block, keeping the AMD/9100 default.

## AI Assistance

Drafted with an AI coding assistant; reviewed by hand and validated locally.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: narrow change; syntax and diff checks pass locally

Commands/results:

```text
git diff --check clean; bash -n on touched scripts passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

