### PR TITLE
fix(egress): preserve forwarded query strings

### DIFF
--- a/ods/bin/remote_provider/egress.py
+++ b/ods/bin/remote_provider/egress.py
@@ -208,8 +208,9 @@ def sanitize_forward_headers(
     return forwarded
 
 
-def _join_openai_path(base_url: str, path: str) -> str:
-    base = base_url.rstrip("/")
+def _join_openai_path(base_url: str, path: str, query_string: str = "") -> str:
+    parts = urlsplit(base_url)
+    base_path = parts.path.rstrip("/")
     suffix = path
     if suffix.startswith("/v1/"):
         suffix = suffix[len("/v1"):]
@@ -217,7 +218,14 @@ def _join_openai_path(base_url: str, path: str) -> str:
         suffix = ""
     if suffix and not suffix.startswith("/"):
         suffix = f"/{suffix}"
-    return f"{base}{suffix}"
+    query = "&".join(value for value in (parts.query, query_string) if value)
+    return urlunsplit((
+        parts.scheme,
+        parts.netloc,
+        f"{base_path}{suffix}",
+        query,
+        parts.fragment,
+    ))
 
 
 def _provider_host_port(base_url: str) -> tuple[str, int]:
@@ -329,6 +337,7 @@ def prepare_upstream_request(
     provider_secret: str,
     max_body_bytes: int = DEFAULT_MAX_BODY_BYTES,
     resolved_addresses: list[str] | None = None,
+    query_string: str = "",
 ) -> UpstreamRequest:
     """Validate and rewrite one OpenAI-compatible request for the provider."""
     required_method = FORWARD_PATHS.get(path)
@@ -391,7 +400,7 @@ def prepare_upstream_request(
     content = json.dumps(payload, separators=(",", ":")).encode("utf-8")
     return UpstreamRequest(
         method=required_method,
-        url=_join_openai_path(upstream_base_url, path),
+        url=_join_openai_path(upstream_base_url, path, query_string),
         headers=sanitize_forward_headers(headers, provider_secret=provider_secret),
         content=content,
         requested_model=requested_model,

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -352,6 +352,7 @@ async def forward(full_path: str, request: Request) -> Response:
             provider_secret=secret,
             max_body_bytes=MAX_BODY_BYTES,
             resolved_addresses=resolved_addresses,
+            query_string=request.scope.get("query_string", b"").decode("ascii"),
         )
     except EgressError as exc:
         return _error_response(exc)

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -168,6 +168,24 @@ def test_route_state_prepares_direct_provider_request_without_client_auth() -> N
     assert_true("connection" not in {key.lower() for key in upstream.headers}, "hop-by-hop headers must be stripped")
 
 
+def test_prepare_upstream_request_preserves_query_contract() -> None:
+    route = route_from_state(route_state())
+    upstream = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        query_string="trace=a%2Fb&trace=second",
+        headers={},
+        body=b'{"model":"ods/current","messages":[]}',
+        route=route,
+        provider_secret="unit-test-provider-token",
+    )
+    assert_true(
+        upstream.url
+        == "https://gpu.example.test/v1/chat/completions?trace=a%2Fb&trace=second",
+        f"provider query contract drifted: {upstream.url}",
+    )
+
+
 def test_direct_resolution_allows_only_global_provider_addresses() -> None:
     route = route_from_state(route_state())
     addresses = validate_direct_provider_resolution(
@@ -458,6 +476,7 @@ def main() -> int:
         test_manifest_and_network_policy_mark_no_lan_exposure,
         test_image_copies_shared_policy_package,
         test_route_state_prepares_direct_provider_request_without_client_auth,
+        test_prepare_upstream_request_preserves_query_contract,
         test_direct_resolution_allows_only_global_provider_addresses,
         test_direct_resolution_rejects_unsafe_dns_answers,
         test_ssh_route_uses_internal_tunnel_without_direct_dns,


### PR DESCRIPTION
## Why this matters

`remote-provider-egress` is the production boundary between OpenAI-compatible clients and a configured remote runtime. The catch-all route validated the path and body but discarded the incoming query string, so provider features expressed as encoded or repeated query parameters silently changed in transit.

## Root cause and invariant

The FastAPI handler passed only `/{full_path}` into `prepare_upstream_request`, and `_join_openai_path` built a URL from that path alone. The invariant is: after the path allowlist is applied, the original raw query string must reach the same upstream request without decoding, reordering, or collapsing repeated keys.

This change passes Starlette's raw ASCII query string into the pure request-preparation helper and composes it with `urllib.parse`, while path authorization remains exact and unchanged.

## Overlap check

Searched open and closed PRs for `remote provider egress query string`, `egress query passthrough`, and the changed production files. Open PRs touching `app/main.py` are #2733 (caller auth), #2708 (bounded request bodies), #2702 (client LRU), and #2700 (non-blocking probes). None preserves query semantics; `ods/bin/remote_provider/egress.py` has no overlapping open PR.

## Regression coverage

The request-preparation contract now exercises an encoded value plus a repeated key and asserts the exact upstream URL. This is the nearest deterministic boundary before the HTTP client sends the production request, and the FastAPI handler is wired to supply the raw ASGI query bytes.

## Validation

- `python ods/tests/contracts/test-remote-provider-egress-service.py` — 16 passed
- `python -m py_compile ods/bin/remote_provider/egress.py ods/extensions/services/remote-provider-egress/app/main.py`
- `git diff --check`

## Tradeoffs and rollback

No query parameters are interpreted or trusted by ODS; they remain provider-owned data after the existing path, route, DNS, body, and credential controls pass. Rollback is a clean revert of this commit, restoring the prior query-dropping behavior.