### PR TITLE
fix(token-spy): bind PostgreSQL hour intervals

### DIFF
--- a/ods/extensions/services/token-spy/db_postgres.py
+++ b/ods/extensions/services/token-spy/db_postgres.py
@@ -258,7 +258,7 @@ def query_usage(agent: str | None = None, hours: int = 24, limit: int = 200) -> 
                 FROM requests r
                 LEFT JOIN agents a ON r.agent_id = a.id
                 WHERE r.tenant_id = %s
-                AND r.timestamp > NOW() - INTERVAL '%s hours'
+                AND r.timestamp > NOW() - (%s * INTERVAL '1 hour')
             """
             params = [_tenant_id, hours]
 
@@ -510,7 +510,7 @@ def query_summary(hours: int = 24) -> list[dict]:
                 FROM requests r
                 LEFT JOIN agents a ON r.agent_id = a.id
                 WHERE r.tenant_id = %s
-                AND r.timestamp > NOW() - INTERVAL '%s hours'
+                AND r.timestamp > NOW() - (%s * INTERVAL '1 hour')
                 GROUP BY a.name
                 """,
                 (_tenant_id, hours)

--- a/ods/extensions/services/token-spy/tests/test_postgres_query_intervals.py
+++ b/ods/extensions/services/token-spy/tests/test_postgres_query_intervals.py
@@ -1,0 +1,83 @@
+"""PostgreSQL query contracts that do not require a live database."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from uuid import UUID, uuid4
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load_postgres_module(monkeypatch):
+    psycopg2 = types.ModuleType("psycopg2")
+    extras = types.ModuleType("psycopg2.extras")
+    extras.RealDictCursor = object
+    extras.register_uuid = lambda: None
+
+    class ThreadedConnectionPool:
+        pass
+
+    psycopg2.pool = types.SimpleNamespace(
+        ThreadedConnectionPool=ThreadedConnectionPool
+    )
+    monkeypatch.setitem(sys.modules, "psycopg2", psycopg2)
+    monkeypatch.setitem(sys.modules, "psycopg2.extras", extras)
+
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_postgres_intervals_{uuid4().hex}",
+        TOKEN_SPY_DIR / "db_postgres.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class RecordingCursor:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def execute(self, sql, params=None):
+        self.calls.append((sql, params))
+
+    def fetchall(self):
+        return []
+
+
+class RecordingConnection:
+    def __init__(self) -> None:
+        self.cursor_instance = RecordingCursor()
+
+    def cursor(self, **_kwargs):
+        return self.cursor_instance
+
+
+def test_hour_windows_use_a_bound_postgres_interval_multiplier(monkeypatch):
+    db = _load_postgres_module(monkeypatch)
+    connection = RecordingConnection()
+    db._tenant_id = UUID(int=1)
+    monkeypatch.setattr(db, "_get_conn", lambda: connection)
+    monkeypatch.setattr(db, "_put_conn", lambda _connection: None)
+
+    assert db.query_usage(agent="agent-a", hours=7, limit=3) == []
+    assert db.query_summary(hours=11) == []
+
+    data_queries = [
+        (sql, params)
+        for sql, params in connection.cursor_instance.calls
+        if "FROM requests" in sql
+    ]
+    assert len(data_queries) == 2
+    assert all("(%s * INTERVAL '1 hour')" in sql for sql, _ in data_queries)
+    assert all("INTERVAL '%s hours'" not in sql for sql, _ in data_queries)
+    assert data_queries[0][1] == [UUID(int=1), 7, "agent-a", 3]
+    assert data_queries[1][1] == (UUID(int=1), 11)


### PR DESCRIPTION
## Why this matters

With `DB_BACKEND=postgres`, Token Spy's `/api/usage` and `/api/summary` paths generated invalid parameterized interval SQL. PostgreSQL deployments could fail every recent-usage query even though the equivalent SQLite path worked.

## Root cause and invariant

Both queries placed the psycopg `%s` placeholder inside a quoted SQL literal: `INTERVAL '%s hours'`. Psycopg placeholders must not be quoted; the driver substitutes a value expression, not text inside a literal. The invariant is that the hour count remains a bound parameter while PostgreSQL receives a typed interval expression.

The predicates now use `NOW() - (%s * INTERVAL '1 hour')` for both detail and summary queries.

## Overlap check

Searched open and closed PRs for `token spy postgres interval hours`, `psycopg interval placeholder`, and `ods/extensions/services/token-spy/db_postgres.py`. No semantic or open same-file overlap was found. Existing Token Spy PRs touching `main.py` do not modify the PostgreSQL backend.

## Regression coverage

A driver-independent database-boundary test loads the real module with a minimal psycopg shim, records cursor executions from both public query functions, and asserts the placeholder is outside the interval literal with exact bound parameters. This runs without a live PostgreSQL service while validating the SQL handed to psycopg.

## Validation

- `pytest -q ods/extensions/services/token-spy/tests/test_postgres_query_intervals.py` — 1 passed
- `python -m py_compile ods/extensions/services/token-spy/db_postgres.py ods/extensions/services/token-spy/tests/test_postgres_query_intervals.py`
- `git diff --check`

## Tradeoffs and rollback

The expression is standard PostgreSQL interval arithmetic and preserves integer parameter binding; result windows are unchanged. Static cursor validation proves SQL construction, not a live TimescaleDB round trip. Rollback is a code-only revert with no schema or data change.