### PR TITLE
fix(session-cleanup): do not prune sessions created mid-cycle

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -77,6 +77,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh
 	@echo ""
+	@echo "=== session cleanup snapshot race ==="
+	@bash tests/test-session-cleanup-race.sh
+	@echo ""
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh
 	@echo ""

--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -71,6 +71,16 @@ if [[ -z "$PYTHON_CMD" ]] || ! "$PYTHON_CMD" -c 'import json' >/dev/null 2>&1; t
     exit 1
 fi
 
+# Snapshot marker, stamped *before* the active set is read. A session created
+# between that read and the deletion pass below is not in the active set yet,
+# but it is very much live — judging it by this snapshot would delete the
+# user's just-opened conversation. Files newer than the marker are left alone
+# and picked up by the next run. It lives in SESSIONS_DIR so its mtime comes
+# from the same filesystem clock as the session files it is compared against.
+SNAPSHOT_REF="$SESSIONS_DIR/.cleanup-snapshot.$$"
+: > "$SNAPSHOT_REF"
+trap 'rm -f "$SNAPSHOT_REF"' EXIT
+
 ACTIVE_IDS_OUTPUT=""
 ACTIVE_IDS_EXIT=0
 ACTIVE_IDS_OUTPUT=$("$PYTHON_CMD" - "$SESSIONS_JSON" <<'PY'
@@ -143,6 +153,13 @@ REMOVED_BLOATED=0
 for f in "$SESSIONS_DIR"/*.jsonl; do
     [ -f "$f" ] || continue
     BASENAME=$(basename "$f" .jsonl)
+
+    # Created or touched after the snapshot: the active set we read predates it,
+    # so it cannot tell us whether this session is live. Leave it for next run.
+    if [ "$f" -nt "$SNAPSHOT_REF" ]; then
+        echo "[$(date)] Skipping session newer than this cleanup cycle: $BASENAME"
+        continue
+    fi
 
     # Check if this session is active
     IS_ACTIVE=false

--- a/ods/tests/test-session-cleanup-race.sh
+++ b/ods/tests/test-session-cleanup-race.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Regression: a session created after the active set is read must survive the
+# cleanup pass that is already running (#2931).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLEANUP="$ROOT/scripts/session-cleanup.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+SESSIONS="$tmp/sessions"
+mkdir -p "$SESSIONS"
+
+# sessions.json lists one active session; a second .jsonl is genuinely stale.
+cat > "$SESSIONS/sessions.json" <<'JSON'
+{
+  "a": {"sessionId": "active-one"}
+}
+JSON
+echo '{"role":"user"}' > "$SESSIONS/active-one.jsonl"
+echo '{"role":"user"}' > "$SESSIONS/stale-one.jsonl"
+
+# A third session appears *after* the cleanup stamps its snapshot — the race in
+# #2931. What matters is the ordering (session mtime > snapshot mtime), so stage
+# it deterministically with timestamps rather than trying to win a real race:
+# the index and the pre-existing sessions are backdated, the new one is dated
+# ahead of any marker the script can stamp during this run.
+touch -t 202601010000 "$SESSIONS/sessions.json" \
+    "$SESSIONS/active-one.jsonl" "$SESSIONS/stale-one.jsonl"
+echo '{"role":"user"}' > "$SESSIONS/just-created.jsonl"
+touch -t 209901010000 "$SESSIONS/just-created.jsonl"
+
+out=$(SESSIONS_DIR="$SESSIONS" bash "$CLEANUP" 2>&1)
+
+fail=0
+if [ -f "$SESSIONS/just-created.jsonl" ]; then
+    echo "PASS: session created mid-cleanup survives"
+else
+    echo "FAIL: session created mid-cleanup was deleted"
+    echo "$out"
+    fail=1
+fi
+
+if [ -f "$SESSIONS/active-one.jsonl" ]; then
+    echo "PASS: active session retained"
+else
+    echo "FAIL: active session was deleted"
+    fail=1
+fi
+
+if [ ! -f "$SESSIONS/stale-one.jsonl" ]; then
+    echo "PASS: genuinely inactive session still pruned"
+else
+    echo "FAIL: inactive session was not pruned — the guard is too broad"
+    fail=1
+fi
+
+# The marker must not be left behind in the sessions directory.
+if ! ls "$SESSIONS"/.cleanup-snapshot.* >/dev/null 2>&1; then
+    echo "PASS: snapshot marker cleaned up"
+else
+    echo "FAIL: snapshot marker left in $SESSIONS"
+    fail=1
+fi
+
+[ "$fail" -eq 0 ] || exit 1
+echo "All session-cleanup race tests passed"


### PR DESCRIPTION
## Summary

Fixes #2931.

`ods/scripts/session-cleanup.sh` reads the active session set from `sessions.json` (line ~76), then iterates `"$SESSIONS_DIR"/*.jsonl` (line ~143) and deletes anything not in that set. A session the gateway creates *between* the read and the deletion pass is not in the active set yet — but it is live, and it gets deleted mid-conversation, leaving a dangling index entry once sessions.json is rewritten.

The fix stamps a marker file in `SESSIONS_DIR` immediately *before* the active set is read, and the deletion pass skips any session file newer than that marker:

```bash
SNAPSHOT_REF="$SESSIONS_DIR/.cleanup-snapshot.$$"
: > "$SNAPSHOT_REF"
trap 'rm -f "$SNAPSHOT_REF"' EXIT
...
if [ "$f" -nt "$SNAPSHOT_REF" ]; then
    echo "[$(date)] Skipping session newer than this cleanup cycle: $BASENAME"
    continue
fi
```

A skipped session is not leaked — the next cycle reads an index that now contains it and judges it normally. The marker lives in `SESSIONS_DIR` so its mtime comes from the same filesystem clock as the files it is compared against, and its name (leading dot) cannot be caught by the `*.jsonl`, `*.deleted.*`, or `*.bak*` passes.

## AI Assistance

Claude Code drafted the patch and the regression test and ran the validation recorded below. The human author reviewed the diff, chose the validation, and is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: the change is one guard in one loop in a single script; the new test covers the raced session, the active session, and the genuinely stale session so the guard is shown not to be over-broad.

Commands/results:

```text
$ bash tests/test-session-cleanup-race.sh
PASS: session created mid-cleanup survives
PASS: active session retained
PASS: genuinely inactive session still pruned
PASS: snapshot marker cleaned up
All session-cleanup race tests passed

# against the unpatched script
$ git stash push -- ods/scripts/session-cleanup.sh && bash tests/test-session-cleanup-race.sh
FAIL: session created mid-cleanup was deleted
PASS: active session retained
PASS: genuinely inactive session still pruned
exit=1

$ make lint
=== Shell syntax ===
=== Python compile ===
All lint checks passed.

$ shellcheck --exclude=SC1091,SC2034 --severity=warning \
    ods/scripts/session-cleanup.sh ods/tests/test-session-cleanup-race.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- New `tests/test-session-cleanup-race.sh`, wired into `make test`. It stages the race by timestamp ordering (session mtime ahead of any marker the run can stamp) rather than trying to win a real race, so it is deterministic rather than flaky. The comment in the test says so explicitly.
- The test also asserts the genuinely-inactive session is *still* pruned, so the guard cannot regress into "never delete anything".
- The marker is removed by an `EXIT` trap; the test checks `SESSIONS_DIR` is clean afterwards. This is the script's first trap, so nothing was overwritten.

