### PR TITLE
fix(privacy-shield): support declared WebSocket clients

### DIFF
--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -431,6 +431,20 @@ async def proxy(request: Request, path: str):
     )
 
 
+def _websocket_client_connector():
+    """Return the connector and header keyword supported by websockets.
+
+    The declared 12.x-15.x range spans the legacy-to-new asyncio API rename.
+    Prefer the new client when present, but retain the declared 12.x lane.
+    """
+    try:
+        from websockets.asyncio.client import connect
+        return connect, "additional_headers"
+    except ImportError:
+        from websockets.legacy.client import connect
+        return connect, "extra_headers"
+
+
 @app.websocket("/{path:path}")
 async def proxy_websocket(client_ws: WebSocket, path: str):
     """Transparent WebSocket passthrough for upstreams that upgrade.
@@ -460,7 +474,7 @@ async def proxy_websocket(client_ws: WebSocket, path: str):
     else:
         await client_ws.accept()
     try:
-        import websockets
+        websocket_connect, header_argument = _websocket_client_connector()
     except ModuleNotFoundError:
         logger.error("WebSocket upgrade requested but 'websockets' is not installed")
         await client_ws.close(code=1011, reason="WebSocket passthrough unavailable")
@@ -479,8 +493,8 @@ async def proxy_websocket(client_ws: WebSocket, path: str):
     import anyio
 
     try:
-        async with websockets.connect(
-            upstream_url, additional_headers=extra_headers, open_timeout=5
+        async with websocket_connect(
+            upstream_url, open_timeout=5, **{header_argument: extra_headers}
         ) as upstream_ws:
 
             async def client_to_upstream():

--- a/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
+++ b/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
@@ -30,6 +30,7 @@ import os
 import re
 import sys
 import threading
+import types
 from pathlib import Path
 
 import httpx
@@ -285,6 +286,29 @@ class TestBinaryPassthrough:
 # ── 4. WebSocket upgrade lane ───────────────────────────────────────────────
 
 class TestWebSocketLane:
+    def test_connector_supports_new_asyncio_header_keyword(self, monkeypatch):
+        sentinel = object()
+        new_client = types.ModuleType("websockets.asyncio.client")
+        new_client.connect = sentinel
+        monkeypatch.setitem(sys.modules, "websockets.asyncio.client", new_client)
+
+        connector, header_argument = proxy._websocket_client_connector()
+
+        assert connector is sentinel
+        assert header_argument == "additional_headers"
+
+    def test_connector_falls_back_to_legacy_header_keyword(self, monkeypatch):
+        sentinel = object()
+        legacy_client = types.ModuleType("websockets.legacy.client")
+        legacy_client.connect = sentinel
+        monkeypatch.setitem(sys.modules, "websockets.asyncio.client", None)
+        monkeypatch.setitem(sys.modules, "websockets.legacy.client", legacy_client)
+
+        connector, header_argument = proxy._websocket_client_connector()
+
+        assert connector is sentinel
+        assert header_argument == "extra_headers"
+
     def test_websocket_route_registered(self):
         ws_routes = [
             r for r in proxy.app.router.routes


### PR DESCRIPTION
## Why this matters

Privacy Shield declares support for websockets 12 through 15, but its WebSocket proxy always passed the new asyncio client's additional_headers keyword through the top-level connector. websockets 12 exposes the legacy connector, whose documented keyword is extra_headers, so an otherwise supported install can fail every WebSocket upgrade before reaching the upstream model.

This keeps the HTTP lane unchanged and selects the connector plus header keyword that belongs to the installed API generation.

## Root cause and invariant

The dependency range spans the legacy-to-new asyncio API transition, but the implementation assumed only the new signature.

Invariant: every version admitted by Privacy Shield's requirements must receive authentication headers through the keyword its connector accepts.

## Overlap check

Searched open and closed upstream PRs for privacy shield websockets, additional_headers, extra_headers, and changes to ods/extensions/services/privacy-shield/proxy.py. Dependabot PR #1438 is a broad, currently conflicting dependency update against a stale path and does not repair the current proxy. Closed dependency PR #1418 proposed moving to websockets 16 but did not add the requested focused WebSocket compatibility coverage. No existing implementation PR covers this runtime fix.

## Validation

- pytest -q tests/test_streaming_proxy.py -k WebSocketLane ? 4 passed
- pytest -q tests ? 54 passed
- git diff --check ? passed

The regression tests exercise the connector selection boundary for both the new asyncio module and the declared legacy API, while the existing TestClient round trip verifies the registered WebSocket route.

## Tradeoffs and rollback

Feature detection is preferred over parsing package versions, so behavior follows the importable API. The lazy import remains intact: HTTP proxying still works when the optional WebSocket client is unavailable. Rollback is a single commit, but would restore the incompatibility for websockets 12.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


