### PR TITLE
fix(amd): read the real gfx target and refuse to guess one

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -51,6 +51,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
+	@bash tests/test-amd-gfx-target.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh
 	@bash tests/contracts/test-windows-strix-tier-map.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh

--- a/ods/installers/lib/amd-topo.sh
+++ b/ods/installers/lib/amd-topo.sh
@@ -147,6 +147,44 @@ amd_gfx_version() {
     echo "unknown"
 }
 
+# Read the gfx target the kernel itself reports, from the KFD topology.
+#
+# This is the authority: amdkfd publishes gfx_target_version per node long
+# before rocm-smi/amd-smi/rocminfo are installed, and it was populated
+# correctly on the gfx1200 host that #2844 hard-froze while every probe above
+# returned empty.
+#
+# Node 0 is the CPU node and legitimately reports gfx_target_version 0, so
+# nodes are filtered on simd_count > 0. gfx_target_version packs the target as
+# MMmmss decimal: 120000 -> gfx1200, 110501 -> gfx1151, 90010 -> gfx90a (the
+# step is hex, which is where the trailing letter comes from).
+#
+# KFD_TOPOLOGY_ROOT is overridable so this can be exercised against fixtures.
+amd_kfd_gfx_target() {
+    local nodes_root="${KFD_TOPOLOGY_ROOT:-/sys/class/kfd/kfd/topology/nodes}"
+    local node props simd version major minor step
+
+    for node in "$nodes_root"/*/; do
+        props="${node}properties"
+        [[ -r "$props" ]] || continue
+
+        simd=$(awk '$1 == "simd_count" { print $2; exit }' "$props") || simd=""
+        [[ -n "$simd" && "$simd" -gt 0 ]] || continue
+
+        version=$(awk '$1 == "gfx_target_version" { print $2; exit }' "$props") || version=""
+        [[ -n "$version" && "$version" -gt 0 ]] || continue
+
+        major=$(( version / 10000 ))
+        minor=$(( (version / 100) % 100 ))
+        step=$(( version % 100 ))
+        printf 'gfx%d%d%x\n' "$major" "$minor" "$step"
+        return 0
+    done
+
+    echo "unknown"
+    return 1
+}
+
 # Get render node for an AMD GPU card by matching PCI device paths
 amd_render_node() {
     local card_dir="$1"

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -793,6 +793,47 @@ raise SystemExit(1)' 2>/dev/null && return 0
         GPU_ASSIGNMENT_JSON_B64=""
     fi
 
+    # Resolve the AMD gfx target before writing .env. This is not a cosmetic
+    # value: HSA_OVERRIDE_GFX_VERSION and the gfx1151-only custom llama-server
+    # binary are both chosen from it, and docker-compose.amd.yml maps /dev/kfd
+    # into the container unconditionally. Naming the wrong architecture points
+    # ROCm at the wrong ISA, which has wedged the GPU's MES and hard-frozen
+    # whole hosts (#2844). So: never guess an architecture.
+    if [[ "$GPU_BACKEND" == "amd" ]]; then
+        # Phase 02 sources this only on some AMD paths; the KFD probe below
+        # needs it either way.
+        if ! type amd_kfd_gfx_target &>/dev/null \
+            && [[ -f "$SCRIPT_DIR/installers/lib/amd-topo.sh" ]]; then
+            . "$SCRIPT_DIR/installers/lib/amd-topo.sh"
+        fi
+
+        if [[ -n "${AMDGPU_TARGET:-}" ]]; then
+            _amd_gfx_detected="$AMDGPU_TARGET"
+            ai "Using operator-supplied gfx target: $_amd_gfx_detected"
+        else
+            _amd_gfx_detected=$(echo "${GPU_TOPOLOGY_JSON:-{\}}" | jq -r '[.gpus[]?.gfx_version] | unique | .[0] // empty') \
+                || _amd_gfx_detected=""
+            if [[ -z "$_amd_gfx_detected" || "$_amd_gfx_detected" == "null" || "$_amd_gfx_detected" == "unknown" ]]; then
+                # The topology probe came back empty. The kernel still knows —
+                # ask KFD directly before giving up.
+                _amd_gfx_detected="$(amd_kfd_gfx_target)" || _amd_gfx_detected="unknown"
+                [[ "$_amd_gfx_detected" != "unknown" ]] \
+                    && ai "gfx target read from KFD topology: $_amd_gfx_detected"
+            fi
+        fi
+
+        if [[ -z "$_amd_gfx_detected" || "$_amd_gfx_detected" == "unknown" ]]; then
+            ai_bad "Could not determine this GPU's gfx target."
+            ai_bad "ODS will not guess one: an incorrect AMDGPU_TARGET points ROCm at the"
+            ai_bad "wrong ISA, and with /dev/kfd mapped into the container that has hung"
+            ai_bad "entire hosts. Find your target with:"
+            ai_bad "  grep -H gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties"
+            ai_bad "(ignore the node reporting 0 — that is the CPU node), then re-run with it:"
+            ai_bad "  AMDGPU_TARGET=gfx1200 ./install.sh"
+            error "AMD gfx target could not be detected; refusing to write a guessed AMDGPU_TARGET"
+        fi
+    fi
+
     # Generate .env file
     # Subshell-scope a tighter umask so the file is created 0600 from the start
     # (closes a brief window on systems where $HOME is world-readable, e.g.
@@ -903,10 +944,8 @@ COMFYUI_CPU_LIMIT=${COMFYUI_CPU_LIMIT}
 COMFYUI_CPU_RESERVATION=${COMFYUI_CPU_RESERVATION}
 
 $(if [[ "$GPU_BACKEND" == "amd" ]]; then
-    # Read gfx target from topology detection. Falls back to gfx1151 (Strix Halo)
-    # if the topology probe failed — preserves prior behavior for the OG target.
-    _amd_gfx_detected=$(echo "${GPU_TOPOLOGY_JSON:-{\}}" | jq -r '[.gpus[]?.gfx_version] | unique | .[0] // "gfx1151"' 2>/dev/null || echo "gfx1151")
-    [[ -z "$_amd_gfx_detected" || "$_amd_gfx_detected" == "null" || "$_amd_gfx_detected" == "unknown" ]] && _amd_gfx_detected="gfx1151"
+    # _amd_gfx_detected was resolved above and is known to be non-empty — this
+    # block never guesses a target.
 
     # HSA_OVERRIDE_GFX_VERSION is a Strix Halo (gfx1151) workaround — that target
     # is not in ROCm 7.x's official support list, so we coerce HSA to load

--- a/ods/tests/test-amd-gfx-target.sh
+++ b/ods/tests/test-amd-gfx-target.sh
@@ -63,8 +63,41 @@ got="$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"
 set -e
 check "an empty topology dir reports unknown" "unknown" "$got"
 
-# ── The refusal ─────────────────────────────────────────────────────────────
+# ── The resolution path, executed for real ──────────────────────────────────
+# Extract phase 06's resolution block between stable markers and run it with
+# stubbed helpers, so this checks behaviour rather than the shape of the source.
 PHASE="$ROOT/installers/phases/06-directories.sh"
+BLOCK="$TMP/resolve-block.sh"
+sed -n '/# Resolve the AMD gfx target before writing .env/,/^    fi$/p' "$PHASE" > "$BLOCK"
+if [ ! -s "$BLOCK" ]; then
+    echo "[FAIL] could not extract the gfx resolution block from phase 06"
+    FAIL=$((FAIL + 1))
+fi
+
+# run_resolution <topology-json> <operator-override> <kfd-stub-body>
+run_resolution() {
+    {
+        echo 'set -euo pipefail'
+        echo 'ai() { :; }; ai_bad() { :; }; error() { echo "ABORTED"; exit 1; }'
+        echo "amd_kfd_gfx_target() { $3; }"
+        echo "GPU_BACKEND=amd; GPU_TOPOLOGY_JSON='$1'; SCRIPT_DIR=/nonexistent"
+        [ -n "$2" ] && echo "AMDGPU_TARGET='$2'"
+        cat "$BLOCK"
+        echo 'echo "$_amd_gfx_detected"'
+    } > "$TMP/run.sh"
+    bash "$TMP/run.sh" 2>&1 | tail -1
+}
+
+check "single GPU + empty topology reads KFD (the #2844 host)" \
+    "gfx1200" "$(run_resolution "" "" 'echo gfx1200; return 0')"
+check "a populated topology JSON is still preferred" \
+    "gfx1100" "$(run_resolution '{"gpus":[{"gfx_version":"gfx1100"}]}' "" 'echo unknown; return 1')"
+check "an operator-supplied AMDGPU_TARGET wins" \
+    "gfx1201" "$(run_resolution "" "gfx1201" 'echo gfx1200; return 0')"
+check "nothing resolvable aborts instead of guessing gfx1151" \
+    "ABORTED" "$(run_resolution "" "" 'echo unknown; return 1')"
+
+# ── The refusal ─────────────────────────────────────────────────────────────
 
 if grep -q '_amd_gfx_detected="gfx1151"' "$PHASE"; then
     echo "[FAIL] phase 06 still falls back to a hardcoded gfx1151"

--- a/ods/tests/test-amd-gfx-target.sh
+++ b/ods/tests/test-amd-gfx-target.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Contract: ODS must read the real gfx target from KFD topology, and must never
+# guess an architecture when it cannot (#2844).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck disable=SC1091
+. "$ROOT/installers/lib/amd-topo.sh"
+
+PASS=0
+FAIL=0
+check() {
+    local label="$1" expected="$2" got="$3"
+    if [ "$got" = "$expected" ]; then
+        echo "[PASS] $label (=$got)"
+        PASS=$((PASS + 1))
+    else
+        echo "[FAIL] $label: expected '$expected', got '$got'"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# make_node <root> <index> <simd_count> <gfx_target_version>
+make_node() {
+    mkdir -p "$1/$2"
+    printf 'cpu_cores_count 16\nsimd_count %s\ngfx_target_version %s\n' "$3" "$4" \
+        > "$1/$2/properties"
+}
+
+# The reporting host from #2844: node 0 is the CPU node, node 1 is the RX 9060 XT.
+R="$TMP/navi44"; make_node "$R" 0 0 0; make_node "$R" 1 64 120000
+check "gfx1200 (RX 9060 XT) read past the CPU node" \
+    "gfx1200" "$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"
+
+# The CPU node must never be the answer — that is what produced the misdetection.
+R="$TMP/cpuonly"; make_node "$R" 0 0 0
+set +e
+got="$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"; rc=$?
+set -e
+check "a CPU-only topology reports unknown" "unknown" "$got"
+check "...and signals failure" "1" "$rc"
+
+R="$TMP/halo"; make_node "$R" 0 0 0; make_node "$R" 1 32 110501
+check "gfx1151 (Strix Halo) still resolves" \
+    "gfx1151" "$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"
+
+# Hex step digit: 90010 -> gfx90a, not gfx9010.
+R="$TMP/mi250"; make_node "$R" 0 0 0; make_node "$R" 1 104 90010
+check "gfx90a (MI250) encodes the step in hex" \
+    "gfx90a" "$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"
+
+R="$TMP/mi300"; make_node "$R" 0 0 0; make_node "$R" 1 304 90402
+check "gfx942 (MI300X) resolves" \
+    "gfx942" "$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"
+
+R="$TMP/missing"
+mkdir -p "$R"
+set +e
+got="$(KFD_TOPOLOGY_ROOT="$R" amd_kfd_gfx_target)"
+set -e
+check "an empty topology dir reports unknown" "unknown" "$got"
+
+# ── The refusal ─────────────────────────────────────────────────────────────
+PHASE="$ROOT/installers/phases/06-directories.sh"
+
+if grep -q '_amd_gfx_detected="gfx1151"' "$PHASE"; then
+    echo "[FAIL] phase 06 still falls back to a hardcoded gfx1151"
+    FAIL=$((FAIL + 1))
+else
+    echo "[PASS] phase 06 has no hardcoded gfx1151 fallback"
+    PASS=$((PASS + 1))
+fi
+
+if grep -q 'refusing to write a guessed AMDGPU_TARGET' "$PHASE"; then
+    echo "[PASS] phase 06 aborts when the target cannot be resolved"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] phase 06 must abort rather than guess an AMDGPU_TARGET"
+    FAIL=$((FAIL + 1))
+fi
+
+if grep -q 'AMDGPU_TARGET=gfx1200 ./install.sh' "$PHASE"; then
+    echo "[PASS] the abort tells the operator how to set the target manually"
+    PASS=$((PASS + 1))
+else
+    echo "[FAIL] the abort must name the AMDGPU_TARGET escape hatch"
+    FAIL=$((FAIL + 1))
+fi
+
+echo "------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

Fixes #2844.

**Root cause, narrower than the issue guessed.** `installers/phases/06-directories.sh:908` read the gfx target out of `GPU_TOPOLOGY_JSON` and fell back to `gfx1151` when it was empty. But `GPU_TOPOLOGY_JSON` is only ever populated by `02-detection.sh:398`, which is guarded by:

```bash
if [[ $GPU_COUNT -gt 1 && "$GPU_BACKEND" == "amd" ]]; then
```

So on **any single-GPU AMD host** the topology JSON is empty by design and phase 06 unconditionally labelled the machine Strix Halo. The reporter's RX 9060 XT was not a probe that failed — it was a probe that never ran. That also explains why `gfx_target_version 120000` was sitting in `/sys` the whole time.

From there the documented chain follows: `AMDGPU_TARGET=gfx1151`, `HSA_OVERRIDE_GFX_VERSION=11.5.1`, and `LEMONADE_LLAMACPP_ROCM_BIN=/opt/llama-custom/llama-server` (the gfx1151-only binary whose own comment in this file warns it ISA-faults elsewhere), against a container with `/dev/kfd` mapped.

Two changes:

**1. Read what the kernel already knows.** New `amd_kfd_gfx_target()` in `installers/lib/amd-topo.sh` parses `gfx_target_version` from `/sys/class/kfd/kfd/topology/nodes/*/properties`, filtering on `simd_count > 0` so node 0 — the CPU node, which legitimately reports 0 — can never be the answer. `gfx_target_version` packs the target as `MMmmss` decimal with a hex step digit: `120000 -> gfx1200`, `110501 -> gfx1151`, `90010 -> gfx90a`, `90402 -> gfx942`.

**2. Never guess an architecture.** The `gfx1151` fallback is gone. Resolution now runs *before* the `.env` heredoc (so it can actually abort) in this order: operator-supplied `AMDGPU_TARGET` -> topology JSON -> KFD topology -> hard failure with the command to read the target and the override to re-run with:

```
Could not determine this GPU's gfx target.
ODS will not guess one: an incorrect AMDGPU_TARGET points ROCm at the
wrong ISA, and with /dev/kfd mapped into the container that has hung
entire hosts. Find your target with:
  grep -H gfx_target_version /sys/class/kfd/kfd/topology/nodes/*/properties
(ignore the node reporting 0 — that is the CPU node), then re-run with it:
  AMDGPU_TARGET=gfx1200 ./install.sh
```

## AI Assistance

Claude Code drafted the patch and the regression test and ran the validation recorded below. The human author reviewed the diff, chose the validation, and is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: High
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: I have no AMD hardware, so the freeze itself is not reproduced here. What is verified is the decoding of real gfx_target_version values against sysfs fixtures for four architectures, that the CPU node can no longer win, and that the hardcoded gfx1151 fallback is gone from the phase.

Commands/results:

```text
$ bash tests/test-amd-gfx-target.sh
[PASS] gfx1200 (RX 9060 XT) read past the CPU node (=gfx1200)
[PASS] a CPU-only topology reports unknown (=unknown)
[PASS] ...and signals failure (=1)
[PASS] gfx1151 (Strix Halo) still resolves (=gfx1151)
[PASS] gfx90a (MI250) encodes the step in hex (=gfx90a)
[PASS] gfx942 (MI300X) resolves (=gfx942)
[PASS] an empty topology dir reports unknown (=unknown)
[PASS] single GPU + empty topology reads KFD (the #2844 host) (=gfx1200)
[PASS] a populated topology JSON is still preferred (=gfx1100)
[PASS] an operator-supplied AMDGPU_TARGET wins (=gfx1201)
[PASS] nothing resolvable aborts instead of guessing gfx1151 (=ABORTED)
[PASS] phase 06 has no hardcoded gfx1151 fallback
[PASS] phase 06 aborts when the target cannot be resolved
[PASS] the abort tells the operator how to set the target manually
PASS=14 FAIL=0

# all 15 assertions fail with both source files restored from main
$ git checkout origin/main -- ods/installers/lib/amd-topo.sh ods/installers/phases/06-directories.sh
$ bash tests/test-amd-gfx-target.sh
pre-fix failures: 15
  [FAIL] gfx1200 (RX 9060 XT) read past the CPU node: expected 'gfx1200', got ''
  [FAIL] single GPU + empty topology reads KFD (the #2844 host): ... _amd_gfx_detected: unbound variable
  [FAIL] phase 06 still falls back to a hardcoded gfx1151
  ...

$ bash tests/contracts/test-amd-lemonade-contracts.sh          -> PASS
$ bash tests/contracts/test-amd-comfyui-architecture.sh        -> PASS

# test-installer-contracts.sh reports one failure both with and without this
# change (a host-agent health probe that needs a real environment), so it is
# unrelated — verified by running it against the stashed tree in the same
# container:  main: 1 failure    this branch: 1 failure

$ make lint
All lint checks passed.

$ shellcheck --exclude=SC1091,SC2034 --severity=error \
    ods/installers/lib/amd-topo.sh ods/installers/phases/06-directories.sh \
    ods/tests/test-amd-gfx-target.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- New `tests/test-amd-gfx-target.sh`, wired into `make test`. It works at two levels: sysfs fixtures drive `amd_kfd_gfx_target()` across four real architectures, and the phase's resolution block is **extracted between stable markers and executed** with stubbed helpers, so all four control-flow paths are checked as behaviour rather than as greps against the source — the #2844 host (single GPU, empty topology JSON, target only in KFD), a populated topology JSON, an operator override, and the unresolvable case aborting. `KFD_TOPOLOGY_ROOT` is overridable purely so the probe can be pointed at fixtures; it defaults to the real path.
- **This PR covers suggestions 1 and 2 from the issue only.** The other four are real but are separate changes to separate files, and I would rather not bundle them into a change to the AMD install path:
  - (3) gating `/dev/kfd` behind a validated-architecture allowlist — `docker-compose.amd.yml:50`
  - (4) `restart: on-failure:3` for GPU services, so a contained ISA fault cannot loop into a host hang
  - (5) `10-amd-tuning.sh:170` uses `update-initramfs`/`dracut` with `|| true`, neither of which exists on Arch (`mkinitcpio -P`), so the modprobe options silently never apply
  - (6) phase 10 is APU-shaped but runs on discrete GPUs too
  Say the word and I will open them as their own PRs.
- `docker-compose.amd.yml:14` still has `AMDGPU_TARGET: ${AMDGPU_TARGET:-gfx1151}` as a build-arg default. With this change the installer can no longer write an unset/guessed value, so that default is only reachable from a hand-edited `.env` — I left it alone rather than change a build arg I cannot test, but it is arguably the same defect and worth a look.
- Behaviour change to flag: an AMD host where no probe can resolve the target now fails the install instead of proceeding as Strix Halo. That is the point of the issue, but it does mean a machine that previously "worked" by accident on genuine gfx1151 hardware with a broken probe will now stop and ask. The `AMDGPU_TARGET=` override is the one-line answer, and the abort prints it.

