### PR TITLE
fix(health): skip port probe for host-network services per registry contract

### DIFF
--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -167,6 +167,21 @@ test_service() {
     local port="$default_port"
     [[ -n "$port_env" ]] && port="${!port_env:-$default_port}"
 
+    # Host-network services share the host network namespace: there is no
+    # Docker-mapped port to probe (see SERVICE_HOST_NETWORK contract in
+    # lib/service-registry.sh), so judge them by container state only.
+    if [[ "${SERVICE_HOST_NETWORK[$sid]:-}" == "1" ]]; then
+        local hn_state
+        hn_state=$(check_container_state "$sid")
+        if [[ "$hn_state" == "running" ]]; then
+            result_set "$sid" "ok"
+            return 0
+        fi
+        result_set "$sid" "fail"
+        ANY_FAIL=true
+        return 1
+    fi
+
     [[ -z "$health" || "$port" == "0" ]] && return 1
 
     # Check container state first (if docker available)


### PR DESCRIPTION
## Summary

`scripts/health-check.sh` failed every `host_network` extension: `test_service` bailed at the mapped-port gate before the container-state probe ever ran, so a healthy tailscale container produced a permanent `DEGRADED` verdict (exit 1) on every run. The registry documents that callers must skip port checks when `SERVICE_HOST_NETWORK[sid]` is `"1"` — `ods-cli`'s status path already honors this; the standalone health check now does too.

### Behavior and invariants

| Invariant | Implementation |
|---|---|
| Healthy host-network service reports ok | Judged by container state alone |
| Stopped/crash-looped service still fails | Same container-state gate as before |

## AI Assistance

AI-assisted enumeration of registry-contract callers. The author reviewed both consumers and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `bash ods/tests/test-health-check.sh` - passed (22 checks).
- `bash -n ods/scripts/health-check.sh` - passed.
