### PR TITLE
fix(setup): persist wizard state through host agent

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -385,6 +385,7 @@ _update_status_lock = threading.Lock()
 _update_thread: threading.Thread | None = None
 _update_usable_bash: str | bool | None = None
 _usable_bash: str | bool | None = None
+_setup_state_lock = threading.Lock()
 
 
 def _model_download_thread_alive() -> bool:
@@ -2119,6 +2120,155 @@ def _atomic_write_text(
 ) -> None:
     """Atomically replace a UTF-8 text file."""
     _atomic_write_bytes(path, text.encode("utf-8"), mode, uid, gid)
+
+
+def _read_setup_json(path: Path) -> tuple[bool, dict | None]:
+    """Read one fixed setup-state file without following a symlink."""
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return False, None
+    except OSError as exc:
+        raise RuntimeError(f"Could not inspect setup state {path}: {exc}") from exc
+
+    if stat_mod.S_ISLNK(metadata.st_mode):
+        raise RuntimeError(f"Refusing symlinked setup state file: {path}")
+    if not stat_mod.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"Refusing non-regular setup state file: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError) as exc:
+        raise RuntimeError(f"Could not read setup state {path}: {exc}") from exc
+    except json.JSONDecodeError:
+        logger.warning("Ignoring malformed setup state file: %s", path)
+        return True, None
+    if not isinstance(payload, dict):
+        logger.warning("Ignoring non-object setup state file: %s", path)
+        return True, None
+    return True, payload
+
+
+def _setup_state_payload() -> dict:
+    """Return the persisted setup state from the host-owned data directory."""
+    state_dir = DATA_DIR / "config"
+    with _setup_state_lock:
+        complete_exists, _ = _read_setup_json(state_dir / "setup-complete.json")
+        _, progress = _read_setup_json(state_dir / "setup-progress.json")
+        _, persona_data = _read_setup_json(state_dir / "persona.json")
+
+    step = progress.get("step", 0) if progress else 0
+    if not isinstance(step, int) or isinstance(step, bool) or step < 0:
+        step = 0
+    persona = persona_data.get("persona") if persona_data else None
+    if not isinstance(persona, str):
+        persona = None
+    return {
+        "first_run": not complete_exists,
+        "step": step,
+        "persona": persona,
+        "persona_data": persona_data,
+    }
+
+
+def _validate_setup_persona_payload(payload: dict) -> dict[str, str]:
+    limits = {
+        "persona": 64,
+        "name": 128,
+        "system_prompt": 100_000,
+        "icon": 32,
+        "selected_at": 64,
+    }
+    normalized: dict[str, str] = {}
+    for key, limit in limits.items():
+        value = payload.get(key)
+        if not isinstance(value, str) or not value or len(value) > limit:
+            raise ValueError(f"{key} must be a non-empty string of at most {limit} characters")
+        if "\0" in value:
+            raise ValueError(f"{key} contains a NUL character")
+        normalized[key] = value
+    return normalized
+
+
+def _restore_setup_snapshots(snapshots: list[tuple[Path, dict]]) -> None:
+    rollback_errors = []
+    for path, snapshot in snapshots:
+        try:
+            _restore_text_file(path, snapshot)
+        except (OSError, RuntimeError) as exc:
+            rollback_errors.append(f"{path.name}: {exc}")
+    if rollback_errors:
+        raise RuntimeError("Setup state rollback failed: " + "; ".join(rollback_errors))
+
+
+def _write_setup_persona(payload: dict) -> None:
+    """Atomically publish persona and progress through one serialized owner."""
+    persona = _validate_setup_persona_payload(payload)
+    state_dir = DATA_DIR / "config"
+    persona_path = state_dir / "persona.json"
+    progress_path = state_dir / "setup-progress.json"
+    with _setup_state_lock:
+        snapshots = [
+            (persona_path, _snapshot_text_file(persona_path)),
+            (progress_path, _snapshot_text_file(progress_path)),
+        ]
+        try:
+            _atomic_write_text(
+                persona_path,
+                json.dumps(persona, indent=2) + "\n",
+                mode=0o600,
+            )
+            _atomic_write_text(
+                progress_path,
+                json.dumps({"step": 2, "persona_selected": True}, indent=2) + "\n",
+                mode=0o600,
+            )
+        except (OSError, RuntimeError) as exc:
+            try:
+                _restore_setup_snapshots(snapshots)
+            except RuntimeError as rollback_exc:
+                raise RuntimeError(f"Could not persist setup persona; {rollback_exc}") from exc
+            raise
+
+
+def _unlink_setup_file(path: Path) -> None:
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError:
+        return
+    if stat_mod.S_ISLNK(metadata.st_mode):
+        raise RuntimeError(f"Refusing to remove symlinked setup state file: {path}")
+    if not stat_mod.S_ISREG(metadata.st_mode):
+        raise RuntimeError(f"Refusing to remove non-regular setup state file: {path}")
+    path.unlink()
+
+
+def _complete_setup() -> None:
+    """Publish the completion marker and remove progress transactionally."""
+    state_dir = DATA_DIR / "config"
+    complete_path = state_dir / "setup-complete.json"
+    progress_path = state_dir / "setup-progress.json"
+    with _setup_state_lock:
+        snapshots = [
+            (complete_path, _snapshot_text_file(complete_path)),
+            (progress_path, _snapshot_text_file(progress_path)),
+        ]
+        marker = {
+            "completed_at": datetime.now(timezone.utc).isoformat(),
+            "version": "1.0.0",
+        }
+        try:
+            _atomic_write_text(
+                complete_path,
+                json.dumps(marker, indent=2) + "\n",
+                mode=0o600,
+            )
+            _unlink_setup_file(progress_path)
+        except (OSError, RuntimeError) as exc:
+            try:
+                _restore_setup_snapshots(snapshots)
+            except RuntimeError as rollback_exc:
+                raise RuntimeError(f"Could not complete setup; {rollback_exc}") from exc
+            raise
 
 
 def _snapshot_text_file(path: Path) -> dict:
