### PR TITLE
fix(windows): quote spaced paths in host agent Start-Process args

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2774,6 +2774,7 @@ function Invoke-Agent {
             $_agentCommand = @"
 `$env:PATH = $_dockerPathLiteral + `$env:PATH
 `$agentArgs = $_pythonPrefixArgsLiteral + @($_agentScriptLiteral, '--port', '$port', '--pid-file', $_pidFileLiteral, '--install-dir', $_installDirLiteral)
+`$agentArgs = `$agentArgs | ForEach-Object { if (`$_ -match '\s') { '"' + `$_ + '"' } else { `$_ } }
 Set-Location $_installDirLiteral
 Start-Process -FilePath $_pythonLiteral -ArgumentList `$agentArgs -WorkingDirectory $_installDirLiteral -WindowStyle Hidden -RedirectStandardError $_logFileLiteral
 "@

--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -470,6 +470,7 @@ if (Test-Path $_agentScript) {
         $_agentCommand = @"
 `$env:PATH = $_dockerPathLiteral + `$env:PATH
 `$agentArgs = $_pythonPrefixArgsLiteral + @($_agentScriptLiteral, '--port', '$($script:ODS_AGENT_PORT)', '--pid-file', $_pidFileLiteral, '--install-dir', $_installDirLiteral)
+`$agentArgs = `$agentArgs | ForEach-Object { if (`$_ -match '\s') { '"' + `$_ + '"' } else { `$_ } }
 Set-Location $_installDirLiteral
 Start-Process -FilePath $_pythonLiteral -ArgumentList `$agentArgs -WorkingDirectory $_installDirLiteral -WindowStyle Hidden -RedirectStandardError $_logFileLiteral -Wait
 "@


### PR DESCRIPTION
## Summary

Windows PowerShell 5.1 joins `Start-Process -ArgumentList` elements with spaces but no quoting, so any install path containing a space produced a truncated argv for the host agent (`C:\Users\John` instead of `C:\Users\John Smith\...`) and python exited instantly while the installer continued green. Agent args containing whitespace are now double-quoted before launch.

## AI Assistance

AI-assisted review of generated task-script quoting. The author traced the argv split and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [ ] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- Diff reviewed against PS 5.1 `Start-Process -ArgumentList` joining semantics; `PSScriptAnalyzer` (lint-powershell.yml) will parse-check in CI (no local pwsh).
