### PR TITLE
fix(opencode): preserve a user-configured small_model on model swaps

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10786,7 +10786,6 @@ def _opencode_config_matches(
     model_ref = f"{provider_id}/{model_id}"
     return bool(
         config.get("model") == model_ref
-        and config.get("small_model") == model_ref
         and isinstance(options, dict)
         and options.get("baseURL") == base_url
         and options.get("apiKey") == api_key
@@ -10815,7 +10814,11 @@ def _update_opencode_config(
         config = json.loads(json.dumps(source))
         previous_model_ref = config.get("model")
         config["model"] = model_ref
-        config["small_model"] = model_ref
+        # Only refresh small_model when ODS previously owned it (it pointed at
+        # the old main model). A user-configured distinct small_model is a
+        # deliberate choice and must survive model swaps.
+        if not config.get("small_model") or config.get("small_model") == previous_model_ref:
+            config["small_model"] = model_ref
         config.setdefault("$schema", "https://opencode.ai/config.json")
 
         providers = config.setdefault("provider", {})


### PR DESCRIPTION
## Summary

Model swaps rewrote the opencode config wholesale and clobbered a `small_model` the user had configured. The upsert now preserves an existing user-set value and injects the default only when the key is absent.

## AI Assistance

AI-assisted edge-case enumeration around config upserts. The author reviewed the preservation logic and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `python3 -m py_compile ods/bin/ods-host-agent.py` - passed.
