### PR TITLE
fix(bark): enforce configured API keys

### DIFF
--- a/ods/extensions/library/services/bark/README.md
+++ b/ods/extensions/library/services/bark/README.md
@@ -32,11 +32,13 @@ Your data is preserved when disabling. To re-enable later: `ods enable bark`
 # Generate speech (Base64 response)
 curl -X POST http://localhost:9200/tts \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $BARK_API_KEY" \
   -d '{"text": "Hello! [laughs] This is Bark TTS.", "voice_preset": "v2/en_speaker_6"}'
 
 # Get raw audio (WAV)
 curl -X POST http://localhost:9200/tts/stream \
   -H "Content-Type: application/json" \
+  -H "X-API-Key: $BARK_API_KEY" \
   -d '{"text": "Hello from Bark!", "voice_preset": "v2/en_speaker_3"}' \
   --output output.wav
 
@@ -55,3 +57,6 @@ Bark understands non-verbal cues in brackets: `[laughter]`, `[sighs]`, `[music]`
 | `BARK_USE_SMALL_MODELS` | Use smaller/faster models (less VRAM) | `false` |
 | `BARK_OFFLOAD_CPU` | Offload to CPU between requests | `false` |
 | `BARK_API_KEY` | API key for authentication (optional) | _(empty)_ |
+
+When `BARK_API_KEY` is set, `/tts` and `/tts/stream` require the same value in
+the `X-API-Key` header. Health and voice discovery remain available without a key.

--- a/ods/extensions/library/services/bark/server.py
+++ b/ods/extensions/library/services/bark/server.py
@@ -6,13 +6,15 @@ Compatible with the ODS extensions ecosystem.
 
 import io
 import base64
+import hmac
 import logging
+import os
 import threading
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor
 
 import soundfile as sf
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, Header, HTTPException
 from fastapi.responses import Response
 from pydantic import BaseModel, Field, field_validator
 
@@ -120,6 +122,16 @@ class TTSResponse(BaseModel):
     format: str
 
 
+def _require_api_key(x_api_key: Optional[str] = Header(default=None)) -> None:
+    """Enforce the optional API key advertised by the extension manifest."""
+    expected_key = os.environ.get("BARK_API_KEY", "")
+    if not expected_key:
+        return
+
+    if x_api_key is None or not hmac.compare_digest(x_api_key, expected_key):
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+
 def _generate_audio_sync(text: str, voice_preset: str, output_format: str) -> dict:
     """Synchronous audio generation — runs in thread pool."""
     from bark import generate_audio, SAMPLE_RATE
@@ -144,7 +156,11 @@ def health():
     return {"status": "ok", "models_loaded": _models_loaded}
 
 
-@app.post("/tts", response_model=TTSResponse)
+@app.post(
+    "/tts",
+    response_model=TTSResponse,
+    dependencies=[Depends(_require_api_key)],
+)
 def text_to_speech(req: TTSRequest):
     """
     Generate speech audio from text using Bark.
@@ -178,7 +194,7 @@ def text_to_speech(req: TTSRequest):
         raise HTTPException(status_code=500, detail="TTS generation failed. Please try again.")
 
 
-@app.post("/tts/stream")
+@app.post("/tts/stream", dependencies=[Depends(_require_api_key)])
 def text_to_speech_stream(req: TTSRequest):
     """
     Generate speech and return raw audio bytes (wav).

--- a/ods/extensions/library/services/bark/test_server.py
+++ b/ods/extensions/library/services/bark/test_server.py
@@ -2,8 +2,10 @@
 
 import pytest
 import base64
+import json
 import threading
 import numpy as np
+from pathlib import Path
 from unittest.mock import patch
 from fastapi.testclient import TestClient
 
@@ -15,8 +17,9 @@ client = TestClient(server.app)
 
 # Fixtures
 @pytest.fixture(autouse=True)
-def reset_globals():
+def reset_globals(monkeypatch):
     """Reset global state before each test."""
+    monkeypatch.delenv("BARK_API_KEY", raising=False)
     # Use setattr to modify the module's attribute, not a local variable
     original = server._models_loaded
     server._models_loaded = False
@@ -81,6 +84,65 @@ def test_health_after_load(mock_bark_preload_models):
     data = response.json()
     assert data["status"] == "ok"
     assert data["models_loaded"] is True
