### PR TITLE
fix(models): expose speedBytesPerSec in bootstrap download-status fallback

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -1396,6 +1396,7 @@ def model_download_status(api_key: str = Depends(verify_api_key)):
             "bytesDownloaded": int((bootstrap_info.downloaded_gb or 0) * 1024**3),
             "bytesTotal": int((bootstrap_info.total_gb or 0) * 1024**3),
             "speedMbps": bootstrap_info.speed_mbps,
+            "speedBytesPerSec": int((bootstrap_info.speed_mbps or 0) * 1024 * 1024),
             "eta": bootstrap_info.eta_seconds,
         }
     try:

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -2655,3 +2655,28 @@ def test_load_model_rejects_local_gguf_path_separators(test_client, monkeypatch,
     )
 
     assert resp.status_code == 404
+
+
+def test_download_status_bootstrap_fallback_exposes_speed_bytes_per_sec(test_client, monkeypatch, tmp_path):
+    """The bootstrap fallback must speak the same speed contract as the
+    file-based and host-agent payloads so the UI progress bar can render MB/s."""
+    models_router, _install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    monkeypatch.setattr(models_router, "_get_agent_model_status", lambda: None)
+    monkeypatch.setattr(
+        models_router,
+        "get_bootstrap_status",
+        lambda: BootstrapStatus(
+            active=True,
+            model_name="Qwen3.5-9B-Q4_K_M.gguf",
+            percent=12.5,
+            speed_mbps=3.5,
+        ),
+    )
+
+    resp = test_client.get("/api/models/download-status", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["status"] == "downloading"
+    assert payload["speedMbps"] == 3.5
+    assert payload["speedBytesPerSec"] == int(3.5 * 1024 * 1024)


### PR DESCRIPTION
## Summary

First-run model downloads reported **0.0 MB/s** for the whole transfer: the bootstrap fallback in `/api/models/download-status` emitted only `speedMbps`, while the UI progress hook reads `speedBytesPerSec` — the field the other two payload sources already provide. The fallback now derives bytes/sec from its `speed_mbps` value using the same conversion as `helpers.py`.

## AI Assistance

AI-assisted diff of the three payload sources. The author reviewed the conversion and added focused regression coverage, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [x] Dashboard API
- [ ] CI workflows

## Validation

- `pytest tests/test_models.py -k bootstrap_fallback_exposes` (dashboard-api) - passed.
- `python3 -m py_compile ods/extensions/services/dashboard-api/routers/models.py` - passed.
