### PR TITLE
test(dashboard): add coverage for Usage emptyReport

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.emptyReport.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.emptyReport.test.jsx
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'vitest'
+import { emptyReport } from './Usage'
+
+describe('emptyReport', () => {
+  test('builds a zeroed-out summary and period', () => {
+    const report = emptyReport('2026-05-01', '2026-05-03')
+    expect(report.period).toEqual({ start: '2026-05-01', end: '2026-05-03' })
+    expect(report.summary.spend_usd).toBe(0)
+    expect(report.summary.total_tokens).toBe(0)
+    expect(report.models).toEqual([])
+    expect(report.services).toEqual([])
+    expect(report.sources).toEqual([])
+  })
+
+  test('generates one zeroed daily entry per day in the range, inclusive', () => {
+    const report = emptyReport('2026-05-01', '2026-05-03')
+    expect(report.daily).toHaveLength(3)
+    expect(report.daily.map(d => d.date)).toEqual(['2026-05-01', '2026-05-02', '2026-05-03'])
+    expect(report.daily.every(d => d.spend_usd === 0 && d.requests === 0)).toBe(true)
+  })
+
+  test('produces a single-day list when start equals end', () => {
+    const report = emptyReport('2026-05-01', '2026-05-01')
+    expect(report.daily).toHaveLength(1)
+  })
+
+  test('marks the source as unavailable with the given detail message', () => {
+    const report = emptyReport('2026-05-01', '2026-05-01', 'Token Spy is not installed')
+    expect(report.source).toEqual({
+      name: 'token-spy',
+      status: 'unavailable',
+      detail: 'Token Spy is not installed',
+    })
+  })
+
+  test('defaults detail to null when not provided', () => {
+    const report = emptyReport('2026-05-01', '2026-05-01')
+    expect(report.source.detail).toBeNull()
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -114,7 +114,7 @@ function addMonths(date, delta) {
   return new Date(date.getFullYear(), date.getMonth() + delta, 1)
 }
 
-function emptyReport(start, end, detail = null) {
+export function emptyReport(start, end, detail = null) {
   const startDate = new Date(`${start}T00:00:00`)
   const endDate = new Date(`${end}T00:00:00`)
   const daily = []


### PR DESCRIPTION
## Summary
- `emptyReport()` in `Usage.jsx` builds the zeroed-out fallback report shown on the Usage page when Token Spy is unavailable or a period has no data, but had no direct unit test.
- Exported the function (no behavior change) and added a co-located test file covering the summary/period shape, the inclusive per-day `daily` array (including the single-day edge case), and the `source.detail` message with its default `null`.

## Test plan
- `npx vitest run src/pages/Usage.emptyReport.test.jsx` — 5/5 passed
- `npx vitest run src/pages/Usage.test.jsx` — 7/7 passed (no regression)
- `npx eslint src/pages/Usage.jsx src/pages/Usage.emptyReport.test.jsx` — clean