### PR TITLE
test(dashboard): add coverage for Usage serviceTokens

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -955,7 +955,7 @@ function TopConsumers({ services }) {
   )
 }
 
-function serviceTokens(service) {
+export function serviceTokens(service) {
   return Number(service.input_tokens || 0) + Number(service.output_tokens || 0) + Number(service.cache_read_tokens || 0) + Number(service.cache_write_tokens || 0)
 }
 

--- a/ods/extensions/services/dashboard/src/pages/Usage.serviceTokens.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.serviceTokens.test.jsx
@@ -1,0 +1,33 @@
+import { describe, test, expect } from 'vitest'
+import { serviceTokens } from './Usage'
+
+describe('serviceTokens', () => {
+  test('sums input, output, cache read, and cache write tokens', () => {
+    const total = serviceTokens({
+      input_tokens: 10,
+      output_tokens: 20,
+      cache_read_tokens: 5,
+      cache_write_tokens: 3,
+    })
+    expect(total).toBe(38)
+  })
+
+  test('treats missing token fields as 0', () => {
+    expect(serviceTokens({})).toBe(0)
+  })
+
+  test('treats partially populated fields as 0 for the rest', () => {
+    expect(serviceTokens({ input_tokens: 100 })).toBe(100)
+  })
+
+  test('ignores unrelated fields on the service object', () => {
+    const total = serviceTokens({
+      service: 'llama-server',
+      input_tokens: 1,
+      output_tokens: 1,
+      cache_read_tokens: 0,
+      cache_write_tokens: 0,
+    })
+    expect(total).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- `serviceTokens()` in `Usage.jsx` sums a service's input/output/cache-read/cache-write token counts and feeds both the top-services bar list and the tokens-by-service donut chart, but had no direct unit test.
- Exported the function (no behavior change) and added a co-located test file covering the full sum, missing fields defaulting to 0, partially populated fields, and that unrelated object properties are ignored.

## Test plan
- `npx vitest run src/pages/Usage.serviceTokens.test.jsx src/pages/Usage.test.jsx` — 11/11 passed (no regression)
- `npx eslint src/pages/Usage.jsx src/pages/Usage.serviceTokens.test.jsx` — clean