### PR TITLE
fix(talk): guard duplicate text submissions

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -83,6 +83,7 @@ export default function ODSTalk() {
   const recorderRef = useRef(null)
   const recordingChunksRef = useRef([])
   const streamControllerRef = useRef(null)
+  const textSendInFlightRef = useRef(false)
   // Track the currently-playing TTS state so we can shut down whatever
   // is in flight before starting the next reply's audio.
   const activeSpeechRef = useRef(null)
@@ -370,7 +371,8 @@ export default function ODSTalk() {
     // prompt for images ("Describe what you see in this image."). Without
     // either a caption or an attachment, there's nothing to send.
     if (!clean && !attachment) return
-    if (sending || status !== 'ready') return
+    if (sending || textSendInFlightRef.current || status !== 'ready') return
+    textSendInFlightRef.current = true
     setSending(true)
 
     const userId = transcriptId || makeId('user')
@@ -527,6 +529,7 @@ export default function ODSTalk() {
       if (streamControllerRef.current === controller) {
         streamControllerRef.current = null
       }
+      textSendInFlightRef.current = false
       setSending(false)
     }
   }, [sending, speak, status])

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { render } from '../test/test-utils'
 import ODSTalk from './ODSTalk' // eslint-disable-line no-unused-vars
 
@@ -96,6 +96,39 @@ describe('ODSTalk', () => {
 
     expect(await screen.findByText('What can you do?')).toBeInTheDocument()
     expect(await screen.findByText('I can help from this ODS.')).toBeInTheDocument()
+  })
+
+  test('submits one text turn when submit events arrive in the same task', async () => {
+    let releaseStream
+    const pendingStream = new Promise(resolve => { releaseStream = resolve })
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') {
+        return response({ capabilities: { text_chat: true } })
+      }
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
+        await pendingStream
+        return sseResponse([{ type: 'done' }])
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ODSTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Message ODS'), {
+      target: { value: 'send once' },
+    })
+    const form = screen.getByRole('button', { name: 'Send message' }).closest('form')
+
+    await act(async () => {
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }))
+      await Promise.resolve()
+    })
+
+    const sends = fetchMock.mock.calls.filter(([url]) => url === '/api/talk/message/stream')
+    expect(sends).toHaveLength(1)
+    releaseStream()
   })
 
   test('shows model compatibility reason and disables send when text chat is blocked', async () => {


### PR DESCRIPTION
## Why this matters

ODS Talk used React state as its only text-send guard. Two submit events delivered in the same browser task both observed the stale sending=false closure, created duplicate user/assistant bubbles, and issued two POSTs. The second request also aborted the first stream through the shared AbortController, so a fast double activation could cancel the valid turn it duplicated.

The invariant is: only one text/attachment stream transaction may enter before React commits the pending state. A synchronous ref acquires at the function boundary and releases in finally for success, HTTP failure, abort, or parser failure.

## Overlap check

Searched open and closed PRs for ODS Talk duplicate message/send and the production file ODSTalk.jsx. Open #2959 releases the microphone on navigation and #1573 is a broad native-RAG feature; neither changes text submit concurrency or stream ownership. No semantic duplicate was found.

## Validation

- Regression on upstream main: expected one POST, observed two
- npm test -- --run src/pages/ODSTalk.test.jsx (16 passed)
- npm run lint -- --quiet
- git diff --check

The regression dispatches two native submit events in one task while the first SSE fetch remains pending and asserts one /api/talk/message/stream call.

## Tradeoffs and rollback

Duplicate activations are dropped, not queued. Retry remains available after the active transaction settles, and audio-message state is unchanged. The ref mirrors the existing sending lifecycle and is released at the same terminal boundary. Rollback removes the ref check/acquire/release.
