### PR TITLE
fix(brave-search): tolerate malformed result entries

### DIFF
--- a/ods/extensions/services/brave-search/proxy.mjs
+++ b/ods/extensions/services/brave-search/proxy.mjs
@@ -183,9 +183,9 @@ async function handleV1Search(res, params) {
   const results = braveWebResults(outcome.data)
     .slice(0, count)
     .map((r) => ({
-      title: (r.title ?? "").trim(),
-      url: (r.url ?? "").trim(),
-      snippet: (r.description ?? "").trim(),
+      title: stringField(r.title),
+      url: stringField(r.url),
+      snippet: stringField(r.description),
     }))
     .filter((r) => r.url.length > 0);
 
@@ -210,7 +210,16 @@ function searxngEnvelope(query, results, unresponsiveEngines) {
 }
 
 function braveWebResults(data) {
-  return Array.isArray(data?.web?.results) ? data.web.results : [];
+  if (!Array.isArray(data?.web?.results)) {
+    return [];
+  }
+  return data.web.results.filter(
+    (result) => result !== null && typeof result === "object" && !Array.isArray(result),
+  );
+}
+
+function stringField(value) {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 // Python urlparse 6-tuple (scheme, netloc, path, params, query, fragment),
@@ -230,7 +239,7 @@ function toSearxngResults(data) {
   const raw = braveWebResults(data).slice(0, SEARXNG_PAGE_SIZE);
   const results = [];
   for (const r of raw) {
-    const urlText = (r.url ?? "").trim();
+    const urlText = stringField(r.url);
     if (!urlText) {
       continue;
     }
@@ -245,8 +254,8 @@ function toSearxngResults(data) {
     const position = results.length + 1;
     const item = {
       url: urlText,
-      title: (r.title ?? "").trim(),
-      content: (r.description ?? "").trim(),
+      title: stringField(r.title),
+      content: stringField(r.description),
       engine: "brave",
       engines: ["brave"],
       positions: [position],

--- a/ods/tests/test-brave-search-searxng-compat.mjs
+++ b/ods/tests/test-brave-search-searxng-compat.mjs
@@ -76,6 +76,24 @@ function stubHandler(req, res) {
     respond(200, "null");
   } else if (q === "badshape") {
     respond(200, JSON.stringify({ web: { results: "not-an-array" } }));
+  } else if (q === "baditems") {
+    respond(
+      200,
+      JSON.stringify({
+        web: {
+          results: [
+            null,
+            "not-an-object",
+            { title: 42, url: 99, description: { nested: true } },
+            {
+              title: " Valid Result ",
+              url: "https://example.com/valid",
+              description: " Valid snippet ",
+            },
+          ],
+        },
+      }),
+    );
   } else if (q === "slow") {
     setTimeout(() => respond(200, braveBody()), SLOW_UPSTREAM_DELAY_MS);
   } else if (q === "redirect") {
@@ -224,6 +242,16 @@ async function testV1Route(base) {
       JSON.stringify(oddShape),
     );
   }
+
+  const badItems = await getJson(base, "/v1/search?q=baditems");
+  check(
+    "malformed result entries are skipped without losing valid siblings",
+    badItems.status === 200 &&
+      badItems.body.results.length === 1 &&
+      badItems.body.results[0].title === "Valid Result" &&
+      badItems.body.results[0].url === "https://example.com/valid",
+    JSON.stringify(badItems.body),
+  );
 }
 
 async function testCompatDisabled(base) {
@@ -369,6 +397,17 @@ async function testCompatEnabled(base) {
       JSON.stringify(oddShape.body),
     );
   }
+
+
+  const badItems = await getJson(base, "/search?format=json&q=baditems");
+  check(
+    "compat skips malformed result entries without a 500",
+    badItems.status === 200 &&
+      badItems.body.results.length === 1 &&
+      badItems.body.results[0].title === "Valid Result" &&
+      badItems.body.results[0].url === "https://example.com/valid",
+    JSON.stringify(badItems.body),
+  );
 }
 
 // ── main ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Why this matters

Brave Search is a live external I/O boundary used directly and through Perplexica's SearXNG compatibility path. One `null`, scalar, or non-string field inside an otherwise valid upstream results array currently throws during `.trim()`, turning the whole search into a 500 and discarding valid sibling results.

## Root cause and invariant

The proxy checked that `web.results` was an array but assumed every element was an object and every mapped field was a string. The invariant is that malformed individual upstream records cannot crash the service; only object records with a usable string URL become public results, while valid siblings retain their stable shapes.

The shared extractor now rejects non-object entries and a single string normalizer handles title, URL, and description in both response formats.

## Overlap check

Searched open and closed PRs for `brave search malformed upstream result`, `invalid upstream payload`, and the changed files. Open same-production-file PR #2734 adds caller authentication to the native route and does not touch upstream result mapping. No semantic duplicate was found.

## Regression coverage

The existing loopback end-to-end harness now makes the stub Brave server return null, scalar, wrong-typed fields, and one valid sibling. It exercises both real proxy child processes and asserts `/v1/search` plus SearXNG `/search` return 200 with exactly the valid normalized result.

## Validation

- `bash ods/tests/test-brave-search-searxng-compat.sh` ? all checks passed
- `node --check ods/extensions/services/brave-search/proxy.mjs`
- `node --check ods/tests/test-brave-search-searxng-compat.mjs`
- `git diff --check`

## Tradeoffs and rollback

Malformed entries are skipped rather than failing the whole response, matching the existing behavior for empty URLs and malformed top-level shapes. ODS does not invent values for invalid fields. Revert restores the per-item crash behavior; no configuration or data migration is required.
