### PR TITLE
fix(dashboard): bracket IPv6 service hosts

### DIFF
--- a/ods/extensions/services/dashboard/src/lib/serviceUrls.js
+++ b/ods/extensions/services/dashboard/src/lib/serviceUrls.js
@@ -8,8 +8,14 @@ export function dashboardHost() {
   return typeof window !== 'undefined' ? window.location.hostname : 'localhost'
 }
 
-export function fallbackServiceUrl(port, path = '') {
-  return port ? appendPath(`http://${dashboardHost()}:${port}`, path) : null
+export function urlHost(hostname) {
+  const host = String(hostname || '').trim()
+  if (host.includes(':') && !host.startsWith('[')) return `[${host}]`
+  return host
+}
+
+export function fallbackServiceUrl(port, path = '', hostname = dashboardHost()) {
+  return port ? appendPath(`http://${urlHost(hostname)}:${port}`, path) : null
 }
 
 export function serviceUrl(service, path = '') {

--- a/ods/extensions/services/dashboard/src/lib/serviceUrls.test.js
+++ b/ods/extensions/services/dashboard/src/lib/serviceUrls.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { appendPath, fallbackServiceUrl, serviceUrl } from './serviceUrls'
+import { appendPath, fallbackServiceUrl, serviceUrl, urlHost } from './serviceUrls'
 
 describe('service URL helpers', () => {
   it('uses configured public URLs as exact operator-facing links by default', () => {
@@ -24,5 +24,13 @@ describe('service URL helpers', () => {
   it('keeps appendPath and fallback helpers stable for root paths', () => {
     expect(appendPath('https://svc.example.test/', '/')).toBe('https://svc.example.test/')
     expect(fallbackServiceUrl(8080, '/')).toBe('http://localhost:8080')
+  })
+
+  it('brackets IPv6 dashboard hosts before a service port is appended', () => {
+    expect(urlHost('2001:db8::7')).toBe('[2001:db8::7]')
+    expect(urlHost('[2001:db8::7]')).toBe('[2001:db8::7]')
+    expect(urlHost('ods.local')).toBe('ods.local')
+    expect(fallbackServiceUrl(3005, '/dashboard', '2001:db8::7'))
+      .toBe('http://[2001:db8::7]:3005/dashboard')
   })
 })


### PR DESCRIPTION
## Summary
- normalize literal IPv6 dashboard hostnames into bracketed URL hosts
- apply the normalization before constructing host-port fallback links
- cover expanded and already-bracketed IPv6 addresses at the service-link boundary

## Why this matters
Extensions, Service Map, Settings, Dashboard launchers, and Sidebar all reach `fallbackServiceUrl` when no operator `public_url` exists. Concatenating an expanded hostname directly produced `http://2001:db8::7:3005`, which is not a valid authority and breaks service launch links on IPv6-only/LAN access. The invariant is that a literal IPv6 host is bracketed exactly once before a port is appended.

## Overlap check
Searched open and closed PRs for dashboard service URL IPv6 fallbacks and `serviceUrls/dashboardHost`. PR #2781 fixes IPv6 parsing in the dashboard-api feature-instructions endpoint (`routers/features.py`); it does not touch the shared frontend helper or its five consumers. No PR found covers this independent link-construction boundary.

## Validation
- `npm test -- --run src/lib/serviceUrls.test.js` — 5 passed
- `npx eslint src/lib/serviceUrls.js src/lib/serviceUrls.test.js` — passed
- `git diff --cached --check` — passed

## Platform and rollback
Hostname and IPv4 behavior is unchanged; expanded and pre-bracketed IPv6 forms are covered. Reverting the commit restores the invalid unbracketed fallback. Browser integration was not run on an IPv6 host; the exact generated authority is asserted deterministically.

Generated with Codex