### PR TITLE
fix(token-spy): rebuild headers for decoded responses

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -403,6 +403,29 @@ def _uses_openai_upstream() -> bool:
     return API_PROVIDER in ("openai", "moonshot", "local", "ollama", "vllm", "llama-server")
 
 
+_DECODED_RESPONSE_HEADERS_TO_DROP = {
+    "connection",
+    "content-encoding",
+    "content-length",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def _decoded_response_headers(headers) -> dict[str, str]:
+    """Keep end-to-end headers that still describe httpx's decoded body."""
+    return {
+        name: value
+        for name, value in headers.items()
+        if name.lower() not in _DECODED_RESPONSE_HEADERS_TO_DROP
+    }
+
+
 _db_available = True
 
 @app.on_event("startup")
@@ -821,7 +844,7 @@ async def _handle_non_streaming(client, raw_body, headers, model, sys_analysis,
     return Response(
         content=resp.content,
         status_code=resp.status_code,
-        headers=dict(resp.headers),
+        headers=_decoded_response_headers(resp.headers),
     )
 
 
@@ -1044,7 +1067,7 @@ async def _handle_openai_non_streaming(client, raw_body, headers, model, sys_ana
     return Response(
         content=resp.content,
         status_code=resp.status_code,
-        headers=dict(resp.headers),
+        headers=_decoded_response_headers(resp.headers),
     )
 
 
@@ -2495,7 +2518,7 @@ async def proxy_other(request: Request, path: str):
         return Response(
             content=resp.content,
             status_code=resp.status_code,
-            headers=dict(resp.headers),
+            headers=_decoded_response_headers(resp.headers),
         )
     except Exception as e:
         log.error(f"Proxy passthrough error: {e}")

--- a/ods/extensions/services/token-spy/tests/test_decoded_response_headers.py
+++ b/ods/extensions/services/token-spy/tests/test_decoded_response_headers.py
@@ -1,0 +1,89 @@
+"""Response-header contracts for decoded Token Spy proxy bodies."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import Mock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+DECODED_BODY = b'{"ok":true}'
+
+
+class FakeResponse:
+    content = DECODED_BODY
+    status_code = 200
+    headers = {
+        "content-encoding": "gzip",
+        "content-length": "99",
+        "content-type": "application/json",
+        "connection": "keep-alive",
+        "transfer-encoding": "chunked",
+        "x-upstream-request-id": "req-123",
+    }
+
+    def json(self):
+        return {}
+
+
+class FakeClient:
+    async def request(self, *args, **kwargs):
+        return FakeResponse()
+
+
+@pytest.fixture()
+def token_spy(monkeypatch):
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "decoded-headers-key")
+    monkeypatch.setenv("API_PROVIDER", "local")
+    monkeypatch.setenv("DB_BACKEND", "sqlite")
+    monkeypatch.syspath_prepend(str(TOKEN_SPY_DIR))
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_decoded_headers_{uuid4().hex}",
+        TOKEN_SPY_DIR / "main.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.get_filter_settings = Mock(return_value={"enabled": False})
+    module._log_entry = Mock()
+    return module
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "client_getter"),
+    [
+        (
+            "/v1/messages",
+            {"model": "test-model", "messages": [], "stream": False},
+            "get_http_client",
+        ),
+        (
+            "/v1/chat/completions",
+            {"model": "test-model", "messages": [], "stream": False},
+            "get_moonshot_client",
+        ),
+        ("/v1/models", None, "get_moonshot_client"),
+    ],
+)
+def test_decoded_body_drops_stale_representation_headers(
+    token_spy, path, body, client_getter
+):
+    setattr(token_spy, client_getter, Mock(return_value=FakeClient()))
+    client = TestClient(token_spy.app)
+    headers = {"Authorization": "Bearer decoded-headers-key"}
+    if body is None:
+        response = client.get(path, headers=headers)
+    else:
+        response = client.post(path, json=body, headers=headers)
+
+    assert response.status_code == 200
+    assert response.content == DECODED_BODY
+    assert "content-encoding" not in response.headers
+    assert "connection" not in response.headers
+    assert "transfer-encoding" not in response.headers
+    assert response.headers["content-length"] == str(len(DECODED_BODY))
+    assert response.headers["x-upstream-request-id"] == "req-123"


### PR DESCRIPTION
## Why this matters

Token Spy returns `resp.content`, which HTTPX automatically decompresses, but copied the upstream headers unchanged. A gzip response therefore reached clients as decoded bytes still labeled `Content-Encoding: gzip` and with the compressed `Content-Length`; real HTTPX clients fail with `DecodingError`, and other clients can truncate or double-decode the payload.

Root cause: representation and hop-by-hop headers were reused after the response representation had changed. HTTPX documents that `Response.content` automatically decodes gzip/deflate while raw streaming is required to preserve wire encoding: https://www.python-httpx.org/quickstart/#binary-response-content

Behavioral invariant: buffered proxy responses describe the body actually sent downstream, while safe end-to-end metadata remains intact.

## Overlap check

Searched open and closed upstream PRs for Token Spy content-encoding/content-length/decoded-response/header passthrough terms and inspected current PRs touching `ods/extensions/services/token-spy/main.py`. Existing changes cover streaming status/error logging, SSE cursors, pricing, persistence, and request auth; none rebuild response headers after HTTPX decoding. This scope is independent.

## What changed

- Added one response-header filter for decoded, buffered proxy bodies.
- Removed stale `Content-Encoding`/`Content-Length` and standard hop-by-hop fields.
- Applied the contract to Anthropic non-streaming, OpenAI-compatible non-streaming, and catch-all passthrough responses.
- Preserved end-to-end headers such as content type and upstream request IDs; Starlette now emits the correct downstream content length.

## Validation

- Red before fix: all three public proxy paths failed at the client boundary; HTTPX attempted a second gzip decode and raised `DecodingError`.
- `pytest tests/test_decoded_response_headers.py -q` — 3 passed.
- `pytest tests -q` — 23 passed, 1 skipped.
- `python -m py_compile main.py tests/test_decoded_response_headers.py` — passed.
- `git diff --check` — passed.

## Tradeoffs and rollback

This keeps buffered proxy behavior; it does not convert large non-streaming responses to raw streaming. Headers tied to a specific hop or encoded wire body are intentionally not forwarded. Rollback is one commit with no persisted-state impact.
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.