### PR TITLE
fix(perplexica): bound model sync requests

### DIFF
--- a/ods/extensions/services/perplexica/sync-model-config.js
+++ b/ods/extensions/services/perplexica/sync-model-config.js
@@ -33,10 +33,13 @@ if (!model || !baseURL) {
 }
 
 async function request(url, payload) {
-  const response = await fetch(url, payload === undefined ? undefined : {
+  const response = await fetch(url, payload === undefined ? {
+    signal: AbortSignal.timeout(5_000),
+  } : {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5_000),
   });
   if (!response.ok) {
     throw new Error(`${response.status} ${response.statusText}`);

--- a/ods/tests/test-perplexica-entrypoint.py
+++ b/ods/tests/test-perplexica-entrypoint.py
@@ -9,6 +9,7 @@ import re
 import shutil
 import subprocess
 import threading
+import time
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
@@ -487,6 +488,51 @@ def test_sync_script_normalizes_base_url_without_v1_suffix() -> None:
         "baseURL": "http://custom-litellm:4000/v1",
         "apiKey": "custom-key",
     }
+
+
+def test_model_sync_aborts_an_unresponsive_config_api() -> None:
+    node = _node_cmd_or_skip()
+    if node is None:
+        return
+
+    release_request = threading.Event()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            release_request.wait(timeout=10)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    started_at = time.monotonic()
+    try:
+        env = os.environ.copy()
+        env.update({
+            "PERPLEXICA_CONFIG_URL": f"http://127.0.0.1:{server.server_port}/api/config",
+            "ODS_MODE": "local",
+            "LLM_MODEL": "test-model",
+            "OPENAI_BASE_URL": "http://llama-server:8080/v1",
+        })
+        result = subprocess.run(
+            [node, str(SYNC_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=8,
+            env=env,
+        )
+    finally:
+        release_request.set()
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result.returncode == 1
+    assert "model-route sync failed" in result.stderr
+    assert time.monotonic() - started_at < 8
 
 
 def _run_search_route_sync(


### PR DESCRIPTION
## Why this matters

Perplexica's container entrypoint retries model-route reconciliation, but every attempt delegated to `sync-model-config.js`, whose GET and POST requests had no deadline. A reachable TCP endpoint that stopped responding could therefore hold the first attempt forever: later retries, the entrypoint's warning, and normal service startup would never run.

Root cause: the independently shipped search-route reconciler already bounded each config request to five seconds, while the model-route reconciler called `fetch` without an abort signal.

The preserved invariant is that every model reconciliation attempt completes with success or a visible failure within a bounded interval. Both reads and writes now use the same five-second timeout as search reconciliation.

## Overlap check

Searched open and closed upstream PRs for `Perplexica model sync timeout` and `sync-model-config.js`. No open PR overlaps. Closed PR #2182 changed shell-side model-id resolution and merged PR #1914 introduced switchboard routing; neither bounds Perplexica config I/O or tests an unresponsive endpoint.

## Regression coverage

`test_model_sync_aborts_an_unresponsive_config_api` runs the production Node script against an HTTP server that accepts the request but never sends a response. It asserts that the script exits non-zero, emits its normal model-sync failure receipt, and finishes before the subprocess safety deadline.

## Validation

- `python -m pytest ods/tests/test-perplexica-entrypoint.py -q -k model_sync_aborts` ? 1 passed.
- Full module ? 18 passed; 3 pre-existing Windows/WSL Bash stdin failures (`set: pipefail: invalid option name`) remain outside this JavaScript scope.
- `node --check ods/extensions/services/perplexica/sync-model-config.js` ? passed.
- `python -m py_compile ods/tests/test-perplexica-entrypoint.py` ? passed.
- `git diff --check` ? passed.

## Tradeoffs and rollback

A severely overloaded config API now causes one retry attempt to fail after five seconds rather than waiting indefinitely; the entrypoint's existing retry loop remains the owner of subsequent attempts. Rollback restores unbounded waits and does not affect persisted Perplexica configuration.
