### PR TITLE
fix(macos): name Podman instead of blaming the Docker daemon

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -106,6 +106,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh
+	@bash tests/test-macos-podman-detection.sh
 	@echo ""
 	@echo "=== CLI preset restore user extensions ==="
 	@bash tests/test-cli-preset-restore-user-extensions.sh

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1163,6 +1163,21 @@ if ! $DOCKER_INSTALLED; then
 fi
 ai_ok "Docker CLI found"
 
+# Podman answers to `docker` but is not Docker Engine. Say so here, the way the
+# Linux preflight already does — otherwise a podman host either gets told to
+# "start Docker Desktop" (when the machine is stopped) or sails past this gate
+# into an unsupported runtime and fails somewhere far less legible.
+if [[ "${DOCKER_BACKEND:-unknown}" == "podman" ]]; then
+    ai_err "\`docker\` on this machine resolves to Podman, not Docker Engine."
+    ai_err "Podman is not a supported ODS runtime yet."
+    ai_err "Install one of these and make sure it owns \`docker\` in your PATH:"
+    ai_err "  - Docker Desktop:  https://docs.docker.com/desktop/install/mac-install/"
+    ai_err "  - Colima (CLI):    brew install colima docker docker-compose && colima start"
+    ai_err "  - Rancher Desktop: https://rancherdesktop.io"
+    ai_err "  - OrbStack:        https://orbstack.dev"
+    exit 1
+fi
+
 if ! $DOCKER_RUNNING; then
     ai_err "Docker daemon is not responding."
     case "${DOCKER_BACKEND:-unknown}" in

--- a/ods/installers/macos/lib/detection.sh
+++ b/ods/installers/macos/lib/detection.sh
@@ -99,15 +99,37 @@ get_macos_version() {
 docker_cli_is_podman() {
     command -v docker >/dev/null 2>&1 || return 1
 
-    docker --version 2>/dev/null | grep -qi 'podman' && return 0
+    local _v
+    _v="$(docker --version 2>/dev/null || true)"
+
+    # 1. Podman naming itself, when it has not been relabelled.
+    printf '%s\n' "$_v" | grep -qi 'podman' && return 0
+
+    # 2. Podman's docker shim relabelling itself. The log in #2933 shows
+    #    `docker --version` printing "docker version 6.1.0" on a podman Mac.
+    #    Docker Engine's CLI has always printed "Docker version <v>, build <sha>"
+    #    — capital D, and a build field — so a lowercase, build-less banner is
+    #    not Docker Engine. (6.x is a podman version; Docker CLI is on 2x.)
+    if printf '%s\n' "$_v" | grep -Eq '^docker version [0-9]' \
+        && ! printf '%s\n' "$_v" | grep -q ', build '; then
+        return 0
+    fi
 
     local docker_path docker_real
     docker_path="$(command -v docker)" || return 1
-    command -v readlink >/dev/null 2>&1 || return 1
-    docker_real="$(readlink -f "$docker_path")" || return 1
-    case "$(basename "$docker_real")" in
-        podman|podman-docker) return 0 ;;
-    esac
+
+    # 3. podman-docker installs `docker` as a symlink onto podman.
+    if command -v readlink >/dev/null 2>&1; then
+        docker_real="$(readlink -f "$docker_path" 2>/dev/null || true)"
+        case "$(basename "${docker_real:-$docker_path}")" in
+            podman|podman-docker) return 0 ;;
+        esac
+    fi
+
+    # 4. ...or as a shell wrapper that execs podman.
+    if [[ -f "$docker_path" ]] && head -n1 "$docker_path" 2>/dev/null | grep -q '^#!'; then
+        grep -qi 'podman' "$docker_path" && return 0
+    fi
 
     return 1
 }

