### PR TITLE
fix(model-router): enforce public model aliases

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -887,7 +887,20 @@ async def forward(full_path: str, request: Request) -> Response:
             status_code=400,
         )
 
-    requested_alias = str(payload.get("model") or PUBLIC_ALIASES[0])
+    requested_model = payload.get("model")
+    if requested_model in (None, ""):
+        requested_alias = PUBLIC_ALIASES[0]
+    elif not isinstance(requested_model, str) or requested_model not in PUBLIC_ALIASES:
+        return JSONResponse(
+            {"error": {
+                "message": "model must be one of: " + ", ".join(PUBLIC_ALIASES),
+                "type": "invalid_request_error",
+                "code": "400",
+            }},
+            status_code=400,
+        )
+    else:
+        requested_alias = requested_model
 
     global _inflight
     async with _inflight_lock:

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -171,6 +171,21 @@ class _RecordingTelemetry:
 
 
 class TestForwarding:
+    @pytest.mark.parametrize("model", ["Concrete.gguf", "unknown", 42, True, []])
+    def test_rejects_models_outside_public_alias_contract(self, router, model):
+        mod, client, write_state, calls = router
+        write_state()
+
+        response = client.post("/v1/chat/completions", json={
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+        assert response.status_code == 400
+        assert response.json()["error"]["type"] == "invalid_request_error"
+        assert "ods/current, default" in response.json()["error"]["message"]
+        assert calls == []
+
     def test_alias_rewritten_in_and_out(self, router):
         mod, client, write_state, calls = router
         write_state()


### PR DESCRIPTION
## Why this matters

The model router publishes exactly `ods/current` and `default` from `/v1/models`, but its forwarding route accepted any `model` value and silently mapped it to the active runtime. Clients could believe a concrete or misspelled model was honored while ODS served a different model and rewrote the response back to the unsupported name.

## Root cause and invariant

The request body used `str(payload.get(model) or PUBLIC_ALIASES[0])`, coercing arbitrary strings, numbers, booleans, and containers into apparent aliases. The invariant is that the forwarding boundary accepts only aliases the discovery endpoint advertises; the existing missing/empty-model compatibility default remains `ods/current`.

Unsupported values now receive an OpenAI-shaped 400 before queue admission or any upstream request.

## Overlap check

Searched open and closed PRs for `model router unsupported alias`, `public model alias validation`, and the changed production file. Open same-file PRs are #2843 (MLX runtime family) and #2719 (internal-key auth); neither validates the public model contract. No semantic match was found.

## Regression coverage

The FastAPI contract suite now submits a concrete runtime ID, an unknown string, a number, a boolean, and a list. Each must return 400 `invalid_request_error` and the mock upstream must receive zero calls. Existing coverage proves both advertised aliases continue to route and rewrite correctly.

## Validation

- `pytest -q ods/extensions/services/model-router/tests/test_router.py -x` — 53 passed
- `python -m py_compile ods/extensions/services/model-router/app/main.py ods/extensions/services/model-router/tests/test_router.py`
- `git diff --check`

## Tradeoffs and rollback

This deliberately closes an undocumented permissive behavior. Clients selecting a concrete runtime must use the switchboard/control plane, then call the stable alias. Revert restores permissive alias coercion; no state or config migration is involved.