### PR TITLE
fix(installers): fall back to system RAM for unified-memory NVIDIA GPUs

### DIFF
--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -141,8 +141,8 @@ function Get-GpuInfo {
                 $lines = @($raw -split "`n" | Where-Object { $_.Trim() })
                 $first = $lines[0] -split ","
                 $gpuName = $first[0].Trim()
-                $vramStr = $first[1].Trim() -replace "[^\d]", ""
-                $vramMB  = [int]$vramStr
+                $vramField = $first[1].Trim()
+                $vramStr = $vramField -replace "[^\d]", ""
                 $driverVer = $first[2].Trim()
                 $computeCap = $first[3].Trim()
                 $gpuCount = $lines.Count
@@ -158,12 +158,24 @@ function Get-GpuInfo {
                     if ($ccMajor -ge 12) { $isBlackwell = $true }
                 }
 
+                # Unified memory detection (GB10, GB200): nvidia-smi reports
+                # "[N/A]" for memory.total when the GPU shares system RAM.
+                # Mirrors installers/lib/detection.sh's GPU_VRAM==0 fallback.
+                $memoryType = "discrete"
+                if ([string]::IsNullOrEmpty($vramStr)) {
+                    $memoryType = "unified"
+                    $systemRamGB = [math]::Floor((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1073741824)
+                    $vramMB = [int]($systemRamGB * 1024)
+                } else {
+                    $vramMB = [int]$vramStr
+                }
+
                 return @{
                     Backend       = "nvidia"
                     Name          = $gpuName
                     VramMB        = $vramMB
                     Count         = $gpuCount
-                    MemoryType    = "discrete"
+                    MemoryType    = $memoryType
                     DeviceId      = ""
                     DriverVersion = $driverVer
                     DriverMajor   = $driverMajor

--- a/ods/tests/test-windows-nvidia-unified-memory.ps1
+++ b/ods/tests/test-windows-nvidia-unified-memory.ps1
@@ -1,0 +1,53 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$detectionPath = Join-Path $root "installers\windows\lib\detection.ps1"
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Label)
+    if ($Actual -ne $Expected) {
+        throw "$Label expected '$Expected', got '$Actual'"
+    }
+}
+
+# Mock nvidia-smi and Win32_ComputerSystem before sourcing detection.ps1, so
+# Get-GpuInfo's calls resolve to these fakes instead of touching real hardware.
+function nvidia-smi {
+    if ($env:MOCK_NVIDIA_SMI_OUTPUT) {
+        return $env:MOCK_NVIDIA_SMI_OUTPUT -split "`n"
+    }
+    return $null
+}
+$global:LASTEXITCODE = 0
+
+function Get-CimInstance {
+    param($ClassName, $ErrorAction)
+    if ($ClassName -eq "Win32_ComputerSystem") {
+        return [pscustomobject]@{ TotalPhysicalMemory = [uint64](128GB) }
+    }
+    return @()
+}
+
+. $detectionPath
+
+# Regression: unified-memory NVIDIA systems (GB10, GB200) report "[N/A]" for
+# memory.total. Get-GpuInfo must fall back to system RAM instead of throwing
+# on [int]"" and silently reporting "no GPU" (Backend falls through to none).
+$env:MOCK_NVIDIA_SMI_OUTPUT = "NVIDIA GB10, [N/A], 580.65.06, 12.1"
+$global:LASTEXITCODE = 0
+$info = Get-GpuInfo
+Assert-Equal $info.Backend "nvidia" "Unified-memory GPU must still report nvidia backend"
+Assert-Equal $info.MemoryType "unified" "Unified-memory GPU must be classified as unified"
+Assert-Equal $info.VramMB 131072 "Unified-memory GPU must use system RAM as VRAM budget (128GB)"
+
+# Discrete NVIDIA GPUs (a real memory.total value) must be unaffected.
+$env:MOCK_NVIDIA_SMI_OUTPUT = "NVIDIA GeForce RTX 4090, 24564 MiB, 560.94, 8.9"
+$global:LASTEXITCODE = 0
+$discreteInfo = Get-GpuInfo
+Assert-Equal $discreteInfo.Backend "nvidia" "Discrete GPU must report nvidia backend"
+Assert-Equal $discreteInfo.MemoryType "discrete" "Discrete GPU must be classified as discrete"
+Assert-Equal $discreteInfo.VramMB 24564 "Discrete GPU VRAM must come from nvidia-smi, not system RAM"
+
+Remove-Item Env:\MOCK_NVIDIA_SMI_OUTPUT -ErrorAction SilentlyContinue
+
+Write-Host "[PASS] Windows NVIDIA unified-memory detection fallback"


### PR DESCRIPTION
## Summary
- `Get-GpuInfo` in `installers/windows/lib/detection.ps1` assumed `nvidia-smi` always reports a numeric `memory.total`.
- On unified-memory systems (NVIDIA GB10/GB200, e.g. DGX Spark) `nvidia-smi` reports `[N/A]` for VRAM instead. Stripping non-digits from `"[N/A]"` yields an empty string, and `[int]""` throws — caught by the surrounding `try/catch` ("nvidia-smi exists but failed -- fall through to AMD") — so a real NVIDIA GPU silently falls through past AMD detection to `Backend = "none"`.
- `installers/lib/detection.sh` (the file's own documented canonical source) already handles this exact case with a `[N/A]` → `/proc/meminfo` fallback; this port never had the Windows equivalent.
- Adds the same fallback: use system RAM (via `Win32_ComputerSystem`) as the VRAM budget and classify `MemoryType = "unified"`.

## Test plan
- [x] Added `tests/test-windows-nvidia-unified-memory.ps1`, mocking `nvidia-smi` and `Get-CimInstance` to cover both the `[N/A]` unified-memory path and the normal discrete-VRAM path
- [x] `powershell.exe -File tests/test-windows-nvidia-unified-memory.ps1` — PASS
- [x] Existing `tests/test-windows-amd-memory-detection.ps1` still passes (no regression)
- [x] PowerShell tokenizer syntax check on the modified file — no errors