### PR TITLE
fix(privacy-shield): isolate upstream authorization

### DIFF
--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -251,12 +251,12 @@ async def stats():
 
 
 def _build_upstream_headers(request: Request, scrubbed_len: int | None) -> dict:
-    """Forward client headers to upstream, stripping hop-by-hop + host."""
+    """Forward safe client headers without leaking the Shield credential."""
     headers = {
         k: v
         for k, v in request.headers.items()
         if k.lower() not in _HOP_BY_HOP
-        and k.lower() not in ("host", "content-length")
+        and k.lower() not in ("host", "content-length", "authorization")
     }
     headers["host"] = TARGET_API_BASE.split("//")[-1].split("/")[0]
     if scrubbed_len is not None:

--- a/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
+++ b/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
@@ -131,6 +131,37 @@ class TestStreamingNotBuffered:
         )
 
 
+class TestUpstreamAuthorization:
+    @pytest.mark.parametrize(
+        ("target_key", "expected_authorization"),
+        [
+            ("not-needed", None),
+            ("provider-secret", "Bearer provider-secret"),
+        ],
+    )
+    def test_shield_credential_is_not_forwarded_upstream(
+        self,
+        client,
+        install_upstream,
+        monkeypatch,
+        target_key,
+        expected_authorization,
+    ):
+        seen = {}
+
+        def handler(request):
+            seen["authorization"] = request.headers.get("authorization")
+            return _resp(200, {"content-type": "application/json"}, [b"{}"])
+
+        install_upstream(handler)
+        monkeypatch.setattr(proxy, "TARGET_API_KEY", target_key)
+
+        response = client.get("/models", headers=AUTH)
+
+        assert response.status_code == 200
+        assert seen["authorization"] == expected_authorization
+
+
 # ── 1b. Oversized-text cutover keeps ONE upstream iterator (#1268) ─────────
 #
 # When a textual body crosses SHIELD_RESTORE_MAX_BYTES mid-stream, body_iter()

--- a/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
+++ b/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
@@ -131,37 +131,6 @@ class TestStreamingNotBuffered:
         )
 
 
-class TestUpstreamAuthorization:
-    @pytest.mark.parametrize(
-        ("target_key", "expected_authorization"),
-        [
-            ("not-needed", None),
-            ("provider-secret", "Bearer provider-secret"),
-        ],
-    )
-    def test_shield_credential_is_not_forwarded_upstream(
-        self,
-        client,
-        install_upstream,
-        monkeypatch,
-        target_key,
-        expected_authorization,
-    ):
-        seen = {}
-
-        def handler(request):
-            seen["authorization"] = request.headers.get("authorization")
-            return _resp(200, {"content-type": "application/json"}, [b"{}"])
-
-        install_upstream(handler)
-        monkeypatch.setattr(proxy, "TARGET_API_KEY", target_key)
-
-        response = client.get("/models", headers=AUTH)
-
-        assert response.status_code == 200
-        assert seen["authorization"] == expected_authorization
-
-
 # ── 1b. Oversized-text cutover keeps ONE upstream iterator (#1268) ─────────
 #
 # When a textual body crosses SHIELD_RESTORE_MAX_BYTES mid-stream, body_iter()
@@ -495,3 +464,34 @@ class TestWebSocketAuth:
             if loop and stop:
                 loop.call_soon_threadsafe(stop.set)
             t.join(timeout=5)
+
+
+class TestUpstreamAuthorization:
+    @pytest.mark.parametrize(
+        ("target_key", "expected_authorization"),
+        [
+            ("not-needed", None),
+            ("provider-secret", "Bearer provider-secret"),
+        ],
+    )
+    def test_shield_credential_is_not_forwarded_upstream(
+        self,
+        client,
+        install_upstream,
+        monkeypatch,
+        target_key,
+        expected_authorization,
+    ):
+        seen = {}
+
+        def handler(request):
+            seen["authorization"] = request.headers.get("authorization")
+            return _resp(200, {"content-type": "application/json"}, [b"{}"])
+
+        install_upstream(handler)
+        monkeypatch.setattr(proxy, "TARGET_API_KEY", target_key)
+
+        response = client.get("/models", headers=AUTH)
+
+        assert response.status_code == 200
+        assert seen["authorization"] == expected_authorization


### PR DESCRIPTION
## Why this matters

Privacy Shield authenticates clients with its own Bearer token, then proxies to a separate trust boundary. `_build_upstream_headers` copied the inbound `Authorization` field before optionally adding the provider key. With `TARGET_API_KEY=not-needed`, the Shield credential leaked to the model upstream; with a provider key configured, HTTPX combined both values into one invalid Authorization header.

Root cause: Shield-bound credentials were treated as ordinary end-to-end application headers, and the differently-cased replacement key did not overwrite the lowercase dictionary entry.

Behavioral invariant: the Shield Bearer token terminates at the Shield boundary; upstream receives no Authorization header unless `TARGET_API_KEY` supplies exactly one provider credential.

## Overlap check

Searched open and closed upstream PRs for Privacy Shield authorization/credential/upstream-header/token-forwarding terms and inspected PRs touching `ods/extensions/services/privacy-shield/proxy.py`. Current PRs address response information leakage and a missing await, not cross-boundary authorization. No existing PR enforces this invariant.

## What changed

- Exclude inbound `Authorization` while constructing upstream headers.
- Continue injecting exactly `Bearer <TARGET_API_KEY>` when a provider key is configured.
- Add authenticated public proxy tests for both local/no-key and provider-key deployments.

## Validation

- Red before fix: local upstream received the Shield Bearer token; configured upstream received a comma-joined Shield token plus provider token.
- `pytest tests/test_streaming_proxy.py::TestUpstreamAuthorization -q` — 2 passed.
- `pytest tests -q` — 54 passed.
- `python -m py_compile proxy.py tests/test_streaming_proxy.py` — passed.
- `git diff --check` — passed.

## Platform, risk, and rollback

This affects the shared Python proxy on Linux, macOS, and Windows/WSL. Other client headers and PII processing remain unchanged. Deployments that intentionally reused the Shield credential as an upstream credential must set `TARGET_API_KEY` explicitly; that separation is the intended configuration contract. Rollback is one commit and needs no data migration.
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.