@@ -4583,8 +4733,19 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_remote_provider_ssh_supervisor_status()
         elif path == "/v1/host/port":
             self._handle_host_port_status(parse_qs(parsed.query))
+        elif path == "/v1/setup/state":
+            self._handle_setup_state()
         else:
             json_response(self, 404, {"error": "Not found"})
+
+    def _handle_setup_state(self):
+        if not check_auth(self):
+            return
+        try:
+            json_response(self, 200, _setup_state_payload())
+        except (OSError, RuntimeError) as exc:
+            logger.exception("Could not read setup state")
+            json_response(self, 500, {"error": f"Could not read setup state: {exc}"})
 
     def _handle_host_port_status(self, query: dict[str, list[str]]):
         """Return whether a host-local TCP port is reachable.
@@ -4946,6 +5107,10 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_invalidate_compose_cache()
         elif self.path == "/v1/env/update":
             self._handle_env_update()
+        elif self.path == "/v1/setup/persona":
+            self._handle_setup_persona()
+        elif self.path == "/v1/setup/complete":
+            self._handle_setup_complete()
         elif self.path in ("/v1/update/check", "/v1/update/backup", "/v1/update/start"):
             self._handle_update_action()
         elif self.path == "/v1/network/wifi-connect":
@@ -4954,6 +5119,37 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_network_wifi_forget()
         else:
             json_response(self, 404, {"error": "Not found"})
+
+    def _handle_setup_persona(self):
+        if not check_auth(self):
+            return
+        body = read_optional_json_body(self)
+        if body is None:
+            return
+        try:
+            _write_setup_persona(body)
+        except ValueError as exc:
+            json_response(self, 400, {"error": str(exc)})
+            return
+        except (OSError, RuntimeError) as exc:
+            logger.exception("Could not persist setup persona")
+            json_response(self, 500, {"error": f"Could not persist setup persona: {exc}"})
+            return
+        json_response(self, 200, {"success": True})
+
+    def _handle_setup_complete(self):
+        if not check_auth(self):
+            return
+        body = read_optional_json_body(self)
+        if body is None:
+            return
+        try:
+            _complete_setup()
+        except (OSError, RuntimeError) as exc:
+            logger.exception("Could not persist setup completion")
+            json_response(self, 500, {"error": f"Could not persist setup completion: {exc}"})
+            return
+        json_response(self, 200, {"success": True})
 
     def _handle_remote_provider_plan(self):
         """Validate a remote-provider lifecycle request without side effects."""

--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -1,7 +1,6 @@
 """Setup wizard, persona management, and chat endpoints."""
 
 import asyncio
-import json
 import logging
 import os
 import re
@@ -13,7 +12,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field, field_validator
 
-from config import SERVICES, PERSONAS, SETUP_CONFIG_DIR, INSTALL_DIR, read_live_env_value
+from config import SERVICES, PERSONAS, INSTALL_DIR, read_live_env_value
 from host_agent_client import (
     AgentHTTPError,
     AgentProtocolError,
@@ -30,42 +29,36 @@ router = APIRouter(tags=["setup"])
 
 def get_active_persona_prompt() -> str:
     """Get the system prompt for the active persona."""
-    persona_file = SETUP_CONFIG_DIR / "persona.json"
-    if persona_file.exists():
-        try:
-            with open(persona_file) as f:
-                data = json.load(f)
-                return data.get("system_prompt", PERSONAS["general"]["system_prompt"])
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
-            logger.debug("Failed to read persona.json, using default prompt")
+    try:
+        state = request_agent_json("GET", "/v1/setup/state", timeout=5)
+    except (AgentHTTPError, AgentUnavailable, AgentProtocolError) as exc:
+        logger.warning("Could not read persona state from host agent: %s", exc)
+        return PERSONAS["general"]["system_prompt"]
+    persona_data = state.get("persona_data")
+    if isinstance(persona_data, dict):
+        prompt = persona_data.get("system_prompt")
+        if isinstance(prompt, str) and prompt:
+            return prompt
     return PERSONAS["general"]["system_prompt"]
 
 
 @router.get("/api/setup/status")
 async def setup_status(api_key: str = Depends(verify_api_key)):
     """Check if this is a first-run scenario."""
-    setup_complete_file = SETUP_CONFIG_DIR / "setup-complete.json"
-    first_run = not setup_complete_file.exists()
-
-    step = 0
-    progress_file = SETUP_CONFIG_DIR / "setup-progress.json"
-    if progress_file.exists():
-        try:
-            with open(progress_file) as f:
-                step = json.load(f).get("step", 0)
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
-            logger.debug("Failed to read setup-progress.json")
-
-    persona = None
-    persona_file = SETUP_CONFIG_DIR / "persona.json"
-    if persona_file.exists():
-        try:
-            with open(persona_file) as f:
-                persona = json.load(f).get("persona")
-        except (FileNotFoundError, PermissionError, json.JSONDecodeError):
-            logger.debug("Failed to read persona.json for setup status")
-
-    return {"first_run": first_run, "step": step, "persona": persona, "personas_available": list(PERSONAS.keys())}
+    state = await asyncio.to_thread(_call_agent, "/v1/setup/state", "GET", None, 10)
+    first_run = state.get("first_run") is not False
+    step = state.get("step", 0)
+    if not isinstance(step, int) or isinstance(step, bool) or step < 0:
+        step = 0
+    persona = state.get("persona")
+    if not isinstance(persona, str):
+        persona = None
+    return {
+        "first_run": first_run,
+        "step": step,
+        "persona": persona,
+        "personas_available": list(PERSONAS.keys()),
+    }
 
 
 @router.post("/api/setup/persona")
@@ -75,18 +68,18 @@ async def setup_persona(request: PersonaRequest, api_key: str = Depends(verify_a
         raise HTTPException(status_code=400, detail=f"Invalid persona. Choose from: {list(PERSONAS.keys())}")
 
     persona_info = PERSONAS[request.persona]
-    SETUP_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-
     persona_data = {
         "persona": request.persona, "name": persona_info["name"],
         "system_prompt": persona_info["system_prompt"], "icon": persona_info["icon"],
         "selected_at": datetime.now(timezone.utc).isoformat()
     }
-    with open(SETUP_CONFIG_DIR / "persona.json", "w") as f:
-        json.dump(persona_data, f, indent=2)
-
-    with open(SETUP_CONFIG_DIR / "setup-progress.json", "w") as f:
-        json.dump({"step": 2, "persona_selected": True}, f)
+    await asyncio.to_thread(
+        _call_agent,
+        "/v1/setup/persona",
+        "POST",
+        persona_data,
+        10,
+    )
 
     return {"success": True, "persona": request.persona, "name": persona_info["name"], "message": f"Great choice! Your assistant is now a {persona_info['name']}."}
 
@@ -94,14 +87,13 @@ async def setup_persona(request: PersonaRequest, api_key: str = Depends(verify_a
 @router.post("/api/setup/complete")
 async def setup_complete(api_key: str = Depends(verify_api_key)):
     """Mark the first-run setup as complete."""
-    SETUP_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-
-    with open(SETUP_CONFIG_DIR / "setup-complete.json", "w") as f:
-        json.dump({"completed_at": datetime.now(timezone.utc).isoformat(), "version": "1.0.0"}, f, indent=2)
-
-    progress_file = SETUP_CONFIG_DIR / "setup-progress.json"
-    if progress_file.exists():
-        progress_file.unlink()
+    await asyncio.to_thread(
+        _call_agent,
+        "/v1/setup/complete",
+        "POST",
+        {},
+        10,
+    )
 
     return {"success": True, "redirect": "/", "message": "Setup complete! Welcome to ODS."}
 
@@ -201,7 +193,9 @@ async def run_setup_diagnostics(api_key: str = Depends(verify_api_key)):
 @router.post("/api/chat")
 async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
     """Simple chat endpoint for the setup wizard QuickWin step."""
-    system_prompt = request.system or get_active_persona_prompt()
+    system_prompt = request.system
+    if not system_prompt:
+        system_prompt = await asyncio.to_thread(get_active_persona_prompt)
 
     _llm = SERVICES.get("llama-server", {})
     llm_url = os.environ.get("OLLAMA_URL", f"http://{_llm.get('host', 'llama-server')}:{_llm.get('port', 0)}")

--- a/ods/extensions/services/dashboard-api/tests/conftest.py
+++ b/ods/extensions/services/dashboard-api/tests/conftest.py
@@ -60,14 +60,57 @@ def data_dir(tmp_path, monkeypatch):
 
 @pytest.fixture()
 def setup_config_dir(tmp_path, monkeypatch):
-    """Provide an isolated config directory for setup/persona files."""
+    """Provide isolated setup files behind a fake host-agent boundary."""
     d = tmp_path / "config"
     d.mkdir()
-    import config
-    monkeypatch.setattr(config, "SETUP_CONFIG_DIR", d)
-    # Also patch the setup router which imports SETUP_CONFIG_DIR at the top
     import routers.setup as setup_router
-    monkeypatch.setattr(setup_router, "SETUP_CONFIG_DIR", d)
+
+    def fake_setup_agent(method, path, payload=None, timeout=5):
+        del timeout
+        if method == "GET" and path == "/v1/setup/state":
+            def read_object(name):
+                state_file = d / name
+                if not state_file.exists():
+                    return False, None
+                try:
+                    value = json.loads(state_file.read_text(encoding="utf-8"))
+                except json.JSONDecodeError:
+                    return True, None
+                return True, value if isinstance(value, dict) else None
+
+            complete_exists, _ = read_object("setup-complete.json")
+            _, progress = read_object("setup-progress.json")
+            _, persona_data = read_object("persona.json")
+            return {
+                "first_run": not complete_exists,
+                "step": progress.get("step", 0) if progress else 0,
+                "persona": persona_data.get("persona") if persona_data else None,
+                "persona_data": persona_data,
+            }
+
+        if method == "POST" and path == "/v1/setup/persona":
+            assert payload is not None
+            (d / "persona.json").write_text(
+                json.dumps(payload, indent=2),
+                encoding="utf-8",
+            )
+            (d / "setup-progress.json").write_text(
+                json.dumps({"step": 2, "persona_selected": True}),
+                encoding="utf-8",
+            )
+            return {"success": True}
+
+        if method == "POST" and path == "/v1/setup/complete":
+            (d / "setup-complete.json").write_text(
+                json.dumps({"completed_at": "now", "version": "1.0.0"}),
+                encoding="utf-8",
+            )
+            (d / "setup-progress.json").unlink(missing_ok=True)
+            return {"success": True}
+
+        raise AssertionError(f"Unexpected setup host-agent request: {method} {path}")
+
+    monkeypatch.setattr(setup_router, "request_agent_json", fake_setup_agent)
     return d
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -6,6 +6,7 @@ import io
 import json
 import logging
 import os
+import stat
 import subprocess
 import sys
 import threading
@@ -918,6 +919,152 @@ class TestComposeCacheInvalidationWire:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
+
+
+class TestSetupStateWire:
+    """Dashboard setup state crosses the authenticated host-agent boundary."""
+
+    def test_unwritable_container_mount_does_not_block_setup(
+        self,
+        tmp_path,
+        monkeypatch,
+        host_agent_wire_client,
+        test_client,
+    ):
+        from http.server import HTTPServer
+
+        from routers import setup as setup_router
+
+        host_data = tmp_path / "host-data"
+        blocked_mount = tmp_path / "container-data"
+        blocked_mount.write_text("not a directory", encoding="utf-8")
+        monkeypatch.setattr(
+            setup_router,
+            "SETUP_CONFIG_DIR",
+            blocked_mount / "config",
+            raising=False,
+        )
+        monkeypatch.setattr(_mod, "DATA_DIR", host_data)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            host_agent_wire_client(port, key="wrong-secret")
+            denied = test_client.post(
+                "/api/setup/persona",
+                json={"persona": "coding"},
+                headers=test_client.auth_headers,
+            )
+            assert denied.status_code == 403
+            assert not (host_data / "config" / "persona.json").exists()
+
+            host_agent_wire_client(port)
+            persona = test_client.post(
+                "/api/setup/persona",
+                json={"persona": "coding"},
+                headers=test_client.auth_headers,
+            )
+            assert persona.status_code == 200
+
+            status_response = test_client.get(
+                "/api/setup/status",
+                headers=test_client.auth_headers,
+            )
+            assert status_response.status_code == 200
+            assert status_response.json()["persona"] == "coding"
+            assert status_response.json()["step"] == 2
+
+            complete = test_client.post(
+                "/api/setup/complete",
+                headers=test_client.auth_headers,
+            )
+            assert complete.status_code == 200
+            assert test_client.post(
+                "/api/setup/complete",
+                headers=test_client.auth_headers,
+            ).status_code == 200
+
+            state_dir = host_data / "config"
+            persona_file = state_dir / "persona.json"
+            complete_file = state_dir / "setup-complete.json"
+            assert persona_file.is_file()
+            assert complete_file.is_file()
+            assert not (state_dir / "setup-progress.json").exists()
+            assert json.loads(persona_file.read_text(encoding="utf-8"))["persona"] == "coding"
+            if os.name != "nt":
+                assert stat.S_IMODE(persona_file.stat().st_mode) == 0o600
+                assert stat.S_IMODE(complete_file.stat().st_mode) == 0o600
+
+            final_status = test_client.get(
+                "/api/setup/status",
+                headers=test_client.auth_headers,
+            )
+            assert final_status.status_code == 200
+            assert final_status.json()["first_run"] is False
+        finally:
+            # Release httpx's HTTP/1.1 keep-alive connection before stopping
+            # the single-threaded test server.
+            host_agent_wire_client(port)
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
+class TestSetupStateTransactions:
+    def test_persona_write_rolls_back_both_files_on_partial_failure(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        state_dir = tmp_path / "config"
+        state_dir.mkdir()
+        persona_path = state_dir / "persona.json"
+        progress_path = state_dir / "setup-progress.json"
+        persona_path.write_text('{"persona":"general"}\n', encoding="utf-8")
+        progress_path.write_text('{"step":1}\n', encoding="utf-8")
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        real_atomic_write = _mod._atomic_write_text
+        failed_once = False
+
+        def flaky_atomic_write(path, text, *args, **kwargs):
+            nonlocal failed_once
+            if path == progress_path and not failed_once:
+                failed_once = True
+                raise RuntimeError("simulated progress write failure")
+            return real_atomic_write(path, text, *args, **kwargs)
+
+        monkeypatch.setattr(_mod, "_atomic_write_text", flaky_atomic_write)
+        payload = {
+            "persona": "coding",
+            "name": "Coding Assistant",
+            "system_prompt": "Help with code.",
+            "icon": "code",
+            "selected_at": "2026-08-25T00:00:00+00:00",
+        }
+
+        with pytest.raises(RuntimeError, match="simulated progress write failure"):
+            _mod._write_setup_persona(payload)
+
+        assert persona_path.read_text(encoding="utf-8") == '{"persona":"general"}\n'
+        assert progress_path.read_text(encoding="utf-8") == '{"step":1}\n'
+
+    def test_state_reader_refuses_symlinked_marker(self, tmp_path, monkeypatch):
+        if not can_create_symlinks(tmp_path):
+            pytest.skip("symlinks are unavailable")
+
+        state_dir = tmp_path / "config"
+        state_dir.mkdir(exist_ok=True)
+        target = tmp_path / "outside-marker.json"
+        target.write_text("{}", encoding="utf-8")
+        (state_dir / "setup-complete.json").symlink_to(target)
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        with pytest.raises(RuntimeError, match="Refusing symlinked setup state"):
+            _mod._setup_state_payload()
 
 
 class TestUpdateWire:


### PR DESCRIPTION
Fixes #3140

## Summary

- route setup status, persona selection, and completion through the existing authenticated host-agent boundary
- keep setup state in the same data/config JSON files while letting the host owner perform filesystem mutations
- serialize paired writes, use durable atomic replacements with mode 0600, reject symlinked/non-regular state files, and roll back partial transactions
- keep the dashboard API contract and persisted JSON schema compatible

## Why this matters

A fresh Ubuntu install can mount the host data directory into dashboard-api while the fixed container UID cannot create /data/config. The setup wizard then reaches POST /api/setup/complete and returns HTTP 500, so an otherwise healthy local installation cannot finish onboarding. Broadening data or .env permissions would expose unrelated state and secrets; this change moves only setup persistence to the component that already owns host mutations.

## Root cause

The dashboard-api container directly created and modified setup JSON below its /data bind mount. Host ownership is not guaranteed to match container UID 1000 across rootful Docker, rootless namespaces, macOS, Windows, or installs run by a non-default user. The observed symptom was PermissionError from SETUP_CONFIG_DIR.mkdir; the invariant is that container mount writability must not decide whether authenticated setup state can be persisted.

## Production contract

1. The authenticated dashboard setup endpoint validates the built-in persona or completion action.
2. Dashboard API forwards the request to the loopback host agent using the existing bearer-key transport.
3. Host agent validates the payload and writes host-owned data/config state atomically under one setup lock.
4. Persona and progress updates roll back together on a partial failure; completion writes its marker and removes progress as one transaction.
5. GET /api/setup/status reads the persisted state back through the host agent, providing the verification receipt after restart.
6. Duplicate completion requests remain successful. Authentication, invalid payloads, unavailable host agent, unsafe file types, and terminal I/O failures return explicit HTTP errors without a fallback write.

The persisted persona.json, setup-progress.json, and setup-complete.json names and fields remain compatible. Reverting this commit restores the old direct-container writes; existing state files require no migration either way.

## Overlap check

Searched open and closed upstream PRs for setup complete, dashboard permission, setup.py, host agent, issue #3140, and both changed production paths. No current open PR touches either production file or addresses this failure. Closed/merged file overlaps are independent: #2221 repairs selected rootless service bind mounts, #2237 changes local app access/auth behavior, and closed #2714 combines unrelated packaging/mDNS/config changes. None routes setup persistence or covers the reported /data/config failure.

## Regression coverage

The nearest public-boundary test runs the real dashboard API against the real host-agent HTTP handler while replacing the dashboard container mount with an unwritable path. It proves:

- a wrong host-agent key returns 403 and creates no state
- persona selection and status reconciliation succeed despite the blocked container path
- completion is idempotent and removes progress
- state lands in the host data directory and uses mode 0600 on POSIX
- partial persona/progress writes restore both previous files
- symlinked state markers are refused where the platform permits symlink creation

Before the production change, this boundary test failed at routers/setup.py with PermissionError while trying to create the blocked container path.

## Validation

- python -m pytest tests/test_setup.py tests/test_routers.py tests/test_host_agent.py::TestSetupStateWire tests/test_host_agent.py::TestSetupStateTransactions -q: 80 passed, 1 skipped on this Windows host because unprivileged symlink creation is unavailable
- python -m pytest tests/ -q: 2105 passed, 15 skipped, 1 failed only at the unrelated Windows symlink fixture test_user_extensions.py::TestScanUserExtensions::test_scan_symlink_skipped
- the same isolated symlink test fails identically on a clean upstream/main worktree at 6ff9b4fc with WinError 1314
- uvx ruff check ods/ --select E,F,W --ignore E501,E701,E731,E741,E402: passed
- Python compile checks for all changed Python modules and the Makefile lint entrypoints: passed
- git diff --check: passed

A live Ubuntu 24.04 Docker install was not available on this workstation. The HTTP boundary test proves the reported permission condition without claiming a live-container receipt; Linux CI remains the POSIX mode and symlink gate.

## Compatibility and limits

Linux, macOS, rootless/session-agent, and Windows paths all use the existing host-agent transport and host-resolved ODS_DATA_DIR. No Compose permissions, UID mappings, network exposure, API keys, or secret-file modes change. The non-fatal model-info warning about reading protected /ods/.env shown in the issue is separate from the setup 500 and remains out of scope; this PR intentionally does not weaken .env mode 0600.