### PR TITLE
fix(node): add encoding fallback, UnicodeError handling, and unit test suite

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/node.py
+++ b/ods/extensions/services/dashboard-api/routers/node.py
@@ -49,7 +49,7 @@ def _read_ods_version(fallback: str) -> str:
 
     version_file = root / ".version"
     try:
-        raw = version_file.read_text().strip()
+        raw = version_file.read_text(encoding="utf-8").strip()
         if raw:
             if raw.startswith("{"):
                 data = json.loads(raw)
@@ -57,7 +57,7 @@ def _read_ods_version(fallback: str) -> str:
                     return str(data["version"])
             else:
                 return raw
-    except (OSError, json.JSONDecodeError, ValueError):
+    except (OSError, json.JSONDecodeError, ValueError, UnicodeError):
         pass
 
     return fallback

--- a/ods/extensions/services/dashboard-api/tests/test_node_router_resilience.py
+++ b/ods/extensions/services/dashboard-api/tests/test_node_router_resilience.py
@@ -1,0 +1,30 @@
+"""Unit tests for node capability router version resolution resilience."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from routers.node import _read_ods_version
+
+
+def test_read_ods_version_from_env(tmp_path: Path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("ODS_VERSION=1.5.0\n")
+    with patch("routers.node._install_root", return_value=tmp_path):
+        ver = _read_ods_version("0.1.0")
+        assert ver == "1.5.0"
+
+
+def test_read_ods_version_from_json_version(tmp_path: Path):
+    version_file = tmp_path / ".version"
+    version_file.write_text('{"version": "2.0.0"}')
+    with patch("routers.node._install_root", return_value=tmp_path):
+        ver = _read_ods_version("0.1.0")
+        assert ver == "2.0.0"
+
+
+def test_read_ods_version_fallback_on_corrupt(tmp_path: Path):
+    version_file = tmp_path / ".version"
+    version_file.write_bytes(b"\x80\xff\xfeinvalid")
+    with patch("routers.node._install_root", return_value=tmp_path):
+        ver = _read_ods_version("0.1.0")
+        assert ver == "0.1.0"


### PR DESCRIPTION
## Context & Problem

In `ods/extensions/services/dashboard-api/routers/node.py`, `_read_ods_version()` reads the installed ODS version string from `.env` or `.version` files. Reading binary-corrupted or non-UTF8 encoded `.version` files without explicit encoding specs could leak unhandled `UnicodeError` exceptions.

## Implementation Details

- **Encoding Fallback & Error Trapping**: Updated `version_file.read_text(encoding="utf-8")` in `_read_ods_version()` and added `UnicodeError` to exception handling bounds.
- **Unit Test Suite**: Added `test_node_router_resilience.py` with tests validating version reading from `.env`, JSON formatted `.version` files, and fallback to app version on binary file corruption.

## Verification & Tests

Executed pytest test suite:
```
python3 -m pytest tests/test_node_router_resilience.py tests/test_node.py
======================== 14 passed, 1 warning in 0.49s =========================
```