### PR TITLE
fix(installer): honor unavailable sudo in Docker fallback

### DIFF
--- a/ods/installers/phases/05-docker.sh
+++ b/ods/installers/phases/05-docker.sh
@@ -309,7 +309,13 @@ _docker_try_with_optional_sudo() {
     # password prompt. Merely finding the binary is not enough here: in a
     # --non-interactive install, raw `sudo docker` would otherwise hang when
     # Docker exists but this user cannot access its socket.
-    if [[ "$DOCKER_CMD" != "sudo docker" ]] && ods_sudo_available && command -v sudo &>/dev/null; then
+    # Respect the explicit result of the up-front sudo probe. The shared
+    # ods_sudo_available helper treats uid 0 as privileged even when that probe
+    # recorded `false`, which would otherwise poison the rest of this phase
+    # with a `sudo docker` command after rootless/no-sudo setup was selected.
+    if [[ "${ODS_SUDO_AVAILABLE:-true}" != "false" ]] && \
+       [[ "$DOCKER_CMD" != "sudo docker" ]] && \
+       ods_sudo_available && command -v sudo &>/dev/null; then
         DOCKER_CMD="sudo docker"
         DOCKER_COMPOSE_CMD="sudo docker compose"
         if docker_run "$@" &>/dev/null; then


### PR DESCRIPTION
﻿## Why this matters

`make test` on current `upstream/main` fails at `tests/test-installer-noninteractive-sudo.sh`: after the installer has explicitly recorded `ODS_SUDO_AVAILABLE=false`, the Docker permission fallback still promotes the session to `sudo docker` when the process runs as uid 0. The shared `ods_sudo_available` helper treats uid 0 as privileged, so it overrides the probe result and violates the phase's no-sudo invariant. That leaves the release gate red and can carry an unavailable or intentionally-disabled `sudo` wrapper into later Docker/Compose calls.

This change makes the Docker fallback honor the explicit probe result before consulting the shared privilege helper. When sudo was actually available, the existing promotion behavior is preserved.

Behavioral invariant: once the installer records sudo as unavailable, Docker fallback must return promptly without invoking sudo or mutating `DOCKER_CMD`; an available sudo probe may still promote the command.

## Overlap check

Searched open and closed PRs for `no-sudo Docker fallback`, `rootless Docker sudo privilege`, and `05-docker.sh optional sudo`, then inspected open `tang-vu` PRs changing the Docker setup path. No PR covers this regression. #2804 introduced the rootless privilege contract and its boundary test; this PR is a narrow follow-up to make that merged contract pass. #2201 only changes temp-file test coverage, and #3100 only changes Podman registry parsing.

Changed production file searched: `ods/installers/phases/05-docker.sh`.

## Regression test

The existing nearest-boundary contract extracts and runs the real production helpers from phase 05 with executable Docker/sudo fixtures. It now passes all five assertions, including both unavailable-sudo non-mutation and available-sudo promotion.

## Validation

- `bash tests/test-installer-noninteractive-sudo.sh` ? 5 passed, 0 failed
- `bash tests/test-podman-rootless-contracts.sh` ? 24 passed
- `bash -n installers/phases/05-docker.sh` ? passed
- `git diff --check` ? passed

`make test` was first run from a clean LF Linux worktree at `6ff9b4fc` and reproduced the two failing no-sudo assertions before this fix. Live Docker-daemon permission fallback was not exercised on a separate rootless host; the executable contract proves command selection and mutation behavior without requiring host Docker changes.

## Tradeoffs and rollback

The check is deliberately local to the Docker fallback rather than changing `ods_sudo_available`, whose uid-0 behavior is used by other privileged installer paths. Rollback is a one-line behavioral revert, but would restore the failing release contract and allow explicit no-sudo state to be ignored in this phase.

## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
