### PR TITLE
fix(ape): bound audit log queries

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -68,7 +68,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import yaml
-from fastapi import FastAPI, Request, HTTPException, Header, Depends
+from fastapi import FastAPI, Request, HTTPException, Header, Depends, Query
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
@@ -1012,7 +1012,10 @@ async def approve(req: ApproveRequest, request: Request,
 
 
 @app.get("/audit")
-async def audit(last_n: int = 50, api_key: str = Depends(verify_api_key)):
+async def audit(
+    last_n: int = Query(default=50, ge=1, le=1000),
+    api_key: str = Depends(verify_api_key),
+):
     """Return the last N audit log entries."""
     if not AUDIT_LOG.exists():
         return {"entries": []}

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -108,6 +108,24 @@ def test_audit_endpoint_contract(make_client):
     assert isinstance(body["entries"], list)
 
 
+def test_audit_accepts_maximum_page_size(make_client):
+    client, _ = make_client()
+    _verify(client)
+
+    response = client.get("/audit", params={"last_n": 1000})
+
+    assert response.status_code == 200
+    assert len(response.json()["entries"]) == 1
+
+
+def test_audit_rejects_out_of_range_page_sizes(make_client):
+    client, _ = make_client()
+
+    for last_n in (-1, 0, 1001):
+        response = client.get("/audit", params={"last_n": last_n})
+        assert response.status_code == 422
+
+
 def test_api_key_required(make_client):
     client, _ = make_client()
     r = client.post("/verify", headers={"X-API-Key": "wrong"},


### PR DESCRIPTION
## Why this matters

APE's authenticated `/audit` endpoint accepted arbitrary `last_n` values. Very large values force the reverse scanner to walk the entire audit file and retain an equally large result; zero can trigger an internal empty-list pop once a log exists, which is then swallowed into an HTTP 200 error payload. Operators need a predictable bounded API contract.

Root cause: `last_n` was typed but had no HTTP-boundary validation.

Behavioral invariant: audit page size is 1-1000, invalid values fail with 422 before file I/O, and the maximum valid page still returns the newest entries.

## Overlap check

Searched open and closed upstream PRs for APE audit/last_n/page-size/log-bound/query-limit terms and inspected PRs changing `ods/extensions/services/ape/main.py`. Current APE work addresses classifier and allowlist behavior; no PR bounds audit reads. The separate metrics-total PR changes only decision aggregation and composes independently.

## What changed

- Added FastAPI query constraints for `last_n`: minimum 1, maximum 1000, default 50.
- Added public authenticated regressions for the valid maximum and invalid negative/zero/over-limit values.

## Validation

- Red before fix: out-of-range audit queries returned HTTP 200 rather than boundary validation errors.
- `pytest tests/test_main.py::test_audit_accepts_maximum_page_size tests/test_main.py::test_audit_rejects_out_of_range_page_sizes -q` — 2 passed.
- `pytest tests -q` — 46 passed.
- `python -m py_compile main.py tests/test_main.py` — passed.
- `git diff --check` — passed.

## Tradeoffs and rollback

The 1000-entry cap is large enough for operational inspection while bounding memory and scan work per request. Bulk log analysis should read the persisted audit artifact rather than an online control-plane endpoint. No schema/state changes; rollback is one commit.
## Batch compatibility

Validated as an independent ten-PR batch from upstream `main` `6ff9b4fc5190099705043acaab7e9b6ad9c8b8f1`. The final PR heads merged without conflicts in this order: #2964 -> #2965 -> #2967 -> #2969 -> #2970 -> #2971 -> #2972 -> #2973 -> #2974 -> #2975. The resulting local synthetic merge head is `4ae60eadad9696a9accb735aad71af87d2be802d`.

Combined validation on that exact tree:

- Dashboard API boundary suites: 323 passed, 4 skipped.
- Token Spy suite: 36 passed, 1 skipped.
- Privacy Shield suite: 55 passed.
- APE suite: 47 passed.
- Python compile checks and `git diff --check`: passed.

The scopes are behaviorally independent. The stated order is the tested rollback/merge sequence for shared-file changes; each PR remains individually useful and revertible.