### PR TITLE
fix(install): copy repo contents, not the dir, in rsync fallback

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -459,7 +459,7 @@ if [[ -d "$TEMP_DIR/repo/ods" ]]; then
             "$TEMP_DIR/repo/ods/" "$INSTALL_DIR/"
     else
         # Fallback to cp if rsync not available
-        cp -r "$TEMP_DIR/repo/ods" "$INSTALL_DIR"
+        cp -r "$TEMP_DIR/repo/ods/." "$INSTALL_DIR"
         # Remove dev-only files after copy
         rm -rf "$INSTALL_DIR/tests" "$INSTALL_DIR/docs" "$INSTALL_DIR/examples" "$INSTALL_DIR/.github" 2>/dev/null || true
         rm -f "$INSTALL_DIR"/*.md "$INSTALL_DIR/.shellcheckrc" "$INSTALL_DIR/PSScriptAnalyzerSettings.psd1" "$INSTALL_DIR/test-stack.sh" "$INSTALL_DIR/.gitignore" 2>/dev/null || true


### PR DESCRIPTION
When `rsync` isn't available, `get-ods.sh` falls back to `cp -r "$TEMP_DIR/repo/ods" "$INSTALL_DIR"`, which copies the `ods` *directory* into the install dir instead of its contents. The later `chmod +x "$INSTALL_DIR/install.sh"` and `cd "$INSTALL_DIR"; exec ./install.sh` then fail because the files actually landed in `$INSTALL_DIR/ods/`.

Mirror the rsync path by copying the contents: `cp -r "$TEMP_DIR/repo/ods/." "$INSTALL_DIR"`.