### PR TITLE
fix(windows): skip build-only services during update pulls

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -96,6 +96,10 @@ jobs:
         shell: pwsh
         run: ./tests/contracts/test-windows-runtime-recovery.ps1
 
+      - name: Windows CLI Update Pull Contract
+        shell: pwsh
+        run: ./tests/contracts/test-windows-cli-update-pull.ps1
+
       - name: Windows Installed Footprint Contract
         if: runner.os == 'Windows'
         shell: pwsh

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2429,7 +2429,8 @@ function Invoke-Update {
 
         $flags = Get-ComposeFlags
         Write-AI "Pulling latest images..."
-        $pullExit = Invoke-ODSDockerCompose -InstallDir $InstallDir -ComposeFlags $flags -ComposeArgs @("pull")
+        $pullExit = Invoke-ODSDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+            -ComposeArgs @("pull", "--ignore-buildable")
         if ($pullExit -ne 0) {
             Write-AIError "docker compose pull failed (exit code: $pullExit)"
             Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "ods.ps1 update (pull)"

--- a/ods/tests/contracts/test-windows-cli-update-pull.ps1
+++ b/ods/tests/contracts/test-windows-cli-update-pull.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$cliPath = Join-Path $root "installers\windows\ods.ps1"
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $cliPath,
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -gt 0) {
+    throw "Windows CLI failed to parse: $($errors[0].Message)"
+}
+
+$updateAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Invoke-Update"
+}, $true)
+if (-not $updateAst) {
+    throw "Invoke-Update was not found"
+}
+. ([scriptblock]::Create($updateAst.Extent.Text))
+
+$script:composeCalls = @()
+$script:statusCalled = $false
+$InstallDir = "C:\ods-test"
+
+function Test-Install { }
+function Ensure-LlamaCpuBudget { }
+function Get-ComposeFlags { return @("-f", "docker-compose.base.yml") }
+function Push-Location { param([string]$Path) }
+function Pop-Location { }
+function Write-AI { param([string]$Message) }
+function Write-AISuccess { param([string]$Message) }
+function Write-AIError { param([string]$Message) }
+function Write-ODSComposeDiagnostics {
+    param([string]$InstallDir, [string[]]$ComposeFlags, [string]$Phase)
+}
+function Start-Sleep { param([int]$Seconds) }
+function Invoke-Status { $script:statusCalled = $true }
+function Invoke-ODSDockerCompose {
+    param(
+        [string]$InstallDir,
+        [string[]]$ComposeFlags,
+        [string[]]$ComposeArgs
+    )
+    $script:composeCalls += ,@($ComposeArgs)
+    return 0
+}
+
+Invoke-Update
+
+if ($script:composeCalls.Count -ne 2) {
+    throw "Update executed $($script:composeCalls.Count) compose commands instead of pull and up"
+}
+
+$pullArgs = $script:composeCalls[0]
+if (($pullArgs -join " ") -ne "pull --ignore-buildable") {
+    throw "Update pull arguments changed: $($pullArgs -join ' ')"
+}
+
+$upArgs = $script:composeCalls[1]
+if (($upArgs -join " ") -ne "up -d --force-recreate") {
+    throw "Update recreate arguments changed: $($upArgs -join ' ')"
+}
+
+if (-not $script:statusCalled) {
+    throw "Update no longer reaches its post-update status receipt"
+}
+
+Write-Host "[PASS] Windows CLI update skips pull attempts for build-only services"


### PR DESCRIPTION
## Why this matters

`ods.ps1 update` currently runs `docker compose pull` across the complete resolved stack. Four bundled Windows-capable extensions (`ape`, `brave-search`, `privacy-shield`, and `token-spy`) contain local `build:` definitions, and some intentionally have no registry image. Docker Compose therefore attempts to pull services that must be built locally and can abort an otherwise valid Windows update.

Root cause: the Windows updater did not use Compose's build-aware pull mode, while the shipped macOS updater already passes `--ignore-buildable`.

This change preserves the update invariant: registry-backed images are pulled, build-only services are skipped, and the stack is then force-recreated before the status receipt.

## Overlap check

Searched open and closed upstream PRs for `windows pull`, `windows update`, `compose pull`, `ignore-buildable`, and the changed production file `installers/windows/ods.ps1`. No PR covers the Windows update path. Closed PR #1724 mentions `--ignore-buildable` only in an unrelated dashboard model action.

## Changes

- pass `--ignore-buildable` from the Windows `update` command
- add a PowerShell boundary contract around the real `Invoke-Update` function
- run that contract in the existing Linux/Windows PowerShell CI matrix

## Validation

- `powershell -NoProfile -ExecutionPolicy Bypass -File ods/tests/contracts/test-windows-cli-update-pull.ps1`
- PSScriptAnalyzer on `ods/installers/windows/ods.ps1` with repository settings
- `git diff --check`

All passed locally. The contract verifies the exact public update sequence: `pull --ignore-buildable`, `up -d --force-recreate`, then the status receipt.

## Platform and tradeoffs

Windows is the affected runtime. Linux already resolves external images before pulling, and macOS already uses `pull --ignore-buildable`; neither path changes. This relies on the Docker Compose v2 option already used by ODS on macOS. Rollback is the single CLI argument change; no persistent state or migration is involved.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


