### PR TITLE
fix(setup): validate first-run response flags

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useFirstRun.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useFirstRun.test.js
@@ -1,0 +1,40 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useFirstRun } from '../useFirstRun'
+
+describe('useFirstRun', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('does not coerce a string first_run flag into first-run mode', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ first_run: 'false' }),
+    })
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.firstRun).toBe(false)
+    expect(result.current.error).toBe('setup-status returned an invalid first_run value')
+  })
+
+  test.each([true, false])('accepts the boolean first_run contract (%s)', async (firstRun) => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ first_run: firstRun }),
+    })
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.firstRun).toBe(firstRun)
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/ods/extensions/services/dashboard/src/hooks/useFirstRun.js
+++ b/ods/extensions/services/dashboard/src/hooks/useFirstRun.js
@@ -30,7 +30,15 @@ export function useFirstRun() {
       const resp = await fetch('/api/setup/status')
       if (!resp.ok) throw new Error(`setup-status returned ${resp.status}`)
       const data = await resp.json()
-      setFirstRun(!!data.first_run)
+      if (
+        !data ||
+        typeof data !== 'object' ||
+        Array.isArray(data) ||
+        typeof data.first_run !== 'boolean'
+      ) {
+        throw new Error('setup-status returned an invalid first_run value')
+      }
+      setFirstRun(data.first_run)
       setError(null)
     } catch (err) {
       // See the failure-mode comment above. We mark loading=false so the


### PR DESCRIPTION
## Summary
- require `/api/setup/status.first_run` to be a JSON boolean
- preserve the fail-open dashboard behavior for malformed responses instead of coercing strings
- cover both valid boolean values and the misleading string `false`

## Why this matters
`App -> useFirstRun -> /api/setup/status` controls whether the setup wizard replaces the normal dashboard. JavaScript treats the string `false` as truthy, so the previous `!!data.first_run` could force an already-configured device back into first-run UI when the API contract drifted. The invariant is that only the explicit JSON boolean `true` activates first-run mode.

## Overlap check
Searched open and closed upstream PRs for first-run response coercion, setup status booleans, and `useFirstRun`. Open PR #2186 only mocks the hook while fixing bootstrap size units. Closed PRs #1157/#1158 introduced server-side first-boot gating but do not validate response types. No PR found covers malformed `first_run` values.

## Validation
- `npm test -- --run src/hooks/__tests__/useFirstRun.test.js` — 3 passed
- `npx eslint src/hooks/useFirstRun.js src/hooks/__tests__/useFirstRun.test.js` — passed
- `git diff --cached --check` — passed

## Design and rollback
Malformed data follows the hook's documented fail-open behavior: the wizard stays hidden, the error is exposed, and the dashboard remains usable. Reverting the commit restores truthiness coercion. This is release-contract validation for a repository-owned API response, not a security claim.

Generated with Codex