### PR TITLE
fix(service-registry): explicitly report error when PyYAML is unavailable

### DIFF
--- a/ods/lib/service-registry.sh
+++ b/ods/lib/service-registry.sh
@@ -79,7 +79,7 @@ sr_load() {
             declare -f warn &>/dev/null && warn "Install manually: pip3 install pyyaml"
             _SR_LOADED=true  # Prevent repeated retries
             _SR_FAILED=true
-            return 0
+            return 1
         fi
     fi
 


### PR DESCRIPTION
## Summary
Ensures `sr_load` returns exit code 1 when PyYAML is unavailable instead of silently continuing with partial or broken service registry state.

## Verification
Tested service registry initialization without PyYAML installed.