### PR TITLE
test(dashboard): add coverage for Models hashString

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.hashString.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.hashString.test.jsx
@@ -1,0 +1,27 @@
+import { describe, test, expect } from 'vitest'
+import { hashString } from './Models'
+
+describe('hashString', () => {
+  test('returns the FNV offset basis for an empty string', () => {
+    expect(hashString('')).toBe(2166136261)
+  })
+
+  test('is deterministic for the same input', () => {
+    expect(hashString('llama-3.1-8b')).toBe(hashString('llama-3.1-8b'))
+  })
+
+  test('produces different hashes for different strings', () => {
+    expect(hashString('llama-3.1-8b')).not.toBe(hashString('mistral-7b'))
+  })
+
+  test('coerces non-string values via String()', () => {
+    expect(hashString(123)).toBe(hashString('123'))
+  })
+
+  test('always returns a non-negative 32-bit unsigned integer', () => {
+    const hash = hashString('some-very-long-model-id:32768')
+    expect(Number.isInteger(hash)).toBe(true)
+    expect(hash).toBeGreaterThanOrEqual(0)
+    expect(hash).toBeLessThanOrEqual(0xffffffff)
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -1954,7 +1954,7 @@ function formatNumber(value) {
   return numeric.toFixed(1)
 }
 
-function hashString(value) {
+export function hashString(value) {
   return String(value).split('').reduce((hash, char) => {
     return ((hash << 5) - hash + char.charCodeAt(0)) >>> 0
   }, 2166136261)


### PR DESCRIPTION
## Summary
- `hashString()` in `Models.jsx` is the deterministic FNV-1a-style hash used to seed each model's speed-profile sparkline (`buildSpeedProfilePoints`), but had no direct unit test.
- Exported the function (no behavior change) and added a co-located test file covering the empty-string base case (FNV offset basis), determinism for repeated calls, differing hashes for differing input, non-string coercion via `String()`, and that the output stays within the unsigned 32-bit integer range.

## Test plan
- `npx vitest run src/pages/Models.hashString.test.jsx src/pages/Models.test.jsx` — 41/41 passed (no regression)
- `npx eslint src/pages/Models.jsx src/pages/Models.hashString.test.jsx` — clean