### PR TITLE
fix(remote-provider): enforce boolean adapter outcomes

### DIFF
--- a/ods/bin/remote_provider/reconciler.py
+++ b/ods/bin/remote_provider/reconciler.py
@@ -46,7 +46,7 @@ def _rollback(adapter: ActivationAdapter, env: dict[str, str]) -> dict[str, Any]
         outcome = adapter.rollback(env)
     except Exception as exc:
         return result(False, f"rollback raised: {exc}")
-    if not isinstance(outcome, dict) or "ok" not in outcome:
+    if not isinstance(outcome, dict) or type(outcome.get("ok")) is not bool:
         return result(False, "rollback returned a non-contract result")
     return outcome
 
@@ -65,7 +65,7 @@ def run_activation_transaction(
             if committed or phase == "commit":
                 payload["rollback"] = _rollback(adapter, env)
             return payload
-        if not isinstance(outcome, dict) or "ok" not in outcome:
+        if not isinstance(outcome, dict) or type(outcome.get("ok")) is not bool:
             payload = result(False, "adapter returned a non-contract result", phase=phase)
             if committed or phase == "commit":
                 payload["rollback"] = _rollback(adapter, env)

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -575,6 +575,21 @@ def test_activation_transaction_fails_closed_and_rolls_back_after_commit() -> No
     )
 
 
+def test_activation_transaction_rejects_truthy_non_boolean_status() -> None:
+    class MalformedAdapter(FakeActivationAdapter):
+        def stage(self, env: dict[str, str]) -> dict[str, object]:
+            self.calls.append("stage")
+            return {"ok": "false", "detail": "not a boolean"}
+
+    adapter = MalformedAdapter()
+    run = run_activation_transaction(adapter, {})
+
+    assert_true(run["ok"] is False, "truthy string status must not pass activation")
+    assert_true(run["phase"] == "stage", "malformed status phase drifted")
+    assert_true("non-contract" in run["detail"], "malformed status detail drifted")
+    assert_true(adapter.calls == ["stage"], "malformed status must stop the sequence")
+
+
 def test_lifecycle_configure_operation_is_redacted_and_typed() -> None:
     operation = plan_lifecycle_operation(
         {
@@ -901,6 +916,7 @@ def main() -> int:
         test_activation_receipt_redacts_secret_references,
         test_activation_transaction_orders_phases,
         test_activation_transaction_fails_closed_and_rolls_back_after_commit,
+        test_activation_transaction_rejects_truthy_non_boolean_status,
         test_lifecycle_configure_operation_is_redacted_and_typed,
         test_lifecycle_peer_operation_tracks_peer_token_without_leaks,
         test_lifecycle_test_disable_and_remove_write_intent,


### PR DESCRIPTION
## Summary
- require adapter and rollback `ok` fields to be actual booleans
- classify truthy strings and integers as contract violations
- stop the activation sequence at the first malformed phase receipt

## Why this matters
`run_activation_transaction` is the commit/rollback coordinator for remote-provider activation. It previously checked only that an `ok` key existed and then used truthiness. A malformed adapter receipt such as `{ "ok": "false" }` therefore advanced through stage/validate/commit and could finish as a proven activation. The invariant is that transaction control flow accepts only typed boolean outcomes.

## Overlap check
Searched open and closed upstream PRs for remote-provider adapter outcome typing, non-contract results, and `run_activation_transaction`. Checked the reconciler against open-PR file metadata. No PR found covers non-boolean `ok` values.

## Validation
- `python tests/contracts/test-remote-provider-egress-policy.py` ? 27 contract checks passed
- `python -m py_compile bin/remote_provider/reconciler.py` ? passed
- `git diff --cached --check` ? passed

## Design and rollback
The shared `result()` helper already emits booleans, so conforming adapters are unchanged. The same rule now applies to rollback receipts; malformed rollback remains visible as a failed rollback. Reverting restores truthiness-based sequencing. The test exercises the public transaction coordinator with a deliberately malformed adapter.

Generated with Codex
