### PR TITLE
fix(privacy): add status and toggle endpoint error resilience unit test suite

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_privacy_router_resilience.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy_router_resilience.py
@@ -1,0 +1,24 @@
+"""Unit tests for privacy shield router status and toggle endpoints."""
+
+from unittest.mock import AsyncMock, patch
+import pytest
+
+from routers.privacy import get_privacy_shield_status, toggle_privacy_shield
+from models import PrivacyShieldToggle
+
+
+@pytest.mark.asyncio
+async def test_get_privacy_shield_status_defaults_when_unreachable():
+    with patch("aiohttp.ClientSession.get", side_effect=OSError("Unreachable")):
+        status = await get_privacy_shield_status(api_key="valid-key")
+        assert status.enabled is False
+        assert status.container_running is False
+        assert "not running" in status.message
+
+
+@pytest.mark.asyncio
+async def test_toggle_privacy_shield_start_action():
+    with patch("routers.privacy.request_agent_json", return_value={"status": "ok"}):
+        req = PrivacyShieldToggle(enable=True)
+        res = await toggle_privacy_shield(req, api_key="valid-key")
+        assert res["success"] is True

--- a/ods/extensions/services/dashboard-api/tests/test_privacy_router_resilience.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy_router_resilience.py
@@ -1,6 +1,6 @@
 """Unit tests for privacy shield router status and toggle endpoints."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 import pytest
 
 from routers.privacy import get_privacy_shield_status, toggle_privacy_shield


### PR DESCRIPTION
## Context & Problem

In `ods/extensions/services/dashboard-api/routers/privacy.py`, Privacy Shield status monitoring (`get_privacy_shield_status`) and activation toggling (`toggle_privacy_shield`) interact with privacy-shield health endpoints and host-agent extension routers. Unreachable services or host-agent failures must return structured fallback status objects without throwing unhandled server exceptions.

## Implementation Details

- **Test Verification Suite**: Added `test_privacy_router_resilience.py` with unit tests validating:
  - Default status fallbacks when privacy-shield health probes fail with `OSError`.
  - Start action dispatch and success response payload verification.

## Verification & Tests

Executed pytest test suite:
```
python3 -m pytest tests/test_privacy_router_resilience.py tests/test_privacy.py
======================== 19 passed, 1 warning in 0.49s =========================
```