### PR TITLE
fix(privacy): keep unknown-length streams in restore mode

### DIFF
--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -42,8 +42,10 @@ _TEXTUAL_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Bodies larger than this are passed through untouched even if textual, so a
-# pathological response cannot pin the box buffering a hold-back window.
+# Bodies with a declared length larger than this are passed through untouched
+# even if textual. Unknown-length streams stay in their initial mode: changing
+# from restored to raw bytes after a prefix has been emitted would leak PII
+# placeholders from the remainder. StreamRestorer is independently bounded.
 RESTORE_MAX_BYTES = int(os.getenv("SHIELD_RESTORE_MAX_BYTES", str(8 * 1024 * 1024)))
 
 
@@ -377,33 +379,16 @@ async def proxy(request: Request, path: str):
                 yield raw
 
     async def body_iter():
-        # One iterator for the whole response. httpx response streams are
-        # single-consumption, so the oversized-text cutover must keep draining
-        # *this same* generator (switching mode to raw passthrough and
-        # re-emitting the chunk that crossed the cap) rather than calling
-        # raw_chunks() a second time — re-iterating the httpx response would
-        # drop the remainder of a large text body.
+        # One iterator and one transform mode for the whole response. httpx
+        # streams are single-consumption, and switching from restored to raw
+        # bytes mid-response would leak any placeholders in the remainder.
         chunks = raw_chunks()
         try:
             if do_restore:
                 # do_restore is only true when the body is uncompressed text,
                 # so raw bytes == decoded bytes here and stay byte-exact.
                 restorer = StreamRestorer(shield.detector, charset)
-                seen = 0
                 async for chunk in chunks:
-                    seen += len(chunk)
-                    if seen > RESTORE_MAX_BYTES:
-                        # Exceeded cap mid-stream: stop restoring, flush what
-                        # we held, then pass the rest through untouched.
-                        # Continue draining the SAME iterator — do NOT
-                        # re-iterate the upstream response.
-                        tail = restorer.finalize()
-                        if tail:
-                            yield tail.encode(charset, "replace")
-                        yield chunk
-                        async for rest in chunks:
-                            yield rest
-                        return
                     out = restorer.feed(chunk)
                     if out:
                         yield out.encode(charset, "replace")

--- a/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
+++ b/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
@@ -131,27 +131,20 @@ class TestStreamingNotBuffered:
         )
 
 
-# ── 1b. Oversized-text cutover keeps ONE upstream iterator (#1268) ─────────
+# ── 1b. Unknown-length text keeps one restore mode (#1268) ─────────────────
 #
-# When a textual body crosses SHIELD_RESTORE_MAX_BYTES mid-stream, body_iter()
-# stops PII-restoring and passes the rest through untouched. The bug: it used
-# to start a *fresh* raw_chunks() loop after the cutover, abandoning the
-# original aiter_raw() generator and trying to iterate the single-consumption
-# httpx response a second time — silently dropping/truncating the remainder of
-# a large text response. Fix: keep draining the SAME already-open iterator.
+# A response without Content-Length cannot be classified as oversized before
+# streaming begins. Once restoration emits a prefix, changing to raw
+# passthrough would create a mixed response and leak later PII placeholders.
 
