### PR TITLE
fix(model-router): retain routes on malformed endpoint shapes

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -330,7 +330,14 @@ def _load_endpoints() -> dict[str, dict[str, Any]]:
     endpoints: dict[str, dict[str, Any]] = {}
     try:
         raw = json.loads(ENDPOINTS_PATH.read_text(encoding="utf-8"))
-        for entry in raw.get("endpoints", []):
+        if not isinstance(raw, dict):
+            raise ValueError("endpoint allowlist root must be an object")
+        entries = raw.get("endpoints")
+        if not isinstance(entries, list):
+            raise ValueError("endpoint allowlist 'endpoints' must be an array")
+        if any(not isinstance(entry, dict) for entry in entries):
+            raise ValueError("endpoint allowlist entries must be objects")
+        for entry in entries:
             endpoint_id = str(entry.get("id") or "")
             base_url = str(entry.get("baseUrl") or "")
             if not endpoint_id or not base_url.startswith(("http://", "https://")):

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -774,6 +774,39 @@ class TestEndpointsReload:
         assert still_ok.status_code == 200
         assert calls[-1]["url"].startswith("http://upstream:8080")
 
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            None,
+            [],
+            {},
+            {"endpoints": None},
+            {"endpoints": {}},
+            {"endpoints": [None]},
+            {"endpoints": ["http://unexpected:8080"]},
+        ],
+    )
+    def test_wrong_shape_rewrite_retains_last_good_allowlist(
+        self, router, tmp_path, payload
+    ):
+        mod, client, write_state, calls = router
+        write_state()
+        assert client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "warm cache"}],
+        }).status_code == 200
+
+        self._endpoints_path(tmp_path).write_text(
+            json.dumps(payload), encoding="utf-8"
+        )
+        still_ok = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "after rewrite"}],
+        })
+
+        assert still_ok.status_code == 200
+        assert calls[-1]["url"].startswith("http://upstream:8080")
+
     def test_health_reports_allowlist_health(self, router, tmp_path):
         mod, client, write_state, calls = router
         healthy = client.get("/health")


### PR DESCRIPTION
﻿## Summary
- validate the root, `endpoints` collection, and entry container shapes before rebuilding the router allowlist
- classify wrong-shape but syntactically valid JSON the same as malformed JSON
- prove the last good route remains usable across seven malformed rewrite shapes

## Why this matters
The endpoint allowlist is re-rendered during activation and read again without restarting model-router. Its documented runtime contract is to retain the last good allowlist while the file is missing or invalid. That worked for broken JSON, but valid JSON such as `null`, `[]`, `{"endpoints": null}`, or a scalar entry raised `AttributeError`. At startup this could stop model-router; during an activation it turned otherwise routable inference requests into 500 responses instead of serving through the last verified endpoint.

Root cause: parsing validated JSON syntax but dereferenced `.get()` on the root and every entry without validating their container types.

Invariant: a rewritten allowlist replaces the cache only after its structural containers are valid. Any invalid rewrite leaves the last good endpoint map active.

## Overlap check
Searched open and closed upstream PRs for malformed model-router endpoint roots, endpoint allowlist shapes, and `model-router/app/main.py`. Merged #1914 established the allowlist and last-good-cache contract. Open #2991 handles public aliases, #2992 preserves upstream headers, and #2719 adds forward-route authentication. None validates JSON container shapes or protects a cached route from wrong-shape rewrites.

## Regression coverage
A parameterized HTTP-boundary test warms the production allowlist, rewrites `endpoints.json` with each of these payloads, and sends another `/v1/chat/completions` request:

- `null`
- root array
- missing `endpoints`
- null/object `endpoints`
- null/string entries

Every request remains HTTP 200 and reaches the original allowlisted upstream.

## Validation
- `pytest -q tests/test_router.py -k EndpointsReload` ? 10 passed
- `pytest -q tests` ? 55 passed
- `python -m compileall -q app/main.py tests/test_router.py` ? passed
- `git diff --check` ? passed

## Design and rollback
Field-level behavior is unchanged: object entries with missing or unsupported URLs are still skipped as before. The patch only prevents non-object containers from escaping the existing `ValueError` I/O boundary. Rollback is one commit, but restores startup/request crashes on syntactically valid malformed config.
