### PR TITLE
test(dashboard): add coverage for HuggingFaceModelBrowser formatters

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
@@ -426,50 +426,50 @@ async function responseJson(response) {
   try { return await response.json() } catch { return {} }
 }
 
-function errorMessage(body, fallback) {
+export function errorMessage(body, fallback) {
   if (typeof body?.detail === 'string') return body.detail
   if (typeof body?.detail?.message === 'string') return body.detail.message
   if (typeof body?.error === 'string') return body.error
   return fallback
 }
 
-function formatCompact(value) {
+export function formatCompact(value) {
   return new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 }).format(Number(value || 0))
 }
 
-function formatDate(value) {
+export function formatDate(value) {
   if (!value) return 'unknown'
   const date = new Date(value)
   if (Number.isNaN(date.getTime())) return 'unknown'
   return new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric', year: 'numeric' }).format(date)
 }
 
-function formatLicense(value) {
+export function formatLicense(value) {
   return value ? String(value).replace(/-/g, ' ').toUpperCase() : 'Not declared'
 }
 
-function formatPipeline(value) {
+export function formatPipeline(value) {
   return String(value || 'text-generation').replace(/-/g, ' ')
 }
 
-function formatBytes(value) {
+export function formatBytes(value) {
   const bytes = Number(value || 0)
   if (bytes >= 1024 ** 3) return `${(bytes / (1024 ** 3)).toFixed(1)} GB`
   return `${Math.round(bytes / (1024 ** 2))} MB`
 }
 
-function formatContext(value) {
+export function formatContext(value) {
   const tokens = Number(value || 0)
   return tokens ? `${Math.round(tokens / 1024)}K tokens` : 'Unknown'
 }
 
-function contextSourceLabel(source) {
+export function contextSourceLabel(source) {
   if (source === 'gguf_metadata') return 'GGUF metadata'
   if (source === 'hub_config') return 'Hub config'
   return 'Not published by repository'
 }
 
-function authorFallbackStyle(author) {
+export function authorFallbackStyle(author) {
   const value = String(author || 'huggingface')
   const hash = Array.from(value).reduce((total, char) => ((total * 31) + char.charCodeAt(0)) >>> 0, 0)
   const hue = hash % 360

--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.test.jsx
@@ -1,0 +1,126 @@
+import { describe, test, expect } from 'vitest'
+import {
+  errorMessage,
+  formatCompact,
+  formatDate,
+  formatLicense,
+  formatPipeline,
+  formatBytes,
+  formatContext,
+  contextSourceLabel,
+  authorFallbackStyle,
+} from './HuggingFaceModelBrowser'
+
+describe('errorMessage', () => {
+  test('prefers a plain string detail', () => {
+    expect(errorMessage({ detail: 'not found' }, 'fallback')).toBe('not found')
+  })
+
+  test('falls back to detail.message when detail is an object', () => {
+    expect(errorMessage({ detail: { message: 'bad request' } }, 'fallback')).toBe('bad request')
+  })
+
+  test('falls back to a top-level error string', () => {
+    expect(errorMessage({ error: 'rate limited' }, 'fallback')).toBe('rate limited')
+  })
+
+  test('falls back to the provided default when nothing matches', () => {
+    expect(errorMessage({}, 'fallback')).toBe('fallback')
+    expect(errorMessage(null, 'fallback')).toBe('fallback')
+  })
+})
+
+describe('formatCompact', () => {
+  test('formats large numbers compactly', () => {
+    expect(formatCompact(1500000)).toBe('1.5M')
+    expect(formatCompact(950)).toBe('950')
+  })
+
+  test('treats missing/falsy values as 0', () => {
+    expect(formatCompact(undefined)).toBe('0')
+    expect(formatCompact(null)).toBe('0')
+  })
+})
+
+describe('formatDate', () => {
+  test('formats a valid ISO date', () => {
+    expect(formatDate('2026-03-15T00:00:00Z')).toBe('Mar 15, 2026')
+  })
+
+  test('returns "unknown" for a missing or invalid value', () => {
+    expect(formatDate(null)).toBe('unknown')
+    expect(formatDate('not-a-date')).toBe('unknown')
+  })
+})
+
+describe('formatLicense', () => {
+  test('replaces dashes and uppercases a declared license', () => {
+    expect(formatLicense('apache-2.0')).toBe('APACHE 2.0')
+  })
+
+  test('returns "Not declared" when missing', () => {
+    expect(formatLicense(null)).toBe('Not declared')
+    expect(formatLicense('')).toBe('Not declared')
+  })
+})
+
+describe('formatPipeline', () => {
+  test('replaces dashes with spaces', () => {
+    expect(formatPipeline('text-generation')).toBe('text generation')
+  })
+
+  test('defaults to "text generation" when missing', () => {
+    expect(formatPipeline(null)).toBe('text generation')
+  })
+})
+
+describe('formatBytes', () => {
+  test('formats gigabyte-scale values with one decimal', () => {
+    expect(formatBytes(5 * 1024 ** 3)).toBe('5.0 GB')
+  })
+
+  test('formats sub-gigabyte values in whole megabytes', () => {
+    expect(formatBytes(512 * 1024 ** 2)).toBe('512 MB')
+  })
+
+  test('treats missing values as 0 bytes', () => {
+    expect(formatBytes(undefined)).toBe('0 MB')
+  })
+})
+
+describe('formatContext', () => {
+  test('formats a token count in K tokens', () => {
+    expect(formatContext(32768)).toBe('32K tokens')
+  })
+
+  test('returns "Unknown" for zero/missing context', () => {
+    expect(formatContext(0)).toBe('Unknown')
+    expect(formatContext(undefined)).toBe('Unknown')
+  })
+})
+
+describe('contextSourceLabel', () => {
+  test('maps known source keys to their labels', () => {
+    expect(contextSourceLabel('gguf_metadata')).toBe('GGUF metadata')
+    expect(contextSourceLabel('hub_config')).toBe('Hub config')
+  })
+
+  test('falls back for an unrecognized or missing source', () => {
+    expect(contextSourceLabel('something-else')).toBe('Not published by repository')
+    expect(contextSourceLabel(undefined)).toBe('Not published by repository')
+  })
+})
+
+describe('authorFallbackStyle', () => {
+  test('is deterministic for the same author', () => {
+    expect(authorFallbackStyle('unsloth')).toEqual(authorFallbackStyle('unsloth'))
+  })
+
+  test('differs for different authors (not a constant fallback)', () => {
+    expect(authorFallbackStyle('unsloth')).not.toEqual(authorFallbackStyle('ggml-org'))
+  })
+
+  test('defaults to a stable value when author is missing', () => {
+    expect(authorFallbackStyle(undefined)).toEqual(authorFallbackStyle('huggingface'))
+  })
+})


### PR DESCRIPTION
## Summary
- `HuggingFaceModelBrowser` has 9 pure formatting/helper functions (`errorMessage`, `formatCompact`, `formatDate`, `formatLicense`, `formatPipeline`, `formatBytes`, `formatContext`, `contextSourceLabel`, `authorFallbackStyle`) with real edge cases — missing values, unrecognized keys, invalid dates — but they were module-private and had no test coverage.
- Adds `export` to each (no behavior change — same functions, same call sites, now also importable) and adds `HuggingFaceModelBrowser.test.jsx` covering each function's normal and fallback paths.
- Covers: error-message extraction precedence (`detail` string → `detail.message` → `error` → fallback), compact-number formatting and the missing-value-as-0 default, date formatting and the "unknown" fallback for missing/invalid dates, license/pipeline dash-to-space + fallback text, byte formatting at the GB/MB boundary, context-length K-token formatting and the "Unknown" fallback, context-source label mapping, and the per-author color hash being deterministic yet author-specific.

## Test plan
- [x] `npx vitest run src/components/model-library/HuggingFaceModelBrowser.test.jsx` — 22/22 passed
- [x] `npx eslint` on both changed files — no errors