### PR TITLE
fix(hermes): close partial connections on cancellation

### DIFF
--- a/ods/extensions/services/dashboard-api/hermes_bridge.py
+++ b/ods/extensions/services/dashboard-api/hermes_bridge.py
@@ -220,11 +220,18 @@ async def _open_connection(session_key: str) -> _HermesConnection:
     http_session = aiohttp.ClientSession(timeout=timeout)
     try:
         ws = await _connect_ws(http_session)
+    except asyncio.CancelledError:
+        await http_session.close()
+        raise
     except Exception:
         await http_session.close()
         raise
     try:
         session_id = await _create_session_on_ws(ws, timeout=30)
+    except asyncio.CancelledError:
+        await ws.close()
+        await http_session.close()
+        raise
     except Exception:
         await ws.close()
         await http_session.close()

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -636,6 +636,107 @@ def test_hermes_bridge_slow_open_does_not_block_other_keys(monkeypatch):
     assert _run_with_one_loop(main)
 
 
+def test_hermes_bridge_cancelled_connect_closes_http_session(monkeypatch):
+    """Client disconnects cancel the bridge task.  If cancellation lands while
+    ws_connect is pending, the newly allocated aiohttp session must not leak.
+    """
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    class FakeHTTP:
+        closed = False
+
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def close(self):
+            self.closed = True
+
+    created = []
+
+    def fake_client_session(*, timeout):
+        session = FakeHTTP(timeout=timeout)
+        created.append(session)
+        return session
+
+    async def main():
+        connect_started = _asyncio.Event()
+
+        async def blocked_connect(_session):
+            connect_started.set()
+            await _asyncio.Event().wait()
+
+        monkeypatch.setattr(hermes_bridge.aiohttp, "ClientSession", fake_client_session)
+        monkeypatch.setattr(hermes_bridge, "_connect_ws", blocked_connect)
+
+        task = _asyncio.create_task(hermes_bridge._open_connection("cancel-connect"))
+        await connect_started.wait()
+        task.cancel()
+        with pytest.raises(_asyncio.CancelledError):
+            await task
+
+    _run_with_one_loop(main)
+    assert len(created) == 1
+    assert created[0].closed is True
+
+
+def test_hermes_bridge_cancelled_session_create_closes_ws_and_http(monkeypatch):
+    """Cancellation after ws_connect succeeds must release both resources."""
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    class FakeHTTP:
+        closed = False
+
+        def __init__(self, *, timeout):
+            self.timeout = timeout
+
+        async def close(self):
+            self.closed = True
+
+    class FakeWS:
+        closed = False
+
+        async def close(self):
+            self.closed = True
+
+    created_http = []
+    created_ws = []
+
+    def fake_client_session(*, timeout):
+        session = FakeHTTP(timeout=timeout)
+        created_http.append(session)
+        return session
+
+    async def fake_connect(_session):
+        ws = FakeWS()
+        created_ws.append(ws)
+        return ws
+
+    async def main():
+        create_started = _asyncio.Event()
+
+        async def blocked_create(_ws, *, timeout):
+            create_started.set()
+            await _asyncio.Event().wait()
+
+        monkeypatch.setattr(hermes_bridge.aiohttp, "ClientSession", fake_client_session)
+        monkeypatch.setattr(hermes_bridge, "_connect_ws", fake_connect)
+        monkeypatch.setattr(hermes_bridge, "_create_session_on_ws", blocked_create)
+
+        task = _asyncio.create_task(hermes_bridge._open_connection("cancel-create"))
+        await create_started.wait()
+        task.cancel()
+        with pytest.raises(_asyncio.CancelledError):
+            await task
+
+    _run_with_one_loop(main)
+    assert len(created_http) == 1
+    assert len(created_ws) == 1
+    assert created_http[0].closed is True
+    assert created_ws[0].closed is True
+
+
 def test_hermes_bridge_transparent_retry_on_send_reset(monkeypatch):
     """Most insidious dead-WS pattern: ``ws.closed`` reports False, but the
     next ``send_str`` raises ClientConnectionResetError because the upstream


### PR DESCRIPTION
﻿## Summary
- close the newly allocated HTTP session when a bridge task is cancelled during WebSocket connection
- close both the WebSocket and HTTP session when cancellation lands during `session.create`
- cover both partial-allocation phases with cancellation regression tests

## Why this matters
The Talk SSE endpoint deliberately cancels its Hermes bridge task when a browser disconnects. In Python 3.11+, `asyncio.CancelledError` is a `BaseException`, so the existing `except Exception` cleanup in `_open_connection` did not run. A disconnect during a slow Hermes connect or session-create could therefore leak an `aiohttp.ClientSession`, and in the latter phase a WebSocket too. Repeated mobile disconnects could accumulate sockets/file descriptors in the long-running dashboard API.

Root cause: cancellation was allowed to propagate (correctly), but it bypassed the partial-resource cleanup branches.

Invariant: cancelling any phase of connection establishment propagates cancellation only after every resource allocated by that phase has been closed.

## Overlap check
Searched open and closed upstream PRs by `hermes_bridge.py`, `Hermes CancelledError cleanup`, and `Hermes connection leak`. Existing bridge PRs #1321, #1323, #1592, #1860, open #1533, and open #2842 cover streaming lifecycle, pooling/locking, response parsing, and HTML decoding. None handles cancellation while `_open_connection` owns partially allocated resources. The changed production lines are confined to the two cleanup boundaries in `_open_connection`.

## Validation
- focused cancellation regression tests ? 2 passed
- `pytest -q tests/test_talk.py` ? 41 passed
- `python -m compileall -q hermes_bridge.py tests/test_talk.py` ? passed
- `git diff --check` ? passed

## Design and rollback
Cancellation is still re-raised immediately after deterministic cleanup; there is no retry, fallback, or behavior change for successful connections. Rollback is a single commit, but would restore the resource leak window on client disconnect or server task cancellation.
