### PR TITLE
fix(windows): stop PS 5.1 native stderr from aborting ods.ps1

### DIFF
--- a/ods/docs/WINDOWS-QUICKSTART.md
+++ b/ods/docs/WINDOWS-QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ODS is fully supported on Windows 10 2004+ and Windows 11 (NVIDIA and AMD). The installer detects your GPU, selects the right model, downloads it, starts all Docker services, and creates a Desktop shortcut.
 
-**Prerequisites:** [Docker Desktop](https://www.docker.com/products/docker-desktop/) with WSL2 backend enabled. NVIDIA GPU or AMD Strix Halo recommended (CPU-only works with smaller models). 4GB+ RAM minimum, 16GB+ recommended.
+**Prerequisites:** [Docker Desktop](https://www.docker.com/products/docker-desktop/) **4.20+** with WSL2 backend enabled (older Desktop builds such as 4.15 / Engine 20.10 can fail Hermes OCI image validation and emit memory-limit warnings that break `ods.ps1` on PowerShell 5.1). NVIDIA GPU or AMD Strix Halo recommended (CPU-only works with smaller models). 4GB+ RAM minimum, 16GB+ recommended.
 
 Open a normal **PowerShell** session and run:
 
@@ -138,6 +138,8 @@ select it; constrained machines can stay lower. No extra flags needed.
 |-------|-----|
 | "Docker not running" | Start Docker Desktop, wait for whale icon |
 | "WSL2 not found" | `wsl --install` then restart |
+| Hermes image unavailable / `unsupported manifest media type` | Upgrade Docker Desktop to **4.20+**, then re-run `.\install.ps1`. Pre-`4.20` clients often cannot resolve modern OCI tags such as `nousresearch/hermes-agent:v2026.6.5`. |
+| `ods.ps1` dies on `WARNING: No memory limit support` | Upgrade Docker Desktop to **4.20+** (preferred). On current ODS builds this is also hardened so PowerShell 5.1 no longer treats that Docker warning as a fatal error. |
 | "nvidia-smi fails" | Update NVIDIA drivers; restart Docker Desktop |
 | "Port in use" | Edit `.env`, change `WEBUI_PORT=3001` |
 | Out of memory | Lower tier: `.\install.ps1 -Tier 1` |

--- a/ods/installers/windows/lib/ui.ps1
+++ b/ods/installers/windows/lib/ui.ps1
@@ -134,7 +134,50 @@ function Get-ODSHuggingFaceDownloadHelper {
     return $null
 }
 
+function Invoke-ODSNativeCapture {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+
+    $prevEAP = $ErrorActionPreference
+    $exitCode = 1
+    $output = @()
+    try {
+        # Windows PowerShell 5.1 promotes native stderr (via 2>&1) into
+        # ErrorRecords. Under Stop those terminate the script; under
+        # SilentlyContinue they are dropped from assignment. Use Continue so
+        # merged stderr stays in $output as non-terminating ErrorRecords.
+        $ErrorActionPreference = "Continue"
+        $output = @(& $FilePath @Arguments 2>&1)
+        if ($null -ne $LASTEXITCODE) { $exitCode = $LASTEXITCODE }
+    } catch {
+        $exitCode = 1
+        if ($_.Exception -and -not [string]::IsNullOrWhiteSpace($_.Exception.Message)) {
+            $output = @($_.Exception.Message)
+        }
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+
+    return [pscustomobject]@{
+        ExitCode = $exitCode
+        Output   = $output
+    }
+}
+
 function Invoke-ODSNativeQuiet {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+
+    # Expected failed native probes must return an exit code under
+    # Windows PowerShell 5.1 strict installer semantics.
+    return (Invoke-ODSNativeCapture -FilePath $FilePath -Arguments $Arguments).ExitCode
+}
+
+function Invoke-ODSNativeHost {
     param(
         [Parameter(Mandatory = $true)][string]$FilePath,
         [string[]]$Arguments = @()
@@ -143,10 +186,10 @@ function Invoke-ODSNativeQuiet {
     $prevEAP = $ErrorActionPreference
     $exitCode = 1
     try {
-        # Expected failed native probes must return an exit code under
-        # Windows PowerShell 5.1 strict installer semantics.
         $ErrorActionPreference = "SilentlyContinue"
-        & $FilePath @Arguments 2>&1 | Out-Null
+        # Keep stdout on the host; discard stderr noise that would otherwise
+        # become terminating ErrorRecords under Stop on Windows PowerShell 5.1.
+        & $FilePath @Arguments 2>$null
         if ($null -ne $LASTEXITCODE) { $exitCode = $LASTEXITCODE }
     } catch {
         $exitCode = 1

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -68,8 +68,9 @@ function Test-DockerRunning {
     .SYNOPSIS
         Quick check if Docker daemon is responsive. Shows friendly message if not.
     #>
-    $null = docker info 2>$null
-    if ($LASTEXITCODE -ne 0) {
+    # Do not redirect docker stderr under Stop on PS 5.1 — warnings like
+    # "No memory limit support" become terminating NativeCommandError.
+    if ((Invoke-ODSNativeQuiet -FilePath "docker" -Arguments @("info")) -ne 0) {
         Write-AIError "Docker Desktop is not running."
         Write-AI "Start it from the Start Menu, then try again."
         return $false
@@ -183,12 +184,7 @@ function Test-ODSArgumentPresent {
 }
 
 function Test-ODSDockerRunningQuiet {
-    try {
-        $null = & docker info 2>$null
-        return ($LASTEXITCODE -eq 0)
-    } catch {
-        return $false
-    }
+    return ((Invoke-ODSNativeQuiet -FilePath "docker" -Arguments @("info")) -eq 0)
 }
 
 function Get-ODSDockerProjectResourceNames {
@@ -199,21 +195,16 @@ function Get-ODSDockerProjectResourceNames {
     )
 
     $filter = "label=com.docker.compose.project=ods"
-    try {
-        switch ($Kind) {
-            "container" {
-                return @(& docker ps -aq --filter $filter 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-            }
-            "network" {
-                return @(& docker network ls -q --filter $filter 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-            }
-            "volume" {
-                return @(& docker volume ls -q --filter $filter 2>$null | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-            }
-        }
-    } catch {
-        return @()
+    $dockerArgs = switch ($Kind) {
+        "container" { @("ps", "-aq", "--filter", $filter) }
+        "network"   { @("network", "ls", "-q", "--filter", $filter) }
+        "volume"    { @("volume", "ls", "-q", "--filter", $filter) }
     }
+    $result = Invoke-ODSNativeCapture -FilePath "docker" -Arguments $dockerArgs
+    if ($result.ExitCode -ne 0) { return @() }
+    return @($result.Output |
+        ForEach-Object { "$_" } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 }
 
 function Test-ODSComposeFlagsFilesAvailable {
@@ -598,10 +589,13 @@ function Invoke-HermesSoulRefresh {
     }
 
     if ($SyncContainer) {
-        $names = & docker ps --format "{{.Names}}" 2>$null
+        $namesResult = Invoke-ODSNativeCapture -FilePath "docker" -Arguments @("ps", "--format", "{{.Names}}")
+        $names = @($namesResult.Output | ForEach-Object { "$_" })
         if ($names -contains "ods-hermes") {
-            & docker exec ods-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md *>> $script:ODS_LOG_FILE
-            if ($LASTEXITCODE -eq 0) {
+            $syncExit = Invoke-ODSNativeQuiet -FilePath "docker" -Arguments @(
+                "exec", "ods-hermes", "cp", "/opt/hermes/docker/SOUL.md", "/opt/data/SOUL.md"
+            )
+            if ($syncExit -eq 0) {
                 Write-AISuccess "Synced Hermes SOUL.md"
             } else {
                 Write-AIWarn "Could not sync Hermes SOUL.md into running container"
@@ -667,8 +661,11 @@ function Invoke-ODSSttModelDownloadTrigger {
     # bounded so slow Hugging Face transfers do not wedge ods.ps1 or install.
     $curl = Get-Command curl.exe -ErrorAction SilentlyContinue
     if ($curl) {
-        $curlOutput = & $curl.Source --fail --silent --show-error --max-time 30 -X POST $ModelUrl 2>&1
-        $curlExit = $LASTEXITCODE
+        $curlResult = Invoke-ODSNativeCapture -FilePath $curl.Source -Arguments @(
+            "--fail", "--silent", "--show-error", "--max-time", "30", "-X", "POST", $ModelUrl
+        )
+        $curlExit = $curlResult.ExitCode
+        $curlOutput = $curlResult.Output
         if ($curlExit -eq 0 -or $curlExit -eq 28) { return $true }
         Write-AIWarn "STT model download trigger returned curl exit $curlExit; verifying cache before failing."
         if ($curlOutput) {
@@ -757,36 +754,39 @@ function Test-ODSComposeServiceAvailable {
         [Parameter(Mandatory = $true)][string]$Service
     )
 
-    try {
-        $services = & docker compose @ComposeFlags config --services 2>$null
-        return ($services -contains $Service)
-    } catch {
-        return $false
-    }
+    $result = Invoke-ODSNativeCapture -FilePath "docker" -Arguments (
+        @("compose") + @($ComposeFlags) + @("config", "--services")
+    )
+    if ($result.ExitCode -ne 0) { return $false }
+    $services = @($result.Output | ForEach-Object { "$_" })
+    return ($services -contains $Service)
 }
 
 function Get-ODSRunningComposeServices {
     param([string[]]$ComposeFlags)
 
-    try {
-        $services = & docker compose @ComposeFlags ps --services --filter "status=running" 2>$null
-        if ($LASTEXITCODE -eq 0 -and $services) {
-            return @($services |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-                Sort-Object -Unique)
-        }
-    } catch { }
+    $result = Invoke-ODSNativeCapture -FilePath "docker" -Arguments (
+        @("compose") + @($ComposeFlags) + @("ps", "--services", "--filter", "status=running")
+    )
+    if ($result.ExitCode -eq 0 -and $result.Output) {
+        $services = @($result.Output |
+            ForEach-Object { "$_" } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique)
+        if ($services.Count -gt 0) { return $services }
+    }
 
-    try {
-        $services = & docker ps `
-            --filter "label=com.docker.compose.project=ods" `
-            --format "{{.Label ""com.docker.compose.service""}}" 2>$null
-        if ($LASTEXITCODE -eq 0 -and $services) {
-            return @($services |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
-                Sort-Object -Unique)
-        }
-    } catch { }
+    $result = Invoke-ODSNativeCapture -FilePath "docker" -Arguments @(
+        "ps",
+        "--filter", "label=com.docker.compose.project=ods",
+        "--format", "{{.Label ""com.docker.compose.service""}}"
+    )
+    if ($result.ExitCode -eq 0 -and $result.Output) {
+        return @($result.Output |
+            ForEach-Object { "$_" } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique)
+    }
 
     return @()
 }
@@ -807,12 +807,15 @@ function Test-ODSComposeServicesStarted {
         }
 
         $ids = @()
-        try {
-            $ids = @(& docker compose @ComposeFlags ps --all -q $service 2>$null |
-                Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
-        } catch {
+        $idsResult = Invoke-ODSNativeCapture -FilePath "docker" -Arguments (
+            @("compose") + @($ComposeFlags) + @("ps", "--all", "-q", $service)
+        )
+        if ($idsResult.ExitCode -ne 0) {
             return $false
         }
+        $ids = @($idsResult.Output |
+            ForEach-Object { "$_" } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
 
         if (-not $ids -or $ids.Count -eq 0) {
             return $false
@@ -820,12 +823,14 @@ function Test-ODSComposeServicesStarted {
 
         foreach ($id in $ids) {
             $state = ""
-            try {
-                $state = & docker inspect --format "{{.State.Status}} {{.State.ExitCode}}" $id 2>$null
-            } catch {
+            $stateResult = Invoke-ODSNativeCapture -FilePath "docker" -Arguments @(
+                "inspect", "--format", "{{.State.Status}} {{.State.ExitCode}}", $id
+            )
+            if ($stateResult.ExitCode -ne 0) {
                 return $false
             }
-            if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($state)) {
+            $state = (@($stateResult.Output | ForEach-Object { "$_" }) -join "`n").Trim()
+            if ([string]::IsNullOrWhiteSpace($state)) {
                 return $false
             }
 
@@ -912,14 +917,14 @@ function Write-ODSMissingComposeServiceHint {
     }
 
     Write-AI "Active compose services:"
-    try {
-        $services = & docker compose @ComposeFlags config --services 2>$null
-        if ($services) {
-            $services | ForEach-Object { Write-AI "  $_" }
-        } else {
-            Write-AI "  (none returned by docker compose config --services)"
-        }
-    } catch {
+    $servicesResult = Invoke-ODSNativeCapture -FilePath "docker" -Arguments (
+        @("compose") + @($ComposeFlags) + @("config", "--services")
+    )
+    if ($servicesResult.ExitCode -eq 0 -and $servicesResult.Output) {
+        $servicesResult.Output | ForEach-Object { Write-AI "  $_" }
+    } elseif ($servicesResult.ExitCode -eq 0) {
+        Write-AI "  (none returned by docker compose config --services)"
+    } else {
         Write-AI "  Could not inspect compose services. Run the diagnostic command below manually."
     }
 
@@ -1975,7 +1980,9 @@ function Invoke-Status {
 
         # Docker services
         Write-Host ""
-        & docker compose @flags ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>$null
+        $null = Invoke-ODSNativeHost -FilePath "docker" -Arguments (
+            @("compose") + @($flags) + @("ps", "--format", "table {{.Name}}\t{{.Status}}\t{{.Ports}}")
+        )
 
         # Health checks
         Write-Host ""
@@ -2012,17 +2019,19 @@ function Invoke-Status {
         $gpuInfo = Get-GpuInfo
         if ($gpuInfo.Backend -eq "nvidia") {
             Write-Host "  GPU Status" -ForegroundColor Cyan
-            try {
-                $gpuStats = & nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu --format=csv,noheader,nounits 2>$null
-                if ($gpuStats) {
-                    $gpuStats -split "`n" | ForEach-Object {
-                        $parts = $_ -split ","
-                        if ($parts.Count -ge 5) {
-                            Write-Host "  $($parts[0].Trim()): $($parts[1].Trim())% GPU | $($parts[2].Trim())MB/$($parts[3].Trim())MB VRAM | $($parts[4].Trim())C" -ForegroundColor White
-                        }
+            $gpuResult = Invoke-ODSNativeCapture -FilePath "nvidia-smi" -Arguments @(
+                "--query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu",
+                "--format=csv,noheader,nounits"
+            )
+            $gpuStats = (@($gpuResult.Output | ForEach-Object { "$_" }) -join "`n").Trim()
+            if ($gpuResult.ExitCode -eq 0 -and $gpuStats) {
+                $gpuStats -split "`n" | ForEach-Object {
+                    $parts = $_ -split ","
+                    if ($parts.Count -ge 5) {
+                        Write-Host "  $($parts[0].Trim()): $($parts[1].Trim())% GPU | $($parts[2].Trim())MB/$($parts[3].Trim())MB VRAM | $($parts[4].Trim())C" -ForegroundColor White
                     }
                 }
-            } catch { }
+            }
         } elseif ($gpuInfo.Backend -eq "amd") {
             Write-Host "  GPU: $($gpuInfo.Name) ($($gpuInfo.MemoryType) memory)" -ForegroundColor White
         }
@@ -2629,17 +2638,8 @@ function Test-ODSHostAgentPythonCandidate {
         return $false
     }
 
-    try {
-        $prevEAP = $ErrorActionPreference
-        $ErrorActionPreference = "SilentlyContinue"
-        $version = & $FilePath @PrefixArgs --version 2>&1
-        $exitCode = $LASTEXITCODE
-        $ErrorActionPreference = $prevEAP
-        return ($exitCode -eq 0 -and (($version | Out-String) -match 'Python 3\.'))
-    } catch {
-        $ErrorActionPreference = $prevEAP
-        return $false
-    }
+    $probe = Invoke-ODSNativeCapture -FilePath $FilePath -Arguments (@($PrefixArgs) + @("--version"))
+    return ($probe.ExitCode -eq 0 -and (($probe.Output | Out-String) -match 'Python 3\.'))
 }
 
 function New-ODSHostAgentPythonCandidate {
@@ -3362,15 +3362,13 @@ function Invoke-Disable {
 
     # Best-effort container stop -- skip gracefully when Docker Desktop is
     # offline so the rename + flags update always succeeds.
-    $dockerRunning = $false
-    try { $null = docker info 2>$null; $dockerRunning = ($LASTEXITCODE -eq 0) } catch { }
+    $dockerRunning = ((Invoke-ODSNativeQuiet -FilePath "docker" -Arguments @("info")) -eq 0)
     if ($dockerRunning) {
         $flags = Get-ComposeFlags
         Write-AI "Stopping $ServiceId..."
-        $prevEAP = $ErrorActionPreference
-        $ErrorActionPreference = "SilentlyContinue"
-        & docker compose @flags stop $ServiceId 2>$null
-        $ErrorActionPreference = $prevEAP
+        $null = Invoke-ODSNativeQuiet -FilePath "docker" -Arguments (
+            @("compose") + @($flags) + @("stop", $ServiceId)
+        )
     } else {
         Write-AIWarn "Docker Desktop is not running -- skipping container stop. $ServiceId will be excluded from the next 'ods start'."
     }


### PR DESCRIPTION
﻿## Summary

Fixes #3003: under Windows PowerShell 5.1 with `$ErrorActionPreference='Stop'`, native stderr redirects (`2>$null` / `2>&1`) become terminating `NativeCommandError`s. That made `.\ods.ps1 status/start` die on harmless Docker warnings such as `WARNING: No memory limit support`, and aborted `repair voice` before curl exit-28 tolerance.

Adds shared `Invoke-ODSNativeCapture` / `Invoke-ODSNativeHost` helpers next to existing `Invoke-ODSNativeQuiet`, and routes the vulnerable `ods.ps1` Docker/curl/nvidia-smi call sites through them.

Also documents Docker Desktop **4.20+** in `WINDOWS-QUICKSTART.md` (Hermes OCI manifest validation and the memory-limit warning path), matching the existing `MIN_DOCKER_VERSION` constant.

## AI Assistance

Cursor agent drafted the PowerShell helpers/call-site updates, Windows quickstart troubleshooting notes, and this PR body. Human author remains accountable for the diff, validation choices, and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline Windows CLI/lifecycle fix.
```

## Changed Surface

- [x] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# Parser (Windows PowerShell 5.1)
ui.ps1 / ods.ps1: 0 parse errors

# Platform bug still present without helpers
$ErrorActionPreference='Stop'
$null = cmd /c "echo boom 1>&2" 2>$null
# => throws NativeCommandError

# Helpers under Stop
Invoke-ODSNativeCapture cmd /c "echo boom 1>&2"  => output contains "boom", no throw
Invoke-ODSNativeQuiet docker info               => exit 0
Invoke-ODSNativeQuiet cmd /c "echo warn 1>&2"   => exit 0

# Live install smoke (temp-swapped PR files, then restored)
.\ods.ps1 version => ODS v2.6.0 (Windows), exit 0
.\ods.ps1 status  => exit 0; Host Agent / LLM / Chat UI / Dashboard healthy;
                     no abort on Docker stderr warnings
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Narrow Windows lifecycle CLI fix plus docs. No compose/service default changes. Live validation was local Windows PowerShell 5.1 + Docker Desktop against an existing ODS install (`ods.ps1 status`), not a full fleet matrix.
