### PR TITLE
fix(dashboard): keep telemetry polls single-flight

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -612,8 +612,11 @@ export default function Dashboard({ status, loading }) {
 
   useEffect(() => {
     let mounted = true
+    let inFlight = false
 
     const fetchFeatures = async () => {
+      if (inFlight) return
+      inFlight = true
       try {
         const res = await fetch('/api/features')
         if (!res.ok) return
@@ -621,6 +624,8 @@ export default function Dashboard({ status, loading }) {
         if (mounted) setFeaturesData(data)
       } catch {
         // Feature cards degrade gracefully to status-only view when API fails.
+      } finally {
+        inFlight = false
       }
     }
 
@@ -639,8 +644,11 @@ export default function Dashboard({ status, loading }) {
 
   useEffect(() => {
     let mounted = true
+    let inFlight = false
 
     const fetchServiceResources = async () => {
+      if (inFlight) return
+      inFlight = true
       try {
         const res = await fetch('/api/services/resources')
         if (!res.ok) return
@@ -648,6 +656,8 @@ export default function Dashboard({ status, loading }) {
         if (mounted) setServiceResources(data)
       } catch {
         // Service rows keep rendering status data when per-container metrics are unavailable.
+      } finally {
+        inFlight = false
       }
     }
 

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor, within } from '@testing-library/react'
 import { render } from '../test/test-utils'
 import Dashboard from './Dashboard' // eslint-disable-line no-unused-vars
 
@@ -112,6 +112,45 @@ describe('Dashboard system overview', () => {
     delete document.documentElement.dataset.theme
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('keeps auxiliary telemetry polls single-flight', async () => {
+    vi.useFakeTimers()
+    const featuresDeferred = createDeferred()
+    const resourcesDeferred = createDeferred()
+    fetch.mockImplementation(url => {
+      if (String(url).includes('/api/features')) return featuresDeferred.promise
+      if (String(url).includes('/api/services/resources')) return resourcesDeferred.promise
+      throw new Error(`Unmocked fetch: ${url}`)
+    })
+
+    render(<Dashboard status={baseStatus} loading={false} />)
+    const countCalls = path => fetch.mock.calls.filter(([url]) => String(url).includes(path)).length
+    expect(countCalls('/api/features')).toBe(1)
+    expect(countCalls('/api/services/resources')).toBe(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(30000)
+      await Promise.resolve()
+    })
+
+    expect(countCalls('/api/features')).toBe(1)
+    expect(countCalls('/api/services/resources')).toBe(1)
+
+    featuresDeferred.resolve({
+      ok: true,
+      json: async () => ({ features: [], suggestions: [], summary: { progress: 0 } }),
+    })
+    resourcesDeferred.resolve({ ok: true, json: async () => mockResources })
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      vi.advanceTimersByTime(15000)
+    })
+
+    expect(countCalls('/api/features')).toBe(2)
+    expect(countCalls('/api/services/resources')).toBe(2)
   })
 
   it('renders the system overview panel and both telemetry charts', async () => {


### PR DESCRIPTION
Keep Dashboard feature and resource polling single-flight independently.

## Why this matters
Slow feature/resource responses currently accumulate every interval and visibility event, adding avoidable load while the host is already busy.

Root cause: Each telemetry effect starts new requests without recording an outstanding full receipt.

Behavioral invariant: The features and resources effects each permit one pending observation and admit the next poll after it settles.

## Implementation and compatibility
Use effect-local in-flight guards released in finally. Keep independent endpoint state, existing visibility pause/resume and last-observed data.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/pages/Dashboard.jsx`.

Relevant same-file results: #5125 (open: feat(dashboard): export received service resource snapshots), #4207 (merged: feat(beta): workspace UX, Portal mascot and Settings refinement)

#5125 exports received resource snapshots and does not own the polling admission path. Preserve #4207's compact dashboard composition. This is the original #3062 polling fix adapted to current beta.

## Regression and validation
Candidate commit: `fa21b4ef62b1c1635721b5ebe2bfecd61fae5763`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/pages/Dashboard` — **26 passed**.
- The public Dashboard test holds both endpoints beyond several intervals, asserts one request each, then resolves and proves polling resumes. It fails against beta; all 26 candidate tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `fa21b4ef62b1c1635721b5ebe2bfecd61fae5763`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: External #5125 conflicts in Dashboard.jsx. Preserve the feature/resource in-flight guards when wiring its resource-export UI; that external combination was not runtime-tested.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
