### PR TITLE
fix(gpu): require boolean host capability flags

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -412,9 +412,9 @@ def get_gpu_info_windows_host() -> Optional[GPUInfo]:
         ),
         gpu_backend="amd",
         gpu_count=gpu_count,
-        memory_usage_available=bool(payload.get("memory_usage_available", False)),
-        utilization_available=bool(payload.get("utilization_available", False)),
-        temperature_available=bool(payload.get("temperature_available", False)),
+        memory_usage_available=payload.get("memory_usage_available") is True,
+        utilization_available=payload.get("utilization_available") is True,
+        temperature_available=payload.get("temperature_available") is True,
     )
 
 
@@ -447,9 +447,9 @@ def get_gpu_info_windows_host_detailed() -> Optional[list[IndividualGPU]]:
                     "unified" if item.get("memory_type") == "unified" else "discrete"
                 ),
                 assigned_services=["llama-server"],
-                memory_usage_available=bool(item.get("memory_usage_available", False)),
-                utilization_available=bool(item.get("utilization_available", False)),
-                temperature_available=bool(item.get("temperature_available", False)),
+                memory_usage_available=item.get("memory_usage_available") is True,
+                utilization_available=item.get("utilization_available") is True,
+                temperature_available=item.get("temperature_available") is True,
             ))
     except (TypeError, ValueError):
         return None

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -197,6 +197,25 @@ class TestWindowsHostGpuInfo:
         assert info is not None
         assert info.memory_type == "unified"
 
+    def test_fail_closed_on_non_boolean_capability_flags(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: {
+            "schema_version": "ods.host-gpu-metrics.v1",
+            "name": "AMD Radeon RX 9070 XT",
+            "memory_total_mb": 16368,
+            "memory_usage_available": "false",
+            "utilization_available": 1,
+            "temperature_available": [],
+        })
+
+        info = get_gpu_info_windows_host()
+
+        assert info is not None
+        assert info.memory_usage_available is False
+        assert info.utilization_available is False
+        assert info.temperature_available is False
+
     def test_maps_per_adapter_host_payload(self, monkeypatch):
         monkeypatch.setenv("GPU_BACKEND", "amd")
         monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
@@ -223,6 +242,27 @@ class TestWindowsHostGpuInfo:
         assert gpus is not None
         assert [gpu.uuid for gpu in gpus] == ["luid-a", "luid-b"]
         assert [gpu.utilization_percent for gpu in gpus] == [30, 70]
+
+    def test_per_adapter_flags_require_json_booleans(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: {
+            "schema_version": "ods.host-gpu-metrics.v1",
+            "gpus": [{
+                "name": "AMD Radeon RX 7900 XTX",
+                "memory_total_mb": 24560,
+                "memory_usage_available": "false",
+                "utilization_available": 1,
+                "temperature_available": {},
+            }],
+        })
+
+        gpus = get_gpu_info_windows_host_detailed()
+
+        assert gpus is not None
+        assert gpus[0].memory_usage_available is False
+        assert gpus[0].utilization_available is False
+        assert gpus[0].temperature_available is False
 
     def test_rejects_invalid_aggregate_count(self, monkeypatch):
         monkeypatch.setenv("GPU_BACKEND", "amd")


### PR DESCRIPTION
## Why this matters

On Windows AMD hosts, dashboard GPU availability fields come from the host-agent JSON boundary. Python truthiness treated strings such as false and numeric values such as 1 as proof that a sensor was available, so the UI could present zero/default telemetry as measured data.

The invariant is: a capability is advertised only when the host agent sends the JSON boolean true. Missing or schema-incompatible values fail closed; valid booleans preserve current behavior. This covers both aggregate and per-adapter Windows host paths. Linux, macOS, and native NVIDIA/AMD collectors are unchanged.

## Overlap check

Searched open and closed PRs for Windows host GPU availability boolean and the production file gpu.py. Open PRs #2838, #2580, #2526, #1895, #1781, #1746, and #1663 touch that file but cover encoding, payload-root validation, persisted state, networking, memory accounting, env readers, or idle detection. None validates the three sensor capability fields. The scope is independent.

## Validation

- pytest -q tests/test_gpu.py (53 passed)
- git diff --check

Regression tests exercise the public GPU mapping boundary for both aggregate and per-adapter host-agent receipts, including string false, 1, and container values.

## Tradeoffs and rollback

This deliberately fails closed for legacy producers that send truthy non-booleans. The shipped host agent already emits JSON booleans, so compatible hosts are unaffected. Rollback is the six expression changes; no persisted state or migration is involved.
