### PR TITLE
fix(env): decode dashboard dotenv escapes

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -1,6 +1,27 @@
 """Small, dependency-free helpers for values read from ODS ``.env`` files."""
 
 
+_DOUBLE_QUOTE_ESCAPES = {'"', "$", "`", "\\"}
+
+
+def _decode_double_quoted(value: str) -> str:
+    """Decode the escape set shared by Bash and ODS's dotenv serializer."""
+    decoded: list[str] = []
+    index = 0
+    while index < len(value):
+        char = value[index]
+        if (
+            char == "\\"
+            and index + 1 < len(value)
+            and value[index + 1] in _DOUBLE_QUOTE_ESCAPES
+        ):
+            index += 1
+            char = value[index]
+        decoded.append(char)
+        index += 1
+    return "".join(decoded)
+
+
 def strip_matching_quotes(value: str) -> str:
     """Trim whitespace and remove exactly one matching outer quote pair.
 
@@ -10,5 +31,6 @@ def strip_matching_quotes(value: str) -> str:
     """
     value = value.strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
-        return value[1:-1]
+        inner = value[1:-1]
+        return _decode_double_quoted(inner) if value[0] == '"' else inner
     return value

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -20,6 +20,11 @@ from env_values import strip_matching_quotes
         ('"value\'', '"value\''),
         ("''value''", "'value'"),
         ('""value""', '"value"'),
+        ('"path=C:\\\\models"', "path=C:\\models"),
+        ('"token=abc\\$123"', "token=abc$123"),
+        ('"say \\"hello\\""', 'say "hello"'),
+        ('"keep\\ntext"', r"keep\ntext"),
+        (r"'keep\\literal'", r"keep\\literal"),
     ],
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):


### PR DESCRIPTION
## Summary
- decode the double-quoted escape set emitted by ODS's shared dotenv serializer
- preserve unknown backslash sequences and all single-quoted content literally
- cover backslashes, dollars, quotes, and non-special escapes

## Why this matters
`lib/dotenv-quote.sh` emits double-quoted values when a value contains a single quote, escaping backslashes, quotes, and dollar signs. Eight dashboard-api production readers call `strip_matching_quotes`; previously they removed only the outer quotes and returned the escape backslashes as data. A serialized token therefore differed between dashboard behavior and Bash/Compose. The invariant is that repository-written dotenv values round-trip to the same logical value for every consumer.

## Overlap check
Searched open and closed PRs for double-quoted dotenv parsing and `strip_matching_quotes`. Open PR #2944 routes one additional token reader through the helper but does not change helper semantics; this PR improves that shared path and is independently useful to all existing callers. No PR found decodes serializer escapes.

## Validation
- `pytest tests/test_env_values.py -q` ? 19 passed
- `python -m py_compile env_values.py` ? passed
- `git diff --cached --check` ? passed

## Design and rollback
Only characters Bash treats specially inside double quotes are decoded. Unknown sequences such as backslash-n remain literal, avoiding an incompatible general-purpose dotenv parser. Single quotes remain fully literal. Reverting restores quote-only stripping.

Generated with Codex
