### PR TITLE
test(dashboard): add coverage for Settings route severity sort

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -118,7 +118,7 @@ const matchesEnvSearch = (key, field, query) => {
 }
 
 const routeSeverityOrder = { down: 0, unhealthy: 1, degraded: 2, unknown: 3, healthy: 4 }
-const sortRoutesBySeverity = (items) => [...(items || [])].sort((a, b) => (routeSeverityOrder[a.status] ?? 9) - (routeSeverityOrder[b.status] ?? 9))
+export const sortRoutesBySeverity = (items) => [...(items || [])].sort((a, b) => (routeSeverityOrder[a.status] ?? 9) - (routeSeverityOrder[b.status] ?? 9))
 const routeFilterDotClass = {
   online: 'bg-emerald-400',
   degraded: 'bg-amber-400',

--- a/ods/extensions/services/dashboard/src/pages/Settings.routeSort.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.routeSort.test.jsx
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'vitest'
+import { sortRoutesBySeverity } from './Settings'
+
+describe('sortRoutesBySeverity', () => {
+  test('orders by severity: down, unhealthy, degraded, unknown, healthy', () => {
+    const items = [
+      { id: 'a', status: 'healthy' },
+      { id: 'b', status: 'down' },
+      { id: 'c', status: 'unknown' },
+      { id: 'd', status: 'degraded' },
+      { id: 'e', status: 'unhealthy' },
+    ]
+    expect(sortRoutesBySeverity(items).map(i => i.id)).toEqual(['b', 'e', 'd', 'c', 'a'])
+  })
+
+  test('places an unrecognized status after all known statuses', () => {
+    const items = [
+      { id: 'a', status: 'healthy' },
+      { id: 'b', status: 'some-future-status' },
+      { id: 'c', status: 'down' },
+    ]
+    expect(sortRoutesBySeverity(items).map(i => i.id)).toEqual(['c', 'a', 'b'])
+  })
+
+  test('does not mutate the input array', () => {
+    const items = [{ id: 'a', status: 'healthy' }, { id: 'b', status: 'down' }]
+    const original = [...items]
+    sortRoutesBySeverity(items)
+    expect(items).toEqual(original)
+  })
+
+  test('handles null/undefined input without throwing', () => {
+    expect(sortRoutesBySeverity(null)).toEqual([])
+    expect(sortRoutesBySeverity(undefined)).toEqual([])
+  })
+
+  test('handles an empty array', () => {
+    expect(sortRoutesBySeverity([])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- `sortRoutesBySeverity()` drives the RoutingTableCard's default sort order (`down` > `unhealthy` > `degraded` > `unknown` > `healthy`), but had no test — `Settings.test.jsx` never renders or references the routing table at all.
- Exports the function (no behavior change) and adds `Settings.routeSort.test.jsx`.
- Covers: the full severity ordering, an unrecognized status sorting after all known statuses, non-mutation of the input array, and null/undefined/empty input.

## Test plan
- [x] `npx vitest run src/pages/Settings.routeSort.test.jsx` — 5/5 passed
- [x] `npx vitest run src/pages/Settings.test.jsx` (existing suite) — 8/8 still passing
- [x] `npx eslint` on both changed files — no errors