### PR TITLE
test(dashboard-api): cover the service_id format guard on restart

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -314,6 +314,21 @@ class TestServiceResources:
 
         assert resp.status_code == 404
 
+    def test_restart_service_rejects_malformed_service_id(self, test_client, monkeypatch):
+        """Restart endpoint's _SERVICE_ID_RE guard rejects ids that don't match
+        the expected shape (e.g. uppercase), before ever consulting SERVICES."""
+        monkeypatch.setattr("routers.resources.SERVICES", {"BadID": {"name": "x", "container_name": "x"}})
+
+        with patch("routers.resources._post_agent_json") as post_agent:
+            resp = test_client.post(
+                "/api/services/BadID/restart",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 400
+        assert resp.json()["detail"] == "Invalid service_id"
+        post_agent.assert_not_called()
+
     def test_restart_service_rejects_non_docker_service(self, test_client, monkeypatch):
         """Restart endpoint rejects known services that do not map to Docker."""
         monkeypatch.setattr("routers.resources.SERVICES", {


### PR DESCRIPTION
## Summary
- `restart_service()` in `routers/resources.py` checks `_SERVICE_ID_RE.match(service_id)` and returns 400 "Invalid service_id" for malformed ids before ever consulting `SERVICES` — but no existing test exercised this guard. The only 400 test (`test_restart_service_rejects_non_docker_service`) uses a valid-looking id and hits the separate restartability check instead.
- Adds `test_restart_service_rejects_malformed_service_id`, posting an uppercase id (which the pattern `^[a-z0-9][a-z0-9_-]*$` rejects) and confirming it 400s with the correct detail message and never reaches `_post_agent_json`.

## Test plan
- [x] `pytest tests/test_resources.py -v -k "malformed or restart_service"` — 4/4 passed
- [x] `pytest tests/test_resources.py` (full file) — 21/21 passed