### PR TITLE
fix(dashboard): guard buildSparkShape against non-numeric values producing NaN

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -182,9 +182,12 @@ function computeDelta(current, previous) {
   return ((Number(current || 0) - prev) / prev) * 100
 }
 
-function buildSparkShape(values, width = 126, height = 46) {
+export function buildSparkShape(values, width = 126, height = 46) {
   if (!values.length) return { line: '', area: '' }
-  const numericValues = values.map(value => Number(value || 0))
+  const numericValues = values.map(value => {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : 0
+  })
   const max = Math.max(...numericValues)
   const min = Math.min(...numericValues)
   const spread = max === min ? (Math.abs(max) || 1) : max - min

--- a/ods/extensions/services/dashboard/src/pages/Usage.sparkShape.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.sparkShape.test.jsx
@@ -1,0 +1,42 @@
+import { describe, test, expect } from 'vitest'
+import { buildSparkShape } from './Usage'
+
+describe('buildSparkShape', () => {
+  test('returns empty line/area for no values', () => {
+    expect(buildSparkShape([])).toEqual({ line: '', area: '' })
+  })
+
+  test('builds an SVG path starting with M for a single value', () => {
+    const { line, area } = buildSparkShape([5])
+    expect(line.startsWith('M')).toBe(true)
+    expect(area).toContain('Z')
+  })
+
+  test('spans the full width for multiple values, first point at x=0', () => {
+    const { line } = buildSparkShape([1, 2, 3], 100, 50)
+    const firstPoint = line.split(' ').slice(0, 3).join(' ')
+    expect(firstPoint).toBe('M 0.00 44.00')
+  })
+
+  test('does not divide by zero when all values are identical', () => {
+    const { line } = buildSparkShape([7, 7, 7], 100, 50)
+    expect(line).not.toContain('NaN')
+    expect(line).not.toContain('Infinity')
+  })
+
+  test('does not divide by zero when all values are identically zero', () => {
+    const { line } = buildSparkShape([0, 0, 0], 100, 50)
+    expect(line).not.toContain('NaN')
+  })
+
+  test('treats missing/non-numeric entries as 0', () => {
+    const { line } = buildSparkShape([null, undefined, 'x'], 100, 50)
+    expect(line).not.toContain('NaN')
+  })
+
+  test('the area path closes back to the baseline forming a filled region', () => {
+    const { line, area } = buildSparkShape([1, 5, 2], 100, 50)
+    expect(area.startsWith(line)).toBe(true)
+    expect(area).toMatch(/L 100\.00 46\.00 L 0 46\.00 Z$/)
+  })
+})


### PR DESCRIPTION
## Summary
- Found while adding test coverage for `buildSparkShape` (which had no test at all): the function coerced values via `Number(value || 0)`, which only catches **falsy** inputs (`null`/`undefined`/`0`/`''`).
- A truthy non-numeric value — e.g. a corrupted history entry like `"x"` — makes `value || 0` evaluate to the string itself, so `Number("x")` returns `NaN`. That `NaN` then poisons `Math.max`/`Math.min` across the whole series, breaking **every** point's y-coordinate into `NaN` and rendering an invalid SVG path for the entire sparkline, not just the one bad sample.
- Fixes it to use `Number.isFinite()` explicitly, falling back to 0 only for genuinely non-numeric values, and exports the function (no other behavior change) with a full unit test.

## Test plan
- [x] Reproduced the bug first (`buildSparkShape([null, undefined, 'x'])` produced `"M 0.00 NaN L 50.00 NaN L 100.00 NaN"`), then fixed and re-verified
- [x] `npx vitest run src/pages/Usage.sparkShape.test.jsx` — 7/7 passed, including the non-numeric-entry case
- [x] `npx vitest run src/pages/Usage.test.jsx` (existing suite) — 7/7 still passing, no regression
- [x] `npx eslint` on both changed files — no errors