### PR TITLE
fix(models): validate dashboard model snapshots

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -85,6 +85,20 @@ describe('useModels', () => {
     expect(result.current.error).toBeNull()
   })
 
+  test('rejects a malformed models list without corrupting render state', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: { id: 'not-a-list' } }),
+    })
+
+    const { result } = renderHook(() => useModels())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.models).toEqual([])
+    expect(result.current.error).toBe('Models API returned an invalid models list')
+  })
+
   test('surfaces backend-owned activation as a pending model action', async () => {
     const target = 'slow-model'
     fetch.mockResolvedValue(modelsResponse(

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -235,6 +235,14 @@ export function useModels() {
       const response = await fetch('/api/models', { signal: controller.signal })
       if (!response.ok) throw new Error('Failed to fetch models')
       const data = await response.json()
+      if (
+        !data ||
+        typeof data !== 'object' ||
+        Array.isArray(data) ||
+        !Array.isArray(data.models)
+      ) {
+        throw new Error('Models API returned an invalid models list')
+      }
 
       // A slower, older request must not overwrite a newer snapshot.
       if (requestId < latestSettledModelsRequestRef.current) return data


### PR DESCRIPTION
## Summary
- validate that `/api/models` returns an object with a `models` array before updating hook state
- keep the previous safe array state when the response contract is malformed
- add a regression at the dashboard hook boundary

## Why this matters
The Models page consumes `useModels().models` as an array. Previously a successful HTTP response such as `{ models: {} }` assigned that object directly to React state, allowing downstream `.map()`/`.find()` calls to crash the page. The invariant is that a models snapshot cannot replace render state until its primary collection satisfies the API contract.

## Overlap check
Searched open and closed upstream PRs for malformed Models API snapshots, `useModels data.models`, and response validation. Also checked all open-PR changed-file metadata for this production hook. No PR found covers the `/api/models` collection shape or this failure mode.

## Validation
- `npm test -- --run src/hooks/__tests__/useModels.test.js` — 35 passed
- `npx eslint src/hooks/useModels.js src/hooks/__tests__/useModels.test.js` — passed
- `git diff --cached --check` — passed

## Design and rollback
The validation is intentionally limited to the collection required by every consumer; optional metadata keeps its existing degradation behavior. Reverting the commit restores direct assignment. This validates repository-owned release data and does not make a security claim.

Generated with Codex