### PR TITLE
fix(health): fail clearly when registry cannot load

### DIFF
--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -36,6 +36,15 @@ if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then
     . "$SCRIPT_DIR/lib/service-registry.sh" 
     sr_load 
 fi
+if [[ "${_SR_FAILED:-false}" == "true" ]]; then
+    if $JSON_OUTPUT; then
+        printf '%s\n' '{"status":"critical","error":"Service registry unavailable: PyYAML is required","remediation":"Install PyYAML with: pip3 install pyyaml"}'
+    else
+        echo "CRITICAL: Service registry unavailable because PyYAML is not installed." >&2
+        echo "Install PyYAML with: pip3 install pyyaml" >&2
+    fi
+    exit 2
+fi
 INSTALL_DIR="${INSTALL_DIR:-$HOME/ods}"
 LLM_HOST="${LLM_HOST:-localhost}"
 LLM_PORT="${LLM_PORT:-8080}"

--- a/ods/tests/test-health-check.sh
+++ b/ods/tests/test-health-check.sh
@@ -117,7 +117,38 @@ else
     pass "no hardcoded /v1/completions probe remains"
 fi
 
-# 8. Async service failures must reach the summary, exit code, and JSON.
+# 8. Registry load failures must stop at the health-check boundary with an
+# actionable critical result instead of an empty report or nounset crash.
+REGISTRY_SANDBOX=$(mktemp -d)
+mkdir -p "$REGISTRY_SANDBOX/scripts" "$REGISTRY_SANDBOX/lib" "$REGISTRY_SANDBOX/bin"
+cp "$ROOT_DIR/scripts/health-check.sh" "$REGISTRY_SANDBOX/scripts/"
+cp "$ROOT_DIR/lib/service-registry.sh" "$REGISTRY_SANDBOX/lib/"
+cat > "$REGISTRY_SANDBOX/bin/python3" <<'PYTHON_STUB'
+#!/bin/sh
+exit 1
+PYTHON_STUB
+cp "$REGISTRY_SANDBOX/bin/python3" "$REGISTRY_SANDBOX/bin/python"
+chmod +x "$REGISTRY_SANDBOX/bin/python3" "$REGISTRY_SANDBOX/bin/python"
+
+set +e
+registry_json=$(cd "$REGISTRY_SANDBOX" && PATH="$REGISTRY_SANDBOX/bin:$PATH" \
+    bash scripts/health-check.sh --json 2>/dev/null)
+registry_exit=$?
+set -e
+
+if [[ "$registry_exit" -eq 2 ]]; then
+    pass "missing PyYAML is a critical health-check failure"
+else
+    fail "missing PyYAML should exit 2; got $registry_exit"
+fi
+if echo "$registry_json" | grep -q '"error":"Service registry unavailable: PyYAML is required"'; then
+    pass "missing PyYAML produces an actionable JSON error"
+else
+    fail "missing PyYAML JSON error is absent or malformed"
+fi
+rm -rf "$REGISTRY_SANDBOX"
+
+# 9. Async service failures must reach the summary, exit code, and JSON.
 # The per-service checks run in background subshells, so the parent has to
 # aggregate their results — a regression here reports HEALTHY/exit 0 with
 # services down and omits them from the JSON services map.


### PR DESCRIPTION
## Summary
- stop health-check execution when the service registry reports a load failure
- return exit 2 with actionable PyYAML remediation
- preserve machine-readable JSON in `--json` mode
- exercise the CLI boundary with Python/PyYAML unavailable

## Why this matters
Without PyYAML, `sr_load` deliberately returns an empty registry marked failed. Health-check then either crashes on older Bash 4 releases or reports an empty stack, hiding the actual dependency problem. The invariant is that health results are never produced from an unavailable registry.

Fixes #3138

## Overlap check
Searched open and closed PR titles for health-check, service registry, and PyYAML, plus PR bodies naming `scripts/health-check.sh` with `_SR_FAILED`. No overlapping PR was found. Existing PyYAML installer work provisions dependencies; this scope makes the diagnostic boundary fail clearly when provisioning is absent or broken.

## Test plan
- [x] `bash -n scripts/health-check.sh tests/test-health-check.sh`
- [x] `bash tests/test-health-check.sh` (24 passed)
- [x] `git diff --check`

## Production contract
Registry loader failure flag -> health-check JSON/human error -> critical exit code 2. No service probes execute on incomplete registry state.

## Platform scope and rollback
Linux and modern-Bash macOS health checks. Windows PowerShell paths are unchanged. Revert restores empty-report behavior.

Generated with Codex