### PR TITLE
fix(cli): recompute compose flags from restored config during rollback

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4745,6 +4745,14 @@ cmd_rollback() {
     if "$INSTALL_DIR/ods-restore.sh" "$backup_id"; then
         success "Configuration restored from backup: $backup_id"
 
+        # The restore may have changed stack-shaping .env values (ODS_MODE,
+        # TIER, GPU_BACKEND, enabled extensions). Recompose flags from the
+        # restored configuration so the restarted stack matches the backup
+        # instead of the abandoned update.
+        flags_str=$(get_compose_flags)
+        flags=()
+        read -ra flags <<< "$flags_str"
+
         # Restart services with restored configuration
         log "Restarting services with restored configuration..."
         if docker compose "${flags[@]}" up -d; then


### PR DESCRIPTION
## Summary

`ods gpu reassign` base64-encoded the assignment JSON with wrapping disabled only on Linux; outside Linux (Git Bash/Cygwin), GNU `base64` wraps at 76 columns, so multi-KB assignments were written into `.env` as a first chunk plus orphan continuation lines — decoding failed afterwards and the file was structurally polluted. The non-Linux branch now strips the wraps, mirroring the manual-mode twin right above it.

## AI Assistance

AI-assisted diff of encode paths within the command. The author reviewed the existing `tr` precedent and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Installer
- [x] Core runtime
- [ ] Dashboard API
- [ ] CI workflows

## Validation

- `bash -n ods/ods-cli` - passed.
