### PR TITLE
fix(token-spy): stop remote session ids re-parsing in the remote shell

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -140,6 +140,9 @@ test: ## Run unit and contract tests
 	@echo "=== token-spy session manager active-id extraction ==="
 	@bash tests/test-token-spy-session-manager.sh
 	@echo ""
+	@echo "=== token-spy remote session cleanup argv safety ==="
+	@bash tests/test-token-spy-remote-rm.sh
+	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 	@echo ""

--- a/ods/extensions/services/token-spy/session-manager.sh
+++ b/ods/extensions/services/token-spy/session-manager.sh
@@ -286,12 +286,30 @@ REMOTESCRIPT
   log "  Sessions: $session_count total, ${#to_remove[@]} to remove"
 
   if [ "${#to_remove[@]}" -gt 0 ]; then
-    local rm_args=""
+    # Session ids come from remote gateway output. Interpolating them into the
+    # remote command line lets shell metacharacters re-parse over there, so send
+    # them NUL-delimited on stdin and let xargs build rm's argv directly — the
+    # remote shell never sees them. The directory stays on the command line
+    # (unquoted, as before) so a leading '~' still expands remotely, and the
+    # chdir keeps the ids themselves free of any path of their own.
+    local rm_names=()
+    local sid
     for sid in "${to_remove[@]}"; do
