### PR TITLE
test(dashboard): add coverage for Usage date-label helpers

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.dateLabels.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.dateLabels.test.jsx
@@ -1,0 +1,25 @@
+import { describe, test, expect } from 'vitest'
+import { formatDateLabel, formatRangeLabel } from './Usage'
+
+describe('formatDateLabel', () => {
+  test('formats a date key as "Mon D"', () => {
+    expect(formatDateLabel('2026-05-16')).toBe('May 16')
+  })
+
+  test('does not shift across a month/year boundary (local midnight parsing)', () => {
+    expect(formatDateLabel('2026-01-01')).toBe('Jan 1')
+    expect(formatDateLabel('2025-12-31')).toBe('Dec 31')
+  })
+})
+
+describe('formatRangeLabel', () => {
+  test('formats a same-month range as "Mon D - Mon D, YYYY"', () => {
+    const label = formatRangeLabel({ start: '2026-05-01', end: '2026-05-31' })
+    expect(label).toBe('May 1 - May 31, 2026')
+  })
+
+  test('formats a cross-month range showing both month names', () => {
+    const label = formatRangeLabel({ start: '2026-04-15', end: '2026-05-15' })
+    expect(label).toBe('Apr 15 - May 15, 2026')
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -165,12 +165,12 @@ function formatInteger(value) {
   return new Intl.NumberFormat('en-US').format(Math.round(Number(value || 0)))
 }
 
-function formatDateLabel(dateKey) {
+export function formatDateLabel(dateKey) {
   const date = new Date(`${dateKey}T00:00:00`)
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
-function formatRangeLabel(range) {
+export function formatRangeLabel(range) {
   const start = new Date(`${range.start}T00:00:00`)
   const end = new Date(`${range.end}T00:00:00`)
   return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} - ${end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}`


### PR DESCRIPTION
## Summary
- `formatDateLabel` and `formatRangeLabel` render chart-axis labels and the month-range header, but no test ever asserted their date text.
- Exports both (no behavior change) and adds `Usage.dateLabels.test.jsx`.
- Covers: basic "Mon D" formatting, month/year-boundary dates (Jan 1 / Dec 31), and range labels for both same-month and cross-month spans.

## Test plan
- [x] `npx vitest run src/pages/Usage.dateLabels.test.jsx` — 4/4 passed
- [x] `npx vitest run src/pages/Usage.test.jsx` (existing suite) — 7/7 still passing
- [x] `npx eslint` on both changed files — no errors