### PR TITLE
fix(model-router): require boolean stream flags

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -887,6 +887,13 @@ async def forward(full_path: str, request: Request) -> Response:
             status_code=400,
         )
 
+    if "stream" in payload and type(payload["stream"]) is not bool:
+        return JSONResponse(
+            {"error": {"message": "stream must be a boolean",
+                       "type": "invalid_request_error", "code": "400"}},
+            status_code=400,
+        )
+
     requested_alias = str(payload.get("model") or PUBLIC_ALIASES[0])
 
     global _inflight
@@ -936,7 +943,7 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
     payload["model"] = route["runtimeModelId"]
     request_id = str(uuid.uuid4())
     probe_id = _verify_probe_marker(raw_body.decode("utf-8", "replace"))
-    is_stream = bool(payload.get("stream"))
+    is_stream = payload.get("stream", False)
 
     headers = _sanitize_headers(request)
     api_key = os.environ.get(route["apiKeyEnv"], "") if route["apiKeyEnv"] else ""

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -171,6 +171,22 @@ class _RecordingTelemetry:
 
 
 class TestForwarding:
+    @pytest.mark.parametrize("stream", ["false", "true", 0, 1, None, [], {}])
+    def test_rejects_non_boolean_stream_before_upstream(self, router, stream):
+        mod, client, write_state, calls = router
+        write_state()
+
+        response = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "stream": stream,
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+        assert response.status_code == 400
+        assert response.json()["error"]["type"] == "invalid_request_error"
+        assert response.json()["error"]["message"] == "stream must be a boolean"
+        assert calls == []
+
     def test_alias_rewritten_in_and_out(self, router):
         mod, client, write_state, calls = router
         write_state()


### PR DESCRIPTION
## Why this matters

The model router is the deployed OpenAI-compatible boundary for `/v1/chat/completions`, `/v1/completions`, and `/v1/responses`. It previously converted `stream` with JavaScript-style truthiness in Python, so a client payload such as `stream: false` selected the streaming/SSE forwarding path. That changes response framing and admission ownership even though the caller explicitly intended a non-streamed response.

## Root cause and invariant

The router used `bool(payload.get(stream))`, which treats every non-empty string, list, and object as true. The invariant is that an explicitly supplied OpenAI `stream` field is a JSON boolean; malformed values are rejected before queue admission or upstream I/O. An omitted field continues to mean non-streaming.

## Overlap check

Searched open and closed PRs for `stream boolean model router`, `invalid stream flag`, and the changed production/test files. Open same-file PRs #2992, #2991, #2843, #2719, #2322, #2097, and #1933 cover response headers, model aliases, runtimes, auth, endpoint state, evidence, and SSE buffering; none validates the `stream` request type. Recent closed same-file PRs were also reviewed and do not cover this boundary.

## Regression coverage

The FastAPI contract test submits strings, integers, null, arrays, and objects as `stream`, asserts an OpenAI-shaped 400, and proves the mock runtime receives no request. The complete router suite also proves `true`, `false`, and omitted streaming behavior remain intact.

## Validation

- `python -m pytest -q tests/test_router.py -x` — 55 passed
- `git diff --check` — passed

## Tradeoffs and rollback

This intentionally rejects permissive truthy values that are outside the documented boolean contract. Standards-compliant clients are unchanged. Reverting restores coercion and requires no state migration.