### PR TITLE
fix(dashboard): tolerate blocked localStorage in theme persistence

### DIFF
--- a/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
@@ -12,15 +12,32 @@ const DEFAULT_THEME = 'ods'
 
 const ThemeContext = createContext(null)
 
-export function ThemeProvider({ children }) {
-  const [theme, setThemeState] = useState(() => {
+function readStoredTheme() {
+  try {
     const stored = localStorage.getItem(STORAGE_KEY)
     return THEMES.includes(stored) ? stored : DEFAULT_THEME
-  })
+  } catch {
+    // Storage access itself throws when site data is blocked (strict
+    // cookie settings, kiosk profiles): fall back to the default theme
+    // instead of crashing the whole provider tree.
+    return DEFAULT_THEME
+  }
+}
+
+function persistTheme(nextTheme) {
+  try {
+    localStorage.setItem(STORAGE_KEY, nextTheme)
+  } catch {
+    // Same blocked-storage case on write; session-only theme is fine.
+  }
+}
+
+export function ThemeProvider({ children }) {
+  const [theme, setThemeState] = useState(readStoredTheme)
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme)
-    localStorage.setItem(STORAGE_KEY, theme)
+    persistTheme(theme)
   }, [theme])
 
   const setTheme = useCallback((t) => {


### PR DESCRIPTION
## Summary

With site data blocked (strict cookie settings, MDM/kiosk profiles, partitioned webviews) `localStorage.getItem` itself throws, and the ThemeProvider's state initializer crashed the entire dashboard into the root error screen. Reads and writes now go through guarded helpers that fall back to the default theme; every other storage touchpoint here already wrapped access the same way.

## AI Assistance

AI-assisted audit of storage access patterns. The author reviewed the guard placement and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `esbuild --loader:.jsx=jsx` parse of `ThemeContext.jsx` - passed.
