### PR TITLE
fix(macos): reject translated Bash bootstrap

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -34,6 +34,18 @@ _ods_bash_is_modern() {
   "$1" -c '[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]' >/dev/null 2>&1
 }
 
+_ods_bash_matches_host_arch() {
+  local host_arch candidate_arch
+  [ -x "$1" ] || return 1
+  host_arch="${2:-$(uname -m)}"
+  candidate_arch="$("$1" -c 'uname -m' 2>/dev/null)" || return 1
+  [ "$candidate_arch" = "$host_arch" ]
+}
+
+_ods_bash_is_compatible() {
+  _ods_bash_is_modern "$1" && _ods_bash_matches_host_arch "$1"
+}
+
 # Guard: macOS ships Bash 3.2 (GPL). ods-cli and our libs need Bash 4+.
 if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
   # Default candidate paths cover standard Apple Silicon and Intel Homebrew
@@ -45,7 +57,7 @@ if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
     [ -n "$brew_prefix" ] && candidates=("$brew_prefix/bin/bash" "${candidates[@]}")
   fi
   for candidate in "${candidates[@]}"; do
-    if _ods_bash_is_modern "$candidate"; then
+    if _ods_bash_is_compatible "$candidate"; then
       exec "$candidate" "$0" "$@"
     fi
   done
@@ -75,11 +87,11 @@ if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
   echo "Installing Bash 4+ via Homebrew (one-time setup)..."
   brew install bash || { echo "brew install bash failed" >&2; exit 1; }
   brew_prefix="$(brew --prefix 2>/dev/null)"
-  if [ -n "$brew_prefix" ] && _ods_bash_is_modern "$brew_prefix/bin/bash"; then
+  if [ -n "$brew_prefix" ] && _ods_bash_is_compatible "$brew_prefix/bin/bash"; then
     exec "$brew_prefix/bin/bash" "$0" "$@"
   fi
   for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
-    if _ods_bash_is_modern "$candidate"; then
+    if _ods_bash_is_compatible "$candidate"; then
       exec "$candidate" "$0" "$@"
     fi
   done

--- a/ods/tests/test-bash32-guards.sh
+++ b/ods/tests/test-bash32-guards.sh
@@ -65,5 +65,35 @@ else
     fail "ods-cli config validate should run validate-manifests.sh through active Bash"
 fi
 
+extract_function() {
+    sed -n "/^${1}() {/,/^}/p" "$ROOT_DIR/installers/macos/install-macos.sh"
+}
+
+eval "$(extract_function _ods_bash_matches_host_arch)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+cat > "$TMP_DIR/bash-arm64" <<'EOF'
+#!/bin/sh
+printf 'arm64\n'
+EOF
+cat > "$TMP_DIR/bash-x86_64" <<'EOF'
+#!/bin/sh
+printf 'x86_64\n'
+EOF
+chmod +x "$TMP_DIR/bash-arm64" "$TMP_DIR/bash-x86_64"
+
+if _ods_bash_matches_host_arch "$TMP_DIR/bash-arm64" arm64 \
+    && ! _ods_bash_matches_host_arch "$TMP_DIR/bash-x86_64" arm64; then
+    pass "macOS bootstrap rejects a Rosetta Bash on an arm64 host"
+else
+    fail "macOS bootstrap must compare candidate and host architectures"
+fi
+
+if grep -q 'if _ods_bash_is_compatible "$candidate"' "$ROOT_DIR/installers/macos/install-macos.sh"; then
+    pass "macOS bootstrap gates candidate re-exec on architecture compatibility"
+else
+    fail "macOS bootstrap candidate loop bypasses architecture compatibility"
+fi
+
 echo "Result: $PASS passed, $FAIL failed"
 [[ "$FAIL" -eq 0 ]]

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -373,8 +373,8 @@ bootstrap_dry_line="$(grep -n '\[ "\$_ods_bootstrap_dry_run" = true \]' "$INSTAL
 brew_install_line="$(grep -n '^  brew install bash' "$INSTALLER" | head -1 | cut -d: -f1)"
 [[ -n "$bootstrap_dry_line" && -n "$brew_install_line" && "$bootstrap_dry_line" -lt "$brew_install_line" ]] \
     || fail "Bash bootstrap can mutate the host before honoring --dry-run"
-[[ "$(grep -Fc 'if _ods_bash_is_modern "$candidate"; then' "$INSTALLER")" -eq 2 ]] \
-    || fail "Bash bootstrap can hand off to an unsupported shell and recurse"
+[[ "$(grep -Fc 'if _ods_bash_is_compatible "$candidate"; then' "$INSTALLER")" -eq 2 ]] \
+    || fail "Bash bootstrap can hand off to an unsupported or translated shell"
 pass "cloud health fails closed and dry-run skips host-agent mutation"
 
 echo "[OK] macOS installer transition contracts hold"


### PR DESCRIPTION
## Summary
- verify each Homebrew Bash candidate reports the same machine architecture as the bootstrap shell
- reject Rosetta/x86_64 Bash before re-exec on Apple Silicon
- cover matching and mismatched candidate architectures in the Bash bootstrap contract suite

## Why this matters
On Apple Silicon systems that retain an Intel Homebrew prefix, the installer can re-exec into `/usr/local/bin/bash` under Rosetta. Every later `uname -m` then reports `x86_64`, so the production macOS preflight rejects genuine Apple Silicon hardware. The invariant is that the Bash 4+ handoff must preserve the host architecture.

Fixes #3256

## Overlap check
Searched open and closed PR titles for `Rosetta`, `Homebrew Bash`, and `macOS architecture`, PR bodies for `install-macos.sh` plus Bash architecture, and the current production file. No PR covers this handoff. #3257 touches the later image preflight path and is already fixed on main, so it is intentionally excluded.

## Test plan
- [x] `bash -n installers/macos/install-macos.sh tests/test-bash32-guards.sh`
- [x] `bash tests/test-bash32-guards.sh` (12 passed)
- [x] `git diff --check`

## Platform scope
macOS bootstrap only. Linux and Windows installer paths are unchanged. The test uses executable candidate doubles for arm64 and x86_64; live dual-Homebrew Apple hardware was not available locally.

## Rollback
Reverting the commit restores version-only Bash candidate selection.

Generated with Codex

## CI follow-up
Commit def87589 updated the existing macOS transition contract to assert the new architecture-aware predicate. Revalidated: ash tests/test-bash32-guards.sh (12 passed) and ash tests/test-macos-installer-transitions.sh (all passed). The remaining openSUSE failure was a repository mirror timeout while installing rsync, outside this diff.
