### PR TITLE
fix(talk): surface TTS upstream failures

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -315,7 +315,35 @@ async def _transcribe_bytes(data: bytes, filename: str, content_type: str) -> st
     return text.strip()
 
 
-async def _stream_speech(text: str) -> AsyncIterator[bytes]:
+def _speech_payload(text: str) -> dict[str, Any]:
+    return {
+        "model": _tts_model(),
+        "voice": _tts_voice(),
+        "input": text,
+        "response_format": "mp3",
+        "stream": True,
+    }
+
+
+async def _relay_speech(
+    client: httpx.AsyncClient,
+    response: httpx.Response,
+) -> AsyncIterator[bytes]:
+    """Relay an accepted Kokoro response and release both HTTP resources."""
+    try:
+        async for chunk in response.aiter_bytes():
+            if chunk:
+                yield chunk
+    except (httpx.HTTPError, httpx.StreamError) as exc:
+        # The public status is committed once the first chunk is requested.
+        # Preserve already-delivered audio and close a broken stream cleanly.
+        logger.warning("kokoro stream ended early: %s", exc)
+    finally:
+        await response.aclose()
+        await client.aclose()
+
+
+async def _open_speech_stream(text: str) -> AsyncIterator[bytes]:
     """Stream MP3 bytes from Kokoro as they arrive instead of buffering the
     whole reply before sending anything back to the SPA.
 
@@ -332,39 +360,44 @@ async def _stream_speech(text: str) -> AsyncIterator[bytes]:
     silence — strictly better UX than the previous buffer-then-503
     failure mode, which the SPA had to silently swallow.
     """
-    payload = {
-        "model": _tts_model(),
-        "voice": _tts_voice(),
-        "input": text,
-        "response_format": "mp3",
-        # Explicitly request streaming. Kokoro's default is true but the
-        # request schema lets clients override; pinning makes the
-        # contract obvious to anyone tracing the call.
-        "stream": True,
-    }
     timeout = httpx.Timeout(connect=10.0, read=180.0, write=30.0, pool=10.0)
+    client = httpx.AsyncClient(timeout=timeout)
     try:
-        async with httpx.AsyncClient(timeout=timeout) as client:
-            async with client.stream(
-                "POST",
-                f"{_tts_url()}/v1/audio/speech",
-                json=payload,
-            ) as resp:
-                if resp.status_code >= 400:
-                    body = await resp.aread()
-                    logger.warning(
-                        "kokoro returned %s for /v1/audio/speech: %s",
-                        resp.status_code, body.decode("utf-8", errors="replace")[:200],
-                    )
-                    return
-                async for chunk in resp.aiter_bytes():
-                    if chunk:
-                        yield chunk
-    except (httpx.HTTPError, httpx.StreamError) as exc:
-        # Mid-stream errors: log + return. The browser sees the response
-        # close early and plays whatever audio it already buffered.
-        logger.warning("kokoro stream ended early: %s", exc)
-        return
+        request = client.build_request(
+            "POST",
+            f"{_tts_url()}/v1/audio/speech",
+            json=_speech_payload(text),
+        )
+        response = await client.send(request, stream=True)
+    except asyncio.CancelledError:
+        await client.aclose()
+        raise
+    except httpx.HTTPError as exc:
+        await client.aclose()
+        raise HTTPException(
+            status_code=503,
+            detail="Speech synthesis is not available right now.",
+        ) from exc
+
+    if response.status_code >= 400:
+        try:
+            body = await response.aread()
+        except httpx.HTTPError:
+            body = b"<response body unavailable>"
+        finally:
+            await response.aclose()
+            await client.aclose()
+        logger.warning(
+            "kokoro returned %s for /v1/audio/speech: %s",
+            response.status_code,
+            body.decode("utf-8", errors="replace")[:200],
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Speech synthesis is not available right now.",
+        )
+
+    return _relay_speech(client, response)
 
 
 async def _send_to_hermes(session_key: str, text: str) -> dict[str, Any]:
@@ -803,8 +836,9 @@ async def talk_speak(request: Request, text: str = Form(...)) -> StreamingRespon
         raise HTTPException(status_code=422, detail="Text is required.")
     if len(clean) > MAX_MESSAGE_CHARS:
         raise HTTPException(status_code=413, detail="Text is too long.")
