### PR TITLE
fix(bootstrap): skip timeout prefix safely when binary is missing

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -939,7 +939,10 @@ restart_windows_lemonade_with_full_model() {
     if command -v timeout >/dev/null 2>&1; then
         ps_timeout_prefix=(timeout --foreground --kill-after=5s "${restart_timeout}s")
     fi
-    if "${ps_env_cmd[@]}" "${ps_timeout_prefix[@]}" \
+    # The prefix stays empty on hosts without GNU timeout; expanding an empty
+    # array unguarded aborts with "unbound variable" under `set -u` on
+    # Bash < 4.4 (macOS 3.2, RHEL 7) instead of just skipping the timeout.
+    if "${ps_env_cmd[@]}" ${ps_timeout_prefix[@]+"${ps_timeout_prefix[@]}"} \
         "$ps_cmd" -NoProfile -ExecutionPolicy Bypass -Command '
         $ErrorActionPreference = "Stop"
 

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -619,3 +619,11 @@ grep -qF 'write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES"' <<<"$docker_t
 grep -qF 'exit 1' <<<"$docker_timeout_block" \
     || fail "Docker hot-swap timeout must exit non-zero"
 pass "Docker hot-swap timeout is honest"
+
+# The Windows Lemonade restart prepends GNU timeout only when the binary
+# exists. Hosts without it leave ps_timeout_prefix empty; an unguarded
+# "${ps_timeout_prefix[@]}" expansion aborts the whole restart with "unbound
+# variable" under `set -u` on Bash < 4.4 (macOS 3.2, RHEL 7).
+grep -qF '${ps_timeout_prefix[@]+"${ps_timeout_prefix[@]}"}' "$TARGET" \
+    || fail "Lemonade restart must expand the timeout prefix with the set -u safe guarded form"
+pass "Windows Lemonade restart tolerates a missing timeout binary"


### PR DESCRIPTION
## Summary

Fixes #3136. The Windows Lemonade restart prepends GNU timeout only when the binary exists; otherwise `ps_timeout_prefix` stays empty and its unguarded expansion aborts the whole restart under `set -u` on Bash < 4.4 (`ps_timeout_prefix[@]: unbound variable`). The hot-swap then reports failure while leaving Lemonade stopped, even though running PowerShell without a timeout cap is exactly what older hosts did before the prefix was introduced. Guarded expansion restores that behavior.

## AI Assistance

AI-assisted triage and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [x] Installer
- [x] Core runtime (bootstrap upgrade path)
- [ ] Tests only

## Validation

- `bash -n scripts/bootstrap-upgrade.sh tests/test-bootstrap-upgrade-hotswap-contract.sh` - passed.
- `bash tests/test-bootstrap-upgrade-hotswap-contract.sh` - passed, including a new assertion that the guarded expansion form is present.
- `git diff --check upstream/main...HEAD` - clean.
