### PR TITLE
fix(token-spy): validate settings updates

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -1601,6 +1601,51 @@ def api_get_settings():
     return settings
 
 
+def _validate_settings_update(body: object) -> None:
+    """Validate the scalar/container contract before mutating settings."""
+    if not isinstance(body, dict):
+        raise ValueError("settings payload must be a JSON object")
+
+    def validate_integer(name: str, value: object, *, allow_none: bool, minimum: int, maximum: int | None = None):
+        if value is None and allow_none:
+            return
+        if type(value) is not int:
+            raise ValueError(f"{name} must be an integer")
+        if value < minimum:
+            raise ValueError(f"{name} must be >= {minimum}")
+        if maximum is not None and value > maximum:
+            raise ValueError(f"{name} must be {minimum}-{maximum}")
+
+    if "session_char_limit" in body:
+        validate_integer("session_char_limit", body["session_char_limit"], allow_none=False, minimum=10000)
+    if "poll_interval_minutes" in body:
+        validate_integer(
+            "poll_interval_minutes", body["poll_interval_minutes"],
+            allow_none=False, minimum=1, maximum=60,
+        )
+    if "filters" in body and not isinstance(body["filters"], dict):
+        raise ValueError("filters must be a JSON object")
+
+    agents = body.get("agents", {})
+    if not isinstance(agents, dict):
+        raise ValueError("agents must be a JSON object")
+    for agent_name, updates in agents.items():
+        if not isinstance(updates, dict):
+            raise ValueError(f"agents.{agent_name} must be a JSON object")
+        if "session_char_limit" in updates:
+            validate_integer(
+                f"agents.{agent_name}.session_char_limit", updates["session_char_limit"],
+                allow_none=True, minimum=10000,
+            )
+        if "poll_interval_minutes" in updates:
+            validate_integer(
+                f"agents.{agent_name}.poll_interval_minutes", updates["poll_interval_minutes"],
+                allow_none=True, minimum=1, maximum=60,
+            )
+        if "filters" in updates and not isinstance(updates["filters"], dict):
+            raise ValueError(f"agents.{agent_name}.filters must be a JSON object")
+
+
 @app.post("/api/settings", dependencies=[Depends(verify_api_key)])
 async def api_update_settings(request: Request):
     """Update settings. Accepts partial updates (only provided keys are changed).
@@ -1610,23 +1655,22 @@ async def api_update_settings(request: Request):
       {"agents": {"my-agent": {"session_char_limit": 100000}}}
       {"poll_interval_minutes": 3}
     """
-    body = await request.json()
+    try:
+        body = await request.json()
+    except json.JSONDecodeError:
+        return JSONResponse({"error": "settings payload must be valid JSON"}, status_code=400)
+    try:
+        _validate_settings_update(body)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
     settings = load_settings()
 
     if "session_char_limit" in body:
         val = body["session_char_limit"]
-        if val is not None:
-            val = int(val)
-            if val < 10000:
-                return JSONResponse({"error": "session_char_limit must be >= 10000"}, status_code=400)
         settings["session_char_limit"] = val
 
     if "poll_interval_minutes" in body:
         val = body["poll_interval_minutes"]
-        if val is not None:
-            val = int(val)
-            if val < 1 or val > 60:
-                return JSONResponse({"error": "poll_interval_minutes must be 1-60"}, status_code=400)
         settings["poll_interval_minutes"] = val
 
     # Deep-merge filter settings (hot-reloadable)
@@ -1647,8 +1691,6 @@ async def api_update_settings(request: Request):
             for key in ("session_char_limit", "poll_interval_minutes"):
                 if key in agent_updates:
                     val = agent_updates[key]
-                    if val is not None:
-                        val = int(val)
                     settings["agents"][agent_name][key] = val
             # Per-agent filter overrides
             if "filters" in agent_updates:

