### PR TITLE
fix(cli): wire rollback to the written rollback-point marker

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4711,18 +4711,18 @@ cmd_rollback() {
     cd "$INSTALL_DIR"
     load_env
 
-    if [[ ! -f "$INSTALL_DIR/.last-backup-id" ]]; then
+    if [[ ! -x "$INSTALL_DIR/ods-update.sh" ]]; then
+        error "ods-update.sh not found or not executable"
+    fi
+
+    local rollback_point
+    rollback_point=$(jq -r '.last_rollback_point // empty' "$INSTALL_DIR/.version" 2>/dev/null || true)
+
+    if [[ -z "$rollback_point" ]]; then
         error "No rollback point found. Rollback is only available after a failed update."
     fi
 
-    local backup_id
-    backup_id=$(cat "$INSTALL_DIR/.last-backup-id")
-
-    if [[ -z "$backup_id" ]]; then
-        error "Invalid rollback point (empty backup ID)"
-    fi
-
-    log "Rolling back to pre-update state (backup: $backup_id)..."
+    log "Rolling back to pre-update state (snapshot: $(basename "$rollback_point"))..."
     echo ""
     warn "This will restore configuration from before the last update."
     read -p "Continue with rollback? [y/N] " -n 1 -r
@@ -4733,32 +4733,12 @@ cmd_rollback() {
         return 0
     fi
 
-    # Stop services before rollback
-    log "Stopping services..."
-    local flags_str
-    flags_str=$(get_compose_flags)
-    local -a flags
-    read -ra flags <<< "$flags_str"
-    docker compose "${flags[@]}" down 2>/dev/null || true
-
-    # Restore from backup
-    if "$INSTALL_DIR/ods-restore.sh" "$backup_id"; then
-        success "Configuration restored from backup: $backup_id"
-
-        # Restart services with restored configuration
-        log "Restarting services with restored configuration..."
-        if docker compose "${flags[@]}" up -d; then
-            success "Rollback complete"
-            rm -f "$INSTALL_DIR/.last-backup-id"
-
-            log "Checking service health..."
-            sleep 5
-            cmd_status
-        else
-            error "Failed to restart services after rollback. Check 'docker compose logs' for details."
-        fi
+    # Delegate to ods-update.sh, which resolves the recorded pre-update
+    # snapshot, stops the stack, restores it, and brings services back up.
+    if "$INSTALL_DIR/ods-update.sh" rollback "$(basename "$rollback_point")"; then
+        success "Rollback complete"
     else
-        error "Failed to restore from backup. Your system may be in an inconsistent state."
+        error "Rollback failed. Check 'ods-update.sh rollback' for details."
     fi
 }
 


### PR DESCRIPTION
## Summary

cmd_rollback read $INSTALL_DIR/.last-backup-id, which nothing in the
repo ever writes, so the documented post-update-failure recovery always
errored "No rollback point found". Rollback now reads the rollback
point from .version.last_rollback_point (written by ods-update.sh during
updates) and delegates the restore to ods-update.sh rollback.

## AI Assistance

Written with an AI pair; reviewed and tested on this machine.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Not required because: narrow change; syntax and diff checks pass locally

Commands/results:

```text
git diff --check clean; bash -n on touched scripts passes
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

