### PR TITLE
fix(dashboard): release microphone when leaving ODS Talk mid-recording

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -188,6 +188,18 @@ export default function ODSTalk() {
     return () => {
       streamControllerRef.current?.abort()
       streamControllerRef.current = null
+      // Leaving the page mid-recording must release the microphone. The
+      // recorder's onstop handler is what stops the media tracks, so stop
+      // the recorder here instead of only through the button path.
+      const recorder = recorderRef.current
+      recorderRef.current = null
+      if (recorder && recorder.state !== 'inactive') {
+        try {
+          recorder.stop()
+        } catch (err) {
+          console.debug('recorder stop on unmount failed', err)
+        }
+      }
     }
   }, [])
 


### PR DESCRIPTION
## Summary

Leaving ODS Talk mid-recording aborted the chat stream but never touched the `MediaRecorder`: tracks stop only inside its `onstop`, which fires solely from the button path. Navigating away kept the microphone live and buffering audio. Unmount cleanup now stops the recorder, releasing capture through the existing `onstop` handler.

## AI Assistance

AI-assisted trace of recording teardown paths. The author reviewed the cleanup addition and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Installer
- [ ] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `esbuild --loader:.jsx=jsx` parse of `ODSTalk.jsx` - passed.
