### PR TITLE
feat(status): attest Compose deployment drift

### DIFF
--- a/ods/lib/deployment-receipt.sh
+++ b/ods/lib/deployment-receipt.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Purpose: record and compare the last fully reconciled Docker Compose deployment.
+# Expects: docker, jq, INSTALL_DIR-compatible paths, and resolved compose flags.
+# Provides: ods_deployment_receipt_write, ods_deployment_attestation_json.
+
+ods_deployment_receipt_path() {
+    printf '%s/data/deployment-receipt.json\n' "$1"
+}
+
+_ods_deployment_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+        return
+    fi
+    if command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 | awk '{print $1}'
+        return
+    fi
+    return 1
+}
+
+_ods_deployment_plan_hash() {
+    local install_dir="$1"
+    shift
+    local rendered
+    if ! rendered=$(cd "$install_dir" && docker compose "$@" config --format json); then
+        return 1
+    fi
+    printf '%s' "$rendered" | _ods_deployment_sha256
+}
+
+_ods_deployment_runtime_hash() {
+    local install_dir="$1"
+    shift
+    local ids="" rows="" id="" inspected=""
+    if ! ids=$(cd "$install_dir" \
+        && docker compose "$@" ps --all --format '{{.ID}}'); then
+        return 1
+    fi
+
+    while IFS= read -r id; do
+        [[ -n "$id" ]] || continue
+        if ! inspected=$(docker inspect --format \
+            '{{.Id}}|{{.Image}}|{{index .Config.Labels "com.docker.compose.service"}}' \
+            "$id"); then
+            return 1
+        fi
+        rows+="${inspected}"$'\n'
+    done <<< "$ids"
+
+    printf '%s' "$rows" | LC_ALL=C sort | _ods_deployment_sha256
+}
+
+ods_deployment_receipt_write() {
+    local install_dir="$1" action="$2"
+    shift 2
+    local plan_hash runtime_hash receipt_path source_revision=""
+    plan_hash=$(_ods_deployment_plan_hash "$install_dir" "$@") || return 1
+    runtime_hash=$(_ods_deployment_runtime_hash "$install_dir" "$@") || return 1
+    receipt_path=$(ods_deployment_receipt_path "$install_dir")
+    if command -v git >/dev/null 2>&1; then
+        source_revision=$(git -C "$install_dir" rev-parse HEAD 2>/dev/null || true)
+    fi
+
+    mkdir -p "$(dirname "$receipt_path")"
+    local tmp_file
+    tmp_file=$(mktemp "${receipt_path}.tmp.XXXXXX")
+    jq -n \
+        --arg schema "ods.deployment-receipt.v1" \
+        --arg state "applied" \
+        --arg action "$action" \
+        --arg planSha256 "$plan_hash" \
+        --arg runtimeSha256 "$runtime_hash" \
+        --arg sourceRevision "$source_revision" \
+        --arg recordedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg composeFlags "$*" \
+        '{schema:$schema, state:$state, action:$action,
+          planSha256:$planSha256, runtimeSha256:$runtimeSha256,
+          sourceRevision:$sourceRevision, recordedAt:$recordedAt,
+          composeFlags:$composeFlags}' > "$tmp_file"
+    chmod 600 "$tmp_file"
+    mv -f "$tmp_file" "$receipt_path"
+}
+
+ods_deployment_attestation_json() {
+    local install_dir="$1"
+    shift
+    local receipt_path
+    receipt_path=$(ods_deployment_receipt_path "$install_dir")
+    if [[ ! -f "$receipt_path" ]]; then
+        jq -n '{state:"missing", message:"No successful full-stack deployment receipt is available."}'
+        return
+    fi
+    if ! jq -e '
+        .schema == "ods.deployment-receipt.v1"
+        and .state == "applied"
+        and (.planSha256 | type == "string" and length == 64)
+        and (.runtimeSha256 | type == "string" and length == 64)
+    ' "$receipt_path" >/dev/null 2>&1; then
+        jq -n '{state:"invalid_receipt", message:"The deployment receipt is invalid."}'
+        return
+    fi
+
+    local expected_plan expected_runtime current_plan current_runtime action recorded_at
+    expected_plan=$(jq -r '.planSha256' "$receipt_path")
+    expected_runtime=$(jq -r '.runtimeSha256' "$receipt_path")
+    action=$(jq -r '.action' "$receipt_path")
+    recorded_at=$(jq -r '.recordedAt' "$receipt_path")
+    if ! current_plan=$(_ods_deployment_plan_hash "$install_dir" "$@"); then
+        jq -n \
+            --arg action "$action" --arg recordedAt "$recorded_at" \
+            '{state:"unavailable", action:$action, recordedAt:$recordedAt,
+              message:"The current Compose plan could not be rendered."}'
+        return
+    fi
+    if [[ "$current_plan" != "$expected_plan" ]]; then
+        jq -n \
+            --arg action "$action" --arg recordedAt "$recorded_at" \
+            --arg expected "$expected_plan" --arg current "$current_plan" \
+            '{state:"desired_config_changed", action:$action, recordedAt:$recordedAt,
+              expectedPlanSha256:$expected, currentPlanSha256:$current,
+              message:"The desired Compose plan changed after the last full reconciliation."}'
+        return
+    fi
+
+    if ! current_runtime=$(_ods_deployment_runtime_hash "$install_dir" "$@"); then
+        jq -n \
+            --arg action "$action" --arg recordedAt "$recorded_at" \
+            '{state:"unavailable", action:$action, recordedAt:$recordedAt,
+              message:"The running Compose resources could not be inspected."}'
+        return
+    fi
+    if [[ "$current_runtime" != "$expected_runtime" ]]; then
+        jq -n \
+            --arg action "$action" --arg recordedAt "$recorded_at" \
+            --arg expected "$expected_runtime" --arg current "$current_runtime" \
+            '{state:"runtime_changed", action:$action, recordedAt:$recordedAt,
+              expectedRuntimeSha256:$expected, currentRuntimeSha256:$current,
+              message:"Compose container or image identity changed after the last full reconciliation."}'
+        return
+    fi
+
+    jq -n \
+        --arg action "$action" --arg recordedAt "$recorded_at" \
+        --arg planSha256 "$current_plan" --arg runtimeSha256 "$current_runtime" \
+        '{state:"in_sync", action:$action, recordedAt:$recordedAt,
+          planSha256:$planSha256, runtimeSha256:$runtimeSha256,
+          message:"Desired Compose plan and running resource identities match the receipt."}'
+}

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -715,9 +715,30 @@ _check_version_compat() {
 # Safe .env loading (no eval; use lib/safe-env.sh)
 #=============================================================================
 [[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
+[[ -f "$SCRIPT_DIR/lib/deployment-receipt.sh" ]] && . "$SCRIPT_DIR/lib/deployment-receipt.sh"
 load_env() {
     [[ -f "$INSTALL_DIR/.env" ]] || { warn ".env not found at $INSTALL_DIR — run installer first"; return 1; }
     load_env_file "$INSTALL_DIR/.env"
+}
+
+_ods_cli_record_full_deployment() {
+    local action="$1"
+    shift
+    if ! declare -F ods_deployment_receipt_write >/dev/null 2>&1; then
+        warn "Deployment receipt helper is unavailable; status cannot attest runtime drift."
+        return 0
+    fi
+    if ! ods_deployment_receipt_write "$INSTALL_DIR" "$action" "$@"; then
+        warn "Deployment succeeded, but its receipt could not be recorded."
+    fi
+}
+
+_ods_cli_deployment_attestation_json() {
+    if ! declare -F ods_deployment_attestation_json >/dev/null 2>&1; then
+        jq -n '{state:"unavailable", message:"Deployment receipt helper is unavailable."}'
+        return
+    fi
+    ods_deployment_attestation_json "$INSTALL_DIR" "$@"
 }
 
 #=============================================================================
@@ -1283,6 +1304,16 @@ cmd_status() {
     # Container status
     docker compose "${flags[@]}" ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || docker-compose ps
 
+    local deployment_json deployment_state deployment_message
+    deployment_json=$(_ods_cli_deployment_attestation_json "${flags[@]}")
+    deployment_state=$(jq -r '.state' <<< "$deployment_json")
+    deployment_message=$(jq -r '.message' <<< "$deployment_json")
+    if [[ "$deployment_state" == "in_sync" ]]; then
+        success "Deployment receipt: in sync"
+    else
+        warn "Deployment receipt: ${deployment_state} — ${deployment_message}"
+    fi
+
     echo ""
 
     # Registry-driven health checks (parallel)
@@ -1481,6 +1512,8 @@ cmd_status_json() {
     fi
 
     # Aggregate into a single document
+    local deployment_json
+    deployment_json=$(_ods_cli_deployment_attestation_json "${flags[@]}")
     jq -s \
         --arg installDir "$INSTALL_DIR" \
         --arg composeFlags "$flags_str" \
@@ -1488,12 +1521,14 @@ cmd_status_json() {
         --arg tier "${TIER:-}" \
         --arg currentModel "${LLM_MODEL:-}" \
         --argjson gpu "$gpu_summary_json" \
+        --argjson deployment "$deployment_json" \
         '{installDir: $installDir,
           composeFlags: $composeFlags,
           mode: $mode,
           tier: $tier,
           currentModel: $currentModel,
           gpu: $gpu,
+          deployment: $deployment,
           services: .}' "$tmp"
 }
 
@@ -1592,6 +1627,10 @@ cmd_restart() {
 
     if [[ -z "$resolved_service" || "$resolved_service" == "llama-server" ]]; then
         _ods_cli_maybe_resume_bootstrap_upgrade || true
+    fi
+
+    if [[ -z "$resolved_service" ]]; then
+        _ods_cli_record_full_deployment "restart" "${flags[@]}"
     fi
 }
 
@@ -1794,6 +1833,10 @@ cmd_start() {
 
     if [[ -z "$resolved_service" || "$resolved_service" == "llama-server" ]]; then
         _ods_cli_maybe_resume_bootstrap_upgrade || true
+    fi
+
+    if [[ -z "$resolved_service" ]]; then
+        _ods_cli_record_full_deployment "start" "${flags[@]}"
     fi
 }
 
@@ -2102,6 +2145,8 @@ cmd_update() {
     # Restart host agent so new endpoints / code changes take effect
     log "Restarting host agent..."
     cmd_agent restart || warn "Host agent restart failed (non-fatal)"
+
+    _ods_cli_record_full_deployment "update" "${flags[@]}"
 
     success "Update complete"
 

--- a/ods/tests/test-cli-update-verification.sh
+++ b/ods/tests/test-cli-update-verification.sh
@@ -42,6 +42,8 @@ mkdir -p "$FIXTURE/lib" "$FIXTURE/extensions/services/bsvc" "$FIXTURE/extensions
 cp "$ROOT_DIR/ods-cli" "$FIXTURE/ods-cli"
 cp "$ROOT_DIR"/lib/*.sh "$FIXTURE/lib/"
 : > "$FIXTURE/docker-compose.base.yml"
+echo '{"services":{"bsvc":{"image":"example/bsvc:v1"},"oneshot":{"image":"example/oneshot:v1"}}}' \
+    > "$FIXTURE/compose-plan.json"
 
 cat > "$FIXTURE/extensions/services/bsvc/manifest.yaml" <<'EOF'
 schema_version: ods.services.v1
@@ -92,8 +94,12 @@ if [[ "${1:-}" == "compose" ]]; then
     for a in "$@"; do case "$a" in config|ps|pull|up|down|version) sub=$a; break;; esac; done
     case "$sub" in
         config)
-            echo "bsvc"
-            echo "oneshot"
+            if [[ " $* " == *" --services "* ]]; then
+                echo "bsvc"
+                echo "oneshot"
+            else
+                cat "${FAKE_COMPOSE_PLAN:?}"
+            fi
             ;;
         pull)
             seen=0
@@ -122,6 +128,10 @@ case "${1:-}" in
         ;;
     inspect)
         for last in "$@"; do :; done
+        if [[ " $* " == *".Id"* ]]; then
+            echo "container-${FAKE_CONTAINER_GENERATION:-1}-${last}|image-${last}|${last#id-}"
+            exit 0
+        fi
         case "$last" in
             id-bsvc)
                 if [[ "${FAKE_DOCKER_PS_EMPTY:-}" == "1" ]]; then echo "exited 1"; else echo "running 0"; fi
@@ -144,7 +154,20 @@ cat > "$FIXTURE/bin/curl" <<'SH'
 echo "curl: (7) Failed to connect" >&2
 exit 7
 SH
-chmod +x "$FIXTURE/bin/docker" "$FIXTURE/bin/curl"
+cat > "$FIXTURE/bin/systemctl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat > "$FIXTURE/bin/sudo" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat > "$FIXTURE/bin/sleep" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$FIXTURE/bin/docker" "$FIXTURE/bin/curl" "$FIXTURE/bin/systemctl" \
+    "$FIXTURE/bin/sudo" "$FIXTURE/bin/sleep"
 
 reset_env() {
     cat > "$FIXTURE/.env" <<'EOF'
@@ -156,8 +179,21 @@ EOF
 
 run_update() {
     # Never let a non-zero CLI exit kill the test; callers assert on output/state
-    PATH="$FIXTURE/bin:$PATH" ODS_HOME="$FIXTURE" \
+    FAKE_COMPOSE_PLAN="$FIXTURE/compose-plan.json" \
+        PATH="$FIXTURE/bin:$PATH" ODS_HOME="$FIXTURE" \
         bash "$FIXTURE/ods-cli" update 2>&1 || true
+}
+
+run_status_json() {
+    FAKE_COMPOSE_PLAN="$FIXTURE/compose-plan.json" \
+        PATH="$FIXTURE/bin:$PATH" ODS_HOME="$FIXTURE" \
+        bash "$FIXTURE/ods-cli" status --json 2>&1 || true
+}
+
+run_cli() {
+    FAKE_COMPOSE_PLAN="$FIXTURE/compose-plan.json" \
+        PATH="$FIXTURE/bin:$PATH" ODS_HOME="$FIXTURE" \
+        bash "$FIXTURE/ods-cli" "$@" 2>&1 || true
 }
 
 echo ""
@@ -186,6 +222,19 @@ if echo "$output" | grep -q "Update verification failed"; then
     fail "update reported a false verification failure"
 else
     pass "update reported no verification failure"
+fi
+receipt="$FIXTURE/data/deployment-receipt.json"
+if [[ -f "$receipt" ]] && [[ "$(jq -r '.action' "$receipt")" == "update" ]]; then
+    pass "successful update publishes a deployment receipt"
+else
+    fail "successful update did not publish its deployment receipt"
+fi
+status_output=$(run_status_json)
+status_json=$(echo "$status_output" | awk '/^[[:space:]]*\{/{found=1} found')
+if [[ "$(jq -r '.deployment.state' <<< "$status_json")" == "in_sync" ]]; then
+    pass "public JSON status attests the reconciled deployment"
+else
+    fail "public JSON status did not report in_sync: $status_output"
 fi
 
 # ---------------------------------------------------------------------------
@@ -226,6 +275,50 @@ if grep -q "ghcr.io/example/upstream:1.2.3" "$FIXTURE/pull.log" 2>/dev/null && !
     pass "update pulls registry images without pulling local build tags"
 else
     fail "external-only pull not exercised: $(cat "$FIXTURE/pull.log" 2>/dev/null)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. changing the desired canonical plan is visible even while containers run
+# ---------------------------------------------------------------------------
+echo '{"services":{"bsvc":{"image":"example/bsvc:v2"},"oneshot":{"image":"example/oneshot:v1"}}}' \
+    > "$FIXTURE/compose-plan.json"
+status_output=$(run_status_json)
+status_json=$(echo "$status_output" | awk '/^[[:space:]]*\{/{found=1} found')
+if [[ "$(jq -r '.deployment.state' <<< "$status_json")" == "desired_config_changed" ]]; then
+    pass "status detects desired Compose plan drift"
+else
+    fail "status missed desired Compose plan drift: $status_output"
+fi
+
+# Restore the receipted plan, then replace container identities without
+# changing health or service membership.
+echo '{"services":{"bsvc":{"image":"example/bsvc:v1"},"oneshot":{"image":"example/oneshot:v1"}}}' \
+    > "$FIXTURE/compose-plan.json"
+export FAKE_CONTAINER_GENERATION=2
+status_output=$(run_status_json)
+unset FAKE_CONTAINER_GENERATION
+status_json=$(echo "$status_output" | awk '/^[[:space:]]*\{/{found=1} found')
+if [[ "$(jq -r '.deployment.state' <<< "$status_json")" == "runtime_changed" ]]; then
+    pass "status detects container identity drift"
+else
+    fail "status missed container identity drift: $status_output"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. other public full-stack reconciliation commands refresh the receipt
+# ---------------------------------------------------------------------------
+rm -f "$receipt"
+run_cli start >/dev/null
+if [[ "$(jq -r '.action' "$receipt")" == "start" ]]; then
+    pass "full-stack start publishes a deployment receipt"
+else
+    fail "full-stack start did not publish its receipt"
+fi
+run_cli restart >/dev/null
+if [[ "$(jq -r '.action' "$receipt")" == "restart" ]]; then
+    pass "full-stack restart refreshes the deployment receipt"
+else
+    fail "full-stack restart did not refresh its receipt"
 fi
 
 echo ""


### PR DESCRIPTION
**Ready for independent review (2026-09-15).** Candidate `9c0a3587c4e3057629941d29ce0a75493c3a0dda` has a successful GitHub check rollup and no base-branch conflict at this review snapshot. This supersedes earlier draft-status wording only. All validation gaps, migration requirements, live gates and independent human review requirements below remain in force; this is not a merge-ready approval.

## Why this matters

`ods status` currently reports container health but cannot answer whether those healthy containers still represent the Compose plan ODS most recently reconciled. An operator can change `.env`, overlays, or extension composition without recreating the stack, or a container can be replaced outside the ODS lifecycle, while health remains green.

The reachable producer is the shipped full-stack `ods start`, `ods restart`, and verified `ods update` commands. The public consumers are `ods status` and `ods status --json`.

## Root cause and invariant

Root cause: ODS did not persist a receipt joining the canonical desired Compose model to the container/image identities created by a successful full-stack lifecycle operation.

Invariant: a successful full reconciliation records only digests and non-secret metadata. Status recomputes the current desired-plan and runtime-identity digests and never calls a deployment `in_sync` unless both still match that receipt.

## What changed

- Add `lib/deployment-receipt.sh` with portable SHA-256, atomic mode-0600 receipt publication, and read-only attestation.
- Render the effective Compose model with `docker compose ... config --format json`, hash it in memory, and never persist interpolated Compose output.
- Fingerprint the project containers from container ID, image ID, and Compose service identity obtained through `docker inspect`.
- Publish `data/deployment-receipt.json` after successful full-stack start/restart and after update verification.
- Expose `deployment.state` through `ods status --json` and a concise receipt line in human status.
- Distinguish `missing`, `invalid_receipt`, `unavailable`, `desired_config_changed`, `runtime_changed`, and `in_sync`.
- Treat receipt publication as diagnostic: a receipt failure warns but does not turn an otherwise successful deployment into an outage.

## Why not Compose's container config-hash label

Docker documents `docker compose config` as the canonical model renderer and supports JSON output. This PR hashes that model but deliberately does not compare it with the implementation-private `com.docker.compose.config-hash` label. Docker Compose issue #14001 documents versions where `config --hash` disagrees with the container label for `env_file` services. Container/image identity is therefore recorded as an independent runtime receipt instead.

- CLI contract: https://docs.docker.com/reference/cli/docker/compose/convert/
- Upstream mismatch: https://github.com/docker/compose/issues/14001

## Overlap check

Searched open and closed ODS PRs for `deployment receipt`, `runtime drift`, `compose drift`, `running container config`, and `config hash status`, plus current open PRs changing `ods/ods-cli`.

No PR owns desired-plan/runtime attestation or a deployment receipt. #2709 concerns crash recovery for the separate source-update transaction; model activation and remote-provider probe receipts cover different state machines.

## Regression test

`bash tests/test-cli-update-verification.sh` runs the real public CLI against an isolated install and Docker shim. It proves:

- verified update publishes an `action=update` receipt;
- immediate public JSON status returns `deployment.state=in_sync`;
- a changed canonical Compose model returns `desired_config_changed` while services remain present;
- replaced container identities return `runtime_changed` without changing health or membership;
- full-stack start and restart publish/refresh their own receipts;
- failed update verification does not publish a success receipt.

Validation:

- `bash tests/test-cli-update-verification.sh` — 12 passed
- `bash -n ods-cli lib/deployment-receipt.sh tests/test-cli-update-verification.sh` — passed
- `make lint` — passed
- `git diff --check` — passed

No live Docker daemon was used locally; CI and the fixture validate command contracts, hashing, atomic receipt behavior, and the public JSON boundary. Live multi-overlay validation remains the reviewer/runtime gate.

## Compatibility and rollback

Missing helpers and receipt-write failures degrade to explicit `unavailable`/warnings. Existing status fields are unchanged; `deployment` is additive JSON. Partial service lifecycle and enable/disable operations intentionally do not refresh the full-stack receipt, so status reports drift until the next full reconciliation instead of overstating convergence.

Reverting removes the diagnostic and leaves the mode-0600 receipt as inert data. No Compose resources or operator configuration are mutated by attestation.