### PR TITLE
fix(dashboard): load template previews after commit

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   MessageSquare, Image, Code, Shield, Layers, Package,
   Loader2, X, Check, AlertTriangle, HardDrive,
@@ -9,11 +9,16 @@ const TEMPLATE_APPLY_TIMEOUT_MS = 30 * 60 * 1000
 
 const fetchJson = async (url, options = {}) => {
   const c = new AbortController()
-  const t = setTimeout(() => c.abort(), options.timeout || 30000)
+  const { signal, timeout = 30000, ...fetchOptions } = options
+  const abort = () => c.abort()
+  if (signal?.aborted) abort()
+  signal?.addEventListener('abort', abort, { once: true })
+  const t = setTimeout(abort, timeout)
   try {
-    return await fetch(url, { ...options, signal: c.signal })
+    return await fetch(url, { ...fetchOptions, signal: c.signal })
   } finally {
     clearTimeout(t)
+    signal?.removeEventListener('abort', abort)
   }
 }
 
@@ -128,19 +133,32 @@ export function TemplatePreview({ template, onClose, onApplied }) {
 
   const Icon = ICON_MAP[template.icon] || Package
 
-  const loadPreview = async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const res = await fetchJson(`/api/templates/${template.id}/preview`, { method: 'POST' })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      setPreviewData(await res.json())
-    } catch (err) {
-      setError(err.name === 'AbortError' ? 'Request timed out' : 'Failed to load preview')
-    } finally {
-      setLoading(false)
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const loadPreview = async () => {
+      setLoading(true)
+      setError(null)
+      setPreviewData(null)
+      try {
+        const res = await fetchJson(`/api/templates/${template.id}/preview`, {
+          method: 'POST',
+          signal: controller.signal,
+        })
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        setPreviewData(await res.json())
+      } catch (err) {
+        if (!controller.signal.aborted) {
+          setError(err.name === 'AbortError' ? 'Request timed out' : 'Failed to load preview')
+        }
+      } finally {
+        if (!controller.signal.aborted) setLoading(false)
+      }
     }
-  }
+
+    loadPreview()
+    return () => controller.abort()
+  }, [template.id])
 
   const handleApply = async () => {
     setApplying(true)
@@ -166,11 +184,6 @@ export function TemplatePreview({ template, onClose, onApplied }) {
     } finally {
       setApplying(false)
     }
-  }
-
-  // Load preview on mount
-  if (!previewData && !loading && !error) {
-    loadPreview()
   }
 
   const changes = previewData?.changes || {}

--- a/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.apply.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.apply.test.jsx
@@ -61,6 +61,42 @@ describe('TemplatePreview apply result', () => {
     expect(await screen.findByText(/template applied/i)).toBeInTheDocument()
   })
 
+  test('aborts a stale preview when the selected template changes', async () => {
+    let firstSignal
+    const fetchMock = vi.fn()
+      .mockImplementationOnce((_url, options) => {
+        firstSignal = options.signal
+        return new Promise((_, reject) => {
+          options.signal.addEventListener('abort', () => {
+            const error = new Error('Aborted')
+            error.name = 'AbortError'
+            reject(error)
+          }, { once: true })
+        })
+      })
+      .mockResolvedValueOnce(response({
+        changes: { to_enable: [], already_enabled: ['svc-b'], incompatible: [] },
+        warnings: [],
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { rerender } = render(
+      <TemplatePreview template={template} onClose={vi.fn()} />,
+    )
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    rerender(
+      <TemplatePreview
+        template={{ ...template, id: 'next-template', services: ['svc-b'] }}
+        onClose={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(firstSignal.aborted).toBe(true)
+    expect(await screen.findByText('svc-b')).toBeInTheDocument()
+  })
+
   test('does not report all services active when apply skipped a service', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(response({


### PR DESCRIPTION
Load template previews after React commits the component and cancel obsolete preview requests.

## Why this matters
Starting preview POSTs during render causes unowned side effects and stale service plans when template identity changes. Operators must see the currently selected template before applying it.

Root cause: TemplatePreview calls an async loader from its render body, without effect cleanup or request ownership.

Behavioral invariant: Each committed template/refresh attempt owns its preview; an old body cannot replace the current plan; apply retains its long deadline and recovery flow.

## Implementation and compatibility
Move loading into an effect, forward its cancellation to the JSON helper, retain the full body timeout, and make Refresh preview advance the effect attempt. Include late-body and template-switch regressions.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/components/TemplatePicker.jsx`.

Relevant same-file results: #5276 (open: fix(templates): contain keyboard focus within the preview dialog), #5064 (merged: fix(templates): recognize installed CLI tools as ready), #5062 (merged: fix(dashboard): review and retry failed template installations), #4359 (merged: fix(templates): retain pending apply dialog ownership)

Preserves #4359's apply ownership, #5062's partial-failure retry and #5064's installed CLI handling. #5276 is a keyboard-focus change; this original #3312 addresses request lifecycle. The affected retry/apply suites run together.

## Regression and validation
Candidate commit: `bace0c152f2ea1f920d152564c8d6e214b92d532`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/components/__tests__/TemplatePicker` — **25 passed**.
- Template-switch and stale-body assertions fail with the baseline component; all 25 candidate preview, retry, apply and dismissal tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `bace0c152f2ea1f920d152564c8d6e214b92d532`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: External #5276 conflicts in TemplatePicker.jsx. Preserve effect-owned preview cancellation while adding its keyboard-focus lifecycle; that external combination was not runtime-tested.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
