### PR TITLE
fix(brave-search): reject blank queries

### DIFF
--- a/ods/extensions/services/brave-search/proxy.mjs
+++ b/ods/extensions/services/brave-search/proxy.mjs
@@ -153,7 +153,7 @@ async function fetchBraveWeb(query, count, offset) {
 }
 
 async function handleV1Search(res, params) {
-  const query = params.get("q");
+  const query = (params.get("q") ?? "").trim();
   if (!query) {
     send(res, 400, { error: "missing_query_param_q" });
     return;
@@ -285,7 +285,7 @@ async function handleSearxngSearch(res, params) {
     send(res, 400, { error: "unsupported_format", detail: "only format=json is supported" });
     return;
   }
-  const query = params.get("q");
+  const query = (params.get("q") ?? "").trim();
   if (!query) {
     send(res, 400, { error: "missing_query_param_q" });
     return;

--- a/ods/tests/test-brave-search-searxng-compat.mjs
+++ b/ods/tests/test-brave-search-searxng-compat.mjs
@@ -195,6 +195,19 @@ async function testV1Route(base) {
     JSON.stringify(noQ),
   );
 
+  const upstreamCallsBeforeBlank = observedTokens.length;
+  const blankQ = await getJson(base, "/v1/search?q=%20%20%20");
+  check(
+    "400 for a whitespace-only q",
+    blankQ.status === 400 && blankQ.body.error === "missing_query_param_q",
+    JSON.stringify(blankQ),
+  );
+  check(
+    "whitespace-only q does not consume an upstream request",
+    observedTokens.length === upstreamCallsBeforeBlank,
+    `before=${upstreamCallsBeforeBlank} after=${observedTokens.length}`,
+  );
+
   const err = await getJson(base, "/v1/search?q=err500");
   check(
     "502 on upstream HTTP error",
@@ -297,6 +310,19 @@ async function testCompatEnabled(base) {
     "400 without q",
     noQ.status === 400 && noQ.body.error === "missing_query_param_q",
     JSON.stringify(noQ),
+  );
+
+  const upstreamCallsBeforeBlank = observedTokens.length;
+  const blankQ = await getJson(base, "/search?format=json&q=%20%20%20");
+  check(
+    "400 for a whitespace-only q",
+    blankQ.status === 400 && blankQ.body.error === "missing_query_param_q",
+    JSON.stringify(blankQ),
+  );
+  check(
+    "compat whitespace-only q does not consume an upstream request",
+    observedTokens.length === upstreamCallsBeforeBlank,
+    `before=${upstreamCallsBeforeBlank} after=${observedTokens.length}`,
   );
 
   const images = await getJson(base, "/search?format=json&q=ok&categories=images");


### PR DESCRIPTION
## Why this matters

Both Brave proxy routes accept a whitespace-only `q` because non-empty strings are truthy. Those requests reach the paid upstream despite carrying no meaningful search terms, consuming quota and producing provider-dependent results.

Root cause: presence validation did not apply the same trimming used for returned result fields.

Behavioral invariant: missing and whitespace-only queries receive the existing `400 missing_query_param_q` contract and never call Brave; valid queries are trimmed once and used consistently.

## Overlap check

Searched open and closed upstream PRs for “brave search whitespace query” and reviewed PRs changing `brave-search/proxy.mjs`. Open PR #2998 validates malformed result entries and #2734 concerns caller authentication. Neither validates the query boundary; no matching closed PR was found.

## Regression test

The loopback contract suite sends blank queries through real proxy processes for both `/v1/search` and enabled `/search?format=json`. It asserts the 400 body and verifies the stub-upstream request counter does not change.

## Validation

- `bash tests/test-brave-search-searxng-compat.sh` — passed
- `node --check extensions/services/brave-search/proxy.mjs` — passed
- `node --check tests/test-brave-search-searxng-compat.mjs` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

Leading and trailing whitespace is normalized before forwarding, which matches user search semantics while preserving internal whitespace. The response error code remains backward-compatible. Rollback is one commit.