### PR TITLE
fix(dashboard): keep extension progress polls single-flight

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -103,6 +103,7 @@ export default function Extensions() {
   const [pollingLost, setPollingLost] = useState(false)
   const installProgressRef = useRef(null)
   const activePollers = useRef({})
+  const progressPollInFlight = useRef({})
   // Per-service recovery tracker: counts consecutive fetch failures and
   // fires onThresholdReached/onRecovered to drive the polling-lost banner.
   // Keyed by serviceId because multiple installs can be polling concurrently.
@@ -121,6 +122,8 @@ export default function Extensions() {
       onRecovered: () => setPollingLost(prev => (prev ? false : prev)),
     })
     activePollers.current[serviceId] = setInterval(async () => {
+      if (progressPollInFlight.current[serviceId]) return
+      progressPollInFlight.current[serviceId] = true
       try {
         const res = await fetchJson(`/api/extensions/${serviceId}/progress`)
         // Successful fetch (regardless of HTTP status) means the dashboard
@@ -166,6 +169,8 @@ export default function Extensions() {
         // at a silent spinner forever.
         console.warn('poll fetch failed:', err)
         recoveryTrackers.current[serviceId]?.recordFailure()
+      } finally {
+        delete progressPollInFlight.current[serviceId]
       }
     }, 3000)
   }
