### PR TITLE
fix(sessions): tolerate an empty active-session index

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -144,9 +144,12 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
     [ -f "$f" ] || continue
     BASENAME=$(basename "$f" .jsonl)
 
-    # Check if this session is active
+    # Check if this session is active. ACTIVE_IDS is empty when the gateway
+    # has no registered sessions (fresh install or all wiped); expanding it
+    # unguarded aborts with "unbound variable" under `set -u` on Bash < 4.4,
+    # so the cleanup timer dies exactly when there is nothing to keep.
     IS_ACTIVE=false
-    for ID in "${ACTIVE_IDS[@]}"; do
+    for ID in ${ACTIVE_IDS[@]+"${ACTIVE_IDS[@]}"}; do
         if [ "$BASENAME" = "$ID" ]; then
             IS_ACTIVE=true
             break

--- a/ods/tests/test-session-cleanup.sh
+++ b/ods/tests/test-session-cleanup.sh
@@ -304,6 +304,42 @@ else
 fi
 
 # ============================================================================
+# Test 8g: Empty active set must not abort under set -u (Bash < 4.4 guard)
+# ============================================================================
+# A fresh install (or a gateway with every session wiped) has sessions.json
+# entries without sessionId or an empty object entirely. ACTIVE_IDS then ends
+# up empty, and an unguarded "${ACTIVE_IDS[@]}" loop kills the cleanup timer
+# with "unbound variable" on Bash < 4.4 — precisely when there is nothing to
+# keep, so bloated files are never pruned.
+SDIR7="$TEMP_DIR/empty-active"
+mkdir -p "$SDIR7"
+printf '{}' > "$SDIR7/sessions.json"
+printf 'stale payload\n' > "$SDIR7/orphaned.jsonl"
+
+empty_exit=0
+SESSIONS_DIR="$SDIR7" MAX_SIZE=100 \
+    bash "$SESSION_CLEANUP_SCRIPT" >"$TEMP_DIR/empty-active.log" 2>&1 || empty_exit=$?
+if [[ $empty_exit -ne 0 ]] && grep -q 'unbound variable' "$TEMP_DIR/empty-active.log"; then
+    fail "Empty ACTIVE_IDS aborted the run under nounset (exit $empty_exit)"
+elif [[ $empty_exit -ne 0 ]]; then
+    fail "Empty ACTIVE_IDS run failed unexpectedly (exit $empty_exit)"
+else
+    pass "Empty active set completes without an unbound-variable abort"
+fi
+
+if [[ ! -f "$SDIR7/orphaned.jsonl" ]]; then
+    pass "Orphaned session file is still removed when no session is active"
+else
+    fail "Orphaned session file survived an empty-index cleanup"
+fi
+
+if ! grep -qE 'for ID in "\$\{ACTIVE_IDS\[@\]\}"' "$SESSION_CLEANUP_SCRIPT"; then
+    pass "ACTIVE_IDS loop uses the set -u safe guarded expansion"
+else
+    fail "Unguarded ACTIVE_IDS expansion remains (crashes on Bash < 4.4)"
+fi
+
+# ============================================================================
 # Test 9: Script does not use silent error suppression
 # ============================================================================
 suppression_count=0


### PR DESCRIPTION
## Summary

Fixes #3132. The session-cleanup timer aborted on Bash < 4.4 whenever the index had no active sessions: `for ID in "${ACTIVE_IDS[@]}"` under `set -u` treats an empty array as unbound, so the run died before inspecting any `.jsonl` file. That is precisely the state right after a fresh install or a full wipe â€” exactly when oversized files still need pruning. Switched to the guarded expansion so an empty index simply means "nothing is active".

Adds lifecycle coverage: empty `{}` index plus one orphaned file must complete with exit 0, remove the orphan, and use the guarded form.

## AI Assistance

AI-assisted edge-case enumeration and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Core runtime (session lifecycle script)
- [ ] Tests only

## Validation

- `bash -n scripts/session-cleanup.sh tests/test-session-cleanup.sh` - passed.
- `bash tests/test-session-cleanup.sh` - passed (22 passed, including the three new empty-index cases).
- `git diff --check upstream/main...HEAD` - clean.
