### PR TITLE
fix(dashboard): retain last good version snapshot

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useVersion.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useVersion.test.js
@@ -8,6 +8,7 @@ describe('useVersion', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -103,5 +104,32 @@ describe('useVersion', () => {
     })
     expect(result.current.error).toBeTruthy()
     expect(result.current.version).toBeNull()
+  })
+
+  test('retains the last good snapshot across a failed poll and clears the error on recovery', async () => {
+    vi.useFakeTimers()
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ current: '1.0.0', latest: '2.0.0', update_available: true })
+      })
+      .mockRejectedValueOnce(new Error('dashboard-api restarting'))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ current: '1.0.0', latest: '2.1.0', update_available: true })
+      })
+
+    const { result } = renderHook(() => useVersion())
+    await act(async () => { await Promise.resolve() })
+
+    expect(result.current.version.latest).toBe('2.0.0')
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(30 * 60 * 1000) })
+    expect(result.current.error).toBe('dashboard-api restarting')
+    expect(result.current.version.latest).toBe('2.0.0')
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(30 * 60 * 1000) })
+    expect(result.current.error).toBeNull()
+    expect(result.current.version.latest).toBe('2.1.0')
   })
 })

--- a/ods/extensions/services/dashboard/src/hooks/useVersion.js
+++ b/ods/extensions/services/dashboard/src/hooks/useVersion.js
@@ -26,9 +26,9 @@ export function useVersion() {
           data.update_available = false
         }
         setVersion(data)
+        setError(null)
       } catch (err) {
         setError(err.message)
-        setVersion(null)
       } finally {
         setLoading(false)
       }


### PR DESCRIPTION
Keep the last verified version snapshot during a failed background poll, then clear the warning when the endpoint recovers.

## Why this matters
A transient API restart currently removes the update/version information already shown to the operator.

Root cause: The poll's catch handler replaces the last successful version with null and successful recovery does not clear the prior error.

Behavioral invariant: A failed observation is not evidence that the previous version disappeared; a newer successful receipt replaces it and clears the error.

## Implementation and compatibility
Preserve version state on failure and clear error on success. Tests cover network, HTTP and JSON failures plus a previously dismissed update and a genuinely newer release.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useVersion.js`.

Relevant same-file results: No public-beta PR touched these production files in the all-state changed-file index.

Retains #3046 as the original canonical change. Browser-storage access is a separate known concern (#2780), not folded into this failure-retention fix.

## Regression and validation
Candidate commit: `6eb08c2986b4db2bb58fed90029f68573b1fd75f`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useVersion.test.js` — **9 passed**.
- Unmodified beta production code fails all 3 new retention/recovery scenarios; candidate passes 9 tests.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `6eb08c2986b4db2bb58fed90029f68573b1fd75f`: 36 successful checks; 1 failed; 0 pending; 4 skipped review/security jobs (not counted as passes). [distro: cachyos](https://github.com/Osmantic/ODS/actions/runs/35099303232/job/104804366628).

The failed CachyOS job stopped while installing checkout prerequisites: the distro repository signature was invalid, before this candidate was checked out. Later candidates passed the same distro job, but this exact head remains red. GitHub refused the failed-run rerun with “Must have admin rights to Repository.” A maintainer rerun is still required; no signature checks were disabled.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #2780, production code merges cleanly; retain the union of retention/recovery and denied-storage tests.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
