### PR TITLE
fix(chat): propagate API failures across CLIs

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -88,6 +88,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
+	@bash tests/test-chat-error-exit-parity.sh
 	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -983,8 +983,16 @@ cmd_chat() {
         return 1
     }
 
+    local content
+    if ! content=$(printf '%s' "$response" | jq -er '.choices[0].message.content'); then
+        local api_error
+        api_error=$(printf '%s' "$response" | jq -r '.error.message // "unparseable response"')
+        ai_err "LLM error: ${api_error}"
+        return 1
+    fi
+
     echo ""
-    echo "$response" | jq -r '.choices[0].message.content // .error.message // "Error: no response"'
+    printf '%s\n' "$content"
     echo ""
 }
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2411,13 +2411,20 @@ function Invoke-Chat {
             -Method POST -Body $body -ContentType "application/json" -TimeoutSec 120
 
         if ($resp.choices -and $resp.choices[0].message) {
+            $content = [string]$resp.choices[0].message.content
+            if ([string]::IsNullOrWhiteSpace($content)) {
+                throw "Chat response did not contain assistant content"
+            }
             Write-Host ""
-            Write-Host $resp.choices[0].message.content
+            Write-Host $content
             Write-Host ""
+        } else {
+            throw "Chat response did not contain assistant content"
         }
     } catch {
         Write-AIError "Chat request failed: $_"
         Write-AI "Is llama-server running? Try: .\ods.ps1 status"
+        exit 1
     }
 }
 

--- a/ods/tests/test-chat-error-exit-parity.sh
+++ b/ods/tests/test-chat-error-exit-parity.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Contract: chat commands must return nonzero for transport and response errors.
+
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+linux_cli="$root_dir/ods-cli"
+macos_cli="$root_dir/installers/macos/ods-macos.sh"
+windows_cli="$root_dir/installers/windows/ods.ps1"
+
+linux_chat="$(awk '/^cmd_chat\(\)/,/^}/' "$linux_cli")"
+macos_chat="$(awk '/^cmd_chat\(\)/,/^}/' "$macos_cli")"
+windows_chat="$(awk '/^function Invoke-Chat/,/^}/' "$windows_cli")"
+
+grep -q "jq -er '.choices\[0\].message.content'" <<< "$linux_chat" || {
+    printf '[FAIL] Linux chat no longer rejects error-only response payloads\n' >&2
+    exit 1
+}
+grep -q "jq -er '.choices\[0\].message.content'" <<< "$macos_chat" || {
+    printf '[FAIL] macOS chat does not reject error-only response payloads\n' >&2
+    exit 1
+}
+grep -q 'Chat response did not contain assistant content' <<< "$windows_chat" || {
+    printf '[FAIL] Windows chat accepts a response without assistant content\n' >&2
+    exit 1
+}
+
+windows_catch="$(awk '
+    /^function Invoke-Chat/ { in_chat=1 }
+    in_chat && /} catch {/ { in_catch=1 }
+    in_catch { print }
+    in_catch && /^    }$/ { exit }
+' "$windows_cli")"
+grep -q 'exit 1' <<< "$windows_catch" || {
+    printf '[FAIL] Windows chat swallows transport/response errors with exit 0\n' >&2
+    exit 1
+}
+
+printf '[PASS] chat errors return nonzero on every platform\n'

--- a/ods/tests/test-macos-cli-mode-routing.sh
+++ b/ods/tests/test-macos-cli-mode-routing.sh
@@ -43,6 +43,11 @@ cat > "$MOCK_BIN/jq" <<'MOCK_JQ'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "-n" ]]; then
     printf '%s\n' '{"model":"default","messages":[{"role":"user","content":"test"}]}'
+elif [[ "${TEST_CHAT_API_ERROR:-0}" == "1" ]]; then
+    if [[ " $* " == *" -e"* || " $* " == *" -er "* ]]; then
+        exit 1
+    fi
+    printf '%s\n' 'model unavailable'
 else
     printf '%s\n' 'mock answer'
 fi
@@ -57,6 +62,10 @@ for arg in "$@"; do
         exit 0
     fi
 done
+if [[ "${TEST_CHAT_API_ERROR:-0}" == "1" ]]; then
+    printf '%s\n' '{"error":{"message":"model unavailable"}}'
+    exit 0
+fi
 printf '%s\n' '{"choices":[{"message":{"content":"mock answer"}}]}'
 MOCK_CURL
 
@@ -125,6 +134,15 @@ if run_cli chat "missing key" >/dev/null 2>&1; then
 fi
 [[ ! -s "$CURL_LOG" ]] || fail "cloud chat contacted LiteLLM without a key"
 pass "cloud chat fails before transport when authentication is unavailable"
+
+write_local_env
+: > "$CURL_LOG"
+if TEST_CHAT_API_ERROR=1 run_cli chat "API error" > "$TMP_DIR/chat-error.out" 2>&1; then
+    fail "macOS chat returned success for an API error payload"
+fi
+grep -Fq 'LLM error: model unavailable' "$TMP_DIR/chat-error.out" \
+    || fail "macOS chat did not surface the API error message"
+pass "macOS chat fails on an API error payload"
 
 write_local_env
 : > "$CURL_LOG"


### PR DESCRIPTION
﻿## Why this matters

The macOS chat command currently renders an API error message as ordinary output and exits zero when an OpenAI-compatible backend returns an error-only JSON payload with HTTP 200. The Windows command catches transport or JSON failures, prints an error, and also falls through with exit zero; it likewise accepts a 2xx response with no assistant content. Shell scripts and operators therefore cannot distinguish a generated answer from a failed request by exit status.

This aligns both CLIs with the existing Linux behavior. macOS requires assistant message content via `jq -e`, surfaces the backend error message, and returns nonzero when content is absent. Windows validates non-empty assistant content, turns malformed success envelopes into the same failure path, and exits nonzero from its catch boundary.

Behavioral invariant: `chat` exits zero only after receiving non-empty assistant content; transport failures and API error or malformed payloads must be visible failures.

## Overlap check

Searched open and closed PRs for `chat exit code macOS Windows`, `ods chat error response`, and the changed production functions in `ods/installers/macos/ods-macos.sh` and `ods/installers/windows/ods.ps1`. No PR covers this behavior.

Linux `ods-cli` already uses `jq -er` and exits through `error()` for missing assistant content. The new parity contract treats that implementation as the established boundary and leaves it unchanged.

## Regression test

`tests/test-macos-cli-mode-routing.sh` now drives the real macOS chat command with a successful HTTP response containing only the backend error `model unavailable`. Before the fix it printed that message and returned zero; the regression requires a nonzero exit and an actionable `LLM error: model unavailable` receipt.

`tests/test-chat-error-exit-parity.sh` verifies all three platform implementations reject error-only or missing-content responses and that the Windows catch path exits nonzero. Existing local/cloud route and authentication assertions continue to run around the new negative case.

## Validation

- `bash tests/test-macos-cli-mode-routing.sh` ? passed all local, cloud, auth, routing, and API-error cases
- `bash tests/test-chat-error-exit-parity.sh` ? passed Linux/macOS/Windows contract
- `bash tests/test-ods-cli-pipefail-tolerance.sh` ? 16 passed, 0 failed, 0 skipped
- `make lint` ? passed
- PowerShell parser on `installers/windows/ods.ps1` ? passed
- `git diff --check` ? passed

The macOS regression executes the real CLI with boundary shims. Windows validation is parser and static-contract based because no live Windows inference endpoint was used; it proves control-flow placement, not a real network request. Reverting restores the false-success exit codes and needs no state migration.
## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