+
+
+@pytest.mark.parametrize("path", ["/tts", "/tts/stream"])
+def test_tts_requires_configured_api_key(monkeypatch, path):
+    """Configured synthesis endpoints reject missing and incorrect keys."""
+    monkeypatch.setenv("BARK_API_KEY", "configured-secret")
+
+    missing = client.post(path, json={"text": "Hello"})
+    incorrect = client.post(
+        path,
+        headers={"X-API-Key": "wrong-secret"},
+        json={"text": "Hello"},
+    )
+
+    assert missing.status_code == 401
+    assert incorrect.status_code == 401
+
+
+def test_tts_accepts_configured_api_key(
+    monkeypatch,
+    mock_bark_generate_audio,
+    mock_soundfile_write,
+):
+    """The documented X-API-Key header reaches the synthesis boundary."""
+    monkeypatch.setenv("BARK_API_KEY", "configured-secret")
+
+    with patch("server._models_loaded", True):
+        response = client.post(
+            "/tts",
+            headers={"X-API-Key": "configured-secret"},
+            json={"text": "Hello"},
+        )
+
+    assert response.status_code == 200
+
+
+def test_bundled_workflows_forward_bark_api_key():
+    """Bundled n8n callers keep working when Bark authentication is enabled."""
+    service_dir = Path(__file__).resolve().parent
+    repo_dir = service_dir.parents[3]
+    workflow_paths = [
+        service_dir / "workflow-tts.json",
+        repo_dir / "extensions/library/workflows/bark/tts-synthesize.json",
+    ]
+
+    for workflow_path in workflow_paths:
+        workflow = json.loads(workflow_path.read_text(encoding="utf-8"))
+        bark_request = next(
+            node for node in workflow["nodes"]
+            if node["type"] == "n8n-nodes-base.httpRequest"
+        )
+        headers = bark_request["parameters"]["headers"]["list"]
+        assert {
+            "name": "X-API-Key",
+            "value": "={{ $env.BARK_API_KEY || '' }}",
+        } in headers
+
+    n8n_compose = repo_dir / "extensions/services/n8n/compose.yaml"
+    assert "BARK_API_KEY=${BARK_API_KEY:-}" in n8n_compose.read_text(encoding="utf-8")
 
 
 # Tests for /tts endpoint

--- a/ods/extensions/library/services/bark/workflow-tts.json
+++ b/ods/extensions/library/services/bark/workflow-tts.json
@@ -105,6 +105,14 @@
       "parameters": {
         "url": "={{ ($env.BARK_HOST || 'http://bark:9200').replace(/\\/$/, '') }}/tts",
         "method": "POST",
+        "headers": {
+          "list": [
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.BARK_API_KEY || '' }}"
+            }
+          ]
+        },
         "body": {
           "mimeType": "application/json",
           "raw": "={{ JSON.stringify({ text: $('Check Valid').item.json.text, voice_preset: $('Check Valid').item.json.voice_preset, output_format: $('Check Valid').item.json.output_format }) }}"

--- a/ods/extensions/library/workflows/bark/tts-synthesize.json
+++ b/ods/extensions/library/workflows/bark/tts-synthesize.json
@@ -24,6 +24,10 @@
             {
               "name": "Content-Type",
               "value": "application/json"
+            },
+            {
+              "name": "X-API-Key",
+              "value": "={{ $env.BARK_API_KEY || '' }}"
             }
           ]
         },

--- a/ods/extensions/services/n8n/compose.yaml
+++ b/ods/extensions/services/n8n/compose.yaml
@@ -18,6 +18,7 @@ services:
       - ODS_BIND_ADDRESS=${BIND_ADDRESS:-127.0.0.1}
       - N8N_SECURE_COOKIE=${N8N_SECURE_COOKIE:-auto}
       - GENERIC_TIMEZONE=${TIMEZONE:-UTC}
+      - BARK_API_KEY=${BARK_API_KEY:-}
     volumes:
       - ./extensions/services/n8n/n8n-cookie-policy.sh:/opt/ods/n8n-cookie-policy.sh:ro,z
       - ./extensions/services/n8n/n8n-entrypoint.sh:/opt/ods/n8n-entrypoint.sh:ro,z


### PR DESCRIPTION
## Why this matters

The Bark extension manifest and generated compose stack expose `BARK_API_KEY` as an optional authentication control, but the FastAPI service never read it. Operators could configure the key and still receive unauthenticated synthesis requests on both production endpoints.

Root cause: the configuration was passed into the Bark container without an HTTP boundary dependency, and the two bundled n8n callers did not forward the configured value.

This change enforces the invariant that a non-empty `BARK_API_KEY` protects `/tts` and `/tts/stream` with an `X-API-Key` header while an empty value preserves the existing unauthenticated local setup. `/health` and `/voices` remain public so health checks and discovery continue to work. The n8n service receives the same configuration and both bundled Bark workflows forward it.

## Overlap check

Searched open and closed upstream PRs for `Bark API key authentication` and `BARK_API_KEY server`, plus production-file references to `server.py`, `workflow-tts.json`, and the Bark workflow catalog. No open or closed PR implements the server-side authentication contract or the workflow handoff.

## Regression coverage

- FastAPI boundary tests exercise missing, incorrect, and valid keys against both synthesis routes.
- A workflow contract test parses both bundled JSON workflows and verifies the n8n compose handoff.
- Empty-key behavior is retained by the existing unauthenticated endpoint tests.

## Validation

- `python -c <lightweight Bark dependency stubs + pytest test_server.py -q -k "api_key or bundled">` ? 4 passed.
- Full test file with the same dependency stubs ? 18 passed; 3 pre-existing validation assertions fail under the local FastAPI version because `detail` is a list rather than a string.
- `python -m py_compile server.py test_server.py` ? passed.
- Both changed workflow JSON documents parsed successfully.
- `git diff --check` ? passed.

## Tradeoffs and rollback

Authentication remains opt-in to preserve existing local installations. Constant-time comparison avoids leaking configured key contents. Rolling back removes enforcement and the n8n secret handoff; it does not alter persisted Bark data or model caches.
