### PR TITLE
test(dashboard): add coverage for Usage seriesFromHistory

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -268,7 +268,7 @@ function appendUsageHistory(report) {
   return next
 }
 
-function seriesFromHistory(history, key, fallback = []) {
+export function seriesFromHistory(history, key, fallback = []) {
   const values = (history || []).map(sample => Number(sample?.[key] || 0))
   const hasSignal = values.some((value, index) => index > 0 && value !== values[index - 1])
   if (hasSignal) return values

--- a/ods/extensions/services/dashboard/src/pages/Usage.seriesFromHistory.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.seriesFromHistory.test.jsx
@@ -1,0 +1,40 @@
+import { describe, test, expect } from 'vitest'
+import { seriesFromHistory } from './Usage'
+
+describe('seriesFromHistory', () => {
+  test('returns the raw values when they vary across samples', () => {
+    const history = [{ spend_usd: 1 }, { spend_usd: 4 }, { spend_usd: 2 }]
+    expect(seriesFromHistory(history, 'spend_usd')).toEqual([1, 4, 2])
+  })
+
+  test('falls back to the provided series when history is flat and the fallback has signal', () => {
+    const history = [{ spend_usd: 5 }, { spend_usd: 5 }, { spend_usd: 5 }]
+    const fallback = [0, 3, 7]
+    expect(seriesFromHistory(history, 'spend_usd', fallback)).toBe(fallback)
+  })
+
+  test('returns the flat values when both history and fallback are flat/zero', () => {
+    const history = [{ spend_usd: 0 }, { spend_usd: 0 }]
+    expect(seriesFromHistory(history, 'spend_usd', [0, 0])).toEqual([0, 0])
+  })
+
+  test('returns the flat values when history is flat and no fallback is given', () => {
+    const history = [{ spend_usd: 5 }, { spend_usd: 5 }]
+    expect(seriesFromHistory(history, 'spend_usd')).toEqual([5, 5])
+  })
+
+  test('treats missing key values as 0', () => {
+    const history = [{}, { spend_usd: 3 }, {}]
+    expect(seriesFromHistory(history, 'spend_usd')).toEqual([0, 3, 0])
+  })
+
+  test('treats a null/undefined history as an empty series', () => {
+    expect(seriesFromHistory(null, 'spend_usd')).toEqual([])
+    expect(seriesFromHistory(undefined, 'spend_usd', [1, 2])).toEqual([1, 2])
+  })
+
+  test('a single-sample history has no signal and falls back when possible', () => {
+    expect(seriesFromHistory([{ spend_usd: 9 }], 'spend_usd', [1, 2])).toEqual([1, 2])
+    expect(seriesFromHistory([{ spend_usd: 9 }], 'spend_usd')).toEqual([9])
+  })
+})


### PR DESCRIPTION
## Summary
- `seriesFromHistory()` in `Usage.jsx` derives a sparkline series from stored usage history: it returns the live history values when they show movement between samples, and falls back to a caller-provided series when history is flat and the fallback has real signal.
- This derivation logic had no direct test coverage — the existing `Usage.historyStorage`-style tests only cover the underlying storage helpers, not what gets derived from them.
- Exported the function (no behavior change) and added a co-located test file covering: varying history, flat history with a signal-bearing fallback, flat history with an all-zero/no fallback, missing key values defaulting to 0, and null/undefined/single-sample history.

## Test plan
- `npx vitest run src/pages/Usage.seriesFromHistory.test.jsx src/pages/Usage.test.jsx` — 14/14 passed (no regression)
- `npx eslint src/pages/Usage.jsx src/pages/Usage.seriesFromHistory.test.jsx` — clean