### PR TITLE
fix(update): publish configuration backups transactionally

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -565,6 +565,11 @@ cmd_status() {
 
 cmd_backup() {
     local backup_name="${1:-}"
+    if [[ -n "$backup_name" && ! "$backup_name" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$ ]]; then
+        log_error "Invalid backup name. Use 1-64 letters, numbers, underscores, or hyphens."
+        return 1
+    fi
+
     local timestamp
     timestamp=$(date +%Y%m%d-%H%M%S)
     local backup_id="backup-${timestamp}"
@@ -574,10 +579,27 @@ cmd_backup() {
     fi
     
     local backup_path="${BACKUP_DIR}/${backup_id}"
+    local lock_path="${BACKUP_DIR}/.${backup_id}.lock"
+    local staging_path=""
     
     log_info "Creating backup: ${backup_id}"
-    
-    mkdir -p "$backup_path"
+
+    mkdir -p "$BACKUP_DIR"
+    if ! mkdir "$lock_path"; then
+        log_error "Backup already in progress: ${backup_id}"
+        return 1
+    fi
+    if [[ -e "$backup_path" ]]; then
+        rmdir "$lock_path"
+        log_error "Backup already exists: ${backup_id}"
+        return 1
+    fi
+
+    # Build out of sight, then publish with one rename. Interrupted copies or
+    # metadata failures must never leave a partial directory that rollback can
+    # select as the newest backup.
+    trap 'if [[ -n "${staging_path:-}" && -d "$staging_path" ]]; then rm -rf "$staging_path" || log_warn "Could not remove incomplete backup staging directory: $staging_path"; fi; if [[ -n "${lock_path:-}" && -d "$lock_path" ]]; then rmdir "$lock_path" || log_warn "Could not remove backup lock: $lock_path"; fi' ERR EXIT
+    staging_path=$(mktemp -d "${BACKUP_DIR}/.${backup_id}.tmp.XXXXXX")
     
     # Backup compose files
     # NB: x=$((x + 1)) not ((x++)) — the post-increment form evaluates to 0
@@ -587,7 +609,7 @@ cmd_backup() {
     for pattern in "docker-compose*.yml" "docker-compose*.yaml" ".env" ".env.*"; do
         for file in "${INSTALL_DIR}"/${pattern}; do
             if [[ -f "$file" ]]; then
-                cp "$file" "$backup_path/"
+                cp "$file" "$staging_path/"
                 files_backed_up=$((files_backed_up + 1))
             fi
         done
@@ -595,7 +617,7 @@ cmd_backup() {
 
     # Backup version file
     if [[ -f "$VERSION_FILE" ]]; then
-        cp "$VERSION_FILE" "$backup_path/.version"
+        cp "$VERSION_FILE" "$staging_path/.version"
         files_backed_up=$((files_backed_up + 1))
     fi
     
@@ -607,7 +629,13 @@ cmd_backup() {
         --argjson fc "$files_backed_up" \
         --arg dir "$INSTALL_DIR" \
         '{backup_id: $bid, timestamp: $ts, version: $ver, files_count: $fc, install_dir: $dir}' \
-        > "$backup_path/metadata.json"
+        > "$staging_path/metadata.json"
+
+    mv "$staging_path" "$backup_path"
+    staging_path=""
+    rmdir "$lock_path"
+    lock_path=""
+    trap - ERR EXIT
     
     log_ok "Backup created: ${backup_path}"
     log_info "Files backed up: ${files_backed_up}"

--- a/ods/tests/test-update-script-backup.sh
+++ b/ods/tests/test-update-script-backup.sh
@@ -111,6 +111,84 @@ else
     fail "rotation removed the backup it just created"
 fi
 
+# ---------------------------------------------------------------------------
+# 4. backup labels cannot escape the backup directory
+# ---------------------------------------------------------------------------
+rm -rf "$BACKUPS"
+mkdir -p "$BACKUPS"
+output=$(run_backup "../../../escaped")
+
+if echo "$output" | grep -q "Invalid backup name" && \
+        ! find "$FIXTURE/home/.ods" -type d -name "escaped-*" | grep -q .; then
+    pass "backup rejects path-like labels before writing"
+else
+    fail "path-like backup label escaped or was accepted: $output"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. failed backups never become visible rollback candidates
+# ---------------------------------------------------------------------------
+rm -rf "$BACKUPS"
+mkdir -p "$BACKUPS"
+FAIL_BIN="$FIXTURE/fail-bin"
+mkdir -p "$FAIL_BIN"
+printf '#!/bin/sh\nexit 17\n' > "$FAIL_BIN/cp"
+chmod +x "$FAIL_BIN/cp"
+output=$(PATH="$FAIL_BIN:$PATH" run_backup broken)
+
+if ! find "$BACKUPS" -maxdepth 1 -type d -name "backup-broken-*" | grep -q . && \
+        ! find "$BACKUPS" -maxdepth 1 -type d -name ".backup-broken-*" | grep -q .; then
+    pass "failed backup leaves no final or staging directory"
+else
+    remaining_failed=$(find "$BACKUPS" -maxdepth 1 -type d -name "*backup-broken-*" -print)
+    fail "failed backup remained selectable ($remaining_failed): $output"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. a repeated backup id cannot overwrite a completed snapshot
+# ---------------------------------------------------------------------------
+rm -rf "$BACKUPS"
+mkdir -p "$BACKUPS"
+DATE_BIN="$FIXTURE/date-bin"
+mkdir -p "$DATE_BIN"
+# shellcheck disable=SC2016  # ${1:-} belongs to the generated date stub.
+printf '%s\n' \
+    '#!/bin/sh' \
+    'if [ "${1:-}" = "-u" ]; then' \
+    '  echo 2026-08-23T12:34:56Z' \
+    'else' \
+    '  echo 20260823-123456' \
+    'fi' > "$DATE_BIN/date"
+chmod +x "$DATE_BIN/date"
+
+first_output=$(PATH="$DATE_BIN:$PATH" run_backup collision)
+echo '{"version": "9.9.9"}' > "$FIXTURE/.version"
+second_output=$(PATH="$DATE_BIN:$PATH" run_backup collision)
+collision_count=$(find "$BACKUPS" -maxdepth 1 -type d -name "backup-collision-*" | wc -l)
+collision_dir=$(find "$BACKUPS" -maxdepth 1 -type d -name "backup-collision-*" | head -1)
+
+if [[ "$collision_count" -eq 1 ]] && \
+        grep -q '"version": "2.0.0"' "$collision_dir/.version" && \
+        echo "$second_output" | grep -Eq "already exists|already in progress"; then
+    pass "repeated backup id preserves the completed snapshot"
+else
+    fail "repeated backup id overwrote or duplicated the snapshot: first=$first_output second=$second_output"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. an in-progress backup id rejects a concurrent writer
+# ---------------------------------------------------------------------------
+rm -rf "$BACKUPS"
+mkdir -p "$BACKUPS/.backup-concurrent-20260823-123456.lock"
+output=$(PATH="$DATE_BIN:$PATH" run_backup concurrent)
+
+if echo "$output" | grep -q "Backup already in progress" && \
+        ! find "$BACKUPS" -maxdepth 1 -type d -name "backup-concurrent-*" | grep -q .; then
+    pass "backup lock rejects a concurrent writer"
+else
+    fail "backup ignored an active transaction lock: $output"
+fi
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]] || exit 1


### PR DESCRIPTION
**Ready for independent review (2026-09-15).** Candidate `ef87fcea7e3ee198a94ebc1330b1e4ba47aacdca` has a successful GitHub check rollup and no base-branch conflict at this review snapshot. This supersedes earlier draft-status wording only. All validation gaps, migration requirements, live gates and independent human review requirements below remain in force; this is not a merge-ready approval.

## Why this matters

`ods-update.sh backup` produces the configuration snapshot that operators can later select through `ods-update.sh rollback`. Today it creates the final `backup-*` directory before copying any files. A failed copy or metadata write therefore leaves a partial directory that looks like a valid rollback candidate. Two calls with the same name in the same second also share that directory and silently overwrite/mix contents. Direct CLI labels are interpolated into the path without the host-agent's label validation, so path-like names can escape the intended leaf directory.

All three paths are reachable through the shipped Bash command; same-ID calls are also reachable through concurrent dashboard backup requests. A successful-looking or selectable partial backup weakens the update safety net exactly when rollback is needed.

## Root cause and invariant

Root cause: backup construction and publication were the same directory operation (`mkdir -p` on the final path), with no transaction boundary, duplicate writer guard, or validation at the Bash entry point.

Invariant: only a fully copied snapshot with valid metadata may appear under the public `backup-*` namespace; one ID has one writer and can never overwrite a completed snapshot; labels remain plain identifiers at every entry point.

## What changed

- Validate optional backup names with the same 1-64 character plain-label contract enforced by the host agent.
- Acquire a hidden per-ID directory lock before writing.
- Build into a unique hidden `mktemp -d` staging directory.
- Clean staging and lock paths on command errors/exits, with logged cleanup failures.
- Atomically rename the completed staging directory into the existing final naming scheme only after metadata succeeds.
- Refuse IDs that are already in progress or already complete instead of merging into their directories.
- Extend the real-script fixture with traversal, injected copy failure, repeated-ID preservation, and active-lock regressions.

## Overlap check

Searched open and closed PRs for backup traversal/name validation, partial/transactional backups, concurrent backup collisions, and scanned every open PR changing `ods/ods-update.sh`.

- #3018 changes full data/model backup/restore behavior and only touches the changelog section of `ods-update.sh`; it does not change `cmd_backup`.
- #2709 owns source rollback after failed releases, not general-backup publication.
- #1755 and #2455 own compose resolution during rollback/update.
- #2863, #2874, #2880, #3017, and other file-level matches cover prerequisites, a version temp file, health output, or changelog behavior.
- No semantic or file-level match owns label containment, partial publication, or duplicate writers in `cmd_backup`.

## Focused validation

Concrete red evidence on the pre-fix production script after adding the first three regressions:

- `bash tests/test-update-script-backup.sh` ? **6 passed, 3 failed**: path-like label accepted, failed copy left a selectable directory, repeated ID overwrote the completed snapshot.

After the fix:

- `bash tests/test-update-script-backup.sh` ? **10 passed, 0 failed**
- `bash tests/test-ods-update-runtime-compose.sh` ? **5 passed**
- `bash tests/test-update-rollback-contract.sh` ? **5 passed**
- `bash -n ods-update.sh tests/test-update-script-backup.sh` ? passed
- `shellcheck --rcfile /dev/null --severity=error ods-update.sh tests/test-update-script-backup.sh` ? passed
- `git diff --check` ? passed

The ordinary local ShellCheck invocation could not parse the checkout's CRLF `.shellcheckrc` and also reported pre-existing warnings in unrelated lines; the explicit error-severity run bypassed that local config artifact. No live operator backup or rollback was performed. The real script ran against isolated temporary HOME/install fixtures and the rollback contract verified restored hashes.

## Design, platform, and rollback

The final `backup-<name>-<timestamp>` format and lexicographic rotation behavior remain unchanged. Hidden staging/lock names do not match rollback or rotation globs. Directory creation, `mktemp -d`, `mv`, and traps are available on the supported Bash paths: Linux, macOS, and Windows through WSL2/Git Bash; the focused suite ran under Git Bash on Windows.

A process killed without a catchable exit may leave hidden staging/lock directories, but they are deliberately invisible to rollback selection. A later timestamp remains usable, and operators can inspect/remove stale hidden paths manually. This PR does not add automatic stale-lock deletion because guessing whether another writer is alive would weaken the one-writer invariant.

Rollback is a normal revert, but restores partial-publication and same-ID overwrite behavior. Human review is requested because this code protects rollback artifacts.
