### PR TITLE
fix(windows): add backup creation and fallback JSON serialization recovery in opencode-config.ps1

### DIFF
--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -163,7 +163,7 @@ function Sync-WindowsOpenCodeConfig {
 
     if ($_existingConfigFile) {
         try {
-            $_configObject = Get-Content $_existingConfigFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            $_configObject = Get-Content $_existingConfigFile -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
             $_configStatus = "updated"
         } catch {
             $_configStatus = "regenerated"

--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -165,6 +165,8 @@ function Sync-WindowsOpenCodeConfig {
         try {
             $_configObject = Get-Content $_existingConfigFile -Raw -Encoding UTF8 | ConvertFrom-Json -ErrorAction Stop
             $_configStatus = "updated"
+            $_bakFile = "$_existingConfigFile.bak"
+            Copy-Item -Path $_existingConfigFile -Destination $_bakFile -Force -ErrorAction SilentlyContinue
         } catch {
             $_configStatus = "regenerated"
         }
@@ -179,7 +181,19 @@ function Sync-WindowsOpenCodeConfig {
         -ApiKey $ApiKey `
         -ProviderName $ProviderName
 
-    $_configJson = $_configObject | ConvertTo-Json -Depth 12
+    try {
+        $_configJson = $_configObject | ConvertTo-Json -Depth 12 -ErrorAction Stop
+    } catch {
+        $_configObject = New-WindowsOpenCodeConfigObject `
+            -LlmEndpoint $LlmEndpoint `
+            -ModelId $ModelId `
+            -ModelName $ModelName `
+            -ContextLimit $ContextLimit `
+            -ApiKey $ApiKey `
+            -ProviderName $ProviderName
+        $_configJson = $_configObject | ConvertTo-Json -Depth 12
+    }
+
     $_utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllText($_ocConfigFile, $_configJson, $_utf8NoBom)
     [System.IO.File]::WriteAllText($_ocCompatConfigFile, $_configJson, $_utf8NoBom)


### PR DESCRIPTION
## Problem

In `ods/installers/windows/lib/opencode-config.ps1`, `Sync-WindowsOpenCodeConfig` reads and updates existing OpenCode JSON configuration files on Windows. Reading existing files with `Get-Content` without explicit `-Encoding UTF8` can corrupt UTF-8 strings or BOM headers on Windows PowerShell, while JSON serialization failures can corrupt configuration state without creating backups.

## Fix

Add explicit `-Encoding UTF8` to `Get-Content`, create automated `.bak` backup files before updating existing configurations, and add `try...catch` fallback recovery around `ConvertTo-Json -Depth 12` in `Sync-WindowsOpenCodeConfig`.

## Verification

Verified formatting and line endings with `git diff --check`.