### PR TITLE
fix(opencode): set the mutated flag only after a verified config update

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -8268,7 +8268,6 @@ class AgentHandler(BaseHTTPRequestHandler):
                         if windows_host_lemonade
                         else gguf_file if windows_native_llama else llm_model_name
                     )
-                    opencode_config_mutated = True
                     _update_opencode_config(
                         env,
                         opencode_snapshot,
@@ -8276,6 +8275,11 @@ class AgentHandler(BaseHTTPRequestHandler):
                         int(context_length),
                         display_name=llm_model_name,
                     )
+                    # Set the mutated flag only after a successful, verified
+                    # write. If the update raises, the snapshot restore already
+                    # returned OpenCode to its prior state, and forcing a restart
+                    # during rollback is wasteful and risks masking the error.
+                    opencode_config_mutated = True
 
                 # Restart dependent services so they pick up the new model
                 litellm_restart_attempted = container_states["ods-litellm"]["running"]


### PR DESCRIPTION
## Summary

The host agent flipped its `mutated` flag before confirming the config write landed. A failed upsert therefore left the agent convinced the document had changed and skipped later correction attempts. The flag now sets only after the updated content verifies.

## AI Assistance

AI-assisted control-flow trace of the upsert path. The author reviewed the ordering change and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `python3 -m py_compile ods/bin/ods-host-agent.py` - passed.