+    audio_stream = await _open_speech_stream(clean)
     return StreamingResponse(
-        _stream_speech(clean),
+        audio_stream,
         media_type="audio/mpeg",
         # X-Accel-Buffering: no tells nginx (and similar reverse proxies)
         # NOT to buffer the audio stream — otherwise our streaming work

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1,6 +1,10 @@
 """Tests for the ODS Talk mobile portal API."""
 
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
 import pytest
+from fastapi import HTTPException
 
 
 @pytest.fixture()
@@ -231,11 +235,14 @@ def test_talk_speak_streams_audio(talk_client, monkeypatch):
     headers are set so reverse proxies don't re-buffer the stream."""
     async def fake_stream(text):
         assert text == "read this"
-        # Simulate Kokoro emitting two chunks as the audio synthesises.
-        yield b"mp3 chunk 1 "
-        yield b"mp3 chunk 2"
 
-    monkeypatch.setattr("routers.talk._stream_speech", fake_stream)
+        async def chunks():
+            yield b"mp3 chunk 1 "
+            yield b"mp3 chunk 2"
+
+        return chunks()
+
+    monkeypatch.setattr("routers.talk._open_speech_stream", fake_stream)
 
     resp = talk_client.post("/api/talk/speak", data={"text": "read this"})
     assert resp.status_code == 200, resp.text
@@ -246,21 +253,66 @@ def test_talk_speak_streams_audio(talk_client, monkeypatch):
     assert resp.headers.get("X-Accel-Buffering") == "no"
 
 
-def test_talk_speak_handles_empty_stream(talk_client, monkeypatch):
-    """If Kokoro errors before any audio is produced, the streaming
-    response should close cleanly with empty body — the SPA's `if (!resp.ok
-    || !resp.body)` short-circuit then suppresses playback without
-    interrupting the text chat."""
+def test_talk_speak_rejects_upstream_error_before_committing_200(talk_client, monkeypatch):
+    """A Kokoro rejection must remain an HTTP error at the public boundary."""
     async def fake_stream(text):
-        # Kokoro upstream failure: nothing to yield.
-        if False:
-            yield b""  # pragma: no cover
+        raise HTTPException(
+            status_code=503,
+            detail="Speech synthesis is not available right now.",
+        )
 
-    monkeypatch.setattr("routers.talk._stream_speech", fake_stream)
+    monkeypatch.setattr("routers.talk._open_speech_stream", fake_stream)
 
     resp = talk_client.post("/api/talk/speak", data={"text": "silent"})
-    assert resp.status_code == 200
-    assert resp.content == b""
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Speech synthesis is not available right now."
+
+
+@pytest.mark.asyncio
+async def test_open_speech_stream_closes_rejected_upstream(monkeypatch):
+    """Exercise the Kokoro HTTP handoff, not only the route exception map."""
+    from routers import talk
+
+    request = httpx.Request("POST", "http://tts:8880/v1/audio/speech")
+    response = httpx.Response(422, request=request, content=b"bad voice")
+    client = MagicMock()
+    client.send = AsyncMock()
+    client.aclose = AsyncMock()
+    client.build_request.return_value = request
+    client.send.return_value = response
+    monkeypatch.setattr(talk.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await talk._open_speech_stream("hello")
+
+    assert exc_info.value.status_code == 503
+    client.send.assert_awaited_once_with(request, stream=True)
+    client.aclose.assert_awaited_once()
+    assert response.is_closed
+
+
+@pytest.mark.asyncio
+async def test_open_speech_stream_relays_and_closes_accepted_upstream(monkeypatch):
+    from routers import talk
+
+    request = httpx.Request("POST", "http://tts:8880/v1/audio/speech")
+    response = httpx.Response(
+        200,
+        request=request,
+        stream=httpx.ByteStream(b"streamed mp3"),
+    )
+    client = MagicMock()
+    client.send = AsyncMock(return_value=response)
+    client.aclose = AsyncMock()
+    client.build_request.return_value = request
+    monkeypatch.setattr(talk.httpx, "AsyncClient", lambda **_kwargs: client)
+
+    stream = await talk._open_speech_stream("hello")
+    audio = b"".join([chunk async for chunk in stream])
+
+    assert audio == b"streamed mp3"
+    assert response.is_closed
+    client.aclose.assert_awaited_once()
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

ODS Talk's speech endpoint returned HTTP 200 before it knew whether Kokoro accepted the synthesis request. If Kokoro rejected an invalid voice/model or returned any 4xx/5xx, the async generator simply ended and the browser received a successful response with an empty audio body. That hides the operational failure and makes the Talk UI silently do nothing.

The endpoint now opens the upstream stream before committing its public response. Pre-stream transport failures and Kokoro rejections become an actionable 503; accepted responses still stream MP3 chunks immediately.

## Root cause and invariant

StreamingResponse commits status and headers before iterating its body generator. The old generator performed the Kokoro request only after that commit, when changing the public status was no longer possible.

Invariant: ODS must not return 200 from POST /api/talk/speak unless Kokoro has accepted the corresponding synthesis request.

## Overlap check

Searched open and closed upstream PRs for ODS Talk Kokoro error status, talk speak empty 200, stream speech upstream error, talk TTS error, and all open PRs touching routers/talk.py. Existing Talk PRs cover transcript decoding, empty uploads, model-name normalization, model defaults, compatibility shapes, and vision chunks. None changes the TTS response-commit boundary or upstream resource lifecycle.

## Regression coverage

- The authenticated POST /api/talk/speak boundary now asserts a pre-stream rejection is HTTP 503 instead of 200 with an empty body.
- The Kokoro handoff test asserts a rejected upstream response is closed and the client is released.
- The accepted-stream test consumes real httpx streaming bytes and verifies both upstream response and client close after relay.
- Existing endpoint coverage still verifies concatenated audio and anti-buffering headers.

## Validation

- Focused Talk speech tests ? 4 passed
- pytest -q tests/test_talk.py ? 41 passed
- python -m py_compile routers/talk.py tests/test_talk.py ? passed
- git diff --check ? passed

## Tradeoffs and rollback

This intentionally maps internal Kokoro transport and rejection failures to a stable 503 without exposing upstream response bodies to the browser; the sanitized body prefix remains in server logs. Mid-stream transport failures cannot change an already committed status, so ODS preserves any delivered audio and closes cleanly, matching normal streaming semantics.

The HTTP client and response are closed on rejection, cancellation, normal completion, and mid-stream failure. Reverting the commit restores the silent empty-200 behavior; no persisted state changes are involved.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


