### PR TITLE
fix(installer): make Linux preflight probe Podman instead of failing it out

### DIFF
--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -138,39 +138,34 @@ else
     append_check "DOCKER_INSTALLED" "pass" "Docker CLI: ${DV:-present}" ""
     if docker_cli_looks_like_podman; then
         DOCKER_IS_PODMAN=true
-        append_check "DOCKER_ENGINE" "fail" \
-            "docker resolves to Podman compatibility mode, not Docker Engine" \
-            "Install Docker Engine and Docker Compose v2. Podman is not a supported ODS runtime yet; remove podman-docker or put Docker Engine first in PATH."
+        append_check "DOCKER_ENGINE" "pass" \
+            "docker resolves to Podman (rootless-compatible container runtime; see phase 05 for Podman-specific setup)" ""
     else
         append_check "DOCKER_ENGINE" "pass" "Docker CLI appears to target Docker Engine" ""
     fi
 fi
 
 # --- Docker daemon ---
+# Probed the same way for Docker Engine and Podman: both serve `docker info`
+# through the CLI resolved above (Podman via its docker-compatible shim).
 DOCKER_INFO_OK=false
-if [[ "$DOCKER_IS_PODMAN" == true ]]; then
-    append_check "DOCKER_DAEMON" "fail" \
-        "Skipped Docker daemon probe because docker resolves to Podman" \
-        "Install Docker Engine; ODS does not currently support Podman as the container runtime."
-elif command -v docker >/dev/null 2>&1; then
+if command -v docker >/dev/null 2>&1; then
     if docker info >/dev/null 2>&1; then
         DOCKER_INFO_OK=true
         append_check "DOCKER_DAEMON" "pass" "Docker daemon is reachable" ""
     else
         append_check "DOCKER_DAEMON" "fail" \
             "Docker daemon not running or not accessible" \
-            "Start the service (e.g. sudo systemctl start docker) or log in to Docker Desktop; add your user to the docker group if permission denied (see LINUX-TROUBLESHOOTING-GUIDE.md#docker_daemon)."
+            "Start the service (e.g. sudo systemctl start docker, or 'podman machine start' / 'systemctl --user start podman.socket' for Podman) or log in to Docker Desktop; add your user to the docker group if permission denied (see LINUX-TROUBLESHOOTING-GUIDE.md#docker_daemon)."
     fi
 else
     append_check "DOCKER_DAEMON" "fail" "Skipped — Docker CLI missing" ""
 fi
 
 # --- Docker Compose v2 / v1 ---
-if [[ "$DOCKER_IS_PODMAN" == true ]]; then
-    append_check "COMPOSE_CLI" "fail" \
-        "Skipped Compose probe because docker resolves to Podman" \
-        "Install Docker Engine with the Docker Compose v2 plugin. podman compose is not a supported substitute for ODS installs yet."
-elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+# Probed the same way for Docker Engine and Podman: `docker compose` works
+# through Podman's docker-compatible shim once a compose provider is present.
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
     CV="$(docker compose version 2>/dev/null | head -1 || true)"
     append_check "COMPOSE_CLI" "pass" "Compose: $CV" ""
 elif command -v docker-compose >/dev/null 2>&1; then

--- a/ods/tests/test-linux-install-preflight.sh
+++ b/ods/tests/test-linux-install-preflight.sh
@@ -80,7 +80,10 @@ else
     fail "python3 not available — skipped JSON contract (unexpected on CI)"
 fi
 
-# Podman compatibility shims are intentionally not accepted as Docker Engine.
+# Podman is a supported ODS runtime (installers/phases/05-docker.sh detects
+# and configures it — see podman-registries.sh and _runtime_is_podman()).
+# Preflight must probe it the same way it probes Docker Engine, not fail it
+# out as unsupported.
 if command -v python3 >/dev/null 2>&1; then
     PODMAN_TMP="$(mktemp -d)"
     cat >"$PODMAN_TMP/docker" <<'EOF'
