### PR TITLE
fix(installer): parse Podman registry arrays structurally

### DIFF
--- a/ods/installers/lib/podman-registries.sh
+++ b/ods/installers/lib/podman-registries.sh
@@ -71,6 +71,29 @@ def strip_toml_comments(value):
     return "".join(output)
 
 
+def toml_array_balance(value):
+    """Count array brackets outside TOML comments and quoted strings."""
+    balance = 0
+    quote = None
+    escaped = False
+    for character in strip_toml_comments(value):
+        if quote:
+            if escaped:
+                escaped = False
+            elif character == "\\" and quote == '"':
+                escaped = True
+            elif character == quote:
+                quote = None
+            continue
+        if character in ('"', "'"):
+            quote = character
+        elif character == "[":
+            balance += 1
+        elif character == "]":
+            balance -= 1
+    return balance
+
+
 def search_registries(path):
     try:
         lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
@@ -95,10 +118,10 @@ def search_registries(path):
 
     expression = lines[key_line].split("=", 1)[1]
     end_line = key_line + 1
-    balance = expression.count("[") - expression.count("]")
+    balance = toml_array_balance(expression)
     while balance > 0 and end_line < first_table:
         expression += lines[end_line]
-        balance += lines[end_line].count("[") - lines[end_line].count("]")
+        balance = toml_array_balance(expression)
         end_line += 1
     if balance != 0:
         print(f"unterminated unqualified-search-registries array in {path}", file=sys.stderr)
@@ -172,9 +195,11 @@ if key_line is None:
     lines[first_table:first_table] = insertion
 else:
     end_line = key_line + 1
-    balance = lines[key_line].count("[") - lines[key_line].count("]")
+    expression = lines[key_line].split("=", 1)[1]
+    balance = toml_array_balance(expression)
     while balance > 0 and end_line < first_table:
-        balance += lines[end_line].count("[") - lines[end_line].count("]")
+        expression += lines[end_line]
+        balance = toml_array_balance(expression)
         end_line += 1
     if balance != 0:
         print(f"unterminated unqualified-search-registries array in {target}", file=sys.stderr)

--- a/ods/tests/test-podman-rootless-contracts.sh
+++ b/ods/tests/test-podman-rootless-contracts.sh
@@ -130,6 +130,18 @@ grep -qx 'unqualified-search-registries = \["registry.example/#team", "quay.io",
     || fail "TOML comments or a quoted hash corrupted the registry list"
 pass "Podman registry parser handles multiline TOML comments and quoted hashes"
 
+bracketed="$TMP_DIR/bracketed.conf"
+cat > "$bracketed" <<'EOF'
+unqualified-search-registries = [
+  "[fd00::1]:5000", # private IPv6 registry; keep this first ]
+  "quay.io",
+]
+EOF
+CONTAINERS_REGISTRIES_CONF="$bracketed" ods_podman_ensure_dockerhub_search
+grep -qx 'unqualified-search-registries = \["\[fd00::1\]:5000", "quay.io", "docker.io"\]' "$bracketed" \
+    || fail "brackets inside TOML strings or comments corrupted the registry list"
+pass "Podman registry parser ignores brackets inside strings and comments"
+
 if grep -Eq 'list\[|\|[[:space:]]*None' "$REGISTRY_LIB"; then
     fail "Podman helper requires a newer Python type-hint syntax"
 fi


### PR DESCRIPTION
﻿## Summary
- count registry-array brackets only when they are outside TOML comments and quoted strings
- use the same structural balance check while reading and replacing an existing assignment
- exercise the real shell helper with a valid IPv6 registry and a comment containing a closing bracket

## Why this matters
Phase 05 now repairs Podman's short-name registry search path before ODS pulls bare Docker Hub image names. The parser decided where a multiline TOML array ended by counting every `[` and `]` byte. A bracket inside a valid comment or registry string could make it stop early, reject a valid `registries.conf`, and abort an otherwise supported rootless Podman installation.

Root cause: lexical characters inside TOML comments and strings were treated as array delimiters.

Invariant: only structural brackets delimit `unqualified-search-registries`; comment text and quoted registry values never change array balance. Existing registry order, tables, modes, symlinks, and atomic replacement remain unchanged.

## Overlap check
Searched upstream PRs for `podman-registries.sh`, `Podman registries.conf`, and bracket/parser terms. The only open file-adjacent PR is #2981, which changes Linux preflight probing and its test; it does not touch this helper. Closed/merged #2804 introduced this helper and rootless Podman support. No open or closed PR handles TOML delimiter characters inside comments or strings.

## Regression coverage
The production helper is sourced and invoked against:

```toml
unqualified-search-registries = [
  "[fd00::1]:5000", # private IPv6 registry; keep this first ]
  "quay.io",
]
```

The boundary assertion verifies the helper preserves both registries and appends `docker.io` instead of failing or truncating the file.

## Validation
- `bash tests/test-podman-rootless-contracts.sh` ? all 25 passed
- `bash -n installers/lib/podman-registries.sh tests/test-podman-rootless-contracts.sh` ? passed
- ShellCheck severity error on both changed shell files ? passed
- `git diff --check` ? passed

## Design and rollback
A small lexical scanner is used because the installer supports Python baselines without `tomllib`. It reuses the existing comment stripping rules and adds no dependency. Rollback is one commit, but restores rejection of valid Podman registry configuration containing bracket characters.
