### PR TITLE
fix(update): iterate old backups safely when names have spaces

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -613,16 +613,14 @@ cmd_backup() {
     log_info "Files backed up: ${files_backed_up}"
     
     # Cleanup old backups
-    local backup_dirs
-    backup_dirs=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
     local count=0
-    for dir in $backup_dirs; do
+    while IFS= read -r dir; do
         count=$((count + 1))
         if ((count > MAX_BACKUPS)); then
             log_info "Removing old backup: $(basename "$dir")"
             rm -rf "$dir"
         fi
-    done
+    done < <(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
 }
 
 #==============================================================================


### PR DESCRIPTION
`for dir in $backup_dirs` word-splits the find output, so a backup directory with a space in its name gets split and the retention prune (`rm -rf "$dir"`) never removes the intended backup.

Read the find output line-by-line into the loop instead.