### PR TITLE
fix(bootstrap): fit the fast-start context to small discrete GPUs

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -25,6 +25,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-tier-map.sh
 	@bash tests/test-installer-context-parity.sh
 	@bash tests/test-hermes-context-floor.sh
+	@bash tests/test-bootstrap-context-vram.sh
 	@echo ""
 	@echo "=== Hermes slash worker prune ==="
 	@bash tests/test-hermes-slash-worker-prune.sh

--- a/ods/installers/lib/bootstrap-model.sh
+++ b/ods/installers/lib/bootstrap-model.sh
@@ -23,6 +23,34 @@ BOOTSTRAP_GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/
 BOOTSTRAP_GGUF_SHA256="aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223"
 BOOTSTRAP_LLM_MODEL="qwen3.5-2b"
 BOOTSTRAP_MAX_CONTEXT=65536
+# Below this much dedicated VRAM, the bootstrap weights plus a 64K KV cache do
+# not fit and the kernel SIGKILLs llama-server at boot (exit 137).
+BOOTSTRAP_MIN_VRAM_MB=8192
+
+# bootstrap_max_context — context the bootstrap server can actually hold.
+#
+# Hermes wants a 64K floor, but raising MAX_CONTEXT to it unconditionally
+# OOM-kills llama-server on small discrete cards: the install reports success
+# over a port nothing is listening on. On such hardware keep the context the
+# tier map already fitted to this GPU's VRAM.
+#
+# Pure. Args: fitted context, VRAM in MB, GPU memory type ("discrete",
+# "unified", "mixed", "none"). Echoes the context to use.
+#
+# Only "discrete" is clamped: unified and mixed memory are not bounded by a
+# dedicated VRAM budget, and a CPU-only install reports 0 MB and pages from RAM.
+bootstrap_max_context() {
+    local fitted="${1:-0}" vram_mb="${2:-0}" memory_type="${3:-}"
+
+    if [[ "$memory_type" == "discrete" \
+          && "$vram_mb" -gt 0 && "$vram_mb" -lt "$BOOTSTRAP_MIN_VRAM_MB" \
+          && "$fitted" -gt 0 && "$fitted" -lt "$BOOTSTRAP_MAX_CONTEXT" ]]; then
+        echo "$fitted"
+        return 0
+    fi
+
+    echo "$BOOTSTRAP_MAX_CONTEXT"
+}
 
 # bootstrap_needed — Should we use the fast-start bootstrap pattern?
 #

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -686,7 +686,10 @@ else
         GGUF_URL="$BOOTSTRAP_GGUF_URL"
         GGUF_SHA256="${BOOTSTRAP_GGUF_SHA256:-}"
         LLM_MODEL="$BOOTSTRAP_LLM_MODEL"
-        MAX_CONTEXT="$BOOTSTRAP_MAX_CONTEXT"
+        MAX_CONTEXT="$(bootstrap_max_context "$FULL_MAX_CONTEXT" "${GPU_VRAM:-0}" "${GPU_MEMORY_TYPE:-}")"
+        if [[ "$MAX_CONTEXT" != "$BOOTSTRAP_MAX_CONTEXT" ]]; then
+            ai_warn "Bootstrap context held at ${MAX_CONTEXT} (not ${BOOTSTRAP_MAX_CONTEXT}): ${GPU_VRAM}MB of dedicated VRAM cannot hold a 64K KV cache."
+        fi
         ai "Fast-start mode: downloading bootstrap model (~1.5GB) for instant chat."
         ai "Your full model ($FULL_LLM_MODEL) will download in the background."
     fi

--- a/ods/tests/test-bootstrap-context-vram.sh
+++ b/ods/tests/test-bootstrap-context-vram.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Contract: the bootstrap fast-start must not raise MAX_CONTEXT to the 64K
+# Hermes floor on a discrete GPU too small to hold the KV cache (#2927).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+. "$ROOT/installers/lib/bootstrap-model.sh"
+
+PASS=0
+FAIL=0
+check() {
+    local label="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+        echo "[PASS] $label (=$got)"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label: expected $expected, got $got"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# fitted context, VRAM MB, memory type
+check "4GB discrete card keeps the tier-fitted context" \
+    8192 "$(bootstrap_max_context 8192 4096 discrete)"
+check "6GB discrete card keeps the tier-fitted context" \
+    16384 "$(bootstrap_max_context 16384 6144 discrete)"
+
+check "8GB discrete card reaches the 64K floor" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 32768 8192 discrete)"
+check "24GB discrete card reaches the 64K floor" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 131072 24576 discrete)"
+
+check "unified memory is exempt regardless of size" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 8192 4096 unified)"
+check "mixed memory is exempt" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 8192 4096 mixed)"
+check "CPU-only (no VRAM) is exempt" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 8192 0 none)"
+
+check "a fitted context already above the floor is not lowered" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 131072 4096 discrete)"
+check "an unknown fitted context falls back to the floor" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 0 4096 discrete)"
+check "an unknown memory type is not clamped" \
+    "$BOOTSTRAP_MAX_CONTEXT" "$(bootstrap_max_context 8192 4096 "")"
+
+# The clamp is worthless if phase 11 still assigns the constant directly.
+if grep -q 'MAX_CONTEXT="$(bootstrap_max_context "$FULL_MAX_CONTEXT"' \
+        "$ROOT/installers/phases/11-services.sh"; then
+    echo "[PASS] phase 11 routes the bootstrap context through bootstrap_max_context"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] phase 11 must set MAX_CONTEXT via bootstrap_max_context"
+    FAIL=$((FAIL + 1))
+fi
+
+echo "------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Fixes #2927.

