### PR TITLE
test(dashboard): add coverage for RemoteProvider summary fallbacks

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -80,7 +80,7 @@ function configurePayload(form) {
   }
 }
 
-function writesSummary(writes) {
+export function writesSummary(writes) {
   const plan = writes && typeof writes === 'object' ? writes : {}
   const labels = []
   if (plan.routingState) labels.push('routing state')
@@ -92,7 +92,7 @@ function writesSummary(writes) {
   return labels.length ? labels.join(', ') : 'None'
 }
 
-function routeSummary(result) {
+export function routeSummary(result) {
   const provider = result?.route?.provider || {}
   if (provider.model) return `${provider.model} via ${provider.transport || 'direct'}`
   if (result?.route?.enabled === false) return 'Disabled route'

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.summary.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.summary.test.jsx
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest'
+import { routeSummary, writesSummary } from './RemoteProvider'
+
+describe('writesSummary', () => {
+  test('lists each true flag by its label, comma-joined', () => {
+    expect(
+      writesSummary({ routingState: true, providerSecret: true }),
+    ).toBe('routing state, provider secret')
+  })
+
+  test('includes ssh identity/known-hosts and removal flags', () => {
+    expect(
+      writesSummary({
+        sshIdentity: true,
+        sshKnownHosts: true,
+        removesRoutingState: true,
+        removesSecrets: true,
+      }),
+    ).toBe('ssh identity, ssh known hosts, routing state removal, stored secret removal')
+  })
+
+  test('returns "None" when every flag is falsy', () => {
+    expect(writesSummary({})).toBe('None')
+    expect(writesSummary({ routingState: false })).toBe('None')
+  })
+
+  test('returns "None" for a non-object input instead of throwing', () => {
+    expect(writesSummary(null)).toBe('None')
+    expect(writesSummary(undefined)).toBe('None')
+  })
+})
+
+describe('routeSummary', () => {
+  test('shows the model and transport when a route is configured', () => {
+    expect(
+      routeSummary({ route: { provider: { model: 'qwen-remote', transport: 'ssh' } } }),
+    ).toBe('qwen-remote via ssh')
+  })
+
+  test('defaults the transport label to "direct" when not specified', () => {
+    expect(
+      routeSummary({ route: { provider: { model: 'qwen-remote' } } }),
+    ).toBe('qwen-remote via direct')
+  })
+
+  test('shows "Disabled route" when the route is explicitly disabled', () => {
+    expect(routeSummary({ route: { enabled: false, provider: {} } })).toBe('Disabled route')
+  })
+
+  test('returns "None" when there is no model and the route is not explicitly disabled', () => {
+    expect(routeSummary({ route: {} })).toBe('None')
+    expect(routeSummary({})).toBe('None')
+    expect(routeSummary(null)).toBe('None')
+  })
+})


### PR DESCRIPTION
## Summary
- `routeSummary()`'s `'None'`/`'Disabled route'` paths and `writesSummary()`'s `'None'` fallback (every write flag falsy) were never exercised — every fixture in `RemoteProvider.test.jsx` supplies a configured model or at least one truthy write flag.
- Exports `routeSummary`/`writesSummary` (no behavior change) and adds `RemoteProvider.summary.test.jsx` covering both functions' fallback paths directly.
- Covers: `writesSummary`'s label-joining for various flag combinations (including ssh/removal flags), the `'None'` fallback for all-falsy and non-object input; `routeSummary`'s model+transport label (including the default "direct" transport), `'Disabled route'`, and `'None'` when no model and the route isn't explicitly disabled.

## Test plan
- [x] `npx vitest run src/pages/RemoteProvider.summary.test.jsx` — 8/8 passed
- [x] `npx vitest run src/pages/RemoteProvider.test.jsx` (existing suite) — 10/10 still passing, no regression
- [x] `npx eslint` on both changed files — no errors