### PR TITLE
fix(remote-provider): poll active peer downloads

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -21,6 +21,7 @@ const PROBE_TIMEOUT_MS = 22000
 const LIFECYCLE_TIMEOUT_MS = 30000
 const PEER_MODELS_TIMEOUT_MS = 30000
 const PEER_MODEL_LOAD_TIMEOUT_MS = 2705000
+const PEER_DOWNLOAD_POLL_MS = 2000
 const INITIAL_FORM = {
   baseUrl: '',
   model: '',
@@ -361,6 +362,25 @@ export default function RemoteProvider() {
     }
     void loadPeerModels()
   }, [loadPeerModels, statusData?.capabilities?.odsPeerLifecycle, statusData])
+
+  useEffect(() => {
+    if (
+      !statusData?.capabilities?.odsPeerLifecycle
+      || !peerDownloadActive(peerDownloadStatus)
+    ) return undefined
+
+    let polling = false
+    const interval = window.setInterval(async () => {
+      if (polling) return
+      polling = true
+      try {
+        await loadPeerModels({ quiet: true })
+      } finally {
+        polling = false
+      }
+    }, PEER_DOWNLOAD_POLL_MS)
+    return () => window.clearInterval(interval)
+  }, [loadPeerModels, peerDownloadStatus, statusData?.capabilities?.odsPeerLifecycle])
 
   useEffect(() => {
     const provider = statusData?.routeState?.provider

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import RemoteProvider from './RemoteProvider'
@@ -497,6 +497,44 @@ test('starts and cancels peer model download through proxy endpoints', async () 
   })
   expect(globalThis.fetch.mock.calls[6][0]).toBe('/api/remote-provider/peer/models/download/cancel')
   expect(globalThis.fetch.mock.calls[6][1].method).toBe('POST')
+})
+
+test('polls an active peer download until it reaches a terminal state', async () => {
+  vi.useFakeTimers()
+  globalThis.fetch
+    .mockResolvedValueOnce(response(peerReadyStatusPayload))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerActiveDownloadStatusPayload))
+    .mockResolvedValueOnce(response(peerModelsPayload))
+    .mockResolvedValueOnce(response(peerDownloadStatusPayload))
+
+  try {
+    render(createElement(RemoteProvider))
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(screen.getByText('Downloading - remote-available - 42%')).toBeInTheDocument()
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000)
+    })
+    expect(screen.getByText('Idle')).toBeInTheDocument()
+    expect(globalThis.fetch.mock.calls.slice(3).map(call => call[0])).toEqual([
+      '/api/remote-provider/peer/models',
+      '/api/remote-provider/peer/models/download-status',
+    ])
+
+    const terminalCallCount = globalThis.fetch.mock.calls.length
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(4000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(terminalCallCount)
+  } finally {
+    vi.useRealTimers()
+  }
 })
 
 test('confirms peer model delete before proxying removal', async () => {


### PR DESCRIPTION
Refresh active remote-peer model downloads until the backend reports a terminal state.

## Why this matters
The remote provider page currently leaves a downloaded model looking active at its initial percentage until an operator manually reloads the inventory.

Root cause: The page reads peer download status during inventory loading but does not schedule observations while that status remains active.

Behavioral invariant: An active supported peer download is periodically observed without overlapping requests; terminal status or unmount removes the poll.

## Implementation and compatibility
Add a two-second active-download effect around the existing bounded loadPeerModels operation. Preserve beta's edit-revision guard, unreadable-receipt handling and extended operation deadlines.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx`.

Relevant same-file results: #4396 (open: feat(identity): make assistant naming generic and configurable), #5059 (merged: fix(remote-provider): retain drafts after unreadable success receipts), #4570 (merged: fix(remote-provider): preserve edits made during configuration), #4267 (merged: fix(dashboard-api): sanitize throughput metric samples in agent monitor), #4266 (merged: fix(dashboard-api): guard null nodes payload in cluster status refresh), #4207 (merged: feat(beta): workspace UX, Portal mascot and Settings refinement)

#4570 preserves provider edits and #5059 rejects unreadable success receipts. The conflict resolution retains those beta implementations and only adds active transfer observations, not the obsolete formDirty effect from main.

## Regression and validation
Candidate commit: `0ed45fe04e1a4fa595787c8edd29c0e5940c5b65`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/pages/RemoteProvider` — **19 passed**.
- The page test advances an active peer download to completion and verifies polling stops. It fails on beta; all 19 candidate remote-provider page tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `0ed45fe04e1a4fa595787c8edd29c0e5940c5b65`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: No other selected PR changes RemoteProvider.jsx; beta form edit-revision ownership remains preserved.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