`installers/lib/bootstrap-model.sh:25` pins `BOOTSTRAP_MAX_CONTEXT=65536`, and `installers/phases/11-services.sh:689` assigned it straight across:

```bash
FULL_MAX_CONTEXT="$MAX_CONTEXT"      # the tier map's VRAM-fitted value
...
MAX_CONTEXT="$BOOTSTRAP_MAX_CONTEXT" # ...thrown away
```

On a discrete card under 8GB the bootstrap weights plus a 64K KV cache do not fit, llama-server is SIGKILLed at boot (exit 137), and the install summary reports success over a port nothing is listening on. The fitted context the tier map had just computed for that exact GPU was already sitting in `FULL_MAX_CONTEXT`.

New pure helper in the lib, called from the phase:

```bash
bootstrap_max_context() {
    local fitted="${1:-0}" vram_mb="${2:-0}" memory_type="${3:-}"
    if [[ "$memory_type" == "discrete" \
          && "$vram_mb" -gt 0 && "$vram_mb" -lt "$BOOTSTRAP_MIN_VRAM_MB" \
          && "$fitted" -gt 0 && "$fitted" -lt "$BOOTSTRAP_MAX_CONTEXT" ]]; then
        echo "$fitted"; return 0
    fi
    echo "$BOOTSTRAP_MAX_CONTEXT"
}
```

Scope of the clamp, deliberately narrow:

- only `GPU_MEMORY_TYPE=discrete` — `unified` and `mixed` are not bounded by a dedicated VRAM budget, and CPU-only reports 0 MB and pages from RAM;
- only when VRAM is a positive reading below 8GB, so an unknown/failed VRAM probe keeps today's behaviour;
- only when the fitted context is *smaller* than the floor, so it can never lower a machine that already reaches 64K.

`BOOTSTRAP_MAX_CONTEXT` itself is unchanged at 65536, so `tests/test-installer-context-parity.sh` (which pins that constant across all three platforms) still passes. When the clamp fires it prints a warning naming the VRAM figure, rather than quietly shipping a different context than the one Hermes asked for.

## AI Assistance

Claude Code drafted the patch and the regression test and ran the validation recorded below. The human author reviewed the diff, chose the validation, and is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: I do not have a sub-8GB discrete NVIDIA host to reproduce the exit-137 crash on. What is verified here is the decision function across the hardware matrix and the fact that the phase now routes through it; the VRAM/memory-type inputs come from existing detection that is already covered by `tests/test-jetson-detection.sh` and phase 02.

Commands/results:

```text
$ bash tests/test-bootstrap-context-vram.sh
[PASS] 4GB discrete card keeps the tier-fitted context (=8192)
[PASS] 6GB discrete card keeps the tier-fitted context (=16384)
[PASS] 8GB discrete card reaches the 64K floor (=65536)
[PASS] 24GB discrete card reaches the 64K floor (=65536)
[PASS] unified memory is exempt regardless of size (=65536)
[PASS] mixed memory is exempt (=65536)
[PASS] CPU-only (no VRAM) is exempt (=65536)
[PASS] a fitted context already above the floor is not lowered (=65536)
[PASS] an unknown fitted context falls back to the floor (=65536)
[PASS] an unknown memory type is not clamped (=65536)
[PASS] phase 11 routes the bootstrap context through bootstrap_max_context
PASS=11 FAIL=0

# against main: the helper does not exist
$ git stash push -- ods/installers/lib/bootstrap-model.sh ods/installers/phases/11-services.sh
$ bash tests/test-bootstrap-context-vram.sh
bootstrap_max_context: command not found
[FAIL] 4GB discrete card keeps the tier-fitted context: expected 8192, got
exit=1

# the two suites that pin context values across platforms still pass
$ bash tests/test-installer-context-parity.sh
Results: 76 passed
$ bash tests/test-hermes-context-floor.sh
  PASS: Linux Hermes floor preserves 128K-capable contexts
  PASS: Windows and macOS Hermes floors are 64K
  PASS: Linux/Windows Hermes feature phases do not force 128K

$ make lint
All lint checks passed.

$ shellcheck --exclude=SC1091,SC2034 --severity=warning \
    ods/installers/lib/bootstrap-model.sh ods/tests/test-bootstrap-context-vram.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- **Linux only.** `install-macos.sh:1944` does the same assignment but Apple Silicon is unified memory and is exempt by the issue's own reasoning. `install-windows.ps1:323` (`$tierConfig.MaxContext = $script:BOOTSTRAP_MAX_CONTEXT`) is a genuine sibling — a Windows host with a 4GB dGPU has the same problem — but I have no way to exercise the Windows installer here, so I left it rather than ship an unverified change to it. Happy to port the same clamp if you want it in this PR.
- The 8GB threshold is the issue's figure. It is a single constant (`BOOTSTRAP_MIN_VRAM_MB`) if you would rather tune it.
- Phase 02 already routes NVIDIA cards under 4096MB to a CPU/Tier-0 fallback, so this mainly covers the 4-8GB band and the exactly-4096MB reading that the `-lt 4096` check there does not catch.
- The issue also mentions exempting an explicit `HERMES_CONTEXT_SIZE` override. That variable is set in the feature phases and never reaches this assignment, so there was nothing to exempt at this site — flagging it in case you read the scope differently.

