### PR TITLE
test(dashboard): add coverage for Extensions friendlyError

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.friendlyError.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.friendlyError.test.jsx
@@ -1,0 +1,52 @@
+import { describe, test, expect } from 'vitest'
+import { friendlyError } from './Extensions'
+
+describe('friendlyError', () => {
+  test('passes through non-string or missing detail unchanged', () => {
+    expect(friendlyError(null)).toBeNull()
+    expect(friendlyError(undefined)).toBeUndefined()
+    expect(friendlyError({ message: 'object detail' })).toEqual({ message: 'object detail' })
+  })
+
+  test('rewrites a build-context error', () => {
+    expect(friendlyError('requires a local build context')).toBe(
+      'This extension requires a local build and cannot be installed through the portal yet.',
+    )
+    expect(friendlyError('no local build available')).toBe(
+      'This extension requires a local build and cannot be installed through the portal yet.',
+    )
+  })
+
+  test('rewrites already-installed/enabled/disabled errors', () => {
+    expect(friendlyError('service already installed')).toBe('This extension is already installed.')
+    expect(friendlyError('service already enabled')).toBe('This extension is already enabled.')
+    expect(friendlyError('service already disabled')).toBe('This extension is already disabled.')
+  })
+
+  test('rewrites the disable-before-remove error', () => {
+    expect(friendlyError('Disable extension before removing')).toBe(
+      'Please disable this extension before removing it.',
+    )
+  })
+
+  test('rewrites the still-enabled (purge) error', () => {
+    expect(friendlyError('extension still enabled')).toBe(
+      'Please disable this extension before purging its data.',
+    )
+  })
+
+  test('rewrites the missing-data-directory error', () => {
+    expect(friendlyError('No data directory found')).toBe('No data directory found for this extension.')
+  })
+
+  test('passes a missing-dependencies error through verbatim (already detailed)', () => {
+    const detail = 'Missing dependencies: qdrant, litellm'
+    expect(friendlyError(detail)).toBe(detail)
+  })
+
+  test('passes an unrecognized error string through unchanged', () => {
+    expect(friendlyError('some backend error we have never seen')).toBe(
+      'some backend error we have never seen',
+    )
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -36,7 +36,7 @@ const ICON_MAP = {
   FileText, Shield, Globe, Music, Video, Search, Puzzle, Box,
 }
 
-const friendlyError = (detail) => {
+export const friendlyError = (detail) => {
   if (!detail || typeof detail !== 'string') return detail
   if (detail.includes('build context') || detail.includes('local build'))
     return 'This extension requires a local build and cannot be installed through the portal yet.'


### PR DESCRIPTION
## Summary
- `friendlyError()` rewrites 7 distinct backend error-detail substrings into user-facing messages (build context, already installed/enabled/disabled, disable-before-remove, still-enabled, no-data-directory, missing-dependencies pass-through), but `Extensions.test.jsx` never exercised any of them.
- Exports `friendlyError` (no behavior change) and adds `Extensions.friendlyError.test.jsx` covering every branch.
- Covers: non-string/missing detail pass-through, each of the 7 rewrite rules, the intentional missing-dependencies verbatim pass-through, and an unrecognized error string passing through unchanged.

## Test plan
- [x] `npx vitest run src/pages/Extensions.friendlyError.test.jsx` — 8/8 passed
- [x] `npx vitest run src/pages/Extensions.test.jsx` (existing suite) — 10/10 still passing
- [x] `npx eslint` on both changed files — no errors