### PR TITLE
ci(compose): validate extension stack profiles

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -7,7 +7,9 @@ on:
       - "ods/docker-compose*.yml"
       - "ods/installers/**/*compose*.yml"
       - "ods/extensions/services/**/compose*.yaml"
+      - "ods/extensions/services/**/compose*.yml"
       - "ods/scripts/resolve-compose-stack.sh"
+      - "ods/tests/test-extension-compose-config.sh"
       - ".github/workflows/validate-compose.yml"
   pull_request:
     branches: [main]
@@ -15,7 +17,9 @@ on:
       - "ods/docker-compose*.yml"
       - "ods/installers/**/*compose*.yml"
       - "ods/extensions/services/**/compose*.yaml"
+      - "ods/extensions/services/**/compose*.yml"
       - "ods/scripts/resolve-compose-stack.sh"
+      - "ods/tests/test-extension-compose-config.sh"
       - ".github/workflows/validate-compose.yml"
 
 permissions:
@@ -34,6 +38,10 @@ jobs:
         run: |
           echo "Validating ods/docker-compose.base.yml"
           docker compose -f ods/docker-compose.base.yml config --quiet
+
+      - name: Validate extension Compose fragments
+        working-directory: ods
+        run: bash tests/test-extension-compose-config.sh
 
       - name: Validate installer compose overlays (base + overlay)
         env:

--- a/ods/tests/test-extension-compose-config.sh
+++ b/ods/tests/test-extension-compose-config.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Validate every enabled extension Compose fragment in the stack it joins.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+EXTENSIONS_DIR="$ROOT_DIR/extensions/services"
+BASE_COMPOSE="$ROOT_DIR/docker-compose.base.yml"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "FAIL: docker is required to validate Compose fragments" >&2
+    exit 1
+fi
+
+if [[ ! -f "$BASE_COMPOSE" || ! -d "$EXTENSIONS_DIR" ]]; then
+    echo "FAIL: expected ODS base Compose file and extension directory" >&2
+    exit 1
+fi
+
+# Required substitutions need non-secret values before Compose can validate the
+# merged model. New required variables intentionally fail this gate until their
+# CI placeholder is declared here.
+export WEBUI_SECRET="${WEBUI_SECRET:-compose-validation-placeholder}"
+export SEARXNG_SECRET="${SEARXNG_SECRET:-compose-validation-placeholder}"
+export N8N_USER="${N8N_USER:-compose-validation@example.invalid}"
+export N8N_PASS="${N8N_PASS:-compose-validation-placeholder}"
+export LITELLM_KEY="${LITELLM_KEY:-compose-validation-placeholder}"
+export OPENCLAW_TOKEN="${OPENCLAW_TOKEN:-compose-validation-placeholder}"
+export HERMES_DASHBOARD_SESSION_TOKEN="${HERMES_DASHBOARD_SESSION_TOKEN:-compose-validation-placeholder}"
+export APE_API_KEY="${APE_API_KEY:-compose-validation-placeholder}"
+export COMFYUI_GPU_UUID="${COMFYUI_GPU_UUID:-GPU-compose-validation}"
+export EMBEDDINGS_GPU_UUID="${EMBEDDINGS_GPU_UUID:-GPU-compose-validation}"
+export WHISPER_GPU_UUID="${WHISPER_GPU_UUID:-GPU-compose-validation}"
+
+extension_bases=()
+amd_overlays=()
+nvidia_overlays=()
+apple_overlays=()
+local_overlays=()
+multigpu_amd_overlays=()
+multigpu_nvidia_overlays=()
+
+while IFS= read -r -d '' fragment; do
+    case "$(basename "$fragment")" in
+        compose.yaml|compose.yml) extension_bases+=(-f "$fragment") ;;
+        compose.amd.yaml|compose.amd.yml) amd_overlays+=(-f "$fragment") ;;
+        compose.nvidia.yaml|compose.nvidia.yml) nvidia_overlays+=(-f "$fragment") ;;
+        compose.apple.yaml|compose.apple.yml) apple_overlays+=(-f "$fragment") ;;
+        compose.local.yaml|compose.local.yml) local_overlays+=(-f "$fragment") ;;
+        compose.multigpu-amd.yaml|compose.multigpu-amd.yml) multigpu_amd_overlays+=(-f "$fragment") ;;
+        compose.multigpu-nvidia.yaml|compose.multigpu-nvidia.yml) multigpu_nvidia_overlays+=(-f "$fragment") ;;
+    esac
+done < <(find "$EXTENSIONS_DIR" -mindepth 2 -maxdepth 2 -type f \
+    \( -name 'compose*.yaml' -o -name 'compose*.yml' \) -print0)
+
+if (( ${#extension_bases[@]} == 0 )); then
+    echo "FAIL: no enabled extension Compose fragments found" >&2
+    exit 1
+fi
+
+failed=0
+validated=0
+
+validate_profile() {
+    local profile="$1"
+    shift
+    if docker compose -f "$BASE_COMPOSE" "$@" config --quiet; then
+        echo "PASS: $profile extension stack"
+    else
+        echo "FAIL: $profile extension stack" >&2
+        failed=1
+    fi
+    validated=$((validated + 1))
+}
+
+validate_profile base "${extension_bases[@]}"
+validate_profile local "${extension_bases[@]}" "${local_overlays[@]}"
+validate_profile amd \
+    -f "$ROOT_DIR/docker-compose.amd.yml" \
+    "${extension_bases[@]}" "${amd_overlays[@]}"
+validate_profile nvidia \
+    -f "$ROOT_DIR/docker-compose.nvidia.yml" \
+    "${extension_bases[@]}" "${nvidia_overlays[@]}"
+validate_profile apple \
+    -f "$ROOT_DIR/docker-compose.apple.yml" \
+    "${extension_bases[@]}" "${apple_overlays[@]}"
+validate_profile multigpu-amd \
+    -f "$ROOT_DIR/docker-compose.amd.yml" \
+    -f "$ROOT_DIR/docker-compose.multigpu-amd.yml" \
+    "${extension_bases[@]}" "${amd_overlays[@]}" "${multigpu_amd_overlays[@]}"
+validate_profile multigpu-nvidia \
+    -f "$ROOT_DIR/docker-compose.nvidia.yml" \
+    -f "$ROOT_DIR/docker-compose.multigpu-nvidia.yml" \
+    "${extension_bases[@]}" "${nvidia_overlays[@]}" "${multigpu_nvidia_overlays[@]}"
+
+echo "Validated $validated extension stack profiles"
+exit "$failed"


### PR DESCRIPTION
## Summary
- add a Docker-backed regression gate for every enabled extension Compose profile
- validate the real merge order for base, local, AMD, NVIDIA, Apple, and both multi-GPU stacks
- trigger the workflow for both `.yaml` and supported `.yml` extension fragments, plus changes to the gate itself

## Why this matters
Changes under `ods/extensions/services/**/compose*.yaml` already trigger `validate-compose.yml`, but no existing step passes those fragments to `docker compose config`. A malformed service dependency, interpolation, overlay, or merged model can therefore leave the Compose workflow green and fail only when an operator enables or starts that extension stack.

The root cause is a coverage mismatch: the workflow validates the root and installer/GPU overlays, while extension fragments?the files named in its own path filter and dynamically merged by `resolve-compose-stack.sh`?are absent from every validation command.

The preserved invariant is: every enabled extension fragment must form a valid Docker Compose model in each runtime profile where it is selected.

## Overlap check
Searched open and closed PRs for `validate extension compose files workflow`, `extension compose CI`, `validate compose extension`, and `validate-compose.yml`, and inspected the workflow plus extension Compose paths.

- Closed #375 targeted the pre-migration `dream-server/` layout and never landed. This implementation uses the current `ods/` tree and validates complete dependency-bearing stacks rather than isolated fragments.
- Merged #1117 validates installer overlays and explicitly records extension overlays as an unhandled follow-up.
- Open PRs returned by the file/keyword search change resolver, service, or installer behavior; none adds this current-tree seven-profile gate.

## Regression test
`ods/tests/test-extension-compose-config.sh` is the boundary test executed by the Compose workflow. It invokes the exact Docker Compose parser shipped by the runner against:

1. base plus all enabled extension bases
2. local overlays
3. AMD overlays
4. NVIDIA overlays
5. Apple overlays
6. AMD multi-GPU overlays in base/backend/multi-GPU order
7. NVIDIA multi-GPU overlays in base/backend/multi-GPU order

Including all enabled extension bases preserves declared cross-extension dependencies such as `hermes-proxy -> hermes`, which isolated-fragment validation would incorrectly reject.

## Validation
- `bash -n tests/test-extension-compose-config.sh` ? pass
- `bash tests/test-extension-compose-config.sh` ? 7/7 stack profiles pass with Docker Compose v5.1.4
- PyYAML parse of `.github/workflows/validate-compose.yml` ? pass
- `git diff --check` ? pass

## Design notes
Placeholder values are used only for required Compose interpolation and never written to an env file. A newly required variable fails closed until the gate declares a non-secret CI value. The change affects release validation only; it does not alter installer or runtime output. Rollback is removal of the workflow step and test script, restoring the prior validation coverage.

## Batch compatibility
This PR remains independently mergeable. It was also merged, without conflicts, into synthetic integration head `fb933c1f0ff2a68b4584d9db645adf6df8ec3629` from current `upstream/main` in validation order #3168, #3170, #3171, #3172, #3173, #3174, #3175, #3176, #3177, #3178.

Combined validation passed: Talk 42 tests; Privacy Shield 54; Token Spy 28 plus 1 skip; APE 44; ODSTalk 15; integration smoke 69 pass/0 fail/3 skips; seven Compose stack profiles; Windows update/failure contracts; network and APE contracts 14 pass/2 platform skips; dashboard lint/build; and repository `make lint`. The order records the tested handoff and is not a merge dependency.


