### PR TITLE
fix(installer): background-task registry: per-UID path, no symlink clobber

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,8 @@ docker-entrypoint* text eol=lf
 *.json text eol=lf
 *.env text eol=lf
 *.shellcheckrc text eol=lf
+Makefile text eol=lf
+*.mk text eol=lf
 
 # PowerShell scripts can use CRLF (native Windows)
 *.ps1 text eol=crlf

--- a/.github/workflows/autonomous-code-scanner.yml
+++ b/.github/workflows/autonomous-code-scanner.yml
@@ -855,14 +855,20 @@ jobs:
           echo "**Secret scan**: Passed" >> $GITHUB_STEP_SUMMARY
 
           # 2. Python syntax check
+          # The loop must not run in a piped subshell: an `exit 1` there only
+          # kills the subshell and the step would report success anyway.
           if git diff --name-only | grep -q '\.py$'; then
-            find . -name "*.py" -type f | while read -r file; do
+            syntax_status=0
+            while IFS= read -r file; do
               if ! python3 -m py_compile "$file" 2>/dev/null; then
                 echo "::error::Syntax error in $file"
                 echo "**Syntax check**: FAILED ($file)" >> $GITHUB_STEP_SUMMARY
-                exit 1
+                syntax_status=1
               fi
-            done
+            done < <(find . -name "*.py" -type f)
+            if [ "$syntax_status" -ne 0 ]; then
+              exit 1
+            fi
             echo "**Syntax check**: Passed" >> $GITHUB_STEP_SUMMARY
           fi
 

--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -206,9 +206,17 @@ jobs:
         run: |
           bash -n install-core.sh
           bash -n installers/lib/packaging.sh
