### PR TITLE
refactor(cli): extract read-only formatting primitives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 # and fails with "no such file or directory").
 *.sh text eol=lf
 *.bash text eol=lf
+*.bats text eol=lf
 ods/ods-cli text eol=lf
 Dockerfile* text eol=lf
 docker-entrypoint* text eol=lf

--- a/ods/docs/ODS_CLI_DECOMPOSITION.md
+++ b/ods/docs/ODS_CLI_DECOMPOSITION.md
@@ -41,6 +41,9 @@ This is a behavior-preserving roadmap. It is not a rewrite proposal.
    - Move table rendering, service alias lookup, and masked config formatting
      into small sourced modules.
    - Validation: CLI smoke and snapshot-style output checks.
+   - Progress: pure status-color, JSON-escaping, and separator primitives now
+     live in `lib/cli-format.sh`; service aliases and config masking remain in
+     their current owners for later independent slices.
 
 2. **Read-only status and logs**
    - Extract commands that inspect Docker/service state without mutating host

--- a/ods/lib/cli-format.sh
+++ b/ods/lib/cli-format.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Purpose: Read-only formatting primitives shared by the ODS shell CLI.
+# Expects: RED, GREEN, YELLOW (empty strings are valid for NO_COLOR output).
+# Provides: _status_color, _json_escape, hr.
+# Modder notes: Keep these helpers side-effect free; callers rely on command
+# substitution and byte-stable JSON/table output.
+
+# Map cmd_list status strings to colors. Unknown future states stay uncolored.
+_status_color() {
+    case "$1" in
+        enabled|always-on) echo "$GREEN" ;;
+        disabled|stopped)  echo "$YELLOW" ;;
+        unhealthy|error)   echo "$RED" ;;
+        *)                 echo "" ;;
+    esac
+}
+
+_json_escape() {
+    local s="${1-}"
+    s=${s//\\/\\\\}
+    s=${s//\"/\\\"}
+    s=${s//$'\b'/\\b}
+    s=${s//$'\f'/\\f}
+    s=${s//$'\n'/\\n}
+    s=${s//$'\r'/\\r}
+    s=${s//$'\t'/\\t}
+    printf '%s' "$s"
+}
+
+# Print a separator of repeated characters filling the given width.
+# Usage: hr <width> [<char=─>]
+hr() {
+    local w="${1:-10}" c="${2:-─}" out=''
+    printf -v out '%*s' "$w" ''
+    printf '%s' "${out// /$c}"
+}

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -55,6 +55,9 @@ else
     NC=''
 fi
 
+# shellcheck source=lib/cli-format.sh
+. "$SCRIPT_DIR/lib/cli-format.sh"
+
 #=============================================================================
 # Helpers
 #=============================================================================
@@ -63,37 +66,6 @@ success() { echo -e "${GREEN}✓${NC} $1"; }
 warn() { echo -e "${YELLOW}⚠${NC} $1" >&2; }
 error() { echo -e "${RED}✗${NC} $1" >&2; exit 1; }
 log_error() { echo -e "${RED}✗${NC} $1" >&2; }
-
-# Map cmd_list status string to a colour. Returns an empty string for unknown
-# statuses so future state names don't break formatting.
-_status_color() {
-    case "$1" in
-        enabled|always-on) echo "$GREEN" ;;
-        disabled|stopped)  echo "$YELLOW" ;;
-        unhealthy|error)   echo "$RED" ;;
-        *)                 echo "" ;;
-    esac
-}
-
-_json_escape() {
-    local s="${1-}"
-    s=${s//\\/\\\\}
-    s=${s//\"/\\\"}
-    s=${s//$'\b'/\\b}
-    s=${s//$'\f'/\\f}
-    s=${s//$'\n'/\\n}
-    s=${s//$'\r'/\\r}
-    s=${s//$'\t'/\\t}
-    printf '%s' "$s"
-}
-
-# Print a separator of repeated characters filling the given width.
-# Usage: hr <width> [<char=─>]
-hr() {
-    local w="${1:-10}" c="${2:-─}" out=''
-    printf -v out '%*s' "$w" ''
-    printf '%s' "${out// /$c}"
-}
 
 # Update or add a key=value in .env
 _env_set() {

--- a/ods/tests/bats-tests/test-cli-formatting.bats
+++ b/ods/tests/bats-tests/test-cli-formatting.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# Behavior contract for the first ODS CLI decomposition slice.
+#
+# The public CLI still owns command syntax and output; lib/cli-format.sh owns
+# only the pure color, JSON escaping, and separator primitives.
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+setup() {
+    export CLI="$BATS_TEST_DIRNAME/../../ods-cli"
+    export MODULE="$BATS_TEST_DIRNAME/../../lib/cli-format.sh"
+    RED='<red>'
+    GREEN='<green>'
+    YELLOW='<yellow>'
+    # shellcheck source=../../lib/cli-format.sh
+    source "$MODULE"
+}
+
+@test "cli-format: ods-cli loads the installed formatting module" {
+    run env -i \
+        HOME="$BATS_TEST_TMPDIR" \
+        PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:/Volumes/X/homebrew/bin" \
+        TERM="dumb" \
+        bash "$CLI" --version
+    assert_success
+    refute_output --partial "lib/cli-format.sh: No such file"
+}
+
+@test "cli-format: status colors preserve the list output contract" {
+    run _status_color enabled
+    assert_output '<green>'
+    run _status_color stopped
+    assert_output '<yellow>'
+    run _status_color error
+    assert_output '<red>'
+    run _status_color future-state
+    assert_output ''
+}
+
+@test "cli-format: JSON escaping covers quotes slashes and controls" {
+    run _json_escape $'quote" slash\\ line\n tab\t return\r back\b form\f'
+    assert_output 'quote\" slash\\ line\n tab\t return\r back\b form\f'
+}
+
+@test "cli-format: separators preserve requested width and character" {
+    run hr 4 '='
+    assert_output '===='
+    run hr 3
+    assert_output '───'
+}

--- a/ods/tests/test-cli-enable-compose-reconciliation.sh
+++ b/ods/tests/test-cli-enable-compose-reconciliation.sh
@@ -19,6 +19,7 @@ make_install() {
         "$install_dir/extensions/services/ods-proxy"
 
     cp "$ROOT_DIR/ods-cli" "$install_dir/ods-cli"
+    cp "$ROOT_DIR/lib/cli-format.sh" "$install_dir/lib/"
     cp "$ROOT_DIR/lib/service-registry.sh" "$install_dir/lib/"
     cp "$ROOT_DIR/lib/python-cmd.sh" "$install_dir/lib/"
     cat > "$install_dir/scripts/resolve-compose-stack.sh" <<'RESOLVER'


### PR DESCRIPTION
## Why this matters

`ods-cli` is a roughly 6,500-line production entry point. The repository's decomposition roadmap calls for behavior-preserving extraction of read-only formatting before stateful commands are split. Keeping status-color mapping, JSON escaping, and separator rendering inline makes their ownership unclear and forces future command extraction to move implementation and behavior at the same time.

This PR completes the first narrow Phase 1 slice: it moves only those pure primitives into `lib/cli-format.sh`, sources that installed module from the existing CLI, and preserves the command syntax and byte-level output contracts. `ods list --json`, human list/status output, template output, and table separators remain owned by the same CLI callers.

The behavioral invariant is: extracting a pure helper must not change any public CLI output, status mapping, JSON escaping, or separator width.

## What changes

- add `lib/cli-format.sh` with the three side-effect-free formatting primitives
- source the module after the CLI initializes color variables, preserving `NO_COLOR` behavior
- remove only the corresponding inline definitions from `ods-cli`
- update the isolated installed-CLI reconciliation fixture to deploy the required module
- add BATS boundary coverage for module loading, status mapping, all JSON control escapes, and separator rendering
- keep `.bats` files LF-normalized so Windows checkouts remain executable by Bash
- record the completed slice and remaining Phase 1 ownership in `docs/ODS_CLI_DECOMPOSITION.md`

## Overlap check

Searched open and closed PRs for `ods-cli decomposition formatting`, `cli-format`, the three helper names, and every open patch touching `ods/ods-cli`. There are 25 open PRs touching the large CLI, but none of their patches contains `_status_color`, `_json_escape`, or `hr`; the closest historical result is merged PR #1100, which standardized logging/banner style rather than these helpers.

Six open PRs (#3019-#3024) touch `.gitattributes`; they add or consume rules for Makefiles/workflows/scripts and do not add the `*.bats` contract. No open PR touches `lib/cli-format.sh`, the new BATS contract, the reconciliation fixture, or the decomposition roadmap. The scope is independently useful and does not replace an existing implementation.

## Regression coverage

Focused validation from the repository root / `ods/`:

- `bash tests/test-ods-list-json-escaping.sh` — pass; exercises the public `ods list --json` boundary
- normalized Linux-tooling run of `test-cli-formatting.bats` — 4/4 pass
- `bash tests/test-phase-c-p1.sh` — 7 passed, 0 failed, 9 authentication-dependent warnings
- `bash -n ods-cli lib/cli-format.sh` — pass
- `shellcheck --rcfile=/dev/null --severity=error ods-cli lib/cli-format.sh` — pass
- `git diff --check` — pass
- `bash tests/test-cli-enable-compose-reconciliation.sh` — pass after the isolated installed-CLI fixture was updated

The repository-downloaded BATS runner in this Windows checkout had CRLF in its own ignored clone, so the same pinned runner/support/assert trees were copied to a verified `/tmp/ods-bats.*` directory, mechanically LF-normalized, and used for the 4/4 receipt. CI's fresh Linux checkout remains the authoritative literal `tests/run-bats.sh` execution.

A broad `tests/contracts/test-installer-contracts.sh` probe also reached an existing failure at `Hermes template bounds each model turn`. Neither that test nor `extensions/services/hermes/cli-config.yaml.template` is changed by this branch; the focused CLI and formatting contracts above pass.

## Design and rollback

The module intentionally has no `set -euo pipefail`: it is sourced into the CLI and inherits caller policy. It expects the already-initialized color variables and performs no I/O other than returning formatted bytes. Service aliases and config masking remain in their current owners until a later independently testable slice.

Rollback is a single revert: restore the three inline functions and remove the source line/module. No persisted state, command syntax, or runtime migration is involved.

## CI follow-up

The first integration-smoke run failed because `test-cli-enable-compose-reconciliation.sh` intentionally builds an isolated installed footprint but copied only `ods-cli` plus two older library dependencies. Commit `bff5cbfc` adds the new required module to that fixture; the exact previously failing test now passes for stale, empty, missing, and dual-marker compose states. All other test fixtures that execute a copied CLI already copy `lib/*.sh` or the full `lib/` tree. The batch integration branch includes the fix at `2c82aaec`. The rerun is fully green: 28 successful checks, 4 intentional skips, including the 3m58s `integration-smoke` job that originally exposed the missing fixture dependency.