### PR TITLE
fix(talk): tolerate empty vision stream choices

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -230,7 +230,14 @@ async def _stream_vision_chat(image_bytes: bytes, content_type: str, prompt_text
                         chunk = json.loads(payload_str)
                     except json.JSONDecodeError:
                         continue
-                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    if not isinstance(chunk, dict):
+                        continue
+                    choices = chunk.get("choices")
+                    if not isinstance(choices, list) or not choices or not isinstance(choices[0], dict):
+                        continue
+                    delta = choices[0].get("delta", {})
+                    if not isinstance(delta, dict):
+                        continue
                     text = delta.get("content")
                     if isinstance(text, str) and text:
                         accumulated.append(text)

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1107,6 +1107,57 @@ def test_talk_attachment_image_uses_filename_when_mobile_uploads_octet_stream(ta
     assert any(f.get("type") == "complete" and f.get("text") == "Red." for f in frames)
 
 
+def test_talk_vision_stream_skips_metadata_and_malformed_choice_frames(monkeypatch):
+    """OpenAI-compatible streams may send usage frames with no choices.
+    Those frames must not abort a valid vision answer that follows."""
+    import asyncio
+    from routers.talk import _stream_vision_chat
+
+    class FakeResponse:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        async def aiter_lines(self):
+            yield 'data: {"choices":[],"usage":{"prompt_tokens":12}}'
+            yield 'data: ["unexpected-root"]'
+            yield 'data: {"choices":[null]}'
+            yield 'data: {"choices":[{"delta":[]}]} '
+            yield 'data: {"choices":[{"delta":{"content":"Red."}}]}'
+            yield "data: [DONE]"
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, traceback):
+            return False
+
+        def stream(self, method, url, **kwargs):
+            return FakeResponse()
+
+    monkeypatch.setattr("routers.talk.httpx.AsyncClient", FakeClient)
+
+    async def collect():
+        return b"".join([
+            frame async for frame in _stream_vision_chat(
+                b"fake-image", "image/png", "what color?"
+            )
+        ])
+
+    frames = _parse_sse_frames(asyncio.run(collect()))
+    assert [frame["type"] for frame in frames] == ["session", "delta", "complete", "done"]
+    assert frames[1]["text"] == "Red."
+    assert frames[2]["text"] == "Red."
+
+
 def test_talk_attachment_image_too_large_returns_413(talk_client):
     """Image size cap is enforced at the multipart boundary."""
     big = b"\x89PNG\r\n\x1a\n" + b"x" * (11 * 1024 * 1024)


### PR DESCRIPTION
## Why this matters

ODS Talk's image path consumes an OpenAI-compatible SSE stream directly. Valid metadata/usage frames can carry `choices: []` (the shipped model-router test fixtures already exercise this shape). The vision consumer indexed element zero unconditionally, so one such frame raised `IndexError`, terminated the response, and discarded valid answer deltas that followed.

Root cause: the SSE parser assumed every decoded JSON root was an object with a non-empty list containing an object and object-shaped `delta`.

The preserved invariant is that non-content frames are ignored while well-formed text deltas continue to stream and produce the normal `complete`/`done` receipts.

## Overlap check

Searched open and closed upstream PRs for `talk empty choices`, `vision stream choices`, `usage chunk talk`, and changes to `routers/talk.py`. Existing Talk PRs cover URL trimming (#2534), attachment validation (#2778), duplicate submissions (#3063), and transcript decoding (#2821). None handles OpenAI-compatible empty-choice/metadata frames.

## Changes

- validate the decoded SSE root, choices collection, first choice, and delta before reading content
- skip metadata and malformed non-content frames without turning them into user-visible output
- add a stream-boundary regression with empty usage choices, non-object roots/choices/deltas, a valid delta, and `[DONE]`

## Validation

- `pytest -q tests/test_talk.py` -> 40 passed
- `python -m py_compile routers/talk.py tests/test_talk.py`
- `git diff --check`

Ruff is not installed in the local environment; repository CI will run the pinned Python lint job. The complete Talk test module passed.

## Tradeoffs and rollback

This intentionally treats malformed non-content frames like the already-ignored blank, non-`data:`, and invalid-JSON frames. It does not conceal transport or HTTP failures, which retain explicit error events. No persisted state or protocol emitted by ODS changes; rollback is a one-block parser revert.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


