### PR TITLE
test(dashboard): add coverage for Models getIconTone

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.getIconTone.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.getIconTone.test.jsx
@@ -1,0 +1,29 @@
+import { describe, test, expect } from 'vitest'
+import { getIconTone } from './Models'
+
+describe('getIconTone', () => {
+  test('returns the orange tone when the model does not fit VRAM, regardless of compatibility', () => {
+    const tone = getIconTone({ fitsVram: false }, { tone: 'green', detail: 'Best' })
+    expect(tone).toEqual({ border: 'border-orange-400/35', bg: 'bg-orange-500/10', text: 'text-orange-400' })
+  })
+
+  test('returns the orange tone when model is missing entirely', () => {
+    const tone = getIconTone(null, { tone: 'green', detail: 'Best' })
+    expect(tone.text).toBe('text-orange-400')
+  })
+
+  test('returns the amber tone when compatibility is amber and the model fits', () => {
+    const tone = getIconTone({ fitsVram: true }, { tone: 'amber', detail: 'Good' })
+    expect(tone).toEqual({ border: 'border-amber-400/35', bg: 'bg-amber-500/10', text: 'text-amber-300' })
+  })
+
+  test('returns the accent tone for the best-fit compatibility detail', () => {
+    const tone = getIconTone({ fitsVram: true }, { tone: 'green', detail: 'Best' })
+    expect(tone).toEqual({ border: 'border-theme-accent/35', bg: 'bg-theme-accent/10', text: 'text-theme-accent' })
+  })
+
+  test('falls back to the emerald tone for a fitting, non-amber, non-best model', () => {
+    const tone = getIconTone({ fitsVram: true }, { tone: 'green', detail: 'Good' })
+    expect(tone).toEqual({ border: 'border-emerald-400/30', bg: 'bg-emerald-500/10', text: 'text-emerald-400' })
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -1853,7 +1853,7 @@ function getModelTags(model, hermesMinimumContext) {
   return tags.slice(0, 3)
 }
 
-function getIconTone(model, compatibility) {
+export function getIconTone(model, compatibility) {
   if (!model?.fitsVram) return { border: 'border-orange-400/35', bg: 'bg-orange-500/10', text: 'text-orange-400' }
   if (compatibility.tone === 'amber') return { border: 'border-amber-400/35', bg: 'bg-amber-500/10', text: 'text-amber-300' }
   if (compatibility.detail === 'Best') return { border: 'border-theme-accent/35', bg: 'bg-theme-accent/10', text: 'text-theme-accent' }


### PR DESCRIPTION
## Summary
- `getIconTone()` in `Models.jsx` picks the publisher-icon color tone (border/bg/text classes) for a model row based on VRAM fit and compatibility, but had no direct unit test.
- Exported the function (no behavior change) and added a co-located test file covering: the orange VRAM-mismatch case (including when `model` is missing entirely), the amber compatibility case, the accent best-fit case, and the default emerald fallback.

## Test plan
- `npx vitest run src/pages/Models.getIconTone.test.jsx src/pages/Models.test.jsx` — 41/41 passed (no regression)
- `npx eslint src/pages/Models.jsx src/pages/Models.getIconTone.test.jsx` — clean