### PR TITLE
test(dashboard): add coverage for Invites formatRelative

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.formatRelative.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.formatRelative.test.jsx
@@ -1,0 +1,45 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest'
+import { formatRelative } from './Invites'
+
+const NOW = new Date('2026-01-01T12:00:00Z')
+
+describe('formatRelative', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('returns null for a missing timestamp', () => {
+    expect(formatRelative(null)).toBeNull()
+    expect(formatRelative(undefined)).toBeNull()
+    expect(formatRelative('')).toBeNull()
+  })
+
+  test('returns null for an unparseable timestamp', () => {
+    expect(formatRelative('not-a-date')).toBeNull()
+  })
+
+  test('collapses sub-minute differences to "just now" / "in seconds"', () => {
+    expect(formatRelative(new Date(NOW.getTime() - 10_000).toISOString())).toBe('just now')
+    expect(formatRelative(new Date(NOW.getTime() + 10_000).toISOString())).toBe('in seconds')
+  })
+
+  test('formats minute-scale differences', () => {
+    expect(formatRelative(new Date(NOW.getTime() - 5 * 60_000).toISOString())).toBe('5m ago')
+    expect(formatRelative(new Date(NOW.getTime() + 5 * 60_000).toISOString())).toBe('in 5m')
+  })
+
+  test('formats hour-scale differences', () => {
+    expect(formatRelative(new Date(NOW.getTime() - 2 * 3_600_000).toISOString())).toBe('2h ago')
+    expect(formatRelative(new Date(NOW.getTime() + 2 * 3_600_000).toISOString())).toBe('in 2h')
+  })
+
+  test('formats day-scale differences', () => {
+    expect(formatRelative(new Date(NOW.getTime() - 3 * 86_400_000).toISOString())).toBe('3d ago')
+    expect(formatRelative(new Date(NOW.getTime() + 3 * 86_400_000).toISOString())).toBe('in 3d')
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -31,7 +31,7 @@ const EXPIRY_PRESETS = [
   { value: 86400, label: '24 hours' },
 ]
 
-function formatRelative(iso) {
+export function formatRelative(iso) {
   if (!iso) return null
   const t = new Date(iso).getTime()
   if (Number.isNaN(t)) return null


### PR DESCRIPTION
## Summary
- `formatRelative()` in `Invites.jsx` turns an ISO timestamp into a relative string (`just now`/`in seconds`, `Xm ago`/`in Xm`, `Xh ago`/`in Xh`, `Xd ago`/`in Xd`) shown next to each invite token, with `null`/unparseable guards.
- No test ever supplied a fixed clock and asserted on the actual formatted output — existing tests only checked for unrelated literal substrings (`'expires'`, `'revoke-only'`), so none of the time-scale branches were verified.
- Exported the function (no behavior change) and added a co-located test file using fake timers pinned to a fixed instant, covering the null/undefined/empty and unparseable-string guards, and every minute/hour/day, past/future branch.

## Test plan
- `npx vitest run src/pages/Invites.formatRelative.test.jsx src/pages/Invites.test.jsx` — 12/12 passed (no regression)
- `npx eslint src/pages/Invites.jsx src/pages/Invites.formatRelative.test.jsx` — clean