### PR TITLE
fix(status): validate LLM metadata response shapes

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -540,18 +540,28 @@ async def get_loaded_model() -> Optional[str]:
         # authoritative source for which model is actually loaded.
         if LLM_BACKEND == "lemonade":
             resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/health")
-            loaded = resp.json().get("model_loaded")
-            return loaded if loaded else None
+            payload = resp.json()
+            if not isinstance(payload, dict):
+                raise ValueError("Lemonade health response is not an object")
+            loaded = payload.get("model_loaded")
+            return loaded if isinstance(loaded, str) and loaded else None
 
         # llama.cpp: /v1/models returns the loaded model with status info.
         resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/models")
-        models = resp.json().get("data", [])
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise ValueError("llama-server models response is not an object")
+        models = payload.get("data", [])
+        if not isinstance(models, list) or not all(isinstance(model, dict) for model in models):
+            raise ValueError("llama-server models data is not a list of objects")
         for m in models:
             status = m.get("status", {})
             if isinstance(status, dict) and status.get("value") == "loaded":
-                return m.get("id")
+                model_id = m.get("id")
+                return model_id if isinstance(model_id, str) and model_id else None
         if models:
-            return models[0].get("id")
+            model_id = models[0].get("id")
+            return model_id if isinstance(model_id, str) and model_id else None
     except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as e:
         logger.debug("get_loaded_model failed: %s", e)
     return None
@@ -574,9 +584,15 @@ async def get_llama_context_size(model_hint: Optional[str] = None) -> Optional[i
             url += f"?model={loaded}"
         client = await _get_httpx_client()
         resp = await client.get(url)
-        n_ctx = resp.json().get("default_generation_settings", {}).get("n_ctx")
+        payload = resp.json()
+        if not isinstance(payload, dict):
+            raise ValueError("llama-server props response is not an object")
+        settings = payload.get("default_generation_settings", {})
+        if not isinstance(settings, dict):
+            raise ValueError("llama-server generation settings are not an object")
+        n_ctx = settings.get("n_ctx")
         return int(n_ctx) if n_ctx else None
-    except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as e:
+    except (httpx.HTTPError, httpx.TimeoutException, TypeError, ValueError, KeyError) as e:
         logger.debug("get_llama_context_size failed: %s", e)
         return None
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -752,6 +752,51 @@ class TestGetLoadedModel:
         result = await get_loaded_model()
         assert result is None
 
+    @pytest.mark.parametrize("payload", [None, [], "loaded", 1, True])
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_object_models_response(self, monkeypatch, payload):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        mock_response = MagicMock()
+        mock_response.json.return_value = payload
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_loaded_model() is None
+
+    @pytest.mark.parametrize("data", [None, {}, "model", ["model"], [1]])
+    @pytest.mark.asyncio
+    async def test_returns_none_for_malformed_models_data(self, monkeypatch, data):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"data": data}
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_loaded_model() is None
+
+    @pytest.mark.parametrize("payload", [None, [], "healthy", 1, True])
+    @pytest.mark.asyncio
+    async def test_lemonade_returns_none_for_non_object_health_response(
+        self, monkeypatch, payload
+    ):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        monkeypatch.setattr("helpers.LLM_BACKEND", "lemonade")
+        mock_response = MagicMock()
+        mock_response.json.return_value = payload
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_loaded_model() is None
+
 
 # --- get_llama_context_size ---
 
@@ -802,6 +847,36 @@ class TestGetLlamaContextSize:
 
         result = await get_llama_context_size(model_hint="test-model")
         assert result is None
+
+    @pytest.mark.parametrize("payload", [None, [], "props", 1, True])
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_object_props_response(self, monkeypatch, payload):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        mock_response = MagicMock()
+        mock_response.json.return_value = payload
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_llama_context_size(model_hint="test-model") is None
+
+    @pytest.mark.parametrize("settings", [None, [], "settings", 1, True])
+    @pytest.mark.asyncio
+    async def test_returns_none_for_non_object_generation_settings(
+        self, monkeypatch, settings
+    ):
+        monkeypatch.setattr("helpers.SERVICES", {
+            "llama-server": {"host": "localhost", "port": 8080},
+        })
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"default_generation_settings": settings}
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        assert await get_llama_context_size(model_hint="test-model") is None
 
 
 # --- get_disk_usage ---


### PR DESCRIPTION
﻿## Summary
- validate the JSON root returned by Lemonade health and llama.cpp model/props endpoints
- validate nested model arrays and generation settings before object access
- expose malformed provider metadata as unavailable runtime state instead of crashing shared status consumers

## Why this matters
`get_loaded_model()` and `get_llama_context_size()` feed `/api/status`, `/api/readiness`, `/api/model-readiness`, model activation state, node metadata, and Talk. Although invalid JSON is already treated as unavailable, valid JSON with a scalar/array root or malformed nested fields raises `AttributeError`/`TypeError`, turning a degraded inference backend into dashboard 500s. These are external HTTP response boundaries and must fail closed to `None` without masking internal programming errors.

## Behavioral invariant
LLM runtime metadata is published only from the documented object/list shapes. Invalid external response shapes produce `None`; valid llama.cpp and Lemonade responses retain their existing behavior.

## Overlap check
Searched all open upstream PR changed-file inventories for `ods/extensions/services/dashboard-api/helpers.py` (no matches), plus open/closed PRs for loaded-model, llama props/context, and response-shape terms. Merged #1995 only guards an absent llama-server in cloud mode. No existing PR validates these HTTP payload structures, so this scope is independent.

## Validation
- `pytest -q tests/test_helpers.py -k 'GetLoadedModel or GetLlamaContextSize'` ? 32 passed
- `pytest -q tests/test_helpers.py` ? 129 passed, 2 skipped
- `python -m compileall -q helpers.py tests/test_helpers.py`
- `git diff --check`

## Tradeoffs and rollback
A malformed entry invalidates the model document instead of guessing around it, which avoids reporting an arbitrary model. This remains fail-soft only at the remote I/O boundary. Reverting the commit restores the prior permissive shape assumptions.