-class TestOversizedTextCutover:
-    def test_oversized_text_remainder_not_dropped(
+class TestUnknownLengthText:
+    def test_unknown_length_text_remainder_not_dropped(
         self, client, install_upstream, monkeypatch
     ):
-        # Tiny cap so a modest multi-chunk text body trips the cutover. No
-        # Content-Length header → declared_len == -1, so do_restore stays True
-        # and the size check happens mid-stream (the buggy code path).
+        # Tiny cap and no Content-Length exercise the unknown-length path.
         monkeypatch.setattr(proxy, "RESTORE_MAX_BYTES", 16)
 
-        # Chunks straddle the 16-byte cap: the cap is crossed inside chunk 2,
-        # and chunks 3..5 are the post-cutover remainder that the old code
-        # dropped by re-iterating the consumed httpx response.
+        # Chunks straddle the cap and must all use the original iterator.
         chunks = [
             b"AAAAAAAAAA",          # 10 bytes  (seen=10, under cap)
             b"BBBBBBBBBB",          # 10 bytes  (seen=20, crosses cap=16)
@@ -173,14 +166,69 @@ class TestOversizedTextCutover:
             assert resp.status_code == 200
             body = b"".join(resp.iter_bytes())
 
-        # Byte-for-byte: the post-cutover remainder (chunks 3-5) must NOT be
-        # dropped or truncated. There is no PII, so restore is identity and
-        # the proxied body must equal the upstream body exactly.
+        # There is no PII, so restore is identity and the proxied body must
+        # remain byte-for-byte equal to the upstream body.
         assert body == expected, (
-            "oversized-text remainder dropped/truncated — proxy re-iterated "
+            "unknown-length text remainder dropped/truncated — proxy re-iterated "
             f"the single-consumption upstream stream: got {len(body)} bytes "
             f"({body!r}), expected {len(expected)} ({expected!r})"
         )
+
+    def test_pii_token_after_size_threshold_is_still_restored(
+        self, client, install_upstream, monkeypatch
+    ):
+        monkeypatch.setattr(proxy, "RESTORE_MAX_BYTES", 16)
+
+        def handler(request):
+            sent = request.content.decode("utf-8", "replace")
+            match = re.search(r"<PII_email_[0-9a-f]{12}>", sent)
+            assert match, f"email not scrubbed before forward: {sent!r}"
+            token = match.group(0).encode()
+            return _resp(
+                200,
+                {"content-type": "text/event-stream"},
+                [b"data: " + b"x" * 20, b" ", token, b"\n\n"],
+            )
+
+        install_upstream(handler)
+        with client.stream(
+            "POST", "/v1/chat/completions", headers=AUTH,
+            json={"messages": [{"content": f"email {EMAIL}"}]},
+        ) as resp:
+            body = b"".join(resp.iter_bytes()).decode("utf-8", "replace")
+
+        assert EMAIL in body
+        assert "<PII_email_" not in body
+
+    def test_declared_oversized_text_stays_on_raw_path(
+        self, client, install_upstream, monkeypatch
+    ):
+        monkeypatch.setattr(proxy, "RESTORE_MAX_BYTES", 16)
+
+        def handler(request):
+            sent = request.content.decode("utf-8", "replace")
+            match = re.search(r"<PII_email_[0-9a-f]{12}>", sent)
+            assert match, f"email not scrubbed before forward: {sent!r}"
+            payload = b"x" * 20 + match.group(0).encode()
+            return _resp(
+                200,
+                {
+                    "content-type": "text/plain",
+                    "content-length": str(len(payload)),
+                },
+                [payload],
+            )
+
+        install_upstream(handler)
+        response = client.post(
+            "/v1/chat/completions", headers=AUTH,
+            json={"messages": [{"content": f"email {EMAIL}"}]},
+        )
+
+        assert response.status_code == 200
+        assert EMAIL not in response.text
+        assert "<PII_email_" in response.text
+        assert response.headers["content-length"] == str(len(response.content))
 
 
 # ── 2. PII token split across SSE chunk boundary round-trips ───────────────


### PR DESCRIPTION
﻿## Summary
- keep chunked textual responses in PII-restore mode once streaming has begun
- retain raw passthrough for responses whose declared Content-Length exceeds the configured cap
- cover post-threshold PII restoration, full remainder delivery, and the declared-oversize raw path at the HTTP boundary

## Why this matters
Privacy Shield chooses its response mode before returning headers. For a textual response without `Content-Length`, the old iterator began restoring, counted streamed bytes, then switched to raw passthrough when the count crossed `SHIELD_RESTORE_MAX_BYTES`. Any PII placeholder after that point reached the client as `<PII_email_...>` instead of the original value, producing a response with mixed semantics. This is common for SSE and other chunked model responses, where length is inherently unknown.

Root cause: an unknown-length response was reclassified after a transformed prefix had already been emitted.

Invariant: one upstream response uses one transform mode from first byte to last. Declared-oversize responses select raw passthrough before streaming; eligible unknown-length responses retain bounded incremental restoration throughout.

## Overlap check
Searched open and closed upstream PRs for `privacy shield oversized restore token`, `privacy-shield/proxy.py`, and unknown-length/cutover terms. Merged #1275 introduced streaming restoration and the size cap. Open #3054 handles unknown charsets, #2972 preserves query strings, #2973 isolates upstream authorization, and #2251 fixes the buffered-read fallback. None prevents a mid-response restore-to-raw mode switch.

## Regression coverage
Three TestClient cases exercise the real proxy route with a chunked mock upstream:

- a token emitted only after the byte threshold is restored and no placeholder escapes
- a multi-chunk unknown-length remainder is complete and byte-stable when restoration is identity
- a response with an explicitly oversized Content-Length remains on the raw path and preserves its length header

## Validation
- focused unknown-length streaming tests ? 3 passed
- `pytest -q tests` ? 54 passed
- `python -m compileall -q proxy.py tests/test_streaming_proxy.py` ? passed
- `git diff --check` ? passed

## Design and rollback
`StreamRestorer` already uses a bounded hold-back window, so continuing it does not buffer the full unknown-length body. The declared-length cap remains the early opt-out for known large responses. Rollback is a single commit, but restores mixed-mode output for chunked streams crossing the threshold.
