### PR TITLE
fix(preflight): report occupied service ports

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PreFlightChecks.jsx
+++ b/ods/extensions/services/dashboard/src/components/PreFlightChecks.jsx
@@ -140,15 +140,6 @@ export function PreFlightChecks({ onComplete, onIssuesFound }) {
         return { status: 'success', message: `${ports.length} ports available` }
       }
 
-      // Ports in use by ODS services are expected, not conflicts
-      // If all "conflicts" are our own services, treat as success
-      const odsPorts = new Set(ports.map(p => p.port))
-      const allOurs = conflicts.every(c => odsPorts.has(c.port))
-
-      if (allOurs) {
-        return { status: 'success', message: `${conflicts.length} services already running` }
-      }
-
       const conflictList = conflicts.map(c => `Port ${c.port} (${c.service})`).join(', ')
       return {
         status: 'warning',

--- a/ods/extensions/services/dashboard/src/components/__tests__/PreFlightChecks.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/PreFlightChecks.test.jsx
@@ -1,0 +1,40 @@
+import { act, render, screen } from '@testing-library/react'
+import { PreFlightChecks } from '../PreFlightChecks'
+
+describe('PreFlightChecks', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('fetch', vi.fn((url) => {
+      const payloads = {
+        '/api/preflight/required-ports': { ports: [{ port: 3000, service: 'Open WebUI' }] },
+        '/api/preflight/docker': { available: true, version: '27.0' },
+        '/api/preflight/gpu': { available: true, name: 'Test GPU', vram: 8 },
+        '/api/preflight/ports': {
+          conflicts: [{ port: 3000, service: 'Open WebUI', in_use: true }],
+        },
+        '/api/preflight/disk': { free: 100e9 },
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payloads[url]),
+      })
+    }))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('reports an occupied requested port instead of assuming ODS owns it', async () => {
+    render(<PreFlightChecks />)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2300)
+    })
+
+    expect(screen.getByText('1 port(s) in use')).toBeInTheDocument()
+    expect(screen.getByText('Port 3000 (Open WebUI)')).toBeInTheDocument()
+    expect(screen.queryByText('1 services already running')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- remove the client-side assumption that every occupied requested port belongs to ODS
- render the API's conflict receipt as a warning with the exact port and service label
- add a component-level regression test for an occupied required port

## Why this matters
`SetupWizard -> PreFlightChecks -> /api/preflight/ports` is the user-visible port readiness boundary. The API only proves that `bind()` failed; it labels the requested port from configuration but does not identify the owning process. Because every returned conflict necessarily used a requested port, the previous `conflicts.every(c => odsPorts.has(c.port))` condition was always true and converted all conflicts into a green “services already running” result. The invariant is that occupancy without ownership proof must remain visible as a conflict warning.

## Overlap check
Searched open and closed upstream PRs for preflight port ownership, occupied ports, and the `allOurs` conflict branch. Mapped the production component against open-PR file metadata. No PR found covers this tautological ownership check.

## Validation
- `npm test -- --run src/components/__tests__/PreFlightChecks.test.jsx` — 1 passed
- focused ESLint — 0 errors (existing flat config reports two non-blocking JSX/ignore warnings)
- `git diff --cached --check` — passed

## Design and rollback
This preserves the existing product decision that port warnings do not hard-block onboarding; it only stops presenting unproven ownership as success. A future backend receipt could safely distinguish ODS-owned listeners. Reverting this commit restores the optimistic label.

Generated with Codex