### PR TITLE
test(dashboard-api): cover model_routes missing-key and 401/403 branches

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_model_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_routes.py
@@ -222,6 +222,39 @@ def test_route_evidence_rejects_mismatched_probe(test_client, monkeypatch):
     assert resp.status_code == 502
 
 
+def test_route_evidence_returns_503_when_no_internal_key_is_configured(test_client, monkeypatch):
+    # _router_internal_key() falls back from ODS_ROUTER_INTERNAL_KEY to
+    # DASHBOARD_API_KEY; conftest.py always sets DASHBOARD_API_KEY globally, so
+    # this "not configured" branch is only reachable when both are absent.
+    probe_id = str(uuid.uuid4())
+    monkeypatch.delenv("ODS_ROUTER_INTERNAL_KEY", raising=False)
+    monkeypatch.delenv("DASHBOARD_API_KEY", raising=False)
+
+    resp = test_client.get(
+        f"/api/models/routes/{probe_id}",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "Model router evidence key is not configured."
+
+
+def test_route_evidence_maps_router_auth_rejection_to_502(test_client, monkeypatch):
+    probe_id = str(uuid.uuid4())
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "internal-secret")
+    calls = _patch_router_client(monkeypatch, httpx.Response(401, json={"error": "unauthorized"}))
+
+    resp = test_client.get(
+        f"/api/models/routes/{probe_id}",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "Model router rejected the dashboard key."
+    # 401/403 are not in the retry-eligible status set, so the router is only hit once.
+    assert len([call for call in calls if call[0] == "get"]) == 1
+
+
 def test_route_evidence_passes_through_instance_id(test_client, monkeypatch):
     probe_id = str(uuid.uuid4())
     monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "internal-secret")


### PR DESCRIPTION
## Summary
- `get_model_route_evidence()` in `routers/model_routes.py` has two untested branches:
  1. A `503` when neither `ODS_ROUTER_INTERNAL_KEY` nor its `DASHBOARD_API_KEY` fallback is configured — unreachable in every existing test because `conftest.py` sets `DASHBOARD_API_KEY` globally for the whole suite.
  2. A `502` mapping specifically for a `401`/`403` response from the model-router ("rejected the dashboard key"), distinct from the generic `>= 400` passthrough a few lines below it.
- Added a test that clears both env vars to hit the missing-key `503`, and a test that returns a `401` from the fake router client to confirm both the `502` mapping and that `401`/`403` responses aren't retried (unlike `404`/`502`/`503`/`504`, which the existing retry tests already cover).

## Test plan
- `python -m pytest tests/test_model_routes.py -q` — 11/11 passed (no regression)