### PR TITLE
fix(update): verify services before success

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -97,6 +97,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== CLI update post-verification ==="
 	@bash tests/test-cli-update-verification.sh
+	@bash tests/test-update-post-verification-parity.sh
 	@echo ""
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -988,6 +988,67 @@ cmd_chat() {
     echo ""
 }
 
+macos_compose_service_completed_ok() {
+    local flags="$1" service="$2"
+    local ids state id
+    # shellcheck disable=SC2086
+    if ! ids=$(docker compose $flags ps --all -q "$service"); then
+        return 1
+    fi
+    [[ -n "$ids" ]] || return 1
+
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        if ! state=$(docker inspect -f '{{.State.Status}} {{.State.ExitCode}}' "$id"); then
+            return 1
+        fi
+        case "$state" in
+            "running "*|"exited 0") ;;
+            *) return 1 ;;
+        esac
+    done <<< "$ids"
+}
+
+macos_verify_compose_update() {
+    local flags="$1"
+    local active_services running_services service
+    # shellcheck disable=SC2086
+    if ! active_services=$(docker compose $flags config --services); then
+        ai_err "Update verification failed: could not read the active Compose stack"
+        return 1
+    fi
+    if [[ -z "$active_services" ]]; then
+        ai_err "Update verification failed: active Compose stack has no services"
+        return 1
+    fi
+    # shellcheck disable=SC2086
+    if ! running_services=$(docker compose $flags ps --services --status running); then
+        ai_err "Update verification failed: could not inspect running Compose services"
+        return 1
+    fi
+
+    local total_services=0 failed_services=0
+    while IFS= read -r service; do
+        [[ -n "$service" ]] || continue
+        total_services=$((total_services + 1))
+        if grep -Fxq "$service" <<< "$running_services"; then
+            continue
+        fi
+        # One-shot jobs are successful when every container exited zero.
+        if macos_compose_service_completed_ok "$flags" "$service"; then
+            continue
+        fi
+        ai_warn "Service $service is not running"
+        failed_services=$((failed_services + 1))
+    done <<< "$active_services"
+
+    if [[ "$failed_services" -gt 0 ]]; then
+        ai_err "Update verification failed: $failed_services/$total_services services are not running"
+        ai "Run './ods-macos.sh status' to inspect the active stack."
+        return 1
+    fi
+}
+
 cmd_update() {
     test_install
     cd "$INSTALL_DIR"
@@ -1013,10 +1074,13 @@ cmd_update() {
     ai "Recreating containers..."
     # shellcheck disable=SC2086
     docker compose $flags up -d --force-recreate
-    ai_ok "Update complete"
-    macos_maybe_resume_bootstrap_upgrade || true
 
     sleep 5
+    ai "Verifying update..."
+    macos_verify_compose_update "$flags" || return 1
+
+    ai_ok "Update complete"
+    macos_maybe_resume_bootstrap_upgrade || true
     cmd_status
 }
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2443,9 +2443,25 @@ function Invoke-Update {
             Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "ods.ps1 update (up --force-recreate)"
             exit 1
         }
-        Write-AISuccess "Update complete"
 
         Start-Sleep -Seconds 5
+        Write-AI "Verifying update..."
+        $activeServices = @(& docker compose @flags config --services |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        if ($LASTEXITCODE -ne 0 -or $activeServices.Count -eq 0) {
+            Write-AIError "Update verification failed: could not read the active Compose stack"
+            Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "ods.ps1 update (verification)"
+            exit 1
+        }
+        if (-not (Test-ODSComposeServicesStarted -ComposeFlags $flags -Services $activeServices)) {
+            Write-AIError "Update verification failed: one or more active services are not running or exited nonzero"
+            Write-AI "Run '.\ods.ps1 status' to inspect the active stack."
+            Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "ods.ps1 update (verification)"
+            exit 1
+        }
+
+        Write-AISuccess "Update complete"
+
         Invoke-Status
     } finally {
         Pop-Location

--- a/ods/tests/test-macos-bootstrap-resume.sh
+++ b/ods/tests/test-macos-bootstrap-resume.sh
@@ -84,6 +84,8 @@ fi
 if [[ "${1:-}" == "compose" ]]; then
     shift
     joined=" $* "
+    [[ "$joined" == *" config --services "* ]] && { printf 'dashboard\n'; exit 0; }
+    [[ "$joined" == *" ps --services --status running "* ]] && { printf 'dashboard\n'; exit 0; }
     [[ "$joined" == *" up "* ]] && exit 0
     [[ "$joined" == *" ps "* ]] && { printf 'ods-dashboard Up 10 seconds 127.0.0.1:3001->3001/tcp\n'; exit 0; }
 fi

--- a/ods/tests/test-macos-cli-update-verification.sh
+++ b/ods/tests/test-macos-cli-update-verification.sh
@@ -57,10 +57,38 @@ if [[ "${1:-}" == "info" ]]; then
     exit 0
 fi
 
+if [[ "${1:-}" == "inspect" ]]; then
+    if [[ "${TEST_UPDATE_MISSING_SERVICE:-0}" == "1" && "${*: -1}" == "dashboard-api-id" ]]; then
+        printf 'exited 1\n'
+    elif [[ "${*: -1}" == "migration-job-id" ]]; then
+        printf 'exited 0\n'
+    else
+        printf 'running 0\n'
+    fi
+    exit 0
+fi
+
 if [[ "${1:-}" == "compose" ]]; then
     shift
     args=("$@")
     joined=" ${args[*]} "
+    if [[ "$joined" == *" config --services "* ]]; then
+        printf '%s\n' dashboard dashboard-api migration-job
+        exit 0
+    fi
+    if [[ "$joined" == *" ps --services --status running "* ]]; then
+        printf '%s\n' dashboard
+        [[ "${TEST_UPDATE_MISSING_SERVICE:-0}" != "1" ]] && printf '%s\n' dashboard-api
+        exit 0
+    fi
+    if [[ "$joined" == *" ps --all -q dashboard-api "* ]]; then
+        printf 'dashboard-api-id\n'
+        exit 0
+    fi
+    if [[ "$joined" == *" ps --all -q migration-job "* ]]; then
+        printf 'migration-job-id\n'
+        exit 0
+    fi
     if [[ "$joined" == *" pull "* ]]; then
         count_file="${TEST_DOCKER_PULL_COUNT:-}"
         count=0
@@ -165,4 +193,27 @@ token_after="$(awk -F= '/^HERMES_DASHBOARD_SESSION_TOKEN=/{print $2}' "$install_
     exit 1
 }
 
-printf '[PASS] macOS update retries transient compose pull failures\n'
+if PATH="$bin_dir:$PATH" \
+    ODS_HOME="$install_dir" \
+    NO_COLOR=1 \
+    TEST_DOCKER_LOG="$docker_log" \
+    TEST_DOCKER_PULL_COUNT="$pull_count_file" \
+    TEST_UPDATE_MISSING_SERVICE=1 \
+        "$BASH" "$macos_cli" update > "$tmp_dir/failed-update.out" 2>&1; then
+    cat "$tmp_dir/failed-update.out" >&2
+    printf '[FAIL] macOS update reported success while dashboard-api exited nonzero\n' >&2
+    exit 1
+fi
+
+grep -q 'Update verification failed: 1/3 services are not running' "$tmp_dir/failed-update.out" || {
+    cat "$tmp_dir/failed-update.out" >&2
+    printf '[FAIL] macOS update did not identify the failed active service count\n' >&2
+    exit 1
+}
+if grep -q 'Update complete' "$tmp_dir/failed-update.out"; then
+    cat "$tmp_dir/failed-update.out" >&2
+    printf '[FAIL] macOS update emitted a success receipt before verification\n' >&2
+    exit 1
+fi
+
+printf '[PASS] macOS update retries pulls and verifies the active Compose stack\n'

--- a/ods/tests/test-update-post-verification-parity.sh
+++ b/ods/tests/test-update-post-verification-parity.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Contract: every platform update command gates its success receipt on the
+# exact active Compose plan. Linux is the established implementation.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+linux_cli="$root_dir/ods-cli"
+macos_cli="$root_dir/installers/macos/ods-macos.sh"
+windows_cli="$root_dir/installers/windows/ods.ps1"
+
+linux_update="$(awk '/^cmd_update\(\)/,/^}/' "$linux_cli")"
+macos_update="$(awk '/^cmd_update\(\)/,/^}/' "$macos_cli")"
+windows_update="$(awk '/^function Invoke-Update/,/^}/' "$windows_cli")"
+
+grep -q 'config --services' <<< "$linux_update" || {
+    printf '[FAIL] Linux update no longer reads the active Compose plan\n' >&2
+    exit 1
+}
+grep -q 'macos_verify_compose_update' <<< "$macos_update" || {
+    printf '[FAIL] macOS update does not gate success on Compose verification\n' >&2
+    exit 1
+}
+grep -q 'config --services' <<< "$windows_update" || {
+    printf '[FAIL] Windows update does not read the active Compose plan\n' >&2
+    exit 1
+}
+grep -q 'Test-ODSComposeServicesStarted' <<< "$windows_update" || {
+    printf '[FAIL] Windows update does not verify active service container states\n' >&2
+    exit 1
+}
+
+windows_verify_line="$(grep -n 'Test-ODSComposeServicesStarted' <<< "$windows_update" | head -1 | cut -d: -f1)"
+windows_success_line="$(grep -n 'Write-AISuccess "Update complete"' <<< "$windows_update" | head -1 | cut -d: -f1)"
+[[ -n "$windows_verify_line" && -n "$windows_success_line" && "$windows_verify_line" -lt "$windows_success_line" ]] || {
+    printf '[FAIL] Windows emits Update complete before service verification\n' >&2
+    exit 1
+}
+
+printf '[PASS] update success is verification-gated on every platform\n'


### PR DESCRIPTION
﻿## Why this matters

The macOS and Windows update commands currently print `Update complete` immediately after `docker compose up -d --force-recreate`. Compose returns once containers are started, not once every active service is still running. Their following status commands only report warnings, so a crashed service such as `dashboard-api` can still yield a successful update exit code and receipt. Linux already verifies the active stack before success.

This completes that contract across platforms. macOS verifies every service selected by `config --services`; each must be running or be a one-shot job whose containers all exited zero. Windows reuses its existing per-container startup verifier against the exact active service plan. Missing containers, nonzero exits, empty plans, and Compose inspection failures all fail the update before its success receipt.

Behavioral invariant: `Update complete` means every service selected by the persisted Compose plan is running or completed successfully; optional disabled services are not evaluated.

## Overlap check

Searched open and closed PRs for `macOS update verification`, `macOS update health`, `ods-macos.sh update services not running`, `macOS update complete unhealthy`, and equivalent Windows/update-receipt terms, plus the changed production files `ods/installers/macos/ods-macos.sh` and `ods/installers/windows/ods.ps1`. No PR covers these post-update gates.

Linux already owns the canonical active-stack verification loop in `ods/ods-cli`. The existing macOS fixture covered retry/image-pull behavior but not runtime success; it is extended rather than duplicated. Windows already had `Test-ODSComposeServicesStarted` for restart race handling, so this PR reuses that lifecycle boundary rather than adding a second state model.

## Regression test

`tests/test-macos-cli-update-verification.sh` invokes the real macOS update command. Its success scenario includes two running services plus a migration job that exited zero. Its failure scenario makes `dashboard-api` exit 1 and proves the CLI exits nonzero, reports the failed active-service count, and never emits `Update complete`.

`tests/test-update-post-verification-parity.sh` asserts Linux, macOS, and Windows all gate success on the active Compose plan and verifies the Windows check occurs before its success receipt. `tests/test-macos-bootstrap-resume.sh` proves successful verified updates still resume failed background model upgrades.

## Validation

- `bash tests/test-macos-cli-update-verification.sh` ? passed success, one-shot, and nonzero-exit scenarios
- `bash tests/test-update-post-verification-parity.sh` ? passed all three platform contracts
- `bash tests/test-macos-bootstrap-resume.sh` ? passed
- `make lint` ? passed
- PowerShell parser on `installers/windows/ods.ps1` ? passed
- `git diff --check` ? passed

Validation uses deterministic Docker boundary fixtures; no live macOS or Windows installation was updated. The gates verify process state/exit status, matching the existing Linux contract; they do not wait for every optional application-level HTTP healthcheck. Reverting removes only the post-update receipt gates and requires no data rollback.
## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
