### PR TITLE
test(dashboard): add coverage for Models pagination page-list builder

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -1890,7 +1890,7 @@ function ModelPublisherIcon({ model, tone, size = 'row' }) {
   )
 }
 
-function buildPageList(page, pageCount) {
+export function buildPageList(page, pageCount) {
   if (pageCount <= 5) return Array.from({ length: pageCount }, (_, index) => index + 1)
   if (page <= 3) return [1, 2, 3, 'gap', pageCount]
   if (page >= pageCount - 2) return [1, 'gap', pageCount - 2, pageCount - 1, pageCount]

--- a/ods/extensions/services/dashboard/src/pages/Models.pagination.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.pagination.test.jsx
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest'
+import { buildPageList } from './Models'
+
+describe('buildPageList', () => {
+  test('lists every page directly when pageCount is 5 or fewer', () => {
+    expect(buildPageList(1, 5)).toEqual([1, 2, 3, 4, 5])
+    expect(buildPageList(3, 5)).toEqual([1, 2, 3, 4, 5])
+    expect(buildPageList(1, 1)).toEqual([1])
+  })
+
+  test('shows the first 3 pages, a gap, then the last page near the start', () => {
+    expect(buildPageList(1, 20)).toEqual([1, 2, 3, 'gap', 20])
+    expect(buildPageList(3, 20)).toEqual([1, 2, 3, 'gap', 20])
+  })
+
+  test('shows the first page, a gap, then the last 3 pages near the end', () => {
+    expect(buildPageList(20, 20)).toEqual([1, 'gap', 18, 19, 20])
+    expect(buildPageList(18, 20)).toEqual([1, 'gap', 18, 19, 20])
+  })
+
+  test('shows first page, gap, current page, gap, last page in the middle', () => {
+    expect(buildPageList(10, 20)).toEqual([1, 'gap', 10, 'gap', 20])
+  })
+
+  test('the boundary between "near start" and "middle" is at page 4', () => {
+    // page<=3 takes the near-start branch; page 4 is the first to fall
+    // through to the middle branch.
+    expect(buildPageList(4, 20)).toEqual([1, 'gap', 4, 'gap', 20])
+  })
+
+  test('the boundary between "middle" and "near end" is at pageCount-2', () => {
+    // page>=pageCount-2 takes the near-end branch (pageCount=20 -> page 18).
+    expect(buildPageList(17, 20)).toEqual([1, 'gap', 17, 'gap', 20])
+    expect(buildPageList(18, 20)).toEqual([1, 'gap', 18, 19, 20])
+  })
+})


### PR DESCRIPTION
## Summary
- `buildPageList()` has 4 distinct branches — all pages when `pageCount<=5`, near-start with a trailing gap, middle with two gaps around the current page, and near-end with a leading gap — driving the model-library pagination UI. No test fixture ever supplied enough models to actually trigger pagination (`PAGE_SIZE=10`), so this function was completely untested.
- Exports `buildPageList` (no behavior change) and adds `Models.pagination.test.jsx`.
- Covers: the all-pages case, near-start/middle/near-end gap placement, and both boundary transitions (`page<=3` → middle at page 4, middle → `page>=pageCount-2` at the near-end threshold).

## Test plan
- [x] `npx vitest run src/pages/Models.pagination.test.jsx` — 6/6 passed
- [x] `npx vitest run src/pages/Models.test.jsx` (existing suite) — 36/36 still passing
- [x] `npx eslint` on both changed files — no errors