### PR TITLE
fix(updates): reject GitHub HTTP error payloads

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -179,6 +179,7 @@ async def _refresh_release_cache() -> Optional[dict]:
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
+        response.raise_for_status()
         data = response.json()
         payload = {
             "latest": data.get("tag_name", "").lstrip("v"),
@@ -232,6 +233,7 @@ async def get_release_manifest():
                 f"{_GITHUB_RELEASES_API}?per_page=5",
                 headers=_GITHUB_HEADERS,
             )
+        resp.raise_for_status()
         releases = resp.json()
         if not isinstance(releases, list):
             raise httpx.HTTPError(f"unexpected releases response: {type(releases).__name__}")
@@ -298,6 +300,7 @@ async def get_update_dry_run():
                 f"{_GITHUB_RELEASES_API}/latest",
                 headers=_GITHUB_HEADERS,
             )
+        resp.raise_for_status()
         data = resp.json()
         latest = _normalize_version(data.get("tag_name")) or None
         changelog_url = data.get("html_url") or None

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import httpx
+import pytest
 
 from host_agent_client import AgentHTTPError, AgentUnavailable
 
@@ -79,6 +80,39 @@ def test_get_version_with_mock_github(test_client, monkeypatch):
     data = resp.json()
     assert data["latest"] == "2.0.0"
     assert data["changelog_url"] == "https://github.com/test"
+
+
+@pytest.mark.asyncio
+async def test_release_refresh_keeps_stale_cache_on_http_error(monkeypatch):
+    """A GitHub HTTP error must not replace useful stale release metadata."""
+    import routers.updates as updates_mod
+
+    stale = {
+        "latest": "2.7.0",
+        "changelog_url": "https://github.com/Osmantic/ODS/releases/tag/v2.7.0",
+        "checked_at": "2026-08-25T00:00:00+00:00",
+    }
+    monkeypatch.setattr(
+        updates_mod,
+        "_version_cache",
+        {"expires_at": 0.0, "payload": stale},
+    )
+
+    response = httpx.Response(
+        403,
+        request=httpx.Request("GET", updates_mod._GITHUB_RELEASES_API),
+        json={"message": "API rate limit exceeded"},
+    )
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        payload = await updates_mod._refresh_release_cache()
+
+    assert payload == stale
+    assert updates_mod._version_cache["payload"] == stale
 
 
 def test_build_version_result_strips_v_prefix_from_current():
@@ -272,6 +306,43 @@ def test_releases_manifest_github_error_fallback(test_client, tmp_path, monkeypa
     assert "error" in data
 
 
+def test_releases_manifest_rejects_non_success_http_payload(test_client, tmp_path, monkeypatch):
+    """A JSON-shaped error body must not be published as a release manifest."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "ods"
+    install_dir.mkdir()
+    (install_dir / ".version").write_text("2.6.0", encoding="utf-8")
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    response = httpx.Response(
+        503,
+        request=httpx.Request("GET", updates_mod._GITHUB_RELEASES_API),
+        json=[
+            {
+                "tag_name": "v999.0.0",
+                "name": "proxy error body",
+                "body": "not a real GitHub release",
+            }
+        ],
+    )
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get(
+            "/api/releases/manifest",
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["releases"][0]["version"] == "2.6.0"
+    assert data["error"] == "Could not fetch release information"
+
+
 def test_releases_manifest_github_error_fallback_reads_json_version(test_client, tmp_path, monkeypatch):
     """GET /api/releases/manifest reads JSON-formatted .version files."""
     import routers.updates as updates_mod
@@ -343,6 +414,38 @@ def test_update_dry_run_with_env_and_version(test_client, tmp_path, monkeypatch)
     assert "GPU_BACKEND" in data["env_keys"]
     assert "LLM_MODEL" in data["env_keys"]
     assert "SOME_OTHER_KEY" not in data["env_keys"]
+
+
+def test_update_dry_run_reports_github_http_error(test_client, tmp_path, monkeypatch):
+    """A rate-limit response is not a valid no-update result."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "ods"
+    install_dir.mkdir()
+    (install_dir / ".env").write_text("ODS_VERSION=2.6.0\n", encoding="utf-8")
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    response = httpx.Response(
+        403,
+        request=httpx.Request("GET", updates_mod._GITHUB_RELEASES_API),
+        json={"message": "API rate limit exceeded"},
+    )
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get(
+            "/api/update/dry-run",
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["latest_version"] is None
+    assert data["update_available"] is False
+    assert "403 Forbidden" in data["version_check_error"]
 
 
 def test_update_dry_run_parses_quoted_ods_version(test_client, tmp_path, monkeypatch):


### PR DESCRIPTION
﻿## Why this matters

All three dashboard consumers of the GitHub Releases API parse JSON without first checking the HTTP status. A rate-limit response (403) is therefore treated as a valid latest-release payload and replaces useful stale cache data with an empty version for five minutes. The update dry-run reports no update and no error. The manifest path also accepts any list-shaped JSON body from a failing proxy as real releases.

This calls `raise_for_status()` before parsing the latest-release cache, release manifest, and dry-run responses. Existing narrow `httpx.HTTPError` boundaries then preserve stale cache data or return the documented local-version fallback/error field instead of manufacturing a successful no-update result.

Behavioral invariant: only a successful GitHub HTTP response may update release metadata; non-2xx responses must preserve last-known-good state or be surfaced through the endpoint fallback contract.

## Overlap check

Searched open and closed PRs for `GitHub release API raise_for_status`, `release rate limit dashboard update`, and the changed production file `ods/extensions/services/dashboard-api/routers/updates.py`. No PR covers HTTP-status validation at these call sites.

Existing tests covered connection exceptions and non-list manifest bodies but not valid JSON delivered with a non-success status. This PR extends that existing router suite rather than adding another release client.

## Regression test

`tests/test_updates.py` adds three concrete contracts:

- a 403 rate-limit response cannot overwrite an expired but useful release cache;
- `/api/update/dry-run` reports the 403 instead of silently returning a clean no-update result; and
- `/api/releases/manifest` rejects a list-shaped JSON body delivered with HTTP 503 and falls back to the installed version.

Before the fix, the cache test was replaced by an empty payload and the dry-run error field was null; the 503 list was published as version 999.0.0.

## Validation

- `python -m pytest tests/test_updates.py -q` ? 32 passed
- `python -m compileall -q routers/updates.py tests/test_updates.py` ? passed
- `make lint` ? passed
- `git diff --check` ? passed

The suite uses real `httpx.Response` status behavior behind deterministic mocked transport and exercises the public FastAPI endpoints for dry-run and manifest. No live GitHub rate limit or outage was induced. Rollback only restores the permissive parser and requires no persisted-data migration.
## Batch compatibility

This PR was validated on synthetic integration head `9af795fc`, which applies #3158 through #3167 in numeric order on `upstream/main` (`6ff9b4fc`). Combined `make lint`, `make test`, `make smoke`, `make simulate`, and all 418 BATS cases passed (one root-specific permission assertion skipped by design).

Recommended merge order: #3158 ? #3159 ? #3160 ? #3161 ? #3162 ? #3163 ? #3164 ? #3165 ? #3166 ? #3167. The only manual reconciliation observed was the adjacent Makefile test insertion shared by #3164 and #3166; retain both `test-unix-restart-recreate-env.sh` and `test-chat-error-exit-parity.sh` lines. Production code merged automatically across the full batch.