--- a/ods/extensions/services/token-spy/tests/test_settings_api.py
+++ b/ods/extensions/services/token-spy/tests/test_settings_api.py
@@ -1,0 +1,87 @@
+"""Authenticated settings API contract tests."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+if str(TOKEN_SPY_DIR) not in sys.path:
+    sys.path.insert(0, str(TOKEN_SPY_DIR))
+os.environ.setdefault("TOKEN_SPY_API_KEY", "settings-test-token")
+
+import main as token_spy  # noqa: E402
+
+
+@pytest.fixture()
+def settings_client(tmp_path, monkeypatch):
+    settings_path = tmp_path / "settings.json"
+    baseline = copy.deepcopy(token_spy._DEFAULT_SETTINGS)
+    baseline["agents"] = {"test-agent": {
+        "session_char_limit": None,
+        "poll_interval_minutes": None,
+    }}
+    settings_path.write_text(json.dumps(baseline), encoding="utf-8")
+    monkeypatch.setattr(token_spy, "SETTINGS_PATH", str(settings_path))
+    monkeypatch.setattr(token_spy, "TOKEN_SPY_API_KEY", "settings-test-token")
+    timer_calls = []
+    monkeypatch.setattr(token_spy, "_update_timer_interval", timer_calls.append)
+    client = TestClient(token_spy.app, raise_server_exceptions=False)
+    yield client, settings_path, baseline, timer_calls
+    client.close()
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ([], "JSON object"),
+        ({"session_char_limit": "200000"}, "must be an integer"),
+        ({"poll_interval_minutes": True}, "must be an integer"),
+        ({"agents": []}, "agents must be a JSON object"),
+        ({"agents": {"test-agent": {"session_char_limit": 9999}}}, "must be >= 10000"),
+        ({"agents": {"test-agent": {"poll_interval_minutes": 61}}}, "must be 1-60"),
+    ],
+)
+def test_invalid_settings_payloads_return_400_without_persisting(
+    settings_client, payload, message,
+):
+    client, settings_path, baseline, timer_calls = settings_client
+
+    response = client.post(
+        "/api/settings",
+        json=payload,
+        headers={"Authorization": "Bearer settings-test-token"},
+    )
+
+    assert response.status_code == 400
+    assert message in response.json()["error"]
+    assert json.loads(settings_path.read_text(encoding="utf-8")) == baseline
+    assert timer_calls == []
+
+
+def test_valid_integer_settings_persist_and_refresh_the_timer(settings_client):
+    client, settings_path, _, timer_calls = settings_client
+
+    response = client.post(
+        "/api/settings",
+        json={
+            "session_char_limit": 250000,
+            "poll_interval_minutes": 7,
+            "agents": {"test-agent": {"session_char_limit": None, "poll_interval_minutes": 3}},
+        },
+        headers={"Authorization": "Bearer settings-test-token"},
+    )
+
+    assert response.status_code == 200
+    persisted = json.loads(settings_path.read_text(encoding="utf-8"))
+    assert persisted["session_char_limit"] == 250000
+    assert persisted["poll_interval_minutes"] == 7
+    assert persisted["agents"]["test-agent"]["poll_interval_minutes"] == 3
+    assert timer_calls == [7]


### PR DESCRIPTION
## Why this matters

Token Spy's authenticated settings endpoint persists live poll/session limits and rewrites the cleanup timer. Schema-invalid JSON can currently be coerced (`5`), treated as integers (`true`), or raise a server error for malformed containers. Invalid per-agent ranges are also persisted without the global bounds.

Root cause: validation happened opportunistically during mutation through `int()` and unguarded `.items()` calls.

Behavioral invariant: the complete partial-update payload is validated before any file or timer mutation; numeric settings are exact JSON integers within their documented ranges, while only per-agent values may be `null` to inherit globals.

## Overlap check

Searched open and closed upstream PRs for “token spy settings invalid integer” and reviewed PRs changing `token-spy/main.py`. Existing Token Spy PRs cover telemetry, routing, and UI behavior; none validates this authenticated settings transaction.

## Regression test

Authenticated TestClient coverage exercises non-object roots, strings, booleans, malformed agent containers, and both per-agent ranges. Every invalid request returns 400 and leaves both the persisted settings and timer untouched. A valid receipt proves integer values still persist and refresh the timer.

## Validation

- `python -m pytest -q tests/test_settings_api.py` — 7 passed
- `python -m pytest -q tests --ignore=tests/test_recent_events_cursor_postgres.py` — 27 passed
- `python -m py_compile main.py tests/test_settings_api.py` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

Global `null` is rejected because only per-agent null inheritance is documented; operators receive a 400 instead of persisting an unusable timer value. Filter contents remain flexible, but their containers must be objects. The live PostgreSQL cursor suite was excluded because it requires an external database and is unrelated. Rollback is one commit.