### PR TITLE
test(bats): isolate host platform and privilege state

### DIFF
--- a/ods/tests/bats-tests/dispatch.bats
+++ b/ods/tests/bats-tests/dispatch.bats
@@ -80,7 +80,16 @@ setup() {
 
 @test "detect_platform: treats non-gnu Linux OSTYPE values as Linux" {
     unset ODS_PLATFORM_OVERRIDE
-    OSTYPE="linux"
+    OSTYPE="linux-musl"
+    # A WSL runner has "microsoft" in its real /proc/version. This case is
+    # specifically about the OSTYPE fallback, so isolate the earlier WSL
+    # probe without weakening WSL precedence in production.
+    grep() {
+        if [[ " $* " == *" microsoft /proc/version "* ]]; then
+            return 1
+        fi
+        command grep "$@"
+    }
 
     run detect_platform
     assert_success

--- a/ods/tests/bats-tests/path-utils.bats
+++ b/ods/tests/bats-tests/path-utils.bats
@@ -135,6 +135,10 @@ teardown() {
 }
 
 @test "validate_install_path: non-writable parent returns error" {
+    if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+        skip "uid 0 bypasses directory mode bits; exercise this assertion as a non-root user"
+    fi
+
     local readonly_dir="$BATS_TEST_TMPDIR/readonly-parent"
     mkdir -p "$readonly_dir"
     chmod 555 "$readonly_dir"

--- a/ods/tests/bats-tests/preflight-phase.bats
+++ b/ods/tests/bats-tests/preflight-phase.bats
@@ -32,9 +32,17 @@ setup() {
     export DRY_RUN=false
     export PKG_MANAGER="apt"
     export VERSION="2.3.0"
+    export TEST_EUID=1000
 
     mkdir -p "$SCRIPT_DIR"
     touch "$LOG_FILE"
+
+    # Preserve the production phase byte-for-byte except for an injectable
+    # effective uid. Root-run containers can then exercise both root rejection
+    # and the remaining non-root preflight boundaries deterministically.
+    export PREFLIGHT_PHASE="$BATS_TEST_TMPDIR/01-preflight-test.sh"
+    sed 's/\[\[ \$EUID -eq 0 \]\]/[[ ${TEST_EUID:-$EUID} -eq 0 ]]/' \
+        "$BATS_TEST_DIRNAME/../../installers/phases/01-preflight.sh" > "$PREFLIGHT_PHASE"
 
     # Create minimal os-release
     mkdir -p "$BATS_TEST_TMPDIR/etc"
@@ -51,10 +59,6 @@ teardown() {
 # ── Root check ──────────────────────────────────────────────────────────────
 
 @test "preflight: fails when run as root" {
-    local patched_phase="$BATS_TEST_TMPDIR/01-preflight-root-test.sh"
-    sed 's/\[\[ \$EUID -eq 0 \]\]/[[ ${TEST_EUID:-$EUID} -eq 0 ]]/' \
-        "$BATS_TEST_DIRNAME/../../installers/phases/01-preflight.sh" > "$patched_phase"
-
     run bash -c '
         export SCRIPT_DIR="'"$SCRIPT_DIR"'"
         export INSTALL_DIR="'"$INSTALL_DIR"'"
@@ -76,7 +80,7 @@ teardown() {
         show_stranger_boot() { :; }
         ods_progress() { :; }
 
-        source "'"$patched_phase"'"
+        source "$PREFLIGHT_PHASE"
     '
     assert_failure
     assert_output --partial "ROOT_ERROR"
@@ -177,7 +181,7 @@ MOCK
         show_stranger_boot() { :; }
         ods_progress() { :; }
 
-        source "'"$BATS_TEST_DIRNAME/../../installers/phases/01-preflight.sh"'"
+        source "$PREFLIGHT_PHASE"
         echo "PHASE_COMPLETE"
     '
     assert_success
@@ -216,7 +220,7 @@ MOCK
         show_stranger_boot() { :; }
         ods_progress() { :; }
 
-        source "'"$BATS_TEST_DIRNAME/../../installers/phases/01-preflight.sh"'"
+        source "$PREFLIGHT_PHASE"
     '
 
     # Should log about existing installation
@@ -268,7 +272,7 @@ MOCK
             builtin command "$@"
         }
 
-        source "'"$BATS_TEST_DIRNAME/../../installers/phases/01-preflight.sh"'"
+        source "$PREFLIGHT_PHASE"
     '
 
     assert_output --partial "rsync"


### PR DESCRIPTION
﻿## Why this matters

`make bats` is not hermetic across supported development environments. On a WSL uid-0 runner, current `upstream/main` reports five failures before this change:

- the Linux-OSTYPE fallback test observes the real WSL `/proc/version` and returns `wsl`;
- a `chmod 0555` directory remains writable to root, so the path test reaches the disk-space warning instead of the non-writable branch;
- three non-root preflight scenarios source the real phase as uid 0 and abort at the intentional root guard before reaching their stated boundary.

These are host-state false failures, not production defects. They make the 418-case BATS release suite red on WSL/root containers and hide regressions later in the run.

This change isolates each declared boundary while preserving production behavior: the OSTYPE case masks only the earlier `/proc/version` grep, the mode-bit assertion skips when uid 0 makes it semantically invalid, and the preflight fixture creates a test-only copy whose root check reads an injected effective uid. The root-rejection case uses `0`; all non-root cases use `1000`.

Behavioral invariant: BATS results must depend on fixture inputs, not the runner's WSL marker or effective privilege, while production WSL precedence and root rejection remain unchanged.

## Overlap check

Searched open and closed PRs for `dispatch.bats WSL OSTYPE`, `path-utils.bats non-writable root`, `preflight-phase.bats TEST_EUID`, and the three changed test files. No PR covers these host-environment failures. This scope changes no production file and is independent of #3158?#3160; those commits were present only on the synthetic integration head used to run the full gate.

## Regression test

The repository's real BATS runner executes all platform dispatch, path utility, and phase-01 tests. Before the change the WSL uid-0 run failed cases 112, 214, and 241?243. After the change all 418 cases complete successfully; case 214 is explicitly skipped under uid 0 because Unix root legitimately bypasses the permission bits, and remains executable on non-root jobs.

## Validation

- `make bats` on a clean-LF WSL uid-0 synthetic integration head ? 418 cases completed, 0 failed, 1 privilege-specific skip
- `make lint` on the same head ? passed
- `make smoke` ? all Linux AMD/NVIDIA, WSL, and macOS dispatch smoke tests passed
- `make simulate` ? installer simulation completed and emitted JSON/Markdown/golden-path artifacts
- `git diff --check` ? passed

No live install or host mutation was performed. This PR improves test determinism only; it does not claim additional runtime platform coverage.

## Tradeoffs and rollback

The preflight copy changes only the root predicate via a narrow `sed` substitution and continues sourcing the rest of the production phase. The non-writable check is skipped, not faked, when root makes its premise false; non-root CI retains the original behavioral assertion. Reverting is production-neutral but restores five reproducible gate failures on WSL uid-0 runners.

## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
