### PR TITLE
fix(magic-link): preserve unreadable token stores

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -234,14 +234,31 @@ def _writable_store_path() -> Path:
 def _ensure_store() -> dict:
     """Load the token store, creating an empty one if missing."""
     store_path = _writable_store_path()
-    if not store_path.exists():
-        return {"tokens": []}
     try:
-        return json.loads(store_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        # Corrupted store — start fresh rather than blocking generation.
-        logger.exception("magic-link store unreadable at %s; starting fresh", store_path)
+        raw_store = store_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
         return {"tokens": []}
+    except OSError as exc:
+        logger.exception("magic-link store unreadable at %s", store_path)
+        raise HTTPException(
+            status_code=503,
+            detail="Magic-link storage is unreadable; existing links were preserved.",
+        ) from exc
+    try:
+        store = json.loads(raw_store)
+    except json.JSONDecodeError as exc:
+        logger.exception("magic-link store contains invalid JSON at %s", store_path)
+        raise HTTPException(
+            status_code=503,
+            detail="Magic-link storage is unreadable; existing links were preserved.",
+        ) from exc
+    if not isinstance(store, dict) or not isinstance(store.get("tokens"), list):
+        logger.error("magic-link store has an invalid root shape at %s", store_path)
+        raise HTTPException(
+            status_code=503,
+            detail="Magic-link storage is unreadable; existing links were preserved.",
+        )
+    return store
 
 
 def _write_store(store: dict) -> None:

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -135,6 +135,25 @@ def test_generate_returns_token_and_url(magic_link_client):
     assert data["url"].endswith(f"/magic-link/{data['token']}")
 
 
+@pytest.mark.parametrize("corrupt_store", ["{not-json", "[]"])
+def test_generate_preserves_unreadable_token_store(
+    magic_link_client, magic_link_module, corrupt_store
+):
+    store_path = magic_link_module._magic_link_store_candidates()[0]
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(corrupt_store, encoding="utf-8")
+
+    response = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "alice"},
+        headers=magic_link_client.auth_headers,
+    )
+
+    assert response.status_code == 503
+    assert "existing links were preserved" in response.json()["detail"]
+    assert store_path.read_text(encoding="utf-8") == corrupt_store
+
+
 def test_generate_with_note_and_reusable(magic_link_client):
     resp = magic_link_client.post(
         "/api/auth/magic-link/generate",


### PR DESCRIPTION
## Why this matters

The magic-link store contains active invite hashes, revocation state, and redemption audit history. If the JSON became unreadable, the loader silently treated it as an empty store; the next generate or list operation then overwrote the file, destroying recoverable authorization state.

## Root cause and invariant

`_ensure_store` caught file and JSON errors together and returned an empty token list. The invariant is that a missing store initializes cleanly, but an existing unreadable or structurally invalid store is never interpreted as empty and never overwritten.

The loader now distinguishes a missing file from read errors, invalid JSON, and invalid root shape. Existing corruption returns an operator-visible 503 while preserving the original bytes.

## Overlap check

Searched open and closed PRs for `magic link corrupt store`, `unreadable token store`, the router, and its test file. No semantic match or open same-file PR was found. This is independent from session signing, proxy readiness, cookie, and redemption behavior already covered by the suite.

## Regression coverage

Parameterized FastAPI tests place both invalid JSON and a valid non-object JSON root at the production store path, call the authenticated generate endpoint, assert 503, and verify the file remains byte-for-byte unchanged.

## Validation

- `pytest -q ods/extensions/services/dashboard-api/tests/test_magic_link.py -x` ? 68 passed
- `python -m py_compile ods/extensions/services/dashboard-api/routers/magic_link.py ods/extensions/services/dashboard-api/tests/test_magic_link.py`
- `git diff --check`

## Tradeoffs and rollback

Operators must repair or intentionally remove a corrupt store before minting new links; this favors preservation over silent recovery. Missing stores still initialize normally. Revert restores the destructive fail-open behavior; no migration is needed.
