### PR TITLE
fix(auth): fail closed on reusable invite flags

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -288,7 +288,7 @@ def _normalize_record(record: dict) -> dict:
         record["reusable"] = True
         record["expires_at"] = None
     else:
-        record["reusable"] = bool(record.get("reusable", False))
+        record["reusable"] = record.get("reusable") is True
 
     if not isinstance(record.get("redemptions"), list):
         record["redemptions"] = []

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -941,6 +941,27 @@ def test_redeem_marks_token_used(magic_link_client, magic_link_module):
     assert second.json()["detail"] == "Invalid or expired magic link"
 
 
+def test_guest_reusable_flag_requires_a_json_boolean(
+    magic_link_client, magic_link_module
+):
+    gen = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "alice"},
+        headers=magic_link_client.auth_headers,
+    )
+    token = gen.json()["token"]
+    store = magic_link_module._ensure_store()
+    store["tokens"][0]["reusable"] = "false"
+    magic_link_module._write_store(store)
+
+    first = magic_link_client.get(f"/auth/magic-link/{token}", follow_redirects=False)
+    second = magic_link_client.get(f"/auth/magic-link/{token}", follow_redirects=False)
+
+    assert first.status_code == 302
+    assert second.status_code == 404
+    assert second.json()["detail"] == "Invalid or expired magic link"
+
+
 # ---------------------------------------------------------------------------
 # Redeem failure modes — all must return the same opaque 404
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

Guest magic links are single-use unless their stored record explicitly enables reuse. Python truthiness made the persisted string false reusable, allowing repeated redemption of a token that the record appeared to mark single-use.

The invariant is: only JSON boolean true makes a guest token reusable. Owner tokens keep their intentional always-reusable contract. A schema-invalid guest value fails closed and is consumed after the first successful redemption.

## Overlap check

Searched open and closed PRs for magic link reusable string false and _normalize_record, plus every open PR touching magic_link.py. #2996/#2321 address revoke-prefix ambiguity, #2995 unreadable stores, #2522 expiry validation, #2521 store-root shape, #2413 legacy timestamps, and #2236/#2020 file permissions. None covers the reusable scalar or redemption cardinality. This scope is independent.

## Validation

- pytest -q tests/test_magic_link.py (67 passed; 1 framework warning)
- git diff --check

The regression writes a schema-incompatible receipt to the real token store, redeems through /auth/magic-link/{token}, and proves the second redemption returns the same opaque 404 as other invalid links.

## Tradeoffs, review, and rollback

This intentionally revokes repeat-use behavior from malformed legacy guest records. Valid reusable booleans and owner-card tokens are unchanged. No store migration is required because normalization applies on read. Because this is an authentication lifecycle change, it should receive independent human review before merge. Rollback is one normalization expression.
