### PR TITLE
fix(cli): make Unix restart recreate containers

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -88,6 +88,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
+	@bash tests/test-unix-restart-recreate-env.sh
 	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -857,7 +857,7 @@ cmd_restart() {
     elif [[ -n "$service" ]]; then
         ai "Restarting ${service}..."
         # shellcheck disable=SC2086
-        docker compose $flags up -d "$service"
+        docker compose $flags up -d --force-recreate --no-build --pull never "$service"
         ai_ok "${service} restarted"
     else
         # Restart native llama-server
@@ -869,7 +869,7 @@ cmd_restart() {
 
         ai "Restarting all services..."
         # shellcheck disable=SC2086
-        docker compose $flags up -d
+        docker compose $flags up -d --force-recreate --no-build --pull never
         ai_ok "All services restarted"
     fi
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1578,9 +1578,11 @@ cmd_restart() {
     fi
 
     if [[ -z "$resolved_service" ]]; then
-        _compose_run_with_summary "Restarting all services" "${flags[@]}" up -d
+        _compose_run_with_summary "Restarting all services" \
+            "${flags[@]}" up -d --force-recreate --no-build --pull never
     else
-        _compose_run_with_summary "Restarting $resolved_service" "${flags[@]}" up -d "$resolved_service"
+        _compose_run_with_summary "Restarting $resolved_service" \
+            "${flags[@]}" up -d --force-recreate --no-build --pull never "$resolved_service"
     fi
 
     # Refresh SOUL.md after compose has ensured Hermes is running, so the

--- a/ods/tests/test-unix-restart-recreate-env.sh
+++ b/ods/tests/test-unix-restart-recreate-env.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Regression: Linux/macOS `restart` must replace running containers so the
+# process is actually restarted and receives current Compose environment.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+install_dir="$tmp_dir/install"
+bin_dir="$tmp_dir/bin"
+docker_log="$tmp_dir/docker.log"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$install_dir/data" "$bin_dir"
+cp "$root_dir/docker-compose.base.yml" "$install_dir/docker-compose.base.yml"
+printf '%s\n' '-f docker-compose.base.yml' > "$install_dir/.compose-flags"
+printf '%s\n' \
+    'ODS_VERSION=2.6.0' \
+    'ODS_MODE=local' \
+    'GPU_BACKEND=apple' \
+    'GPU_COUNT=1' \
+    'TIER=1' \
+    'LLAMA_CPU_LIMIT=8.0' \
+    'LLAMA_CPU_RESERVATION=2.0' \
+    'HERMES_CPU_LIMIT=4.0' \
+    'HERMES_CPU_RESERVATION=0.5' \
+    > "$install_dir/.env"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    'printf '\''%s\n'\'' "$*" >> "${TEST_DOCKER_LOG:?}"' \
+    'case "${1:-}" in' \
+    '    info)' \
+    '        [[ "$*" == *NCPU* ]] && printf '\''16\n'\''' \
+    '        exit 0' \
+    '        ;;' \
+    '    ps) exit 0 ;;' \
+    '    compose)' \
+    '        [[ " $* " == *" up -d "* ]] && exit 0' \
+    '        ;;' \
+    'esac' \
+    'printf '\''unexpected docker invocation: %s\n'\'' "$*" >&2' \
+    'exit 1' \
+    > "$bin_dir/docker"
+chmod +x "$bin_dir/docker"
+
+run_restart_contract() {
+    local platform="$1"
+    local cli="$2"
+    local output="$tmp_dir/${platform}.out"
+    : > "$docker_log"
+
+    PATH="$bin_dir:$PATH" \
+    ODS_HOME="$install_dir" \
+    NO_COLOR=1 \
+    TEST_DOCKER_LOG="$docker_log" \
+        "$BASH" "$cli" restart dashboard > "$output" 2>&1 || {
+            sed -n '1,200p' "$output" >&2
+            return 1
+        }
+    grep -Eq 'compose .*docker-compose.base.yml up -d --force-recreate --no-build --pull never dashboard$' "$docker_log" || {
+        sed -n '1,200p' "$docker_log" >&2
+        printf '[FAIL] %s single-service restart did not replace the container from its pinned image\n' "$platform" >&2
+        return 1
+    }
+
+    : > "$docker_log"
+    PATH="$bin_dir:$PATH" \
+    ODS_HOME="$install_dir" \
+    NO_COLOR=1 \
+    TEST_DOCKER_LOG="$docker_log" \
+        "$BASH" "$cli" restart > "$output" 2>&1 || {
+            sed -n '1,200p' "$output" >&2
+            return 1
+        }
+    grep -Eq 'compose .*docker-compose.base.yml up -d --force-recreate --no-build --pull never$' "$docker_log" || {
+        sed -n '1,200p' "$docker_log" >&2
+        printf '[FAIL] %s all-service restart did not replace containers from pinned images\n' "$platform" >&2
+        return 1
+    }
+}
+
+run_restart_contract linux "$root_dir/ods-cli"
+run_restart_contract macos "$root_dir/installers/macos/ods-macos.sh"
+
+printf '[PASS] Linux and macOS restart recreate env-backed containers\n'


### PR DESCRIPTION
﻿## Why this matters

On Linux and macOS, `ods restart [service]` currently delegates to `docker compose up -d` without `--force-recreate`. Compose leaves an already-running, unchanged container untouched, so the command can report ?restarted? while the process was never restarted. It also leaves environment values captured at container creation stale after an operator edits `.env` or a lifecycle step updates model routing.

This makes both Unix CLIs use `up -d --force-recreate --no-build --pull never` for single-service and all-service restarts. The service selection and native Apple Silicon llama lifecycle stay unchanged. `--no-build --pull never` makes restart consume only already-installed release images; Linux contributors can still opt into the existing `--rebuild-images` path, which builds before recreation.

Behavioral invariant: a successful `restart` replaces every selected Compose container with its current configuration and local pinned image, without implicitly building or pulling artifacts.

## Overlap check

Searched open and closed PRs for `macOS restart force recreate`, `ods-macos restart environment`, `restart force-recreate`, and `restart env-backed containers`, plus open issues for restart no-op/environment behavior. No open or closed PR covers the Linux/macOS paths.

The historical Windows change carried in closed #1724 established this same invariant for `ods.ps1` and added the Windows contract; it did not modify `ods/ods-cli` or `ods/installers/macos/ods-macos.sh`. This PR completes platform parity without touching the already-hardened Windows implementation.

## Regression test

`tests/test-unix-restart-recreate-env.sh` invokes the real Linux and macOS CLI boundaries twice each: once for `restart dashboard` and once for `restart` with no service. A Docker fixture records the public Compose command and requires force recreation, no build, no pull, the persisted compose flags, and the correct selected service set.

The test reproduces the previous command before the fix as `up -d [dashboard]`, which does not guarantee any restart.

## Validation

- `bash tests/test-unix-restart-recreate-env.sh` ? passed for Linux and macOS, single/all service cases
- `bash tests/test-macos-bootstrap-resume.sh` ? passed
- `bash tests/test-ods-cli-pipefail-tolerance.sh` ? 16 passed, 0 failed, 0 skipped
- `make lint` ? passed
- `git diff --check` ? passed

No live containers were recreated during validation; the boundary fixture verifies Compose orchestration. Rollback restores the old no-op-prone `up -d` behavior and does not require a data migration.
## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
