### PR TITLE
fix(hermes): block in-container self-updates

### DIFF
--- a/ods/extensions/services/hermes-proxy/Caddyfile
+++ b/ods/extensions/services/hermes-proxy/Caddyfile
@@ -83,6 +83,19 @@
 			file_server
 		}
 
+		# Hermes's bundled updater mutates the writable virtualenv inside the
+		# running container. A normal restart preserves that mutation and can
+		# leave ODS pinned to one image while executing incompatible newer code.
+		# Container lifecycle is owned by `ods update`; reject only the mutating
+		# endpoint before it reaches the upstream and leave all other APIs intact.
+		@hermes_self_update {
+			method POST
+			path /api/hermes/update
+		}
+		handle @hermes_self_update {
+			respond "Hermes self-update is disabled in ODS; use ods update." 409
+		}
+
 		# Real session verification: delegate to dashboard-api's
 		# /api/auth/verify-session. That endpoint reads the ods-session
 		# cookie, verifies the HMAC signature against ODS_SESSION_SECRET,

--- a/ods/tests/test-hermes-proxy-caddyfile.sh
+++ b/ods/tests/test-hermes-proxy-caddyfile.sh
@@ -16,13 +16,22 @@ fail() {
 
 route_line=$(grep -nE '^[[:space:]]*route[[:space:]]*\{' "$CADDYFILE" | head -n 1 | cut -d: -f1)
 health_line=$(grep -nE '^[[:space:]]*@health[[:space:]]+path[[:space:]]+/health' "$CADDYFILE" | head -n 1 | cut -d: -f1)
+self_update_line=$(grep -nE '^[[:space:]]*@hermes_self_update[[:space:]]*\{' "$CADDYFILE" | head -n 1 | cut -d: -f1)
 forward_auth_line=$(grep -nE '^[[:space:]]*forward_auth[[:space:]]+' "$CADDYFILE" | head -n 1 | cut -d: -f1)
 
 [[ -n "$route_line" ]] || fail "Hermes proxy Caddyfile must use route to preserve handler order"
 [[ -n "$health_line" ]] || fail "Hermes proxy health matcher not found"
+[[ -n "$self_update_line" ]] || fail "Hermes proxy must block the in-container self-update endpoint"
 [[ -n "$forward_auth_line" ]] || fail "Hermes proxy forward_auth not found"
-[[ "$route_line" -lt "$health_line" && "$health_line" -lt "$forward_auth_line" ]] \
-    || fail "Hermes proxy route block must put anonymous health handling before forward_auth"
+[[ "$route_line" -lt "$health_line" && "$health_line" -lt "$self_update_line" && "$self_update_line" -lt "$forward_auth_line" ]] \
+    || fail "Hermes proxy must reject self-update before authenticated upstream forwarding"
+
+grep -Eq '^[[:space:]]*method[[:space:]]+POST([[:space:]]|$)' "$CADDYFILE" \
+    || fail "Hermes self-update matcher must be limited to POST"
+grep -Eq '^[[:space:]]*path[[:space:]]+/api/hermes/update([[:space:]]|$)' "$CADDYFILE" \
+    || fail "Hermes self-update matcher must cover /api/hermes/update"
+grep -Eq '^[[:space:]]*respond[[:space:]].*[[:space:]]409([[:space:]]|$)' "$CADDYFILE" \
+    || fail "Hermes self-update rejection must return HTTP 409"
 
 grep -Eq '^[[:space:]]*redir[[:space:]]+\*[[:space:]]+/auth/required[[:space:]]+303([[:space:]]*#.*)?$' "$CADDYFILE" \
     || fail "Hermes proxy denied auth response must redirect with an explicit wildcard matcher"
@@ -42,6 +51,7 @@ grep -Eq '^[[:space:]]*@health[[:space:]]+path([[:space:]]+/[A-Za-z]+)*[[:space:
 
 echo "[PASS] Hermes proxy auth redirect uses explicit wildcard matcher"
 echo "[PASS] Hermes proxy /health and /healthz both anonymous"
+echo "[PASS] Hermes proxy blocks the container self-update endpoint"
 
 # Cap request body size so abusive clients can't stream unbounded uploads
 # through the Hermes proxy, while still leaving room for agent attachments.


### PR DESCRIPTION
﻿## Why this matters

Issue #2380 documents a production-reachable way to bypass ODS's Hermes image pin: the authenticated Hermes UI sends `POST /api/hermes/update`, which upgrades `hermes-agent` inside the container's writable virtualenv. A normal `ods restart hermes` preserves that mutated filesystem. In the reported macOS install, the upgraded binary enforced a newer dashboard-auth contract, stopped listening on internal port 9119, and left `hermes-proxy` returning 502s.

This prevention change makes the ODS-owned Caddy boundary reject exactly that mutating POST with HTTP 409 and an actionable `use ods update` message. Status, chat, WebSocket, auth, and every other Hermes route remain unchanged. Container/image upgrades stay owned by the ODS lifecycle, where the image pin, Compose recreation, and release checks apply.

Behavioral invariant: requests crossing the supported ODS proxy may not mutate the container-managed Hermes installation; supported Hermes APIs must continue to proxy normally.

This addresses the prevention track of #2380. Recovery for containers already mutated remains a separate independently useful lifecycle scope rather than being implied by this route guard.

## Overlap check

Searched open and closed PRs for `Hermes in-container self updater`, `Hermes update endpoint Caddy`, `Hermes self updater proxy`, `Hermes recover force-recreate`, and issue #2380. No PR blocks this endpoint. Open #1976 changes Basic-auth integration for newer Hermes code and does not prevent writable-venv mutation; it also remains unmerged. The earlier #1964 auth-gate report likewise does not own the self-update path.

Changed production file searched: `ods/extensions/services/hermes-proxy/Caddyfile`. Existing proxy/auth/body-limit PRs were inspected through the current contract; none cover `/api/hermes/update`.

## Regression test

`tests/test-hermes-proxy-caddyfile.sh` treats the shipped Caddyfile as the public routing boundary. It requires a POST-only exact-path matcher, verifies the rejection runs before `forward_auth`/upstream forwarding, and requires HTTP 409.

A live exact-version probe additionally started `caddy:2.11.3-alpine` with the candidate config and sent the reported request:

```text
POST /api/hermes/update
HTTP/1.1 409 Conflict
Hermes self-update is disabled in ODS; use ods update.
```

No dashboard-api or Hermes upstream was running, so the 409 also proves the request was handled locally rather than forwarded.

## Validation

- `bash tests/test-hermes-proxy-caddyfile.sh` from clean LF integration worktree ? passed all 5 proxy assertions
- `python3 tests/contracts/test-network-exposure-contracts.py` ? 11 passed
- `docker run --rm ... caddy:2.11.3-alpine caddy validate --config /etc/caddy/Caddyfile` ? `Valid configuration`
- live pinned-Caddy POST probe ? returned 409 with the ODS lifecycle message
- `git diff --check` ? passed

The temporary validation container was stopped and removed. No live Hermes install was upgraded or repaired in this session; validation proves proxy prevention, not recovery of already-mutated container state.

## Tradeoffs and rollback

HTTP 409 is deliberate: the endpoint exists, but conflicts with the container-managed deployment contract. Restricting the matcher to POST avoids hiding any future read-only status route at the same path. Reverting restores the UI updater but also restores the exact pin-bypass and auth-gate failure reported in #2380.

## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
