### PR TITLE
fix(magic-link): reject ambiguous revoke prefixes

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -867,12 +867,23 @@ def revoke_magic_link(token_hash_prefix: str) -> dict:
         raise HTTPException(status_code=400, detail="Invalid token hash prefix")
     with _STORE_LOCK:
         store = _ensure_store()
-        for record in store.get("tokens", []):
-            if record["token_hash"].startswith(token_hash_prefix) and not record.get("revoked_at"):
-                record["revoked_at"] = _now_iso()
-                _write_store(store)
-                logger.info("magic-link revoked target=%s", record["target_username"])
-                return {"revoked": True}
+        matches = [
+            record
+            for record in store.get("tokens", [])
+            if record["token_hash"].startswith(token_hash_prefix)
+            and not record.get("revoked_at")
+        ]
+        if len(matches) > 1:
+            raise HTTPException(
+                status_code=409,
+                detail="Token hash prefix is ambiguous; use a longer prefix.",
+            )
+        if matches:
+            record = matches[0]
+            record["revoked_at"] = _now_iso()
+            _write_store(store)
+            logger.info("magic-link revoked target=%s", record["target_username"])
+            return {"revoked": True}
     raise HTTPException(status_code=404, detail="No active magic link with that prefix")
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -1219,6 +1219,37 @@ def test_revoke_unknown_prefix_returns_404(magic_link_client):
     assert resp.status_code == 404
 
 
+def test_revoke_refuses_ambiguous_hash_prefix(
+    magic_link_client, magic_link_module
+):
+    prefix = "deadbeef"
+    store = {
+        "tokens": [
+            {
+                "token_hash": prefix + ("1" * 56),
+                "target_username": "alice",
+                "revoked_at": None,
+            },
+            {
+                "token_hash": prefix + ("2" * 56),
+                "target_username": "bob",
+                "revoked_at": None,
+            },
+        ]
+    }
+    magic_link_module._write_store(store)
+
+    response = magic_link_client.delete(
+        f"/api/auth/magic-link/{prefix}",
+        headers=magic_link_client.auth_headers,
+    )
+
+    assert response.status_code == 409
+    assert "longer prefix" in response.json()["detail"]
+    persisted = magic_link_module._ensure_store()
+    assert all(record["revoked_at"] is None for record in persisted["tokens"])
+
+
 # ---------------------------------------------------------------------------
 # QR endpoint
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

The admin API revokes links by the hash prefix displayed in the list UI. If two active hashes share that prefix, the current loop revokes whichever record happens to appear first, potentially disabling the wrong user's invite while leaving the intended one valid.

## Root cause and invariant

The endpoint mutated and returned on the first prefix match without proving uniqueness. The invariant is that a shortened identifier may authorize a destructive state change only when it resolves to exactly one active record.

The endpoint now collects active matches under the store lock, returns 409 with guidance when the prefix is ambiguous, and writes only after a unique match is established.

## Overlap check

Searched open and closed PRs for `magic link revoke prefix collision`, `ambiguous token hash prefix`, and the changed router/test files. No semantic match or open same-file PR was found. This is independent from token generation, redemption, and store durability.

## Regression coverage

A FastAPI boundary test persists two active records with the same displayed eight-character prefix, calls the authenticated DELETE endpoint, asserts 409, and reloads the store to prove neither record was revoked.

## Validation

- `pytest -q ods/extensions/services/dashboard-api/tests/test_magic_link.py -x` ? 67 passed
- `python -m py_compile ods/extensions/services/dashboard-api/routers/magic_link.py ods/extensions/services/dashboard-api/tests/test_magic_link.py`
- `git diff --check`

## Tradeoffs and rollback

Prefix collisions are rare, but the check is O(n) over an already capped local store and happens inside the existing lock. Operators can retry with a longer prefix; exact hashes remain unambiguous. Revert restores first-match mutation with no migration.
