### PR TITLE
fix(models): surface download status outages

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -168,6 +168,51 @@ describe('useDownloadProgress', () => {
     })
   })
 
+  test('keeps the last progress snapshot and exposes an HTTP polling error', async () => {
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({
+          status: 'downloading',
+          model: 'test-model',
+          bytesDownloaded: 5,
+          bytesTotal: 10,
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: () => Promise.resolve({ detail: 'Download worker is restarting.' }),
+      })
+
+    const { result } = renderHook(() => useDownloadProgress())
+    await waitFor(() => expect(result.current.progress?.percent).toBe(50))
+
+    await act(async () => {
+      await result.current.refresh()
+    })
+
+    expect(result.current.statusError).toBe('Download worker is restarting.')
+    expect(result.current.progress).toMatchObject({
+      model: 'test-model',
+      status: 'downloading',
+      percent: 50,
+    })
+  })
+
+  test('surfaces a transport failure from the initial status request', async () => {
+    fetch.mockRejectedValue(new Error('connection refused'))
+
+    const { result } = renderHook(() => useDownloadProgress())
+
+    await waitFor(() => {
+      expect(result.current.statusError).toBe(
+        'Download status unavailable: connection refused',
+      )
+    })
+    expect(result.current.progress).toBeNull()
+  })
+
   test('cancelDownload posts to the cancel endpoint and refreshes terminal status', async () => {
     let cancelled = false
     fetch.mockImplementation((url, options) => {

--- a/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -6,7 +6,7 @@ function isTerminalProgress(progress) {
   return TERMINAL_DOWNLOAD_STATUSES.has(progress?.status)
 }
 
-async function cancelErrorFromResponse(response) {
+async function errorFromResponse(response, fallback) {
   try {
     const payload = await response.json()
     const detail = payload?.detail
@@ -16,7 +16,7 @@ async function cancelErrorFromResponse(response) {
   } catch {
     // Fall through to the stable user-facing fallback.
   }
-  return 'Failed to cancel download.'
+  return fallback
 }
 
 /**
@@ -27,6 +27,7 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
   const [progress, setProgress] = useState(null)
   const [isDownloading, setIsDownloading] = useState(false)
   const [completedDownload, setCompletedDownload] = useState(null)
+  const [statusError, setStatusError] = useState(null)
   const [cancelError, setCancelError] = useState(null)
   const [isCancelling, setIsCancelling] = useState(false)
   const lastCompleteKeyRef = useRef(null)
@@ -38,11 +39,20 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
     const requestId = ++progressRequestRef.current
     try {
       const response = await fetch('/api/models/download-status')
-      if (!response.ok) return
+      if (requestId < latestAppliedProgressRequestRef.current) return null
+      latestAppliedProgressRequestRef.current = requestId
+      if (!response.ok) {
+        const detail = await errorFromResponse(
+          response,
+          `Download status unavailable (HTTP ${response.status}).`,
+        )
+        if (requestId < latestAppliedProgressRequestRef.current) return null
+        setStatusError(detail)
+        return null
+      }
       
       const data = await response.json()
-      if (requestId < latestAppliedProgressRequestRef.current) return data
-      latestAppliedProgressRequestRef.current = requestId
+      setStatusError(null)
       
       if (data.status === 'downloading' || data.status === 'verifying') {
         const downloaded = data.bytesDownloaded || 0
@@ -90,8 +100,10 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
         })
       }
       return data
-    } catch {
-      // Silently fail - API might not be available
+    } catch (err) {
+      if (requestId < latestAppliedProgressRequestRef.current) return null
+      latestAppliedProgressRequestRef.current = requestId
+      setStatusError(`Download status unavailable: ${err?.message || 'network error'}`)
       return null
     }
   }, [])
@@ -151,7 +163,9 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
     setCancelError(null)
     try {
       const response = await fetch('/api/models/download/cancel', { method: 'POST' })
-      if (!response.ok) throw new Error(await cancelErrorFromResponse(response))
+      if (!response.ok) {
+        throw new Error(await errorFromResponse(response, 'Failed to cancel download.'))
+      }
       return await fetchProgress()
     } catch (err) {
       setCancelError(err?.message || 'Failed to cancel download.')
@@ -171,6 +185,7 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
     isDownloading,
     progress,
     completedDownload,
+    statusError,
     cancelError,
     isCancelling,
     formatBytes,

--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -232,7 +232,10 @@ export default function Models() {
   }
 
   const pendingModelActions = actionLoadingModels ?? (actionLoading ? [actionLoading] : [])
-  const visibleDownloadProgress = downloadProgress.progress || (downloadStartFailure && {
+  const visibleDownloadProgress = downloadProgress.progress || (downloadProgress.statusError && {
+    status: 'error',
+    error: downloadProgress.statusError,
+  }) || (downloadStartFailure && {
     status: 'error',
     model: downloadStartFailure.modelId,
     error: downloadStartFailure.error,
@@ -1310,7 +1313,7 @@ function MobileMetricLabel({ children }) {
 }
 
 function DownloadProgressBar({ progress, helpers, onRetry }) {
-  const { formatBytes, formatEta, cancelDownload, cancelError, isCancelling } = helpers
+  const { formatBytes, formatEta, cancelDownload, cancelError, statusError, isCancelling } = helpers
 
   if (progress.error) {
     const cancelled = progress.status === 'cancelled'
@@ -1377,6 +1380,12 @@ function DownloadProgressBar({ progress, helpers, onRetry }) {
       {cancelError && (
         <p role="alert" className="mb-3 text-sm text-red-300">
           {cancelError}
+        </p>
+      )}
+
+      {statusError && (
+        <p role="alert" className="mb-3 text-sm text-amber-300">
+          {statusError}
         </p>
       )}
 

--- a/ods/extensions/services/dashboard/src/pages/Models.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.test.jsx
@@ -19,6 +19,7 @@ function baseDownloadState(overrides = {}) {
     isDownloading: false,
     progress: null,
     completedDownload: null,
+    statusError: null,
     cancelError: null,
     isCancelling: false,
     refresh: vi.fn(),
@@ -765,6 +766,18 @@ test('shows terminal download failures with a retry action', async () => {
   expect(clearTerminal).toHaveBeenCalled()
   expect(downloadModel).toHaveBeenCalledWith('qwen3.5-9b-q4')
   await act(async () => {})
+})
+
+test('shows download status polling failures instead of an empty progress area', () => {
+  useModelsMock.mockReturnValue(baseState({ models: [model()] }))
+  useDownloadProgressMock.mockReturnValue(baseDownloadState({
+    statusError: 'Download status unavailable (HTTP 503).',
+  }))
+
+  renderModels()
+
+  expect(screen.getByText('Download Failed')).toBeInTheDocument()
+  expect(screen.getByText('Download status unavailable (HTTP 503).')).toBeInTheDocument()
 })
 
 test.each([


### PR DESCRIPTION
Expose download-status outages while retaining verified transfer progress and allowing a fresh poll to recover.

## Why this matters
A failed progress endpoint currently leaves a stale download bar looking live or displays nothing during an initial outage.

Root cause: Non-success polling responses return silently, and transport failures only reach the browser console.

Behavioral invariant: A status observation failure is visible separately from transfer or cancellation failure; stale successful bodies cannot clear a newer outage.

## Implementation and compatibility
Expose statusError from the hook, render it in Models, preserve progress and cancellation receipts, and guard state publication after JSON decoding. Reconcile with beta's 45-second cancel acknowledgement contract without awaiting a subsequent progress read under that guard.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js`, `ods/extensions/services/dashboard/src/pages/Models.jsx`.

Relevant same-file results: #4396 (open: feat(identity): make assistant naming generic and configurable), #4215 (open: Fix public-beta local reinstall blockers), #3843 (open: feat(models): compare catalog models before downloading), #3803 (open: fix(dashboard): keep dismissed download errors dismissed across polling), #4873 (merged: fix(downloads): bound cancellation acknowledgements), #4267 (merged: fix(dashboard-api): sanitize throughput metric samples in agent monitor), #4266 (merged: fix(dashboard-api): guard null nodes payload in cluster status refresh), #4207 (merged: feat(beta): workspace UX, Portal mascot and Settings refinement)

#4873 bounds cancellation acknowledgements; #3803 handles dismissal of terminal transfer errors; #3843 is model comparison. #3040 serializes progress polling and remains separate. This change reports observation failures without claiming that the backend download failed.

## Regression and validation
Candidate commit: `8ebcc87250e63389838422fb2657c089ba2d6257`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useDownloadProgress src/pages/Models` — **66 passed**.
- Hook outage assertions fail against untouched beta; all 66 candidate hook, cancellation, Models and activation tests pass. The follow-up malformed-JSON regression preserves visible transfer progress and verifies recovery without depending on concurrent polling, so it composes with #3040.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `8ebcc87250e63389838422fb2657c089ba2d6257`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: With #3040, retain its controller-owned single flight and 15-second headers/body race, and return either data or the decoded HTTP error within that race. Preserve this PR’s statusError/UI, the 45-second cancellation acknowledgement boundary, and both test sets. The synthetic merge replaces sequence IDs with controller ownership. External #3803 conflicts only in the progress test file; preserve its dismissal tests when integrating it.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
