### PR TITLE
fix(auth): mint dashboard sessions only after 401

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useSessionBootstrap.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useSessionBootstrap.test.js
@@ -1,0 +1,41 @@
+import { renderHook, waitFor } from '@testing-library/react'
+
+import { useSessionBootstrap } from '../useSessionBootstrap'
+
+describe('useSessionBootstrap', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('mints a session after verify explicitly rejects the cookie', async () => {
+    globalThis.fetch
+      .mockResolvedValueOnce({ ok: false, status: 401 })
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+
+    renderHook(() => useSessionBootstrap())
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2))
+    expect(globalThis.fetch).toHaveBeenNthCalledWith(
+      2,
+      '/api/auth/admin-session',
+      { method: 'POST', credentials: 'same-origin' },
+    )
+  })
+
+  test('does not mint a session when verify is temporarily unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    globalThis.fetch.mockResolvedValueOnce({ ok: false, status: 503 })
+
+    renderHook(() => useSessionBootstrap())
+
+    await waitFor(() => expect(warn).toHaveBeenCalledWith(
+      '[ods-session] verify-session returned',
+      503,
+    ))
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ods/extensions/services/dashboard/src/hooks/useSessionBootstrap.js
+++ b/ods/extensions/services/dashboard/src/hooks/useSessionBootstrap.js
@@ -48,9 +48,17 @@ export function useSessionBootstrap(enabled = true) {
         })
         if (verify.ok) return  // session already present
 
-        // 401 (or any non-2xx, e.g. 503 if dashboard-api is mid-restart) —
-        // try to mint a fresh session. nginx injects the API-key Authorization
-        // header, so the POST is authenticated automatically.
+        // Only an explicit authentication rejection means the browser needs
+        // a new cookie. A 5xx response can mean dashboard-api is restarting or
+        // its signer is unavailable; POSTing in that state turns one failed
+        // read into a duplicate mutation and obscures the original outage.
+        if (verify.status !== 401) {
+          console.warn('[ods-session] verify-session returned', verify.status)
+          return
+        }
+
+        // 401 — try to mint a fresh session. nginx injects the API-key
+        // Authorization header, so the POST is authenticated automatically.
         const mint = await fetch('/api/auth/admin-session', {
           method: 'POST',
           credentials: 'same-origin',


### PR DESCRIPTION
## Summary
- mint the dashboard owner session only when `/api/auth/verify-session` explicitly returns 401
- preserve read-only failure behavior for transient verify failures such as dashboard-api restarts
- cover both the 401 mutation path and the 503 no-mutation path at the React hook boundary

## Why this matters
The dashboard mounts `useSessionBootstrap` on every normal page load. Previously any non-2xx verify response—including a transient 503—triggered `POST /api/auth/admin-session`. That converted an upstream availability failure into an unnecessary credential mutation and could obscure the original outage. The existing auth contract says a missing or invalid cookie is represented by 401; only that response should authorize minting a replacement cookie.

Behavioral invariant: session minting follows an explicit 401 authentication rejection, never an unrelated verify failure.

## Overlap check
Searched open and closed `Osmantic/ODS` PRs for `useSessionBootstrap`, `dashboard session bootstrap`, `admin-session 401 mint`, `verify-session 503`, and the production hook path. PR #1222 introduced the original owner-session flow but no open or closed PR covers this failure classification. The scope is independent of current magic-link and reusable-invite work because it changes only the dashboard's decision to call the existing admin-session endpoint.

## Test plan
- [x] `npm test -- --run src/hooks/__tests__/useSessionBootstrap.test.js`
- [x] `npm run lint -- --quiet`
- [x] `git diff --check`

## Design and rollback
This keeps the existing 401 recovery path unchanged. Non-401 failures are logged and left read-only; a later reload retries verification. Rollback is a single commit and restores the previous any-non-2xx mint behavior.

Generated with Codex