### PR TITLE
test(dashboard): cover writeUsageHistory's localStorage write failure

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.history.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.history.test.jsx
@@ -117,4 +117,25 @@ describe('Usage sparkline history retention', () => {
     await waitFor(() => expect(screen.getByText('Usage')).toBeInTheDocument())
     await waitFor(() => expect(storedPeriods()).toEqual([MAY]))
   })
+
+  it('renders and keeps working when localStorage.setItem throws (quota exceeded / private browsing)', async () => {
+    // Only the usage-history key must throw -- other app code (e.g.
+    // ThemeContext) also writes to localStorage and isn't part of what's
+    // under test here.
+    const realSetItem = window.localStorage.__proto__.setItem
+    const setItemSpy = vi.spyOn(window.localStorage.__proto__, 'setItem')
+      .mockImplementation(function (key, value) {
+        if (key === STORAGE_KEY) throw new Error('QuotaExceededError')
+        return realSetItem.call(this, key, value)
+      })
+
+    render(<Usage status={{}} />)
+
+    // writeUsageHistory's try/catch must swallow the failure silently -- the
+    // page still renders and no unhandled error reaches the test runner.
+    await waitFor(() => expect(screen.getByText('Usage')).toBeInTheDocument())
+    expect(setItemSpy).toHaveBeenCalledWith(STORAGE_KEY, expect.any(String))
+
+    setItemSpy.mockRestore()
+  })
 })


### PR DESCRIPTION
## Summary
- `writeUsageHistory()` wraps `localStorage.setItem` in a try/catch so a full storage quota or private-browsing restriction degrades to in-memory-only sparkline history instead of crashing the page — but no existing test ever made `setItem` throw. The existing malformed-entry test (`renders when storage holds a malformed entry`) only covers a bad *read*.
- Adds a test that makes `setItem` throw specifically for the usage-history storage key (leaving other app writes, like `ThemeContext`'s, unaffected) and confirms the page still renders.

## Test plan
- [x] `npx vitest run src/pages/Usage.history.test.jsx` — 5/5 passed (4 existing + 1 new)
- [x] `npx eslint` on the changed file — no errors