### PR TITLE
fix(privacy): add safe SHIELD_PORT parsing guard in privacy router

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/privacy.py
+++ b/ods/extensions/services/dashboard-api/routers/privacy.py
@@ -23,11 +23,22 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["privacy"])
 
 
+def _get_shield_port() -> int:
+    _ps = SERVICES.get("privacy-shield", {})
+    fallback = _ps.get("port", 0)
+    raw = os.environ.get("SHIELD_PORT", str(fallback)).strip()
+    try:
+        val = int(raw)
+        return val if 1 <= val <= 65535 else 0
+    except (ValueError, TypeError):
+        return 0
+
+
 @router.get("/api/privacy-shield/status", response_model=PrivacyShieldStatus)
 async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield status and configuration."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _get_shield_port()
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
 
     # Check health directly — no Docker socket needed
@@ -94,7 +105,7 @@ async def toggle_privacy_shield(request: PrivacyShieldToggle, api_key: str = Dep
 async def get_privacy_shield_stats(api_key: str = Depends(verify_api_key)):
     """Get Privacy Shield usage statistics."""
     _ps = SERVICES.get("privacy-shield", {})
-    shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
+    shield_port = _get_shield_port()
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
     shield_api_key = os.environ.get("SHIELD_API_KEY", "")
     if not shield_api_key:

--- a/ods/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/ods/extensions/services/dashboard-api/tests/test_privacy.py
@@ -291,3 +291,13 @@ def test_privacy_shield_stats_empty_shield_api_key(test_client, monkeypatch):
     assert resp.status_code == 200
     assert resp.json() == {"error": "SHIELD_API_KEY not configured", "enabled": False}
     session_factory.assert_not_called()
+
+
+def test_privacy_shield_status_invalid_port_fallback(test_client, monkeypatch):
+    """GET /api/privacy-shield/status with invalid SHIELD_PORT does not crash with ValueError."""
+    monkeypatch.setenv("SHIELD_PORT", "invalid_port_123")
+    resp = test_client.get("/api/privacy-shield/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["port"] == 0
+


### PR DESCRIPTION
### Context & Problem
In `ods/extensions/services/dashboard-api/routers/privacy.py`, `SHIELD_PORT` environment variable was converted directly to `int()` (`int(os.environ.get("SHIELD_PORT", ...))`). If `SHIELD_PORT` contains a non-numeric string or whitespace formatting error, requests to `/api/privacy-shield/status` and `/api/privacy-shield/stats` raise unhandled `ValueError` exceptions, causing HTTP 500 server errors.

### Implementation Details
- Introduced `_get_shield_port()` helper function with `try/except (ValueError, TypeError)` safety guard and port range validation (`1 <= val <= 65535`).
- Updated status and stats endpoints to use safe port parsing with zero-value fallback.
- Added regression unit test `test_privacy_shield_status_invalid_port_fallback` in `test_privacy.py`.

### Verification & Tests
Executed pytest test suite:
`python3 -m pytest tests/test_privacy.py` -> 18 passed in 0.77s.