### PR TITLE
fix(models): cancel stale repository details

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
@@ -35,6 +35,7 @@ export default function HuggingFaceModelBrowser({ gpu, downloadBusy, onImportSta
   const [importingArtifact, setImportingArtifact] = useState(null)
   const [searchAttempt, setSearchAttempt] = useState(0)
   const detailsRequestRef = useRef(0)
+  const detailsControllerRef = useRef(null)
 
   useEffect(() => {
     const controller = new AbortController()
@@ -61,7 +62,15 @@ export default function HuggingFaceModelBrowser({ gpu, downloadBusy, onImportSta
     }
   }, [query, sort, searchAttempt])
 
+  useEffect(() => () => {
+    detailsRequestRef.current += 1
+    detailsControllerRef.current?.abort()
+  }, [])
+
   const openRepository = async (model) => {
+    detailsControllerRef.current?.abort()
+    const controller = new AbortController()
+    detailsControllerRef.current = controller
     const requestId = detailsRequestRef.current + 1
     detailsRequestRef.current = requestId
     setSelectedRepo(model)
@@ -69,24 +78,33 @@ export default function HuggingFaceModelBrowser({ gpu, downloadBusy, onImportSta
     setDetailsError(null)
     setDetailsLoading(true)
     try {
-      const response = await fetch(`/api/models/huggingface/repositories/${encodeURI(model.id)}`)
+      const response = await fetch(
+        `/api/models/huggingface/repositories/${encodeURI(model.id)}`,
+        { signal: controller.signal },
+      )
       const body = await responseJson(response)
       if (!response.ok) throw new Error(errorMessage(body, 'Could not inspect this repository'))
       if (detailsRequestRef.current !== requestId) return
       setDetails(body)
     } catch (requestError) {
-      if (detailsRequestRef.current === requestId) setDetailsError(requestError.message)
+      if (requestError?.name !== 'AbortError' && detailsRequestRef.current === requestId) {
+        setDetailsError(requestError.message)
+      }
     } finally {
+      if (detailsControllerRef.current === controller) detailsControllerRef.current = null
       if (detailsRequestRef.current === requestId) setDetailsLoading(false)
     }
   }
 
   const closeRepository = () => {
     if (importingArtifact) return
+    detailsControllerRef.current?.abort()
+    detailsControllerRef.current = null
     detailsRequestRef.current += 1
     setSelectedRepo(null)
     setDetails(null)
     setDetailsError(null)
+    setDetailsLoading(false)
   }
 
   const importArtifact = async (artifact) => {

--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.test.jsx
@@ -1,0 +1,63 @@
+import { act, fireEvent, screen } from '@testing-library/react'
+import { render } from '../../test/test-utils'
+import HuggingFaceModelBrowser from './HuggingFaceModelBrowser' // eslint-disable-line no-unused-vars
+
+const response = (body) => ({
+  ok: true,
+  json: async () => body,
+})
+
+describe('HuggingFaceModelBrowser', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  test('aborts an in-flight repository request when its dialog closes', async () => {
+    vi.useFakeTimers()
+    let detailsSignal
+    const fetchMock = vi.fn((url, options = {}) => {
+      if (String(url).startsWith('/api/models/huggingface/search?')) {
+        return Promise.resolve(response({
+          models: [{
+            id: 'org/model-GGUF',
+            author: 'org',
+            downloads: 10,
+            likes: 2,
+            license: 'apache-2.0',
+            ggufFileCount: 1,
+            runtimeCompatible: true,
+          }],
+          authenticated: false,
+          stale: false,
+        }))
+      }
+      if (String(url).includes('/api/models/huggingface/repositories/')) {
+        detailsSignal = options.signal
+        return new Promise((resolve, reject) => {
+          options.signal.addEventListener('abort', () => {
+            const error = new Error('request aborted')
+            error.name = 'AbortError'
+            reject(error)
+          })
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<HuggingFaceModelBrowser gpu={{ vramTotal: 16 }} />)
+    await act(async () => vi.advanceTimersByTimeAsync(350))
+    vi.useRealTimers()
+
+    fireEvent.click(screen.getByRole('button', { name: /choose file/i }))
+    expect(detailsSignal).toBeDefined()
+    expect(detailsSignal.aborted).toBe(false)
+
+    fireEvent.click(screen.getByTitle('Close'))
+
+    expect(detailsSignal.aborted).toBe(true)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Cancel repository-detail requests when their inspection dialog closes or the Hub browser unmounts.

## Why this matters
Closing a slow Hugging Face repository inspection currently leaves its network request and body read active; rapid inspection changes can accumulate abandoned work.

Root cause: Request sequence IDs reject stale state but do not release the underlying request.

Behavioral invariant: Only the active repository inspection owns a live request; closing, replacing or unmounting cancels the former owner without showing an abort error.

## Implementation and compatibility
Use one AbortController per inspection alongside the existing receipt sequence. Preserve beta's validated artifact shapes, retry UI and search deadlines.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx`.

Relevant same-file results: #4356 (open: fix(models): use a native modal for artifact inspection), #5247 (merged: fix(models): release stalled Hugging Face searches), #4884 (merged: feat(models): filter Hugging Face artifacts by filename or quantization), #4622 (merged: fix(models): recover from invalid Hub detail responses), #4339 (merged: fix(models): reject obsolete Hub search response bodies), #4267 (merged: fix(dashboard-api): sanitize throughput metric samples in agent monitor), #4266 (merged: fix(dashboard-api): guard null nodes payload in cluster status refresh)

#5247 and #4339 govern search, #4622 governs invalid detail receipts, #4884 adds artifact filtering, and #4356 changes dialog focus. Cancellation releases resources in the original #3050 scope; those behaviors remain intact.

## Regression and validation
Candidate commit: `59aef4dd4f240802f672a1806a400358f5249e75`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/components/model-library/HuggingFace` — **15 passed**.
- Both user-close and component-unmount cancellation tests fail against baseline production code; all 15 Hub browser/search/receipt tests pass on the candidate.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `59aef4dd4f240802f672a1806a400358f5249e75`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: External #4356 conflicts in HuggingFaceModelBrowser.jsx. Integrate native-dialog focus with request-controller cleanup explicitly before merging both; that external combination was not runtime-tested.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