+          fails=0
           for f in installers/phases/*.sh; do
-            bash -n "$f" && echo "  OK: $f" || echo "  FAIL: $f"
+            if out=$(bash -n "$f" 2>&1); then
+              echo "  OK: $f"
+            else
+              echo "  FAIL: $f"
+              echo "$out"
+              fails=$((fails + 1))
+            fi
           done
+          exit "$fails"
 
   macos-smoke:
     runs-on: macos-latest

--- a/ods/installers/lib/background-tasks.sh
+++ b/ods/installers/lib/background-tasks.sh
@@ -12,8 +12,27 @@
 #   Add new background task types here.
 # ============================================================================
 
-# Registry file for background tasks
-BG_TASK_REGISTRY="${BG_TASK_REGISTRY:-/tmp/ods-bg-tasks.json}"
+# Registry file for background tasks.
+# Per-UID path + noclobber creation: a fixed shared /tmp name is both a
+# cross-user collision and a symlink-clobber vector (echo > follows
+# symlinks), the same class of issue lib/service-registry.sh avoids with
+# mktemp. Callers may still override BG_TASK_REGISTRY explicitly.
+BG_TASK_REGISTRY="${BG_TASK_REGISTRY:-${TMPDIR:-/tmp}/ods-bg-tasks-${UID}.json}"
+
+# Create the registry atomically if missing; never trust a pre-existing path:
+# refuse symlinks and foreign-owned files instead of writing through them.
+# Returns non-zero if no usable registry exists.
+_bg_task_init_registry() {
+    if [[ -e "$BG_TASK_REGISTRY" || -L "$BG_TASK_REGISTRY" ]]; then
+        # Exists (possibly as a planted symlink): must be a plain,
+        # self-owned regular file.
+        [[ -f "$BG_TASK_REGISTRY" && ! -L "$BG_TASK_REGISTRY" && -O "$BG_TASK_REGISTRY" ]] || return 1
+    else
+        ( set -o noclobber; printf '[]\n' > "$BG_TASK_REGISTRY" ) 2>/dev/null || return 1
+    fi
+    chmod 600 "$BG_TASK_REGISTRY" 2>/dev/null || true
+    [[ -f "$BG_TASK_REGISTRY" && ! -L "$BG_TASK_REGISTRY" && -O "$BG_TASK_REGISTRY" ]]
+}
 
 # Start tracking a background task
 # Usage: bg_task_start <task_id> <pid> <description> <log_file>
@@ -22,11 +41,9 @@ bg_task_start() {
     local pid="$2"
     local description="$3"
     local log_file="$4"
-    
+
     # Create registry if it doesn't exist
-    if [[ ! -f "$BG_TASK_REGISTRY" ]]; then
-        echo "[]" > "$BG_TASK_REGISTRY"
-    fi
+    _bg_task_init_registry || return 1
     
     # Add task to registry
     python3 - "$BG_TASK_REGISTRY" "$task_id" "$pid" "$description" "$log_file" <<'PY'

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -68,7 +68,13 @@ function Test-DockerRunning {
     .SYNOPSIS
         Quick check if Docker daemon is responsive. Shows friendly message if not.
     #>
+    # On Windows PowerShell 5.1 a native stderr redirect becomes an
+    # ErrorRecord, which terminates under the global 'Stop' preference.
+    # Scope it like the other native calls in this script.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = "SilentlyContinue"
     $null = docker info 2>$null
+    $ErrorActionPreference = $prevEAP
     if ($LASTEXITCODE -ne 0) {
         Write-AIError "Docker Desktop is not running."
         Write-AI "Start it from the Start Menu, then try again."
@@ -667,8 +673,14 @@ function Invoke-ODSSttModelDownloadTrigger {
     # bounded so slow Hugging Face transfers do not wedge ods.ps1 or install.
     $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
     if ($curl) {
+        # PS 5.1: '2>&1' turns each stderr line into an ErrorRecord that
+        # terminates under the global 'Stop' preference - before the exit 28
+        # tolerance below could run. Scope it like the other native calls.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "SilentlyContinue"
         $curlOutput = & $curl.Source --fail --silent --show-error --max-time 30 -X POST $ModelUrl 2>&1
         $curlExit = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
         if ($curlExit -eq 0 -or $curlExit -eq 28) { return $true }
         Write-AIWarn "STT model download trigger returned curl exit $curlExit; verifying cache before failing."
         if ($curlOutput) {
@@ -1975,7 +1987,11 @@ function Invoke-Status {
 
         # Docker services
         Write-Host ""
+        # PS 5.1: stderr redirect + global 'Stop' would terminate; scope it.
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = "SilentlyContinue"
         & docker compose @flags ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>$null
+        $ErrorActionPreference = $prevEAP
 
         # Health checks
         Write-Host ""

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -95,9 +95,10 @@ estimate_backup_bytes() {
 
     # cache (models + some caches)
     if [[ "$backup_type" == "full" ]]; then
-        if [[ -d "$ODS_DIR/models" ]]; then
+        # Models live at data/models (docker-compose.base.yml mounts ./data/models:/models)
+        if [[ -d "$ODS_DIR/data/models" ]]; then
             local b
-            b=$(du -sk "$ODS_DIR/models" 2>/dev/null | awk '{print $1 * 1024}')
+            b=$(du -sk "$ODS_DIR/data/models" 2>/dev/null | awk '{print $1 * 1024}')
             total=$(( total + ${b:-0} ))
         fi
         local -a cache_paths=("data/whisper/cache" "data/kokoro/cache")
@@ -409,9 +410,11 @@ backup_cache() {
     local backup_dir="$1"
     log_info "Backing up cache (models, etc.)..."
 
-    if [[ -d "$ODS_DIR/models" ]]; then
-        rsync_with_progress "$ODS_DIR/models" "$backup_dir/" "Backing up models/"
-        log_success "Backed up: models/"
+    # Models live at data/models (docker-compose.base.yml mounts ./data/models:/models);
+    # the old $ODS_DIR/models path never existed, so full backups silently omitted them.
+    if [[ -d "$ODS_DIR/data/models" ]]; then
+        rsync_with_progress "$ODS_DIR/data/models" "$backup_dir/" "Backing up data/models/"
+        log_success "Backed up: data/models/"
     fi
 
     # Docker volumes that contain cache data

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -383,16 +383,55 @@ dry_run_preview() {
 stop_containers() {
     log_step "Stopping containers..."
 
-    if ! docker compose ls --quiet 2>/dev/null | grep -q "$(basename "$ODS_DIR")"; then
+    # The install tree ships no top-level docker-compose.yml (the stack is
+    # base + overlays), so a bare `docker compose down` fails with "no
+    # configuration file provided" and restore would then rsync over live
+    # volumes. Resolve the same flag set ods-uninstall.sh uses.
+    local flags=""
+
+    if [[ -f "$ODS_DIR/.compose-flags" ]]; then
+        flags="$(tr '\n' ' ' < "$ODS_DIR/.compose-flags" | xargs 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -x "$ODS_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        flags="$("$ODS_DIR/scripts/resolve-compose-stack.sh" \
+            --script-dir "$ODS_DIR" \
+            --tier "${TIER:-1}" \
+            --gpu-backend "${GPU_BACKEND:-nvidia}" \
+            --gpu-count "${GPU_COUNT:-1}" \
+            --ods-mode "${ODS_MODE:-local}" 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -f "$ODS_DIR/docker-compose.base.yml" ]]; then
+        flags="-f docker-compose.base.yml"
+        case "${GPU_BACKEND:-}" in
+            amd|nvidia|intel|apple|arc|cpu)
+                [[ -f "$ODS_DIR/docker-compose.${GPU_BACKEND}.yml" ]] && flags="$flags -f docker-compose.${GPU_BACKEND}.yml"
+                ;;
+        esac
+    fi
+
+    if [[ -z "$flags" ]]; then
+        log_error "Could not resolve the compose stack for: $ODS_DIR"
+        log_error "Refusing to restore over potentially running containers."
+        log_error "Stop the stack manually (see ods-uninstall.sh) and re-run the restore."
+        return 1
+    fi
+
+    local compose_args=()
+    read -ra compose_args <<< "$flags"
+
+    if ! docker compose "${compose_args[@]}" ps -q 2>/dev/null | grep -q .; then
         log_info "No running containers found"
         return 0
     fi
 
     cd "$ODS_DIR"
-    if docker compose down; then
+    if docker compose "${compose_args[@]}" down --remove-orphans; then
         log_success "Containers stopped"
     else
-        log_warn "Some containers may not have stopped cleanly"
+        log_error "Failed to stop containers; refusing to restore over a live stack."
+        return 1
     fi
 }
 

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -350,7 +350,7 @@ dry_run_preview() {
     if [[ "$restore_data" == "true" ]]; then
         echo "User Data to Restore:"
         echo "───────────────────────────────────────────────────────────────────"
-        local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama")
+        local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama" "data/models")
         for dir in "${data_dirs[@]}"; do
             if [[ -d "$backup_dir/$dir" ]]; then
                 local size
@@ -440,7 +440,7 @@ restore_user_data() {
     local backup_dir="$1"
     log_step "Restoring user data..."
 
-    local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama")
+    local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama" "data/models")
 
     local restored_any=false
     for dir in "${data_dirs[@]}"; do

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -889,7 +889,16 @@ cmd_changelog() {
         else
             log_warn "No local CHANGELOG.md found."
             log_info "Fetching latest release notes from GitHub..."
-            cmd_changelog "$(curl -sf --max-time 15 "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | jq -r '.tag_name // empty')" || true
+            # Resolve the latest tag here instead of recursing: a failed or
+            # empty fetch would re-enter this same branch and poll GitHub
+            # unboundedly.
+            local latest_tag
+            latest_tag="$(curl -sf --max-time 15 "https://api.github.com/repos/${GITHUB_REPO}/releases/latest" | jq -r '.tag_name // empty')" || true
+            if [[ -z "$latest_tag" ]]; then
+                log_error "Could not determine the latest release tag."
+                return 1
+            fi
+            cmd_changelog "$latest_tag"
         fi
     fi
 }

--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -235,33 +235,36 @@ cmd_migrate() {
     
     # Run migrations in order
     local failed=0
-    local ls_exit=0
-    local migrations
-    migrations=$(ls -1 "$MIGRATIONS_DIR"/migrate-v*.sh 2>&1 | sort) || ls_exit=$?
-    if [[ $ls_exit -ne 0 ]]; then
+    local migration_scripts=()
+    # Use a glob array instead of parsing `ls`: an unquoted for-loop over the
+    # output word-splits on spaces, so install paths containing a space would
+    # skip every migration yet still fall through to stamping the version.
+    shopt -s nullglob
+    migration_scripts=("$MIGRATIONS_DIR"/migrate-v*.sh)
+    shopt -u nullglob
+    if (( ${#migration_scripts[@]} == 0 )); then
         log_success "No migration scripts found"
         return 0
     fi
 
-    for migration in $migrations; do
-        if [[ -f "$migration" ]]; then
-            local migration_version
-            migration_version=$(basename "$migration" | sed 's/migrate-v//;s/.sh//')
-            
-            # Check if this migration is needed
-            local mig_cmp=0
-            compare_versions "$migration_version" "$last_migrated" || mig_cmp=$?
-            if [[ $mig_cmp -eq 1 ]]; then
-                log_info "Running migration: $migration_version"
-                
-                if bash "$migration"; then
-                    log_success "Migration $migration_version completed"
-                    set_last_migrated_version "$migration_version"
-                else
-                    log_error "Migration $migration_version failed!"
-                    failed=$((failed + 1))
-                    break
-                fi
+    # Glob expansion is sorted, preserving the previous `sort` ordering.
+    for migration in "${migration_scripts[@]}"; do
+        local migration_version
+        migration_version=$(basename "$migration" | sed 's/migrate-v//;s/.sh//')
+
+        # Check if this migration is needed
+        local mig_cmp=0
+        compare_versions "$migration_version" "$last_migrated" || mig_cmp=$?
+        if [[ $mig_cmp -eq 1 ]]; then
+            log_info "Running migration: $migration_version"
+
+            if bash "$migration"; then
+                log_success "Migration $migration_version completed"
+                set_last_migrated_version "$migration_version"
+            else
+                log_error "Migration $migration_version failed!"
+                failed=$((failed + 1))
+                break
             fi
         fi
     done

--- a/ods/scripts/simulate-installers.sh
+++ b/ods/scripts/simulate-installers.sh
@@ -28,16 +28,14 @@ chmod +x "${FAKEBIN}/curl"
 cd "$ROOT_DIR"
 
 # 1) Linux installer dry-run simulation
+# Capture the real exit code. Note: inside `if ! cmd; then`, $? is the status
+# of the negated pipeline (always 0 on failure), so use `cmd || var=$?` instead.
 LINUX_EXIT=0
-if ! PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1; then
-  LINUX_EXIT=$?
-fi
+PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1 || LINUX_EXIT=$?
 
 # 2) macOS installer MVP simulation
 MACOS_EXIT=0
-if ! bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1; then
-  MACOS_EXIT=$?
-fi
+bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1 || MACOS_EXIT=$?
 
 # 3) Windows scenario simulation via preflight engine (since pwsh may be unavailable in CI/sandbox)
 scripts/preflight-engine.sh \
@@ -55,9 +53,7 @@ scripts/preflight-engine.sh \
 
 # 4) Doctor snapshot for current machine context
 DOCTOR_EXIT=0
-if ! scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1; then
-  DOCTOR_EXIT=$?
-fi
+scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1 || DOCTOR_EXIT=$?
 
 PYTHON_CMD="python3"
 if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then

--- a/ods/scripts/validate-sim-summary.py
+++ b/ods/scripts/validate-sim-summary.py
@@ -84,7 +84,11 @@ def _as_mapping(v: Any) -> Optional[Mapping[str, Any]]:
 
 
 def _as_sequence(v: Any) -> Optional[Sequence[Any]]:
-    return v if isinstance(v, Sequence) and not isinstance(v, (str, bytes, bytearray)) else None
+    return (
+        v
+        if isinstance(v, Sequence) and not isinstance(v, (str, bytes, bytearray))
+        else None
+    )
 
 
 def _require_key(v: Validator, obj: Mapping[str, Any], path: str, key: str) -> Any:
@@ -121,7 +125,9 @@ def _optional_type(v: Validator, value: Any, path: str, expected: str) -> None:
     _require_type(v, value, path, expected)
 
 
-def _require_one_of(v: Validator, value: Any, path: str, allowed: Sequence[str]) -> None:
+def _require_one_of(
+    v: Validator, value: Any, path: str, allowed: Sequence[str]
+) -> None:
     if not isinstance(value, str):
         v.add(path, f"expected string enum {list(allowed)}, got {_type_name(value)}")
         return
@@ -147,7 +153,10 @@ def _require_iso8601ish(v: Validator, value: Any, path: str) -> None:
     _require_type(v, value, path, "string")
     if isinstance(value, str):
         # Very lightweight check: 2026-03-15T12:34:56+00:00 / Z / with fractional seconds.
-        if not re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$", value):
+        if not re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$",
+            value,
+        ):
             v.add(path, "expected ISO8601 timestamp (UTC or offset)")
 
 
@@ -156,9 +165,18 @@ def _require_iso8601ish(v: Validator, value: Any, path: str) -> None:
 # -----------------------------
 
 
+def _require_success_exit_code(v: Validator, exit_code: Any, path: str) -> None:
+    # The simulation summary is a release-gate artifact: a recorded non-zero
+    # exit code means the simulated run failed and must fail validation even
+    # though the summary itself is structurally valid.
+    if _is_int(exit_code) and exit_code != 0:
+        v.add(f"{path}.exit_code", f"expected 0 (success), got {exit_code}")
+
+
 def validate_linux_dryrun(v: Validator, linux: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, linux, path, "exit_code")
     _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_success_exit_code(v, exit_code, path)
 
     signals = _require_key(v, linux, path, "signals")
     _require_type(v, signals, f"{path}.signals", "object")
@@ -188,6 +206,7 @@ def validate_linux_dryrun(v: Validator, linux: Mapping[str, Any], path: str) -> 
 def validate_macos_installer(v: Validator, mac: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, mac, path, "exit_code")
     _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_success_exit_code(v, exit_code, path)
 
     log_path = _require_key(v, mac, path, "log")
     _require_path_like(v, log_path, f"{path}.log")
@@ -225,9 +244,12 @@ def validate_windows_scenario(v: Validator, win: Mapping[str, Any], path: str) -
         _require_type(v, warnings, f"{path}.report.summary.warnings", "int")
 
 
-def validate_doctor_snapshot(v: Validator, doctor: Mapping[str, Any], path: str) -> None:
+def validate_doctor_snapshot(
+    v: Validator, doctor: Mapping[str, Any], path: str
+) -> None:
     exit_code = _require_key(v, doctor, path, "exit_code")
     _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_success_exit_code(v, exit_code, path)
 
     report = _require_key(v, doctor, path, "report")
     _require_type(v, report, f"{path}.report", "object")
@@ -238,14 +260,21 @@ def validate_doctor_snapshot(v: Validator, doctor: Mapping[str, Any], path: str)
     if "autofix_hints" not in report:
         v.add(f"{path}.report", "missing required key 'autofix_hints'")
     else:
-        _require_type(v, report.get("autofix_hints"), f"{path}.report.autofix_hints", "array")
+        _require_type(
+            v, report.get("autofix_hints"), f"{path}.report.autofix_hints", "array"
+        )
 
     # Newer doctor outputs include a summary block; validate if present.
     if "summary" in report:
         _require_type(v, report.get("summary"), f"{path}.report.summary", "object")
         summary = report.get("summary")
         if isinstance(summary, Mapping) and "runtime_ready" in summary:
-            _require_type(v, summary.get("runtime_ready"), f"{path}.report.summary.runtime_ready", "bool")
+            _require_type(
+                v,
+                summary.get("runtime_ready"),
+                f"{path}.report.summary.runtime_ready",
+                "bool",
+            )
 
 
 def validate_golden_paths(v: Validator, golden: Mapping[str, Any], path: str) -> None:
@@ -342,7 +371,11 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
         description="Validate ODS installer simulation summary JSON.",
     )
     p.add_argument("summary_json", help="Path to summary.json")
-    p.add_argument("--strict", action="store_true", help="Fail on unknown keys and require generated_at")
+    p.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on unknown keys and require generated_at",
+    )
     return p.parse_args(argv)
 
 


### PR DESCRIPTION
## Summary
`installers/lib/background-tasks.sh` used a fixed `/tmp/ods-bg-tasks.json` registry with non-atomic creation:

1. **Cross-user collision** — two installs/users on one host share the file; each probes the other's PIDs via `os.kill(pid, 0)` (PID-reuse misclassification included).
2. **Symlink-clobber** — `echo "[]" > "$path"` follows symlinks, and the `[[ ! -f ]]` guard also *follows* them, so a local user could pre-plant a symlink at that name and make the installer overwrite an arbitrary target. The repo already treats this class as serious: `lib/service-registry.sh` calls a predictable `/tmp` path a "local code-injection vector".

Changes:
- Default path is per-UID: `\${TMPDIR:-/tmp}/ods-bg-tasks-\${UID}.json` (override still honored).
- New `_bg_task_init_registry()`: if the path exists it must be a **plain regular file owned by the current euid**, otherwise it refuses; missing paths are created with `set -o noclobber` (O_EXCL-style); perms tightened to 0600 where supported.
- `bg_task_start` fails instead of writing through a hostile link.

## Testing
- `bash -n` clean.
- Clean-create path exercised end-to-end (`[]` written once).
- Symlink-refusal branch verified by predicate unit-check; note this dev host cannot create NTFS symlinks without elevation, but `-L`/`-O` are standard POSIX tests on the macOS/Linux targets this library serves.

Fixes #3008