### PR TITLE
fix(dashboard): reserve extension toggle for state

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -671,7 +671,7 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
   const isStopped = status === 'stopped'
   const isUnhealthy = status === 'unhealthy'
   const isCliInstalled = status === 'cli_installed'
-  const isToggleable = isUserExt && (status === 'enabled' || status === 'cli_installed' || status === 'disabled' || status === 'error' || status === 'stopped' || status === 'unhealthy')
+  const isToggleable = isUserExt && (status === 'enabled' || status === 'cli_installed' || status === 'disabled')
   const showRemove = isUserExt && (status === 'disabled' || isError)
   const showInstall = status === 'not_installed' && ext.installable
   const showUpdate = isUserExt && ext.installable && (
@@ -731,9 +731,6 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
                 title={disabledTitle}
                 onClick={() => onAction(ext, status === 'disabled' ? 'enable' : 'disable')}
                 className={`relative inline-flex h-[18px] w-[32px] shrink-0 rounded-full transition-colors disabled:opacity-50 ${
-                  status === 'error' ? 'bg-red-500' :
-                  status === 'stopped' ? 'bg-amber-500' :
-                  status === 'unhealthy' ? 'bg-amber-500' :
                   (status === 'enabled' || isCliInstalled) ? 'bg-green-500' : 'bg-theme-border'
                 }`}
               >

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -98,7 +98,7 @@ describe('Extensions page — unhealthy + install derivations', () => {
     expect(badge.className).toContain('text-amber-400')
   })
 
-  it('renders toggle switch for unhealthy user ext (isToggleable=true)', async () => {
+  it('does not render a conflicting toggle for unhealthy user ext', async () => {
     installFetchMock({
       extensions: [
         {
@@ -119,10 +119,34 @@ describe('Extensions page — unhealthy + install derivations', () => {
     const { container } = render(<Extensions />)
     await screen.findByText('Unhealthy User Service')
 
-    // The toggle button is rendered (L676-695) when isToggleable is true.
-    await waitFor(() => {
-      expect(findToggleButton(container)).toBeTruthy()
+    await waitFor(() => expect(findToggleButton(container)).toBeUndefined())
+    expect(screen.getByRole('button', { name: /Check Logs/i })).toBeInTheDocument()
+  })
+
+  it.each([
+    ['stopped', 'Start'],
+    ['error', 'Retry'],
+  ])('uses the dedicated %s recovery action without a toggle', async (status, action) => {
+    installFetchMock({
+      extensions: [{
+        id: `svc-${status}`,
+        name: `${status} service`,
+        status,
+        source: 'user',
+        installable: false,
+        features: [baseFeature],
+        description: 'desc',
+      }],
+      summary: baseSummary({ [status]: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
     })
+
+    const { container } = render(<Extensions />)
+    await screen.findByText(`${status} service`)
+
+    expect(findToggleButton(container)).toBeUndefined()
+    expect(screen.getByRole('button', { name: action })).toBeInTheDocument()
   })
 
   it('renders cli_installed user ext as installed and toggleable', async () => {


### PR DESCRIPTION
Use dedicated recovery actions for stopped, unhealthy and failed extensions instead of also offering a misleading enable/disable toggle.

## Why this matters
Operators currently see a switch implying enablement state for runtime failures, alongside Start, Retry or Check Logs. Those controls represent different operations and can conflict.

Root cause: isToggleable includes runtime-health statuses, although toggle direction is based on enabled/disabled state.

Behavioral invariant: The state toggle represents enabled, CLI-installed or disabled state; runtime failures expose their existing specific recovery action.

## Implementation and compatibility
Restrict toggle eligibility while retaining recovery buttons and existing enabled/disabled behavior. No backend action or auth boundary changes.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/pages/Extensions.jsx`.

Relevant same-file results: #5009 (open: feat(extensions): add local text-to-diagram rendering API), #5003 (open: feat(extensions): add offline spelling and grammar API), #4961 (open: fix(aider): make the advertised CLI launch reach Aider), #3848 (open: feat(extensions): save browser-local extension favorites), #5238 (merged: fix(dashboard): preserve internal-only service port declarations), #5067 (merged: fix(dashboard): serialize manual and automatic console log reads), #5065 (merged: fix(dashboard): honor extension update confirmation states), #4982 (merged: fix(extensions): show credentials from the installation config), #4207 (merged: feat(beta): workspace UX, Portal mascot and Settings refinement)

#5065 governs update confirmation, #5067 governs console requests, #3848 adds favorites, and #4961 fixes CLI launch routing. This canonical toggle-contract change is independent of those workflows.

## Regression and validation
Candidate commit: `47aae9b57898b501bf22b280ff244dfd6824006f`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/pages/Extensions` — **29 passed**.
- The stopped/error/unhealthy recovery-control regressions fail on beta source; all 29 candidate extension page and dialog tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `47aae9b57898b501bf22b280ff244dfd6824006f`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #3065, production and test changes merge cleanly. External #3848 favorites has a clean textual merge only; its runtime behavior was not included in the combined test run.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
