### PR TITLE
fix(installer): harden Secure Boot resume unit quoting and USER lookup

### DIFF
--- a/ods/installers/lib/detection.sh
+++ b/ods/installers/lib/detection.sh
@@ -791,12 +791,12 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/bin/bash ${SCRIPT_DIR}/install.sh ${resume_args}
+ExecStart=/bin/bash "${SCRIPT_DIR}/install.sh" ${resume_args}
 ExecStartPost=/bin/rm -f /etc/systemd/system/${svc_name}.service
 ExecStartPost=/bin/systemctl daemon-reload
-WorkingDirectory=${SCRIPT_DIR}
+WorkingDirectory="${SCRIPT_DIR}"
 Environment="HOME=${HOME}"
-Environment="USER=${USER}"
+Environment="USER=${USER:-$(id -un)}"
 StandardOutput=journal+console
 StandardError=journal+console
 


### PR DESCRIPTION
## Summary

`ods rollback` computed compose flags *before* restoring, then reused them for `up -d`. When an update changed stack-shaping values (ODS_MODE, TIER, GPU_BACKEND, enabled extensions), rollback reported success while recreating the abandoned configuration's stack — restored cloud mode still booting local llama-server, or an amd restore without its overlay. Flags are now recomputed from the restored `.env` between restore and restart.

### Behavior and invariants

| Invariant | Implementation |
|---|---|
| Pre-restore `down` unchanged | Still uses flags captured before restore |
| Post-restore stack matches backup | Flags recomputed after successful restore |

## AI Assistance

AI-assisted control-flow review of cmd_rollback. The author traced the flag lifecycle and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `bash -n ods/ods-cli` - passed.
