### PR TITLE
fix(lemonade-client): use json.loads for request body matching in tests

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -1,3 +1,5 @@
+import json
+
 import httpx
 import pytest
 
@@ -88,8 +90,9 @@ async def test_chat_completion_posts_openai_shape():
 
     assert payload["choices"][0]["message"]["content"] == "ok"
     assert seen["url"] == "http://lemonade:13305/api/v1/chat/completions"
-    assert b'"model":"Qwen3-0.6B-GGUF"' in seen["body"]
-    assert b'"temperature":0' in seen["body"]
+    body_data = json.loads(seen["body"])
+    assert body_data.get("model") == "Qwen3-0.6B-GGUF"
+    assert body_data.get("temperature") == 0
     await client.aclose()
 
 


### PR DESCRIPTION
### Context & Problem
In `ods/extensions/services/dashboard-api/tests/test_lemonade_client.py`, `test_chat_completion_posts_openai_shape` performed exact raw bytes substring matching (`b'"model":"Qwen3-0.6B-GGUF"'`) on the HTTP request body payload. Across Python 3.13 / Starlette / httpx runtimes, JSON serialization includes formatting space separators (`{"model": "Qwen3-0.6B-GGUF"}`), causing test suite assertions to fail unexpectedly.

### Implementation Details
- Replaced rigid raw bytes substring assertions with structured `json.loads()` payload parsing.
- Validates `model` and `temperature` properties directly on the parsed JSON dictionary.

### Verification & Tests
Executed pytest test suite:
`python3 -m pytest tests/test_lemonade_client.py` -> 9 passed in 0.31s.