### PR TITLE
fix(dashboard): add aria-label to details button in Extensions

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -921,6 +921,7 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
           )}
           <button
             onClick={onDetails}
+            aria-label="View details"
             className="flex items-center gap-1 px-2 py-1.5 text-[10px] text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover/40 rounded-lg transition-colors"
           >
             <Info size={11} />


### PR DESCRIPTION
## Summary
- The per-extension "view details" button (`Info` icon only) in `Extensions.jsx` had no text, `title`, or `aria-label`.
- Screen readers announce it as just "button", with no indication of what it does.
- Adds `aria-label="View details"`.

## Test plan
- [x] `npx eslint` on the changed file — no new errors
- [x] Purely additive prop, no behavior change