### PR TITLE
fix(privacy-shield): preserve unknown charset responses

### DIFF
--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -4,6 +4,7 @@ M3: API Privacy Shield - HTTP Proxy (ODS Integration)
 FastAPI-based proxy with connection pooling and PII caching.
 """
 
+import codecs
 import logging
 import os
 import re
@@ -48,13 +49,17 @@ RESTORE_MAX_BYTES = int(os.getenv("SHIELD_RESTORE_MAX_BYTES", str(8 * 1024 * 102
 
 
 def _parse_content_type(content_type: str) -> tuple[str, str]:
-    """Return (lowercased mime, charset) from a Content-Type header value."""
+    """Return (lowercased mime, charset), or an empty charset if unsupported."""
     mime = content_type.split(";", 1)[0].strip().lower()
     charset = "utf-8"
     for part in content_type.split(";")[1:]:
         part = part.strip()
         if part.lower().startswith("charset="):
             charset = part.split("=", 1)[1].strip().strip('"').lower() or "utf-8"
+    try:
+        codecs.lookup(charset)
+    except LookupError:
+        charset = ""
     return mime, charset
 
 
@@ -336,6 +341,7 @@ async def proxy(request: Request, path: str):
     do_restore = (
         body_str is not None
         and _is_textual(mime)
+        and bool(charset)
         and not content_encoding
         and not (0 <= declared_len > RESTORE_MAX_BYTES)
     )

--- a/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
+++ b/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
@@ -267,6 +267,25 @@ class TestBinaryPassthrough:
         assert resp.status_code == 200, "non-utf8 body raised instead of passthrough"
         assert resp.content == blob
 
+    def test_unknown_text_charset_passthrough_is_complete(self, client, install_upstream):
+        payload = b'{"prefix":"kept","raw":"\xff\xfe","suffix":"also-kept"}'
+        install_upstream(
+            lambda r: _resp(
+                200,
+                {
+                    "content-type": "application/json; charset=not-a-real-codec",
+                    "content-length": str(len(payload)),
+                },
+                [payload[:13], payload[13:31], payload[31:]],
+            )
+        )
+
+        resp = client.post("/v1/chat/completions", headers=AUTH, json={"messages": []})
+
+        assert resp.status_code == 200
+        assert resp.content == payload
+        assert resp.headers["content-length"] == str(len(payload))
+
     def test_non_utf8_request_body_forwarded(self, client, install_upstream):
         seen = {}
 


### PR DESCRIPTION
## Why this matters

Privacy Shield restores PII in textual upstream responses using the declared charset. If an upstream or intermediary supplies an unknown codec name, the streaming decoder fails after headers have already been sent; the broad stream boundary then logs the error and the client receives a truncated body.

Root cause: textual eligibility checked MIME and compression but never verified that Python supports the declared charset.

Behavioral invariant: response transformation starts only for a recognized codec. Unknown charsets stay on the transparent byte-for-byte path with their original length and content type.

## Overlap check

Searched open and closed upstream PRs for “privacy shield invalid charset” and reviewed PRs changing `privacy-shield/proxy.py`. Open PRs #2973 and #2972 concern auth isolation and query preservation; #2253/#2251 cover health/await behavior. None covers response decoding eligibility.

## Regression test

A TestClient request traverses the real proxy streaming boundary while the mock upstream returns chunked, non-UTF-8 JSON with `charset=not-a-real-codec`. The test verifies the complete byte sequence and original Content-Length reach the client.

## Validation

- `python -m pytest -q tests/test_streaming_proxy.py` — 15 passed
- `python -m py_compile proxy.py tests/test_streaming_proxy.py` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

For an unknown charset, Privacy Shield cannot safely inspect or restore textual PII, so availability and byte integrity take precedence and the response is passed through. Recognized charsets retain existing restoration behavior. No live external model was required; the test exercises the HTTP streaming boundary with exact chunks. Rollback is one commit.