### PR TITLE
test(dashboard): add coverage for Invites token status/relative-time helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -31,7 +31,7 @@ const EXPIRY_PRESETS = [
   { value: 86400, label: '24 hours' },
 ]
 
-function formatRelative(iso) {
+export function formatRelative(iso) {
   if (!iso) return null
   const t = new Date(iso).getTime()
   if (Number.isNaN(t)) return null
@@ -47,11 +47,11 @@ function formatRelative(iso) {
   return future ? `in ${days}d` : `${days}d ago`
 }
 
-function isOwnerToken(token) {
+export function isOwnerToken(token) {
   return token.token_type === 'owner'
 }
 
-function tokenStatus(token) {
+export function tokenStatus(token) {
   if (token.revoked_at) return { label: 'revoked', tone: 'bg-theme-border text-theme-text-muted' }
   if (!isOwnerToken(token) && token.expires_at && new Date(token.expires_at).getTime() < Date.now()) {
     return { label: 'expired', tone: 'bg-theme-border text-theme-text-muted' }
@@ -65,7 +65,7 @@ function tokenStatus(token) {
   return { label: 'active', tone: 'bg-green-500/20 text-green-400' }
 }
 
-function tokenCanRevoke(token) {
+export function tokenCanRevoke(token) {
   const status = tokenStatus(token).label
   return status === 'active' || status.startsWith('used')
 }

--- a/ods/extensions/services/dashboard/src/pages/Invites.tokenStatus.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.tokenStatus.test.jsx
@@ -1,0 +1,91 @@
+import { describe, test, expect } from 'vitest'
+import { formatRelative, isOwnerToken, tokenStatus, tokenCanRevoke } from './Invites'
+
+describe('formatRelative', () => {
+  test('returns null for a missing or invalid date', () => {
+    expect(formatRelative(null)).toBeNull()
+    expect(formatRelative('not-a-date')).toBeNull()
+  })
+
+  test('formats a recent past time in minutes', () => {
+    const iso = new Date(Date.now() - 5 * 60_000).toISOString()
+    expect(formatRelative(iso)).toBe('5m ago')
+  })
+
+  test('formats a recent future time in minutes', () => {
+    const iso = new Date(Date.now() + 5 * 60_000).toISOString()
+    expect(formatRelative(iso)).toBe('in 5m')
+  })
+
+  test('formats an hour-scale past time in hours', () => {
+    const iso = new Date(Date.now() - 3 * 3_600_000).toISOString()
+    expect(formatRelative(iso)).toBe('3h ago')
+  })
+
+  test('formats a day-scale future time in days', () => {
+    const iso = new Date(Date.now() + 2 * 86_400_000).toISOString()
+    expect(formatRelative(iso)).toBe('in 2d')
+  })
+
+  test('says "just now" for the past under a minute, "in seconds" for the future under a minute', () => {
+    expect(formatRelative(new Date(Date.now() - 10_000).toISOString())).toBe('just now')
+    expect(formatRelative(new Date(Date.now() + 10_000).toISOString())).toBe('in seconds')
+  })
+})
+
+describe('isOwnerToken', () => {
+  test('true only for token_type "owner"', () => {
+    expect(isOwnerToken({ token_type: 'owner' })).toBe(true)
+    expect(isOwnerToken({ token_type: 'guest' })).toBe(false)
+  })
+})
+
+describe('tokenStatus', () => {
+  test('revoked takes precedence over everything else', () => {
+    expect(
+      tokenStatus({ revoked_at: '2020-01-01', redemption_count: 5, reusable: true }).label,
+    ).toBe('revoked')
+  })
+
+  test('a non-owner token past its expiry is "expired"', () => {
+    const past = new Date(Date.now() - 86_400_000).toISOString()
+    expect(tokenStatus({ token_type: 'guest', expires_at: past }).label).toBe('expired')
+  })
+
+  test('an owner token is never "expired" even with a past expires_at', () => {
+    const past = new Date(Date.now() - 86_400_000).toISOString()
+    expect(tokenStatus({ token_type: 'owner', expires_at: past }).label).not.toBe('expired')
+  })
+
+  test('a single-use non-reusable guest token that has been redeemed is "used"', () => {
+    expect(
+      tokenStatus({ token_type: 'guest', redemption_count: 1, reusable: false }).label,
+    ).toBe('used')
+  })
+
+  test('a reusable token with redemptions shows "used x N"', () => {
+    expect(
+      tokenStatus({ token_type: 'guest', redemption_count: 3, reusable: true }).label,
+    ).toBe('used x 3')
+  })
+
+  test('a fresh unused token is "active"', () => {
+    expect(
+      tokenStatus({ token_type: 'guest', redemption_count: 0, reusable: true }).label,
+    ).toBe('active')
+  })
+})
+
+describe('tokenCanRevoke', () => {
+  test('active and used tokens can be revoked', () => {
+    expect(tokenCanRevoke({ token_type: 'guest', redemption_count: 0, reusable: true })).toBe(true)
+    expect(tokenCanRevoke({ token_type: 'guest', redemption_count: 1, reusable: false })).toBe(true)
+    expect(tokenCanRevoke({ token_type: 'guest', redemption_count: 2, reusable: true })).toBe(true)
+  })
+
+  test('already-revoked or expired tokens cannot be revoked again', () => {
+    expect(tokenCanRevoke({ revoked_at: '2020-01-01' })).toBe(false)
+    const past = new Date(Date.now() - 86_400_000).toISOString()
+    expect(tokenCanRevoke({ token_type: 'guest', expires_at: past })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- `Invites.jsx`'s `tokenStatus()` has several branches — `revoked`, `expired` (non-owner tokens only), `used` (non-reusable, single redemption), `used x N` (reusable), and `active` — and `formatRelative()` has minute/hour/day and past/future branches. `Invites.test.jsx` only ever renders owner tokens and freshly-created guest tokens, so none of these branches were ever exercised.
- Exports `formatRelative`, `isOwnerToken`, `tokenStatus`, `tokenCanRevoke` (no behavior change — same functions, same call sites, now also importable) and adds `Invites.tokenStatus.test.jsx` covering each branch directly.
- Covers: `formatRelative`'s null/invalid-date, minute/hour/day, and past/future/"just now"/"in seconds" cases; `tokenStatus`'s full precedence order (revoked > expired > used > used-xN > active), including that owner tokens are exempt from expiry; and `tokenCanRevoke`'s active/used-can-revoke vs revoked/expired-cannot cases.

## Test plan
- [x] `npx vitest run src/pages/Invites.tokenStatus.test.jsx` — 15/15 passed
- [x] `npx vitest run src/pages/Invites.test.jsx` (existing suite) — 6/6 still passing, no regression
- [x] `npx eslint` on both changed files — no errors