### PR TITLE
fix(invites): isolate owner status failures

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -83,18 +83,24 @@ export default function Invites() {
   const refresh = useCallback(async () => {
     setRefreshing(true)
     try {
-      const [resp, ownerStatusResp] = await Promise.all([
+      const [listResult, ownerStatusResult] = await Promise.allSettled([
         fetchJson('/api/auth/magic-link/list'),
         fetchJson('/api/auth/magic-link/owner-card/status'),
       ])
+      if (listResult.status === 'rejected') throw listResult.reason
+      const resp = listResult.value
       if (!resp.ok) throw new Error(`list failed: ${resp.status}`)
       const data = await resp.json()
-      if (ownerStatusResp.ok) {
+      if (ownerStatusResult.status === 'fulfilled' && ownerStatusResult.value.ok) {
+        const ownerStatusResp = ownerStatusResult.value
         setOwnerCardStatus(await ownerStatusResp.json())
       } else {
+        const reason = ownerStatusResult.status === 'fulfilled'
+          ? `Owner-card status unavailable (${ownerStatusResult.value.status})`
+          : 'Owner-card status unavailable.'
         setOwnerCardStatus({
           ready: false,
-          reason: `Owner-card status unavailable (${ownerStatusResp.status})`,
+          reason,
         })
       }
       setTokens(data.tokens || [])

--- a/ods/extensions/services/dashboard/src/pages/Invites.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.test.jsx
@@ -250,4 +250,38 @@ describe('Invites', () => {
     expect(screen.getByRole('button', { name: 'Print owner card' })).toBeDisabled()
     expect(screen.getByRole('button', { name: 'Create owner card' })).toBeDisabled()
   })
+
+  test('keeps listed invites when owner-card status is unreachable', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url === '/api/auth/magic-link/list') {
+        return response({
+          tokens: [{
+            token_hash_prefix: 'guest123',
+            target_username: 'guest-user',
+            scope: 'chat',
+            reusable: false,
+            token_type: 'guest',
+            url_mode: 'auto',
+            created_at: new Date().toISOString(),
+            expires_at: future,
+            redemption_count: 0,
+            last_redeemed_at: null,
+            revoked_at: null,
+            note: 'support session',
+          }],
+        })
+      }
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        throw new TypeError('owner status connection failed')
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Invites />)
+
+    expect(await screen.findByText('guest-user')).toBeInTheDocument()
+    expect(screen.getByText('Owner-card status unavailable.')).toBeInTheDocument()
+    expect(screen.queryByText('owner status connection failed')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Keep the access-link inventory available when the separate owner-card status endpoint fails or returns unreadable data.

## Why this matters
An operator still needs to see and revoke guest links during an owner-card status outage. Currently that auxiliary request can suppress the entire inventory.

Root cause: The list and owner status share a rejecting Promise.all, and parsing the auxiliary receipt can escape into the primary list error handler.

Behavioral invariant: A valid inventory receipt remains visible independently of owner-card network, HTTP, JSON or shape failures; unavailable owner controls stay disabled.

## Implementation and compatibility
Settle the two external reads independently, including owner JSON decoding, and display an explicit unavailable owner-card state. Existing body deadlines, list errors and expiry behavior remain intact.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/pages/Invites.jsx`.

Relevant same-file results: #4955 (open: fix(invites): contain access-dialog focus and restore its opener), #3846 (open: feat(invites): search and filter the access-link inventory), #5295 (merged: fix(invites): refresh time-dependent access-link status), #5291 (merged: fix(invites): retain pending access-link creation dialogs), #4353 (merged: fix(invites): keep deadlines active through JSON body reads), #4210 (merged: fix(beta): owner access layout, contained menus and Portal idle sleep)

#4353 supplies body deadlines; #5295 supplies time-based expiry; #5291 supplies mutation-dialog ownership. #3846 inventory filters and #4955 focus handling are orthogonal; the selected batch is runtime-tested together, while external #3846 has only a separate textual merge probe.

## Regression and validation
Candidate commit: `503687f615c7d4cc8f92537ed05c596ce49bb507`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/pages/Invites` — **24 passed**.
- Four public-page failure scenarios fail on unchanged beta source; all 24 candidate Invites tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `503687f615c7d4cc8f92537ed05c596ce49bb507`: 36 successful checks; 1 failed; 0 pending; 4 skipped review/security jobs (not counted as passes). [distro: cachyos](https://github.com/Osmantic/ODS/actions/runs/35099329518/job/104804458749).

The failed CachyOS job stopped while installing checkout prerequisites: the distro repository signature was invalid, before this candidate was checked out. Later candidates passed the same distro job, but this exact head remains red. GitHub refused the failed-run rerun with “Must have admin rights to Repository.” A maintainer rerun is still required; no signature checks were disabled.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: External #3846 has a clean textual merge with the combined head; its added filter behavior was not included in the 1,279-test run.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
