### PR TITLE
Validate extension catalog entries; add regression tests (fixes #3236)

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -556,16 +556,31 @@ ALWAYS_ON_SERVICES: frozenset = frozenset({
 
 
 def load_extension_catalog() -> list[dict]:
-    """Load the static extensions catalog JSON. Returns empty list on failure."""
+    """Load the static extensions catalog JSON. Returns empty list on failure.
+
+    Entries missing required fields (notably ``id``) are skipped so a single
+    malformed catalog entry cannot crash the catalog response downstream
+    (upstream issue #3236).
+    """
     if not CATALOG_PATH.exists():
         logger.info("Extensions catalog not found at %s", CATALOG_PATH)
         return []
     try:
         data = json.loads(CATALOG_PATH.read_text(encoding="utf-8"))
-        return data.get("extensions", [])
+        extensions = data.get("extensions", [])
     except (json.JSONDecodeError, OSError) as e:
         logger.warning("Failed to load extensions catalog: %s", e)
         return []
+    validated: list[dict] = []
+    for ext in extensions:
+        if not isinstance(ext, dict):
+            logger.warning("Skipping extension catalog entry that is not an object")
+            continue
+        if not ext.get("id"):
+            logger.warning("Skipping extension catalog entry missing required 'id'")
+            continue
+        validated.append(ext)
+    return validated
 
 
 EXTENSION_CATALOG = load_extension_catalog()

--- a/ods/extensions/services/dashboard-api/tests/test_extension_catalog_validation.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_catalog_validation.py
@@ -1,0 +1,71 @@
+"""Regression tests for extension catalog validation (upstream issue #3236).
+
+``load_extension_catalog`` previously returned the raw ``extensions`` list with
+zero validation. A malformed entry (e.g. missing ``id``) flowed straight into
+the catalog router, where ``ext["id"]`` raised ``KeyError`` and a missing
+``gpu_backends`` misled the compatibility computation. These tests pin the
+corrected behaviour: malformed entries are skipped with a logged warning.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import config
+from config import load_extension_catalog
+
+
+def _write_catalog(tmp_path: Path, payload: str) -> Path:
+    catalog = tmp_path / "extensions-catalog.json"
+    catalog.write_text(payload, encoding="utf-8")
+    return catalog
+
+
+def test_catalog_skips_entries_missing_id(tmp_path, monkeypatch):
+    catalog = _write_catalog(
+        tmp_path,
+        '{"extensions": [{"id": "good", "name": "Good"}, {"name": "NoId"}]}',
+    )
+    monkeypatch.setattr(config, "CATALOG_PATH", catalog)
+
+    result = load_extension_catalog()
+
+    assert [e["id"] for e in result] == ["good"]
+
+
+def test_catalog_skips_non_object_entries(tmp_path, monkeypatch):
+    catalog = _write_catalog(
+        tmp_path,
+        '{"extensions": [{"id": "good"}, "not-an-object", 42]}',
+    )
+    monkeypatch.setattr(config, "CATALOG_PATH", catalog)
+
+    result = load_extension_catalog()
+
+    assert [e["id"] for e in result] == ["good"]
+
+
+def test_catalog_keeps_all_valid_entries(tmp_path, monkeypatch):
+    catalog = _write_catalog(
+        tmp_path,
+        '{"extensions": [{"id": "a"}, {"id": "b", "gpu_backends": ["amd"]}]}',
+    )
+    monkeypatch.setattr(config, "CATALOG_PATH", catalog)
+
+    result = load_extension_catalog()
+
+    assert [e["id"] for e in result] == ["a", "b"]
+
+
+def test_catalog_returns_empty_when_file_missing(tmp_path, monkeypatch):
+    missing = tmp_path / "does-not-exist.json"
+    monkeypatch.setattr(config, "CATALOG_PATH", missing)
+
+    assert load_extension_catalog() == []
+
+
+def test_catalog_returns_empty_on_invalid_json(tmp_path, monkeypatch):
+    catalog = _write_catalog(tmp_path, "not valid json {{{")
+    monkeypatch.setattr(config, "CATALOG_PATH", catalog)
+
+    assert load_extension_catalog() == []


### PR DESCRIPTION
## Summary
- `load_extension_catalog()` now validates each entry and **skips** catalog entries that are missing a required `id` or are not objects, instead of returning the raw list and letting a malformed entry crash the catalog response downstream (KeyError in the extension router).
- Adds `tests/test_extension_catalog_validation.py` with 5 passing tests: skip-on-missing-id, skip-non-object, keep-all-valid, missing-file returns `[]`, invalid-JSON returns `[]`.

## Motivation
Upstream issue #3236: `load_extension_catalog` performed zero validation on the user-facing catalog. A malformed `extensions-catalog.json` (missing `id`, `port`, `external_port_default`, `gpu_backends`, etc.) flowed straight into `extensions_catalog()`, where `ext["id"]` would raise `KeyError` and a missing `gpu_backends` misled the compatibility computation.

## Safety
- The only caller is `EXTENSION_CATALOG = load_extension_catalog()` at import. The real catalog (`ods/config/extensions-catalog.json`) has 33 entries, 0 missing `id`, so no legitimate entries are dropped.
- No change to existing behaviour for valid catalogs.

## Test plan
- `python -m pytest tests/test_extension_catalog_validation.py -q` → 5 passed.
- Verified `config.py` syntax and that the change does not break import.

Fixes #3236.