### PR TITLE
fix(model-router): preserve upstream response headers

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -92,6 +92,7 @@ _HOP_BY_HOP = {
     "te", "trailer", "transfer-encoding", "upgrade", "host", "authorization",
     "content-length",
 }
+_DROP_RESPONSE_HEADERS = _HOP_BY_HOP | {"content-encoding"}
 
 _PROBE_RE = re.compile(
     r"\[ODS_PROBE id=([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}) "
@@ -630,6 +631,24 @@ def _sanitize_headers(request: Request) -> dict[str, str]:
     return headers
 
 
+def _response_headers(
+    headers: httpx.Headers,
+    overrides: dict[str, str],
+) -> dict[str, str]:
+    blocked = set(_DROP_RESPONSE_HEADERS)
+    blocked.update(name.lower() for name in overrides)
+    blocked.update(
+        token.strip().lower()
+        for token in headers.get("connection", "").split(",")
+        if token.strip()
+    )
+    return {
+        name: value
+        for name, value in headers.items()
+        if name.lower() not in blocked
+    }
+
+
 def _strip_chat_template_artifacts(text: str) -> str:
     cleaned = text
     for pattern in _CHAT_TEMPLATE_ARTIFACTS:
@@ -1027,7 +1046,11 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                                               "text/event-stream")
             return StreamingResponse(
                 stream_body(), status_code=upstream.status_code,
-                media_type=media_type, headers=ods_headers,
+                media_type=media_type,
+                headers={
+                    **_response_headers(upstream.headers, ods_headers),
+                    **ods_headers,
+                },
             ), True
 
         upstream = await client.post(
@@ -1098,7 +1121,9 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
 
     media_type = upstream.headers.get("content-type", "application/json")
     return Response(content=content, status_code=upstream.status_code,
-                    media_type=media_type, headers=ods_headers), False
+                    media_type=media_type,
+                    headers={**_response_headers(upstream.headers, ods_headers),
+                             **ods_headers}), False
 
 
 @app.on_event("startup")

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -171,6 +171,44 @@ class _RecordingTelemetry:
 
 
 class TestForwarding:
+    @pytest.mark.parametrize("stream", [False, True])
+    def test_preserves_end_to_end_upstream_response_headers(self, router, stream):
+        mod, client, write_state, calls = router
+        write_state()
+
+        def handler(_request):
+            return httpx.Response(
+                429,
+                json={"error": "runtime busy"},
+                headers={
+                    "retry-after": "17",
+                    "x-runtime-request-id": "up-123",
+                    "cache-control": "no-store",
+                    "connection": "x-private",
+                    "x-private": "must-not-cross-proxy",
+                    "content-length": "999",
+                },
+            )
+
+        asyncio.run(mod.app.state.http.aclose())
+        mod.app.state.http = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        )
+
+        response = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "stream": stream,
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+        assert response.status_code == 429
+        assert response.headers["retry-after"] == "17"
+        assert response.headers["x-runtime-request-id"] == "up-123"
+        assert response.headers["cache-control"] == "no-store"
+        assert "connection" not in response.headers
+        assert "x-private" not in response.headers
+        assert response.headers.get("content-length") != "999"
+
     def test_alias_rewritten_in_and_out(self, router):
         mod, client, write_state, calls = router
         write_state()


### PR DESCRIPTION
## Why this matters

The model router preserved upstream status codes and bodies but discarded end-to-end response metadata. In particular, a runtime returning 429/503 lost `Retry-After`, request correlation IDs, and cache directives, leaving OpenAI-compatible clients unable to back off correctly or correlate failures.

## Root cause and invariant

Both streaming and buffered response constructors passed only ODS-generated headers. The invariant is that end-to-end upstream headers survive both response paths, while hop-by-hop fields, connection-nominated fields, stale body framing/encoding, and ODS-owned metadata never cross incorrectly.

A shared response filter now removes hop-by-hop headers, `Content-Length`, `Content-Encoding`, every token named by `Connection`, and case-insensitive collisions with ODS headers. Remaining headers are merged into both response paths.

## Overlap check

Searched open and closed PRs for `model router response headers`, `Retry-After`, and the changed production file. Same-file open PRs are #2843 (MLX runtime family) and #2719 (internal-key auth); neither covers response metadata. Token Spy header PR #2971 affects a different proxy and implementation.

## Regression coverage

A FastAPI boundary test covers buffered and streaming requests. It asserts preservation of `Retry-After`, an upstream request ID, and `Cache-Control`, while proving `Connection`, its nominated private header, and a stale `Content-Length` do not leak. The full router suite also protects existing ODS header behavior; an initial duplicate-case collision was caught and fixed before commit.

## Validation

- `pytest -q ods/extensions/services/model-router/tests/test_router.py -x` — 50 passed
- `python -m py_compile ods/extensions/services/model-router/app/main.py ods/extensions/services/model-router/tests/test_router.py`
- `git diff --check`

## Tradeoffs and rollback

The filter preserves arbitrary end-to-end extension headers because model runtimes use provider-specific rate-limit and correlation names. Body framing is always regenerated after decoding/rewriting. Revert is isolated and requires no state migration.