### PR TITLE
fix(remote-provider): require model-list probe receipts

### DIFF
--- a/ods/bin/remote_provider/probe.py
+++ b/ods/bin/remote_provider/probe.py
@@ -65,16 +65,28 @@ def _read_probe_body(response: Any) -> bytes:
     return body
 
 
-def _model_count(body: bytes) -> int | None:
+def _model_count(body: bytes) -> int:
     try:
         payload = json.loads(body.decode("utf-8"))
     except (UnicodeDecodeError, ValueError):
-        return None
+        raise ProbeError(
+            502,
+            "provider_invalid_response",
+            "remote provider models endpoint returned invalid JSON",
+        )
     if not isinstance(payload, Mapping):
-        return None
+        raise ProbeError(
+            502,
+            "provider_invalid_response",
+            "remote provider models endpoint did not return an object",
+        )
     models = payload.get("data")
     if not isinstance(models, list):
-        return None
+        raise ProbeError(
+            502,
+            "provider_invalid_response",
+            "remote provider models endpoint did not return a data array",
+        )
     return len(models)
 
 

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -790,6 +790,26 @@ def test_direct_provider_probe_is_bounded_and_redacted() -> None:
     )
 
 
+def test_direct_provider_probe_rejects_non_model_success_payloads() -> None:
+    route = plan_route(cloud_direct_env())
+
+    error = assert_raises_probe_error(
+        lambda: probe_direct_provider(
+            route,
+            provider_secret="unit-test-provider-token",
+            resolver=_public_resolver,
+            opener=lambda *_args, **_kwargs: _ProbeResponse(b'{"status":"ok"}'),
+        ),
+        "HTTP 200 without an OpenAI model list should not prove the provider",
+    )
+
+    assert_true(error.status == 502, "invalid model-list response status drifted")
+    assert_true(
+        error.code == "provider_invalid_response",
+        "invalid model-list response code drifted",
+    )
+
+
 def test_public_probe_receipt_is_redacted_and_typed() -> None:
     receipt = public_probe_receipt(
         {
@@ -907,6 +927,7 @@ def main() -> int:
         test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks,
         test_lifecycle_rejects_unsafe_or_secret_public_inputs,
         test_direct_provider_probe_is_bounded_and_redacted,
+        test_direct_provider_probe_rejects_non_model_success_payloads,
         test_public_probe_receipt_is_redacted_and_typed,
         test_direct_provider_probe_fails_closed_before_unsafe_dns_request,
         test_generic_ssh_provider_probe_uses_tunnel_boundary,


### PR DESCRIPTION
## Summary
- require the OpenAI-compatible `/v1/models` probe to return valid JSON object data
- require the `data` member to be an array before a provider can be marked proven
- return a stable 502 `provider_invalid_response` classification for semantic failures

## Why this matters
Remote-provider activation reaches `probe_provider_route -> /v1/models` before recording a route receipt. Previously any HTTP 2xx body, including HTML, `{ "status": "ok" }`, or a JSON scalar, produced `ok: true` with `modelCount: null`. That could greenlight the wrong upstream endpoint and persist a misleading provider proof. The invariant is that transport reachability alone is insufficient: the endpoint must satisfy the minimum OpenAI model-list contract.

## Overlap check
Searched open and closed upstream PRs for remote-provider model-list probe validation, `_model_count`, and provider invalid-response handling. Checked the production probe file against open PR metadata. No PR found covers semantic validation of a successful `/v1/models` response.

## Validation
- `python tests/contracts/test-remote-provider-egress-policy.py` ? 27 contract checks passed
- `python -m py_compile bin/remote_provider/probe.py tests/contracts/test-remote-provider-egress-policy.py` ? passed
- `git diff --cached --check` ? passed

## Design and rollback
An empty `data` array remains valid because it proves the endpoint contract even when no models are installed. Response size, DNS policy, auth redaction, and timeouts are unchanged. Reverting restores reachability-only success. No live external provider was used; the HTTP boundary is exercised with a deterministic 200 non-model payload.

Generated with Codex
