### PR TITLE
test(dashboard): add coverage for Usage formatCompact/formatInteger

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.format.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.format.test.jsx
@@ -1,0 +1,34 @@
+import { describe, test, expect } from 'vitest'
+import { formatCompact, formatInteger } from './Usage'
+
+describe('formatCompact', () => {
+  test('formats billions/millions/thousands with a unit suffix', () => {
+    expect(formatCompact(2_500_000_000)).toBe('2.5B')
+    expect(formatCompact(1_500_000)).toBe('1.5M')
+    expect(formatCompact(3_400)).toBe('3.4k')
+  })
+
+  test('rounds small values to a whole number with no suffix', () => {
+    expect(formatCompact(42.6)).toBe('43')
+  })
+
+  test('treats missing/falsy values as 0', () => {
+    expect(formatCompact(undefined)).toBe('0')
+    expect(formatCompact(null)).toBe('0')
+  })
+})
+
+describe('formatInteger', () => {
+  test('formats with thousands separators', () => {
+    expect(formatInteger(1234567)).toBe('1,234,567')
+  })
+
+  test('rounds a fractional value', () => {
+    expect(formatInteger(42.6)).toBe('43')
+  })
+
+  test('treats missing/falsy values as 0', () => {
+    expect(formatInteger(undefined)).toBe('0')
+    expect(formatInteger(null)).toBe('0')
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -153,7 +153,7 @@ function formatCurrencyAxis(value) {
   return formatCurrency(number)
 }
 
-function formatCompact(value) {
+export function formatCompact(value) {
   const number = Number(value || 0)
   if (number >= 1_000_000_000) return `${(number / 1_000_000_000).toFixed(1)}B`
   if (number >= 1_000_000) return `${(number / 1_000_000).toFixed(1)}M`
@@ -161,7 +161,7 @@ function formatCompact(value) {
   return `${Math.round(number)}`
 }
 
-function formatInteger(value) {
+export function formatInteger(value) {
   return new Intl.NumberFormat('en-US').format(Math.round(Number(value || 0)))
 }
 


### PR DESCRIPTION
## Summary
- `formatCompact` and `formatInteger` drive most of the token-count text on the Usage page (Input/Output/tracked tokens, etc.), but `Usage.test.jsx` checks structural headings and currency only — no test ever asserted a compact or integer token value.
- Exports both (no behavior change) and adds `Usage.format.test.jsx`.
- Covers: `formatCompact`'s B/M/k suffixing, small-value rounding, and missing-value default; `formatInteger`'s thousands-separator formatting, fractional rounding, and missing-value default.

## Test plan
- [x] `npx vitest run src/pages/Usage.format.test.jsx` — 6/6 passed
- [x] `npx vitest run src/pages/Usage.test.jsx` (existing suite) — 7/7 still passing
- [x] `npx eslint` on both changed files — no errors