### PR TITLE
fix(workflows): use n8n public activation contract

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -209,10 +209,13 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
             async with session.post(f"{N8N_URL}/api/v1/workflows", headers=headers, json=workflow_data) as resp:
                 if resp.status in (200, 201):
                     result = await resp.json()
-                    n8n_id = result.get("data", {}).get("id")
+                    n8n_id = result.get("id") if isinstance(result, dict) else None
                     activated = False
                     if n8n_id:
-                        async with session.patch(f"{N8N_URL}/api/v1/workflows/{n8n_id}", headers=headers, json={"active": True}) as activate_resp:
+                        async with session.post(
+                            f"{N8N_URL}/api/v1/workflows/{n8n_id}/activate",
+                            headers=headers,
+                        ) as activate_resp:
                             activated = activate_resp.status == 200
                     return {"status": "success", "workflowId": workflow_id, "n8nId": n8n_id, "activated": activated, "message": f"{wf_info['name']} is now active!"}
                 else:

--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -217,7 +217,12 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
                             headers=headers,
                         ) as activate_resp:
                             activated = activate_resp.status == 200
-                    return {"status": "success", "workflowId": workflow_id, "n8nId": n8n_id, "activated": activated, "message": f"{wf_info['name']} is now active!"}
+                    message = (
+                        f"{wf_info['name']} is now active!"
+                        if activated
+                        else f"{wf_info['name']} was imported but could not be activated."
+                    )
+                    return {"status": "success", "workflowId": workflow_id, "n8nId": n8n_id, "activated": activated, "message": message}
                 else:
                     error_text = await resp.text()
                     raise HTTPException(status_code=resp.status, detail=f"n8n API error: {error_text}")

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -664,12 +664,12 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     (workflow_dir / "ok-wf.json").write_text(json.dumps({"name": "OK Workflow", "nodes": []}))
     monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
 
-    # Mock n8n POST (create) → 201 with id
+    # Mock n8n POST (create) → 200 with a top-level workflow object.
     create_resp = AsyncMock()
-    create_resp.status = 201
-    create_resp.json = AsyncMock(return_value={"data": {"id": "n8n-99"}})
+    create_resp.status = 200
+    create_resp.json = AsyncMock(return_value={"id": "n8n-99", "name": "OK Workflow"})
 
-    # Mock n8n PATCH (activate) → 200
+    # Mock n8n POST /{id}/activate → 200
     activate_resp = AsyncMock()
     activate_resp.status = 200
 
@@ -682,8 +682,7 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     activate_ctx.__aexit__ = AsyncMock(return_value=False)
 
     session_mock = AsyncMock()
-    session_mock.post = MagicMock(return_value=create_ctx)
-    session_mock.patch = MagicMock(return_value=activate_ctx)
+    session_mock.post = MagicMock(side_effect=[create_ctx, activate_ctx])
     session_mock.__aenter__ = AsyncMock(return_value=session_mock)
     session_mock.__aexit__ = AsyncMock(return_value=False)
 
@@ -698,6 +697,9 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     assert data["status"] == "success"
     assert data["n8nId"] == "n8n-99"
     assert data["activated"] is True
+    assert session_mock.post.call_args_list[1].args[0].endswith(
+        "/api/v1/workflows/n8n-99/activate"
+    )
 
 
 def test_workflow_enable_n8n_error(test_client, tmp_path, monkeypatch):

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -697,9 +697,67 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     assert data["status"] == "success"
     assert data["n8nId"] == "n8n-99"
     assert data["activated"] is True
+    assert data["message"] == "OK Workflow is now active!"
     assert session_mock.post.call_args_list[1].args[0].endswith(
         "/api/v1/workflows/n8n-99/activate"
     )
