### PR TITLE
fix(installer): honor PERPLEXICA_PORT override in Windows auto-config

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2301,6 +2301,15 @@ if ($enableVoice) {
     }
 }
 
+$readinessEnv = Get-WindowsODSEnvMap -InstallDir $installDir
+function Get-ReadinessPort {
+    param([string]$Name, [string]$Default)
+    if ($readinessEnv.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($readinessEnv[$Name])) {
+        return $readinessEnv[$Name]
+    }
+    return $Default
+}
+
 # ── Auto-configure Perplexica ─────────────────────────────────────────────────
 if (Test-ODSWindowsServiceEnabled -ServiceId "perplexica" -Plan $servicePlan) {
     Write-AI "Configuring Perplexica..."
@@ -2341,21 +2350,13 @@ if (Test-ODSWindowsServiceEnabled -ServiceId "perplexica" -Plan $servicePlan) {
     if (($useLemonade -or $cloudMode -or $switchboardMode -eq "enabled") -and $windowsEnvMap.ContainsKey("LITELLM_KEY") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["LITELLM_KEY"])) {
         $perplexicaApiKey = $windowsEnvMap["LITELLM_KEY"]
     }
-    $perplexicaOk = Set-PerplexicaConfig -PerplexicaPort 3004 -LlmModel $perplexicaModel -LlmBaseUrl $perplexicaBaseUrl -ApiKey $perplexicaApiKey
+    $perplexicaPort = Get-ReadinessPort -Name "PERPLEXICA_PORT" -Default "3004"
+    $perplexicaOk = Set-PerplexicaConfig -PerplexicaPort $perplexicaPort -LlmModel $perplexicaModel -LlmBaseUrl $perplexicaBaseUrl -ApiKey $perplexicaApiKey
     if ($perplexicaOk) {
         Write-AISuccess "Perplexica configured (model: $perplexicaModel)"
     } else {
-        Write-AIWarn "Perplexica auto-config skipped -- complete setup at http://localhost:3004"
+        Write-AIWarn "Perplexica auto-config skipped -- complete setup at http://localhost:$perplexicaPort"
     }
-}
-
-$readinessEnv = Get-WindowsODSEnvMap -InstallDir $installDir
-function Get-ReadinessPort {
-    param([string]$Name, [string]$Default)
-    if ($readinessEnv.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($readinessEnv[$Name])) {
-        return $readinessEnv[$Name]
-    }
-    return $Default
 }
 
 $dashboardPort = Get-ReadinessPort -Name "DASHBOARD_PORT" -Default "3001"


### PR DESCRIPTION
## Summary

The auto-config block hardcoded port 3004 while readiness and compose honor a PERPLEXICA_PORT override, leaving Perplexica unconfigured on re-install. Resolve the port via Get-ReadinessPort and use it for both the config call and warning URL.

## AI Assistance

AI-assisted draft; human reviewed the diff and chose the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: narrow change; syntax and diff checks pass locally

Commands/results:

```text
git diff --check clean; bash -n on touched scripts passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

