### PR TITLE
fix(setup): accept standard 64-hex Wi-Fi PSKs

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5330,9 +5330,17 @@ class AgentHandler(BaseHTTPRequestHandler):
         if any(c in ssid for c in ("\n", "\r", "\0")):
             json_response(self, 400, {"error": "ssid contains invalid characters"})
             return
-        if not isinstance(password, str) or len(password) > 63:
-            # WPA2 PSK max is 63 chars. Open networks pass empty string.
-            json_response(self, 400, {"error": "password must be 0-63 chars"})
+        valid_raw_psk = (
+            isinstance(password, str)
+            and len(password) == 64
+            and re.fullmatch(r"[0-9A-Fa-f]{64}", password) is not None
+        )
+        if not isinstance(password, str) or (len(password) > 63 and not valid_raw_psk):
+            # WPA-PSK accepts an 8-63 character passphrase or a raw 64-hex key.
+            # Open and legacy networks may pass shorter values through to nmcli.
+            json_response(self, 400, {
+                "error": "password must be 0-63 chars or a 64-character hexadecimal PSK",
+            })
             return
         if any(c in password for c in ("\n", "\r", "\0")):
             json_response(self, 400, {"error": "password contains invalid characters"})

--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -251,7 +251,7 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
 
 class WifiConnectRequest(BaseModel):
     ssid: str = Field(..., min_length=1, max_length=32)
-    password: str = Field(default="", max_length=63)
+    password: str = Field(default="", max_length=64)
 
     @field_validator("ssid")
     @classmethod
@@ -265,6 +265,8 @@ class WifiConnectRequest(BaseModel):
     def _password_no_control_chars(cls, v: str) -> str:
         if any(c in v for c in ("\n", "\r", "\0")):
             raise ValueError("password contains invalid characters")
+        if len(v) == 64 and re.fullmatch(r"[0-9A-Fa-f]{64}", v) is None:
+            raise ValueError("64-character password must be a hexadecimal PSK")
         return v
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -687,6 +687,33 @@ class TestNetworkHandlers:
         }
         assert body["networks"][1]["ssid"] == "Guest"
 
+    def test_wifi_connect_passes_64_hex_character_psk_to_nmcli(self, monkeypatch):
+        psk = "0123456789abcdef" * 4
+        calls = []
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="",
+                stderr="",
+            )
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _FakeHandler(json.dumps({
+            "ssid": "Raw PSK",
+            "password": psk,
+        }).encode("utf-8"))
+
+        _mod.AgentHandler._handle_network_wifi_connect(handler)
+
+        assert handler.response_code == 200
+        assert calls == [[
+            "nmcli", "device", "wifi", "connect", "Raw PSK",
+            "password", psk,
+        ]]
+
     def test_wifi_forget_refuses_non_wifi_profile(self, monkeypatch):
         calls = []
 

--- a/ods/extensions/services/dashboard-api/tests/test_network_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_network_config.py
@@ -118,13 +118,29 @@ def test_wifi_connect_rejects_oversized_ssid(test_client):
     assert resp.status_code == 422
 
 
-def test_wifi_connect_rejects_oversized_password(test_client):
+def test_wifi_connect_rejects_non_hex_64_character_password(test_client):
     resp = test_client.post(
         "/api/setup/wifi-connect",
         json={"ssid": "ok", "password": "x" * 64},
         headers=test_client.auth_headers,
     )
     assert resp.status_code == 422
+
+
+def test_wifi_connect_accepts_64_hex_character_psk(test_client):
+    psk = "0123456789abcdef" * 4
+    with patch(
+        "routers.setup.request_agent_json",
+        return_value={"success": True, "ssid": "Raw PSK"},
+    ) as request_agent:
+        resp = test_client.post(
+            "/api/setup/wifi-connect",
+            json={"ssid": "Raw PSK", "password": psk},
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    assert request_agent.call_args.kwargs["payload"]["password"] == psk
 
 
 def test_wifi_connect_rejects_control_chars_in_ssid(test_client):


### PR DESCRIPTION
## Summary
- allow 64-character hexadecimal WPA pre-shared keys through the setup API
- enforce the same PSK shape at the host-agent mutation boundary
- retain the existing 63-character ceiling for non-hex passwords

## Why this matters
NetworkManager's shipped contract accepts either an ASCII WPA passphrase or a 64-character hexadecimal pre-shared key. ODS capped the password field at 63 characters in both dashboard-api and host-agent, so a Linux operator whose access point is configured with a raw standards-compliant PSK could never connect through first-run setup.

Root cause: ODS modeled only the passphrase form of `802-11-wireless-security.psk`. The invariant is parity between browser validation and host-agent validation: 64 characters are accepted only when every character is hexadecimal, and the exact value reaches `nmcli` unchanged.

NetworkManager contract: https://www.networkmanager.dev/docs/api/latest/nm-settings-nmcli.html

## Overlap check
Searched open and closed PR titles for `wifi password`, `WiFi PSK`, `64 hex PSK`, and `NetworkManager password`. No matching PR exists. I inspected all open PRs touching `routers/setup.py` and `ods-host-agent.py`; setup PRs #2816/#2572/#2437/#2323 concern atomic or malformed persisted state, while current host-agent PRs concern OpenCode, GPU/runtime, rootless connectivity, and lifecycle state. None changes Wi-Fi credential validation.

## Regression tests
Two public handoff points are covered:

- authenticated `POST /api/setup/wifi-connect` accepts a 64-hex PSK and forwards it unchanged
- `AgentHandler._handle_network_wifi_connect` accepts the same request and invokes `nmcli device wifi connect ... password <psk>`

Both tests failed before the implementation (dashboard returned 422; host-agent returned 400). Post-fix validation:

- `pytest tests/test_network_config.py -q` — 18 passed
- `pytest tests/test_host_agent.py -q` — 258 passed, 4 skipped
- Python compile checks — passed
- `git diff --check` — passed

## Platform scope, tradeoffs, and rollback
The browser schema is shared, but Wi-Fi mutation remains Linux/NetworkManager-only; macOS and Windows continue to receive the existing unsupported-platform response from host-agent. Non-hex 64-character values remain rejected, avoiding accidental expansion beyond NetworkManager's raw-PSK form. Revert commit `bab15063` to roll back; no state migration is required.

Generated with Codex
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.