### PR TITLE
fix(restore): read manifest from its real tar member

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -155,7 +155,7 @@ list_backups() {
             size=$(du -sh "$backup" 2>/dev/null | cut -f1)
             # Try to read manifest from tar
             if tar -tzf "$backup" 2>/dev/null | grep -q "manifest.json"; then
-                manifest=$(tar -xzf "$backup" -O */manifest.json 2>/dev/null || echo "")
+                manifest=$(tar -xzf "$backup" -O "$(tar -tzf "$backup" 2>/dev/null | grep -m1 'manifest\.json')" 2>/dev/null || echo "")
                 if [[ -n "$manifest" ]]; then
                     backup_type=$(echo "$manifest" | grep -o '"backup_type": "[^"]*"' | cut -d'"' -f4 || echo "unknown")
                     description=$(echo "$manifest" | grep -o '"description": "[^"]*"' | cut -d'"' -f4 || echo "")


### PR DESCRIPTION
In the compressed-backup listing path, `tar -xzf "$backup" -O */manifest.json` passes `*/manifest.json` as a *literal* member name (tar doesn't do shell globbing), so extraction silently fails and the backup type/description come back empty for every compressed backup.

Resolve the real member name from `tar -tzf` first and extract that.