### PR TITLE
fix(token-spy): preserve upstream streaming status

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -8,6 +8,7 @@ Supports Anthropic, Moonshot, OpenAI, and generic OpenAI-compatible APIs.
 """
 
 import asyncio
+from contextlib import asynccontextmanager
 import ipaddress
 import json
 import logging
@@ -320,6 +321,15 @@ _openai_client: httpx.AsyncClient | None = None
 
 _CLIENT_TIMEOUT = httpx.Timeout(connect=10.0, read=300.0, write=30.0, pool=30.0)
 _CLIENT_LIMITS = httpx.Limits(max_connections=20, max_keepalive_connections=10)
+
+
+@asynccontextmanager
+async def _close_stream(upstream):
+    """Close an upstream response when downstream streaming ends."""
+    try:
+        yield upstream
+    finally:
+        await upstream.aclose()
 
 
 def get_http_client() -> httpx.AsyncClient:
@@ -702,6 +712,20 @@ async def _handle_streaming(client, raw_body, headers, model, sys_analysis,
                             msg_analysis, tools, start_time):
     """Stream SSE response through while capturing token metrics."""
 
+    upstream_request = client.build_request(
+        "POST", "/v1/messages",
+        content=raw_body,
+        headers=headers,
+    )
+    try:
+        opened_upstream = await client.send(upstream_request, stream=True)
+    except httpx.HTTPError as e:
+        log.error(f"Upstream request error: {e}")
+        return JSONResponse(
+            status_code=502,
+            content={"error": {"type": "proxy_error", "message": "Upstream request failed"}},
+        )
+
     # State for capturing usage from SSE events
     usage = {
         "input_tokens": 0,
@@ -715,11 +739,7 @@ async def _handle_streaming(client, raw_body, headers, model, sys_analysis,
         current_event = None
         logged = False
         try:
-            async with client.stream(
-                "POST", "/v1/messages",
-                content=raw_body,
-                headers=headers,
-            ) as upstream:
+            async with _close_stream(opened_upstream) as upstream:
                 async for line in upstream.aiter_lines():
                     # Yield line immediately for transparent passthrough
                     yield line + "\n"
@@ -776,6 +796,7 @@ async def _handle_streaming(client, raw_body, headers, model, sys_analysis,
 
     return StreamingResponse(
         stream_and_capture(),
+        status_code=opened_upstream.status_code,
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",
@@ -930,6 +951,20 @@ async def proxy_chat_completions(request: Request):
 async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysis,
                                    msg_analysis, tools, start_time, filter_result=None):
     """Stream OpenAI SSE response through while capturing token metrics."""
+    upstream_request = client.build_request(
+        "POST", "/v1/chat/completions",
+        content=raw_body,
+        headers=headers,
+    )
+    try:
+        opened_upstream = await client.send(upstream_request, stream=True)
+    except httpx.HTTPError as e:
+        log.error(f"Upstream request error: {e}")
+        return JSONResponse(
+            status_code=502,
+            content={"error": {"message": "Upstream request failed", "type": "proxy_error"}},
+        )
+
     usage = {
         "input_tokens": 0,
         "output_tokens": 0,
@@ -941,11 +976,7 @@ async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysi
     async def stream_and_capture():
         logged = False
         try:
-            async with client.stream(
-                "POST", "/v1/chat/completions",
-                content=raw_body,
-                headers=headers,
-            ) as upstream:
+            async with _close_stream(opened_upstream) as upstream:
                 if upstream.status_code >= 400:
                     err_body = b""
                     async for chunk in upstream.aiter_bytes():
@@ -999,6 +1030,7 @@ async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysi
 
     return StreamingResponse(
         stream_and_capture(),
+        status_code=opened_upstream.status_code,
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/ods/extensions/services/token-spy/tests/test_streaming_status.py
+++ b/ods/extensions/services/token-spy/tests/test_streaming_status.py
@@ -1,0 +1,93 @@
+"""HTTP status passthrough contracts for Token Spy streaming proxies."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+class FakeUpstream:
+    status_code = 429
+
+    def __init__(self):
+        self.closed = False
+
+    async def aiter_bytes(self):
+        yield b'{"error":{"message":"rate limited"}}'
+
+    async def aiter_lines(self):
+        yield '{"error":{"message":"rate limited"}}'
+
+
+    async def aclose(self):
+        self.closed = True
+
+
+class FakeClient:
+    def __init__(self):
+        self.upstream = FakeUpstream()
+
+    def build_request(self, method, path, **kwargs):
+        return method, path, kwargs
+
+    async def send(self, request, *, stream):
+        assert stream is True
+        return self.upstream
+
+
+@pytest.fixture()
+def token_spy(monkeypatch):
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "stream-status-key")
+    monkeypatch.setenv("API_PROVIDER", "local")
+    monkeypatch.setenv("DB_BACKEND", "sqlite")
+    monkeypatch.syspath_prepend(str(TOKEN_SPY_DIR))
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_stream_status_{uuid4().hex}",
+        TOKEN_SPY_DIR / "main.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.get_filter_settings = Mock(return_value={"enabled": False})
+    module._log_entry = Mock()
+    return module
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "client_getter"),
+    [
+        (
+            "/v1/messages",
+            {"model": "test-model", "messages": [], "stream": True},
+            "get_http_client",
+        ),
+        (
+            "/v1/chat/completions",
+            {"model": "test-model", "messages": [], "stream": True},
+            "get_moonshot_client",
+        ),
+    ],
+)
+def test_streaming_proxy_preserves_upstream_error_status(
+    token_spy, path, body, client_getter
+):
+    upstream_client = FakeClient()
+    setattr(token_spy, client_getter, Mock(return_value=upstream_client))
+    client = TestClient(token_spy.app)
+
+    response = client.post(
+        path,
+        json=body,
+        headers={"Authorization": "Bearer stream-status-key"},
+    )
+
+    assert response.status_code == 429
+    assert "rate limited" in response.text
+    assert upstream_client.upstream.closed is True


