### PR TITLE
fix(remote-provider): require regular SSH secret files

### DIFF
--- a/ods/bin/remote_provider/ssh_supervisor.py
+++ b/ods/bin/remote_provider/ssh_supervisor.py
@@ -7,6 +7,7 @@ spawn ssh or open sockets.
 
 from __future__ import annotations
 
+import stat
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -25,12 +26,14 @@ DEFAULT_SSH_SECRET_DIR = Path("/state/remote-provider/secrets")
 
 def _file_status(path: Path) -> dict[str, Any]:
     try:
-        stat = path.stat()
+        stat_result = path.stat()
     except FileNotFoundError:
         return {"configured": False, "bytes": 0}
     except OSError:
         return {"configured": False, "bytes": None}
-    return {"configured": stat.st_size > 0, "bytes": stat.st_size}
+    if not stat.S_ISREG(stat_result.st_mode):
+        return {"configured": False, "bytes": None}
+    return {"configured": stat_result.st_size > 0, "bytes": stat_result.st_size}
 
 
 def ssh_secret_status(secret_dir: str | Path = DEFAULT_SSH_SECRET_DIR) -> dict[str, Any]:

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -490,6 +490,23 @@ def test_ssh_secret_status_is_support_bundle_safe() -> None:
     assert_true("AAAATEST" not in dumped, "known_hosts contents leaked into secret status")
 
 
+def test_ssh_secret_status_rejects_directories_as_secret_files() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        secret_dir = Path(tmp)
+        (secret_dir / "ssh-identity").mkdir()
+        (secret_dir / "known_hosts").mkdir()
+        status = ssh_secret_status(secret_dir)
+
+    assert_true(
+        status["sshIdentity"] == {"configured": False, "bytes": None},
+        "identity directory must not satisfy secret custody",
+    )
+    assert_true(
+        status["sshKnownHosts"] == {"configured": False, "bytes": None},
+        "known_hosts directory must not satisfy secret custody",
+    )
+
+
 def test_public_env_forbids_remote_secrets() -> None:
     validate_public_env_keys(
         {
@@ -897,6 +914,7 @@ def main() -> int:
         test_ssh_supervisor_plan_is_redacted_and_start_gated,
         test_ssh_supervisor_plan_blocks_missing_secret_custody,
         test_ssh_secret_status_is_support_bundle_safe,
+        test_ssh_secret_status_rejects_directories_as_secret_files,
         test_public_env_forbids_remote_secrets,
         test_activation_receipt_redacts_secret_references,
         test_activation_transaction_orders_phases,


### PR DESCRIPTION
## Summary
- require SSH identity and known-hosts custody paths to be regular files
- report directories and other non-regular nodes as unconfigured
- add a contract regression covering both required secret paths

## Why this matters
The SSH tunnel service reaches `ssh_secret_status -> ssh_supervisor_plan` before deciding `readyToStart`. `Path.stat().st_size > 0` also succeeds for directories on common filesystems, so a bad bind mount that created `/state/.../ssh-identity` or `known_hosts` as a directory could be reported as configured. Startup would then proceed and fail later when SSH tried to read it. The invariant is that secret custody is ready only when each required path is a non-empty regular file.

## Overlap check
Searched open and closed upstream PRs for SSH secret status, directory mounts, regular-file custody, and `ssh_secret_status`. Checked the production planner against open-PR file metadata. No PR found covers file type validation at this boundary.

## Validation
- `python tests/contracts/test-remote-provider-egress-policy.py` ? 27 contract checks passed
- `python -m py_compile bin/remote_provider/ssh_supervisor.py` ? passed
- `git diff --cached --check` ? passed

## Design and rollback
Missing files keep the existing zero-byte receipt; unreadable and non-regular paths use `bytes: null` without exposing filesystem content. Symlinks to regular secret files retain existing behavior. Reverting restores size-only readiness. No live SSH tunnel was started; the exact supervisor input receipt is exercised on disk.

Generated with Codex
