### PR TITLE
fix(hermes): add verified container recovery

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -29,6 +29,7 @@ test: ## Run unit and contract tests
 	@echo "=== Hermes slash worker prune ==="
 	@bash tests/test-hermes-slash-worker-prune.sh
 	@python3 tests/contracts/test-hermes-worker-guardrails.py
+	@bash tests/test-hermes-container-repair.sh
 	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -15,6 +15,7 @@
 #   ./ods-macos.sh config edit         # Open .env in $EDITOR
 #   ./ods-macos.sh chat "message"      # Quick chat via API
 #   ./ods-macos.sh update              # Pull latest images and restart
+#   ./ods-macos.sh repair hermes       # Restore pinned Hermes containers
 #   ./ods-macos.sh version             # Show version
 #   ./ods-macos.sh help                # Show help
 #
@@ -878,6 +879,69 @@ cmd_restart() {
     fi
 }
 
+cmd_repair_hermes() {
+    test_install
+    cd "$INSTALL_DIR"
+
+    local flags services required_service
+    flags=$(get_compose_flags)
+    # shellcheck disable=SC2086
+    services=$(docker compose $flags config --services)
+    for required_service in hermes hermes-proxy; do
+        if ! grep -Fxq "$required_service" <<< "$services"; then
+            ai_err "Hermes recovery requires '$required_service' in the active Compose stack."
+            return 1
+        fi
+    done
+
+    ai "Restoring pinned Hermes containers..."
+    # Recreate only the runtime and its proxy. Named volumes and bind mounts
+    # remain intact; --pull never restores exactly the image pinned by ODS.
+    # shellcheck disable=SC2086
+    docker compose $flags up -d --no-deps --force-recreate --pull never hermes hermes-proxy
+
+    local health_status="" _i
+    for _i in $(seq 1 60); do
+        if ! health_status=$(docker inspect --format \
+            '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+            ods-hermes); then
+            ai_err "Could not inspect restored Hermes container 'ods-hermes'."
+            return 1
+        fi
+        if [[ "$health_status" == "healthy" ]]; then
+            break
+        fi
+        if [[ "$health_status" == "unhealthy" ]]; then
+            ai_err "Restored Hermes container is unhealthy. Check: ./ods-macos.sh logs hermes"
+            return 1
+        fi
+        sleep 2
+    done
+    if [[ "$health_status" != "healthy" ]]; then
+        ai_err "Timed out waiting for restored Hermes. Check: ./ods-macos.sh logs hermes"
+        return 1
+    fi
+
+    if ! docker exec ods-hermes-proxy \
+        wget -qO- -T 5 http://ods-hermes:9119/api/status >/dev/null; then
+        ai_err "Hermes is healthy, but its proxy cannot reach the restored runtime. Check: ./ods-macos.sh logs hermes-proxy"
+        return 1
+    fi
+    ai_ok "Hermes container recovery complete"
+}
+
+cmd_repair() {
+    local target="${1:-}"
+    case "$target" in
+        hermes|hermes-recover) cmd_repair_hermes ;;
+        *)
+            ai "Usage: ./ods-macos.sh repair hermes"
+            ai_warn "Unknown repair target: ${target:-<missing>}"
+            return 1
+            ;;
+    esac
+}
+
 cmd_logs() {
     local service="${1:-}"
     local lines="${2:-100}"
@@ -1042,6 +1106,7 @@ show_help() {
     echo -e "  ${GRN}  config edit${NC}         ${DGRN}Open .env in \$EDITOR${NC}"
     echo -e "  ${GRN}  chat \"message\"${NC}      ${DGRN}Quick chat via API${NC}"
     echo -e "  ${GRN}  update${NC}              ${DGRN}Pull latest images and restart${NC}"
+    echo -e "  ${GRN}  repair hermes${NC}       ${DGRN}Restore pinned Hermes containers${NC}"
     echo -e "  ${GRN}  version${NC}             ${DGRN}Show version${NC}"
     echo -e "  ${GRN}  help${NC}                ${DGRN}Show this help${NC}"
     echo ""
@@ -1049,6 +1114,7 @@ show_help() {
     echo -e "  ${DGRN}  ./ods-macos.sh status${NC}"
     echo -e "  ${DGRN}  ./ods-macos.sh logs llama-server 50${NC}"
     echo -e "  ${DGRN}  ./ods-macos.sh restart open-webui${NC}"
+    echo -e "  ${DGRN}  ./ods-macos.sh repair hermes${NC}"
     echo -e "  ${DGRN}  ./ods-macos.sh chat \"What is quantum computing?\"${NC}"
     echo ""
 }
@@ -1080,6 +1146,7 @@ case "$COMMAND" in
         ;;
     chat)       cmd_chat "$*" ;;
     update)     cmd_update ;;
