### PR TITLE
fix(doctor): reuse shared safe-env loader for .env parsing

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -41,22 +41,16 @@ if [[ -f "$ROOT_DIR/lib/safe-env.sh" ]]; then
     . "$ROOT_DIR/lib/safe-env.sh"
 fi
 
-# Safe .env loading (no direct source to avoid injection)
-load_env_safe() {
-    local env_file="${1:-$ROOT_DIR/.env}"
-    [[ -f "$env_file" ]] || return 0
-    while IFS='=' read -r key value; do
-        value="${value%$'\r'}"
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        value="${value%\"}"
-        value="${value#\"}"
-        value="${value%\'}"
-        value="${value#\'}"
-        export "$key=$value"
-    done < "$env_file"
-}
+# Safe .env loading: delegate to the shared matched-pair quote parser
+# in lib/safe-env.sh so doctor sees exactly the values ods-cli and
+# Compose see (the removed copy stripped each quote type independently
+# and rejected keys with leading whitespace, producing wrong ports and
+# secrets in doctor reports).
+if declare -F load_env_file >/dev/null 2>&1; then
+    load_env_safe() {
+        load_env_file "${1:-$ROOT_DIR/.env}"
+    }
+fi
 load_env_safe "$ROOT_DIR/.env"
 sr_resolve_ports
 _DASHBOARD_PORT="${SERVICE_PORTS[dashboard]:-3001}"


### PR DESCRIPTION
## Summary

Doctor shipped a private `.env` parser that diverged from `lib/safe-env.sh` in two visible ways: keys with leading whitespace were rejected outright (so doctor probed default ports against stacks listening on overridden ones), and each quote type was stripped independently — the exact pattern safe-env's header calls out as corrupting values that legitimately begin or end with the other quote. `load_env_safe` now delegates to the shared `load_env_file` behind a `declare -F` guard, so doctor sees precisely what ods-cli and Compose see.

## AI Assistance

AI-assisted comparison of the two parsers. The author verified delegation behavior against leading-whitespace and mixed-quote fixtures and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `bash -n ods/scripts/ods-doctor.sh` - passed.
- Delegation sanity-checked locally: leading-whitespace key resolves and matched-pair quotes survive verbatim.
