### PR TITLE
fix(cli): rebuild only active local images

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -32,6 +32,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
+	@bash tests/test-cli-rebuild-active-services.sh
 	@bash tests/test-external-services.sh
 	@bash tests/test-resolve-compose-resilient.sh
 	@bash tests/test-phase03-multigpu-tty.sh

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1153,15 +1153,39 @@ _check_docker_access() {
 #=============================================================================
 _ods_cli_rebuild_images() {
     local flags=("$@")
-    local svcs=(dashboard dashboard-api ape token-spy privacy-shield)
+    local candidate_services=(
+        dashboard dashboard-api model-router remote-provider-egress
+        remote-provider-ssh-tunnel ape token-spy privacy-shield brave-search
+    )
     # Mirror phases/11-services.sh conditional builds: ComfyUI when enabled
     # and llama-server on AMD (Lemonade builds the binary in the container).
     # Other GPU backends pull pre-built images.
-    [[ "${ENABLE_COMFYUI:-}" == "true" ]] && svcs+=(comfyui)
-    [[ "${GPU_BACKEND:-}" == "amd" ]] && svcs+=(llama-server)
+    [[ "${ENABLE_COMFYUI:-}" == "true" ]] && candidate_services+=(comfyui)
+    [[ "${GPU_BACKEND:-}" == "amd" ]] && candidate_services+=(llama-server)
     _check_docker_access
+
+    local enabled_services
+    if ! enabled_services=$(docker compose "${flags[@]}" config --services); then
+        error "Could not resolve enabled Compose services for local image rebuilds."
+    fi
+
+    local -a build_services=()
+    local service
+    for service in "${candidate_services[@]}"; do
+        if [[ $'\n'"$enabled_services"$'\n' == *$'\n'"$service"$'\n'* ]]; then
+            build_services+=("$service")
+        else
+            log "Skipping local image rebuild for disabled service: $service"
+        fi
+    done
+
+    if (( ${#build_services[@]} == 0 )); then
+        success "No enabled local images require rebuilding"
+        return 0
+    fi
+
     log "Rebuilding local-built images (--rebuild-images)..."
-    if ! docker compose "${flags[@]}" build --no-cache "${svcs[@]}"; then
+    if ! docker compose "${flags[@]}" build --no-cache "${build_services[@]}"; then
         warn "One or more images failed to rebuild (continuing — see compose output above)"
     fi
 }

--- a/ods/tests/test-cli-rebuild-active-services.sh
+++ b/ods/tests/test-cli-rebuild-active-services.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Regression: --rebuild-images must target the active Compose stack, including
+# newer build-only services, without naming disabled optional services.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+cli_path="$root_dir/ods-cli"
+tmp_dir="$(mktemp -d)"
+docker_log="$tmp_dir/docker.log"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+function_source="$(awk '/^_ods_cli_rebuild_images\(\)/,/^}/' "$cli_path")"
+[[ -n "$function_source" ]] || {
+    printf '[FAIL] could not extract _ods_cli_rebuild_images\n' >&2
+    exit 1
+}
+
+log() { :; }
+success() { :; }
+warn() { :; }
+_check_docker_access() { :; }
+error() {
+    printf '%s\n' "$1" >&2
+    exit 1
+}
+docker() {
+    printf '%s\n' "$*" >> "$docker_log"
+    if [[ " $* " == *" config --services "* ]]; then
+        [[ "${TEST_CONFIG_FAIL:-}" != "1" ]] || return 24
+        printf '%s\n' "${TEST_ENABLED_SERVICES:-}"
+    fi
+}
+
+eval "$function_source"
+
+TEST_ENABLED_SERVICES=$'dashboard\nmodel-router\nbrave-search' \
+    _ods_cli_rebuild_images -f docker-compose.base.yml
+
+grep -q '^compose -f docker-compose.base.yml config --services$' "$docker_log" || {
+    printf '[FAIL] rebuild helper did not resolve the active Compose services\n' >&2
+    cat "$docker_log" >&2
+    exit 1
+}
+grep -q '^compose -f docker-compose.base.yml build --no-cache dashboard model-router brave-search$' "$docker_log" || {
+    printf '[FAIL] rebuild helper did not select the exact active local-build services\n' >&2
+    cat "$docker_log" >&2
+    exit 1
+}
+
+: > "$docker_log"
+TEST_ENABLED_SERVICES=n8n _ods_cli_rebuild_images -f docker-compose.base.yml
+if grep -q ' build ' "$docker_log"; then
+    printf '[FAIL] rebuild helper invoked Compose build with no active local services\n' >&2
+    cat "$docker_log" >&2
+    exit 1
+fi
+
+: > "$docker_log"
+set +e
+failure_output="$(TEST_CONFIG_FAIL=1 _ods_cli_rebuild_images -f docker-compose.base.yml 2>&1)"
+failure_rc=$?
+set -e
+[[ "$failure_rc" -ne 0 ]] || {
+    printf '[FAIL] rebuild helper continued after Compose service resolution failed\n' >&2
+    exit 1
+}
+grep -q 'Could not resolve enabled Compose services' <<< "$failure_output" || {
+    printf '[FAIL] rebuild helper did not explain the Compose resolution failure\n' >&2
+    exit 1
+}
+if grep -q ' build ' "$docker_log"; then
+    printf '[FAIL] rebuild helper guessed a build list after resolution failed\n' >&2
+    cat "$docker_log" >&2
+    exit 1
+fi
+
+printf '[PASS] CLI rebuilds exactly the active local-image services\n'

--- a/ods/tests/test-local-image-build-coverage.py
+++ b/ods/tests/test-local-image-build-coverage.py
@@ -2,9 +2,9 @@
 """Local-image build coverage contract.
 
 Every service that can only exist as a locally built image must appear in each
-installer's local-build list, or the installer runs ``docker compose up
---no-build --pull never`` against an image that was never built and fails with
-"No such image" on a fresh host.
+installer's local-build list and the ODS CLI rebuild list. Otherwise a fresh
+install can reach ``docker compose up --no-build --pull never`` without an
+image, or ``ods update --rebuild-images`` can silently omit contributor edits.
 
 This is the negative self-test for the model-router fleet regression
 (build-only core service missing from the hardcoded installer build lists):
@@ -39,6 +39,7 @@ EXTENSIONS = ROOT / "extensions" / "services"
 LINUX = ROOT / "installers" / "phases" / "11-services.sh"
 MACOS = ROOT / "installers" / "macos" / "install-macos.sh"
 WINDOWS = ROOT / "installers" / "windows" / "install-windows.ps1"
+CLI = ROOT / "ods-cli"
 
 # An image reference that no registry can serve. Compose started with
 # `--pull never` can only satisfy these from a local build.
@@ -141,9 +142,18 @@ def main() -> int:
         windows.update(re.findall(r'"([a-z0-9-]+)"', m.group(1)))
     windows.update(re.findall(r'\$_buildServices \+= "([a-z0-9-]+)"', win_text))
 
+    # ODS CLI: candidate_services=(...) plus conditional += lines.
+    cli_text = CLI.read_text(encoding="utf-8")
+    cli = set()
+    m = re.search(r"candidate_services=\(([^)]*)\)", cli_text, re.DOTALL)
+    if m:
+        cli.update(re.findall(r"[a-z0-9][a-z0-9-]+", m.group(1)))
+    cli.update(re.findall(r"candidate_services\+=\(([a-z0-9-]+)\)", cli_text))
+
     for name, present in (("Linux 11-services.sh", linux),
                           ("macOS install-macos.sh", macos),
-                          ("Windows install-windows.ps1", windows)):
+                          ("Windows install-windows.ps1", windows),
+                          ("ods-cli --rebuild-images", cli)):
         missing = required - present
         if missing:
             errors.append(f"{name}: build-only services not in build list: {sorted(missing)}")


### PR DESCRIPTION
﻿## Summary
- resolve the active Compose service set before an opt-in CLI image rebuild
- build only enabled local-image services and skip disabled optional services
- add model-router, remote-provider-egress, remote-provider-ssh-tunnel, and brave-search to the CLI build inventory
- extend the build-only coverage gate to keep Linux, macOS, Windows, and `ods-cli` aligned

## Why this matters
`ods start|restart|update --rebuild-images` currently passes a fixed list to Compose. A valid stack with an optional service disabled can fail with `no such service`, while newer build-only services missing from that list keep running stale images even though the operator explicitly requested a rebuild. The installer paths already resolve the selected stack; the CLI is the remaining inconsistent production path.

## Behavioral invariant
An opt-in CLI rebuild targets every build-only service present in the resolved stack, and no service absent from that stack. If Compose cannot report the active service set, the CLI stops rather than guessing.

## Overlap check
Searched open/closed PRs for CLI rebuild selection, disabled-service failures, active Compose services, model-router rebuilds, and all open `ods-cli` changed-file inventories. Merged #1331 and #1327 implement this invariant for Linux/macOS installers only. Merged #1089 introduced the CLI flag with the older fixed list. No open PR updates CLI service selection or its build-only coverage contract.

## Validation
- `bash tests/test-cli-rebuild-active-services.sh` ? PASS; exact active-set selection, empty active local set, and resolution-failure paths
- `python3 tests/test-local-image-build-coverage.py` ? all 9 build-only services covered by Linux, macOS, Windows, and CLI
- `python -m compileall -q tests/test-local-image-build-coverage.py`
- `bash -n ods-cli tests/test-cli-rebuild-active-services.sh`
- `shellcheck --rcfile /dev/null --severity=error ods-cli tests/test-cli-rebuild-active-services.sh`
- `git diff --check`

## Batch composition
This PR and #3106 touch the shared rebuild helper but preserve independent invariants. Merge this PR first, then port/rebase #3106's fatal build-failure line. Synthetic integration head `0511d01171c3787d14089012a3dc1e0305afe5b0` contains both changes in that order; both focused CLI tests, build-only coverage, Bash syntax, ShellCheck error gate, and diff check pass together.

## Tradeoffs and rollback
The extra `docker compose config --services` call is local and bounded by Compose parsing; it avoids speculative builds. An empty local-build intersection is a successful no-op. Reverting restores the fixed list, including stale-image omissions and disabled-service failures.
