### PR TITLE
test(dashboard): add coverage for Settings status/error text helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -81,7 +81,7 @@ const formatCheckedAt = (value) => {
   return parsed.toLocaleString()
 }
 
-const formatUsageSource = (source) => {
+export const formatUsageSource = (source) => {
   const status = source?.status
   if (!status) return 'Usage source unavailable'
   if (status === 'ok') return 'Token Spy connected'
@@ -89,7 +89,7 @@ const formatUsageSource = (source) => {
   return titleCase(status)
 }
 
-const getErrorText = (err) => (
+export const getErrorText = (err) => (
   err?.name === 'AbortError' ? 'Request timed out' : (err?.details?.message || err?.message || 'Failed to load settings')
 )
 
@@ -108,7 +108,7 @@ const formatCompact = (value) => {
   return `${Math.round(number)}`
 }
 
-const titleCase = (value) => String(value || '')
+export const titleCase = (value) => String(value || '')
   .replace(/[_-]+/g, ' ')
   .replace(/\b\w/g, char => char.toUpperCase())
 

--- a/ods/extensions/services/dashboard/src/pages/Settings.statusText.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.statusText.test.jsx
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'vitest'
+import { formatUsageSource, getErrorText, titleCase } from './Settings'
+
+describe('titleCase', () => {
+  test('replaces underscores/dashes with spaces and capitalizes each word', () => {
+    expect(titleCase('not_configured')).toBe('Not Configured')
+    expect(titleCase('rate-limited')).toBe('Rate Limited')
+  })
+
+  test('returns an empty string for a missing value', () => {
+    expect(titleCase(null)).toBe('')
+    expect(titleCase(undefined)).toBe('')
+  })
+})
+
+describe('formatUsageSource', () => {
+  test('reports unavailable when there is no status', () => {
+    expect(formatUsageSource(null)).toBe('Usage source unavailable')
+    expect(formatUsageSource({})).toBe('Usage source unavailable')
+  })
+
+  test('reports "Token Spy connected" for an ok status', () => {
+    expect(formatUsageSource({ status: 'ok' })).toBe('Token Spy connected')
+  })
+
+  test('reports partial telemetry for a partial status', () => {
+    expect(formatUsageSource({ status: 'partial' })).toBe('Partial usage telemetry')
+  })
+
+  test('title-cases any other status as a fallback', () => {
+    expect(formatUsageSource({ status: 'rate_limited' })).toBe('Rate Limited')
+  })
+})
+
+describe('getErrorText', () => {
+  test('reports a timeout for an AbortError', () => {
+    const err = new Error('irrelevant')
+    err.name = 'AbortError'
+    expect(getErrorText(err)).toBe('Request timed out')
+  })
+
+  test('prefers a structured details.message over the plain message', () => {
+    const err = new Error('generic message')
+    err.details = { message: 'specific backend detail' }
+    expect(getErrorText(err)).toBe('specific backend detail')
+  })
+
+  test('falls back to err.message when there are no details', () => {
+    const err = new Error('plain failure')
+    expect(getErrorText(err)).toBe('plain failure')
+  })
+
+  test('falls back to a generic message when the error has neither', () => {
+    expect(getErrorText({})).toBe('Failed to load settings')
+    expect(getErrorText(null)).toBe('Failed to load settings')
+  })
+})


### PR DESCRIPTION
## Summary
- `titleCase`, `formatUsageSource`, and `getErrorText` had no test — error banners and the usage-source label render whatever these produce with no verification.
- Exports the three functions (no behavior change) and adds `Settings.statusText.test.jsx`.
- Covers: `titleCase`'s underscore/dash-to-space + capitalization and empty-input case; `formatUsageSource`'s unavailable/ok/partial/fallback branches; `getErrorText`'s precedence order (AbortError > details.message > message > generic fallback).

## Test plan
- [x] `npx vitest run src/pages/Settings.statusText.test.jsx src/pages/Settings.test.jsx` — 18/18 passed, no regression
- [x] `npx eslint` on both changed files — no errors