### PR TITLE
fix(dashboard): bound status polling requests

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useSystemStatus.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useSystemStatus.test.js
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { useSystemStatus } from '../useSystemStatus'
 
 describe('useSystemStatus', () => {
@@ -67,6 +67,49 @@ describe('useSystemStatus', () => {
       expect(result.current.error).toBe('network down')
     })
     expect(result.current.loading).toBe(false)
+  })
+
+  test('times out a hung initial request and retries on the next poll', async () => {
+    vi.useFakeTimers()
+    const recoveredStatus = {
+      gpu: { name: 'Recovered GPU' },
+      services: [],
+      model: null,
+      bootstrap: null,
+      uptime: 200,
+    }
+    fetch
+      .mockImplementationOnce((_url, options) => new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () => {
+          const error = new Error('aborted')
+          error.name = 'AbortError'
+          reject(error)
+        })
+      }))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(recoveredStatus),
+      })
+
+    try {
+      const { result } = renderHook(() => useSystemStatus())
+      expect(result.current.loading).toBe(true)
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(12000)
+      })
+      expect(result.current.loading).toBe(false)
+      expect(result.current.error).toBe('Status request timed out')
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(3000)
+      })
+      expect(result.current.status.gpu?.name).toBe('Recovered GPU')
+      expect(result.current.error).toBeNull()
+      expect(fetch).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('does not clear status on error (preserves previous data)', async () => {

--- a/ods/extensions/services/dashboard/src/hooks/useSystemStatus.js
+++ b/ods/extensions/services/dashboard/src/hooks/useSystemStatus.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 
 const POLL_INTERVAL = 5000 // 5 seconds
+const STATUS_REQUEST_TIMEOUT_MS = 12000
 
 // Mock data for development/demo - gated behind VITE_USE_MOCK_DATA env var
 const USE_MOCK_DATA = import.meta.env.VITE_USE_MOCK_DATA === 'true'
@@ -54,6 +55,7 @@ export function useSystemStatus() {
   // llama-server under inference load) we skip the next poll rather
   // than stacking concurrent requests that can amplify the problem.
   const fetchInFlight = useRef(false)
+  const activeRequest = useRef(null)
   // Allow the very first fetch to run even on a hidden tab so that
   // users who open the dashboard in a background window (multi-monitor,
   // restored session, browser automation) don't see a permanently stuck
@@ -62,6 +64,7 @@ export function useSystemStatus() {
   const hasInitialData = useRef(false)
 
   useEffect(() => {
+    let cancelled = false
     const fetchStatus = async () => {
       if (USE_MOCK_DATA) {
         setLoading(false)
@@ -75,19 +78,27 @@ export function useSystemStatus() {
       // Skip this tick if the previous fetch hasn't returned yet.
       if (fetchInFlight.current) return
       fetchInFlight.current = true
+      const controller = new AbortController()
+      activeRequest.current = controller
+      const timeout = setTimeout(() => controller.abort(), STATUS_REQUEST_TIMEOUT_MS)
 
       try {
-        const response = await fetch('/api/status')
+        const response = await fetch('/api/status', { signal: controller.signal })
         if (!response.ok) throw new Error('Failed to fetch status')
         const data = await response.json()
+        if (cancelled) return
         setStatus(data)
         setError(null)
         hasInitialData.current = true
       } catch (err) {
-        setError(err.message)
+        if (!cancelled) {
+          setError(err?.name === 'AbortError' ? 'Status request timed out' : err.message)
+        }
       } finally {
+        clearTimeout(timeout)
+        if (activeRequest.current === controller) activeRequest.current = null
         fetchInFlight.current = false
-        setLoading(false)
+        if (!cancelled) setLoading(false)
       }
     }
 
@@ -99,6 +110,9 @@ export function useSystemStatus() {
     document.addEventListener('visibilitychange', onVisibility)
 
     return () => {
+      cancelled = true
+      activeRequest.current?.abort()
+      activeRequest.current = null
       clearInterval(interval)
       document.removeEventListener('visibilitychange', onVisibility)
     }


### PR DESCRIPTION
Bound status polling through response-body completion and cancel the previous effect lifetime before React starts its replacement.

## Why this matters
App's live status hook drives service health and loading state. One stalled /api/status response currently occupies the poll forever, leaving the dashboard frozen even after the API recovers.

Root cause: The in-flight guard has no deadline and is shared across effect lifetimes.

Behavioral invariant: At most one request runs per live effect; a timed-out or disposed request cannot publish status; the next scheduled poll can recover.

## Implementation and compatibility
A 12-second deadline races both headers and JSON. Cleanup aborts the request and removes timers. Effect-local ownership preserves React StrictMode replay while retaining the last successful snapshot.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useSystemStatus.js`.

Relevant same-file results: No public-beta PR touched these production files in the all-state changed-file index.

No beta same-file overlap. The existing #3044 is the canonical timeout fix; this follow-up adds body-stall and StrictMode coverage instead of creating another PR.

## Regression and validation
Candidate commit: `c082562fa1d316f75c7cc58954c4f11d5e3b64b4`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useSystemStatus.test.js` — **10 passed**.
- Running the same tests with untouched beta production code produces 3 failures (hung headers, late body, StrictMode ownership); the candidate passes all 10.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `c082562fa1d316f75c7cc58954c4f11d5e3b64b4`: 36 successful checks; 1 failed; 0 pending; 4 skipped review/security jobs (not counted as passes). [distro: cachyos](https://github.com/Osmantic/ODS/actions/runs/35099290184/job/104804322677).

The failed CachyOS job stopped while installing checkout prerequisites: the distro repository signature was invalid, before this candidate was checked out. Later candidates passed the same distro job, but this exact head remains red. GitHub refused the failed-run rerun with “Must have admin rights to Repository.” A maintainer rerun is still required; no signature checks were disabled.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: No other selected PR changes this hook.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
