### PR TITLE
fix(backup): make writable snapshots application-consistent

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -115,6 +115,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
+	@echo "=== application-consistent backup transaction ==="
+	@bash tests/test-backup-quiesce.sh
 	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh

--- a/ods/lib/backup-quiesce.sh
+++ b/ods/lib/backup-quiesce.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# Purpose: Quiesce and recover the running ODS Compose project around backups.
+# Expects: ODS_DIR, docker, jq.
+# Provides: ods_backup_quiesce_begin, ods_backup_quiesce_resume,
+#           ods_backup_quiesce_recover_dead.
+
+ODS_BACKUP_QUIESCE_STATE="${ODS_DIR}/data/backup-quiesce.json"
+ODS_BACKUP_QUIESCE_LOCK="${ODS_DIR}/data/.backup-quiesce.lock"
+ODS_BACKUP_QUIESCE_ACTIVE="false"
+ODS_BACKUP_QUIESCE_COUNT=0
+
+_ods_backup_quiesce_log() {
+    printf '[backup] %s\n' "$*" >&2
+}
+
+_ods_backup_quiesce_owner() {
+    [[ -f "$ODS_BACKUP_QUIESCE_LOCK/owner" ]] || return 1
+    local owner
+    owner=$(<"$ODS_BACKUP_QUIESCE_LOCK/owner")
+    [[ "$owner" =~ ^[1-9][0-9]*$ ]] || return 1
+    printf '%s\n' "$owner"
+}
+
+_ods_backup_quiesce_release_lock() {
+    rm -f "$ODS_BACKUP_QUIESCE_LOCK/owner"
+    rmdir "$ODS_BACKUP_QUIESCE_LOCK"
+}
+
+_ods_backup_quiesce_acquire() {
+    mkdir -p "${ODS_DIR}/data"
+
+    if mkdir "$ODS_BACKUP_QUIESCE_LOCK" 2>/dev/null; then
+        chmod 700 "$ODS_BACKUP_QUIESCE_LOCK"
+        printf '%s\n' "$$" > "$ODS_BACKUP_QUIESCE_LOCK/owner"
+        return 0
+    fi
+
+    local owner
+    if ! owner=$(_ods_backup_quiesce_owner); then
+        _ods_backup_quiesce_log "Invalid backup lock; refusing automatic recovery: $ODS_BACKUP_QUIESCE_LOCK"
+        return 1
+    fi
+    if kill -0 "$owner" 2>/dev/null; then
+        _ods_backup_quiesce_log "Backup transaction is already owned by live process $owner"
+        return 1
+    fi
+
+    local stale="${ODS_BACKUP_QUIESCE_LOCK}.stale.$$"
+    if ! mv "$ODS_BACKUP_QUIESCE_LOCK" "$stale" 2>/dev/null; then
+        _ods_backup_quiesce_log "Another process is recovering the interrupted backup"
+        return 1
+    fi
+    rm -f "$stale/owner"
+    rmdir "$stale"
+
+    mkdir "$ODS_BACKUP_QUIESCE_LOCK"
+    chmod 700 "$ODS_BACKUP_QUIESCE_LOCK"
+    printf '%s\n' "$$" > "$ODS_BACKUP_QUIESCE_LOCK/owner"
+}
+
+_ods_backup_quiesce_write_state() {
+    local state="$1"
+    shift
+    local tmp="${ODS_BACKUP_QUIESCE_STATE}.tmp.$$"
+    printf '%s\n' "$@" | jq -Rsc \
+        --arg state "$state" \
+        --argjson owner_pid "$$" \
+        '{version: 1, state: $state, owner_pid: $owner_pid,
+          container_ids: (split("\n") | map(select(length > 0)))}' > "$tmp"
+    chmod 600 "$tmp"
+    mv "$tmp" "$ODS_BACKUP_QUIESCE_STATE"
+}
+
+_ods_backup_quiesce_read_ids() {
+    jq -er '.version == 1 and (.owner_pid | type == "number") and
+        (.container_ids | type == "array") and
+        all(.container_ids[]; type == "string" and test("^[a-fA-F0-9]{12,64}$"))' \
+        "$ODS_BACKUP_QUIESCE_STATE" >/dev/null
+    jq -r '.container_ids[]' "$ODS_BACKUP_QUIESCE_STATE"
+}
+
+_ods_backup_quiesce_start_recorded() {
+    local -a ids=()
+    local output id running
+    output=$(_ods_backup_quiesce_read_ids) || return 1
+    if [[ -n "$output" ]]; then
+        while IFS= read -r id; do
+            ids+=("$id")
+        done <<< "$output"
+    fi
+    if [[ ${#ids[@]} -gt 0 ]]; then
+        _ods_backup_quiesce_log "Restarting ${#ids[@]} container(s) captured by the backup transaction"
+        docker start "${ids[@]}" >/dev/null
+        for id in "${ids[@]}"; do
+            running=$(docker inspect --format '{{.State.Running}}' "$id")
+            if [[ "$running" != "true" ]]; then
+                _ods_backup_quiesce_log "Container did not remain running after restart: $id"
+                return 1
+            fi
+        done
+    fi
+}
+
+ods_backup_quiesce_recover_dead() {
+    [[ -f "$ODS_BACKUP_QUIESCE_STATE" ]] || return 0
+
+    local owner
+    if ! owner=$(jq -er '.owner_pid | select(type == "number")' "$ODS_BACKUP_QUIESCE_STATE"); then
+        _ods_backup_quiesce_log "Invalid recovery receipt; refusing to guess which containers to start"
+        return 1
+    fi
+    if [[ "$owner" != "$$" ]] && kill -0 "$owner" 2>/dev/null; then
+        _ods_backup_quiesce_log "Backup transaction is still active in process $owner"
+        return 1
+    fi
+
+    _ods_backup_quiesce_acquire
+    if ! _ods_backup_quiesce_start_recorded; then
+        _ods_backup_quiesce_log "Container recovery failed; receipt retained for the next attempt"
+        _ods_backup_quiesce_release_lock
+        return 1
+    fi
+    rm -f "$ODS_BACKUP_QUIESCE_STATE"
+    _ods_backup_quiesce_release_lock
+    _ods_backup_quiesce_log "Recovered containers from the interrupted backup"
+}
+
+ods_backup_quiesce_begin() {
+    ods_backup_quiesce_recover_dead
+    _ods_backup_quiesce_acquire
+
+    local -a ids=()
+    local output id
+    if ! output=$(docker ps \
+        --filter 'label=com.docker.compose.project=ods' \
+        --format '{{.ID}}'); then
+        _ods_backup_quiesce_log "Could not enumerate the running ODS containers"
+        _ods_backup_quiesce_release_lock
+        return 1
+    fi
+    if [[ -n "$output" ]]; then
+        while IFS= read -r id; do
+            ids+=("$id")
+        done <<< "$output"
+    fi
+    for id in "${ids[@]}"; do
+        if [[ ! "$id" =~ ^[a-fA-F0-9]{12,64}$ ]]; then
+            _ods_backup_quiesce_log "Docker returned an invalid container ID: $id"
+            _ods_backup_quiesce_release_lock
+            return 1
+        fi
+    done
+    ODS_BACKUP_QUIESCE_COUNT=${#ids[@]}
+    _ods_backup_quiesce_write_state "stopping" "${ids[@]}"
+    ODS_BACKUP_QUIESCE_ACTIVE="true"
+
+    if [[ ${#ids[@]} -gt 0 ]]; then
+        _ods_backup_quiesce_log "Stopping ${#ids[@]} running ODS container(s) for a consistent snapshot"
+        docker stop "${ids[@]}" >/dev/null
+    fi
+    _ods_backup_quiesce_write_state "stopped" "${ids[@]}"
+}
+
+ods_backup_quiesce_resume() {
+    [[ "$ODS_BACKUP_QUIESCE_ACTIVE" == "true" ]] || return 0
+    if ! _ods_backup_quiesce_start_recorded; then
+        _ods_backup_quiesce_log "Container restart failed; receipt retained at $ODS_BACKUP_QUIESCE_STATE"
+        return 1
+    fi
+    rm -f "$ODS_BACKUP_QUIESCE_STATE"
+    _ods_backup_quiesce_release_lock
+    ODS_BACKUP_QUIESCE_ACTIVE="false"
+}

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -30,6 +30,21 @@ log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 
 # Source shared rsync utilities
 . "$ODS_DIR/lib/rsync.sh"
+# shellcheck source=lib/backup-quiesce.sh
+. "$SCRIPT_DIR/lib/backup-quiesce.sh"
+
+_backup_exit() {
+    local status=$?
+    trap - EXIT
+    if [[ "$ODS_BACKUP_QUIESCE_ACTIVE" == "true" ]] && ! ods_backup_quiesce_resume; then
+        status=1
+    fi
+    exit "$status"
+}
+trap _backup_exit EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 # Convert bytes to a human-friendly string (best-effort)
 fmt_bytes() {
@@ -170,6 +185,7 @@ OPTIONS:
     -o, --output DIR        Custom backup directory (default: .backups/)
     -t, --type TYPE         Backup type: full, user-data, config (default: full)
     -c, --compress          Compress backup to .tar.gz
+    --live                  Copy writable data without stopping containers
     -l, --list              List existing backups
     -d, --delete ID         Delete specific backup by ID
     --description DESC      Add description to backup manifest
@@ -276,6 +292,8 @@ create_manifest() {
     local backup_dir="$1"
     local backup_type="$2"
     local description="${3:-}"
+    local consistency="${4:-quiesced}"
+    local container_count="${5:-0}"
     local version
     # .version is a JSON file written by ods-update.sh; extract the version
     # string rather than embedding the entire JSON blob (see get_current_version
@@ -296,6 +314,8 @@ create_manifest() {
         --arg dv "$version" \
         --arg hn "$(hostname)" \
         --arg desc "$description" \
+        --arg consistency "$consistency" \
+        --argjson cc "$container_count" \
         --argjson ud "$has_user_data" \
         --argjson cfg "$has_config" \
         --argjson ca "$has_cache" \
@@ -307,6 +327,8 @@ create_manifest() {
           ods_version: $dv,
           hostname: $hn,
           description: $desc,
+          consistency: $consistency,
+          quiesced_container_count: $cc,
           contents: { user_data: $ud, config: $cfg, cache: $ca },
           paths: {
             data_open_webui: "data/open-webui",
@@ -480,6 +502,7 @@ do_backup() {
     local backup_type="${1:-user-data}"
     local compress="${2:-false}"
     local description="${3:-}"
+    local live="${4:-false}"
 
     # Generate backup ID
     local backup_id
@@ -492,11 +515,22 @@ do_backup() {
     # Disk space preflight (best-effort)
     ensure_backup_space "$backup_type"
 
+    local consistency="config-only"
+    if [[ "$backup_type" == "full" || "$backup_type" == "user-data" ]]; then
+        if [[ "$live" == "true" ]]; then
+            consistency="live-best-effort"
+            log_warn "Live backup selected: writable application data may not be transactionally consistent"
+        else
+            ods_backup_quiesce_begin
+            consistency="quiesced"
+        fi
+    fi
+
     # Create backup directory
     mkdir -p "$backup_dir"
 
     # Create manifest
-    create_manifest "$backup_dir" "$backup_type" "$description"
+    create_manifest "$backup_dir" "$backup_type" "$description" "$consistency" "$ODS_BACKUP_QUIESCE_COUNT"
 
     # Perform backup based on type
     case "$backup_type" in
@@ -520,6 +554,10 @@ do_backup() {
 
     # Generate checksums after files are copied into place
     create_checksums "$backup_dir"
+
+    # Keep the outage window to the data copy itself. Compression and retention
+    # operate only on the completed snapshot and do not require stopped apps.
+    ods_backup_quiesce_resume
 
     # Compress if requested
     if [[ "$compress" == "true" ]]; then
@@ -611,6 +649,7 @@ main() {
     local list_mode="false"
     local delete_id=""
     local verify_id=""
+    local live="false"
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -645,6 +684,10 @@ main() {
                 ;;
             -c|--compress)
                 compress="true"
+                shift
+                ;;
+            --live)
+                live="true"
                 shift
                 ;;
             -l|--list)
@@ -706,7 +749,7 @@ main() {
     mkdir -p "$BACKUP_ROOT"
 
     # Perform backup
-    do_backup "$backup_type" "$compress" "$description"
+    do_backup "$backup_type" "$compress" "$description" "$live"
 }
 
 main "$@"

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1728,6 +1728,13 @@ cmd_start() {
     check_install
     cd "$INSTALL_DIR"
     load_env
+    if [[ -f "$INSTALL_DIR/lib/backup-quiesce.sh" ]]; then
+        ODS_DIR="$INSTALL_DIR"
+        # shellcheck source=lib/backup-quiesce.sh
+        source "$INSTALL_DIR/lib/backup-quiesce.sh"
+        ods_backup_quiesce_recover_dead \
+            || error "Could not recover containers from an interrupted backup."
+    fi
     ensure_llama_cpu_budget
     sr_load
 

--- a/ods/tests/test-backup-integrity.sh
+++ b/ods/tests/test-backup-integrity.sh
@@ -41,7 +41,7 @@ echo "world" > "$FAKE_ODS/config/settings.json"
 BACKUPS_DIR="$TMP_ROOT/backups"
 
 info "Creating backup"
-ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$BACKUPS_DIR" --type full >/dev/null
+ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$BACKUPS_DIR" --type full --live >/dev/null
 
 backup_id="$(ls -1 "$BACKUPS_DIR" | head -n 1)"
 [[ -n "$backup_id" ]] || fail "No backup created"

--- a/ods/tests/test-backup-quiesce.sh
+++ b/ods/tests/test-backup-quiesce.sh
@@ -15,6 +15,11 @@ FAKE_ODS="$TMP_ROOT/ods"
 FAKE_BIN="$TMP_ROOT/bin"
 mkdir -p "$FAKE_ODS/data/open-webui" "$FAKE_ODS/lib" "$FAKE_BIN"
 cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
+# PR #2190 centralizes the data path list in this optional sibling. Copy it
+# when present so this boundary test composes with that independent change.
+if [[ -f "$SCRIPT_DIR/../lib/backup-paths.sh" ]]; then
+    cp "$SCRIPT_DIR/../lib/backup-paths.sh" "$FAKE_ODS/lib/"
+fi
 printf '{"version":"test"}\n' > "$FAKE_ODS/.version"
 printf 'operator data\n' > "$FAKE_ODS/data/open-webui/value.txt"
 

--- a/ods/tests/test-backup-quiesce.sh
+++ b/ods/tests/test-backup-quiesce.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# Boundary tests for application-consistent `ods-backup.sh` transactions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ODS_BACKUP="$SCRIPT_DIR/../ods-backup.sh"
+TMP_ROOT=$(mktemp -d)
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+fail() { printf 'FAIL: %s\n' "$*" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$*"; }
+
+FAKE_ODS="$TMP_ROOT/ods"
+FAKE_BIN="$TMP_ROOT/bin"
+mkdir -p "$FAKE_ODS/data/open-webui" "$FAKE_ODS/lib" "$FAKE_BIN"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
+printf '{"version":"test"}\n' > "$FAKE_ODS/.version"
+printf 'operator data\n' > "$FAKE_ODS/data/open-webui/value.txt"
+
+DOCKER_LOG="$TMP_ROOT/docker.log"
+RUNNING_FILE="$TMP_ROOT/running"
+RSYNC_LOG="$TMP_ROOT/rsync.log"
+export DOCKER_LOG RUNNING_FILE RSYNC_LOG
+
+cat > "$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+    ps)
+        [[ "${FAKE_DOCKER_PS_FAIL:-0}" != "1" ]] || exit 70
+        [[ -f "$RUNNING_FILE" ]] && cat "$RUNNING_FILE"
+        ;;
+    stop)
+        shift
+        printf 'stop %s\n' "$*" >> "$DOCKER_LOG"
+        : > "$RUNNING_FILE"
+        ;;
+    start)
+        shift
+        printf 'start %s\n' "$*" >> "$DOCKER_LOG"
+        printf '%s\n' "$@" > "$RUNNING_FILE"
+        ;;
+    inspect)
+        if [[ "${FAKE_DOCKER_INSPECT_FALSE:-0}" == "1" ]]; then
+            echo false
+        else
+            echo true
+        fi
+        ;;
+    *) exit 64 ;;
+esac
+EOF
+
+cat > "$FAKE_BIN/rsync" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "--help" ]]; then
+    echo 'info=progress2'
+    exit 0
+fi
+printf 'copy\n' >> "$RSYNC_LOG"
+if [[ -n "${FAKE_RSYNC_WAIT_DIR:-}" ]]; then
+    touch "$FAKE_RSYNC_WAIT_DIR/ready"
+    while [[ ! -f "$FAKE_RSYNC_WAIT_DIR/release" ]]; do
+        sleep 0.05
+    done
+fi
+if [[ "${FAKE_RSYNC_KILL:-0}" == "1" && ! -f "${RSYNC_LOG}.killed" ]]; then
+    touch "${RSYNC_LOG}.killed"
+    kill -KILL "$PPID"
+    exit 137
+fi
+[[ "${FAKE_RSYNC_FAIL:-0}" != "1" ]] || exit 23
+src="${@: -2:1}"
+dest="${@: -1}"
+cp -a "$src" "$dest"
+EOF
+chmod +x "$FAKE_BIN/docker" "$FAKE_BIN/rsync"
+
+run_backup() {
+    local output="$1"
+    shift
+    PATH="$FAKE_BIN:$PATH" ODS_DIR="$FAKE_ODS" \
+        bash "$ODS_BACKUP" --output "$output" --type user-data "$@"
+}
+
+container_id=aaaaaaaaaaaa
+printf '%s\n' "$container_id" > "$RUNNING_FILE"
+run_backup "$TMP_ROOT/normal" >/dev/null
+[[ $(sed -n '1p' "$DOCKER_LOG") == "stop $container_id" ]] || fail "containers were not stopped first"
+[[ $(sed -n '2p' "$DOCKER_LOG") == "start $container_id" ]] || fail "exact container was not restarted"
+manifest=$(find "$TMP_ROOT/normal" -name manifest.json -print -quit)
+[[ $(jq -r '.consistency' "$manifest") == quiesced ]] || fail "manifest does not attest quiesced consistency"
+[[ $(jq -r '.quiesced_container_count' "$manifest") == 1 ]] || fail "manifest container count is wrong"
+pass "successful backup stops and restarts the exact running set"
+
+: > "$DOCKER_LOG"
+printf '%s\n' "$container_id" > "$RUNNING_FILE"
+wait_dir="$TMP_ROOT/wait"
+mkdir -p "$wait_dir"
+FAKE_RSYNC_WAIT_DIR="$wait_dir" run_backup "$TMP_ROOT/concurrent-first" >/dev/null 2>&1 &
+first_pid=$!
+for _ in {1..100}; do
+    [[ -f "$wait_dir/ready" ]] && break
+    sleep 0.05
+done
+[[ -f "$wait_dir/ready" ]] || fail "first backup did not reach its copy boundary"
+if run_backup "$TMP_ROOT/concurrent-second" >/dev/null 2>&1; then
+    fail "concurrent backup bypassed the transaction lock"
+fi
+[[ $(grep -c '^stop ' "$DOCKER_LOG") -eq 1 ]] || fail "concurrent backup changed container state"
+touch "$wait_dir/release"
+wait "$first_pid" || fail "first concurrent backup failed"
+pass "concurrent backup is rejected without a second lifecycle mutation"
+
+: > "$DOCKER_LOG"
+printf '%s\n' "$container_id" > "$RUNNING_FILE"
+if FAKE_RSYNC_FAIL=1 run_backup "$TMP_ROOT/failure" >/dev/null 2>&1; then
+    fail "copy failure was swallowed"
+fi
+grep -qx "start $container_id" "$DOCKER_LOG" || fail "copy failure did not restart the container"
+[[ ! -f "$FAKE_ODS/data/backup-quiesce.json" ]] || fail "successful recovery left a receipt"
+pass "copy failure preserves the error and restores availability"
+
+: > "$DOCKER_LOG"
+printf '%s\n' "$container_id" > "$RUNNING_FILE"
+if FAKE_DOCKER_INSPECT_FALSE=1 run_backup "$TMP_ROOT/restart-failure" >/dev/null 2>&1; then
+    fail "failed restart verification was treated as success"
+fi
+[[ -f "$FAKE_ODS/data/backup-quiesce.json" ]] || fail "restart failure discarded its recovery receipt"
+run_backup "$TMP_ROOT/restart-recovery" >/dev/null
+[[ ! -f "$FAKE_ODS/data/backup-quiesce.json" ]] || fail "restart retry left a recovery receipt"
+pass "restart verification failure is terminal and remains recoverable"
+
+: > "$DOCKER_LOG"
+: > "$RSYNC_LOG"
+printf '%s\n' "$container_id" > "$RUNNING_FILE"
+set +e
+FAKE_RSYNC_KILL=1 run_backup "$TMP_ROOT/killed" >/dev/null 2>&1
+killed_status=$?
+set -e
+[[ $killed_status -ne 0 ]] || fail "SIGKILL simulation unexpectedly succeeded"
+[[ -f "$FAKE_ODS/data/backup-quiesce.json" ]] || fail "SIGKILL did not leave a recovery receipt"
+[[ ! -s "$RUNNING_FILE" ]] || fail "SIGKILL fixture did not leave the container stopped"
+
+run_backup "$TMP_ROOT/recovered" >/dev/null
+start_count=$(grep -c "^start $container_id$" "$DOCKER_LOG")
+[[ $start_count -eq 2 ]] || fail "next backup did not recover then resume the container"
+[[ ! -f "$FAKE_ODS/data/backup-quiesce.json" ]] || fail "recovered transaction left a receipt"
+pass "next public backup invocation recovers a process-death interruption"
+
+: > "$DOCKER_LOG"
+printf '%s\n' "$container_id" > "$RUNNING_FILE"
+run_backup "$TMP_ROOT/live" --live >/dev/null
+[[ ! -s "$DOCKER_LOG" ]] || fail "--live unexpectedly changed container state"
+live_manifest=$(find "$TMP_ROOT/live" -name manifest.json -print -quit)
+[[ $(jq -r '.consistency' "$live_manifest") == live-best-effort ]] \
+    || fail "live manifest does not disclose weaker consistency"
+pass "--live is explicit and records its weaker guarantee"
+
+if FAKE_DOCKER_PS_FAIL=1 run_backup "$TMP_ROOT/daemon-failure" >/dev/null 2>&1; then
+    fail "Docker enumeration failure was treated as a consistent backup"
+fi
+[[ ! -f "$FAKE_ODS/data/backup-quiesce.json" ]] || fail "enumeration failure left a false receipt"
+[[ ! -d "$FAKE_ODS/data/.backup-quiesce.lock" ]] || fail "enumeration failure left a lock"
+pass "Docker enumeration failure fails closed before copying data"

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -38,7 +38,7 @@ mkdir -p "$SRC/lib"
 cp "$SCRIPT_DIR/../lib/rsync.sh" "$SRC/lib/"
 
 info "Creating backup from source"
-ODS_DIR="$SRC" bash "$ODS_BACKUP" --type full >/dev/null 2>&1 || fail "Backup failed"
+ODS_DIR="$SRC" bash "$ODS_BACKUP" --type full --live >/dev/null 2>&1 || fail "Backup failed"
 
 # Find the backup ID
 BACKUP_ID=$(ls -1 "$SRC/.backups" | head -n 1)

--- a/ods/tests/test-update-rollback-contract.sh
+++ b/ods/tests/test-update-rollback-contract.sh
@@ -98,7 +98,7 @@ EOF
 
 baseline_hash="$(sha256sum "$SRC/.env" "$SRC/config/settings.json" "$SRC/data/open-webui/data.txt" | sha256sum | awk '{print $1}')"
 
-ODS_DIR="$SRC" RETENTION_COUNT=10 bash "$ODS_BACKUP" --type full >/dev/null 2>&1
+ODS_DIR="$SRC" RETENTION_COUNT=10 bash "$ODS_BACKUP" --type full --live >/dev/null 2>&1
 BACKUP_ID="$(find "$SRC/.backups" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | tail -n 1)"
 [[ -n "$BACKUP_ID" ]] || fail "backup ID was not created"
 pass "backup created before update mutation: $BACKUP_ID"


### PR DESCRIPTION
## Why this matters

`ods backup` currently rsyncs databases and writable application stores while their containers are mutating them. A checksum-valid archive can therefore combine files from different transaction points and still be unusable or internally inconsistent at restore time.

This change makes `full` and `user-data` backups application-consistent by default: it captures the exact running ODS container set, writes a durable transaction receipt, stops that set before the first data copy, restarts exactly that set, and verifies every captured container is running before reporting success. `--live` remains an explicit availability-first opt-out and the manifest records `live-best-effort` rather than overstating its guarantee.

### Root cause and invariant

Root cause: integrity checks prove copied bytes were not later corrupted; they do not prove that independently written files came from one application state.

Invariant: a backup marked `quiesced` is produced only after the recorded running container set has stopped, and backup success is impossible until that same set has restarted and is observed running.

## Transaction and recovery contract

- Producer: `ods backup` captures containers labeled `com.docker.compose.project=ods` (the project name declared by the shipped Compose stack).
- Persisted state: an atomic, mode-0600 `data/backup-quiesce.json` receipt records owner PID, phase, and validated container IDs; an atomic directory lock rejects concurrent lifecycle mutations.
- Consumers: the next consistent `ods backup` and full `ods start` recover a receipt whose owner process is dead.
- Runtime effect: only containers running before the snapshot are stopped and restarted. Config-only backups do not interrupt services.
- Verification: `docker inspect` must report every captured container running before the receipt is removed or success is printed.
- Terminal failure: copy/restart failures remain failures; a failed restart retains the receipt for a later recovery attempt.
- Rollback: recover any retained receipt first, then revert these commits to restore the previous live-copy behavior. Existing backup archives and manifests remain readable because the manifest fields are additive.

## Overlap check

Searched open and closed PRs for `quiesce backup`, `application consistent backup`, and `live backup`, plus production-file overlap around `ods-backup.sh` and `ods-cli`; no PR implements service quiescence or crash recovery.

- #2190 is the canonical `tang-vu` PR for **which** bundled service paths are backed up. It is stronger than the later Hermes/persona subset #3254 and remains open; this PR independently controls **when** writable paths are copied.
- #3018 adds models to full backups; #3251 fixes restore project-name behavior. Neither overlaps this transaction boundary.
- This PR intentionally updates rather than replaces any of those scopes.

Merge order for the shared backup surface: **#2190 first, then this PR**. A synthetic integration head containing #2190, #3259, and this PR required only additive conflict reconciliation in `ods-backup.sh`/`Makefile`; the centralized path list and consistency transaction then passed together. #2709 has no shared production file with this change.

## Validation

Candidate head: `83c0c05b`.

Passed:

- `bash tests/test-backup-quiesce.sh`
  - stop/copy/restart ordering and exact-set preservation
  - concurrent backup rejection without duplicate lifecycle mutation
  - copy failure recovery with original nonzero result
  - restart-verification failure receipt and next-run recovery
  - true parent `SIGKILL` and next public backup recovery
  - explicit `--live` manifest semantics
  - Docker enumeration failure fails closed before copying
- `bash tests/test-backup-integrity.sh`
- `bash tests/test-backup-restore-roundtrip.sh`
- `bash tests/test-update-rollback-contract.sh`
- `make lint`
- `bash -n lib/backup-quiesce.sh ods-backup.sh ods-cli`
- `git diff --check`

Synthetic integration head (#2190 → #3259 → this PR) also passed:

- `test-backup-data-coverage.sh`
- all focused backup suites above
- `test-cli-update-verification.sh` (12/12)
- combined Bash syntax validation

`make test` was attempted but stopped before the changed backup lane at the existing unrelated assertion `Hermes template bounds each model turn` in `test-installer-context-parity.sh`. The focused and combined suites above ran separately and passed.

## Tradeoffs and live gates

The consistency guarantee introduces a bounded outage for the data-copy/checksum window; compression and retention run after services resume. `--live` preserves the previous no-outage behavior with an honest manifest label. This changes lifecycle-critical backup behavior and has not yet been exercised on a live multi-service Docker host at this exact SHA, so the PR is Ready for review but still requires independent human review and a live backup/restore/recovery probe before merge.


## Review status update — 2026-09-15

Ready for review at the author's request. **Not merge-ready.** The branch conflicts with public-beta and the application-consistent backup/restore live gate remains incomplete. Independent human review and a documented successful restore are still required.

Reviewed head: 83c0c05bdc8b52047802dbe3078219ef4f7cdc6f. Changing draft status does not bypass these gates or authorize a merge.
