### PR TITLE
fix(readiness): require boolean host-agent receipt

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -318,7 +318,7 @@ def _build_readiness_payload(
         detail="Dashboard API is serving this readiness response",
     ))
 
-    host_agent_ready = bool(host_agent.get("available"))
+    host_agent_ready = host_agent.get("available") is True
     checks.append(_readiness_check(
         check_id="host-agent",
         name="Host Agent",

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -377,6 +377,29 @@ class TestReadinessPayload:
         assert result["canChat"] is False
         assert "ods restart llama-server" in result["repairHints"]
 
+    def test_host_agent_readiness_requires_a_boolean_receipt(self):
+        from models import BootstrapStatus, ServiceStatus
+
+        statuses = [
+            ServiceStatus(id="llama-server", name="LLM", port=8080, external_port=8080, status="healthy"),
+            ServiceStatus(id="open-webui", name="Open WebUI", port=3000, external_port=3000, status="healthy"),
+        ]
+
+        result = _build_readiness_payload(
+            service_statuses=statuses,
+            loaded_model="Test-32B",
+            context_size=32768,
+            bootstrap_info=BootstrapStatus(active=False),
+            host_agent={"available": "false"},
+            stt_model_cached=None,
+            stt_model_name="Systran/faster-whisper-base",
+        )
+
+        host_check = next(check for check in result["checks"] if check["id"] == "host-agent")
+        assert host_check["ready"] is False
+        assert host_check["status"] == "needs_repair"
+        assert host_check["repair"] == "ods agent restart"
+
     def test_voice_ready_requires_services_and_cached_stt_model(self):
         from models import BootstrapStatus, ServiceStatus
 


### PR DESCRIPTION
## Why this matters

The readiness API turns the host-agent diagnostic receipt into the operator-facing Host Agent check. Python truthiness made a schema-invalid value such as string false look reachable, suppressing the repair hint while the agent was unavailable.

The invariant is: only the JSON boolean true proves host-agent reachability. Chat readiness remains independent because Host Agent is optional, but its individual status and repair guidance now fail closed.

## Overlap check

Searched open and closed PRs for host agent readiness available boolean and the production file dashboard-api/main.py. Open PRs touching that file cover CORS, version/token parsing, observability, process cleanup, authentication, and health extensions. None changes the Host Agent readiness receipt. This is also independent of PR #3055, which maps Windows GPU sensor capability fields rather than the /api/readiness diagnostic.

## Validation

- pytest -q tests/test_main.py (75 passed; 2 pre-existing framework warnings)
- git diff --check

The regression test exercises _build_readiness_payload, the pure boundary used by /api/readiness, and verifies status plus the operator repair receipt.

## Tradeoffs and rollback

Legacy diagnostic stubs returning 1 or a string now report needs_repair. The shipped producer returns a boolean. No required readiness gate, stored data, or other platform path changes; rollback is one expression and one regression test.
