### PR TITLE
fix(comfyui): fail on workflow copy errors

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -124,6 +124,9 @@ jobs:
       - name: n8n Cookie Policy Tests
         run: bash tests/test-n8n-cookie-policy.sh
 
+      - name: ComfyUI Startup Workflow Tests
+        run: bash tests/test-comfyui-startup.sh
+
       - name: brave-search searxng Compat Tests
         run: bash tests/test-brave-search-searxng-compat.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -76,6 +76,7 @@ test: ## Run unit and contract tests
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh
+	@bash tests/test-comfyui-startup.sh
 	@echo ""
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh

--- a/ods/extensions/services/comfyui/startup.sh
+++ b/ods/extensions/services/comfyui/startup.sh
@@ -9,11 +9,11 @@
 
 set -euo pipefail
 
-COMFYUI_DIR="/opt/comfyui"
-MODELS_MOUNT="/models"
-OUTPUT_MOUNT="/output"
-INPUT_MOUNT="/input"
-WORKFLOWS_MOUNT="/workflows"
+COMFYUI_DIR="${ODS_COMFYUI_DIR:-/opt/comfyui}"
+MODELS_MOUNT="${ODS_COMFYUI_MODELS_MOUNT:-/models}"
+OUTPUT_MOUNT="${ODS_COMFYUI_OUTPUT_MOUNT:-/output}"
+INPUT_MOUNT="${ODS_COMFYUI_INPUT_MOUNT:-/input}"
+WORKFLOWS_MOUNT="${ODS_COMFYUI_WORKFLOWS_MOUNT:-/workflows}"
 
 #-----------------------------------------------------------------------------
 # Create model subdirectories in bind mount (idempotent)
@@ -56,10 +56,13 @@ done
 #-----------------------------------------------------------------------------
 # Copy workflow templates (read-only mount → writable user dir)
 #-----------------------------------------------------------------------------
