### PR TITLE
fix(dashboard): surface GPU detail HTTP failures

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useGPUDetailed.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useGPUDetailed.test.js
@@ -1,0 +1,26 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useGPUDetailed } from '../useGPUDetailed'
+
+describe('useGPUDetailed', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn((url) => Promise.resolve({
+      ok: url !== '/api/gpu/detailed',
+      status: url === '/api/gpu/detailed' ? 503 : 200,
+      json: () => Promise.resolve({}),
+    })))
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('surfaces a failed detailed snapshot instead of reporting a clean poll', async () => {
+    const { result } = renderHook(() => useGPUDetailed())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.detailed).toBeNull()
+    expect(result.current.error).toBe('GPU detail request failed (503)')
+    expect(fetch).toHaveBeenCalledWith('/api/gpu/detailed')
+  })
+})

--- a/ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js
+++ b/ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js
@@ -23,7 +23,14 @@ export function useGPUDetailed() {
           fetch('/api/gpu/history'),
           fetch('/api/gpu/topology'),
         ])
-        if (detRes.ok) setDetailed(await detRes.json())
+        // The detailed snapshot drives the entire GPU Monitor page. Treat an
+        // HTTP failure as an outage instead of clearing the error and leaving
+        // an older snapshot looking live. History and topology are optional
+        // enhancements, so they may still degrade independently.
+        if (!detRes.ok) {
+          throw new Error(`GPU detail request failed (${detRes.status})`)
+        }
+        setDetailed(await detRes.json())
         if (histRes.ok) setHistory(await histRes.json())
         if (topoRes.ok) setTopology(await topoRes.json())
         setError(null)


### PR DESCRIPTION
Report failed GPU detail HTTP responses while preserving the last good GPU snapshot and beta's bounded polling lifecycle.

## Why this matters
The GPU Monitor can currently present stale detail as a clean successful poll when /api/gpu/detailed returns HTTP 503.

Root cause: The response mapper converts every non-success endpoint into undefined, then unconditionally clears the error.

Behavioral invariant: A failed primary detail observation must produce an outage warning; a later success must clear it without losing the last verified snapshot in between.

## Implementation and compatibility
Require a successful detail status before publishing the combined poll. Preserve #4444's timeout, abort and stale-result ownership. Optional history/topology HTTP failures retain their existing degradation behavior.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js`.

Relevant same-file results: #4444 (merged: fix(gpu): recover monitoring after stalled response bodies)

#4444 addresses stalled response bodies, not HTTP errors. #3313 also contained an HTTP check: the primary detail HTTP contract stays here in earlier #3025; #3313 will be narrowed to its independent initial-hidden-tab behavior.

## Regression and validation
Candidate commit: `b34081ffe3231d766b5fb3f9a8b4eab21c78a17b`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useGPUDetailed` — **6 passed**.
- Both HTTP-outage tests fail against unchanged beta code; all 6 candidate HTTP and deadline-recovery tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `b34081ffe3231d766b5fb3f9a8b4eab21c78a17b`: 36 successful checks; 1 failed; 0 pending; 4 skipped review/security jobs (not counted as passes). [distro: cachyos](https://github.com/Osmantic/ODS/actions/runs/35099316939/job/104804415244).

The failed CachyOS job stopped while installing checkout prerequisites: the distro repository signature was invalid, before this candidate was checked out. Later candidates passed the same distro job, but this exact head remains red. GitHub refused the failed-run rerun with “Must have admin rights to Repository.” A maintainer rerun is still required; no signature checks were disabled.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #3313, GPU code and the separate HTTP/initial-load test files merge cleanly; both contracts pass on the combined head.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
