### PR TITLE
fix(egress): reject non-object route state roots

### DIFF
--- a/ods/bin/remote_provider/egress.py
+++ b/ods/bin/remote_provider/egress.py
@@ -103,7 +103,7 @@ def load_route_state(path: str | Path) -> dict[str, Any]:
     """Read generated remote routing state; missing means disabled."""
     state_path = Path(path)
     try:
-        return json.loads(state_path.read_text(encoding="utf-8"))
+        state = json.loads(state_path.read_text(encoding="utf-8"))
     except FileNotFoundError:
         return {
             "schema": ROUTING_STATE_SCHEMA,
@@ -113,6 +113,13 @@ def load_route_state(path: str | Path) -> dict[str, Any]:
         }
     except (OSError, ValueError) as exc:
         raise EgressError(503, "invalid_route_state", str(exc)) from exc
+    if not isinstance(state, Mapping):
+        raise EgressError(
+            503,
+            "invalid_route_state",
+            "routing-state root must be a JSON object",
+        )
+    return dict(state)
 
 
 def _route_env_from_state(state: Mapping[str, Any], provider: Mapping[str, Any]) -> dict[str, str]:
@@ -142,6 +149,8 @@ def route_from_state(
     policy: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Validate generated routing-state metadata and return a public route."""
+    if not isinstance(state, Mapping):
+        raise EgressError(503, "invalid_route_state", "routing-state root must be an object")
     if state.get("schema") != ROUTING_STATE_SCHEMA:
         raise EgressError(503, "invalid_route_state", "unknown routing-state schema")
     mode = str(state.get("mode") or "cloud")

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(ROOT / "bin"))
 
 from remote_provider.egress import (  # noqa: E402
     EgressError,
+    load_route_state,
     prepare_upstream_request,
     provider_secret_status,
     route_from_state,
@@ -257,6 +258,27 @@ def test_egress_fails_closed_without_secret_or_supported_transport() -> None:
     )
 
 
+def test_route_state_rejects_non_object_json_roots() -> None:
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        state_path = Path(tmp_dir) / "routing-state.json"
+        for payload in (None, [], [route_state()], "enabled", 1, True):
+            state_path.write_text(json.dumps(payload), encoding="utf-8")
+            exc = assert_egress_error(
+                lambda: load_route_state(state_path),
+                "invalid_route_state",
+            )
+            assert_true(exc.status == 503, f"wrong status for {payload!r}: {exc.status}")
+
+            direct_exc = assert_egress_error(
+                lambda: route_from_state(payload),
+                "invalid_route_state",
+            )
+            assert_true(
+                direct_exc.status == 503,
+                f"route_from_state returned wrong status for {payload!r}",
+            )
+
+
 def test_secret_file_status_is_support_bundle_safe() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         missing = Path(tmp) / "provider-api-key"
@@ -462,6 +484,7 @@ def main() -> int:
         test_direct_resolution_rejects_unsafe_dns_answers,
         test_ssh_route_uses_internal_tunnel_without_direct_dns,
         test_egress_fails_closed_without_secret_or_supported_transport,
+        test_route_state_rejects_non_object_json_roots,
         test_secret_file_status_is_support_bundle_safe,
         test_probe_response_returns_redacted_ssh_receipt_through_tunnel_boundary,
         test_probe_response_fails_closed_when_ssh_tunnel_is_not_ready,


### PR DESCRIPTION
﻿## Summary
- validate that decoded remote-provider routing state is a JSON object before exposing it to route planning
- retain the same `invalid_route_state` 503 receipt for both file-backed and direct helper callers
- cover null, array, scalar, and boolean roots against the public egress contract

## Why this matters
`routing-state.json` is produced by the host agent and consumed on every egress health/probe/forward operation. Invalid JSON was translated into a typed 503, but syntactically valid JSON with a non-object root reached `route_from_state`, where `.get()` raised `AttributeError`. That turned `/health` and inference forwarding into untyped 500s and could also crash callers during a partial or corrupt state rewrite.

Root cause: the file boundary validated JSON syntax but not the document container required by `ods.remote-routing-state.v1`.

Invariant: every malformed routing-state document fails at the egress boundary as `EgressError(status=503, code=invalid_route_state)`; no arbitrary Python exception escapes to the service.

## Overlap check
Searched open and closed upstream PRs for remote route-state malformed roots, egress state validation, and `remote_provider/egress.py`. Open #2711 serializes host-agent state transactions, #2989 preserves forwarded query strings, and #3061 validates stream flags. Merged #2135 hardens DNS resolution and #2154 adds SSH transport. None validates the JSON root consumed by egress.

## Regression coverage
The shipped egress contract writes six valid-JSON invalid roots (`null`, empty/nested arrays, string, integer, boolean), then verifies both `load_route_state(path)` and direct `route_from_state(payload)` return the typed 503 receipt.

## Validation
- `python tests/contracts/test-remote-provider-egress-service.py` ? all 16 contracts passed
- `python tests/contracts/test-remote-provider-egress-policy.py` ? all 8 passed
- `python tests/contracts/test-remote-provider-ssh-tunnel-service.py` ? all 10 passed
- `python tests/contracts/test-remote-provider-cli.py` ? passed
- `python tests/test-render-runtime-configs.py` ? all 23 passed
- compileall on both changed Python files ? passed
- `git diff --check` ? passed

## Design and rollback
Missing state still means disabled, preserving first-run behavior. Object documents continue through the existing schema/policy checks unchanged. The direct helper guard is defense-in-depth for non-file callers and uses the same stable receipt. Rollback is a single commit, but restores untyped 500s for wrong-root state.