@@ -179,6 +184,7 @@ export default function Extensions() {
     return () => {
       Object.values(activePollers.current).forEach(clearInterval)
       activePollers.current = {}
+      progressPollInFlight.current = {}
       recoveryTrackers.current = {}
     }
   }, [])

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -1121,7 +1121,10 @@ function ConsoleModal({ ext, onClose }) {
   // Fetch install progress info
   useEffect(() => {
     let active = true
+    let inFlight = false
     const fetchProgress = async () => {
+      if (inFlight) return
+      inFlight = true
       try {
         const res = await fetchJson(`/api/extensions/${ext.id}/progress`)
         if (res.ok && active) {
@@ -1129,6 +1132,7 @@ function ConsoleModal({ ext, onClose }) {
           if (data.status !== 'idle') setInstallInfo(data)
         }
       } catch { /* ignore */ }
+      finally { inFlight = false }
     }
     fetchProgress()
     const interval = setInterval(fetchProgress, 5000)

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -121,6 +121,64 @@ describe('Extensions page — unhealthy + install derivations', () => {
     expect(progressCallCount()).toBe(2)
   })
 
+  it('keeps the logs modal progress polling single-flight', async () => {
+    vi.useFakeTimers()
+    const catalog = {
+      extensions: [{
+        id: 'console-progress',
+        name: 'Console Progress',
+        status: 'enabled',
+        source: 'user',
+        installable: true,
+        features: [baseFeature],
+        description: 'Enabled extension with a slow progress response.',
+      }],
+      summary: baseSummary({ installed: 1 }),
+      gpu_backend: 'nvidia',
+      agent_available: true,
+    }
+    let resolveProgress
+    const pendingProgress = new Promise((resolve) => { resolveProgress = resolve })
+    const fetchMock = vi.fn((url) => {
+      const target = String(url)
+      if (target.includes('/api/extensions/catalog')) {
+        return Promise.resolve(makeJsonResponse(catalog))
+      }
+      if (target.includes('/api/templates')) {
+        return Promise.resolve(makeJsonResponse({ templates: [] }))
+      }
+      if (target.includes('/api/extensions/console-progress/progress')) {
+        return pendingProgress
+      }
+      if (target.includes('/api/extensions/console-progress/logs')) {
+        return Promise.resolve(makeJsonResponse({ logs: 'ready' }))
+      }
+      return Promise.reject(new Error(`Unmocked fetch: ${target}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Extensions />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Logs' }))
+    await act(async () => { await Promise.resolve() })
+
+    const progressCallCount = () => fetchMock.mock.calls.filter(
+      ([url]) => String(url).includes('/api/extensions/console-progress/progress'),
+    ).length
+    expect(progressCallCount()).toBe(1)
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(progressCallCount()).toBe(1)
+
+    resolveProgress(makeJsonResponse({ status: 'started', phase_label: 'Starting' }))
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(progressCallCount()).toBe(2)
+  })
+
   it('renders amber unhealthy badge for unhealthy user ext', async () => {
     installFetchMock({
       extensions: [

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { render } from '../test/test-utils'
 import Extensions from './Extensions' // eslint-disable-line no-unused-vars
 
@@ -65,6 +65,62 @@ afterEach(() => {
 })
 
 describe('Extensions page — unhealthy + install derivations', () => {
+  it('keeps slow install-progress polling single-flight', async () => {
+    vi.useFakeTimers()
+    const catalog = {
+      extensions: [{
+        id: 'slow-install',
+        name: 'Slow Install',
+        status: 'installing',
+        source: 'user',
+        installable: true,
+        features: [baseFeature],
+        description: 'Installation whose progress endpoint is slower than the poll cadence.',
+      }],
+      summary: baseSummary({ installing: 1 }),
+      gpu_backend: 'nvidia',
+      agent_available: true,
+    }
+    let resolveProgress
+    const pendingProgress = new Promise((resolve) => { resolveProgress = resolve })
+    const fetchMock = vi.fn((url) => {
+      const target = String(url)
+      if (target.includes('/api/extensions/catalog')) {
+        return Promise.resolve(makeJsonResponse(catalog))
+      }
+      if (target.includes('/api/templates')) {
+        return Promise.resolve(makeJsonResponse({ templates: [] }))
+      }
+      if (target.includes('/api/extensions/slow-install/progress')) {
+        return pendingProgress
+      }
+      return Promise.reject(new Error(`Unmocked fetch: ${target}`))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Extensions />)
+    await act(async () => {
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+    expect(screen.getByText('Slow Install')).toBeInTheDocument()
+
+    const progressCallCount = () => fetchMock.mock.calls.filter(
+      ([url]) => String(url).includes('/api/extensions/slow-install/progress'),
+    ).length
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(progressCallCount()).toBe(1)
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(progressCallCount()).toBe(1)
+
+    resolveProgress(makeJsonResponse({ status: 'installing', phase_label: 'Pulling image' }))
+    await act(async () => { await Promise.resolve() })
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(progressCallCount()).toBe(2)
+  })
+
   it('renders amber unhealthy badge for unhealthy user ext', async () => {
     installFetchMock({
       extensions: [


### PR DESCRIPTION
Prevent overlapping extension-install progress observations in the library and console.

## Why this matters
Progress responses slower than the polling cadence currently stack requests, increasing host load during installations.

Root cause: Each interval starts another progress read without checking whether the preceding full receipt has settled.

Behavioral invariant: Each service poller and the console progress observer permit one outstanding read, releasing their guard on success or failure.

## Implementation and compatibility
Add per-service progress guards and an effect-local console-progress guard. Retain the existing recovery banner, terminal catalog refresh and cleanup. This does not change backend installation admission or add an automatic retry loop.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/pages/Extensions.jsx`.

Relevant same-file results: #5009 (open: feat(extensions): add local text-to-diagram rendering API), #5003 (open: feat(extensions): add offline spelling and grammar API), #4961 (open: fix(aider): make the advertised CLI launch reach Aider), #3848 (open: feat(extensions): save browser-local extension favorites), #5238 (merged: fix(dashboard): preserve internal-only service port declarations), #5067 (merged: fix(dashboard): serialize manual and automatic console log reads), #5065 (merged: fix(dashboard): honor extension update confirmation states), #4982 (merged: fix(extensions): show credentials from the installation config), #4207 (merged: feat(beta): workspace UX, Portal mascot and Settings refinement)

#5067 serializes console LOG reads; this PR serializes progress reads, a different endpoint and state consumer. #3315 changes recovery control eligibility and #3848 adds favorites. The selected #3315 is included in the tested integration; external #3848 is checked separately by a textual merge probe only.

## Regression and validation
Candidate commit: `1da50fc9bd81adac93c98f2d67b8c6e4849636a7`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/pages/Extensions` — **29 passed**.
- Both slow library-progress and console-progress tests fail on beta source; all 29 candidate extension page, console and modal tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `1da50fc9bd81adac93c98f2d67b8c6e4849636a7`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #3315, progress guards and recovery-control eligibility merge cleanly, including the union of tests. External #3848 has a clean textual merge only.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
