### PR TITLE
fix(tailscale): add path validation and comprehensive HTTP exception mapping in _proxy_agent in tailscale.py

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/tailscale.py
+++ b/ods/extensions/services/dashboard-api/routers/tailscale.py
@@ -25,6 +25,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 
 from host_agent_client import (
+    AgentClientError,
     AgentHTTPError,
     AgentProtocolError,
     AgentTimeout,

--- a/ods/extensions/services/dashboard-api/routers/tailscale.py
+++ b/ods/extensions/services/dashboard-api/routers/tailscale.py
@@ -51,7 +51,7 @@ def _proxy_agent(path: str, timeout: int = 15) -> dict:
     except AgentUnavailable as exc:
         logger.warning("host-agent GET %s unreachable: %s", path, exc)
         raise HTTPException(status_code=503, detail="ODS host agent is not reachable.") from exc
-    except AgentProtocolError as exc:
+    except (AgentProtocolError, AgentClientError, OSError, ValueError) as exc:
         logger.exception("host-agent GET %s failed", path)
         raise HTTPException(status_code=500, detail=f"Host agent call failed: {exc}") from exc
 

--- a/ods/extensions/services/dashboard-api/routers/tailscale.py
+++ b/ods/extensions/services/dashboard-api/routers/tailscale.py
@@ -39,20 +39,26 @@ router = APIRouter(tags=["tailscale"])
 
 
 def _proxy_agent(path: str, timeout: int = 15) -> dict:
-    """Forward a GET to the host-agent. Translates HTTPError → HTTPException."""
+    """Forward a GET request to the host-agent with HTTP error mapping."""
+    if not isinstance(path, str) or not path.startswith("/"):
+        raise HTTPException(status_code=400, detail=f"Invalid agent proxy path: {path}")
     try:
-        return request_agent_json("GET", path, timeout=timeout)
+        data = request_agent_json("GET", path, timeout=timeout)
+        if isinstance(data, dict):
+            return data
+        return {"data": data}
     except AgentHTTPError as exc:
-        logger.info("host-agent GET %s -> %s", path, exc.status_code)
-        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+        status_code = exc.status_code if 400 <= exc.status_code <= 599 else 500
+        logger.info("host-agent GET %s -> %s", path, status_code)
+        raise HTTPException(status_code=status_code, detail=exc.detail or "Host agent request failed") from exc
     except AgentTimeout as exc:
-        logger.warning("host-agent GET %s timed out", path)
+        logger.warning("host-agent GET %s timed out after %ds", path, timeout)
         raise HTTPException(status_code=504, detail="ODS host agent request timed out.") from exc
     except AgentUnavailable as exc:
         logger.warning("host-agent GET %s unreachable: %s", path, exc)
         raise HTTPException(status_code=503, detail="ODS host agent is not reachable.") from exc
     except (AgentProtocolError, AgentClientError, OSError, ValueError) as exc:
-        logger.exception("host-agent GET %s failed", path)
+        logger.warning("host-agent GET %s failed: %s", path, exc, exc_info=True)
         raise HTTPException(status_code=500, detail=f"Host agent call failed: {exc}") from exc
 
 


### PR DESCRIPTION
## Problem

In `ods/extensions/services/dashboard-api/routers/tailscale.py`, `_proxy_agent()` forwards status queries to host-agent endpoints. If an invalid path parameter is passed or if `request_agent_json()` encounters generic agent errors (`AgentClientError`, `OSError`, `ValueError`), uncaught exceptions leak to the caller or fail to report proper HTTP status codes.

## Fix

Add input path validation check in `_proxy_agent()`, sanitize HTTP error status codes, and catch `(AgentProtocolError, AgentClientError, OSError, ValueError)` with structured 500 error responses and logging.

## Verification

Verified syntax with `python3 -m py_compile ods/extensions/services/dashboard-api/routers/tailscale.py`. `git diff --check` passed cleanly.