### PR TITLE
fix(api): trim whitespace in DASHBOARD_ALLOWED_ORIGINS entries

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1065,7 +1065,7 @@ app = FastAPI(
 def get_allowed_origins():
     env_origins = os.environ.get("DASHBOARD_ALLOWED_ORIGINS", "")
     if env_origins:
-        return env_origins.split(",")
+        return [origin.strip() for origin in env_origins.split(",") if origin.strip()]
     origins = [
         "http://localhost:3001", "http://127.0.0.1:3001",
         "http://localhost:3000", "http://127.0.0.1:3000",

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -54,6 +54,21 @@ class TestGetAllowedOrigins:
         origins = get_allowed_origins()
         assert origins == ["http://foo:3000", "http://bar:3001"]
 
+    def test_strips_whitespace_around_env_origins(self, monkeypatch):
+        monkeypatch.setenv(
+            "DASHBOARD_ALLOWED_ORIGINS",
+            "http://foo:3000, http://bar:3001 , http://baz:3002",
+        )
+        assert get_allowed_origins() == [
+            "http://foo:3000", "http://bar:3001", "http://baz:3002",
+        ]
+
+    def test_drops_blank_env_origin_entries(self, monkeypatch):
+        monkeypatch.setenv(
+            "DASHBOARD_ALLOWED_ORIGINS", "http://foo:3000,, http://bar:3001"
+        )
+        assert get_allowed_origins() == ["http://foo:3000", "http://bar:3001"]
+
     def test_returns_defaults_when_env_not_set(self, monkeypatch):
         monkeypatch.delenv("DASHBOARD_ALLOWED_ORIGINS", raising=False)
         origins = get_allowed_origins()


### PR DESCRIPTION
## Summary

`get_allowed_origins()` comma-split `DASHBOARD_ALLOWED_ORIGINS` without trimming, and Starlette's CORSMiddleware matches origins byte-exactly — so a space after a comma silently disabled every origin after the first, with no server-side hint. Entries are now trimmed and blanks dropped.

## AI Assistance

AI-assisted check of middleware matching semantics. The author reviewed the parsing change and extended the unit coverage for it, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [x] Dashboard API
- [ ] CI workflows

## Validation

- `pytest tests/test_main.py -k GetAllowedOrigins` (dashboard-api) - passed (6).
- `python3 -m py_compile ods/extensions/services/dashboard-api/main.py` - passed.
