### PR TITLE
fix(talk): release media resources on unmount

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -83,6 +83,10 @@ export default function ODSTalk() {
   const recorderRef = useRef(null)
   const recordingChunksRef = useRef([])
   const streamControllerRef = useRef(null)
+  // Browser-created attachment previews survive React state removal unless
+  // their object URLs are revoked explicitly. Track every live preview so a
+  // route change can release sent-message images as well as the pending one.
+  const attachmentPreviewUrlsRef = useRef(new Set())
   // Track the currently-playing TTS state so we can shut down whatever
   // is in flight before starting the next reply's audio.
   const activeSpeechRef = useRef(null)
@@ -217,6 +221,22 @@ export default function ODSTalk() {
       try { URL.revokeObjectURL(prev.objectUrl) } catch { /* ignore */ }
     }
   }, [])
+
+  useEffect(() => {
+    return () => {
+      stopActiveSpeech()
+      const audio = audioElementRef.current
+      if (audio) {
+        try { audio.removeAttribute?.('src') } catch { /* already detached */ }
+        try { audio.load?.() } catch { /* already detached */ }
+      }
+      audioElementRef.current = null
+      for (const previewUrl of attachmentPreviewUrlsRef.current) {
+        try { URL.revokeObjectURL(previewUrl) } catch { /* already revoked */ }
+      }
+      attachmentPreviewUrlsRef.current.clear()
+    }
+  }, [stopActiveSpeech])
 
   const speak = useCallback(async (text) => {
     if (!spokenReplies || !voiceState.tts || !text.trim()) return
@@ -611,17 +631,24 @@ export default function ODSTalk() {
     if (!file || sending || status === 'expired') return
     const isImage = (file.type || '').startsWith('image/')
     const previewUrl = isImage ? URL.createObjectURL(file) : null
+    if (previewUrl) attachmentPreviewUrlsRef.current.add(previewUrl)
     setPendingAttachment(prev => {
       // Revoke a previous blob URL before swapping in a new one so the
       // browser can GC the old image bytes.
-      if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl)
+      if (prev?.previewUrl) {
+        URL.revokeObjectURL(prev.previewUrl)
+        attachmentPreviewUrlsRef.current.delete(prev.previewUrl)
+      }
       return { file, previewUrl, kind: isImage ? 'image' : 'text', name: file.name || 'attachment' }
     })
   }, [sending, status])
 
   const clearPendingAttachment = useCallback(() => {
     setPendingAttachment(prev => {
-      if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl)
+      if (prev?.previewUrl) {
+        URL.revokeObjectURL(prev.previewUrl)
+        attachmentPreviewUrlsRef.current.delete(prev.previewUrl)
+      }
       return null
     })
   }, [])

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
@@ -338,6 +338,7 @@ describe('ODSTalk', () => {
     // Stub URL.createObjectURL so the blob: URL the SPA generates for the
     // preview doesn't break jsdom (which has no blob support by default).
     const createdUrls = []
+    const revokeObjectURL = vi.fn()
     vi.stubGlobal('URL', {
       ...globalThis.URL,
       createObjectURL: (blob) => {
@@ -345,7 +346,7 @@ describe('ODSTalk', () => {
         createdUrls.push({ url, blob })
         return url
       },
-      revokeObjectURL: () => {},
+      revokeObjectURL,
     })
 
     let attachmentRequest = null
@@ -364,7 +365,7 @@ describe('ODSTalk', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    const { container } = render(<ODSTalk />)
+    const { container, unmount } = render(<ODSTalk />)
     expect(await screen.findByText('Ready')).toBeInTheDocument()
 
     // Pick a fake image file via the hidden file input.
@@ -394,6 +395,10 @@ describe('ODSTalk', () => {
     const userImg = container.querySelector('img[alt="Attached"]')
     expect(userImg).toBeTruthy()
     expect(userImg.getAttribute('src')).toMatch(/^blob:/)
+
+    const previewUrl = userImg.getAttribute('src')
+    unmount()
+    expect(revokeObjectURL).toHaveBeenCalledWith(previewUrl)
   })
 
   test('retry keeps image attachment context after an attachment stream error', async () => {
@@ -514,13 +519,19 @@ describe('ODSTalk', () => {
   })
 
   test('can request spoken replies without blocking text chat', async () => {
-    vi.stubGlobal('Audio', class {
-      addEventListener() {}
-      play() { return Promise.resolve() }
-    })
+    const audio = {
+      addEventListener: vi.fn(),
+      play: vi.fn(() => Promise.resolve()),
+      pause: vi.fn(),
+      removeAttribute: vi.fn(),
+      load: vi.fn(),
+      paused: false,
+    }
+    vi.stubGlobal('Audio', class { constructor() { return audio } })
+    const revokeObjectURL = vi.fn()
     vi.stubGlobal('URL', {
       createObjectURL: () => 'blob:audio',
-      revokeObjectURL: vi.fn(),
+      revokeObjectURL,
     })
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/talk/status') {
@@ -540,6 +551,7 @@ describe('ODSTalk', () => {
         return {
           ok: true,
           status: 200,
+          body: {},
           blob: async () => new globalThis.Blob(['audio'], { type: 'audio/mpeg' }),
         }
       }
@@ -547,7 +559,7 @@ describe('ODSTalk', () => {
     })
     vi.stubGlobal('fetch', fetchMock)
 
-    render(<ODSTalk />)
+    const { unmount } = render(<ODSTalk />)
     expect(await screen.findByText('Ready')).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Turn spoken replies on' }))
     fireEvent.change(screen.getByPlaceholderText('Message ODS'), {
@@ -560,5 +572,12 @@ describe('ODSTalk', () => {
       '/api/talk/speak',
       expect.objectContaining({ method: 'POST' }),
     ))
+    await waitFor(() => expect(audio.play).toHaveBeenCalled())
+
+    unmount()
+    expect(audio.pause).toHaveBeenCalled()
+    expect(audio.removeAttribute).toHaveBeenCalledWith('src')
+    expect(audio.load).toHaveBeenCalled()
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:audio')
   })
 })


### PR DESCRIPTION
## Why this matters

ODS Talk owns browser resources that outlive React state: a shared Audio element, an optional streaming reader and MediaSource, and blob URLs for TTS audio and selected image previews. Starting a new reply cleaned up active speech, but navigating away from ODS Talk only aborted the text SSE controller. Audio could continue after leaving the page, and sent-image preview URLs remained allocated until the entire dashboard document closed.

The component now closes its complete media lifecycle on unmount and tracks every live attachment preview URL so pending, replaced, sent, and route-exit paths release the right resource exactly where it is owned.

## Root cause and invariant

The existing cleanup effect covered the text stream but had no connection to activeSpeechRef, audioElementRef, or preview URLs that had moved from pending attachment state into message history.

Invariant: after ODSTalk unmounts, it owns no active audio playback/reader/MediaSource and no unreleased attachment object URL.

## Overlap check

Searched open and closed upstream PRs for ODS Talk unmount speech, stopActiveSpeech unmount, talk audio navigation, ODSTalk object URL cleanup, and current PRs touching ODSTalk.jsx. Existing work covers attachment upload/retry, streaming playback, model compatibility, and backend behavior. No PR closes component-owned media resources on route exit.

This is independent from #3176: that PR admits browser-local image URLs through nginx CSP; this PR governs the lifetime and release of those URLs inside React.

## Regression coverage

- The image attachment boundary sends and renders a blob preview, unmounts the page, and asserts that exact sent-message URL is revoked.
- The spoken-reply boundary reaches real fallback playback, unmounts, and asserts pause, audio source removal/reload, and TTS blob revocation.
- Existing tests continue to cover attachment retry and normal TTS requests.

## Validation

- npm test -- --run src/pages/ODSTalk.test.jsx ? 15 passed
- npm run lint ? passed
- git diff --check ? passed

## Tradeoffs and rollback

Preview URLs remain alive while their messages are rendered, preserving retry and image display. They are removed from the registry when a pending preview is explicitly replaced or cleared, preventing double ownership. On unmount, cleanup is best-effort because browser media objects can already be detached; each operation is independently guarded.

The change is independently revertible and does not alter API or persisted data. Rollback restores the route-exit audio continuation and blob-memory leak.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


