### PR TITLE
fix(backup): include Hermes and persona state in full backups

### DIFF
--- a/ods/lib/backup-paths.sh
+++ b/ods/lib/backup-paths.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Shared user-data paths for ODS backup and restore.
+#
+# Keep estimate/backup/restore/dry-run previews in sync by sourcing this file
+# instead of re-listing bind-mounted product state in each script.
+#
+# Hermes (`data/hermes`) holds sessions, skills, memories, cron jobs, and audit
+# logs. Persona (`data/persona`) holds the operator-authored SOUL.md and related
+# OAuth state. Both are bind-mounted product state and must survive full
+# backup → wipe → restore.
+
+# shellcheck disable=SC2034
+ODS_USER_DATA_PATHS=(
+    "data/open-webui"
+    "data/n8n"
+    "data/qdrant"
+    "data/openclaw"
+    "data/litellm"
+    "data/livekit"
+    "data/ollama"
+    "data/hermes"
+    "data/persona"
+)

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -28,8 +28,9 @@ log_success() { echo -e "${GREEN}[SUCCESS]${NC} $*"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 
-# Source shared rsync utilities
+# Source shared rsync utilities and canonical user-data path list
 . "$ODS_DIR/lib/rsync.sh"
+. "$SCRIPT_DIR/lib/backup-paths.sh"
 
 # Convert bytes to a human-friendly string (best-effort)
 fmt_bytes() {
@@ -58,17 +59,7 @@ estimate_backup_bytes() {
 
     # user data volumes
     if [[ "$backup_type" == "full" || "$backup_type" == "user-data" ]]; then
-        local -a user_data_paths=(
-            "data/open-webui"
-            "data/n8n"
-            "data/qdrant"
-            "data/openclaw"
-            "data/litellm"
-            "data/livekit"
-            "data/ollama"
-        )
-
-        for p in "${user_data_paths[@]}"; do
+        for p in "${ODS_USER_DATA_PATHS[@]}"; do
             if [[ -d "$ODS_DIR/$p" ]]; then
                 local b
                 b=$(du -sk "$ODS_DIR/$p" 2>/dev/null | awk '{print $1 * 1024}')
@@ -313,6 +304,8 @@ create_manifest() {
             data_n8n: "data/n8n",
             data_qdrant: "data/qdrant",
             data_openclaw: "data/openclaw",
+            data_hermes: "data/hermes",
+            data_persona: "data/persona",
             env: ".env",
             compose: "docker-compose.yml",
             config: "config"
@@ -326,17 +319,7 @@ backup_user_data() {
     local backup_dir="$1"
     log_info "Backing up user data volumes..."
 
-    local user_data_paths=(
-        "data/open-webui"
-        "data/n8n"
-        "data/qdrant"
-        "data/openclaw"
-        "data/litellm"
-        "data/livekit"
-        "data/ollama"
-    )
-
-    for path in "${user_data_paths[@]}"; do
+    for path in "${ODS_USER_DATA_PATHS[@]}"; do
         local full_path="$ODS_DIR/$path"
         if [[ -d "$full_path" ]]; then
             local dest_dir="$backup_dir/$(dirname "$path")"

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -25,8 +25,9 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 log_step() { echo -e "${CYAN}[STEP]${NC} $*"; }
 
-# Source shared rsync utilities
+# Source shared rsync utilities and canonical user-data path list
 . "$ODS_DIR/lib/rsync.sh"
+. "$SCRIPT_DIR/lib/backup-paths.sh"
 
 # Convert bytes to a human-friendly string (best-effort)
 fmt_bytes() {
@@ -311,18 +312,8 @@ validate_backup() {
 
     # Warn if backup looks partial / missing common paths.
     # (Informational only; older/minimal backups are still valid.)
-    local -a expected_data=(
-        "data/open-webui"
-        "data/n8n"
-        "data/qdrant"
-        "data/openclaw"
-        "data/litellm"
-        "data/livekit"
-        "data/ollama"
-    )
-
     local missing_any=false
-    for p in "${expected_data[@]}"; do
+    for p in "${ODS_USER_DATA_PATHS[@]}"; do
         if [[ ! -d "$backup_dir/$p" ]]; then
             missing_any=true
             break
@@ -350,8 +341,7 @@ dry_run_preview() {
     if [[ "$restore_data" == "true" ]]; then
         echo "User Data to Restore:"
         echo "───────────────────────────────────────────────────────────────────"
-        local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama")
-        for dir in "${data_dirs[@]}"; do
+        for dir in "${ODS_USER_DATA_PATHS[@]}"; do
             if [[ -d "$backup_dir/$dir" ]]; then
                 local size
                 size=$(du -sh "$backup_dir/$dir" 2>/dev/null | cut -f1)
@@ -401,10 +391,8 @@ restore_user_data() {
     local backup_dir="$1"
     log_step "Restoring user data..."
 
-    local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama")
-
     local restored_any=false
-    for dir in "${data_dirs[@]}"; do
+    for dir in "${ODS_USER_DATA_PATHS[@]}"; do
         if [[ -d "$backup_dir/$dir" ]]; then
             restored_any=true
             mkdir -p "$ODS_DIR/$(dirname "$dir")"

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -26,12 +26,16 @@ trap 'rm -rf "$TMP"' EXIT
 # Create source ODS directory with minimal data
 SRC="$TMP/src"
 mkdir -p "$SRC/data/open-webui"
+mkdir -p "$SRC/data/hermes"
+mkdir -p "$SRC/data/persona"
 mkdir -p "$SRC/config"
 echo "1.0.0" > "$SRC/.version"
 echo "test-env-value" > "$SRC/.env"
 echo "compose-content" > "$SRC/docker-compose.yml"
 echo "config-data" > "$SRC/config/settings.json"
 echo "user-data-file" > "$SRC/data/open-webui/data.txt"
+echo "hermes-session" > "$SRC/data/hermes/session.json"
+echo "You are a helpful ODS assistant." > "$SRC/data/persona/SOUL.md"
 
 # Both scripts source lib/rsync.sh relative to ODS_DIR
 mkdir -p "$SRC/lib"
@@ -70,6 +74,10 @@ info "Validating restored contents"
 [[ -f "$DST/config/settings.json" ]] || fail "Missing config/settings.json after restore"
 [[ -d "$DST/data/open-webui" ]] || fail "Missing data/open-webui after restore"
 [[ -f "$DST/data/open-webui/data.txt" ]] || fail "Missing data/open-webui/data.txt after restore"
+[[ -d "$DST/data/hermes" ]] || fail "Missing data/hermes after restore"
+[[ -f "$DST/data/hermes/session.json" ]] || fail "Missing data/hermes/session.json after restore"
+[[ -d "$DST/data/persona" ]] || fail "Missing data/persona after restore"
+[[ -f "$DST/data/persona/SOUL.md" ]] || fail "Missing data/persona/SOUL.md after restore"
 
 pass "All expected files/dirs present after restore"
 
@@ -79,6 +87,15 @@ pass "All expected files/dirs present after restore"
 [[ "$(cat "$DST/docker-compose.yml")" == "compose-content" ]] || fail "docker-compose.yml content mismatch"
 [[ "$(cat "$DST/config/settings.json")" == "config-data" ]] || fail "config/settings.json content mismatch"
 [[ "$(cat "$DST/data/open-webui/data.txt")" == "user-data-file" ]] || fail "data/open-webui/data.txt content mismatch"
+[[ "$(cat "$DST/data/hermes/session.json")" == "hermes-session" ]] || fail "data/hermes/session.json content mismatch"
+[[ "$(cat "$DST/data/persona/SOUL.md")" == "You are a helpful ODS assistant." ]] || fail "data/persona/SOUL.md content mismatch"
+
+# Manifest must advertise Hermes/persona paths for operators inspecting backups
+[[ -f "$SRC/.backups/$BACKUP_ID/manifest.json" ]] || fail "Missing backup manifest.json"
+jq -e '.paths.data_hermes == "data/hermes"' "$SRC/.backups/$BACKUP_ID/manifest.json" >/dev/null \
+    || fail "manifest.json missing paths.data_hermes"
+jq -e '.paths.data_persona == "data/persona"' "$SRC/.backups/$BACKUP_ID/manifest.json" >/dev/null \
+    || fail "manifest.json missing paths.data_persona"
 
 pass "All file contents match after restore"
 


### PR DESCRIPTION
﻿## Summary

Fixes #3145: full/user-data backups omitted `data/hermes` (sessions, memories, cron jobs) and `data/persona` (`SOUL.md`), so backup → wipe → restore permanently destroyed Hermes/persona state.

- Add shared `ods/lib/backup-paths.sh` with the canonical user-data path list (including Hermes + persona)
- Use that list in `ods-backup.sh` (estimate + backup) and `ods-restore.sh` (validate/preview/restore)
- Record `data_hermes` / `data_persona` in `manifest.json`
- Extend the backup/restore roundtrip test to assert Hermes/persona survive restore

## AI Assistance

Cursor agent drafted the shared path list, backup/restore wiring, roundtrip test updates, and this PR body. Human author remains accountable for the diff, validation choices, and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline backup/restore fix. Reviewers may also want release/2.6.x if stable installs need the data-loss fix immediately.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
docker run --rm -v "$PWD:/ods" -w /ods/ods/tests alpine:3.20 \
  sh -c 'apk add --no-cache bash rsync jq coreutils >/dev/null \
    && ./test-backup-restore-roundtrip.sh \
    && ./test-backup-integrity.sh'
# roundtrip_exit=0
# integrity_exit=0
# Round-trip asserts data/hermes + data/persona files and manifest paths
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Lifecycle backup/restore only. Distinct from #3005 (models path under `data/models`). Older backups without Hermes/persona still restore; those paths are skipped with a warning when absent.
