### PR TITLE
fix(installer): guard empty podman source list under set -u

### DIFF
--- a/ods/installers/lib/podman-registries.sh
+++ b/ods/installers/lib/podman-registries.sh
@@ -24,7 +24,12 @@ ods_podman_ensure_dockerhub_search() {
         done
     fi
 
-    if python3 - "$target_conf" "$effective_search_json" "${source_confs[@]}" <<'PY'
+    # "${source_confs[@]}" aborts under `set -u` with "unbound variable" when
+    # the array is empty on Bash < 4.4 (macOS 3.2, RHEL 7). The guarded form
+    # passes no extra argument instead, which the Python side already treats
+    # as "no fallback sources".
+    if python3 - "$target_conf" "$effective_search_json" \
+        ${source_confs[@]+"${source_confs[@]}"} <<'PY'
 import ast
 import json
 import os

--- a/ods/tests/test-podman-rootless-contracts.sh
+++ b/ods/tests/test-podman-rootless-contracts.sh
@@ -135,6 +135,14 @@ if grep -Eq 'list\[|\|[[:space:]]*None' "$REGISTRY_LIB"; then
 fi
 pass "Podman helper remains compatible with installer Python baselines"
 
+# The Python invocation forwards fallback sources as argv. An unguarded
+# array expansion aborts under `set -u` with "unbound variable" when no
+# registry config exists on disk (fresh minimal hosts) on Bash < 4.4,
+# killing phase 05 before Podman is usable.
+grep -Fq '${source_confs[@]+"${source_confs[@]}"}' "$REGISTRY_LIB" \
+    || fail "source_confs expansion must use the set -u safe guarded form"
+pass "Podman helper guards empty source_confs under set -u (Bash < 4.4)"
+
 # A Linux host may run systemd while ODS has no system unit because sudo was
 # unavailable during installation. The CLI must use the session fallback and
 # must not call sudo merely because systemd exists on the host.


### PR DESCRIPTION
## Summary

Fixes #3130.

Fixes the phase 05 crash on hosts where Podman has no registry config on disk. `ods_podman_ensure_dockerhub_search` forwarded `source_confs` to its Python helper as argv; when none of the six searched paths exist, that array is empty and its expansion aborts under `set -u` on Bash < 4.4 (`source_confs[@]: unbound variable`) before python starts. The guarded expansion passes no extra argument instead, which the helper already treats as "no fallback sources".

### Behavior and invariants

| Invariant | Implementation |
|---|---|
| Non-empty source list | Passed through unchanged (quoted, same order) |
| Empty source list | No argv entries instead of a nounset abort |
| Docker Hub drop-in contents | Unchanged for both cases |

## AI Assistance

AI-assisted triage and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [ ] Core runtime
- [ ] Tests only

## Validation

- `bash -n installers/lib/podman-registries.sh tests/test-podman-rootless-contracts.sh` - passed.
- `bash tests/test-podman-rootless-contracts.sh` - fresh-config creation, default drop-in preservation, existing-order repair, idempotency and CONTAINERS_REGISTRIES_CONF override all pass; the suite halts later at the symlink atomicity case on this MSYS checkout â€” the identical failure occurs on pristine main locally (cygwin `ln -s`), so it is unrelated to this diff.
- New contract asserts the guarded expansion form is present.
- `git diff --check upstream/main...HEAD` - clean.
