### PR TITLE
test(dashboard): add coverage for ServiceMap layout/status helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -107,11 +107,11 @@ const STATUS = {
   unknown: { color: '#6b7280', text: 'text-zinc-500', dot: 'bg-zinc-500' },
 }
 
-function statusMeta(status) {
+export function statusMeta(status) {
   return STATUS[status] || STATUS.unknown
 }
 
-function normalizeStatus(status) {
+export function normalizeStatus(status) {
   return status || 'unknown'
 }
 
@@ -160,7 +160,7 @@ export function buildTopology(statusData) {
   return { nodes, edges }
 }
 
-function computeLayout(nodes) {
+export function computeLayout(nodes) {
   const rows = Object.fromEntries(LAYERS.map(layer => [layer, []]))
   for (const node of nodes) rows[node.category || 'other']?.push(node)
   for (const row of Object.values(rows)) row.sort((a, b) => a.name.localeCompare(b.name))
@@ -186,7 +186,7 @@ function computeLayout(nodes) {
   return { positions, layerY, svgWidth, svgHeight: Math.max(MIN_H, y + 40) }
 }
 
-function edgePath(source, target) {
+export function edgePath(source, target) {
   const sx = source.x + NODE_W / 2
   const sy = source.y + (source.y > target.y ? 0 : NODE_H)
   const tx = target.x + NODE_W / 2

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.layout.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.layout.test.jsx
@@ -1,0 +1,101 @@
+import { describe, test, expect } from 'vitest'
+import { statusMeta, normalizeStatus, computeLayout, edgePath } from './ServiceMap'
+
+describe('statusMeta', () => {
+  test('returns the meta for a known status', () => {
+    expect(statusMeta('healthy').text).toBe('text-green-400')
+    expect(statusMeta('degraded').text).toBe('text-yellow-400')
+  })
+
+  test('falls back to the unknown meta for an unrecognized status', () => {
+    expect(statusMeta('some-future-status')).toEqual(statusMeta('unknown'))
+    expect(statusMeta(undefined)).toEqual(statusMeta('unknown'))
+  })
+})
+
+describe('normalizeStatus', () => {
+  test('passes a real status through unchanged', () => {
+    expect(normalizeStatus('healthy')).toBe('healthy')
+  })
+
+  test('defaults to "unknown" for a missing status', () => {
+    expect(normalizeStatus(null)).toBe('unknown')
+    expect(normalizeStatus(undefined)).toBe('unknown')
+    expect(normalizeStatus('')).toBe('unknown')
+  })
+})
+
+describe('computeLayout', () => {
+  test('places nodes into rows by category and sizes the canvas to fit', () => {
+    const nodes = [
+      { id: 'a', name: 'Alpha', category: 'core' },
+      { id: 'b', name: 'Beta', category: 'core' },
+      { id: 'c', name: 'Gamma', category: 'middleware' },
+    ]
+    const layout = computeLayout(nodes)
+    expect(Object.keys(layout.positions)).toEqual(['a', 'b', 'c'])
+    // core row has 2 nodes -> a's row starts before b's (sorted alphabetically).
+    expect(layout.positions.a.x).toBeLessThan(layout.positions.b.x)
+    expect(layout.positions.a.y).toBe(layout.positions.b.y)
+    // middleware is a separate row, below core.
+    expect(layout.layerY.middleware).toBeGreaterThan(layout.layerY.core)
+  })
+
+  test('sorts nodes within a row alphabetically by name', () => {
+    const nodes = [
+      { id: 'z', name: 'Zebra', category: 'core' },
+      { id: 'a', name: 'Alpha', category: 'core' },
+    ]
+    const layout = computeLayout(nodes)
+    expect(layout.positions.a.x).toBeLessThan(layout.positions.z.x)
+  })
+
+  test('a missing category falls back to "other"', () => {
+    const nodes = [{ id: 'x', name: 'X' }]
+    const layout = computeLayout(nodes)
+    expect(layout.positions.x).toBeDefined()
+  })
+
+  test('an explicit category not in LAYERS is silently dropped from the layout (rows[cat]?.push is a no-op)', () => {
+    // Only a falsy category falls back to "other" (node.category || 'other').
+    // An explicit unrecognized string looks up a row that doesn't exist in
+    // `rows`, and the optional-chained push silently does nothing -- the
+    // node never gets a position. In the real app this can't happen because
+    // buildTopology() always assigns category via `CATEGORY_MAP[id] || 'other'`,
+    // but computeLayout() itself has no such guard for a directly-passed node.
+    const nodes = [{ id: 'x', name: 'X', category: 'nonexistent-category' }]
+    const layout = computeLayout(nodes)
+    expect(layout.positions.x).toBeUndefined()
+  })
+
+  test('enforces a minimum canvas size for a small graph', () => {
+    const layout = computeLayout([{ id: 'a', name: 'Alpha', category: 'core' }])
+    expect(layout.svgWidth).toBeGreaterThanOrEqual(1080)
+    expect(layout.svgHeight).toBeGreaterThanOrEqual(720)
+  })
+
+  test('handles an empty node list without crashing', () => {
+    const layout = computeLayout([])
+    expect(layout.positions).toEqual({})
+  })
+})
+
+describe('edgePath', () => {
+  test('draws downward when the target is below the source', () => {
+    const source = { x: 0, y: 0 }
+    const target = { x: 100, y: 200 }
+    const path = edgePath(source, target)
+    expect(path.startsWith('M')).toBe(true)
+    expect(path).toContain('L')
+  })
+
+  test('draws upward when the target is above the source', () => {
+    const source = { x: 0, y: 200 }
+    const target = { x: 100, y: 0 }
+    const downPath = edgePath({ x: 0, y: 0 }, { x: 100, y: 200 })
+    const upPath = edgePath(source, target)
+    // The two orientations should produce different path data (the
+    // source/target connection points swap sides based on relative y).
+    expect(upPath).not.toBe(downPath)
+  })
+})


### PR DESCRIPTION
## Summary
- `statusMeta`, `normalizeStatus`, `computeLayout`, and `edgePath` had no test — `ServiceMap.test.jsx` only unit-tests `buildTopology` and never renders `<ServiceMap>`, so the node/edge layout helpers were completely unexercised.
- Exports all four (no behavior change) and adds `ServiceMap.layout.test.jsx`.
- Covers: status meta lookup with the unknown-status fallback, status normalization, row placement/alphabetical sort/canvas sizing/empty-list handling for `computeLayout`, and up-vs-down edge path direction for `edgePath`.
- Also documents a real edge case found while writing the tests: `computeLayout` only falls back to `"other"` for a **falsy** category (`node.category || 'other'`) — an explicit unrecognized category string looks up a row that doesn't exist in the internal `rows` map, and the optional-chained `push` silently drops the node from the layout. This isn't reachable through the normal `buildTopology → computeLayout` flow (`buildTopology` always assigns category via `CATEGORY_MAP[id] || 'other'`), but it's a real gap in `computeLayout` itself if ever called directly with a node carrying an unrecognized category — noted in the test's comment rather than filed as a separate fix, since it's currently unreachable in practice.

## Test plan
- [x] `npx vitest run src/pages/ServiceMap.layout.test.jsx` — 12/12 passed
- [x] `npx vitest run src/pages/ServiceMap.test.jsx` (existing suite) — 2/2 still passing
- [x] `npx eslint` on both changed files — no errors