### PR TITLE
fix(remote-provider): validate boolean receipts

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -118,12 +118,12 @@ def _safe_probe_receipt(value: Any) -> dict[str, Any] | None:
     clean_resolution = None
     if isinstance(resolution, Mapping):
         clean_resolution = {
-            "ok": bool(resolution.get("ok")),
+            "ok": resolution.get("ok") is True,
             "addressCount": _safe_int(resolution.get("addressCount")),
         }
     receipt: dict[str, Any] = {
         "schema": _safe_text(value.get("schema"), max_length=64),
-        "ok": bool(value.get("ok")),
+        "ok": value.get("ok") is True,
         "verifiedAt": _safe_text(value.get("verifiedAt"), max_length=64),
         "endpoint": _safe_text(value.get("endpoint"), max_length=32),
         "httpStatus": _safe_int(value.get("httpStatus")),
@@ -139,7 +139,7 @@ def _safe_probe_receipt(value: Any) -> dict[str, Any] | None:
 def _safe_route_status(value: Any) -> dict[str, Any]:
     status = value if isinstance(value, Mapping) else {}
     clean: dict[str, Any] = {
-        "proven": bool(status.get("proven")),
+        "proven": status.get("proven") is True,
         "reason": _safe_text(status.get("reason"), max_length=128) or "disabled",
     }
     last_probe = _safe_probe_receipt(status.get("lastProbe"))
@@ -215,7 +215,7 @@ def _safe_secret_status(value: Any) -> dict[str, Any]:
     secret = value if isinstance(value, Mapping) else {}
     raw_bytes = secret.get("bytes")
     return {
-        "configured": bool(secret.get("configured")),
+        "configured": secret.get("configured") is True,
         "bytes": raw_bytes if type(raw_bytes) is int or raw_bytes is None else None,
     }
 
@@ -495,8 +495,8 @@ def _safe_ssh_supervisor_status(
         "valid": schema == _SSH_SUPERVISOR_SCHEMA,
         "schema": schema,
         "status": _safe_text(payload.get("status"), max_length=64) or "unknown",
-        "ready": bool(payload.get("ready")),
-        "readyToStart": bool(payload.get("readyToStart")),
+        "ready": payload.get("ready") is True,
+        "readyToStart": payload.get("readyToStart") is True,
         "reason": _safe_text(payload.get("reason"), max_length=128) or "unknown",
         "tunnelBaseUrl": _safe_text(payload.get("tunnelBaseUrl"), max_length=256) or None,
         "tunnels": tunnels,
@@ -519,8 +519,8 @@ def _safe_egress_tunnel(value: Any) -> dict[str, Any] | None:
             "pid": _safe_int(process.get("pid")),
         }
     tunnel: dict[str, Any] = {
-        "ok": bool(value.get("ok")),
-        "ready": bool(value.get("ready")),
+        "ok": value.get("ok") is True,
+        "ready": value.get("ready") is True,
         "status": _safe_text(value.get("status"), max_length=64) or "unknown",
         "reason": _safe_text(value.get("reason"), max_length=128) or "unknown",
         "process": clean_process,
@@ -592,7 +592,7 @@ def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
     clean_resolution = None
     if isinstance(resolution, Mapping):
         clean_resolution = {
-            "ok": bool(resolution.get("ok")),
+            "ok": resolution.get("ok") is True,
             "reason": _safe_text(resolution.get("reason"), max_length=128),
             "addressCount": (
                 resolution.get("addressCount")
@@ -603,7 +603,7 @@ def _sanitize_egress_health(payload: Any) -> dict[str, Any]:
     return {
         "reachable": True,
         "valid": True,
-        "ready": bool(payload.get("ready")),
+        "ready": payload.get("ready") is True,
         "status": _safe_text(payload.get("status"), max_length=64) or "unknown",
         "reason": _safe_text(payload.get("reason"), max_length=128),
         "secret": _safe_secret_status(payload.get("secret")),
@@ -636,7 +636,7 @@ def _sanitize_egress_probe_response(payload: Any) -> dict[str, Any]:
         raise ValueError("invalid_egress_probe_response")
     return {
         "schema": schema,
-        "ok": bool(payload.get("ok")),
+        "ok": payload.get("ok") is True,
         "transport": _safe_text(payload.get("transport"), max_length=32),
         "probe": probe,
         "tunnel": _safe_egress_tunnel(payload.get("tunnel")),

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_status.py
@@ -59,6 +59,58 @@ def test_remote_provider_status_requires_auth(test_client):
     assert resp.status_code == 401
 
 
+def test_remote_provider_receipts_require_json_booleans():
+    from routers import remote_provider_status as rps
+
+    probe = rps._safe_probe_receipt({
+        "ok": "false",
+        "resolution": {"ok": 1},
+    })
+    route = rps._safe_route_status({"proven": "false", "lastProbe": {"ok": 1}})
+    supervisor = rps._safe_ssh_supervisor_status({
+        "schema": "ods.remote-provider-ssh-supervisor-plan.v1",
+        "ready": "false",
+        "readyToStart": 1,
+        "secrets": {"sshIdentity": {"configured": "false"}},
+    })
+
+    assert probe is not None
+    assert probe["ok"] is False
+    assert probe["resolution"]["ok"] is False
+    assert route["proven"] is False
+    assert route["lastProbe"]["ok"] is False
+    assert supervisor["ready"] is False
+    assert supervisor["readyToStart"] is False
+    assert supervisor["secrets"]["sshIdentity"]["configured"] is False
+
+
+def test_remote_provider_egress_receipts_require_json_booleans():
+    from routers import remote_provider_status as rps
+
+    health = rps._sanitize_egress_health({
+        "ready": "false",
+        "secret": {"configured": 1},
+        "resolution": {"ok": "false"},
+        "tunnel": {"ok": "false", "ready": 1},
+    })
+    probe = rps._sanitize_egress_probe_response({
+        "schema": "ods.remote-provider-egress-probe.v1",
+        "ok": "false",
+        "probe": {"ok": "false"},
+        "tunnel": {"ok": 1, "ready": "false"},
+    })
+
+    assert health["ready"] is False
+    assert health["secret"]["configured"] is False
+    assert health["resolution"]["ok"] is False
+    assert health["tunnel"]["ok"] is False
+    assert health["tunnel"]["ready"] is False
+    assert probe["ok"] is False
+    assert probe["probe"]["ok"] is False
+    assert probe["tunnel"]["ok"] is False
+    assert probe["tunnel"]["ready"] is False
+
+
 def test_remote_provider_status_missing_state_is_disabled(
     test_client,
     monkeypatch,


### PR DESCRIPTION
## Why this matters

Remote-provider readiness aggregates routing state, host-agent SSH supervision, egress health, DNS/tunnel proof, secret presence, and probe receipts. Python truthiness allowed schema-invalid values such as string false or numeric 1 to become positive proof. The dashboard could therefore expose lifecycle actions or report a route ready without a valid boolean receipt.

The invariant is: every positive proof at these external I/O boundaries must be the JSON boolean true. Invalid leaf values fail closed while sanitized diagnostic text and numeric evidence remain available.

## Overlap check

Searched open and closed PRs for remote provider status boolean sanitization, _safe_probe_receipt, and the production file remote_provider_status.py. Open PR #2733 adds egress caller authentication and #2710 bounds peer-response streaming. Neither changes sanitization of readiness/proof fields. No semantic match was found across open or closed PRs.

## Validation

- pytest -q tests/test_remote_provider_status.py (28 passed; 1 framework warning)
- git diff --check

Regression tests cover route/probe, SSH supervisor, secret, egress health, DNS resolution, and tunnel receipts through the sanitizer functions used by /api/remote-provider/status and the probe lifecycle.

## Tradeoffs, review, and rollback

Schema-incompatible legacy supervisors or egress services now report not-ready until upgraded. Shipped producers already emit booleans. No mutations, retries, or persisted-state format changes are introduced. Because these receipts gate remote inference and credential-backed lifecycle actions, independent human review is required before merge. Rollback restores the eleven truthiness conversions.
