### PR TITLE
fix(usage): deduplicate readiness actions

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   Activity,
   Box,
@@ -352,6 +352,7 @@ export default function Usage({ status }) {
   const [rangeAnchor, setRangeAnchor] = useState(() => monthRange().anchor)
   const [reloadToken, setReloadToken] = useState(0)
   const [actionState, setActionState] = useState(null)
+  const actionInFlightRef = useRef(false)
   const range = useMemo(() => monthRange(rangeAnchor), [rangeAnchor])
   const { report, previousReport, readiness, history, loading, error } = useUsageReport(range, reloadToken)
   const summary = report.summary || EMPTY_SUMMARY
@@ -375,7 +376,8 @@ export default function Usage({ status }) {
 
   async function runUsageAction(kind) {
     const action = readiness.actions?.[kind]
-    if (!action?.url) return
+    if (!action?.url || actionInFlightRef.current) return
+    actionInFlightRef.current = true
     setActionState({ status: 'running', kind, message: action.label })
     try {
       const response = await fetch(action.url, { method: action.method || 'POST' })
@@ -391,6 +393,8 @@ export default function Usage({ status }) {
       window.setTimeout(() => setReloadToken(value => value + 1), 1200)
     } catch (err) {
       setActionState({ status: 'error', kind, message: err.message })
+    } finally {
+      actionInFlightRef.current = false
     }
   }
 

--- a/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { render } from '../test/test-utils'
 import Usage from './Usage' // eslint-disable-line no-unused-vars
 
@@ -379,5 +379,37 @@ describe('Usage page', () => {
     await waitFor(() => {
       expect(fetch).toHaveBeenCalledWith('/api/services/token-spy/restart', { method: 'POST' })
     })
+  })
+
+  it('submits only one readiness mutation for same-tick repeated activation', async () => {
+    let resolveAction
+    const actionResponse = new Promise((resolve) => { resolveAction = resolve })
+    vi.stubGlobal('fetch', vi.fn((url, options = {}) => {
+      const text = String(url)
+      if (options.method === 'POST') return actionResponse
+      if (text.includes('/api/usage/readiness')) {
+        return Promise.resolve({ ok: true, json: async () => offlineReadiness })
+      }
+      const report = text.includes('start=2026-04-01')
+        ? makeEmptyReport('2026-04-01', '2026-04-30')
+        : makeEmptyReport()
+      return Promise.resolve({ ok: true, json: async () => report })
+    }))
+    render(<Usage status={{}} />)
+    const restartButton = await screen.findByRole('button', { name: /Restart Token Spy/i })
+
+    act(() => {
+      restartButton.click()
+      restartButton.click()
+    })
+
+    const mutationCalls = fetch.mock.calls.filter(([, options = {}]) => options.method === 'POST')
+    expect(mutationCalls).toHaveLength(1)
+
+    await act(async () => {
+      resolveAction({ ok: true, json: async () => ({ message: 'Action accepted' }) })
+      await actionResponse
+    })
+    expect(await screen.findByText('Action accepted')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
Guard usage-tracking mutations synchronously before awaiting a backend receipt.

## Why this matters
Two same-tick activations can currently send duplicate Token Spy restart/enable requests before React commits the running state.

Root cause: A rendered actionState flag is not a synchronous mutation lock.

Behavioral invariant: At most one usage-readiness action is in flight for the mounted page; success and failure both release the guard.

## Implementation and compatibility
Add a ref guard at the existing authenticated mutation entry point and release it in finally. Keep the current beta UsageView, receipt handling and refresh reconciliation.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/pages/Usage.jsx`.

Relevant same-file results: #4983 (merged: perf(usage): fetch only the displayed reporting month), #4419 (merged: fix(usage): recover polling after stalled requests and bodies), #4349 (merged: fix(usage): select reporting months in UTC)

#3043 handles read-side failure isolation; this PR handles write-side duplicate admission. #4419 and #4983's bounded single-month reporting logic is preserved.

## Regression and validation
Candidate commit: `961c95b2be2fcea6b428f0ecfc3089d12e802e0e`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/pages/Usage` — **26 passed**.
- A public-page test clicks the restart action twice in one React act and verifies one POST plus the accepted receipt. It fails on beta; all 26 candidate Usage tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `961c95b2be2fcea6b428f0ecfc3089d12e802e0e`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #3043, read isolation and write admission merge cleanly; the combined Usage suites retain both behaviors.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
