### PR TITLE
fix(api): strip quotes from OPENCLAW_TOKEN read from .env fallback

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1482,7 +1482,7 @@ async def service_tokens():
                     if path.suffix == ".env":
                         for line in path.read_text().splitlines():
                             if line.startswith("OPENCLAW_TOKEN="):
-                                oc_token = line.split("=", 1)[1].strip()
+                                oc_token = strip_matching_quotes(line.split("=", 1)[1])
                                 break
                     else:
                         oc_token = path.read_text().strip()

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -472,6 +472,12 @@ class TestServiceTokens:
         # Either empty dict or no openclaw key
         assert "openclaw" not in data
 
+    def test_env_fallback_token_value_is_unquoted(self):
+        from env_values import strip_matching_quotes
+
+        line = 'OPENCLAW_TOKEN="quoted-token"'
+        assert strip_matching_quotes(line.split("=", 1)[1]) == "quoted-token"
+
 
 # --- /api/external-links ---
 


### PR DESCRIPTION
## Summary

The `/api/service-tokens` fallback read `OPENCLAW_TOKEN` out of `.env` with a bare split-and-strip, so quoted values kept their quotes. Compose strips those same quotes before the container sees the variable, which made one credential simultaneously valid for the gateway and broken for browser-side auth. The fallback now routes through `strip_matching_quotes`, matching every other `.env` reader here.

## AI Assistance

AI-assisted comparison of env-reader implementations. The author reviewed the shared helper semantics and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [x] Dashboard API
- [ ] CI workflows

## Validation

- `pytest tests/test_main.py -k ServiceTokens` (dashboard-api) - passed (3).
- `python3 -m py_compile ods/extensions/services/dashboard-api/main.py` - passed.
