### PR TITLE
fix(config): enforce manifest LLM contract types

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -44,7 +44,12 @@ def normalize_llm_contract(value: Any) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
 
-    consumes = bool(value.get("consumes", False))
+    raw_consumes = value.get("consumes", False)
+    if type(raw_consumes) is bool:
+        consumes = raw_consumes
+    else:
+        logger.warning("Treating invalid llm.consumes value as false: %r", raw_consumes)
+        consumes = False
     route = str(value.get("route") or "").strip().lower()
     pinning = str(value.get("pinning") or "").strip().lower()
     if route not in LLM_CONTRACT_ROUTES:
@@ -60,9 +65,9 @@ def normalize_llm_contract(value: Any) -> dict[str, Any] | None:
 
     min_context = value.get("min_context")
     if min_context is not None:
-        try:
-            normalized["min_context"] = max(0, int(min_context))
-        except (TypeError, ValueError):
+        if type(min_context) is int and min_context >= 0:
+            normalized["min_context"] = min_context
+        else:
             logger.warning("Ignoring invalid llm.min_context value: %r", min_context)
 
     probe = value.get("probe")

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -280,6 +280,39 @@ class TestLoadExtensionManifests:
         assert llm["swap_safe"] is False
         assert llm["badge"] == "not-swap-safe"
 
+    def test_manifest_loader_does_not_coerce_invalid_llm_scalar_types(self, tmp_path, caplog):
+        svc_dir = tmp_path / "invalid-llm-app"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: ods.services.v1\n"
+            "service:\n"
+            "  id: invalid-llm-app\n"
+            "  name: Invalid LLM App\n"
+            "  port: 8080\n"
+            "  health: /health\n"
+            "  llm:\n"
+            "    consumes: 'false'\n"
+            "    route: gateway\n"
+            "    pinning: dynamic\n"
+            "    min_context: '65536'\n"
+        )
+
+        with caplog.at_level(logging.WARNING):
+            services, _, _ = load_extension_manifests(tmp_path, "nvidia")
+
+        llm = services["invalid-llm-app"]["llm"]
+        assert llm["consumes"] is False
+        assert llm["swap_safe"] is False
+        assert "min_context" not in llm
+        assert "invalid llm.consumes" in caplog.text
+        assert "invalid llm.min_context" in caplog.text
+
+    @pytest.mark.parametrize("min_context", [True, -1, "65536"])
+    def test_normalizer_rejects_non_schema_min_context_values(self, min_context):
+        llm = config.normalize_llm_contract({"consumes": True, "min_context": min_context})
+
+        assert "min_context" not in llm
+
     def test_skips_docker_service_when_declared_compose_file_is_absent(self, tmp_path):
         svc_dir = tmp_path / "openclaw"
         svc_dir.mkdir()


### PR DESCRIPTION
## Why this matters

Service manifests drive dashboard model-swap planning. Python currently turns the YAML string `false` into `True` and accepts strings, booleans, and negative values as context sizes. A schema-invalid manifest can therefore be advertised as an LLM consumer or receive an invented context contract.

Root cause: normalization used general-purpose `bool()` and `int()` coercion instead of the shipped manifest schema's exact scalar types.

Behavioral invariant: `llm.consumes` is honored only when it is a YAML boolean, and `llm.min_context` only when it is a non-negative YAML integer (excluding booleans).

## Overlap check

Searched open and closed PRs for “llm manifest consumes boolean” and reviewed PRs changing `dashboard-api/config.py`. Open PR #2525 concerns the core service registry, while other config PRs touch unrelated runtime paths. No PR covers these LLM scalar contracts.

## Regression test

A manifest-loader boundary test loads quoted `consumes` and `min_context` values, proving the service is not marked swap-safe and no context size is emitted. Parameterized tests also cover boolean, negative, and string context values.

## Validation

- `python -m pytest -q tests/test_config.py` — 58 passed
- `python -m py_compile config.py tests/test_config.py` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

Invalid manifests fail closed at the dashboard contract while logging the exact bad field; valid repository manifests are unchanged. Static validation proves schema parity and loader output, not live model swapping. Rollback is one commit.