+    repair)     cmd_repair "${1:-}" ;;
     version)    cmd_version ;;
     help)       show_help ;;
     *)

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -16,6 +16,7 @@
 #   .\ods.ps1 update              # Pull latest images and restart
 #   .\ods.ps1 doctor              # Diagnose runtime readiness
 #   .\ods.ps1 repair voice        # Repair voice/STT/TTS readiness
+#   .\ods.ps1 repair hermes       # Restore pinned Hermes containers
 #   .\ods.ps1 enable <service>    # Enable an extension service (+ its dependencies)
 #   .\ods.ps1 disable <service>   # Disable an extension service
 #   .\ods.ps1 disable <svc> -Force # Disable even when other extensions depend on it
@@ -2597,6 +2598,62 @@ function Invoke-RepairVoice {
     }
 }
 
+function Invoke-RepairHermes {
+    Test-Install
+    Push-Location $InstallDir
+    try {
+        $flags = Get-ComposeFlags
+        foreach ($service in @("hermes", "hermes-proxy")) {
+            if (-not (Test-ODSComposeServiceAvailable -ComposeFlags $flags -Service $service)) {
+                Write-AIError "Hermes recovery requires '$service' in the active Compose stack."
+                exit 1
+            }
+        }
+
+        Write-AI "Restoring pinned Hermes containers..."
+        # Recreate only the runtime and proxy. Compose retains all volumes,
+        # while --pull never restores the exact images pinned by this release.
+        $composeExit = Invoke-ODSDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+            -ComposeArgs @("up", "-d", "--no-deps", "--force-recreate", "--pull", "never", "hermes", "hermes-proxy")
+        if ($composeExit -ne 0) {
+            Write-AIError "Hermes container recovery failed (exit code: $composeExit)"
+            Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "ods.ps1 repair hermes"
+            exit 1
+        }
+
+        $healthStatus = ""
+        for ($attempt = 0; $attempt -lt 60; $attempt++) {
+            $inspectOutput = & docker inspect --format `
+                "{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}" `
+                "ods-hermes"
+            if ($LASTEXITCODE -ne 0) {
+                Write-AIError "Could not inspect restored Hermes container 'ods-hermes'."
+                exit 1
+            }
+            $healthStatus = ([string]$inspectOutput).Trim()
+            if ($healthStatus -eq "healthy") { break }
+            if ($healthStatus -eq "unhealthy") {
+                Write-AIError "Restored Hermes container is unhealthy. Check: .\ods.ps1 logs hermes 100"
+                exit 1
+            }
+            Start-Sleep -Seconds 2
+        }
+        if ($healthStatus -ne "healthy") {
+            Write-AIError "Timed out waiting for restored Hermes. Check: .\ods.ps1 logs hermes 100"
+            exit 1
+        }
+
+        $null = & docker exec ods-hermes-proxy wget -qO- -T 5 http://ods-hermes:9119/api/status
+        if ($LASTEXITCODE -ne 0) {
+            Write-AIError "Hermes is healthy, but its proxy cannot reach the restored runtime. Check: .\ods.ps1 logs hermes-proxy 100"
+            exit 1
+        }
+        Write-AISuccess "Hermes container recovery complete"
+    } finally {
+        Pop-Location
+    }
+}
+
 function Invoke-Repair {
     param([string]$Target)
 
@@ -2608,8 +2665,10 @@ function Invoke-Repair {
         "voice" { Invoke-RepairVoice }
         "stt"   { Invoke-RepairVoice }
         "tts"   { Invoke-RepairVoice }
+        "hermes" { Invoke-RepairHermes }
+        "hermes-recover" { Invoke-RepairHermes }
         default {
-            Write-AI "Usage: .\ods.ps1 repair voice"
+            Write-AI "Usage: .\ods.ps1 repair [voice|hermes]"
             Write-AIWarn "Unknown repair target: $Target"
             exit 1
         }
@@ -3520,6 +3579,8 @@ function Show-Help {
     Write-Host "Diagnose runtime readiness" -ForegroundColor DarkGray
     Write-Host "    repair voice        " -ForegroundColor Cyan -NoNewline
     Write-Host "Start voice services and cache STT model" -ForegroundColor DarkGray
+    Write-Host "    repair hermes       " -ForegroundColor Cyan -NoNewline
+    Write-Host "Restore pinned Hermes containers and verify proxy path" -ForegroundColor DarkGray
     Write-Host "    enable <service>    " -ForegroundColor Cyan -NoNewline
     Write-Host "Enable an extension service and its dependencies" -ForegroundColor DarkGray
     Write-Host "    disable <service>   " -ForegroundColor Cyan -NoNewline
@@ -3540,6 +3601,7 @@ function Show-Help {
     Write-Host "    .\ods.ps1 logs llama-server 50" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 restart open-webui" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 repair voice" -ForegroundColor DarkGray
+    Write-Host "    .\ods.ps1 repair hermes" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 enable comfyui" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 disable langfuse" -ForegroundColor DarkGray
     Write-Host "    .\ods.ps1 disable hermes -Force" -ForegroundColor DarkGray

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -6129,6 +6129,58 @@ cmd_repair() {
 
     local target="${1:-voice}"
     case "$target" in
+        hermes|hermes-recover)
+            local flags_str
+            flags_str=$(get_compose_flags)
+            local -a flags
+            read -ra flags <<< "$flags_str"
+
+            local services
+            services=$(docker compose "${flags[@]}" config --services)
+            local required_service
+            for required_service in hermes hermes-proxy; do
+                if ! grep -Fxq "$required_service" <<< "$services"; then
+                    log_error "Hermes recovery requires '$required_service' in the active Compose stack."
+                    return 1
+                fi
+            done
+
+            local hermes_container proxy_container
+            hermes_container=$(sr_container hermes)
+            proxy_container=$(sr_container hermes-proxy)
+            _compose_run_with_summary \
+                "Restoring pinned Hermes containers" \
+                "${flags[@]}" up -d --no-deps --force-recreate --pull never hermes hermes-proxy
+
+            local health_status="" _i
+            for _i in $(seq 1 60); do
+                if ! health_status=$(docker inspect --format \
+                    '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' \
+                    "$hermes_container"); then
+                    log_error "Could not inspect restored Hermes container '$hermes_container'."
+                    return 1
+                fi
+                if [[ "$health_status" == "healthy" ]]; then
+                    break
+                fi
+                if [[ "$health_status" == "unhealthy" ]]; then
+                    log_error "Restored Hermes container is unhealthy. Check: ods logs hermes"
+                    return 1
+                fi
+                sleep 2
+            done
+            if [[ "$health_status" != "healthy" ]]; then
+                log_error "Timed out waiting for restored Hermes. Check: ods logs hermes"
+                return 1
+            fi
+
+            if ! docker exec "$proxy_container" \
+                wget -qO- -T 5 http://ods-hermes:9119/api/status >/dev/null; then
+                log_error "Hermes is healthy, but its proxy cannot reach the restored runtime. Check: ods logs hermes-proxy"
+                return 1
+            fi
+            success "Hermes container recovery complete"
+            ;;
         hermes-workers|slash-workers)
             local script="$INSTALL_DIR/scripts/prune-hermes-slash-workers.sh"
             [[ -x "$script" ]] || error "Hermes slash worker repair script not found or not executable: $script"
@@ -6201,7 +6253,7 @@ cmd_repair() {
             success "Voice repair complete"
             ;;
         *)
-            log "Usage: ods repair [voice|hermes-workers|rootless-ownership]"
+            log "Usage: ods repair [voice|hermes|hermes-workers|rootless-ownership]"
             log_error "Unknown repair target: $target"
             return 1
             ;;
@@ -6440,8 +6492,8 @@ ${CYAN}Commands:${NC}
   chat "<message>"    Quick chat with the LLM
   benchmark           Run a quick performance test
   doctor [report|--json]   Run diagnostics (--json writes JSON to stdout)
-  repair|fix [voice|hermes-workers]
-                      Repair voice services or prune leaked Hermes slash workers
+  repair|fix [voice|hermes|hermes-workers]
+                      Repair voice, restore Hermes, or prune leaked slash workers
   template [action]   Apply pre-built service templates (list|preview|apply)
   audit [extensions]  Audit extension manifests and compose contracts
   agent [action]      Manage ods host agent (status|start|stop|restart|logs)
@@ -6550,6 +6602,7 @@ ${CYAN}Examples:${NC}
   ods agent status              # Check host agent health
   ods agent restart             # Restart host agent
   ods repair voice              # Start voice services and cache STT model
+  ods repair hermes             # Restore pinned Hermes containers and verify proxy path
   ods repair rootless-ownership # Repair active bind mounts for rootless Docker
   ods repair hermes-workers     # Prune leaked Hermes slash_worker children
 

--- a/ods/tests/test-hermes-container-repair.sh
+++ b/ods/tests/test-hermes-container-repair.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Regression: every platform CLI can replace a Hermes container mutated by the
+# in-app updater and prove that the proxy reaches the restored runtime.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+install_dir="$tmp_dir/install"
+bin_dir="$tmp_dir/bin"
+docker_log="$tmp_dir/docker.log"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$install_dir/data" "$bin_dir"
+cp "$root_dir/docker-compose.base.yml" "$install_dir/docker-compose.base.yml"
+printf '%s\n' '-f docker-compose.base.yml' > "$install_dir/.compose-flags"
+
+printf '%s\n' \
+    'ODS_VERSION=2.6.0' \
+    'ODS_MODE=local' \
+    'GPU_BACKEND=apple' \
+    'GPU_COUNT=1' \
+    'TIER=1' \
+    'LLAMA_CPU_LIMIT=8.0' \
+    'LLAMA_CPU_RESERVATION=2.0' \
+    'HERMES_CPU_LIMIT=4.0' \
+    'HERMES_CPU_RESERVATION=0.5' \
+    > "$install_dir/.env"
+
+apply_test_docker() {
+    printf '%s\n' '#!/usr/bin/env bash' \
+        'set -euo pipefail' \
+        'printf '\''%s\n'\'' "$*" >> "${TEST_DOCKER_LOG:?}"' \
+        'if [[ "${1:-}" == "info" || "${1:-}" == "ps" ]]; then exit 0; fi' \
+        'if [[ "${1:-}" == "compose" && " $* " == *" config --services "* ]]; then' \
+        '    printf '\''%s\n'\'' hermes hermes-proxy' \
+        '    exit 0' \
+        'fi' \
+        'if [[ "${1:-}" == "compose" && " $* " == *" up -d --no-deps --force-recreate --pull never hermes hermes-proxy "* ]]; then exit 0; fi' \
+        'if [[ "${1:-}" == "inspect" && "${*: -1}" == "ods-hermes" ]]; then printf '\''healthy\n'\''; exit 0; fi' \
+        'if [[ "$*" == "exec ods-hermes-proxy wget -qO- -T 5 http://ods-hermes:9119/api/status" ]]; then' \
+        '    [[ "${TEST_PROXY_FAIL:-0}" == "1" ]] && exit 22' \
+        '    exit 0' \
+        'fi' \
+        'printf '\''unexpected docker invocation: %s\n'\'' "$*" >&2' \
+        'exit 1' \
+        > "$bin_dir/docker"
+    chmod +x "$bin_dir/docker"
+}
+
+apply_test_docker
+
+run_repair() {
+    local name="$1"
+    local cli="$2"
+    local output="$tmp_dir/${name}.out"
+    : > "$docker_log"
+
+    PATH="$bin_dir:$PATH" \
+    ODS_HOME="$install_dir" \
+    NO_COLOR=1 \
+    TEST_DOCKER_LOG="$docker_log" \
+        "$BASH" "$cli" repair hermes > "$output" 2>&1 || {
+            sed -n '1,200p' "$output" >&2
+            return 1
+        }
+
+    grep -q 'Hermes container recovery complete' "$output" || {
+        sed -n '1,200p' "$output" >&2
+        printf '[FAIL] %s CLI did not report verified Hermes recovery\n' "$name" >&2
+        return 1
+    }
+    grep -Eq 'compose .*docker-compose.base.yml up -d --no-deps --force-recreate --pull never hermes hermes-proxy' "$docker_log" || {
+        sed -n '1,200p' "$docker_log" >&2
+        printf '[FAIL] %s CLI did not recreate only the pinned Hermes services\n' "$name" >&2
+        return 1
+    }
+    grep -q 'inspect --format .* ods-hermes' "$docker_log" || {
+        sed -n '1,200p' "$docker_log" >&2
+        printf '[FAIL] %s CLI did not wait for the restored Hermes healthcheck\n' "$name" >&2
+        return 1
+    }
+    grep -q 'exec ods-hermes-proxy wget -qO- -T 5 http://ods-hermes:9119/api/status' "$docker_log" || {
+        sed -n '1,200p' "$docker_log" >&2
+        printf '[FAIL] %s CLI did not verify the proxy-to-Hermes path\n' "$name" >&2
+        return 1
+    }
+}
+
+run_repair linux "$root_dir/ods-cli"
+run_repair macos "$root_dir/installers/macos/ods-macos.sh"
+
+failure_output="$tmp_dir/proxy-failure.out"
+if PATH="$bin_dir:$PATH" \
+    ODS_HOME="$install_dir" \
+    NO_COLOR=1 \
+    TEST_DOCKER_LOG="$docker_log" \
+    TEST_PROXY_FAIL=1 \
+        "$BASH" "$root_dir/ods-cli" repair hermes > "$failure_output" 2>&1; then
+    printf '[FAIL] Linux CLI reported success when the Hermes proxy could not reach its upstream\n' >&2
+    exit 1
+fi
+grep -q 'proxy cannot reach the restored runtime' "$failure_output" || {
+    sed -n '1,200p' "$failure_output" >&2
+    printf '[FAIL] Linux CLI did not explain the failed proxy verification\n' >&2
+    exit 1
+}
+if grep -q 'Hermes container recovery complete' "$failure_output"; then
+    printf '[FAIL] Linux CLI emitted a success receipt after failed proxy verification\n' >&2
+    exit 1
+fi
+
+windows_cli="$root_dir/installers/windows/ods.ps1"
+grep -q '^function Invoke-RepairHermes' "$windows_cli" || {
+    printf '[FAIL] Windows CLI does not expose Hermes container recovery\n' >&2
+    exit 1
+}
+grep -q '"up", "-d", "--no-deps", "--force-recreate", "--pull", "never", "hermes", "hermes-proxy"' "$windows_cli" || {
+    printf '[FAIL] Windows recovery does not use the pinned, dependency-isolated Compose contract\n' >&2
+    exit 1
+}
+grep -q 'http://ods-hermes:9119/api/status' "$windows_cli" || {
+    printf '[FAIL] Windows recovery does not verify the internal proxy route\n' >&2
+    exit 1
+}
+
+printf '[PASS] Hermes container recovery is verified across platform CLIs\n'

--- a/ods/tests/test-voice-repair-command.sh
+++ b/ods/tests/test-voice-repair-command.sh
@@ -30,7 +30,7 @@ grep -q '^cmd_repair()' "$ODS_CLI" && pass "ods-cli defines cmd_repair" || fail 
 grep -q 'cmd_stt download' "$ODS_CLI" && pass "repair reuses STT download command" || fail "repair does not cache STT model"
 grep -q 'Starting voice services' "$ODS_CLI" && pass "repair starts voice services" || fail "repair does not start voice services"
 grep -q 'Voice Readiness' "$ODS_CLI" && pass "doctor displays voice readiness" || fail "doctor voice readiness missing"
-grep -q 'repair|fix \[voice\]' "$ODS_CLI" && pass "help documents repair voice" || fail "help missing repair voice"
+grep -q 'repair|fix \[voice|' "$ODS_CLI" && pass "help documents repair voice" || fail "help missing repair voice"
 
 grep -q '"tts_http"' "$ODS_DOCTOR" && pass "doctor report includes TTS status" || fail "doctor missing TTS status"
 grep -q 'ods repair voice' "$ODS_DOCTOR" && pass "doctor suggests repair voice" || fail "doctor missing repair hint"


### PR DESCRIPTION
﻿## Why this matters

Issue #2380 reports an operator-reachable failure: Hermes can upgrade its writable in-container virtualenv beyond the ODS-pinned image, then stop listening on port 9119 after restart. Re-running a normal restart preserves that mutated container filesystem, so Hermes remains degraded and `hermes-proxy` continues returning 502.

This adds `repair hermes` to the Linux, macOS, and Windows CLIs. The command recreates only `hermes` and `hermes-proxy` from the images already pinned locally (`--pull never --no-deps --force-recreate`), waits for the Hermes container healthcheck, then proves the proxy can reach `http://ods-hermes:9119/api/status` before emitting a success receipt. Compose volumes and bind mounts are preserved.

Behavioral invariant: recovery is successful only after the pinned Hermes runtime is healthy and the ODS proxy can reach it; recovery must not restart unrelated services, pull an unreviewed image, or delete user state.

This is the independently useful recovery half of #2380. Prevention is handled separately by #3162; either PR can merge first, while both are required for the complete prevent-and-recover lifecycle.

## Overlap check

Searched open and closed PRs for `repair hermes`, `Hermes recovery`, `Hermes recover force-recreate`, issue #2380, and the changed production files (`ods/ods-cli`, `ods/installers/macos/ods-macos.sh`, `ods/installers/windows/ods.ps1`). No PR implements this recovery command. Closed #2069/#1454 only repair leaked slash workers. Open #1976 changes authentication for newer Hermes code; it neither restores the pinned container nor verifies the proxy path. Open #3162 blocks future in-container updates but explicitly does not recover an already-mutated installation.

## Regression test

`tests/test-hermes-container-repair.sh` invokes the real Linux and macOS CLI boundaries against a deterministic Docker fixture. It asserts the exact isolated Compose recreation, health inspection, and proxy-to-Hermes request. Its negative case makes that internal request fail and proves the Linux CLI exits nonzero without a success receipt. The same recovery contract is asserted for the Windows implementation, whose script also passes the PowerShell parser.

## Validation

- `bash tests/test-hermes-container-repair.sh` ? passed
- `bash tests/test-voice-repair-command.sh` ? 17 passed, 0 failed
- `make lint` ? passed
- PowerShell parser on `installers/windows/ods.ps1` ? passed
- `git diff --check` ? passed

The broader installer contract suite passes through this PR's Linux/macOS/Windows and Hermes context checks, then reaches the existing no-sudo Docker fallback failure on current `upstream/main`; #3158 fixes that independent baseline defect. The combined batch head will be validated with #3158 before this batch is declared compatible.

No live user installation was mutated during validation. The fixture proves command orchestration and success/failure receipts; it does not substitute for a real macOS/Windows recovery run. Rollback is a code revert only: the command does not migrate or delete persisted data.
## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
