### PR TITLE
fix(gguf): handle non-prefixed metadata keys and empty files in gguf inspector

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -163,16 +163,24 @@ def _read_array(reader: _Reader, depth: int = 0) -> Any:
     }
 
 
-def _first_int(metadata: dict[str, Any], suffixes: tuple[str, ...]) -> int | None:
+def _key_matches_target(key: str, targets: tuple[str, ...]) -> bool:
+    for target in targets:
+        clean_target = target.lstrip(".")
+        if key == clean_target or key.endswith("." + clean_target):
+            return True
+    return False
+
+
+def _first_int(metadata: dict[str, Any], targets: tuple[str, ...]) -> int | None:
     for key, value in metadata.items():
-        if key.endswith(suffixes) and isinstance(value, int) and not isinstance(value, bool):
+        if _key_matches_target(key, targets) and isinstance(value, int) and not isinstance(value, bool):
             return value
     return None
 
 
-def _first_value(metadata: dict[str, Any], suffixes: tuple[str, ...]) -> Any:
+def _first_value(metadata: dict[str, Any], targets: tuple[str, ...]) -> Any:
     for key, value in metadata.items():
-        if key.endswith(suffixes):
+        if _key_matches_target(key, targets):
             return value
     return None
 
@@ -193,7 +201,11 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
         return result
 
     try:
-        result["size_bytes"] = p.stat().st_size
+        size = p.stat().st_size
+        result["size_bytes"] = size
+        if size < 4:
+            result["error"] = "not a GGUF file"
+            return result
         with p.open("rb") as f:
             data = f.read(max_metadata_bytes)
         reader = _Reader(data)

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -327,3 +327,29 @@ def test_boolean_metadata_value_is_ignored_for_integer_fields(tmp_path):
 
     assert result["readable"] is True
     assert result["context_length"] is None
+
+
+def test_non_prefixed_metadata_keys_are_normalized(tmp_path):
+    kvs = [
+        ("architecture", STR, "qwen2"),
+        ("name", STR, "Qwen Model"),
+        ("context_length", U32, 8192),
+        ("block_count", U32, 28),
+    ]
+    path = _write(tmp_path, "root_keys.gguf", build_gguf(kvs))
+
+    result = inspect_gguf(path)
+
+    assert result["readable"] is True
+    assert result["context_length"] == 8192
+    assert result["block_count"] == 28
+
+
+def test_empty_or_too_small_file_returns_error(tmp_path):
+    path = _write(tmp_path, "empty.gguf", b"GGU")
+
+    result = inspect_gguf(path)
+
+    assert result["readable"] is False
+    assert result.get("error") == "not a GGUF file"
+

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -1,3 +1,4 @@
+import json
 import httpx
 import pytest
 
@@ -88,8 +89,8 @@ async def test_chat_completion_posts_openai_shape():
 
     assert payload["choices"][0]["message"]["content"] == "ok"
     assert seen["url"] == "http://lemonade:13305/api/v1/chat/completions"
-    assert b'"model":"Qwen3-0.6B-GGUF"' in seen["body"]
-    assert b'"temperature":0' in seen["body"]
+    assert json.loads(seen["body"])["model"] == "Qwen3-0.6B-GGUF"
+    assert json.loads(seen["body"])["temperature"] == 0
     await client.aclose()
 
 


### PR DESCRIPTION
### Summary
This PR improves the GGUF model metadata parser in `gguf_inspector` by expanding key matching to support root-level (un-namespaced) keys alongside namespaced keys, and adding early size validation for small/corrupted files.

### Key Changes
- **Key Matching**: Updated `_first_int` and `_first_value` via `_key_matches_target()` to match both root-level keys (e.g. `context_length`, `name`) and suffix-namespaced keys (e.g. `llama.context_length`).
- **File Validation**: Added an explicit check for files under 4 bytes to return a clean `"not a GGUF file"` error status early instead of throwing unexpected payload exceptions.
- **Unit Tests**: Added test coverage in `test_gguf_inspector.py` for root-level GGUF metadata keys and small/empty files.