### PR TITLE
fix(egress): require boolean stream flags

### DIFF
--- a/ods/bin/remote_provider/egress.py
+++ b/ods/bin/remote_provider/egress.py
@@ -385,6 +385,13 @@ def prepare_upstream_request(
         raise EgressError(400, "invalid_json", f"invalid JSON body: {exc}") from exc
     if not isinstance(payload, dict):
         raise EgressError(400, "invalid_json", "request body must be a JSON object")
+    stream = payload.get("stream", False)
+    if type(stream) is not bool:
+        raise EgressError(
+            400,
+            "invalid_request",
+            "stream must be a JSON boolean when provided",
+        )
     requested_model = str(payload.get("model") or PUBLIC_MODEL_ALIAS)
     provider_model = str(provider.get("model") or "")
     payload["model"] = provider_model
@@ -396,7 +403,7 @@ def prepare_upstream_request(
         content=content,
         requested_model=requested_model,
         provider_model=provider_model,
-        stream=bool(payload.get("stream")),
+        stream=stream,
         tls_server_name=tls_server_name,
         host_header=host_header,
         connection_key=connection_key,

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -168,6 +168,37 @@ def test_route_state_prepares_direct_provider_request_without_client_auth() -> N
     assert_true("connection" not in {key.lower() for key in upstream.headers}, "hop-by-hop headers must be stripped")
 
 
+def test_request_stream_flag_requires_a_json_boolean() -> None:
+    route = route_from_state(route_state())
+    for invalid in ("false", 1, None, []):
+        error = assert_egress_error(
+            lambda invalid=invalid: prepare_upstream_request(
+                method="POST",
+                path="/v1/chat/completions",
+                headers={},
+                body=json.dumps({
+                    "model": "ods/current",
+                    "messages": [],
+                    "stream": invalid,
+                }).encode("utf-8"),
+                route=route,
+                provider_secret="unit-test-provider-token",
+            ),
+            "invalid_request",
+        )
+        assert_true(error.status == 400, "invalid stream flags must be client errors")
+
+    upstream = prepare_upstream_request(
+        method="POST",
+        path="/v1/chat/completions",
+        headers={},
+        body=b'{"model":"ods/current","messages":[],"stream":false}',
+        route=route,
+        provider_secret="unit-test-provider-token",
+    )
+    assert_true(upstream.stream is False, "JSON false must remain non-streaming")
+
+
 def test_direct_resolution_allows_only_global_provider_addresses() -> None:
     route = route_from_state(route_state())
     addresses = validate_direct_provider_resolution(
@@ -458,6 +489,7 @@ def main() -> int:
         test_manifest_and_network_policy_mark_no_lan_exposure,
         test_image_copies_shared_policy_package,
         test_route_state_prepares_direct_provider_request_without_client_auth,
+        test_request_stream_flag_requires_a_json_boolean,
         test_direct_resolution_allows_only_global_provider_addresses,
         test_direct_resolution_rejects_unsafe_dns_answers,
         test_ssh_route_uses_internal_tunnel_without_direct_dns,


### PR DESCRIPTION
## Why this matters

Remote-provider egress decides whether to stream the upstream response from the client request body. Python truthiness interpreted the JSON string false as streaming. The egress service could then select its streaming transaction path for a request that declared non-streaming semantics, producing the wrong response framing or waiting behavior.

The invariant is: stream is optional and defaults to false, but when present it must be a JSON boolean. Invalid scalar/container/null values return a 400 invalid_request before provider credentials are used.

## Overlap check

Searched open and closed PRs for remote provider egress stream boolean, prepare_upstream_request, and the production file egress.py. Open #2989 preserves forwarded query strings and is unrelated. PR #3045 enforces the same external OpenAI invariant in model-router, but remote-provider-egress is a separate credential-bearing implementation and does not call model-router; testing one does not cover the other. This PR changes only the egress boundary.

## Validation

- python tests/contracts/test-remote-provider-egress-service.py (16 contract checks passed)
- python -m py_compile bin/remote_provider/egress.py
- git diff --check

The boundary test covers string, number, null, and list counterexamples plus valid JSON false.

## Tradeoffs, review, and rollback

Schema-incompatible clients now receive 400 instead of accidental streaming. Valid omitted/true/false requests are unchanged. No provider request is attempted on rejection. Because this sits before credential injection and remote I/O, independent human review is required. Rollback removes the scalar check and restores truthiness conversion.
