### PR TITLE
fix(dashboard): escape the sed delimiter when injecting the API key

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -77,6 +77,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh
 	@echo ""
+	@echo "=== dashboard entrypoint API key injection ==="
+	@bash tests/test-dashboard-entrypoint-key.sh
+	@echo ""
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh
 	@echo ""

--- a/ods/extensions/services/dashboard/entrypoint.sh
+++ b/ods/extensions/services/dashboard/entrypoint.sh
@@ -7,7 +7,7 @@
 
 set -e
 
-NGINX_CONF="/etc/nginx/conf.d/default.conf"
+NGINX_CONF="${NGINX_CONF:-/etc/nginx/conf.d/default.conf}"
 API_KEY="${DASHBOARD_API_KEY:-}"
 KEY_FILE="/data/dashboard-api-key.txt"
 
@@ -24,8 +24,8 @@ fi
 # We need to substitute it with the actual value
 if [ -n "$API_KEY" ]; then
     echo "[dashboard] Configuring nginx with API key auth injection"
-    # Escape sed special characters in the API key to prevent injection
-    ESCAPED_KEY=$(printf '%s\n' "$API_KEY" | sed 's/[&/\]/\\&/g')
+    # Escape sed replacement metacharacters and the '|' delimiter used below
+    ESCAPED_KEY=$(printf '%s\n' "$API_KEY" | sed 's/[&|\]/\\&/g')
     # Replace the placeholder (envsubst already ran, but may have left empty value)
     sed -i "s|Bearer \${DASHBOARD_API_KEY}|Bearer ${ESCAPED_KEY}|g" "$NGINX_CONF"
     sed -i "s|Bearer \"\"|Bearer \"${ESCAPED_KEY}\"|g" "$NGINX_CONF"

--- a/ods/tests/test-dashboard-entrypoint-key.sh
+++ b/ods/tests/test-dashboard-entrypoint-key.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Regression: dashboard entrypoint must inject API keys containing sed
+# metacharacters (notably the '|' substitution delimiter) verbatim (#2926).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENTRYPOINT="$ROOT/extensions/services/dashboard/entrypoint.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Stub nginx so the entrypoint's final `exec nginx` is a no-op.
+mkdir -p "$tmp/bin"
+printf '#!/bin/sh\nexit 0\n' > "$tmp/bin/nginx"
+chmod +x "$tmp/bin/nginx"
+
+# The entrypoint runs in Alpine, where `sed -i` takes no suffix argument.
+# On BSD/macOS shim in gsed so the same script is exercised unmodified.
+if ! sed --version >/dev/null 2>&1; then
+    if command -v gsed >/dev/null 2>&1; then
+        ln -s "$(command -v gsed)" "$tmp/bin/sed"
+    else
+        echo "SKIP: GNU sed (or gsed) required to exercise the entrypoint"
+        exit 0
+    fi
+fi
+
+fail=0
+check_key() {
+    local key="$1" conf="$tmp/nginx.conf"
+    # shellcheck disable=SC2016  # the literal placeholder is the point
+    printf '%s\n' '        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";' > "$conf"
+
+    PATH="$tmp/bin:$PATH" NGINX_CONF="$conf" DASHBOARD_API_KEY="$key" \
+        sh "$ENTRYPOINT" >/dev/null
+
+    local expected="        proxy_set_header Authorization \"Bearer ${key}\";"
+    if [ "$(cat "$conf")" = "$expected" ]; then
+        echo "PASS: key '$key' injected verbatim"
+    else
+        echo "FAIL: key '$key' -> $(cat "$conf")"
+        fail=1
+    fi
+}
+
+check_key 'plainkey123'
+check_key 'aa|bb'
+check_key 'a&b\c|d'
+
+[ "$fail" -eq 0 ] || exit 1
+echo "All dashboard entrypoint key-injection tests passed"


### PR DESCRIPTION
## Summary

Fixes #2926.

`ods/extensions/services/dashboard/entrypoint.sh` escaped the API key for a `/`-delimited `sed` expression (`s/[&/\]/\\&/g`) but both substitutions two lines below use `|` as the delimiter. A `DASHBOARD_API_KEY` containing `|` therefore terminated the substitution pattern early, and the corrupted `Authorization: Bearer ...` header was written into the nginx conf — every dashboard→API request returned 401 with no hint that the key's charset was the cause. (Under `set -e` busybox sed actually aborts the entrypoint outright, so the container never starts either.)

Changes:

- Escape the characters that matter for a `|`-delimited `s|||`: `&`, `\`, `|`.
- `NGINX_CONF` is now `${NGINX_CONF:-/etc/nginx/conf.d/default.conf}` so the script can be exercised outside the container without touching its behaviour in one.
- New `ods/tests/test-dashboard-entrypoint-key.sh`, wired into `make test`: runs the real entrypoint (with an `nginx` stub on `PATH`) against `plainkey123`, `aa|bb`, and `a&b\c|d`, asserting the key lands in the conf verbatim.

Not changed: `installers/phases/07-devtools.sh:284-286` has the same escape/delimiter mismatch, but the values there are `$HOME` and binary paths, which realistically never contain `|`. Called out here rather than widened into this diff.

## AI Assistance

Claude Code (Opus) drafted the fix and the regression test and ran the validation below. The human author reviewed the diff and the test results.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: single-line shell escaping fix in one container entrypoint, covered by a new regression test executed against the same sed implementation (busybox) the container ships.

Commands/results:

```text
$ make lint
=== Shell syntax ===
=== Python compile ===
All lint checks passed.

# run against busybox sed, i.e. the same sed the dashboard image ships
$ docker run --rm -v "$PWD:/w" -w /w/ods alpine:3.20 sh -c \
    'apk add --no-cache bash >/dev/null 2>&1; bash tests/test-dashboard-entrypoint-key.sh'
PASS: key 'plainkey123' injected verbatim
PASS: key 'aa|bb' injected verbatim
PASS: key 'a&b\c|d' injected verbatim
All dashboard entrypoint key-injection tests passed

# same test with the escape class reverted to the buggy [&/\] -> fails, so it guards the regression
$ docker run --rm ... bash tests/test-dashboard-entrypoint-key.sh
PASS: key 'plainkey123' injected verbatim
sed: bad option in substitution expression
exit=1

$ docker run --rm -v "$PWD:/mnt" -w /mnt koalaman/shellcheck:stable \
    --exclude=SC1091,SC2034 --severity=warning \
    ods/extensions/services/dashboard/entrypoint.sh ods/tests/test-dashboard-entrypoint-key.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- The test skips itself on hosts without GNU sed (BSD `sed -i` takes a suffix argument); it links in `gsed` when available. CI runs on Linux, so it executes there.
- No behaviour change when `DASHBOARD_API_KEY` contains no sed metacharacters.
