### PR TITLE
fix(ape): fail closed on unknown policy modes

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -692,7 +692,7 @@ def evaluate(intent: str, tool_name: str, args: dict, policy: dict) -> tuple[boo
             return True, "path is within allowed zone"
         return False, f"write to '{real}' is outside allowed paths"
 
-    return True, f"unknown mode '{mode}', defaulting to allow"
+    return False, f"unknown policy mode '{mode}' denied"
 
 
 # ── Audit log ─────────────────────────────────────────────────────────────────

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -85,6 +85,23 @@ def test_policy_endpoint_contract(make_client):
     assert "circuit_breaker" in body
 
 
+def test_unknown_policy_mode_fails_closed_at_verify_boundary(make_client):
+    client, _ = make_client(policy_yaml="""
+version: 1
+intents:
+  ReadFile: {mode: alow}
+rate_limit:
+  requests_per_minute: 10000
+""")
+
+    response = _verify(client, tool="read_file")
+
+    assert response.status_code == 200
+    assert response.json()["allowed"] is False
+    assert response.json()["decision"] == "deny"
+    assert response.json()["reason"] == "unknown policy mode 'alow' denied"
+
+
 def test_metrics_endpoint_contract(make_client):
     client, _ = make_client()
     _verify(client)


### PR DESCRIPTION
## Why this matters

APE is the production authorization boundary for agent tool actions. A typo or newly introduced policy mode currently evaluates as allowed, so malformed operator policy silently weakens enforcement exactly when APE cannot understand the requested rule.

## Root cause and invariant

The evaluator handled known modes explicitly, then allowed every other value. The invariant is fail-closed policy interpretation: only a recognized allow rule may authorize an action; unknown configuration must produce an auditable denial.

Unknown modes now return a normal policy denial. Existing non-strict deployments receive the established 200 decision envelope with `allowed=false`; strict mode continues converting policy denials to 403.

## Overlap check

Searched open and closed PRs for `APE unknown policy mode`, `defaulting to allow`, and `ods/extensions/services/ape/main.py`. Open same-file PRs #2974 and #2975 correct decision totals and audit query bounds. Existing APE PRs around path guards, rate-limit storage, breakers, and state pruning do not change unknown-mode evaluation.

## Regression coverage

A `/verify` boundary test loads a realistic policy with the misspelled mode `alow`, calls a classified `ReadFile` action, and asserts a deny decision plus the explicit reason. This exercises policy loading, intent classification, evaluation, and the public response together.

## Validation

- `pytest -q ods/extensions/services/ape/tests/test_main.py -x` ? 29 passed
- `python -m py_compile ods/extensions/services/ape/main.py ods/extensions/services/ape/tests/test_main.py`
- `git diff --check`

## Tradeoffs and rollback

A malformed policy that previously failed open will now block affected actions until corrected; that operator-visible interruption is intentional. Valid `allow`, `deny`, `allowlist`, and `path_guard` behavior is unchanged. Revert restores fail-open behavior with no state migration.
