### PR TITLE
fix(n8n): recognize expanded IPv6 loopback

### DIFF
--- a/ods/extensions/services/n8n/n8n-cookie-policy.sh
+++ b/ods/extensions/services/n8n/n8n-cookie-policy.sh
@@ -1,5 +1,12 @@
 #!/bin/sh
 
+ods_n8n_is_loopback_bind() {
+    case "${1:-}" in
+        127.0.0.1|localhost|::1|\[::1\]|0:0:0:0:0:0:0:1|\[0:0:0:0:0:0:0:1\]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 # Resolve n8n's session-cookie policy from the public transport and host bind.
 # The caller remains responsible for exporting the returned value.
 ods_n8n_secure_cookie_policy() {
@@ -21,21 +28,11 @@ ods_n8n_secure_cookie_policy() {
             ;;
     esac
 
-    case "$_ods_protocol:$_ods_bind" in
-        http:127.0.0.1|http:localhost|http:::1|http:\[::1\])
-            printf 'false\n'
-            ;;
-        *)
-            printf 'true\n'
-            ;;
-    esac
-}
-
-ods_n8n_is_loopback_bind() {
-    case "${1:-}" in
-        127.0.0.1|localhost|::1|\[::1\]) return 0 ;;
-        *) return 1 ;;
-    esac
+    if [ "$_ods_protocol" = "http" ] && ods_n8n_is_loopback_bind "$_ods_bind"; then
+        printf 'false\n'
+        return 0
+    fi
+    printf 'true\n'
 }
 
 ods_n8n_public_protocol() {

--- a/ods/tests/test-n8n-cookie-policy.sh
+++ b/ods/tests/test-n8n-cookie-policy.sh
@@ -21,11 +21,18 @@ assert_policy false auto http 127.0.0.1
 assert_policy false auto http localhost
 assert_policy false auto http ::1
 assert_policy false auto http '[::1]'
+assert_policy false auto http 0:0:0:0:0:0:0:1
+assert_policy false auto http '[0:0:0:0:0:0:0:1]'
 assert_policy true auto https 127.0.0.1
 assert_policy true auto http 0.0.0.0
 assert_policy true auto http 192.168.1.10
 assert_policy true true http 127.0.0.1
 assert_policy false false https 0.0.0.0
+
+ods_n8n_is_loopback_bind 0:0:0:0:0:0:0:1 || {
+    printf 'FAIL expanded IPv6 loopback was classified as a remote bind\n' >&2
+    failures=$((failures + 1))
+}
 
 [[ "$(ods_n8n_public_protocol http https://n8n.example.com/)" == "https" ]] || {
     printf 'FAIL HTTPS webhook URL did not override the internal protocol\n' >&2


### PR DESCRIPTION
## Why this matters

A local n8n install can bind to IPv6 loopback using the canonical expanded spelling `0:0:0:0:0:0:0:1`. ODS classified only `::1` and `[::1]` as loopback, so `N8N_SECURE_COOKIE=auto` enabled secure cookies on plain HTTP for the expanded address. Browsers then withheld the session cookie and local login appeared broken. The same misclassification also produced a false non-loopback exposure warning when operators explicitly disabled secure cookies.

Root cause: cookie resolution and warning classification carried separate, incomplete address allowlists.

The invariant is now centralized: every accepted spelling of IPv6 loopback receives local-HTTP cookie behavior in both consumers, while HTTPS and non-loopback binds still require secure cookies.

## Overlap check

Searched open and closed upstream PRs for `n8n expanded IPv6 loopback cookie` and `n8n-cookie-policy.sh`. No open PR overlaps. Closed PR #2002 introduced the Windows bind-mount entrypoint behavior but does not handle expanded IPv6 or centralize the loopback classification.

## Regression coverage

The public cookie-policy contract now exercises bracketed and unbracketed expanded IPv6 addresses and calls the shared loopback classifier directly, covering both session-cookie selection and exposure-warning behavior.

## Validation

- `D:\Git\bin\bash.exe ods/tests/test-n8n-cookie-policy.sh` ? passed.
- `D:\Git\bin\bash.exe -n ods/extensions/services/n8n/n8n-cookie-policy.sh ods/tests/test-n8n-cookie-policy.sh` ? passed.
- `git diff --check` ? passed.

## Cross-platform and rollback

The policy is POSIX shell used inside the Linux n8n container on Linux, macOS, and Windows/WSL2; no host-specific implementation is changed. Rollback restores the previous classification and can again make plain-HTTP expanded-IPv6 sessions unusable. No persistent n8n data changes.
