### PR TITLE
test(dashboard): add coverage for Dashboard format/clamp helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Dashboard.format.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.format.test.jsx
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'vitest'
+import { formatTokenCount, formatUptime, clamp } from './Dashboard'
+
+describe('formatTokenCount', () => {
+  test('formats billions/millions/thousands with a unit suffix', () => {
+    expect(formatTokenCount(1_500_000_000)).toBe('1.5B')
+    expect(formatTokenCount(1_500_000)).toBe('1.5M')
+    expect(formatTokenCount(1_234)).toBe('1.2k')
+  })
+
+  test('renders small values as-is with no suffix', () => {
+    expect(formatTokenCount(0)).toBe('0')
+    expect(formatTokenCount(999)).toBe('999')
+  })
+})
+
+describe('formatUptime', () => {
+  test('renders days, hours, and minutes when uptime spans a day or more', () => {
+    expect(formatUptime(90061)).toBe('1d 1h 1m')
+  })
+
+  test('renders hours and minutes for a sub-day uptime', () => {
+    expect(formatUptime(3661)).toBe('1h 1m')
+  })
+
+  test('renders only minutes for a sub-hour uptime', () => {
+    expect(formatUptime(120)).toBe('2m')
+  })
+
+  test('renders an em-dash for zero/falsy uptime (unlike Settings.jsx\'s formatUptime, which renders "0m")', () => {
+    expect(formatUptime(0)).toBe('—')
+    expect(formatUptime(null)).toBe('—')
+    expect(formatUptime(undefined)).toBe('—')
+  })
+})
+
+describe('clamp', () => {
+  test('returns the value unchanged when within range', () => {
+    expect(clamp(5, 0, 10)).toBe(5)
+  })
+
+  test('clamps to the minimum', () => {
+    expect(clamp(-5, 0, 10)).toBe(0)
+  })
+
+  test('clamps to the maximum', () => {
+    expect(clamp(15, 0, 10)).toBe(10)
+  })
+
+  test('handles min === max', () => {
+    expect(clamp(5, 3, 3)).toBe(3)
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -144,7 +144,7 @@ function normalizeFeatureStatus(featureStatus) {
 }
 
 // Format large token counts: 1234 → "1.2k", 1500000 → "1.5M", 1500000000 → "1.5B"
-function formatTokenCount(n) {
+export function formatTokenCount(n) {
   if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`
   if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
   if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
@@ -152,7 +152,7 @@ function formatTokenCount(n) {
 }
 
 // Format uptime: 90061 → "1d 1h 1m"
-function formatUptime(seconds) {
+export function formatUptime(seconds) {
   if (!seconds) return '—'
   const d = Math.floor(seconds / 86400)
   const h = Math.floor((seconds % 86400) / 3600)
@@ -162,7 +162,7 @@ function formatUptime(seconds) {
   return `${m}m`
 }
 
-function clamp(value, min, max) {
+export function clamp(value, min, max) {
   return Math.min(max, Math.max(min, value))
 }
 


### PR DESCRIPTION
## Summary
- `formatTokenCount`, `formatUptime`, and `clamp` had no test — `Dashboard.test.jsx` never asserts formatted uptime or token-count text.
- Exports the three functions (no behavior change) and adds `Dashboard.format.test.jsx`.
- Covers: `formatTokenCount`'s B/M/k suffixing and small-value passthrough; `formatUptime`'s day/hour/minute branches and its zero/falsy → em-dash behavior (worth noting: `Settings.jsx` has its own separate `formatUptime` that renders `"0m"` for zero instead — the two are deliberately different, not duplicated); `clamp`'s within-range/below-min/above-max/min-equals-max cases.

## Test plan
- [x] `npx vitest run src/pages/Dashboard.format.test.jsx` — 10/10 passed
- [x] `npx vitest run src/pages/Dashboard.test.jsx` (existing suite) — 20/20 still passing
- [x] `npx eslint` on both changed files — no errors