### PR TITLE
fix(pwa): deduplicate install prompts

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/usePwaInstallPrompt.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/usePwaInstallPrompt.test.js
@@ -2,12 +2,12 @@ import { renderHook, act } from '@testing-library/react'
 import { usePwaInstallPrompt } from '../usePwaInstallPrompt'
 
 // Helper: fire a synthetic beforeinstallprompt event that the hook listens for.
-function fireBeforeInstall() {
+function fireBeforeInstall(userChoice = Promise.resolve({ outcome: 'accepted' })) {
   const event = new Event('beforeinstallprompt')
   // The real event has prompt() + userChoice + preventDefault. Stub them.
   event.preventDefault = vi.fn()
   event.prompt = vi.fn().mockResolvedValue()
-  event.userChoice = Promise.resolve({ outcome: 'accepted' })
+  event.userChoice = userChoice
   window.dispatchEvent(event)
   return event
 }
@@ -98,6 +98,30 @@ describe('usePwaInstallPrompt', () => {
       await result.current.promptInstall()
     })
     expect(event.prompt).toHaveBeenCalled()
+  })
+
+  test('ignores repeated install clicks while the browser choice is pending', async () => {
+    globalThis.localStorage.setItem('ods-pwa-visit-count', '5')
+    let resolveChoice
+    const userChoice = new Promise(resolve => { resolveChoice = resolve })
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    let event
+    act(() => { event = fireBeforeInstall(userChoice) })
+
+    let firstPrompt
+    let repeatedPrompt
+    act(() => {
+      firstPrompt = result.current.promptInstall()
+      repeatedPrompt = result.current.promptInstall()
+    })
+
+    expect(event.prompt).toHaveBeenCalledOnce()
+    await expect(repeatedPrompt).resolves.toEqual({ outcome: 'pending' })
+    await act(async () => {
+      resolveChoice({ outcome: 'accepted' })
+      await firstPrompt
+    })
+    expect(globalThis.localStorage.getItem('ods-pwa-installed')).toBe('1')
   })
 
   test('appinstalled event marks the PWA installed and hides the banner', () => {

--- a/ods/extensions/services/dashboard/src/hooks/usePwaInstallPrompt.js
+++ b/ods/extensions/services/dashboard/src/hooks/usePwaInstallPrompt.js
@@ -61,6 +61,7 @@ function isIos() {
 
 export function usePwaInstallPrompt() {
   const promptEventRef = useRef(null)
+  const promptPendingRef = useRef(false)
   // installable: browser fired beforeinstallprompt OR we detected iOS
   // (where the install path is manual but the banner is still useful).
   const [installable, setInstallable] = useState(false)
@@ -133,6 +134,8 @@ export function usePwaInstallPrompt() {
       // and the banner's iOS-specific copy explains what to do.
       return { platform: 'ios', outcome: 'manual' }
     }
+    if (promptPendingRef.current) return { outcome: 'pending' }
+    promptPendingRef.current = true
     try {
       await event.prompt()
       const choice = await event.userChoice
@@ -153,6 +156,8 @@ export function usePwaInstallPrompt() {
       promptEventRef.current = null
       setInstallable(false)
       return { outcome: 'error' }
+    } finally {
+      promptPendingRef.current = false
     }
   }, [])
 


### PR DESCRIPTION
Deduplicate repeated PWA install activations while the browser's choice is pending.

## Why this matters
Two rapid install clicks can invoke a one-shot browser prompt twice, discard the live offer and leave inconsistent installed state.

Root cause: promptInstall awaits browser promises before marking the offer as pending, allowing same-tick reentry.

Behavioral invariant: One browser prompt owns its pending choice; repeated activation is ignored, and rejection releases the guard for a fresh browser offer.

## Implementation and compatibility
Use a synchronous ref guard with finally cleanup. Preserve beta's fresh-offer handling after an old installed marker and the manual iOS path.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/usePwaInstallPrompt.js`.

Relevant same-file results: #3841 (open: fix(pwa): tolerate blocked browser storage property access), #4981 (merged: fix(pwa): accept fresh install offers after a stale installed marker)

#4981 governs fresh offers after uninstall and #3841 protects browser storage property access. Both are independent of deduplicating an in-progress browser prompt; pairwise compatibility is included in the batch review.

## Regression and validation
Candidate commit: `6e4703eb8466bb71ff03b6172fef343ae412a48c`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/usePwaInstallPrompt.test.js` — **11 passed**.
- The duplicate-prompt assertion fails on unchanged beta; all 11 candidate install, rejection/re-offer and visit/dismissal tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `6e4703eb8466bb71ff03b6172fef343ae412a48c`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: External #3841 storage-property protection has a clean textual merge with the combined head; its added runtime behavior was not included in the combined test run.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
