### PR TITLE
fix(cli): resolve custom install root from invoked script

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: CLI Install Directory Resolution Tests
+        run: bash tests/test-cli-install-dir-resolution.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -89,6 +89,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
 	@echo ""
+	@echo "=== ods-cli install directory resolution ==="
+	@bash tests/test-cli-install-dir-resolution.sh
+	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
 	@echo ""

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -24,7 +24,26 @@ while [[ -L "$_source" ]]; do
     [[ "$_source" != /* ]] && _source="$_dir/$_source"
 done
 SCRIPT_DIR="$(cd "$(dirname "$_source")" && pwd)"
-INSTALL_DIR="${ODS_HOME:-$HOME/ods}"
+
+_resolve_cli_install_dir() {
+    if [[ -n "${INSTALL_DIR:-}" ]]; then
+        printf '%s\n' "$INSTALL_DIR"
+    elif [[ -n "${ODS_HOME:-}" ]]; then
+        printf '%s\n' "$ODS_HOME"
+    elif [[ -n "${ODS_SCRIPT_HINT:-}" ]] && [[ -f "$ODS_SCRIPT_HINT/.env" ]]; then
+        printf '%s\n' "$ODS_SCRIPT_HINT"
+    elif [[ -n "${ODS_INSTALL_DIR:-}" ]]; then
+        printf '%s\n' "$ODS_INSTALL_DIR"
+    elif [[ -f "$SCRIPT_DIR/docker-compose.base.yml" || -f "$SCRIPT_DIR/docker-compose.yml" ]]; then
+        # Installed copies and symlink targets are self-locating. This keeps a
+        # custom-path CLI from silently operating on an unrelated $HOME/ods.
+        printf '%s\n' "$SCRIPT_DIR"
+    else
+        printf '%s\n' "$HOME/ods"
+    fi
+}
+
+INSTALL_DIR="$(_resolve_cli_install_dir)"
 VERSION="2.6.0"
 if [[ -f "$INSTALL_DIR/.env" ]]; then
     _v=$(awk -F= '/^ODS_VERSION=/{gsub(/^["'"'"']|["'"'"']$/,"",$2); print $2; exit}' "$INSTALL_DIR/.env" 2>/dev/null) || true
@@ -6554,7 +6573,13 @@ ${CYAN}Examples:${NC}
   ods repair hermes-workers     # Prune leaked Hermes slash_worker children
 
 ${CYAN}Environment:${NC}
-  ODS_HOME          Installation directory (default: ~/ods)
+  INSTALL_DIR       Installation directory (highest precedence)
+  ODS_HOME          Legacy installation directory override
+  ODS_SCRIPT_HINT   Populated install hint (must contain .env)
+  ODS_INSTALL_DIR   Legacy macOS installation directory override
+
+Without an override, ods-cli uses the install beside its resolved script or
+symlink target when compose metadata is present, then falls back to ~/ods.
 
 EOF
 }

--- a/ods/tests/test-cli-install-dir-resolution.sh
+++ b/ods/tests/test-cli-install-dir-resolution.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Contract: invoking the CLI from a custom install must target that install,
+# while explicit installer-compatible path variables retain their precedence.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*"; exit 1; }
+
+make_install() {
+    local root="$1" version="$2" marker="$3"
+    mkdir -p "$root/lib"
+    cp "$ROOT_DIR/ods-cli" "$root/ods-cli"
+    cp "$ROOT_DIR/lib/service-registry.sh" "$root/lib/"
+    chmod +x "$root/ods-cli"
+    : > "$root/docker-compose.base.yml"
+    printf 'ODS_VERSION=%s\nCUSTOM_MARKER=%s\n' "$version" "$marker" > "$root/.env"
+}
+
+run_cli() {
+    local cli="$1"
+    shift
+    env -u INSTALL_DIR -u ODS_HOME -u ODS_SCRIPT_HINT -u ODS_INSTALL_DIR \
+        HOME="$FAKE_HOME" bash "$cli" "$@"
+}
+
+FAKE_HOME="$WORK/home"
+DEFAULT_INSTALL="$FAKE_HOME/ods"
+CUSTOM_INSTALL="$WORK/custom install"
+EXPLICIT_INSTALL="$WORK/explicit"
+LEGACY_INSTALL="$WORK/legacy"
+HINT_INSTALL="$WORK/hint"
+
+make_install "$DEFAULT_INSTALL" "1.0.0" "default"
+make_install "$CUSTOM_INSTALL" "2.0.0" "custom"
+make_install "$EXPLICIT_INSTALL" "3.0.0" "explicit"
+make_install "$LEGACY_INSTALL" "4.0.0" "legacy"
+make_install "$HINT_INSTALL" "5.0.0" "hint"
+
+output="$(run_cli "$CUSTOM_INSTALL/ods-cli" config show)"
+grep -Fq "Install dir: $CUSTOM_INSTALL" <<<"$output" \
+    || fail "CLI beside a valid custom install targeted a different directory"
+grep -Fq 'CUSTOM_MARKER=custom' <<<"$output" \
+    || fail "custom install configuration was not read"
+! grep -Fq 'CUSTOM_MARKER=default' <<<"$output" \
+    || fail "CLI silently operated on HOME/ods instead of its own install"
+pass "the invoked CLI targets its own custom install"
+
+mkdir -p "$WORK/bin"
+ln -s "$CUSTOM_INSTALL/ods-cli" "$WORK/bin/ods"
+output="$(run_cli "$WORK/bin/ods" version)"
+[[ "$output" == 'ods-cli v2.0.0' ]] \
+    || fail "symlink invocation did not resolve the target install: $output"
+pass "symlink invocation resolves the target install"
+
+output="$(HOME="$FAKE_HOME" INSTALL_DIR="$EXPLICIT_INSTALL" ODS_HOME="$LEGACY_INSTALL" \
+    ODS_SCRIPT_HINT="$HINT_INSTALL" ODS_INSTALL_DIR="$DEFAULT_INSTALL" \
+    bash "$CUSTOM_INSTALL/ods-cli" version)"
+[[ "$output" == 'ods-cli v3.0.0' ]] \
+    || fail "INSTALL_DIR did not retain highest precedence: $output"
+pass "INSTALL_DIR retains highest precedence"
+
+output="$(HOME="$FAKE_HOME" ODS_HOME="$LEGACY_INSTALL" \
+    ODS_SCRIPT_HINT="$HINT_INSTALL" ODS_INSTALL_DIR="$EXPLICIT_INSTALL" \
+    bash "$CUSTOM_INSTALL/ods-cli" version)"
+[[ "$output" == 'ods-cli v4.0.0' ]] \
+    || fail "ODS_HOME did not retain precedence: $output"
+pass "ODS_HOME retains legacy precedence"
+
+output="$(HOME="$FAKE_HOME" ODS_SCRIPT_HINT="$HINT_INSTALL" \
+    ODS_INSTALL_DIR="$EXPLICIT_INSTALL" bash "$CUSTOM_INSTALL/ods-cli" version)"
+[[ "$output" == 'ods-cli v5.0.0' ]] \
+    || fail "populated ODS_SCRIPT_HINT was ignored: $output"
+pass "populated ODS_SCRIPT_HINT precedes ODS_INSTALL_DIR"
+
+SCRATCH="$WORK/scratch"
+mkdir -p "$SCRATCH/lib"
+cp "$ROOT_DIR/ods-cli" "$SCRATCH/ods-cli"
+cp "$ROOT_DIR/lib/service-registry.sh" "$SCRATCH/lib/"
+output="$(run_cli "$SCRATCH/ods-cli" version)"
+[[ "$output" == 'ods-cli v1.0.0' ]] \
+    || fail "a scratch CLI copy without install sentinels did not fall back to HOME/ods: $output"
+pass "a non-install script directory falls back to HOME/ods"
+
+echo "[PASS] CLI install directory resolution"


### PR DESCRIPTION
## Summary

`ods-cli` resolved its target as `${ODS_HOME:-$HOME/ods}` even though it had already resolved its own symlink-aware `SCRIPT_DIR`. A supported custom-path installation therefore either failed when `~/ods` was absent or silently operated on a different installation when `~/ods` existed.

This change gives the CLI the installer's explicit path precedence, then lets a deployed CLI locate the install beside its resolved script/symlink target when compose metadata is present.

Fixes #3143.

## Why this matters

Every CLI lifecycle operation consumes `INSTALL_DIR`. On a custom-path install, the old wrong-target case could run status, update, backup, restore, or service operations against an unrelated `~/ods` tree. The preserved invariant is: invoking an ODS CLI from a valid install acts on that install unless the operator supplied an explicit higher-precedence path override.

## Changes

- Resolve in this order: `INSTALL_DIR`, `ODS_HOME`, populated `ODS_SCRIPT_HINT`, `ODS_INSTALL_DIR`, resolved CLI directory with a compose sentinel, then `$HOME/ods`.
- Preserve symlink resolution already performed by the CLI header.
- Preserve fail-visible behavior: an explicit but invalid override is selected and rejected by `check_install`; it never silently falls through.
- Document the precedence in `ods help`.
- Add a public-boundary regression test and wire it into `make test` and Linux CI.

## Overlap check

Searched open and closed PRs on 2026-08-25 for `ods-cli`, `SCRIPT_DIR`, `ODS_HOME`, `INSTALL_DIR`, custom install paths, and wrong-install targeting. No PR covers CLI root selection. #3015 is about migration filename iteration under paths containing spaces and changes a separate production path; #2183 is completion parity only. The changed production file was also checked against current open PR titles/scopes, with no equivalent implementation found.

## Test plan

The new `tests/test-cli-install-dir-resolution.sh` invokes the real copied CLI rather than testing a helper in isolation. It proves:

- a custom install whose path contains a space wins over an existing, valid but unrelated `$HOME/ods`;
- the CLI reads the custom install's config through `ods config show`;
- a symlink invocation resolves to the target install;
- `INSTALL_DIR`, `ODS_HOME`, `ODS_SCRIPT_HINT`, and `ODS_INSTALL_DIR` retain installer-compatible precedence;
- a scratch CLI copy without install sentinels falls back to `$HOME/ods`.

Validation:

```text
bash tests/test-cli-install-dir-resolution.sh     # 7 assertions pass
bash tests/test-ods-cli-pipefail-tolerance.sh     # 16 pass
bash tests/test-ods-config-secret-mask.sh         # 9 pass
bash tests/test-cli-preset-restore-user-extensions.sh # 7 pass
bash tests/test-cli-user-extension-deps.sh        # 10 pass
bash tests/test-cli-enable-compose-reconciliation.sh  # pass
bash tests/test-mode-switch-status.sh             # 20 pass
make lint                                         # pass
git diff --check                                  # pass
shellcheck --rcfile=/dev/null --severity=error ... # pass
```

The new regression fails against upstream `main` at the first assertion: the custom CLI targets `$HOME/ods`.

`tests/test-cli-update-verification.sh` remains 5/6 on both this branch and an isolated `upstream/main` worktree: its fixture now lacks `bin/ods-host-agent.py`. That baseline failure is unrelated to install-root selection and is not counted as passing validation here.

## Compatibility and rollback

Existing `ODS_HOME` users retain the same behavior. Explicit overrides remain authoritative even when invalid, preventing a typo from selecting another install. Windows uses `ods.ps1` and is unaffected. Reverting restores the previous `$HOME/ods` default but also restores the wrong-target risk for Linux/macOS custom installs.