### PR TITLE
test(dashboard): add coverage for RemoteProvider boolLabel/modelSize/errorMessage

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.format.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.format.test.jsx
@@ -1,0 +1,57 @@
+import { describe, test, expect } from 'vitest'
+import { boolLabel, modelSize, errorMessage } from './RemoteProvider'
+
+describe('boolLabel', () => {
+  test('renders Yes for a truthy value', () => {
+    expect(boolLabel(true)).toBe('Yes')
+    expect(boolLabel(1)).toBe('Yes')
+  })
+
+  test('renders No for a falsy value', () => {
+    expect(boolLabel(false)).toBe('No')
+    expect(boolLabel(null)).toBe('No')
+    expect(boolLabel(undefined)).toBe('No')
+    expect(boolLabel(0)).toBe('No')
+  })
+})
+
+describe('modelSize', () => {
+  test('prefers an explicit size string', () => {
+    expect(modelSize({ size: '4.2 GB', sizeGb: 999 })).toBe('4.2 GB')
+  })
+
+  test('formats sizeGb to one decimal place when size is absent', () => {
+    expect(modelSize({ sizeGb: 7.456 })).toBe('7.5 GB')
+  })
+
+  test('returns null when neither field is usable', () => {
+    expect(modelSize({})).toBeNull()
+    expect(modelSize(null)).toBeNull()
+    expect(modelSize({ sizeGb: 'not-a-number' })).toBeNull()
+  })
+})
+
+describe('errorMessage', () => {
+  test('prefers a plain string detail', () => {
+    expect(errorMessage({ detail: 'not found' }, 'fallback')).toBe('not found')
+  })
+
+  test('falls back to detail.message, then detail.error, within an object detail', () => {
+    expect(errorMessage({ detail: { message: 'msg form' } }, 'fallback')).toBe('msg form')
+    expect(errorMessage({ detail: { error: 'err form' } }, 'fallback')).toBe('err form')
+  })
+
+  test('falls back to a top-level message or error string', () => {
+    expect(errorMessage({ message: 'top message' }, 'fallback')).toBe('top message')
+    expect(errorMessage({ error: 'top error' }, 'fallback')).toBe('top error')
+  })
+
+  test('treats a blank/whitespace-only detail as absent and falls through', () => {
+    expect(errorMessage({ detail: '   ' }, 'fallback')).toBe('fallback')
+  })
+
+  test('falls back to the provided default when nothing matches', () => {
+    expect(errorMessage({}, 'fallback')).toBe('fallback')
+    expect(errorMessage(null, 'fallback')).toBe('fallback')
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -44,7 +44,7 @@ function titleize(value) {
     .replace(/^./, char => char.toUpperCase())
 }
 
-function boolLabel(value) {
+export function boolLabel(value) {
   return value ? 'Yes' : 'No'
 }
 
@@ -108,7 +108,7 @@ function modelStatus(model, currentModel) {
   return typeof model?.status === 'string' && model.status.trim() ? model.status.trim() : 'unknown'
 }
 
-function modelSize(model) {
+export function modelSize(model) {
   if (model?.size) return model.size
   if (typeof model?.sizeGb === 'number' && Number.isFinite(model.sizeGb)) return `${model.sizeGb.toFixed(1)} GB`
   return null
@@ -145,7 +145,7 @@ async function responsePayload(response) {
   }
 }
 
-function errorMessage(payload, fallback) {
+export function errorMessage(payload, fallback) {
   if (typeof payload?.detail === 'string' && payload.detail.trim()) return payload.detail
   if (payload?.detail && typeof payload.detail === 'object') {
     if (typeof payload.detail.message === 'string' && payload.detail.message.trim()) return payload.detail.message


### PR DESCRIPTION
## Summary
- `boolLabel`, `modelSize`, and `errorMessage` had no test — every existing `RemoteProvider.test.jsx` fixture happens to supply a size string or a non-error response, never exercising these specific formatting/fallback paths.
- Exports the three functions (no behavior change) and adds `RemoteProvider.format.test.jsx`.
- Covers: `boolLabel`'s Yes/No mapping; `modelSize`'s explicit-size vs `sizeGb`-formatting vs null-fallback precedence; `errorMessage`'s full chain (string `detail` → `detail.message` → `detail.error` → top-level `message` → top-level `error` → fallback), including that a blank/whitespace-only string is treated as absent.

## Test plan
- [x] `npx vitest run src/pages/RemoteProvider.format.test.jsx` — 10/10 passed
- [x] `npx vitest run src/pages/RemoteProvider.test.jsx` (existing suite) — 10/10 still passing
- [x] `npx eslint` on both changed files — no errors