### PR TITLE
fix(cli): propagate platform command failures

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Windows Missing Service Hint Tests
         run: bash tests/test-windows-missing-service-hints.sh
 
+      - name: Platform CLI Failure Status Tests
+        run: bash tests/test-platform-cli-failure-status.sh
+
       - name: Install Readiness Summary Tests
         run: bash tests/test-install-readiness-summary.sh
 

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -888,7 +888,7 @@ cmd_logs() {
         echo ""
         ai "For native llama-server logs:"
         ai "  tail -f ${LLAMA_SERVER_LOG}"
-        return
+        return 1
     fi
 
     # Special case: llama-server logs from native process
@@ -898,6 +898,7 @@ cmd_logs() {
             tail -n "$lines" "$LLAMA_SERVER_LOG"
         else
             ai_warn "No llama-server log file found at ${LLAMA_SERVER_LOG}"
+            return 1
         fi
         return
     fi
@@ -1085,5 +1086,6 @@ case "$COMMAND" in
     *)
         ai_warn "Unknown command: ${COMMAND}"
         show_help
+        exit 1
         ;;
 esac

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2344,7 +2344,7 @@ function Invoke-Logs {
     if (-not $Service) {
         Write-AI "Usage: .\ods.ps1 logs <service> [lines]"
         Write-AI "Services: llama-server, open-webui, dashboard-api, n8n, whisper, tts, ..."
-        return
+        exit 1
     }
     Test-Install
     Push-Location $InstallDir
@@ -2354,7 +2354,13 @@ function Invoke-Logs {
             Write-ODSMissingComposeServiceHint -ComposeFlags $flags -Service $Service
             exit 1
         }
-        & docker compose @flags logs -f --tail $Lines $Service
+        $logExit = Invoke-ODSDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+            -ComposeArgs @("logs", "-f", "--tail", [string]$Lines, $Service)
+        if ($logExit -ne 0) {
+            Write-AIError "docker compose logs failed (exit code: $logExit)"
+            Write-ODSComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "ods.ps1 logs"
+            exit 1
+        }
     } finally {
         Pop-Location
     }
@@ -3638,5 +3644,6 @@ switch ($Command.ToLower()) {
     default   {
         Write-AIWarn "Unknown command: $Command"
         Show-Help
+        exit 1
     }
 }

--- a/ods/tests/test-platform-cli-failure-status.sh
+++ b/ods/tests/test-platform-cli-failure-status.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Regression: platform CLIs must return failure for rejected or failed actions.
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+macos_cli="$root_dir/installers/macos/ods-macos.sh"
+windows_cli="$root_dir/installers/windows/ods.ps1"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_failed_with() {
+    local label="$1"
+    local pattern="$2"
+    shift 2
+
+    local output_file="$tmp_dir/${label// /-}.out"
+    local rc=0
+    "$@" >"$output_file" 2>&1 || rc=$?
+    if (( rc == 0 )); then
+        printf '[FAIL] %s returned success\n' "$label" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+    if ! grep -Fq -- "$pattern" "$output_file"; then
+        printf '[FAIL] %s did not emit its failure receipt\n' "$label" >&2
+        cat "$output_file" >&2
+        exit 1
+    fi
+}
+
+ODS_HOME="$tmp_dir/not-installed" NO_COLOR=1 \
+    assert_failed_with "macOS unknown command" "Unknown command: not-a-command" \
+        bash "$macos_cli" not-a-command
+
+ODS_HOME="$tmp_dir/not-installed" NO_COLOR=1 \
+    assert_failed_with "macOS logs missing service" "logs <service>" \
+        bash "$macos_cli" logs
+
+ODS_HOME="$tmp_dir/not-installed" NO_COLOR=1 \
+    assert_failed_with "macOS missing native log" "No llama-server log file found" \
+        bash "$macos_cli" logs llama-server
+
+logs_block="$(awk '
+    /function Invoke-Logs/ { in_block=1 }
+    in_block { print }
+    in_block && /function Invoke-ConfigShow/ { exit }
+' "$windows_cli")"
+
+grep -Fq 'Invoke-ODSDockerCompose -InstallDir $InstallDir' <<<"$logs_block" || {
+    printf '[FAIL] Windows logs bypasses the exit-code-safe Compose wrapper\n' >&2
+    exit 1
+}
+grep -Fq 'if ($logExit -ne 0)' <<<"$logs_block" || {
+    printf '[FAIL] Windows logs does not reject a failed Compose command\n' >&2
+    exit 1
+}
+grep -Fq 'Write-ODSComposeDiagnostics' <<<"$logs_block" || {
+    printf '[FAIL] Windows logs failure omits the diagnostic receipt\n' >&2
+    exit 1
+}
+
+missing_service_block="$(sed -n '/if (-not \$Service)/,/Test-Install/p' <<<"$logs_block")"
+grep -Fq 'exit 1' <<<"$missing_service_block" || {
+    printf '[FAIL] Windows logs without a service still returns success\n' >&2
+    exit 1
+}
+
+default_block="$(sed -n '/default   {/,/^    }/p' "$windows_cli")"
+grep -Fq 'Unknown command:' <<<"$default_block" && grep -Fq 'exit 1' <<<"$default_block" || {
+    printf '[FAIL] Windows unknown commands still return success\n' >&2
+    exit 1
+}
+
+printf '[PASS] platform CLIs propagate invalid and failed command status\n'


### PR DESCRIPTION
## Why this matters

The installed macOS and Windows management CLIs printed errors for rejected operations but still returned status 0 in several public paths. Automation therefore treated an unknown command, a missing `logs` service, or a failed Windows `docker compose logs` process as successful.

Root cause: the platform-specific dispatch/log functions returned normally after printing usage, and Windows invoked native Compose without checking `$LASTEXITCODE`.

The preserved invariant is that a CLI action which was not accepted or did not complete must return non-zero, while successful log streaming retains its existing behavior.

## Overlap check

Searched open and closed upstream PRs for `unknown command`, `logs exit`, `missing service logs`, and the changed production files `installers/macos/ods-macos.sh` and `installers/windows/ods.ps1`. Merged PRs #1759/#1700 add Windows subcommands; #806 adds the API logs endpoint. Open PR #3166 covers chat HTTP failures only. None covers top-level dispatch status or the platform log command's process status.

## Changes

- return failure for missing/missing-native-log macOS requests
- return failure for unknown macOS and Windows commands
- route Windows log streaming through the PS 5.1-safe Compose wrapper
- emit Compose diagnostics and exit non-zero when Windows log streaming fails
- add a public CLI regression covering macOS processes plus the Windows dispatch/log contract

## Validation

- `bash ods/tests/test-platform-cli-failure-status.sh`
- direct `powershell -File ods/installers/windows/ods.ps1 not-a-command` -> exit 1
- direct `powershell -File ods/installers/windows/ods.ps1 logs` -> exit 1
- `bash -n ods/installers/macos/ods-macos.sh ods/tests/test-platform-cli-failure-status.sh`
- PowerShell parser + PSScriptAnalyzer with repository settings
- `git diff --check`

All passed locally.

## Platform, tradeoffs, and rollback

Linux already exits non-zero for these invalid invocations. macOS and Windows now match that contract. The observable compatibility change is intentional: scripts that incorrectly relied on status 0 after an error will now stop. Log arguments/output are unchanged. Rollback requires no state migration; reverting restores the former exit-status behavior.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