--- a/ods/installers/macos/lib/detection.sh
+++ b/ods/installers/macos/lib/detection.sh
@@ -94,11 +94,29 @@ get_macos_version() {
 # interacts with `docker info`, `docker compose`, image pulls, bind
 # mounts — all of which are daemon-agnostic).
 
+# Is the `docker` on PATH actually podman wearing a docker hat?
+# Mirrors docker_cli_looks_like_podman() in scripts/linux-install-preflight.sh.
+docker_cli_is_podman() {
+    command -v docker >/dev/null 2>&1 || return 1
+
+    docker --version 2>/dev/null | grep -qi 'podman' && return 0
+
+    local docker_path docker_real
+    docker_path="$(command -v docker)" || return 1
+    command -v readlink >/dev/null 2>&1 || return 1
+    docker_real="$(readlink -f "$docker_path")" || return 1
+    case "$(basename "$docker_real")" in
+        podman|podman-docker) return 0 ;;
+    esac
+
+    return 1
+}
+
 test_docker_desktop() {
     DOCKER_INSTALLED=false
     DOCKER_RUNNING=false
     DOCKER_VERSION=""
-    DOCKER_BACKEND="unknown"  # "desktop" | "colima" | "rancher" | "orbstack" | "other"
+    DOCKER_BACKEND="unknown"  # "desktop" | "colima" | "rancher" | "orbstack" | "podman" | "other"
 
     # Check if docker CLI is available
     if ! command -v docker >/dev/null 2>&1; then
@@ -121,8 +139,17 @@ test_docker_desktop() {
         *colima*)                                             DOCKER_BACKEND="colima" ;;
         *rancher-desktop*|*rd-sock*)                          DOCKER_BACKEND="rancher" ;;
         *orbstack*)                                           DOCKER_BACKEND="orbstack" ;;
+        *podman*)                                             DOCKER_BACKEND="podman" ;;
         *)                                                    DOCKER_BACKEND="other" ;;
     esac
+
+    # A podman shim answers to `docker` but is not Docker Engine, and the
+    # context hint above does not always name it. Ask the CLI directly, the way
+    # scripts/linux-install-preflight.sh already does, so macOS can give the
+    # same honest answer instead of "start Docker Desktop".
+    if [[ "$DOCKER_BACKEND" != "podman" ]] && docker_cli_is_podman; then
+        DOCKER_BACKEND="podman"
+    fi
 
     # Check if Docker daemon is responsive
     if docker version >/dev/null 2>&1; then

--- a/ods/tests/test-macos-podman-detection.sh
+++ b/ods/tests/test-macos-podman-detection.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Contract: on macOS a `docker` that is really podman must be named as such,
+# not reported as an unresponsive Docker daemon (#2933).
+#
+# Linux already refuses podman with a clear message
+# (scripts/linux-install-preflight.sh); macOS had no podman detection at all,
+# so the same host got "Start Docker Desktop ..." instead.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+# shellcheck disable=SC1091
+. "$ROOT/installers/macos/lib/detection.sh"
+
+# ── a podman shim that reports itself in --version ──────────────────────────
+cat > "$TMP/bin/docker" <<'STUB'
+#!/bin/sh
+case "$1" in
+  --version) echo "podman version 6.1.0" ;;
+  context)   echo "" ;;
+  version)   exit 1 ;;
+  *)         exit 1 ;;
+esac
+STUB
+chmod +x "$TMP/bin/docker"
+
+PATH="$TMP/bin:$PATH" test_docker_desktop
+if [ "${DOCKER_BACKEND:-}" = "podman" ]; then
+    pass "a podman CLI reporting itself in --version is classified as podman"
+else
+    fail "expected DOCKER_BACKEND=podman, got '${DOCKER_BACKEND:-}'"
+fi
+
+# ── a podman-docker shim that only gives itself away via the symlink ────────
+cat > "$TMP/bin/podman" <<'STUB'
+#!/bin/sh
+exit 1
+STUB
+chmod +x "$TMP/bin/podman"
+cat > "$TMP/bin/docker" <<'STUB'
+#!/bin/sh
+case "$1" in
+  --version) echo "Docker version 27.0.0, build abc" ;;
+  *)         exit 1 ;;
+esac
+STUB
+chmod +x "$TMP/bin/docker"
+rm -f "$TMP/bin/docker" && ln -s "$TMP/bin/podman" "$TMP/bin/docker"
+
+PATH="$TMP/bin:$PATH" test_docker_desktop
+if [ "${DOCKER_BACKEND:-}" = "podman" ]; then
+    pass "a docker symlinked to podman is classified as podman"
+else
+    fail "expected DOCKER_BACKEND=podman via symlink, got '${DOCKER_BACKEND:-}'"
+fi
+
+# ── a real Docker CLI must NOT be mistaken for podman ───────────────────────
+rm -f "$TMP/bin/docker" "$TMP/bin/podman"
+cat > "$TMP/bin/docker" <<'STUB'
+#!/bin/sh
+case "$1" in
+  --version) echo "Docker version 27.0.0, build abc" ;;
+  context)   echo "desktop-linux" ;;
+  version)
+    if [ "$2" = "--format" ]; then echo "27.0.0"; fi
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$TMP/bin/docker"
+
+PATH="$TMP/bin:$PATH" test_docker_desktop
+if [ "${DOCKER_BACKEND:-}" = "desktop" ]; then
+    pass "a genuine Docker Desktop CLI is still classified as desktop"
+else
+    fail "expected DOCKER_BACKEND=desktop, got '${DOCKER_BACKEND:-}'"
+fi
+
+# ── the installer must act on it ────────────────────────────────────────────
+MACOS_INSTALLER="$ROOT/installers/macos/install-macos.sh"
+if grep -q 'DOCKER_BACKEND:-unknown}" == "podman"' "$MACOS_INSTALLER"; then
+    pass "macOS installer branches on the podman backend"
+else
+    fail "macOS installer must handle DOCKER_BACKEND=podman explicitly"
+fi
+
+if grep -q 'Podman is not a supported ODS runtime yet' "$MACOS_INSTALLER"; then
+    pass "macOS installer states the podman limitation, matching Linux preflight"
+else
+    fail "macOS installer must say podman is unsupported, as Linux preflight does"
+fi
+
+echo "------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/ods/tests/test-macos-podman-detection.sh
+++ b/ods/tests/test-macos-podman-detection.sh
@@ -40,6 +40,41 @@ else
     fail "expected DOCKER_BACKEND=podman, got '${DOCKER_BACKEND:-}'"
 fi
 
