### PR TITLE
fix(extensions): reject malformed progress receipts

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -195,6 +195,15 @@ def _is_stale(iso_timestamp: str, max_age_seconds: int) -> bool:
         return True
 
 
+def _load_progress_document(progress_file: Path) -> dict | None:
+    """Load one host-agent progress receipt when it has the object shape."""
+    try:
+        data = json.loads(progress_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
 def _progress_blocks_mutation(progress: dict | None) -> bool:
     """True while an in-flight operation should block update/rollback.
 
@@ -221,14 +230,16 @@ def _read_progress(service_id: str) -> dict | None:
     if not progress_file.exists():
         return None
     try:
-        data = json.loads(progress_file.read_text(encoding="utf-8"))
-        updated = data.get("updated_at", "")
-        if updated and _is_stale(updated, max_age_seconds=3600):
-            if data.get("status") not in ("error",):
-                return None
-        return data
-    except (json.JSONDecodeError, OSError):
+        data = _load_progress_document(progress_file)
+    except OSError:
         return None
+    if data is None:
+        return None
+    updated = data.get("updated_at", "")
+    if updated and _is_stale(updated, max_age_seconds=3600):
+        if data.get("status") not in ("error",):
+            return None
+    return data
 
 
 def _cleanup_stale_progress() -> None:
@@ -238,12 +249,14 @@ def _cleanup_stale_progress() -> None:
         return
     for f in progress_dir.glob("*.json"):
         try:
-            data = json.loads(f.read_text(encoding="utf-8"))
+            data = _load_progress_document(f)
+            if data is None:
+                continue
             if data.get("status") == "started" and _is_stale(data.get("updated_at", ""), 900):
                 f.unlink(missing_ok=True)
             elif _is_stale(data.get("updated_at", ""), 3600):
                 f.unlink(missing_ok=True)
-        except (json.JSONDecodeError, OSError):
+        except OSError:
             pass
 
 
@@ -270,11 +283,14 @@ def _write_error_progress(service_id: str, error_msg: str) -> None:
     now = datetime.now(timezone.utc).isoformat()
     data = {"service_id": service_id, "status": "pulling", "error": None,
             "phase_label": "", "started_at": now, "updated_at": now}
+    existing = None
     try:
         if progress_file.exists():
-            data = json.loads(progress_file.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError) as exc:
+            existing = _load_progress_document(progress_file)
+    except OSError as exc:
         logger.warning("Failed to read progress file for %s: %s", service_id, exc)
+    if existing is not None:
+        data = existing
     data["status"] = "error"
     data["error"] = error_msg
     data["updated_at"] = now
@@ -1266,13 +1282,13 @@ def extension_progress(service_id: str, api_key: str = Depends(verify_api_key)):
     if not progress_file.exists():
         return {"service_id": service_id, "status": "idle"}
     try:
-        data = json.loads(progress_file.read_text(encoding="utf-8"))
-        return data
-    except json.JSONDecodeError:
-        return {"service_id": service_id, "status": "idle"}
+        data = _load_progress_document(progress_file)
     except OSError as exc:
         logger.warning("Failed to read progress file for %s: %s", service_id, exc)
         return {"service_id": service_id, "status": "idle"}
+    if data is None:
+        return {"service_id": service_id, "status": "idle"}
+    return data
 
 
 @router.get("/api/extensions/{service_id}")

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3119,6 +3119,23 @@ class TestInstallProgress:
         assert data["status"] == "pulling"
         assert data["phase_label"] == "Downloading image..."
 
+    @pytest.mark.parametrize("payload", [None, [], "pulling", 1, True])
+    def test_progress_endpoint_treats_non_object_receipts_as_idle(
+        self, test_client, monkeypatch, tmp_path, payload
+    ):
+        _patch_mutation_config(monkeypatch, tmp_path)
+        progress_dir = tmp_path / "extension-progress"
+        progress_dir.mkdir()
+        (progress_dir / "my-ext.json").write_text(json.dumps(payload))
+
+        response = test_client.get(
+            "/api/extensions/my-ext/progress",
+            headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"service_id": "my-ext", "status": "idle"}
+
     def test_status_installing_when_progress_pulling(self, monkeypatch, tmp_path):
         """Progress file with status 'pulling' → _compute_extension_status returns 'installing'."""
         from routers.extensions import _compute_extension_status
@@ -3953,6 +3970,25 @@ class TestWriteErrorProgress:
         assert data["status"] == "error"
         assert data["error"] == "Agent unreachable"
         assert "phase_label" in data
+
+    @pytest.mark.parametrize("payload", [None, [], "pulling", 1, True])
+    def test_repairs_non_object_progress_when_recording_error(
+        self, monkeypatch, tmp_path, payload
+    ):
+        from routers.extensions import _write_error_progress
+
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+        progress_dir = tmp_path / "extension-progress"
+        progress_dir.mkdir()
+        progress_file = progress_dir / "my-ext.json"
+        progress_file.write_text(json.dumps(payload))
+
+        _write_error_progress("my-ext", "Agent unavailable")
+
+        repaired = json.loads(progress_file.read_text())
+        assert repaired["service_id"] == "my-ext"
+        assert repaired["status"] == "error"
+        assert repaired["error"] == "Agent unavailable"
 
 # --- _activate_service: built-in (EXTENSIONS_DIR) branch ---
 


### PR DESCRIPTION
﻿## Summary
- centralize loading of extension progress receipts and accept only JSON objects
- return the documented idle receipt when the host-agent file contains any other valid JSON shape
- rebuild an object-shaped error receipt when a failed mutation encounters malformed progress state

## Why this matters
The dashboard API reads progress receipts written across the host-agent boundary. A truncated writer is already handled as invalid JSON, but valid JSON such as `null`, an array, or a scalar currently either crashes object consumers with `.get`/item-assignment errors or leaks a scalar from the public progress endpoint. That can turn an install failure into a second 500 and leaves the UI without its stable `{service_id, status}` contract.

## Behavioral invariant
An extension progress receipt is usable only when its JSON root is an object. Every other root shape is treated as absent, and recording a terminal error repairs the receipt to an object.

## Overlap check
Searched open and closed upstream PRs for extension progress receipts, malformed JSON/document shapes, and the changed production/test files. #3065 changes frontend polling concurrency only; merged #1056 covers catalog timeouts and merged #1724 covers model actions. None validates the backend receipt root or repairs a malformed receipt, so this scope is independent.

## Validation
- `pytest -q tests/test_extensions.py -k 'non_object_progress or non_object_receipts or progress_endpoint_during_install or sets_error_status'` ? 12 passed
- `pytest -q tests/test_extensions.py` ? 265 passed, 5 skipped
- `python -m compileall -q routers/extensions.py tests/test_extensions.py`
- `git diff --check`

## Tradeoffs and rollback
Malformed receipts are deliberately treated like missing state rather than surfaced as an API error, matching the existing invalid-JSON behavior. Files are not deleted, preserving host diagnostics. Reverting this commit restores the prior permissive JSON-root behavior.
