### PR TITLE
fix(simulation): capture real installer exit codes and gate on them

### DIFF
--- a/ods/scripts/simulate-installers.sh
+++ b/ods/scripts/simulate-installers.sh
@@ -28,16 +28,14 @@ chmod +x "${FAKEBIN}/curl"
 cd "$ROOT_DIR"
 
 # 1) Linux installer dry-run simulation
+# Capture the real exit code. Note: inside `if ! cmd; then`, $? is the status
+# of the negated pipeline (always 0 on failure), so use `cmd || var=$?` instead.
 LINUX_EXIT=0
-if ! PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1; then
-  LINUX_EXIT=$?
-fi
+PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1 || LINUX_EXIT=$?
 
 # 2) macOS installer MVP simulation
 MACOS_EXIT=0
-if ! bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1; then
-  MACOS_EXIT=$?
-fi
+bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1 || MACOS_EXIT=$?
 
 # 3) Windows scenario simulation via preflight engine (since pwsh may be unavailable in CI/sandbox)
 scripts/preflight-engine.sh \
@@ -55,9 +53,7 @@ scripts/preflight-engine.sh \
 
 # 4) Doctor snapshot for current machine context
 DOCTOR_EXIT=0
-if ! scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1; then
-  DOCTOR_EXIT=$?
-fi
+scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1 || DOCTOR_EXIT=$?
 
 PYTHON_CMD="python3"
 if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then

--- a/ods/scripts/validate-sim-summary.py
+++ b/ods/scripts/validate-sim-summary.py
@@ -84,7 +84,11 @@ def _as_mapping(v: Any) -> Optional[Mapping[str, Any]]:
 
 
 def _as_sequence(v: Any) -> Optional[Sequence[Any]]:
-    return v if isinstance(v, Sequence) and not isinstance(v, (str, bytes, bytearray)) else None
+    return (
+        v
+        if isinstance(v, Sequence) and not isinstance(v, (str, bytes, bytearray))
+        else None
+    )
 
 
 def _require_key(v: Validator, obj: Mapping[str, Any], path: str, key: str) -> Any:
@@ -121,7 +125,9 @@ def _optional_type(v: Validator, value: Any, path: str, expected: str) -> None:
     _require_type(v, value, path, expected)
 
 
-def _require_one_of(v: Validator, value: Any, path: str, allowed: Sequence[str]) -> None:
+def _require_one_of(
+    v: Validator, value: Any, path: str, allowed: Sequence[str]
+) -> None:
     if not isinstance(value, str):
         v.add(path, f"expected string enum {list(allowed)}, got {_type_name(value)}")
         return
@@ -147,7 +153,10 @@ def _require_iso8601ish(v: Validator, value: Any, path: str) -> None:
     _require_type(v, value, path, "string")
     if isinstance(value, str):
         # Very lightweight check: 2026-03-15T12:34:56+00:00 / Z / with fractional seconds.
-        if not re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$", value):
+        if not re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$",
+            value,
+        ):
             v.add(path, "expected ISO8601 timestamp (UTC or offset)")
 
 
@@ -156,9 +165,18 @@ def _require_iso8601ish(v: Validator, value: Any, path: str) -> None:
 # -----------------------------
 
 
+def _require_success_exit_code(v: Validator, exit_code: Any, path: str) -> None:
+    # The simulation summary is a release-gate artifact: a recorded non-zero
+    # exit code means the simulated run failed and must fail validation even
+    # though the summary itself is structurally valid.
+    if _is_int(exit_code) and exit_code != 0:
+        v.add(f"{path}.exit_code", f"expected 0 (success), got {exit_code}")
+
+
 def validate_linux_dryrun(v: Validator, linux: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, linux, path, "exit_code")
     _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_success_exit_code(v, exit_code, path)
 
     signals = _require_key(v, linux, path, "signals")
     _require_type(v, signals, f"{path}.signals", "object")
@@ -188,6 +206,7 @@ def validate_linux_dryrun(v: Validator, linux: Mapping[str, Any], path: str) -> 
 def validate_macos_installer(v: Validator, mac: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, mac, path, "exit_code")
     _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_success_exit_code(v, exit_code, path)
 
     log_path = _require_key(v, mac, path, "log")
     _require_path_like(v, log_path, f"{path}.log")
@@ -225,9 +244,12 @@ def validate_windows_scenario(v: Validator, win: Mapping[str, Any], path: str) -
         _require_type(v, warnings, f"{path}.report.summary.warnings", "int")
 
 
-def validate_doctor_snapshot(v: Validator, doctor: Mapping[str, Any], path: str) -> None:
+def validate_doctor_snapshot(
+    v: Validator, doctor: Mapping[str, Any], path: str
+) -> None:
     exit_code = _require_key(v, doctor, path, "exit_code")
     _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_success_exit_code(v, exit_code, path)
 
     report = _require_key(v, doctor, path, "report")
     _require_type(v, report, f"{path}.report", "object")
@@ -238,14 +260,21 @@ def validate_doctor_snapshot(v: Validator, doctor: Mapping[str, Any], path: str)
     if "autofix_hints" not in report:
         v.add(f"{path}.report", "missing required key 'autofix_hints'")
     else:
-        _require_type(v, report.get("autofix_hints"), f"{path}.report.autofix_hints", "array")
+        _require_type(
+            v, report.get("autofix_hints"), f"{path}.report.autofix_hints", "array"
+        )
 
     # Newer doctor outputs include a summary block; validate if present.
     if "summary" in report:
         _require_type(v, report.get("summary"), f"{path}.report.summary", "object")
         summary = report.get("summary")
         if isinstance(summary, Mapping) and "runtime_ready" in summary:
-            _require_type(v, summary.get("runtime_ready"), f"{path}.report.summary.runtime_ready", "bool")
+            _require_type(
+                v,
+                summary.get("runtime_ready"),
+                f"{path}.report.summary.runtime_ready",
+                "bool",
+            )
 
 
 def validate_golden_paths(v: Validator, golden: Mapping[str, Any], path: str) -> None:
@@ -342,7 +371,11 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         description="Validate ODS installer simulation summary JSON.",
     )
     p.add_argument("summary_json", help="Path to summary.json")
-    p.add_argument("--strict", action="store_true", help="Fail on unknown keys and require generated_at")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on unknown keys and require generated_at",
+    )
     return p.parse_args(argv)
 
 


### PR DESCRIPTION
## Summary
- `scripts/simulate-installers.sh` captured `$?` inside `if ! cmd; then` — that is the status of the *negated* pipeline, so it is always `0` exactly when the command failed. Failed installer simulations were being recorded as `"exit_code": 0` in `artifacts/installer-sim/summary.json`.
- Capture each run's status with `cmd || var=$?` (set -e safe, preserves the real code) for the Linux dry-run, macOS installer, and doctor legs.
- `scripts/validate-sim-summary.py` only type-checked `exit_code` as int; it now also fails validation when any recorded run has a non-zero exit code — otherwise a broken install simulation could pass the release gate.

## Testing
- `bash -n scripts/simulate-installers.sh` clean; `python -m py_compile scripts/validate-sim-summary.py` clean.
- Functional check of the validator: a summary with `linux_dryrun.exit_code = 1` now fails with `$.runs.linux_dryrun.exit_code: expected 0 (success), got 1`; the same summary with `exit_code = 0` passes.

Fixes #2999