### PR DESCRIPTION
## Why this matters

Token Spy created its downstream `StreamingResponse` before opening the upstream stream. FastAPI therefore committed HTTP 200 even when Anthropic or an OpenAI-compatible provider returned 4xx/5xx. Clients could treat rate limits and provider failures as successful requests, defeating normal retry and error handling.

Root cause: the upstream status was only available inside the response-body iterator, after downstream headers had already been selected.

Behavioral invariant: both supported streaming APIs return the exact upstream HTTP status and still close the upstream response after passthrough.

## Overlap check

Searched open and closed PRs for Token Spy streaming/status/error/passthrough terms and inspected PRs changing `ods/extensions/services/token-spy/main.py`. PR #1963 improves streaming error-body logging but does not propagate the upstream status; other current Token Spy PRs cover SSE cursors, pricing, writes, and exception handling. This change is independent and does not alter the logging payload.

## What changed

- Open each upstream response with httpx's public `build_request`/`send(stream=True)` API before creating the downstream response.
- Set the downstream `StreamingResponse` status from the opened upstream response for Anthropic and OpenAI-compatible routes.
- Close the upstream response in a shared async context even when streaming is cancelled or fails.
- Map a connection failure before headers to the existing 502 proxy-error contract.
- Add authenticated public-endpoint regressions for both protocol routes.

## Validation

- Red before fix: both `/v1/messages` and `/v1/chat/completions` returned HTTP 200 for an upstream 429.
- `pytest tests/test_streaming_status.py -q` — 2 passed.
- `pytest tests -q` — 22 passed, 1 skipped.
- `python -m py_compile main.py tests/test_streaming_status.py` — passed.
- `git diff --check` — passed.

## Tradeoffs and rollback

The proxy now waits for upstream response headers before sending downstream headers; that is required to preserve status and does not buffer the response body. SSE body processing and usage accounting remain unchanged. Rollback is one commit with no state or schema migration.
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.