### PR TITLE
fix(first-boot): validate owner-card receipts

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -50,6 +50,23 @@ const STACK_OPTIONS = [
 
 const TOTAL_STEPS = 4
 
+function isValidOwnerCardReceipt(receipt, username, urlMode) {
+  if (!receipt || typeof receipt !== 'object') return false
+
+  try {
+    const url = new URL(receipt.url)
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false
+  } catch {
+    return false
+  }
+
+  return receipt.target_username === username
+    && receipt.scope === 'hermes'
+    && receipt.reusable === true
+    && receipt.token_type === 'owner'
+    && receipt.url_mode === urlMode
+}
+
 function readProgress() {
   try {
     const raw = globalThis.localStorage?.getItem(PROGRESS_KEY)
@@ -195,6 +212,10 @@ export default function FirstBoot({ onComplete }) {
           throw new Error(body.detail || `generate failed: ${genResp.status}`)
         }
         inviteData = await genResp.json()
+        const expectedUrlMode = ownerCardStatus?.url_mode || 'lan'
+        if (!isValidOwnerCardReceipt(inviteData, username, expectedUrlMode)) {
+          throw new Error('Owner-card service returned an invalid generation receipt. Retry Finish after updating ODS.')
+        }
       }
 
       // Flip the server-side sentinel so this device is "configured".

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
@@ -133,6 +133,33 @@ describe('FirstBoot', () => {
     expect(await screen.findByAltText('QR code for owner card')).toHaveAttribute('src', 'data:image/png;base64,qrpayload')
   })
 
+  test('keeps first-run active when owner-card generation returns an invalid receipt', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
+        return response({
+          url: '',
+          target_username: 'sam',
+          scope: 'hermes',
+          reusable: 'true',
+          token_type: 'owner',
+          url_mode: 'lan',
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard()
+
+    expect(await screen.findByText(/invalid generation receipt/i)).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
+    expect(screen.queryByRole('heading', { name: /you're set/i })).not.toBeInTheDocument()
+  })
+
   test('applies the selected agent stack before creating credentials or completing setup', async () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/auth/magic-link/owner-card/status') {
@@ -152,6 +179,10 @@ describe('FirstBoot', () => {
         return response({
           url: 'http://auth.spark.local/magic-link/agent-token',
           target_username: 'sam',
+          scope: 'hermes',
+          reusable: true,
+          token_type: 'owner',
+          url_mode: 'lan',
         })
       }
       if (url === '/api/setup/complete' && options.method === 'POST') {


### PR DESCRIPTION
## Why this matters

First Boot marks the server configured immediately after the owner-card endpoint returns HTTP 200. A malformed or contract-incompatible success body can therefore complete onboarding while leaving the operator with no usable owner link.

Root cause: the wizard trusted the JSON body without validating the generation receipt.

Behavioral invariant: setup completion is attempted only after the owner-card receipt contains a valid HTTP(S) URL and matches the requested username, Hermes scope, reusable owner semantics, and URL mode.

## Overlap check

Searched open and closed upstream PRs for “FirstBoot validate owner card response” and reviewed PRs changing `src/pages/FirstBoot.jsx`. Open PR #2327 is a clipboard fallback and does not cover the generation/setup transaction. No matching closed PR was found.

## Regression test

The page-level wizard test returns HTTP 200 with a malformed owner-card receipt and verifies that the error is shown, first-run remains active, the success screen is absent, and `/api/setup/complete` is never called.

## Validation

- `npm test -- --run src/pages/FirstBoot.test.jsx` — 11 passed
- `npm run lint -- --quiet` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

The validation intentionally follows the dashboard-api `GenerateResponse` contract. Older or incompatible backends now fail visibly before the irreversible setup sentinel changes. Retrying after updating ODS is safe because setup remains incomplete. Rollback is one commit.