### PR TITLE
fix(opencode): show the real model name in switchboard mode

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10763,7 +10763,9 @@ def _opencode_route(env: dict) -> tuple[str, str]:
 def _opencode_model_route(env: dict, model_id: str) -> tuple[str, str, str]:
     provider_id = "llama-server"
     if _normal_switchboard_mode(env) == "enabled":
-        return provider_id, "ods/current", "ods/current"
+        # The switchboard serves every model under the ods/current alias, but
+        # the model picker should still show the real model name, not the alias.
+        return provider_id, "ods/current", model_id
     return provider_id, model_id, model_id
 
 
@@ -10805,7 +10807,7 @@ def _update_opencode_config(
     """Update both OpenCode compatibility files and verify persisted routing."""
     base_url, api_key = _opencode_route(env)
     provider_id, route_model_id, route_display_name = _opencode_model_route(env, model_id)
-    display_name = route_display_name if route_model_id != model_id else (display_name or model_id)
+    display_name = display_name or route_display_name or model_id
     model_ref = f"{provider_id}/{route_model_id}"
 
     for path, previous in snapshot["files"].items():


### PR DESCRIPTION
## Summary

In switchboard mode the surface showed an internal placeholder instead of the model actually being served. The display name now resolves from the active routing entry so what users see matches what answers.

## AI Assistance

AI-assisted lookup of routing metadata sources. The author reviewed the resolution order and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `python3 -m py_compile ods/bin/ods-host-agent.py` - passed.