-      rm_args="${rm_args} ${remote_dir}/${sid}.jsonl"
+      case "$sid" in
+        */*)
+          log "  [SKIP] Refusing path-like session id: $sid"
+          continue
+          ;;
+      esac
+      rm_names+=("${sid}.jsonl")
     done
-    ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "rm -f ${rm_args}" 2>/dev/null || true
-    log "  [DONE] Removed ${#to_remove[@]} sessions on $host"
+
+    if [ "${#rm_names[@]}" -gt 0 ]; then
+      printf '%s\0' "${rm_names[@]}" |
+        ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "cd ${remote_dir} && exec xargs -0 rm -f" ||
+        log "  [WARN] Remote cleanup failed on $host (non-fatal)"
+      log "  [DONE] Removed ${#rm_names[@]} sessions on $host"
+    fi
   else
     log "  [OK] No cleanup needed"
   fi

--- a/ods/tests/test-token-spy-remote-rm.sh
+++ b/ods/tests/test-token-spy-remote-rm.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Contract: token-spy must not let remote-derived session ids re-parse in the
+# remote shell when it cleans them up (#2929).
+#
+# The stub below is not a mock that merely records argv — it runs the command
+# ssh was handed in a real shell, in a real directory, with the real stdin. If
+# a session id can inject a second command, that command actually executes and
+# the test sees its side effect.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANAGER="$SCRIPT_DIR/../extensions/services/token-spy/session-manager.sh"
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; exit 1; }
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+REMOTE_ROOT="$WORK/remote"          # stands in for the remote host's cwd
+REMOTE_DIR="$REMOTE_ROOT/sessions"
+mkdir -p "$REMOTE_DIR"
+
+# Sessions as the remote host would report them. "live" is active; the other
+# three are inactive and therefore cleanup candidates.
+INJECT='evil; touch pwned'          # a second command, if it ever re-parses
+TRAVERSE='../escaped'               # a path-like id
+for sid in "live" "stale" "$INJECT" "$TRAVERSE"; do
+  echo '{}' > "$REMOTE_DIR/${sid}.jsonl"
+done
+
+cat > "$WORK/remote-info" <<EOF
+SESSION_LIST_START
+live|100|1
+stale|100|1
+${INJECT}|100|1
+${TRAVERSE}|100|1
+SESSION_LIST_END
+ACTIVE_IDS_START
+live
+ACTIVE_IDS_END
+TOTAL_SIZE=400
+EOF
+
+# ── ssh stub ────────────────────────────────────────────────────────────────
+mkdir -p "$WORK/bin"
+cat > "$WORK/bin/ssh" <<EOF
+#!/bin/bash
+set -eu
+while [ "\${1:-}" = "-o" ]; do shift 2; done
+shift                                  # drop the host
+if [ "\${1:-}" = "bash" ]; then
+    cat > /dev/null                    # consume the inventory heredoc
+    cat "$WORK/remote-info"
+    exit 0
+fi
+# Anything else is a real remote command line: run it as the remote shell
+# would, from the remote home directory, with ssh's stdin passed through.
+cd "$REMOTE_ROOT"
+exec /bin/sh -c "\$*"
+EOF
+chmod +x "$WORK/bin/ssh"
+PATH="$WORK/bin:$PATH"
+
+# ── drive the real function ─────────────────────────────────────────────────
+# Same approach as test-token-spy-session-manager.sh: the script's top level
+# runs a main loop, so extract the one function under test.
+FUNCS="$WORK/funcs.sh"
+sed -n '/^manage_remote_agent()/,/^}/p' "$MANAGER" > "$FUNCS"
+log() { echo "$*" >> "$WORK/log"; }
+: > "$WORK/log"
+REMOTE_FILE_SIZE_LIMIT=999999
+RECENT_MINUTES=10
+# shellcheck disable=SC1090
+source "$FUNCS"
+
+manage_remote_agent "testagent" "fake-host" "$REMOTE_DIR"
+
+echo "Test 1: an injected command in a session id never executes remotely"
+[ -e "$REMOTE_ROOT/pwned.jsonl" ] && fail "injected 'touch pwned' ran on the remote host"
+[ -e "$REMOTE_ROOT/pwned" ] && fail "injected 'touch pwned' ran on the remote host"
+pass "no injected side effect"
+
+echo "Test 2: the literal session file is still the thing that got removed"
+[ -e "$REMOTE_DIR/${INJECT}.jsonl" ] && fail "the awkwardly-named session was not removed"
+pass "session with metacharacters removed by exact name"
+
+echo "Test 3: a path-like session id is refused, not deleted through"
+[ -f "$REMOTE_DIR/${TRAVERSE}.jsonl" ] || fail "path-like id was acted on instead of skipped"
+grep -q "Refusing path-like session id" "$WORK/log" || fail "no log line for the refused id"
+pass "path-like id skipped and logged"
+
+echo "Test 4: ordinary cleanup still works"
+[ -e "$REMOTE_DIR/stale.jsonl" ] && fail "inactive session was not cleaned up"
+[ -f "$REMOTE_DIR/live.jsonl" ] || fail "active session was deleted"
+pass "inactive removed, active kept"
+
+echo "All token-spy remote cleanup tests passed"


### PR DESCRIPTION
## Summary

Fixes #2929.

`ods/extensions/services/token-spy/session-manager.sh:293` (pre-patch):

```bash
local rm_args=""
for sid in "${to_remove[@]}"; do
  rm_args="${rm_args} ${remote_dir}/${sid}.jsonl"
done
ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "rm -f ${rm_args}" 2>/dev/null || true
```

`${rm_args}` is interpolated into a command line that the remote shell parses. The ids in it are read out of remote gateway output (`manage_remote_agent` parses them from the inventory `ssh` at line 201), so a session file whose name carries shell metacharacters re-parses on the far end — extra flags, extra paths, or an entire second command can reach `rm`.

Changes:

- Names go NUL-delimited on stdin; `xargs -0 rm -f` builds rm's argv directly, so the remote shell never parses them.
- The command line keeps `cd ${remote_dir}` unquoted, preserving the existing remote expansion of a `~`-relative operator-configured sessions dir. The chdir also means the ids carry no path of their own.
- Ids containing `/` are refused and logged rather than sent at all — belt and braces against a traversal-shaped name.
- The `2>/dev/null || true` is replaced with a `[WARN]` log, per the repo's error-handling rules; a failed remote cleanup was previously indistinguishable from a successful one.

## AI Assistance

Claude Code drafted the patch and the regression test and ran the validation recorded below. The human author reviewed the diff, chose the validation, and is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: the change is confined to the cleanup branch of one function, and the new test drives that function for real against a stubbed host rather than asserting on a constructed string.

Commands/results:

```text
$ bash tests/test-token-spy-remote-rm.sh
Test 1: an injected command in a session id never executes remotely
  + no injected side effect
Test 2: the literal session file is still the thing that got removed
  + session with metacharacters removed by exact name
Test 3: a path-like session id is refused, not deleted through
  + path-like id skipped and logged
Test 4: ordinary cleanup still works
  + inactive removed, active kept
All token-spy remote cleanup tests passed

# the same test against the unpatched script — the injection actually fires
$ git stash push -- ods/extensions/services/token-spy/session-manager.sh
$ bash tests/test-token-spy-remote-rm.sh
  x injected 'touch pwned' ran on the remote host
exit=1

$ make lint
=== Shell syntax ===
=== Python compile ===
All lint checks passed.

# CI gates on error severity; clean there. The two SC2087 warnings on the
# inventory heredoc at line 201 are pre-existing on main (verified by running
# shellcheck against the stashed file) and are deliberate — the comment above
# that heredoc says ${remote_dir} must expand client-side.
$ shellcheck --exclude=SC1091,SC2034 --severity=error \
    ods/extensions/services/token-spy/session-manager.sh \
    ods/tests/test-token-spy-remote-rm.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- New `tests/test-token-spy-remote-rm.sh`, wired into `make test`. It follows the existing `test-token-spy-session-manager.sh` pattern of extracting the function under test, and stubs `ssh` with a script that **actually runs** the command line it is handed, in a real directory, with real stdin — so an injected command genuinely executes and leaves a file behind if the guard fails. It is a demonstration, not a mock assertion.
- Test 4 pins the ordinary path (inactive removed, active kept) so the new guard cannot regress into "never delete anything".
- `xargs -0` is assumed present on the remote host; it is in GNU findutils and busybox alike. If ODS supports a remote target where that is not true, say so and I will fall back to per-argument quoting instead.
- Line 391 also interpolates `${remote_dir}` into a remote command, but that value comes from the operator's local `REMOTE_AGENTS` config rather than from remote output, so it is outside the reported bug. Left alone.

