### PR TITLE
fix(doctor): use unique temp files for capability and preflight JSON

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -24,8 +24,12 @@ esac
 
 REPORT_FILE="${1:-/tmp/ods-doctor-report.json}"
 
-CAP_FILE="/tmp/ods-doctor-capabilities.json"
-PREFLIGHT_FILE="/tmp/ods-doctor-preflight.json"
+# Unique per-run intermediates: two overlapping doctor runs must not share
+# (or symlink-swap) the same fixed /tmp path, and the JSON readers below
+# would otherwise parse a foreign or truncated file mid-run.
+CAP_FILE="$(mktemp "${TMPDIR:-/tmp}/ods-doctor-capabilities.XXXXXXXX")"
+PREFLIGHT_FILE="$(mktemp "${TMPDIR:-/tmp}/ods-doctor-preflight.XXXXXXXX")"
+trap 'rm -f "$CAP_FILE" "$PREFLIGHT_FILE"' EXIT
 DOCTOR_BASH_CMD="${BASH:-}"
 if [[ -z "$DOCTOR_BASH_CMD" || ! -x "$DOCTOR_BASH_CMD" ]]; then
     DOCTOR_BASH_CMD="$(command -v bash 2>/dev/null || printf '%s\n' bash)"


### PR DESCRIPTION
## Summary

Doctor wrote its capability and preflight intermediates to fixed `/tmp` names shared by every run and user. Two overlapping runs interleave writes/reads (corrupting or swapping report inputs), and a planted symlink at either path gets truncated. Both files are now unique per run (`mktemp`) and removed on exit.

## AI Assistance

AI-assisted review of the temp-file lifecycle. The author reproduced the collision shape and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `bash -n ods/scripts/ods-doctor.sh` - passed.
