### PR TITLE
test(dashboard): add coverage for Dashboard service description/key helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -219,7 +219,7 @@ function normalizeMetricNumber(value) {
   return Number.isFinite(n) && n > 0 ? n : 0
 }
 
-function normalizeServiceKey(value) {
+export function normalizeServiceKey(value) {
   return String(value || '')
     .toLowerCase()
     .replace(/\([^)]*\)/g, '')
@@ -227,7 +227,7 @@ function normalizeServiceKey(value) {
     .replace(/^-+|-+$/g, '')
 }
 
-function getServiceDescription(id, name) {
+export function getServiceDescription(id, name) {
   const key = normalizeServiceKey(id || name)
   return SERVICE_DESCRIPTIONS[id] || SERVICE_DESCRIPTIONS[key] || 'ODS service'
 }

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.serviceDescription.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.serviceDescription.test.jsx
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'vitest'
+import { normalizeServiceKey, getServiceDescription } from './Dashboard'
+
+describe('normalizeServiceKey', () => {
+  test('lowercases, strips parenthetical suffixes, and hyphenates', () => {
+    expect(normalizeServiceKey('llama-server (LLM Inference)')).toBe('llama-server')
+  })
+
+  test('collapses runs of non-alphanumeric characters into a single hyphen', () => {
+    expect(normalizeServiceKey('Open   WebUI!!')).toBe('open-webui')
+  })
+
+  test('trims leading/trailing hyphens', () => {
+    expect(normalizeServiceKey('  --n8n--  ')).toBe('n8n')
+  })
+
+  test('returns an empty string for a missing value', () => {
+    expect(normalizeServiceKey(null)).toBe('')
+    expect(normalizeServiceKey(undefined)).toBe('')
+  })
+})
+
+describe('getServiceDescription', () => {
+  test('matches by the exact id first', () => {
+    expect(getServiceDescription('llama-server', 'Anything')).toBe('Local model inference runtime')
+  })
+
+  test('falls back to a normalized-key match when the raw id has no entry', () => {
+    expect(getServiceDescription('llama-server (LLM Inference)', null)).toBe('Local model inference runtime')
+  })
+
+  test('falls back to normalizing the name when no id is given', () => {
+    expect(getServiceDescription(null, 'Open WebUI (Chat)')).toBe('Chat interface for local models')
+  })
+
+  test('returns the generic fallback for an unrecognized service', () => {
+    expect(getServiceDescription('some-future-service', 'Future Service')).toBe('ODS service')
+  })
+})


### PR DESCRIPTION
## Summary
- `normalizeServiceKey` and `getServiceDescription` had no test — service tile descriptions render whatever these produce with no verification.
- Exports both (no behavior change) and adds `Dashboard.serviceDescription.test.jsx`.
- Covers: key normalization (parenthetical suffix stripping, non-alphanumeric collapsing, hyphen trimming, missing-value handling), and description lookup's exact-id → normalized-key (via id or name) → generic-fallback precedence.

## Test plan
- [x] `npx vitest run src/pages/Dashboard.serviceDescription.test.jsx` — 8/8 passed
- [x] `npx vitest run src/pages/Dashboard.test.jsx` (existing suite) — 20/20 still passing
- [x] `npx eslint` on both changed files — no errors