### PR TITLE
fix(compose): honor LLAMA_SERVER_IMAGE override on apple overlay

### DIFF
--- a/ods/docker-compose.apple.yml
+++ b/ods/docker-compose.apple.yml
@@ -9,7 +9,7 @@
 
 services:
   llama-server:
-    image: ghcr.io/ggml-org/llama.cpp:server-b8248
+    image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}
     platform: linux/arm64
     deploy:
       resources:


### PR DESCRIPTION
## Summary

On multi-GPU NVIDIA installs whose assignment JSON lacks an entry for whisper/comfyui/embeddings, jq's `.gpus[0]?` prints the literal string `null`, which phase 03 persists verbatim — compose then renders `device_ids: ["null"]` and `docker compose up` fails container-create with `could not select device "null"`. The three extractions now fall back to empty, matching how the CLI's own reassign path guards the same reads.

## AI Assistance

AI-assisted trace from jq output to rendered compose. The author reviewed the guard style used elsewhere and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Installer
- [ ] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `bash -n ods/installers/phases/03-features.sh` - passed.
