### PR TITLE
test(dashboard): add coverage for Usage computeDelta

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.computeDelta.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.computeDelta.test.jsx
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vitest'
+import { computeDelta } from './Usage'
+
+describe('computeDelta', () => {
+  test('computes a positive percentage change', () => {
+    expect(computeDelta(150, 100)).toBe(50)
+  })
+
+  test('computes a negative percentage change', () => {
+    expect(computeDelta(75, 100)).toBe(-25)
+  })
+
+  test('returns null when the previous value is zero (division by zero guard)', () => {
+    expect(computeDelta(100, 0)).toBeNull()
+  })
+
+  test('returns null when the previous value is negative', () => {
+    expect(computeDelta(100, -10)).toBeNull()
+  })
+
+  test('returns null when the previous value is missing', () => {
+    expect(computeDelta(100, null)).toBeNull()
+    expect(computeDelta(100, undefined)).toBeNull()
+  })
+
+  test('treats a missing current value as 0', () => {
+    expect(computeDelta(undefined, 100)).toBe(-100)
+  })
+
+  test('returns 0 when current equals previous', () => {
+    expect(computeDelta(100, 100)).toBe(0)
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -176,7 +176,7 @@ function formatRangeLabel(range) {
   return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} - ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`
 }
 
-function computeDelta(current, previous) {
+export function computeDelta(current, previous) {
   const prev = Number(previous || 0)
   if (prev <= 0) return null
   return ((Number(current || 0) - prev) / prev) * 100


### PR DESCRIPTION
## Summary
- `computeDelta()` drives the period-over-period delta arrows/percentages on Usage summary tiles, but had no test.
- Exports the function (no behavior change) and adds `Usage.computeDelta.test.jsx`.
- Covers: positive/negative percentage change, the zero/negative-previous division-by-zero guard (returns `null`), missing previous/current values, and the equal-values zero case.

## Test plan
- [x] `npx vitest run src/pages/Usage.computeDelta.test.jsx` — 7/7 passed
- [x] `npx vitest run src/pages/Usage.test.jsx` (existing suite) — 7/7 still passing
- [x] `npx eslint` on both changed files — no errors