+# ── the exact banner from #2933's log: podman relabelled as "docker" ───────
+# get-ods.sh prints `docker --version` verbatim, and the reporter's log reads
+# "docker found: docker version 6.1.0" — lowercase, no build field, version 6.x.
+cat > "$TMP/bin/docker" <<'STUB'
+#!/bin/sh
+case "$1" in
+  --version) echo "docker version 6.1.0" ;;
+  context)   echo "" ;;
+  *)         exit 1 ;;
+esac
+STUB
+chmod +x "$TMP/bin/docker"
+
+PATH="$TMP/bin:$PATH" test_docker_desktop
+if [ "${DOCKER_BACKEND:-}" = "podman" ]; then
+    pass "podman relabelled as 'docker version 6.1.0' (#2933's actual banner) is caught"
+else
+    fail "expected DOCKER_BACKEND=podman for the #2933 banner, got '${DOCKER_BACKEND:-}'"
+fi
+
+# ── a podman-docker wrapper script that execs podman ───────────────────────
+cat > "$TMP/bin/docker" <<'STUB'
+#!/bin/sh
+[ -e /etc/containers/nodocker ] || echo "Emulate Docker CLI using podman." >&2
+exec /usr/bin/podman "$@"
+STUB
+chmod +x "$TMP/bin/docker"
+
+PATH="$TMP/bin:$PATH" test_docker_desktop
+if [ "${DOCKER_BACKEND:-}" = "podman" ]; then
+    pass "a podman-docker wrapper script is caught"
+else
+    fail "expected DOCKER_BACKEND=podman for the wrapper script, got '${DOCKER_BACKEND:-}'"
+fi
+
 # ── a podman-docker shim that only gives itself away via the symlink ────────
 cat > "$TMP/bin/podman" <<'STUB'
 #!/bin/sh
@@ -83,6 +118,26 @@ if [ "${DOCKER_BACKEND:-}" = "desktop" ]; then
     pass "a genuine Docker Desktop CLI is still classified as desktop"
 else
     fail "expected DOCKER_BACKEND=desktop, got '${DOCKER_BACKEND:-}'"
+fi
+
+# Real Docker's banner ("Docker version X, build Y") must never trip the
+# relabelled-banner heuristic, on any context, including an unknown one.
+cat > "$TMP/bin/docker" <<'STUB'
+#!/bin/sh
+case "$1" in
+  --version) echo "Docker version 28.0.1, build 068a01e" ;;
+  context)   echo "some-custom-context" ;;
+  version)   exit 0 ;;
+  *)         exit 0 ;;
+esac
+STUB
+chmod +x "$TMP/bin/docker"
+
+PATH="$TMP/bin:$PATH" test_docker_desktop
+if [ "${DOCKER_BACKEND:-}" = "podman" ]; then
+    fail "a genuine Docker CLI on an unknown context was misread as podman"
+else
+    pass "a genuine Docker CLI on an unknown context is not misread as podman (=${DOCKER_BACKEND:-})"
 fi
 
 # ── the installer must act on it ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #2933.

The reporter's Mac has podman providing `docker`, and got:

```
[  ok ] Docker CLI found
[  xx ] Docker daemon is not responding.
       > Start your docker daemon (Docker Desktop, Colima, Rancher Desktop, OrbStack, ...) and re-run this installer.
```

That message lists every runtime except the one they have installed, and never mentions podman — so it reads as "ODS is broken" rather than "podman is not supported".

