### PR TITLE
fix(config): validate manifest service booleans

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -294,6 +294,15 @@ def _read_manifest_file(path: Path) -> dict[str, Any]:
     return data
 
 
+def _manifest_bool(service: dict[str, Any], key: str, default: bool) -> bool:
+    if key not in service:
+        return default
+    value = service[key]
+    if type(value) is not bool:
+        raise ValueError(f"service.{key} must be a boolean")
+    return value
+
+
 def load_extension_manifests(
     manifest_dir: Path, gpu_backend: str,
 ) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]], list[dict[str, str]]]:
@@ -343,6 +352,11 @@ def load_extension_manifests(
                 service_id = service.get("id")
                 if not service_id:
                     raise ValueError("service.id is required")
+                external_link = _manifest_bool(service, "external_link", True)
+                macos_host_supported = _manifest_bool(
+                    service, "macos_host_supported", False
+                )
+                host_network = _manifest_bool(service, "host_network", False)
                 compose_file = str(service.get("compose_file") or "").strip()
                 if service.get("type") == "docker" and compose_file:
                     compose_path = ext_dir / compose_file
@@ -357,7 +371,7 @@ def load_extension_manifests(
                 if gpu_backend == "apple":
                     if (
                         service.get("type") == "host-systemd"
-                        and not service.get("macos_host_supported", False)
+                        and not macos_host_supported
                     ):
                         continue  # Linux-only service, not available on macOS
                     # All docker services run on macOS regardless of gpu_backends declaration
@@ -385,12 +399,12 @@ def load_extension_manifests(
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
                     "public_url": public_url,
-                    "external_link": bool(service.get("external_link", True)),
-                    "macos_host_supported": bool(service.get("macos_host_supported", False)),
+                    "external_link": external_link,
+                    "macos_host_supported": macos_host_supported,
                     "container_name": service.get("container_name", f"ods-{service_id}"),
                     "depends_on": service.get("depends_on", []),
                     "category": service.get("category", "optional"),
-                    "host_network": bool(service.get("host_network", False)),
+                    "host_network": host_network,
                     "setup_hook": service.get("setup_hook", ""),
                     "hooks": service.get("hooks", {}),
                     "gpu_backends": service.get("gpu_backends", []),

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -411,6 +411,33 @@ class TestLoadExtensionManifests:
 
         assert services["host-network-service"]["host_network"] is True
 
+    @pytest.mark.parametrize(
+        ("field", "yaml_value"),
+        [
+            ("external_link", "'false'"),
+            ("macos_host_supported", "1"),
+            ("host_network", "[]"),
+        ],
+    )
+    def test_rejects_non_boolean_service_flags(self, tmp_path, field, yaml_value):
+        svc_dir = tmp_path / "invalid-flags"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: ods.services.v1\n"
+            "service:\n"
+            "  id: invalid-flags\n"
+            "  name: Invalid Flags\n"
+            "  port: 8080\n"
+            f"  {field}: {yaml_value}\n"
+        )
+
+        services, features, errors = load_extension_manifests(tmp_path, "nvidia")
+
+        assert services == {}
+        assert features == []
+        assert len(errors) == 1
+        assert errors[0]["error"] == f"service.{field} must be a boolean"
+
     def test_skips_wrong_schema_version(self, tmp_path):
         svc_dir = tmp_path / "old-service"
         svc_dir.mkdir()


### PR DESCRIPTION
## Why this matters

The dashboard service registry reads external_link, macos_host_supported, and host_network from shipped extension manifests. Python truthiness made quoted false, numeric 1, or a container act as enabled. That can expose the wrong launch behavior, include a Linux-only host service on macOS, or classify networking incorrectly.

The invariant is: these ods.services.v1 fields are booleans when present. Missing fields retain their documented defaults. A malformed manifest is skipped and surfaced through the existing manifest error receipt rather than being partially loaded.

## Overlap check

Searched open and closed PRs for manifest external_link/host_network/macos_host_supported booleans and load_extension_manifests. No semantic duplicate exists. Merged #271 established manifest error reporting, #701 skips disabled manifests, and #120 covers macOS Docker discovery; this PR reuses those contracts. PR #3048 validates the separate nested llm contract and does not cover service flags.

## Validation

- pytest -q tests/test_config.py (57 passed)
- git diff --check

Parameterized boundary tests load real YAML manifests with string, numeric, and list counterexamples and verify the service is absent plus a precise release-error receipt.

## Tradeoffs and rollback

This is release/configuration correctness, not a security claim: manifests are repository-owned. Invalid third-party manifests now fail as a unit instead of being coerced, while valid and omitted fields are unchanged. No schema version bump is needed because booleans are already the intended v1 types. Rollback removes the helper and restores coercion.
