### PR TITLE
fix(dashboard): allow local image previews in CSP

### DIFF
--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -118,7 +118,7 @@ server {
     add_header X-Frame-Options "SAMEORIGIN" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' data: https://huggingface.co https://cdn-avatars.huggingface.co; connect-src 'self'; media-src 'self' blob:; font-src 'self' https://cdn.jsdelivr.net;" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' data: blob: https://huggingface.co https://cdn-avatars.huggingface.co; connect-src 'self'; media-src 'self' blob:; font-src 'self' https://cdn.jsdelivr.net;" always;
     # Pre-stage HSTS so it activates automatically when TLS lands via
     # Caddy/Tailscale. Harmless over plain HTTP (browsers ignore it).
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;

--- a/ods/tests/contracts/test-network-exposure-contracts.py
+++ b/ods/tests/contracts/test-network-exposure-contracts.py
@@ -153,12 +153,17 @@ def test_dashboard_csp_allows_ods_talk_tts_blob_audio() -> None:
     assert_true("media-src 'self' blob:" in nginx_conf, "ODS Talk TTS playback uses blob: audio URLs")
 
 
-def test_dashboard_csp_allows_huggingface_author_avatars_only_as_images() -> None:
+def test_dashboard_csp_allows_local_previews_and_huggingface_images() -> None:
     nginx_conf = read(SERVICES / "dashboard" / "nginx.conf")
+    talk_page = read(SERVICES / "dashboard" / "src" / "pages" / "ODSTalk.jsx")
 
     assert_true(
-        "img-src 'self' data: https://huggingface.co https://cdn-avatars.huggingface.co;" in nginx_conf,
-        "the Models library renders Hugging Face author avatars",
+        "URL.createObjectURL(file)" in talk_page,
+        "ODS Talk must keep creating local attachment previews",
+    )
+    assert_true(
+        "img-src 'self' data: blob: https://huggingface.co https://cdn-avatars.huggingface.co;" in nginx_conf,
+        "the CSP must admit ODS Talk blob previews and Hugging Face images",
     )
     assert_true(
         "connect-src 'self';" in nginx_conf,


### PR DESCRIPTION
## Why this matters

ODS Talk creates blob URLs with URL.createObjectURL when an operator selects an image, then renders that URL as the pending attachment preview. The dashboard Content Security Policy allowed blob URLs for audio playback but not for images, so a conforming browser blocks the selected-photo preview even though the upload itself is valid.

This admits only the missing blob scheme on img-src. All existing self, data, and Hugging Face image sources remain unchanged; connect-src stays self-only.

## Root cause and invariant

The frontend and nginx security policy evolved independently: the attachment UI introduced a browser-local image source without adding that source to the image directive.

Invariant: every image source the shipped dashboard creates must be admitted by img-src, while API access and script sources remain no broader than before.

## Overlap check

Searched open and closed upstream PRs for dashboard CSP blob image, img-src blob, ODS Talk image preview, and PRs changing dashboard/nginx.conf. No PR covers the local attachment-preview source. Existing Talk PRs concern backend upload/vision behavior, and existing network-exposure work does not add blob to img-src.

## Regression coverage

The network-exposure contract now traces the complete handoff: ODSTalk.jsx must still create the local preview with URL.createObjectURL(file), and nginx must admit blob in the exact img-src directive alongside the existing approved sources. The same test keeps connect-src self-only.

## Validation

- pytest -q tests/contracts/test-network-exposure-contracts.py ? 12 passed
- ODSTalk frontend test file completed without modifying the tree
- git diff --check ? passed

## Tradeoffs and rollback

blob URLs are origin-bound opaque browser resources created by the dashboard itself; this does not allow remote image hosts or broaden script/network execution. The change is a one-token CSP addition and is independently revertible. Rollback restores the blocked-preview behavior without affecting persisted data.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


