### PR TITLE
fix(health): diagnose registry load failure before touching services

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -155,6 +155,10 @@ test: ## Run unit and contract tests
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
 
+	@echo ""
+	@echo "=== health-check registry failure guard ==="
+	@bash tests/test-health-check-registry-guard.sh
+
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="
 	@bash tests/run-bats.sh

--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -36,6 +36,16 @@ if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then
     . "$SCRIPT_DIR/lib/service-registry.sh" 
     sr_load 
 fi
+# sr_load degrades to _SR_FAILED=true when manifests cannot be parsed (usually
+# missing PyYAML) and leaves SERVICE_IDS empty. Every later section iterates
+# "${SERVICE_IDS[@]}", which under `set -u` on Bash < 4.4 aborts with an
+# opaque "unbound variable" long after the real cause scrolled away. Diagnose
+# here, where the failure is still explainable.
+if [[ "${_SR_FAILED:-false}" == "true" ]] || ! declare -p SERVICE_IDS >/dev/null 2>&1; then
+    echo "health-check: service registry unavailable — cannot enumerate services." >&2
+    echo "  Usually PyYAML is missing. Install it with: pip3 install pyyaml" >&2
+    exit 1
+fi
 INSTALL_DIR="${INSTALL_DIR:-$HOME/ods}"
 LLM_HOST="${LLM_HOST:-localhost}"
 LLM_PORT="${LLM_PORT:-8080}"

--- a/ods/tests/test-health-check-registry-guard.sh
+++ b/ods/tests/test-health-check-registry-guard.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Regression: health-check must diagnose a failed service-registry load up
+# front instead of dying later on an unguarded "${SERVICE_IDS[@]}" expansion
+# ("unbound variable" under set -u on Bash < 4.4).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/health-check.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+# Strip comments so explanatory text cannot satisfy or fail the checks.
+active_code="$(grep -v '^[[:space:]]*#' "$TARGET")"
+
+guard_line=$(grep -n '_SR_FAILED:-false' <<<"$active_code" | head -1 | cut -d: -f1)
+[[ -n "$guard_line" ]] || fail "health-check has no service-registry failure guard"
+
+expansion_line=$(grep -n '"${SERVICE_IDS\[@\]}"' <<<"$active_code" | head -1 | cut -d: -f1)
+[[ -n "$expansion_line" ]] || fail "no SERVICE_IDS expansion found (test target moved?)"
+
+(( guard_line < expansion_line )) \
+    || fail "registry failure guard must run before the first SERVICE_IDS expansion"
+pass "registry failure guard runs before the first SERVICE_IDS expansion"
+
+grep -q 'pip3 install pyyaml' <<<"$active_code" \
+    || fail "guard must tell the user how to fix the underlying cause"
+pass "guard names the likely fix (install PyYAML)"


### PR DESCRIPTION
## Summary

Fixes #3138. When PyYAML cannot be imported, `sr_load` sets `_SR_FAILED=true`, returns success, and leaves `SERVICE_IDS` empty â€” health-check then either dies on the first `"${SERVICE_IDS[@]}"` loop with an opaque `unbound variable` (Bash < 4.4 under `set -u`) or silently prints a nearly empty report. Neither output names the cause.

Health-check now checks the flag immediately after loading the registry, explains that the service registry is unavailable, points at `pip3 install pyyaml`, and exits non-zero before any service enumeration starts. The new contract test pins guard-before-expansion ordering and is registered in `make test`.

## AI Assistance

AI-assisted triage and regression-test drafting. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [x] Core runtime (health check)
- [x] Tests only (new contract registered in make test)

## Validation

- `bash -n scripts/health-check.sh tests/test-health-check-registry-guard.sh` - passed.
- `bash tests/test-health-check-registry-guard.sh` - passed (guard precedes the first expansion; fix hint present).
- Makefile `test` target registers the new contract after the session-cleanup suite.
- `git diff --check upstream/main...HEAD` - clean.
