### PR TITLE
test(dashboard): add coverage for Invites tokenStatus/tokenCanRevoke

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -51,7 +51,7 @@ function isOwnerToken(token) {
   return token.token_type === 'owner'
 }
 
-function tokenStatus(token) {
+export function tokenStatus(token) {
   if (token.revoked_at) return { label: 'revoked', tone: 'bg-theme-border text-theme-text-muted' }
   if (!isOwnerToken(token) && token.expires_at && new Date(token.expires_at).getTime() < Date.now()) {
     return { label: 'expired', tone: 'bg-theme-border text-theme-text-muted' }
@@ -65,7 +65,7 @@ function tokenStatus(token) {
   return { label: 'active', tone: 'bg-green-500/20 text-green-400' }
 }
 
-function tokenCanRevoke(token) {
+export function tokenCanRevoke(token) {
   const status = tokenStatus(token).label
   return status === 'active' || status.startsWith('used')
 }

--- a/ods/extensions/services/dashboard/src/pages/Invites.tokenStatus.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.tokenStatus.test.jsx
@@ -1,0 +1,63 @@
+import { describe, test, expect } from 'vitest'
+import { tokenStatus, tokenCanRevoke } from './Invites'
+
+describe('tokenStatus', () => {
+  test('a revoked token is always revoked, regardless of other fields', () => {
+    const token = { revoked_at: '2026-01-01T00:00:00Z', redemption_count: 3, reusable: true }
+    expect(tokenStatus(token).label).toBe('revoked')
+  })
+
+  test('a non-owner token past its expiry is expired', () => {
+    const token = { token_type: 'guest', expires_at: '2000-01-01T00:00:00Z' }
+    expect(tokenStatus(token).label).toBe('expired')
+  })
+
+  test('an owner token past a nominal expires_at is not treated as expired', () => {
+    const token = { token_type: 'owner', expires_at: '2000-01-01T00:00:00Z' }
+    expect(tokenStatus(token).label).not.toBe('expired')
+  })
+
+  test('a single-use non-reusable non-owner token that has been redeemed is used', () => {
+    const token = { token_type: 'guest', redemption_count: 1, reusable: false }
+    expect(tokenStatus(token).label).toBe('used')
+  })
+
+  test('a reusable token that has been redeemed shows the redemption count', () => {
+    const token = { token_type: 'guest', redemption_count: 4, reusable: true }
+    expect(tokenStatus(token).label).toBe('used x 4')
+  })
+
+  test('an owner token that has been redeemed shows the redemption count, not "used"', () => {
+    const token = { token_type: 'owner', redemption_count: 2, reusable: false }
+    expect(tokenStatus(token).label).toBe('used x 2')
+  })
+
+  test('a fresh, unredeemed, unexpired token is active', () => {
+    const token = { token_type: 'guest', redemption_count: 0 }
+    expect(tokenStatus(token).label).toBe('active')
+  })
+})
+
+describe('tokenCanRevoke', () => {
+  test('an active token can be revoked', () => {
+    expect(tokenCanRevoke({ token_type: 'guest', redemption_count: 0 })).toBe(true)
+  })
+
+  test('a redeemed reusable token (used x N) can still be revoked', () => {
+    expect(tokenCanRevoke({ token_type: 'guest', redemption_count: 2, reusable: true })).toBe(true)
+  })
+
+  test('a revoked token cannot be revoked again', () => {
+    expect(tokenCanRevoke({ revoked_at: '2026-01-01T00:00:00Z' })).toBe(false)
+  })
+
+  test('an expired token cannot be revoked', () => {
+    expect(tokenCanRevoke({ token_type: 'guest', expires_at: '2000-01-01T00:00:00Z' })).toBe(false)
+  })
+
+  test('a single-use, already-used token can still be revoked (its label starts with "used")', () => {
+    // tokenCanRevoke checks status.label.startsWith('used'), which matches both
+    // the plain 'used' label and the 'used x N' label - only revoked/expired block it.
+    expect(tokenCanRevoke({ token_type: 'guest', redemption_count: 1, reusable: false })).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- `tokenStatus()` in `Invites.jsx` derives the status badge shown per invite token (`revoked`, `expired`, `used`, `used x N`, `active`) with a defined precedence, and `tokenCanRevoke()` gates the revoke button off that status. The existing `Invites.test.jsx` only ever renders tokens in the `active` and `revoked` states — the `expired`, `used`, and `used x N` branches, and the owner-token exemption from the expiry/used checks, were never exercised.
- Exported both functions (no behavior change) and added a co-located test file covering every status branch and its precedence (revoked wins over everything; owner tokens skip the expired/used checks), plus `tokenCanRevoke`'s behavior across each resulting status.

## Test plan
- `npx vitest run src/pages/Invites.tokenStatus.test.jsx src/pages/Invites.test.jsx` — 18/18 passed (no regression)
- `npx eslint src/pages/Invites.jsx src/pages/Invites.tokenStatus.test.jsx` — clean