### PR TITLE
fix(cli): stop after requested image build failure

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -98,6 +98,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI update post-verification ==="
 	@bash tests/test-cli-update-verification.sh
 	@echo ""
+	@echo "=== CLI local image rebuild failure ==="
+	@bash tests/test-cli-rebuild-image-failure.sh
+	@echo ""
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh
 	@echo ""

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1162,7 +1162,7 @@ _ods_cli_rebuild_images() {
     _check_docker_access
     log "Rebuilding local-built images (--rebuild-images)..."
     if ! docker compose "${flags[@]}" build --no-cache "${svcs[@]}"; then
-        warn "One or more images failed to rebuild (continuing — see compose output above)"
+        error "Failed to rebuild locally-built images; services were not changed."
     fi
 }
 

--- a/ods/tests/test-cli-rebuild-image-failure.sh
+++ b/ods/tests/test-cli-rebuild-image-failure.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Regression: an opt-in local image rebuild must stop lifecycle commands when
+# Docker cannot produce the requested images.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+cli_path="$root_dir/ods-cli"
+tmp_dir="$(mktemp -d)"
+docker_log="$tmp_dir/docker.log"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+function_source="$(awk '/^_ods_cli_rebuild_images\(\)/,/^}/' "$cli_path")"
+[[ -n "$function_source" ]] || {
+    printf '[FAIL] could not extract _ods_cli_rebuild_images\n' >&2
+    exit 1
+}
+
+log() { :; }
+_check_docker_access() { :; }
+error() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+docker() {
+    printf '%s\n' "$*" >> "$docker_log"
+    return "${TEST_DOCKER_BUILD_RC:-0}"
+}
+
+eval "$function_source"
+
+set +e
+failure_output="$(TEST_DOCKER_BUILD_RC=23 _ods_cli_rebuild_images -f docker-compose.base.yml 2>&1)"
+failure_rc=$?
+set -e
+
+[[ "$failure_rc" -ne 0 ]] || {
+    printf '[FAIL] rebuild helper returned success after docker compose build failed\n' >&2
+    exit 1
+}
+grep -q 'Failed to rebuild locally-built images; services were not changed' <<< "$failure_output" || {
+    printf '[FAIL] rebuild helper did not surface an actionable failure\n%s\n' "$failure_output" >&2
+    exit 1
+}
+
+: > "$docker_log"
+TEST_DOCKER_BUILD_RC=0 _ods_cli_rebuild_images -f docker-compose.base.yml
+grep -q '^compose -f docker-compose.base.yml build --no-cache ' "$docker_log" || {
+    printf '[FAIL] successful rebuild did not invoke the expected Compose build boundary\n' >&2
+    cat "$docker_log" >&2
+    exit 1
+}
+
+for command_name in cmd_start cmd_restart cmd_update; do
+    command_source="$(awk "/^${command_name}\\(\\)/,/^}/" "$cli_path")"
+    grep -q '_ods_cli_rebuild_images' <<< "$command_source" || {
+        printf '[FAIL] %s no longer routes --rebuild-images through the guarded helper\n' "$command_name" >&2
+        exit 1
+    }
+done
+
+printf '[PASS] CLI image rebuild failures stop start, restart, and update\n'

--- a/ods/tests/test-cli-rebuild-image-failure.sh
+++ b/ods/tests/test-cli-rebuild-image-failure.sh
@@ -25,6 +25,11 @@ error() {
 }
 docker() {
     printf '%s\n' "$*" >> "$docker_log"
+    if [[ " $* " == *" config --services "* ]]; then
+        printf '%s\n' dashboard dashboard-api model-router remote-provider-egress \
+            remote-provider-ssh-tunnel ape token-spy privacy-shield brave-search
+        return 0
+    fi
     return "${TEST_DOCKER_BUILD_RC:-0}"
 }
 


### PR DESCRIPTION
﻿## Summary
- make an explicitly requested local image rebuild fatal when `docker compose build` fails
- prevent `start`, `restart`, and `update` from continuing with stale locally-built images
- add the real helper to the default test gate with success/failure and caller-routing coverage

## Why this matters
`--rebuild-images` is an explicit operator request to deploy contributor or local source changes. The shared helper currently logs a warning on build failure and returns success, so all three lifecycle commands continue: `start`/`restart` can launch an old tag, and `update` can force-recreate containers from that stale image and later report success. The operator therefore gets the opposite of the requested deployment without a failing exit status.

## Behavioral invariant
When a requested local image cannot be built, no Compose lifecycle step may run against the stale image. A successful build preserves the current start/restart/update flow.

## Overlap check
Searched open and closed upstream PRs by `--rebuild-images`, build-failure/exit-code terms, and every open PR changed-file inventory for `ods/ods-cli`. Merged #1089 introduced the opt-in flag but intentionally made build failure non-fatal; merged #1331/#1327 limit installer build lists and do not change CLI failure propagation. The current open `ods-cli` PRs concern URLs, rootless ownership, config, rollback, status, and refactoring?not local rebuild exit semantics.

## Validation
- `bash tests/test-cli-rebuild-image-failure.sh` ? PASS; failed Docker build returns nonzero, success invokes the expected Compose boundary, and all three callers remain covered
- `bash -n ods-cli tests/test-cli-rebuild-image-failure.sh`
- `shellcheck --rcfile /dev/null --severity=error ods-cli tests/test-cli-rebuild-image-failure.sh`
- `git diff --check`
- `bash tests/contracts/test-installer-contracts.sh` passed the related ?failed requested local builds cannot reuse stale images? contracts, then stopped at the pre-existing unrelated `Hermes template bounds each model turn` assertion

An older aggregate fixture, `tests/test-cli-update-verification.sh`, also has an upstream baseline failure after update verification because its temporary install omits `bin/ods-host-agent.py`; the focused regression does not depend on that fixture.

## Tradeoffs and rollback
This intentionally changes only the opt-in failure path. Operators who do not pass `--rebuild-images` see no behavior change. Pulling external images and taking the pre-update snapshot may already have occurred before an update build fails, but running containers are left untouched. Reverting this commit restores stale-image continuation.


## Batch composition update
#3107 now supplies active-service selection and the complete local-image inventory. Merge #3107 first, then port/rebase this PR's fatal build-failure line. Synthetic integration head `0511d01171c3787d14089012a3dc1e0305afe5b0` contains both changes in that order; both focused CLI regressions, build-only coverage, Bash syntax, ShellCheck error gate, and diff check pass together. Follow-up commit `08e9e755` makes this PR's Docker test double distinguish Compose discovery from the actual build boundary.