@@ -88,6 +91,23 @@ if command -v python3 >/dev/null 2>&1; then
 case "${1:-}" in
   --version)
     echo "podman version 5.0.0"
+    ;;
+  info)
+    # Non-rootless SecurityOptions so ROOTLESS_SUBID stays out of this fixture.
+    if [[ "${2:-}" == "--format" ]]; then
+        echo "[]"
+    else
+        echo "host: {security: {rootless: false}}"
+    fi
+    exit 0
+    ;;
+  compose)
+    if [[ "${2:-}" == "version" ]]; then
+        echo "Docker Compose version v2.29.1 (podman)"
+        exit 0
+    fi
+    echo "podman shim compose: unhandled args: $*" >&2
+    exit 125
     ;;
   *)
     echo "podman shim called: $*" >&2
@@ -107,17 +127,17 @@ with open(path, encoding="utf-8") as f:
     report = json.load(f)
 checks = {c["id"]: c for c in report["checks"]}
 assert checks["DOCKER_INSTALLED"]["status"] == "pass"
-assert checks["DOCKER_ENGINE"]["status"] == "fail"
-assert checks["DOCKER_DAEMON"]["status"] == "fail"
-assert checks["COMPOSE_CLI"]["status"] == "fail"
+assert checks["DOCKER_ENGINE"]["status"] == "pass"
+assert checks["DOCKER_DAEMON"]["status"] == "pass"
+assert checks["COMPOSE_CLI"]["status"] == "pass"
 assert "Podman" in checks["DOCKER_ENGINE"]["message"]
-assert report["summary"]["exit_ok"] is False
+assert checks["ROOTLESS_SUBID"]["status"] == "pass"
 print("ok")
 PY
     then
-        pass "Podman docker shim fails loud as unsupported runtime"
+        pass "Podman docker shim probes as a supported runtime, not a fail-loud one"
     else
-        fail "Podman docker shim did not produce the expected fail-loud checks"
+        fail "Podman docker shim did not produce the expected supported-runtime checks"
     fi
     rm -rf "$PODMAN_TMP"
 else


### PR DESCRIPTION
Fixes #2977
Fixes #2988

PR #2804 added rootless Podman support to the Linux installer. Phase 05 detects and configures Podman through `installers/lib/podman-registries.sh` and `_runtime_is_podman()`, while `installers/lib/sudo.sh` documents Podman as a supported rootless runtime.

`scripts/linux-install-preflight.sh` was never updated to match, which produced two symptoms of the same root cause:

- **#2977:** The test suite asserted contradictory Podman contracts — `test-linux-install-preflight.sh` expected Podman to fail loudly, while `test-podman-rootless-contracts.sh` (added alongside #2804) expected it to work.
- **#2988:** The preflight script itself hard-failed `DOCKER_ENGINE`, `DOCKER_DAEMON`, and `COMPOSE_CLI` for a Podman-backed `docker` CLI and told the user to remove it, without ever probing whether the daemon or Compose actually work.

Both are fixed by the same change, since #2977's test fixture was directly asserting the broken behavior described in #2988.

## Change

Preflight now probes Podman the same way it probes Docker Engine:

- `docker info` works through Podman's Docker-compatible shim.
- `docker compose version` works through the same shim.
- `DOCKER_ENGINE` now reports which runtime was detected instead of failing Podman outright.
- `DOCKER_DAEMON` no longer skips Podman and runs the actual daemon probe.
- `COMPOSE_CLI` no longer skips Podman and runs the actual Compose probe.

This matches the behavior already relied upon by phase 05.

## Tests

Updated the Podman fixture in `tests/test-linux-install-preflight.sh`.

The stub Docker shim now responds to `info` and `compose version` like a working Podman installation, and the assertions have been updated from "fails loud" to "probes and passes."

### Local Verification

```bash
bash tests/test-linux-install-preflight.sh