### PR TITLE
fix(dashboard): handle structured dict metrics and sync tokens per second in agent monitor

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -145,14 +145,27 @@ async def _fetch_token_spy_metrics() -> None:
             ) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    agent_metrics.session_count = len(data)
+                    sessions = []
+                    if isinstance(data, list):
+                        sessions = data
+                    elif isinstance(data, dict):
+                        raw = data.get("sessions") or data.get("summary") or data.get("data")
+                        if isinstance(raw, list):
+                            sessions = raw
+
+                    agent_metrics.session_count = len(sessions)
                     # Token Spy's /api/summary defaults to a 24 h window, so
                     # total_output_tokens is a 24 h aggregate; divide by the
                     # seconds in that window to get an average tokens/sec.
-                    total_out = sum(r.get("total_output_tokens", 0) or 0 for r in data)
+                    total_out = sum(
+                        (r.get("total_output_tokens", 0) or 0)
+                        for r in sessions
+                        if isinstance(r, dict)
+                    )
                     throughput.add_sample(total_out / 86400.0)
+                    agent_metrics.tokens_per_second = float(throughput.get_stats().get("current", 0.0))
                     logger.debug("Token Spy metrics: %d sessions, %d total output tokens",
-                               len(data), total_out)
+                               len(sessions), total_out)
                 else:
                     logger.debug("Token Spy returned status %d", resp.status)
     except aiohttp.ClientError as e:

--- a/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -214,6 +214,27 @@ class TestFetchTokenSpyMetrics:
         with patch("aiohttp.ClientSession", return_value=mock_session_cm):
             await agent_monitor._fetch_token_spy_metrics()
 
+    @pytest.mark.asyncio
+    async def test_handles_dict_response_shape(self, monkeypatch):
+        """Token Spy returning a dict payload with nested sessions updates metrics cleanly."""
+        monkeypatch.setattr(agent_monitor, "TOKEN_SPY_URL", "http://token-spy:8080")
+        monkeypatch.setattr(agent_monitor, "TOKEN_SPY_API_KEY", "")
+
+        dict_payload = {
+            "status": "ok",
+            "sessions": [
+                {"total_output_tokens": 86400},
+                {"total_output_tokens": 172800},
+            ],
+        }
+        mock_session_cm = self._make_session_mock(200, resp_json=dict_payload)
+
+        with patch("aiohttp.ClientSession", return_value=mock_session_cm):
+            await agent_monitor._fetch_token_spy_metrics()
+
+        assert agent_monitor.agent_metrics.session_count == 2
+        assert agent_monitor.agent_metrics.tokens_per_second == 3.0
+
 
 class TestClusterStatusRefresh:
 


### PR DESCRIPTION
### Summary
This PR hardens real-time agent metrics collection against Token Spy API schema variations and synchronizes the live tokens/sec calculation to the overall agent metrics payload.

### Key Changes
- **Dict Response Handling**: Updated `_fetch_token_spy_metrics()` in `agent_monitor.py` to extract the session list when Token Spy returns dictionary responses (e.g. nested under `sessions`, `summary`, or `data` keys).
- **Type Guarding**: Added dictionary type guards when summing `total_output_tokens` across session items to prevent potential `AttributeError` exceptions.
- **Live Throughput Metric Sync**: Updated `agent_metrics.tokens_per_second` with the latest throughput stats value whenever a sample is added.
- **Unit Tests**: Added test coverage in `test_agent_monitor.py` verifying structured dictionary response handling and live throughput metric sync.