### PR TITLE
fix(mode-switch): use atomic file replacement for mode transitions

### DIFF
--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -32,7 +32,7 @@ env_set() {
     if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
         awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
+        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv -f "${ENV_FILE}.tmp" "$ENV_FILE"
     else
         echo "${key}=${val}" >> "$ENV_FILE"
     fi


### PR DESCRIPTION
## Summary
Ensures `.env` updates during mode transitions in `mode-switch.sh` write to a temporary file before renaming, preventing partial file corruption if interrupted.

## Verification
Tested mode switching between preset profiles.