### PR TITLE
fix(lib): service-registry cache counters crash under set -e

### DIFF
--- a/ods/lib/service-registry.sh
+++ b/ods/lib/service-registry.sh
@@ -320,13 +320,13 @@ sr_compose_flags() {
 
     # Return cached result if available
     if [[ "$_SR_COMPOSE_FLAGS_CACHED" == "true" ]]; then
-        ((_SR_CACHE_HITS++))
+        _SR_CACHE_HITS=$((_SR_CACHE_HITS + 1))
         echo "$_SR_COMPOSE_FLAGS_CACHE"
         return 0
     fi
 
     # Cache miss: rebuild flags
-    ((_SR_CACHE_MISSES++))
+    _SR_CACHE_MISSES=$((_SR_CACHE_MISSES + 1))
     local flags=""
     for sid in "${SERVICE_IDS[@]}"; do
         local cf="${SERVICE_COMPOSE[$sid]}"


### PR DESCRIPTION
Found this while testing `sr_compose_flags`. It aborts on the first call whenever the caller runs under `set -e` (which most of our scripts do).

The counters use the post-increment form `((_SR_CACHE_HITS++))`. That expression returns the *pre-increment* value — `0` on the very first hit/miss — so its exit status is `1`, and `set -e` kills the script before it can return the cached flags.

Switched both counters to the assignment form, which always returns `0`:

```bash
_SR_CACHE_HITS=$((_SR_CACHE_HITS + 1))
_SR_CACHE_MISSES=$((_SR_CACHE_MISSES + 1))
```

Verified with `bash -n`. I'll run an installer phase that hits the cache to confirm end-to-end.