-if [ -d "$WORKFLOWS_MOUNT" ] && [ "$(ls -A "$WORKFLOWS_MOUNT" 2>/dev/null)" ]; then
+shopt -s nullglob
+workflow_templates=("$WORKFLOWS_MOUNT"/*.json)
+shopt -u nullglob
+if ((${#workflow_templates[@]} > 0)); then
     WORKFLOW_DIR="${COMFYUI_DIR}/user/default/workflows"
     mkdir -p "$WORKFLOW_DIR"
-    cp -u "$WORKFLOWS_MOUNT"/*.json "$WORKFLOW_DIR/" 2>/dev/null || true
+    cp -u -- "${workflow_templates[@]}" "$WORKFLOW_DIR/"
     echo "[startup] Copied workflow templates to ${WORKFLOW_DIR}"
 fi
 

--- a/ods/tests/test-comfyui-startup.sh
+++ b/ods/tests/test-comfyui-startup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STARTUP="$ROOT_DIR/extensions/services/comfyui/startup.sh"
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+fail() {
+    printf '[FAIL] %s\n' "$*" >&2
+    exit 1
+}
+
+fake_bin="$TEMP_DIR/bin"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/python3" <<'PYTHON'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "-c" ]]; then
+    exit 0
+fi
+printf '%s\n' "$*" > "$COMFYUI_TEST_LAUNCH_RECEIPT"
+PYTHON
+chmod +x "$fake_bin/python3"
+cat > "$fake_bin/cp" <<'COPY'
+#!/usr/bin/env bash
+if [[ "${COMFYUI_TEST_FAIL_COPY:-0}" == "1" ]]; then
+    printf 'injected workflow copy failure\n' >&2
+    exit 73
+fi
+exec /bin/cp "$@"
+COPY
+chmod +x "$fake_bin/cp"
+
+prepare_case() {
+    local case_dir="$1"
+    mkdir -p \
+        "$case_dir/comfyui/models" \
+        "$case_dir/models" \
+        "$case_dir/output" \
+        "$case_dir/input" \
+        "$case_dir/workflows"
+}
+
+run_startup() {
+    local case_dir="$1"
+    env \
+        PATH="$fake_bin:$PATH" \
+        ODS_COMFYUI_DIR="$case_dir/comfyui" \
+        ODS_COMFYUI_MODELS_MOUNT="$case_dir/models" \
+        ODS_COMFYUI_OUTPUT_MOUNT="$case_dir/output" \
+        ODS_COMFYUI_INPUT_MOUNT="$case_dir/input" \
+        ODS_COMFYUI_WORKFLOWS_MOUNT="$case_dir/workflows" \
+        COMFYUI_TEST_LAUNCH_RECEIPT="$case_dir/launch.txt" \
+        COMFYUI_TEST_FAIL_COPY="${COMFYUI_TEST_FAIL_COPY:-0}" \
+        bash "$STARTUP"
+}
+
+success_case="$TEMP_DIR/success"
+prepare_case "$success_case"
+printf '{"workflow":"ready"}\n' > "$success_case/workflows/example.json"
+success_output="$(run_startup "$success_case")"
+[[ -f "$success_case/comfyui/user/default/workflows/example.json" ]] \
+    || fail "workflow template was not copied"
+grep -qF '[startup] Copied workflow templates' <<<"$success_output" \
+    || fail "successful copy did not emit its receipt"
+grep -qF 'main.py --listen 0.0.0.0 --port 8188' "$success_case/launch.txt" \
+    || fail "ComfyUI was not launched after successful setup"
+
+failure_case="$TEMP_DIR/failure"
+prepare_case "$failure_case"
+printf '{"workflow":"blocked"}\n' > "$failure_case/workflows/blocked.json"
+if COMFYUI_TEST_FAIL_COPY=1 run_startup "$failure_case" \
+    >"$failure_case/stdout" 2>"$failure_case/stderr"; then
+    fail "workflow copy failure was ignored"
+fi
+[[ ! -e "$failure_case/launch.txt" ]] \
+    || fail "ComfyUI launched after an incomplete workflow copy"
+[[ ! -s "$failure_case/stdout" ]] \
+    || ! grep -qF '[startup] Copied workflow templates' "$failure_case/stdout" \
+    || fail "failed copy emitted a false success receipt"
+
+empty_case="$TEMP_DIR/no-json"
+prepare_case "$empty_case"
+printf 'not a workflow\n' > "$empty_case/workflows/README.txt"
+empty_output="$(run_startup "$empty_case")"
+if grep -qF '[startup] Copied workflow templates' <<<"$empty_output"; then
+    fail "a mount without JSON templates emitted a copy receipt"
+fi
+[[ -f "$empty_case/launch.txt" ]] \
+    || fail "a mount without templates prevented ComfyUI startup"
+
+printf 'ComfyUI startup workflow tests passed\n'


### PR DESCRIPTION
## Why this matters

The NVIDIA ComfyUI entrypoint copied persisted workflow templates with stderr discarded and `|| true`, then always printed a success receipt. An unreadable source, full filesystem, permission problem, or failed destination write therefore launched ComfyUI without the operator's workflows while claiming they had been copied.

Root cause: the entrypoint used a broad directory-content check and deliberately suppressed the production `cp` failure despite running under `set -euo pipefail`.

The invariant is now explicit: zero JSON templates is a valid no-op; one or more JSON templates must all copy successfully before ComfyUI launches or reports success. A nullglob array distinguishes those states without suppressing I/O errors.

## Overlap check

Searched open and closed upstream PRs for `ComfyUI workflow copy failure` and `extensions/services/comfyui/startup.sh`. No PR overlaps the workflow-copy path. Open PR #2368 only mentions this entrypoint as an already-runnable Python selector and changes two unrelated host scripts.

## Regression coverage

A new entrypoint-level test runs the production startup script in isolated mount trees and verifies:

- a JSON workflow is copied and ComfyUI is launched;
- an injected copy failure exits non-zero, emits no false copy receipt, and never launches ComfyUI;
- a non-empty mount with no JSON templates remains a clean no-op.

The test is wired into both `make test` and Linux CI. Task-specific path overrides preserve container defaults while allowing the exact production script to run without writing host `/opt`, `/models`, `/input`, or `/output` paths.

## Validation

- `D:\Git\bin\bash.exe ods/tests/test-comfyui-startup.sh` ? passed.
- `D:\Git\bin\bash.exe -n ods/extensions/services/comfyui/startup.sh ods/tests/test-comfyui-startup.sh` ? passed.
- `git diff --check` ? passed.
- ShellCheck was unavailable on the local Windows host; the CI shell-lint job remains authoritative for that check.

## Platform scope and rollback

`startup.sh` is used by the NVIDIA ComfyUI image; AMD's native compose path is untouched, and CPU/Apple do not launch this GPU-only service. Rollback restores silent partial startup. The change never deletes persisted workflows and retains `cp -u`, so existing user-modified destination workflows are not overwritten by older templates.
