### PR TITLE
test(dashboard): add coverage for FirstBoot progress persistence

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -50,7 +50,7 @@ const STACK_OPTIONS = [
 
 const TOTAL_STEPS = 4
 
-function readProgress() {
+export function readProgress() {
   try {
     const raw = globalThis.localStorage?.getItem(PROGRESS_KEY)
     return raw ? JSON.parse(raw) : null
@@ -59,7 +59,7 @@ function readProgress() {
   }
 }
 
-function writeProgress(progress) {
+export function writeProgress(progress) {
   try {
     globalThis.localStorage?.setItem(PROGRESS_KEY, JSON.stringify(progress))
   } catch {
@@ -67,7 +67,7 @@ function writeProgress(progress) {
   }
 }
 
-function clearProgress() {
+export function clearProgress() {
   try {
     globalThis.localStorage?.removeItem(PROGRESS_KEY)
   } catch {

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.progress.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.progress.test.jsx
@@ -1,0 +1,54 @@
+import { describe, test, expect, beforeEach } from 'vitest'
+import { readProgress, writeProgress, clearProgress } from './FirstBoot'
+
+const PROGRESS_KEY = 'ods-firstboot-progress'
+
+describe('FirstBoot progress persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  test('readProgress returns null when nothing is stored', () => {
+    expect(readProgress()).toBeNull()
+  })
+
+  test('writeProgress then readProgress round-trips the wizard state', () => {
+    const progress = { step: 3, deviceName: 'ods', username: 'owner', stack: 'chat-agents' }
+    writeProgress(progress)
+    expect(readProgress()).toEqual(progress)
+    expect(window.localStorage.getItem(PROGRESS_KEY)).toBe(JSON.stringify(progress))
+  })
+
+  test('clearProgress removes the stored state', () => {
+    writeProgress({ step: 2 })
+    clearProgress()
+    expect(readProgress()).toBeNull()
+    expect(window.localStorage.getItem(PROGRESS_KEY)).toBeNull()
+  })
+
+  test('readProgress returns null (not throw) for malformed JSON in storage', () => {
+    window.localStorage.setItem(PROGRESS_KEY, '{not valid json')
+    expect(() => readProgress()).not.toThrow()
+    expect(readProgress()).toBeNull()
+  })
+
+  test('writeProgress does not throw when localStorage.setItem fails', () => {
+    const original = window.localStorage.setItem
+    window.localStorage.setItem = () => { throw new Error('quota exceeded') }
+    try {
+      expect(() => writeProgress({ step: 1 })).not.toThrow()
+    } finally {
+      window.localStorage.setItem = original
+    }
+  })
+
+  test('clearProgress does not throw when localStorage.removeItem fails', () => {
+    const original = window.localStorage.removeItem
+    window.localStorage.removeItem = () => { throw new Error('blocked') }
+    try {
+      expect(() => clearProgress()).not.toThrow()
+    } finally {
+      window.localStorage.removeItem = original
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- `readProgress`/`writeProgress`/`clearProgress` persist the wizard's step, device name, username, and stack choice to `localStorage` so a phone refresh mid-wizard doesn't lose state — but the persistence round-trip itself was untested; `FirstBoot.test.jsx` only clears the storage key in setup/teardown.
- Exports the three functions (no behavior change) and adds `FirstBoot.progress.test.jsx`.
- Covers: the round-trip (write then read matches), clearing, a malformed-JSON read degrading to `null` instead of throwing, and both write/clear silently tolerating a `localStorage` failure (private-browsing/quota-exceeded scenarios).

## Test plan
- [x] `npx vitest run src/pages/FirstBoot.progress.test.jsx` — 6/6 passed
- [x] `npx vitest run src/pages/FirstBoot.test.jsx` (existing suite) — 10/10 still passing
- [x] `npx eslint` on both changed files — no errors