### PR TITLE
fix(pwa): scope dashboard cache cleanup

### DIFF
--- a/ods/extensions/services/dashboard/public/sw.js
+++ b/ods/extensions/services/dashboard/public/sw.js
@@ -19,6 +19,7 @@
 // Open WebUI's own service worker, not here.
 
 const VERSION = 'ods-dashboard-sw-v1';
+const CACHE_PREFIX = 'ods-dashboard-sw-';
 
 self.addEventListener('install', (event) => {
   // Skip the waiting-for-existing-pages dance — install immediately.
@@ -27,11 +28,16 @@ self.addEventListener('install', (event) => {
 });
 
 self.addEventListener('activate', (event) => {
-  // Claim all open tabs so the new worker controls them right away,
-  // and clear any caches a previous version may have created.
+  // Claim all open tabs so the new worker controls them right away, and clear
+  // caches created by previous dashboard workers without touching unrelated
+  // applications sharing this origin.
   event.waitUntil(Promise.all([
     self.clients.claim(),
-    caches.keys().then((keys) => Promise.all(keys.map((k) => caches.delete(k)))),
+    caches.keys().then((keys) => Promise.all(
+      keys
+        .filter((key) => key.startsWith(CACHE_PREFIX) && key !== VERSION)
+        .map((key) => caches.delete(key)),
+    )),
   ]));
 });
 

--- a/ods/extensions/services/dashboard/src/test/serviceWorker.test.js
+++ b/ods/extensions/services/dashboard/src/test/serviceWorker.test.js
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { runInNewContext } from 'node:vm'
+
+describe('dashboard service worker', () => {
+  test('activation deletes only stale ODS dashboard caches', async () => {
+    const handlers = {}
+    const worker = {
+      addEventListener: vi.fn((name, handler) => { handlers[name] = handler }),
+      skipWaiting: vi.fn(() => Promise.resolve()),
+      clients: { claim: vi.fn(() => Promise.resolve()) },
+    }
+    const cacheStorage = {
+      keys: vi.fn(() => Promise.resolve([
+        'ods-dashboard-sw-v0',
+        'ods-dashboard-sw-v1',
+        'ods-dashboard-sw-preview',
+        'open-webui-assets',
+        'operator-cache',
+      ])),
+      delete: vi.fn(() => Promise.resolve(true)),
+    }
+    const source = readFileSync(
+      resolve(process.cwd(), 'public/sw.js'),
+      'utf-8',
+    )
+    runInNewContext(source, { self: worker, caches: cacheStorage, Promise })
+
+    let activation
+    handlers.activate({ waitUntil: promise => { activation = promise } })
+    await activation
+
+    expect(worker.clients.claim).toHaveBeenCalledOnce()
+    expect(cacheStorage.delete.mock.calls.map(([key]) => key)).toEqual([
+      'ods-dashboard-sw-v0',
+      'ods-dashboard-sw-preview',
+    ])
+  })
+})


### PR DESCRIPTION
Restrict service-worker activation cleanup to obsolete ODS dashboard caches.

## Why this matters
CacheStorage is shared by applications on the same origin. Activating the ODS dashboard must not remove operator or Open WebUI caches.

Root cause: The activation listener deletes every CacheStorage key regardless of ownership.

Behavioral invariant: Only stale caches with the dashboard-owned prefix are deleted; the current cache and unrelated applications survive activation.

## Implementation and compatibility
Filter cache keys by the existing ODS service-worker namespace and exclude the current VERSION. Preserve client claiming and the network-only fetch behavior.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/public/sw.js`.

Relevant same-file results: No public-beta PR touched these production files in the all-state changed-file index.

No beta changed-file overlap. The original #3041 owns the activation cleanup contract; install-prompt deduplication (#3042) is a separate browser event path.

## Regression and validation
Candidate commit: `f88d0d274e9f6cb56337c4e23e86eb3d3a04b08c`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/test/serviceWorker.test.js` — **1 passed**.
- The test executes the actual service worker in a VM, dispatches activate, awaits waitUntil, and checks stale/current/foreign cache deletion plus client claiming. It fails with the baseline worker.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `f88d0d274e9f6cb56337c4e23e86eb3d3a04b08c`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: No other selected PR changes the service worker.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
