### PR TITLE
fix(opencode): restart Windows OpenCode through the registered task

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10937,9 +10937,23 @@ for ($attempt = 0; $attempt -lt 30; $attempt++) {
     Start-Sleep -Milliseconds 500
 }
 if (@(Get-ODSOpenCodeProcesses).Count -ne 0) { throw 'Could not stop ODS OpenCode' }
-Start-Process -FilePath $exe `
-    -ArgumentList @('web', '--port', [string]$port, '--hostname', '127.0.0.1') `
-    -WindowStyle Hidden | Out-Null
+# Restart through the Task Scheduler task the installer registered so the
+# ODS launcher clears OPENCODE_SERVER_PASSWORD and the process is not orphaned
+# when the logon trigger fires again. Fall back to a direct launch only when
+# the task is missing (e.g. an install that skipped task registration).
+$restarted = $false
+try {
+    $task = Get-ScheduledTask -TaskName 'ODSOpenCodeWeb' -ErrorAction Stop
+    Start-ScheduledTask -TaskName $task.TaskName -ErrorAction Stop
+    $restarted = $true
+} catch {
+    $restarted = $false
+}
+if (-not $restarted) {
+    Start-Process -FilePath $exe `
+        -ArgumentList @('web', '--port', [string]$port, '--hostname', '127.0.0.1') `
+        -WindowStyle Hidden | Out-Null
+}
 'true'
 '''
     command = ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command", script]


### PR DESCRIPTION
## Summary

Restarting Windows OpenCode killed and relaunched the binary directly, bypassing the scheduled task that owns the process lifecycle. Task state went stale and the next trigger started a second instance alongside the manual one. Restarts now go through the registered task so ownership stays consistent.

## AI Assistance

AI-assisted search for restart call sites. The author reviewed the task-based flow and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `python3 -m py_compile ods/bin/ods-host-agent.py` - passed.
