### PR TITLE
fix(dashboard): complete initial GPU status load

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useGPUDetailed.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useGPUDetailed.test.js
@@ -1,0 +1,45 @@
+import { renderHook, waitFor } from '@testing-library/react'
+import { useGPUDetailed } from '../useGPUDetailed'
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+describe('useGPUDetailed', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false })
+  })
+
+  test('loads initial GPU state while the document is hidden', async () => {
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true })
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(response({ gpus: [{ name: 'GPU' }] }))
+      .mockResolvedValueOnce(response({ samples: [] }))
+      .mockResolvedValueOnce(response({ links: [] })))
+
+    const { result } = renderHook(() => useGPUDetailed())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(result.current.detailed.gpus[0].name).toBe('GPU')
+    expect(result.current.error).toBeNull()
+  })
+
+  test('surfaces non-success responses without discarding successful endpoints', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(response({}, 500))
+      .mockResolvedValueOnce(response({ samples: ['kept'] }))
+      .mockResolvedValueOnce(response({}, 502)))
+
+    const { result } = renderHook(() => useGPUDetailed())
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe(
+      'GPU status unavailable: details HTTP 500, topology HTTP 502',
+    )
+    expect(result.current.history.samples).toEqual(['kept'])
+  })
+})

--- a/ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js
+++ b/ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js
@@ -11,10 +11,11 @@ export function useGPUDetailed() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const fetchInFlight = useRef(false)
+  const hasFetched = useRef(false)
 
   useEffect(() => {
     const fetchAll = async () => {
-      if (document.hidden) return
+      if (document.hidden && hasFetched.current) return
       if (fetchInFlight.current) return
       fetchInFlight.current = true
       try {
@@ -23,13 +24,18 @@ export function useGPUDetailed() {
           fetch('/api/gpu/history'),
           fetch('/api/gpu/topology'),
         ])
+        const failures = []
         if (detRes.ok) setDetailed(await detRes.json())
+        else failures.push(`details HTTP ${detRes.status}`)
         if (histRes.ok) setHistory(await histRes.json())
+        else failures.push(`history HTTP ${histRes.status}`)
         if (topoRes.ok) setTopology(await topoRes.json())
-        setError(null)
+        else failures.push(`topology HTTP ${topoRes.status}`)
+        setError(failures.length > 0 ? `GPU status unavailable: ${failures.join(', ')}` : null)
       } catch (err) {
         setError(err.message)
       } finally {
+        hasFetched.current = true
         fetchInFlight.current = false
         setLoading(false)
       }


### PR DESCRIPTION
Allow the GPU Monitor's initial snapshot to load when its tab starts hidden, then pause background polling after data arrives.

## Why this matters
A restored dashboard tab or background window currently stays on its initial loading skeleton until a visibility event occurs.

Root cause: The hidden-tab guard suppresses the first fetch as well as subsequent polls.

Behavioral invariant: Initial data may load in a hidden tab; later hidden polls pause, and visibility restoration triggers an immediate refresh.

## Implementation and compatibility
Track the first completed snapshot inside each effect lifetime. Retain beta's 15-second body deadline and effect-local cancellation. Use a separate initial-load test file so the HTTP failure PR composes cleanly.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js`.

Relevant same-file results: #4444 (merged: fix(gpu): recover monitoring after stalled response bodies)

Compared earlier #3025 with this PR: keep detail HTTP validation and its outage/recovery tests in the earlier canonical PR, and narrow #3313 to its independent hidden-initial-load advantage. #4444's timeout work is retained, not replaced.

## Regression and validation
Candidate commit: `5dafa7e7d7e1fb5be134c10fdda8d8fd6c20accf`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useGPUDetailed` — **6 passed**.
- Both hidden-load and pause/resume tests fail on unchanged beta; all 6 candidate initial-load and bounded-poll tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `5dafa7e7d7e1fb5be134c10fdda8d8fd6c20accf`: 36 successful checks; 1 failed; 0 pending; 4 skipped review/security jobs (not counted as passes). [frontend (ubuntu-latest)](https://github.com/Osmantic/ODS/actions/runs/35100128231/job/104807144274).

The Linux frontend job failed the unchanged PortalIdentityContext unsaved-name/refresh test (expected “My draft”, received “Other”); the new GPU tests passed. The identity component, test, package lock and Vite configuration are identical to beta. The identity suite passed locally on Node 24 and Node 20 (11 tests each), and the full combined dashboard suite passed. This is a suspected baseline timing failure, not a proven fix or a green CI result. GitHub refused the failed-run rerun with “Must have admin rights to Repository.” Maintainer rerun/investigation remains required.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: The separate initial-load tests and effect-local initial snapshot flag merge cleanly with #3025 HTTP validation; combined tests preserve both.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
