### PR TITLE
test(dashboard): add coverage for Settings time-formatting helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -59,13 +59,13 @@ const fetchPayload = async (url, ms = 8000, options = {}) => {
   return response.json()
 }
 
-const formatUptime = (secs = 0) => {
+export const formatUptime = (secs = 0) => {
   const hours = Math.floor(secs / 3600)
   const mins = Math.floor((secs % 3600) / 60)
   return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`
 }
 
-const formatInstallDate = (value) => {
+export const formatInstallDate = (value) => {
   if (!value) return 'Unknown'
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) return value
@@ -74,7 +74,7 @@ const formatInstallDate = (value) => {
     + parsed.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
 }
 
-const formatCheckedAt = (value) => {
+export const formatCheckedAt = (value) => {
   if (!value) return null
   const parsed = new Date(value)
   if (Number.isNaN(parsed.getTime())) return null

--- a/ods/extensions/services/dashboard/src/pages/Settings.timeFormat.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.timeFormat.test.jsx
@@ -1,0 +1,54 @@
+import { describe, test, expect } from 'vitest'
+import { formatUptime, formatInstallDate, formatCheckedAt } from './Settings'
+
+describe('formatUptime', () => {
+  test('shows hours and minutes when uptime exceeds an hour', () => {
+    expect(formatUptime(3661)).toBe('1h 1m')
+  })
+
+  test('shows only minutes when under an hour', () => {
+    expect(formatUptime(120)).toBe('2m')
+  })
+
+  test('defaults to 0m when called with no argument', () => {
+    expect(formatUptime()).toBe('0m')
+  })
+
+  test('handles exactly zero', () => {
+    expect(formatUptime(0)).toBe('0m')
+  })
+})
+
+describe('formatInstallDate', () => {
+  test('returns "Unknown" for a missing value', () => {
+    expect(formatInstallDate(null)).toBe('Unknown')
+    expect(formatInstallDate(undefined)).toBe('Unknown')
+  })
+
+  test('returns the raw value unchanged for an invalid date', () => {
+    expect(formatInstallDate('not-a-date')).toBe('not-a-date')
+  })
+
+  test('formats a valid ISO date with date and time', () => {
+    const result = formatInstallDate('2026-07-20T14:58:20Z')
+    expect(result).toContain('Jul 20, 2026')
+    expect(result).toContain('  -  ')
+  })
+})
+
+describe('formatCheckedAt', () => {
+  test('returns null for a missing value', () => {
+    expect(formatCheckedAt(null)).toBeNull()
+    expect(formatCheckedAt(undefined)).toBeNull()
+  })
+
+  test('returns null for an invalid date (unlike formatInstallDate, which echoes it back)', () => {
+    expect(formatCheckedAt('not-a-date')).toBeNull()
+  })
+
+  test('formats a valid ISO date to a locale string', () => {
+    const result = formatCheckedAt('2026-07-20T14:58:20Z')
+    expect(typeof result).toBe('string')
+    expect(result.length).toBeGreaterThan(0)
+  })
+})


### PR DESCRIPTION
## Summary
- `formatUptime`, `formatInstallDate`, and `formatCheckedAt` are invoked on every successful Settings load, but `Settings.test.jsx` never asserts their rendered output — a regression (wrong pluralization, NaN, swapped fallback behavior) would pass silently.
- Exports the three functions (no behavior change) and adds `Settings.timeFormat.test.jsx`.
- Covers: `formatUptime`'s hour/minute vs minutes-only branches and the default-arg zero case; `formatInstallDate`'s "Unknown" for missing and raw-value echo for invalid dates; `formatCheckedAt`'s null for both missing and invalid dates (a deliberately different fallback from `formatInstallDate`).

## Test plan
- [x] `npx vitest run src/pages/Settings.timeFormat.test.jsx src/pages/Settings.test.jsx` — 18/18 passed, no regression
- [x] `npx eslint` on both changed files — no errors