### PR TITLE
fix(oauth): reject malformed nonce metadata

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -244,15 +244,15 @@ def _prune_expired_nonces(nonce_dir: Path) -> None:
     for path in entries:
         try:
             payload = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            created = int(payload.get("created_at", 0) or 0)
+            ttl = int(payload.get("ttl_seconds", 0) or 0)
+        except (OSError, json.JSONDecodeError, TypeError, ValueError, OverflowError):
             # Unreadable/corrupt — clean it up too.
             try:
                 path.unlink(missing_ok=True)
             except OSError:
                 pass
             continue
-        created = int(payload.get("created_at", 0) or 0)
-        ttl = int(payload.get("ttl_seconds", 0) or 0)
         if not created or not ttl or (now - created) > ttl:
             try:
                 path.unlink(missing_ok=True)
@@ -443,7 +443,9 @@ async def oauth_callback(
 
     try:
         nonce_payload = json.loads(nonce_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+        created = int(nonce_payload.get("created_at", 0) or 0)
+        ttl = int(nonce_payload.get("ttl_seconds", 0) or 0)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError, OverflowError) as exc:
         logger.warning("oauth callback saw unreadable nonce %s: %s", nonce_path, exc)
         try:
             nonce_path.unlink(missing_ok=True)
@@ -455,8 +457,6 @@ async def oauth_callback(
         )
 
     now = int(time.time())
-    created = int(nonce_payload.get("created_at", 0) or 0)
-    ttl = int(nonce_payload.get("ttl_seconds", 0) or 0)
     if not created or not ttl or (now - created) > ttl:
         try:
             nonce_path.unlink(missing_ok=True)

--- a/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
@@ -164,6 +164,27 @@ def test_oauth_init_prunes_expired_nonces(oauth_client):
     assert not stale.exists(), "expired nonce should have been pruned on init"
 
 
+@pytest.mark.parametrize(
+    "invalid_metadata",
+    [
+        {"created_at": "not-a-timestamp", "ttl_seconds": 900},
+        {"created_at": int(time.time()), "ttl_seconds": []},
+    ],
+)
+def test_oauth_init_prunes_type_invalid_nonce_metadata(
+    oauth_client, invalid_metadata
+):
+    nonce_dir = oauth_client.tmp / "oauth-nonces"
+    nonce_dir.mkdir(parents=True, exist_ok=True)
+    corrupt = nonce_dir / "corrupt-nonce-abcdefghijk.json"
+    corrupt.write_text(json.dumps(invalid_metadata), encoding="utf-8")
+
+    state = _init_flow(oauth_client, skill_id="spotify")
+
+    assert not corrupt.exists()
+    assert (nonce_dir / f"{state}.json").exists()
+
+
 # ---------------------------------------------------------------------------
 # /api/oauth/callback — happy path
 # ---------------------------------------------------------------------------
@@ -352,6 +373,24 @@ def test_callback_rejects_unreadable_nonce(oauth_client):
     assert resp.status_code == 400
     assert not (oauth_client.tmp / "oauth_callback.json").exists()
     assert not nonce_file.exists(), "unreadable nonce should be cleaned up"
+
+
+def test_callback_rejects_type_invalid_nonce_metadata(oauth_client):
+    state = _init_flow(oauth_client)
+    nonce_file = oauth_client.tmp / "oauth-nonces" / f"{state}.json"
+    payload = json.loads(nonce_file.read_text(encoding="utf-8"))
+    payload["ttl_seconds"] = {"invalid": True}
+    nonce_file.write_text(json.dumps(payload), encoding="utf-8")
+
+    response = oauth_client.get(
+        "/api/oauth/callback",
+        params={"code": "provider-code", "state": state},
+    )
+
+    assert response.status_code == 400
+    assert "unreadable" in response.text
+    assert not nonce_file.exists()
+    assert not (oauth_client.tmp / "oauth_callback.json").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

OAuth nonces are JSON files at the boundary between the authenticated init call and the public provider callback. Syntactically valid JSON with a non-numeric `created_at` or `ttl_seconds` bypassed the existing corrupt-file handler, raised during integer conversion, and could make every new OAuth init fail or turn a provider callback into a 500.

## Root cause and invariant

Metadata conversion happened outside the narrow read/parse exception boundary in both nonce pruning and callback validation. The invariant is that malformed persisted nonce metadata is rejected and removed like malformed JSON; it must never issue a state, write a callback code, or crash the public flow.

Integer conversion now occurs inside the existing I/O validation blocks with specific type/value/overflow exceptions.

## Overlap check

Searched open and closed PRs for `oauth nonce malformed metadata`, `nonce prune invalid ttl`, and the changed router/test files. No semantic match or open same-file PR was found. Existing OAuth tests covered invalid JSON and expiry, but not valid JSON with invalid metadata types.

## Regression coverage

Two authenticated init-boundary cases plant invalid timestamp/TTL types and prove a fresh nonce is still issued while the corrupt file is pruned. A public callback-boundary test corrupts a live nonce's TTL type, asserts 400, and proves both the nonce and callback side effects are absent.

## Validation

- `pytest -q ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py -x` ? 49 passed, 2 skipped
- `python -m py_compile ods/extensions/services/dashboard-api/routers/oauth_passthrough.py ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py`
- `git diff --check`

## Tradeoffs and rollback

Malformed nonce files are single-use temporary state and are deleted, matching the existing invalid-JSON policy. Valid flows are unchanged. Revert restores the two uncaught conversion paths; no persistent schema migration is involved.
