### PR TITLE
fix(host-agent): detect orphaned Windows OpenCode processes on superseded ports

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -10913,7 +10913,7 @@ $action = $env:ODS_OPENCODE_ACTION
 $exe = $env:ODS_OPENCODE_EXE
 $port = [int]$env:ODS_OPENCODE_PORT
 
-function Get-ODSOpenCodeProcesses {
+function Get-ODSOpenCodeProcessesOnPort {
     @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object {
         $_.ExecutablePath -and
         $_.ExecutablePath.Equals($exe, [StringComparison]::OrdinalIgnoreCase) -and
@@ -10922,9 +10922,21 @@ function Get-ODSOpenCodeProcesses {
     })
 }
 
+# Match any ODS-owned OpenCode web process regardless of the port it was
+# started on. OPENCODE_PORT can be changed after launch, and a process bound to
+# an older port would otherwise be invisible to the port-scoped match above,
+# leaving it running as an orphan that still owns the superseded port.
+function Get-ODSOpenCodeProcesses {
+    @(Get-CimInstance Win32_Process -ErrorAction Stop | Where-Object {
+        $_.ExecutablePath -and
+        $_.ExecutablePath.Equals($exe, [StringComparison]::OrdinalIgnoreCase) -and
+        $_.CommandLine -match '(?i)\b(web|serve)\b'
+    })
+}
+
 $owned = @(Get-ODSOpenCodeProcesses)
 if ($action -eq 'inspect') {
-    if ($owned.Count -gt 0) { 'true' } else { 'false' }
+    if ((@(Get-ODSOpenCodeProcessesOnPort)).Count -gt 0) { 'true' } else { 'false' }
     exit 0
 }
 if ($action -ne 'restart') { throw "Unsupported OpenCode action: $action" }


### PR DESCRIPTION
## Summary

After a port reassignment, opencode processes from the previous configuration were invisible to the host agent's process discovery, leaving orphaned listeners bound to superseded ports. Discovery now also sweeps superseded ports so restart/reap logic can account for the strays.

## AI Assistance

AI-assisted enumeration of discovery call sites. The author reviewed the sweep condition and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `python3 -m py_compile ods/bin/ods-host-agent.py` - passed.
