### PR TITLE
fix(health): require boolean host-agent proofs

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -142,9 +142,9 @@ async def _check_tailscale_health(service_id: str, config: dict) -> ServiceStatu
     except AgentClientError:
         return _service_status_from_config(service_id, config, "not_deployed")
 
-    if not payload.get("running"):
+    if payload.get("running") is not True:
         return _service_status_from_config(service_id, config, "not_deployed")
-    if payload.get("authenticated"):
+    if payload.get("authenticated") is True:
         return _service_status_from_config(service_id, config, "healthy")
     return _service_status_from_config(service_id, config, "unhealthy")
 
@@ -172,7 +172,7 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
     except AgentClientError:
         return _service_status_from_config(service_id, config, "down")
 
-    status = "healthy" if payload.get("reachable") else "not_deployed"
+    status = "healthy" if payload.get("reachable") is True else "not_deployed"
     return ServiceStatus(
         id=service_id,
         name=config["name"],

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -527,6 +527,34 @@ class TestCheckServiceHealth:
         result = await check_service_health("tailscale", config)
         assert result.status == "healthy"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            ({"running": "false", "authenticated": True}, "not_deployed"),
+            ({"running": True, "authenticated": "false"}, "unhealthy"),
+        ],
+    )
+    async def test_tailscale_flags_require_json_booleans(
+        self, monkeypatch, payload, expected
+    ):
+        config = {
+            "name": "Tailscale",
+            "port": 0,
+            "external_port": 0,
+            "health": "/health",
+            "host": "localhost",
+            "host_network": True,
+        }
+        monkeypatch.setattr(
+            "helpers.request_agent_json",
+            AsyncMock(return_value=payload),
+        )
+
+        result = await check_service_health("tailscale", config)
+
+        assert result.status == expected
+
 
 # --- get_all_services ---
 
@@ -1010,6 +1038,22 @@ class TestCheckServiceHealthSystemd:
             "health": "/health", "host": "localhost", "type": "host-systemd",
         }
         result = await check_service_health("opencode", config)
+        assert result.status == "not_deployed"
+        assert result.response_time_ms == 2.0
+
+    @pytest.mark.asyncio
+    async def test_host_systemd_reachability_requires_a_json_boolean(self, monkeypatch):
+        monkeypatch.setattr(
+            "helpers.request_agent_json",
+            AsyncMock(return_value={"reachable": "false", "response_time_ms": 2.0}),
+        )
+        config = {
+            "name": "opencode", "port": 3003, "external_port": 3003,
+            "health": "/health", "host": "localhost", "type": "host-systemd",
+        }
+
+        result = await check_service_health("opencode", config)
+
         assert result.status == "not_deployed"
         assert result.response_time_ms == 2.0
 


### PR DESCRIPTION
## Why this matters

Service health uses authenticated host-agent receipts for Tailscale and host-systemd tools such as OpenCode. Python truthiness interpreted string false as true, so a malformed receipt could mark an unauthenticated VPN or closed host port healthy and launch the operator into a dead service.

The invariant is: only JSON boolean true proves running, authenticated, or reachable. Invalid or missing values retain the existing fail-closed states: not_deployed or unhealthy.

## Overlap check

Searched open and closed PRs for Tailscale authenticated/systemd reachable boolean and the production file helpers.py. PR #2581 validates host-agent payload roots, while the other open same-file PRs cover JSON encoding, model introspection, service ports, atomic writes, metrics, and health transport. None validates these three leaf proofs. The scope is independent.

## Validation

- pytest -q tests/test_helpers.py (107 passed, 2 skipped)
- git diff --check

Tests exercise check_service_health, the same public service-status boundary used by dashboard status and launch controls, for both valid booleans and schema-invalid string receipts.

## Tradeoffs and rollback

Older third-party host agents that emit numeric/string flags now fail closed. The shipped host agent emits booleans. No retries, persistence, or service lifecycle changes are introduced; rollback is limited to three comparisons.
