### PR TITLE
fix(restore): stop the 'ods' stack by its compose project name

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -383,7 +383,7 @@ dry_run_preview() {
 stop_containers() {
     log_step "Stopping containers..."
 
-    if ! docker compose ls --quiet 2>/dev/null | grep -q "$(basename "$ODS_DIR")"; then
+    if ! docker compose ls --quiet 2>/dev/null | grep -qx "ods"; then
         log_info "No running containers found"
         return 0
     fi


### PR DESCRIPTION
`stop_containers` greps `docker compose ls` for `$(basename "$ODS_DIR")`. The compose project name is fixed to `ods` (docker-compose.base.yml `name: ods`), so on any non-default install dir the grep finds nothing, the guard returns early, and the running containers are never stopped.

Match the project name explicitly with `grep -qx "ods"`.