### PR TITLE
fix(migrate-config): handle semver prerelease suffixes in config migration

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -73,6 +73,9 @@ set_last_migrated_version() {
 compare_versions() {
     local v1="${1#v}"
     local v2="${2#v}"
+    # Strip pre-release suffixes (e.g. 2.6.0-beta.1 → 2.6.0)
+    v1="${v1%%-*}"
+    v2="${v2%%-*}"
     
     if [[ "$v1" == "$v2" ]]; then
         return 0


### PR DESCRIPTION
## Summary
Strips `-beta`, `-rc`, and other prerelease tags when comparing integer version components in `migrate-config.sh`, preventing syntax errors in integer comparison arithmetic.

## Verification
Tested with version strings like `v1.2.0-beta.1` and standard releases.