### PR TITLE
fix(helpers): add robust service health status resilience and unit test suite

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -123,9 +123,22 @@ async def _get_httpx_client() -> httpx.AsyncClient:
 
 
 def _service_status_from_config(service_id: str, config: dict, status: str) -> ServiceStatus:
+    if not isinstance(config, dict):
+        config = {}
+    name = str(config.get("name") or service_id)
+    try:
+        port = int(config.get("port") or 0)
+    except (TypeError, ValueError):
+        port = 0
+
+    try:
+        external_port = int(config.get("external_port") or port)
+    except (TypeError, ValueError):
+        external_port = port
+
     return ServiceStatus(
-        id=service_id, name=config["name"], port=config["port"],
-        external_port=config.get("external_port", config["port"]),
+        id=service_id, name=name, port=port,
+        external_port=external_port,
         status=status, response_time_ms=None,
     )
 
@@ -139,7 +152,9 @@ async def _check_tailscale_health(service_id: str, config: dict) -> ServiceStatu
     """
     try:
         payload = await request_agent_json("GET", "/v1/tailscale/status", timeout=5)
-    except AgentClientError:
+        if not isinstance(payload, dict):
+            return _service_status_from_config(service_id, config, "not_deployed")
+    except (AgentClientError, OSError, ValueError):
         return _service_status_from_config(service_id, config, "not_deployed")
 
     if not payload.get("running"):
@@ -158,7 +173,13 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
     open. If the proof is unavailable, fail closed so the dashboard does not
     launch users into a dead localhost URL.
     """
-    port = int(config.get("health_port") or config.get("external_port") or config.get("port") or 0)
+    if not isinstance(config, dict):
+        config = {}
+    try:
+        port = int(config.get("health_port") or config.get("external_port") or config.get("port") or 0)
+    except (TypeError, ValueError):
+        port = 0
+
     if port <= 0:
         return _service_status_from_config(service_id, config, "not_deployed")
 
@@ -169,17 +190,29 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
             params={"host": "127.0.0.1", "port": port},
             timeout=5,
         )
-    except AgentClientError:
+        if not isinstance(payload, dict):
+            return _service_status_from_config(service_id, config, "down")
+    except (AgentClientError, OSError, ValueError):
         return _service_status_from_config(service_id, config, "down")
 
     status = "healthy" if payload.get("reachable") else "not_deployed"
+    name = str(config.get("name") or service_id)
+    service_port = int(config.get("port") or port)
+    external_port = int(config.get("external_port") or service_port)
+    response_time = payload.get("response_time_ms")
+    if response_time is not None:
+        try:
+            response_time = float(response_time)
+        except (TypeError, ValueError):
+            response_time = None
+
     return ServiceStatus(
         id=service_id,
-        name=config["name"],
-        port=config["port"],
-        external_port=config.get("external_port", config["port"]),
+        name=name,
+        port=service_port,
+        external_port=external_port,
         status=status,
-        response_time_ms=payload.get("response_time_ms"),
+        response_time_ms=response_time,
     )
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_service_health_resilience.py
+++ b/ods/extensions/services/dashboard-api/tests/test_service_health_resilience.py
@@ -1,0 +1,54 @@
+"""Tests for service health resilience and fallback status mapping in helpers.py."""
+
+from unittest.mock import patch
+import pytest
+
+from helpers import (
+    _service_status_from_config,
+    _check_tailscale_health,
+    _check_host_systemd_health,
+)
+from host_agent_client import AgentClientError
+
+
+def test_service_status_from_config_handles_missing_keys():
+    status = _service_status_from_config("test-service", {}, "healthy")
+    assert status.id == "test-service"
+    assert status.name == "test-service"
+    assert status.port == 0
+    assert status.external_port == 0
+    assert status.status == "healthy"
+
+
+def test_service_status_from_config_handles_non_dict_config():
+    status = _service_status_from_config("svc-1", None, "down")
+    assert status.id == "svc-1"
+    assert status.name == "svc-1"
+    assert status.status == "down"
+
+
+@pytest.mark.asyncio
+async def test_check_tailscale_health_not_deployed_on_error():
+    with patch("helpers.request_agent_json", side_effect=AgentClientError("Unreachable")):
+        res = await _check_tailscale_health("tailscale", {"name": "Tailscale", "port": 41641})
+        assert res.status == "not_deployed"
+
+
+@pytest.mark.asyncio
+async def test_check_tailscale_health_healthy_when_authenticated():
+    with patch("helpers.request_agent_json", return_value={"running": True, "authenticated": True}):
+        res = await _check_tailscale_health("tailscale", {"name": "Tailscale", "port": 41641})
+        assert res.status == "healthy"
+
+
+@pytest.mark.asyncio
+async def test_check_host_systemd_health_handles_invalid_port():
+    res = await _check_host_systemd_health("opencode", {"name": "OpenCode", "port": "invalid"})
+    assert res.status == "not_deployed"
+
+
+@pytest.mark.asyncio
+async def test_check_host_systemd_health_down_on_agent_error():
+    with patch("helpers.request_agent_json", side_effect=AgentClientError("AgentError")):
+        res = await _check_host_systemd_health("opencode", {"name": "OpenCode", "port": 4096})
+        assert res.status == "down"


### PR DESCRIPTION
## Context & Problem

In `ods/extensions/services/dashboard-api/helpers.py`, service health inspection routines (`_service_status_from_config`, `_check_tailscale_health`, and `_check_host_systemd_health`) inspect configuration dicts and query host-agent status endpoints. If service configuration dicts contain missing keys, non-integer port strings, or if host-agent queries fail with I/O or decode errors, `KeyError` or `ValueError` exceptions leak to callers, crashing dashboard status endpoints.

## Implementation Details

- **Dict Guarding & Fallbacks**: Wrapped `_service_status_from_config` with `isinstance(config, dict)` checks and `try...except (TypeError, ValueError)` integer conversion fallbacks.
- **Exception Boundary Trapping**: Caught `(AgentClientError, OSError, ValueError)` in `_check_tailscale_health` and `_check_host_systemd_health` to return structured fallback `ServiceStatus` instances.
- **Unit Test Suite**: Added `test_service_health_resilience.py` with 6 tests validating health probe mapping, non-dict config handling, and exception recovery.

## Verification & Tests

Executed pytest test suite:
```
python3 -m pytest tests/test_service_health_resilience.py
============================== 6 passed in 0.31s ===============================
```