`installers/macos/lib/detection.sh:test_docker_desktop()` classifies `desktop | colima | rancher | orbstack | other` and has no podman case, so podman lands in `other` and gets the generic fallback guidance.

Linux already handles this honestly — `scripts/linux-install-preflight.sh:139` detects podman (by `docker --version` and by resolving the `docker` symlink to `podman`/`podman-docker`) and reports *"Podman is not a supported ODS runtime yet"*. This change gives macOS the same answer:

- `docker_cli_is_podman()` in the macOS detection lib, mirroring the Linux helper — **plus two signals the Linux helper does not have**, because this issue's own log shows they are needed (see below);
- `podman` added to the backend classification;
- the installer refuses with the podman-specific message **right after CLI detection**, not only when the daemon probe fails — otherwise a Mac whose `podman machine` happens to be running passes this gate and fails later somewhere far less legible.

**This does not add Podman support.** It makes the existing limitation legible on macOS instead of misattributing it to a stopped Docker daemon.

### Why the Linux helper's checks alone are not enough here

`ods/get-ods.sh:352` prints `docker --version` **verbatim**:

```bash
success "docker found: $(docker --version | head -1)"
```

and the log in this issue reads:

```
[  ok ] docker found: docker version 6.1.0
```

So on the reporting Mac, `docker --version` prints `docker version 6.1.0` — podman relabelled, with the word "podman" nowhere in it. A straight `grep -qi podman` on the version string, which is what the Linux helper leads with, would **not** have fired here. Two more signals are added for that:

- a lowercase, build-less `docker version N` banner. Docker Engine's CLI has always printed `Docker version <v>, build <sha>` — capital D, with a build field — and Docker CLI is on 2x, not 6.x. A negative test pins that a genuine `Docker version 28.0.1, build 068a01e` on an unknown context is never misread;
- a `docker` that is a shell wrapper `exec`ing podman, which is how `podman-docker` ships it when it is not a symlink.

## AI Assistance

Claude Code drafted the patch and the regression test and ran the validation recorded below. The human author reviewed the diff, chose the validation, and is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: the change adds one backend classification and one early guard; the Docker Desktop / Colima / Rancher / OrbStack paths are untouched and the new test pins that a genuine Docker CLI is still classified as `desktop`.

Commands/results:

```text
$ bash tests/test-macos-podman-detection.sh
[PASS] a podman CLI reporting itself in --version is classified as podman
[PASS] podman relabelled as 'docker version 6.1.0' (#2933's actual banner) is caught
[PASS] a podman-docker wrapper script is caught
[PASS] a docker symlinked to podman is classified as podman
[PASS] a genuine Docker Desktop CLI is still classified as desktop
[PASS] a genuine Docker CLI on an unknown context is not misread as podman (=other)
[PASS] macOS installer branches on the podman backend
[PASS] macOS installer states the podman limitation, matching Linux preflight
PASS=8 FAIL=0

# same test with both source files restored from main
$ git checkout origin/main -- ods/installers/macos/lib/detection.sh ods/installers/macos/install-macos.sh
$ bash tests/test-macos-podman-detection.sh   ->  FAIL

$ make lint
All lint checks passed.

$ shellcheck --exclude=SC1091,SC2034 --severity=error \
    ods/installers/macos/lib/detection.sh ods/installers/macos/install-macos.sh \
    ods/tests/test-macos-podman-detection.sh
(clean)
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- New `tests/test-macos-podman-detection.sh`, wired into `make test`. It drives the real `test_docker_desktop()` against stub `docker` binaries on `PATH` — one that admits podman in `--version`, one that only gives itself away through the symlink, and one genuine Docker CLI as the negative case. I do not have podman on this machine, so the stubs stand in for it — but one of them emits the **exact banner from this issue's log** (`docker version 6.1.0`), which is the case the first cut of this patch missed, and the wrapper-script stub is `podman-docker`'s real shim text. The negative cases pin that genuine Docker is unaffected.
- **On the sibling issue #2932** (podman on Fedora): that one is not a bug. `scripts/linux-install-preflight.sh:139-143` deliberately detects podman and reports *"Podman is not a supported ODS runtime yet; remove podman-docker or put Docker Engine first in PATH"* — the installer is already saying the right thing there, and "refuses to continue" is the intended behaviour. Real Podman support is a feature, not a fix, so I have not touched it. If you want #2932 kept open, it probably belongs relabelled as an enhancement.
- If ODS does intend to support podman on macOS eventually, this guard is the natural place to flip from "refuse" to "proceed".