+
+
+def test_workflow_enable_reports_activation_rejection(test_client, tmp_path, monkeypatch):
+    """A successful import must not claim a rejected activation succeeded."""
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "manual-wf", "name": "Manual Workflow", "description": "test",
+             "file": "manual-wf.json", "dependencies": []}
+        ],
+        "categories": {}
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "manual-wf.json").write_text(json.dumps({
+        "name": "Manual Workflow",
+        "nodes": [{"type": "n8n-nodes-base.manualTrigger"}],
+    }))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
+
+    create_resp = AsyncMock()
+    create_resp.status = 201
+    create_resp.json = AsyncMock(return_value={"id": "n8n-manual"})
+
+    activate_resp = AsyncMock()
+    activate_resp.status = 400
+
+    create_ctx = AsyncMock()
+    create_ctx.__aenter__ = AsyncMock(return_value=create_resp)
+    create_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    activate_ctx = AsyncMock()
+    activate_ctx.__aenter__ = AsyncMock(return_value=activate_resp)
+    activate_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session_mock = AsyncMock()
+    session_mock.post = MagicMock(side_effect=[create_ctx, activate_ctx])
+    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+    session_mock.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+        resp = test_client.post(
+            "/api/workflows/manual-wf/enable",
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert data["n8nId"] == "n8n-manual"
+    assert data["activated"] is False
+    assert data["message"] == "Manual Workflow was imported but could not be activated."
 
 
 def test_workflow_enable_n8n_error(test_client, tmp_path, monkeypatch):

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -722,7 +722,13 @@ def test_workflow_enable_reports_activation_rejection(test_client, tmp_path, mon
     workflow_dir.mkdir()
     (workflow_dir / "manual-wf.json").write_text(json.dumps({
         "name": "Manual Workflow",
-        "nodes": [{"type": "n8n-nodes-base.manualTrigger"}],
+        "nodes": [
+            {"name": "Start", "type": "n8n-nodes-base.manualTrigger"},
+            {"name": "Do Work", "type": "n8n-nodes-base.set"},
+        ],
+        "connections": {
+            "Start": {"main": [[{"node": "Do Work", "type": "main", "index": 0}]]}
+        },
     }))
     monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
 


### PR DESCRIPTION
﻿## Summary
- read the created n8n workflow ID from the top-level workflow object returned by the Public API
- activate the imported workflow with `POST /api/v1/workflows/{id}/activate`
- update the endpoint regression test to assert the shipped n8n contract

## Why this matters
ODS pins `n8nio/n8n:2.6.4`. Its Public API create operation returns a workflow object, while activation is a dedicated POST endpoint. The dashboard currently reads `data.id` and sends a PATCH to `/workflows/{id}`; therefore `POST /api/workflows/{workflow_id}/enable` can import a workflow but leaves it inactive while claiming it is active.

Root cause: the router test encoded a response shape and activation method that do not match n8n's Public API. The invariant is that a successful ODS enable request must use the ID returned by create and invoke n8n's activation operation for that exact ID.

Provider contract:
- https://github.com/n8n-io/n8n/blob/n8n%402.6.4/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
- https://github.com/n8n-io/n8n/blob/n8n%402.6.4/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.activate.yml

## Overlap check
Searched open and closed PR titles for `n8n workflow activate`, `n8n activate`, and `workflow activation`, and inspected every open PR touching `routers/workflows.py`. No PR covers the create-response/activation contract. Related open PRs are independent: #2114/#2749 change installed-workflow name matching, #2748 bounds execution pagination, #2469 validates workflow-list payloads, and #2187 resolves dependency aliases.

## Regression test
`test_workflow_enable_success` exercises the authenticated `POST /api/workflows/ok-wf/enable` boundary. It now supplies n8n's top-level create response and asserts the second upstream call is `POST .../workflows/n8n-99/activate`.

Pre-fix evidence: the test failed because the endpoint returned `n8nId: null`. Post-fix validation:

- `pytest tests/test_workflows.py -q` ? 45 passed
- `python -m py_compile routers/workflows.py tests/test_workflows.py` ? passed
- `git diff --check` ? passed

## Tradeoffs and rollback
This keeps the existing ODS response shape and accepted create status codes. It does not change import rollback behavior when n8n activation itself rejects a workflow. Reverting commit `028af113` restores the old behavior; no persisted ODS schema or configuration changes are involved.

Generated with Codex
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.

## Follow-up for #3585

Commit dce594fe extends the same endpoint contract after n8n rejects activation (the normal outcome for manual-trigger-only templates). The response now keeps activated: false and reports that import succeeded but activation did not, instead of simultaneously claiming the workflow is active.

Focused validation after the follow-up: pytest tests/test_workflows.py -q ? 46 passed; git diff --check ? passed.

## Integration follow-up

Follow-up `94990a27` keeps the activation-rejection fixture runnable under the non-runnable-template guard in #3591. The branch remains green on `test_workflows.py` (46 passed), and a synthetic merge with #3591 plus #3592/#3593/#3594 passes 54 workflow contract tests.