### PR TITLE
fix(opencode): only consider the ODS-managed binary installed on Windows

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10670,6 +10670,12 @@ def _opencode_config_precedence(path: Path) -> tuple[int, int]:
 
 def _opencode_installed() -> bool:
     executable = "opencode.exe" if platform.system() == "Windows" else "opencode"
+    if platform.system() == "Windows":
+        # Only the ODS-managed binary can be inspected and restarted by
+        # _run_windows_opencode_control. An npm-installed opencode on PATH is a
+        # different binary ODS does not own; claiming it is installed would make
+        # the agent snapshot config for a process it can never restart.
+        return (Path.home() / ".opencode" / "bin" / executable).is_file()
     return bool(
         shutil.which("opencode")
         or (Path.home() / ".opencode" / "bin" / executable).is_file()


### PR DESCRIPTION
## Summary

On Windows the host agent treated any `opencode` binary visible on PATH as proof of an installed managed provider. A standalone user install therefore satisfied the probe, and health/config operations were aimed at a binary ODS does not manage. Only the ODS-managed installation path now counts as installed.

## AI Assistance

AI-assisted repository search to locate the probe. The author reviewed the matching logic and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `python3 -m py_compile ods/bin/ods-host-agent.py` - passed.
