### PR TITLE
fix(token-spy): reject non-object proxy requests

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -662,6 +662,17 @@ async def proxy_messages(request: Request):
         body = json.loads(raw_body)
     except json.JSONDecodeError:
         body = {}
+    if not isinstance(body, dict):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Request body must be a JSON object",
+                },
+            },
+        )
 
     model = body.get("model", "unknown")
     system_blocks = body.get("system", [])
@@ -870,6 +881,18 @@ async def proxy_chat_completions(request: Request):
         body = json.loads(raw_body)
     except json.JSONDecodeError:
         body = {}
+    if not isinstance(body, dict):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "error": {
+                    "message": "Request body must be a JSON object",
+                    "type": "invalid_request_error",
+                    "param": None,
+                    "code": None,
+                },
+            },
+        )
 
     model = body.get("model", "unknown")
     messages = body.get("messages", [])

--- a/ods/extensions/services/token-spy/tests/test_proxy_request_shape.py
+++ b/ods/extensions/services/token-spy/tests/test_proxy_request_shape.py
@@ -1,0 +1,67 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(TOKEN_SPY_DIR))
+
+import main  # noqa: E402
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monkeypatch.setattr(main, "TOKEN_SPY_API_KEY", "test-token-spy-key")
+
+    def unexpected_client():
+        raise AssertionError("invalid request reached the upstream client")
+
+    monkeypatch.setattr(main, "get_http_client", unexpected_client)
+    monkeypatch.setattr(main, "get_moonshot_client", unexpected_client)
+    with TestClient(main.app, raise_server_exceptions=False) as test_client:
+        yield test_client
+
+
+@pytest.mark.parametrize("payload", [[], "text", 42, None])
+def test_anthropic_proxy_rejects_non_object_json(client, payload):
+    response = client.post(
+        "/v1/messages",
+        headers={
+            "Authorization": "Bearer test-token-spy-key",
+            "Content-Type": "application/json",
+        },
+        content=json.dumps(payload),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "message": "Request body must be a JSON object",
+        },
+    }
+
+
+@pytest.mark.parametrize("payload", [[], "text", 42, None])
+def test_openai_proxy_rejects_non_object_json(client, payload):
+    response = client.post(
+        "/v1/chat/completions",
+        headers={
+            "Authorization": "Bearer test-token-spy-key",
+            "Content-Type": "application/json",
+        },
+        content=json.dumps(payload),
+    )
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "message": "Request body must be a JSON object",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": None,
+        },
+    }


### PR DESCRIPTION
## Why this matters

Token Spy is the authenticated public proxy for Anthropic Messages and OpenAI-compatible Chat Completions. Both routes accept raw JSON for transparent forwarding, but their telemetry pre-processing called `.get()` on every decoded value. A valid JSON array, scalar, or `null` therefore produced an internal 500 before any upstream request instead of a client error.

Root cause: JSON syntax validation was treated as equivalent to request-root shape validation.

The preserved invariant is that protocol request bodies must be JSON objects; rejected requests do not touch an upstream client and use each protocol's established error envelope.

## Overlap check

Searched open and closed upstream PRs for `token-spy proxy body`, `token-spy metrics parsing`, `token-spy malformed upstream`, and PRs changing `extensions/services/token-spy/main.py`. #2692 narrows exceptions inside non-streaming upstream response handlers; #2970 preserves streaming HTTP status. Neither validates the inbound JSON root, and the change occurs before both handler families.

## Changes

- reject non-object Anthropic request JSON with its `invalid_request_error` envelope
- reject non-object OpenAI-compatible request JSON with its matching error envelope
- cover array, string, number, and null at both authenticated public endpoints
- assert rejected requests never instantiate either upstream client

## Validation

- pre-fix reproduction: both endpoints returned HTTP 500 for `[]`
- `pytest -q tests/test_proxy_request_shape.py` -> 8 passed
- `pytest -q tests` -> 28 passed, 1 skipped
- `python -m py_compile main.py tests/test_proxy_request_shape.py`
- `git diff --check`

All passed locally; warnings are existing FastAPI/TestClient deprecations.

## Tradeoffs and rollback

Malformed JSON retains the existing transparent-forwarding behavior; this PR changes only syntactically valid non-object roots, which neither upstream API accepts as a request. No payload content is logged or persisted. Rollback is stateless and limited to the two pre-forward guards.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


