### PR TITLE
fix(windows): native inference tasks should start at logon

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -47,10 +47,10 @@ $global:LASTEXITCODE = 0
 & $ODSInstaller @PSBoundParameters
 $installerSucceeded = $?
 $installerExit = if ($null -ne $global:LASTEXITCODE) { [int]$global:LASTEXITCODE } else { 0 }
-if ($installerExit -ne 0) {
-    exit $installerExit
-}
 if ($installerSucceeded) {
     exit 0
+}
+if ($installerExit -ne 0) {
+    exit $installerExit
 }
 exit 1

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -559,7 +559,7 @@ if ($dryRun) {
                 try {
                     $action = New-ODSLemonadeScheduledTaskAction `
                         -Contract $launchContract -EnvPath $_envPath -DiagnosticLogPath $diagnosticLog
-                    $trigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddYears(1))
+                    $trigger = New-ScheduledTaskTrigger -AtLogOn
                     $lemonadeSettings = New-ScheduledTaskSettingsSet `
                         -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
                         -ExecutionTimeLimit ([TimeSpan]::Zero)
@@ -769,7 +769,7 @@ if ($dryRun) {
                     -Execute $script:LLAMA_SERVER_EXE `
                     -Argument $nativeLlamaArgString `
                     -WorkingDirectory $script:LLAMA_SERVER_DIR
-                $nativeLlamaTrigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddYears(1))
+                $nativeLlamaTrigger = New-ScheduledTaskTrigger -AtLogOn
                 $nativeLlamaSettings = New-ScheduledTaskSettingsSet `
                     -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
                     -ExecutionTimeLimit ([TimeSpan]::Zero)

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1554,7 +1554,7 @@ function Start-ODSLemonadeRuntime {
     try {
         $action = New-ODSLemonadeScheduledTaskAction `
             -Contract $launchContract -EnvPath $envPath -DiagnosticLogPath $diagnosticLog
-        $trigger = New-ScheduledTaskTrigger -Once -At ((Get-Date).AddYears(1))
+        $trigger = New-ScheduledTaskTrigger -AtLogOn
         $lemonadeSettings = New-ScheduledTaskSettingsSet `
             -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
             -ExecutionTimeLimit ([TimeSpan]::Zero)


### PR DESCRIPTION
The Lemonade and native `llama-server` runtime scheduled tasks register a trigger of `-Once -At ((Get-Date).AddYears(1))` — i.e. they fire exactly once, a year after install. They start during install, but after a reboot/logoff they won't auto-start, so local inference silently stops until someone runs `ods.ps1 start`.

The host-agent task already uses `-AtLogOn`; switch these two to match.