### PR TITLE
fix(preflight): name the install dir when the log cannot be created

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-preflight-log-writable.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -97,7 +97,14 @@ pass() { log "${GREEN}✓${NC} $1"; PASS=$((PASS+1)); }
 fail() { log "${RED}✗${NC} $1"; FAIL=$((FAIL+1)); }
 warn() { log "${YELLOW}⚠${NC} $1"; WARN=$((WARN+1)); }
 
-echo "" > "$LOG_FILE"
+# Name the problem instead of dying on the bare redirect: under `set -e` an
+# unwritable install dir exits here with a status and no actionable context.
+if ! : > "$LOG_FILE"; then
+    echo "ERROR: cannot create the preflight log: $LOG_FILE" >&2
+    echo "       $ODS_DIR is not writable by $(id -un). Fix ownership and re-run:" >&2
+    echo "       sudo chown -R \"$(id -un):$(id -gn)\" \"$ODS_DIR\"" >&2
+    exit 1
+fi
 log "========================================"
 log "ODS Pre-flight Check"
 log "Started: $(date)"

--- a/ods/tests/test-preflight-log-writable.sh
+++ b/ods/tests/test-preflight-log-writable.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Regression: ods-preflight.sh must name the unwritable install dir instead of
+# dying on a bare redirect under `set -e` (#2930).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# root ignores the write bits, so the unwritable-dir condition cannot be staged.
+if [ "$(id -u)" -eq 0 ]; then
+    echo "SKIP: must run as a non-root user to stage an unwritable directory"
+    exit 0
+fi
+
+tmp="$(mktemp -d)"
+trap 'chmod u+w "$tmp/install" 2>/dev/null; rm -rf "$tmp"' EXIT
+
+# A stand-in install dir holding only the preflight script and the libs it
+# sources before the log is opened, then made read-only.
+mkdir -p "$tmp/install/lib"
+cp "$ROOT/ods-preflight.sh" "$tmp/install/"
+cp "$ROOT/lib/safe-env.sh" "$tmp/install/lib/"
+chmod a-w "$tmp/install"
+
+set +e
+out="$(bash "$tmp/install/ods-preflight.sh" 2>&1)"
+rc=$?
+set -e
+
+fail=0
+if [ "$rc" -eq 0 ]; then
+    echo "FAIL: expected a non-zero exit on an unwritable install dir, got 0"
+    fail=1
+fi
+case "$out" in
+    *"cannot create the preflight log"*) echo "PASS: names the failure" ;;
+    *) echo "FAIL: no actionable error; output was: $out"; fail=1 ;;
+esac
+case "$out" in
+    *"$tmp/install"*) echo "PASS: names the install dir" ;;
+    *) echo "FAIL: error does not name the path; output was: $out"; fail=1 ;;
+esac
+
+[ "$fail" -eq 0 ] || exit 1
+echo "All preflight log-writability tests passed"


### PR DESCRIPTION
## Summary

Fixes #2930.

`ods/ods-preflight.sh:100` opened its log with a bare redirect:

```bash
LOG_FILE="$ODS_DIR/preflight-$(date +%Y%m%d-%H%M%S).log"   # line 19
...
echo "" > "$LOG_FILE"                                       # line 100
```

Run against an install dir the invoking user cannot write (a root-owned `$ODS_DIR` is the common case), `set -euo pipefail` exits right there. All the user gets is bash's terse `Permission denied` — and nothing at all when the caller captures stderr, which is how this surfaces as "the installer does nothing".

Probe writability explicitly and print the path, the user, and the `chown` that fixes it before exiting non-zero.

## AI Assistance

Claude Code drafted the patch and the regression test and ran the validation recorded below. The human author reviewed the diff, chose the validation, and is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: the change only replaces a bare redirect with a guarded one on the failure path; the success path is byte-identical and is covered by the existing preflight tests.

Commands/results:

```text
$ make lint
=== Shell syntax ===
=== Python compile ===
All lint checks passed.

$ bash tests/test-preflight-log-writable.sh
PASS: names the failure
PASS: names the install dir
All preflight log-writability tests passed

# same test against the unpatched script -> fails, so it guards the regression
$ git stash && bash tests/test-preflight-log-writable.sh
FAIL: no actionable error; output was: .../ods-preflight.sh: line 100: .../preflight-....log: Permission denied
exit=1

$ shellcheck --exclude=SC1091,SC2034 --severity=warning \
    ods/ods-preflight.sh ods/tests/test-preflight-log-writable.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- New `tests/test-preflight-log-writable.sh` stages a read-only install dir and asserts the error names both the failure and the path. Wired into `make test`.
- The test skips itself when run as root, since root ignores the write bits and the condition cannot be staged.
- No behaviour change when the log is writable.

