### PR TITLE
test(dashboard): add coverage for Models buildModelInsights

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.buildModelInsights.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.buildModelInsights.test.jsx
@@ -1,0 +1,46 @@
+import { describe, test, expect } from 'vitest'
+import { buildModelInsights } from './Models'
+
+describe('buildModelInsights', () => {
+  test('returns all-zero insights for an empty model list', () => {
+    expect(buildModelInsights([])).toEqual([
+      { label: 'Models That Fit Your GPU', value: 0 },
+      { label: 'Installed Models', value: 0 },
+      { label: 'Available Models', value: 0 },
+      { label: 'Installed Storage', value: '0 GB' },
+      { label: 'Catalog Size', value: '0 GB' },
+    ])
+  })
+
+  test('counts fit/installed/available and sums storage across a mixed model list', () => {
+    const models = [
+      { status: 'downloaded', sizeGb: 4.5, fitsVram: true },
+      { status: 'loaded', sizeGb: 8, fitsVram: true },
+      { status: 'available', sizeGb: 2, fitsVram: false },
+      { status: 'incompatible', sizeGb: 1, fitsVram: false },
+    ]
+    expect(buildModelInsights(models)).toEqual([
+      { label: 'Models That Fit Your GPU', value: 2 },
+      { label: 'Installed Models', value: 2 },
+      { label: 'Available Models', value: 1 },
+      { label: 'Installed Storage', value: '12.5 GB' },
+      { label: 'Catalog Size', value: '15.5 GB' },
+    ])
+  })
+
+  test('strips a trailing .0 from whole-number storage totals', () => {
+    const models = [{ status: 'downloaded', sizeGb: 20, fitsVram: true }]
+    const insights = buildModelInsights(models)
+    expect(insights.find(item => item.label === 'Installed Storage').value).toBe('20 GB')
+  })
+
+  test('treats a missing sizeGb as 0 without breaking the sum', () => {
+    const models = [
+      { status: 'downloaded', fitsVram: true },
+      { status: 'downloaded', sizeGb: 3, fitsVram: true },
+    ]
+    const insights = buildModelInsights(models)
+    // formatNumber only strips a trailing .0 for totals >= 10; below that it keeps one decimal.
+    expect(insights.find(item => item.label === 'Installed Storage').value).toBe('3.0 GB')
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -1614,7 +1614,7 @@ function matchesSpeedFilter(model, filter, hermesMinimumContext) {
   return true
 }
 
-function buildModelInsights(models) {
+export function buildModelInsights(models) {
   const installedModels = models.filter(model => ['downloaded', 'loaded'].includes(model.status))
   const installedSize = installedModels.reduce((total, model) => total + Number(model.sizeGb || 0), 0)
   const catalogSize = models.reduce((total, model) => total + Number(model.sizeGb || 0), 0)


### PR DESCRIPTION
## Summary
- `buildModelInsights()` in `Models.jsx` computes the five summary tiles (GPU fit count, installed/available model counts, installed/catalog storage size) shown above the model list, but had no direct unit test.
- Exported the function (no behavior change) and added a co-located test file covering: an empty model list, a mixed list exercising all five tiles, the trailing-`.0` stripping behavior of the underlying `formatNumber` for totals >= 10 vs. below 10, and a missing `sizeGb` defaulting to 0.

## Test plan
- `npx vitest run src/pages/Models.buildModelInsights.test.jsx src/pages/Models.test.jsx` — 40/40 passed (no regression)
- `npx eslint src/pages/Models.jsx src/pages/Models.buildModelInsights.test.jsx` — clean