### PR TITLE
fix(token-spy): bound usage database queries

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import Depends, FastAPI, HTTPException, Request, Response, Security
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, Security
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from filters import apply_filters
@@ -1686,7 +1686,11 @@ def _update_timer_interval(minutes: int):
         log.warning(f"[SETTINGS] Could not update timer: {e} (may need sudo)")
 
 @app.get("/api/usage", dependencies=[Depends(verify_api_key)])
-def api_usage(agent: str | None = None, hours: int = 24, limit: int = 200):
+def api_usage(
+    agent: str | None = None,
+    hours: int = Query(default=24, ge=1, le=8760),
+    limit: int = Query(default=200, ge=1, le=1000),
+):
     return query_usage(agent=agent, hours=hours, limit=limit)
 
 
@@ -1700,13 +1704,17 @@ def api_report(start: str, end: str):
 
 
 @app.get("/token-usage", dependencies=[Depends(verify_api_key)])
-def token_usage_alias(agent: str | None = None, hours: int = 24, limit: int = 200):
+def token_usage_alias(
+    agent: str | None = None,
+    hours: int = Query(default=24, ge=1, le=8760),
+    limit: int = Query(default=200, ge=1, le=1000),
+):
     """Alias for /api/usage — returns recent token usage events."""
     return query_usage(agent=agent, hours=hours, limit=limit)
 
 
 @app.get("/api/summary", dependencies=[Depends(verify_api_key)])
-def api_summary(hours: int = 24):
+def api_summary(hours: int = Query(default=24, ge=1, le=8760)):
     try:
         result = query_summary(hours=hours) if _db_available else []
     except Exception as e:

--- a/ods/extensions/services/token-spy/tests/test_api_query_bounds.py
+++ b/ods/extensions/services/token-spy/tests/test_api_query_bounds.py
@@ -1,0 +1,85 @@
+"""Public query-boundary tests for Token Spy usage endpoints."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture()
+def token_spy(monkeypatch):
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "query-boundary-key")
+    monkeypatch.setenv("DB_BACKEND", "sqlite")
+    monkeypatch.syspath_prepend(str(TOKEN_SPY_DIR))
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_query_bounds_{uuid4().hex}",
+        TOKEN_SPY_DIR / "main.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.query_usage = Mock(return_value=[])
+    module.query_summary = Mock(return_value=[])
+    return module
+
+
+@pytest.mark.parametrize("path", ["/api/usage", "/token-usage"])
+@pytest.mark.parametrize(
+    ("params", "field"),
+    [
+        ({"hours": 0}, "hours"),
+        ({"hours": 8761}, "hours"),
+        ({"limit": 0}, "limit"),
+        ({"limit": 1001}, "limit"),
+    ],
+)
+def test_usage_endpoints_reject_out_of_range_queries(token_spy, path, params, field):
+    client = TestClient(token_spy.app)
+
+    response = client.get(
+        path,
+        params=params,
+        headers={"Authorization": "Bearer query-boundary-key"},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"][-1] == field
+    token_spy.query_usage.assert_not_called()
+
+
+@pytest.mark.parametrize("hours", [0, 8761])
+def test_summary_rejects_out_of_range_hours(token_spy, hours):
+    client = TestClient(token_spy.app)
+
+    response = client.get(
+        "/api/summary",
+        params={"hours": hours},
+        headers={"Authorization": "Bearer query-boundary-key"},
+    )
+
+    assert response.status_code == 422
+    token_spy.query_summary.assert_not_called()
+
+
+def test_usage_boundary_values_reach_database(token_spy):
+    client = TestClient(token_spy.app)
+
+    response = client.get(
+        "/api/usage",
+        params={"hours": 8760, "limit": 1000},
+        headers={"Authorization": "Bearer query-boundary-key"},
+    )
+
+    assert response.status_code == 200
+    token_spy.query_usage.assert_called_once_with(
+        agent=None,
+        hours=8760,
+        limit=1000,
+    )


### PR DESCRIPTION
## Why this matters

The authenticated Token Spy usage endpoints passed arbitrary `hours` and `limit` values directly to the database layer. A zero/negative SQLite `LIMIT` can remove the row cap, while very large windows or limits create avoidable database work and unpredictable API behavior. The dashboard's supported all-time window is one year, so the public contract is now 1-8760 hours and 1-1000 usage rows.

Root cause: the FastAPI query parameters were typed but had no range constraints.

Behavioral invariant: invalid query ranges are rejected at the HTTP boundary before any database query; documented boundary values still reach the database unchanged.

## Overlap check

Searched open and closed upstream PRs for Token Spy usage/query/hour/limit terms and checked PRs changing `ods/extensions/services/token-spy/main.py` and its tests. Existing work covers atomic writes, exception handling, pricing, logging, streaming error bodies, and SSE cursors; none bounds the `/api/usage`, `/token-usage`, or `/api/summary` database queries. This scope is independent.

## What changed

- Bound `hours` to 1-8760 on usage and summary endpoints.
- Bound usage `limit` to 1-1000 on both the canonical endpoint and its compatibility alias.
- Added authenticated public-boundary regressions that assert rejected requests never call the database and valid maximum values are passed through.

## Validation

- Red before fix: 10 failures; every invalid public query returned HTTP 200 and reached the query function.
- `pytest tests/test_api_query_bounds.py -q` — 11 passed.
- `pytest tests -q` — 31 passed, 1 skipped.
- `python -m py_compile main.py tests/test_api_query_bounds.py` — passed.
- `git diff --check` — passed.

## Tradeoffs and rollback

The one-year window matches the dashboard's existing all-time selector, while 1000 rows is twice its current 500-row request and leaves headroom for API clients. Clients requesting larger exports must paginate or narrow the window. Rollback is a single commit; no persisted state or schema changes are involved.
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.