### PR TITLE
test(dashboard): add coverage for useFirstRun hook

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useFirstRun.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useFirstRun.test.js
@@ -1,0 +1,91 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useFirstRun } from '../useFirstRun'
+
+describe('useFirstRun', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('reports firstRun=true when the API says setup is incomplete', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ first_run: true }),
+    })
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.firstRun).toBe(true)
+    expect(result.current.error).toBeNull()
+  })
+
+  test('reports firstRun=false when the API says setup is complete', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ first_run: false }),
+    })
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.firstRun).toBe(false)
+  })
+
+  test('defaults to firstRun=false when the response is not ok (fail closed)', async () => {
+    fetch.mockResolvedValue({ ok: false, status: 503 })
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.firstRun).toBe(false)
+    expect(result.current.error).toBeTruthy()
+  })
+
+  test('defaults to firstRun=false when the fetch throws (network error)', async () => {
+    fetch.mockRejectedValue(new Error('network error'))
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.firstRun).toBe(false)
+    expect(result.current.error).toBe('network error')
+  })
+
+  test('refresh() re-fetches and can flip firstRun back to true', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ first_run: false }),
+    })
+
+    const { result } = renderHook(() => useFirstRun())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.firstRun).toBe(false)
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ first_run: true }),
+    })
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.firstRun).toBe(true)
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary
- `useFirstRun()` gates the first-boot wizard on dashboard-api's `/api/setup/status` sentinel, with a documented fail-closed policy (API error → `firstRun=false`, not a wizard loop) — but had no test, unlike sibling hooks (`useVersion`, `useModels`, `useSystemStatus`, `usePwaInstallPrompt`, `useDownloadProgress`).
- Adds `hooks/__tests__/useFirstRun.test.js`, following the same `renderHook`/`vi.stubGlobal('fetch', ...)` pattern used by `useVersion.test.js`.
- Covers: `first_run=true`, `first_run=false`, a non-ok HTTP response, a network error (fetch throws), and `refresh()` re-fetching to flip the flag.

## Test plan
- [x] `npx vitest run src/hooks/__tests__/useFirstRun.test.js` — 5/5 passed