### PR TITLE
fix(token-spy): preserve catch-all query strings

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -2485,10 +2485,14 @@ async def proxy_other(request: Request, path: str):
         headers = _build_anthropic_upstream_headers(request)
 
     body = await request.body()
+    upstream_url = f"/{path}"
+    query_string = request.scope.get("query_string", b"")
+    if query_string:
+        upstream_url = f"{upstream_url}?{query_string.decode('ascii')}"
     try:
         resp = await client.request(
             method=request.method,
-            url=f"/{path}",
+            url=upstream_url,
             content=body if body else None,
             headers=headers,
         )

--- a/ods/extensions/services/token-spy/tests/test_proxy_passthrough.py
+++ b/ods/extensions/services/token-spy/tests/test_proxy_passthrough.py
@@ -1,0 +1,44 @@
+"""HTTP-boundary contracts for Token Spy's authenticated catch-all proxy."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import httpx
+from fastapi.testclient import TestClient
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+os.environ.setdefault("TOKEN_SPY_API_KEY", "token-spy-test-key")
+sys.path.insert(0, str(TOKEN_SPY_DIR))
+
+spec = importlib.util.spec_from_file_location("token_spy_proxy_test_app", TOKEN_SPY_DIR / "main.py")
+token_spy = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(token_spy)
+
+
+class RecordingClient:
+    def __init__(self) -> None:
+        self.url = ""
+
+    async def request(self, *, url: str, **_kwargs) -> httpx.Response:
+        self.url = url
+        return httpx.Response(200, json={"ok": True})
+
+
+def test_catch_all_preserves_encoded_and_repeated_query_parameters(monkeypatch):
+    upstream = RecordingClient()
+    monkeypatch.setattr(token_spy, "_uses_openai_upstream", lambda: True)
+    monkeypatch.setattr(token_spy, "get_moonshot_client", lambda: upstream)
+
+    client = TestClient(token_spy.app)
+    response = client.get(
+        "/v1/models?trace=a%2Fb&trace=second",
+        headers={"Authorization": "Bearer token-spy-test-key"},
+    )
+
+    assert response.status_code == 200
+    assert upstream.url == "/v1/models?trace=a%2Fb&trace=second"


### PR DESCRIPTION
## Why this matters

Token Spy's authenticated catch-all is the compatibility path for provider endpoints it does not specialize. It forwarded method, path, body, and headers but silently removed every query parameter. Calls such as model listing or provider-specific operations could therefore target different upstream semantics than the client requested.

## Root cause and invariant

`proxy_other` constructed `url=f/{path}` and never read the ASGI query string. The invariant is that an authenticated passthrough request preserves the raw encoded query component, including repeated keys, without changing the existing provider selection or header isolation.

The handler now appends `scope[query_string]` only when present, decoding the ASGI-defined ASCII bytes without parsing or normalizing them.

## Overlap check

Searched open and closed PRs for `token spy proxy query string`, `catch-all query passthrough`, and `ods/extensions/services/token-spy/main.py`. Existing open changes cover decoded response headers (#2971), streaming status (#2970), usage bounds (#2969), atomic session files (#2803/#2798/#2795), Windows escaping (#2796), and exception narrowing (#2692/#2691). None changes catch-all URL construction.

## Regression coverage

A new FastAPI boundary test sends an authenticated request with an encoded value and a repeated key, records the exact URL handed to the selected upstream client, and verifies the response still passes through.

## Validation

- `pytest -q ods/extensions/services/token-spy/tests/test_proxy_passthrough.py` — 1 passed
- `python -m py_compile ods/extensions/services/token-spy/main.py ods/extensions/services/token-spy/tests/test_proxy_passthrough.py`
- `git diff --check`

## Tradeoffs and rollback

Token Spy does not interpret query values; upstream remains responsible for them. Authentication headers stay isolated by the existing header builders. Reverting this commit restores the former query-dropping behavior without a data migration.