### PR TITLE
fix(windows): restart Lemonade without GNU timeout

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -917,7 +917,7 @@ restart_windows_lemonade_with_full_model() {
 
     log "Restarting native Windows Lemonade with ${target_label}: ${target_gguf}"
     local ps_output model_id ps_rc restart_timeout ps_output_file
-    local -a ps_env_cmd ps_timeout_prefix
+    local -a ps_env_cmd
     restart_timeout="${ODS_LEMONADE_RESTART_PS_TIMEOUT:-180}"
     case "$restart_timeout" in ''|*[!0-9]*|0) restart_timeout=180 ;; esac
     mkdir -p "$INSTALL_DIR/logs" 2>/dev/null || true
@@ -935,11 +935,10 @@ restart_windows_lemonade_with_full_model() {
         "ODS_WIN_LEMONADE_TASK=ODSLemonadeRuntime"
         "ODS_WIN_GGUF_FILE=$target_gguf"
     )
-    ps_timeout_prefix=()
     if command -v timeout >/dev/null 2>&1; then
-        ps_timeout_prefix=(timeout --foreground --kill-after=5s "${restart_timeout}s")
+        ps_env_cmd+=(timeout --foreground --kill-after=5s "${restart_timeout}s")
     fi
-    if "${ps_env_cmd[@]}" "${ps_timeout_prefix[@]}" \
+    if "${ps_env_cmd[@]}" \
         "$ps_cmd" -NoProfile -ExecutionPolicy Bypass -Command '
         $ErrorActionPreference = "Stop"
 

--- a/ods/tests/contracts/test-windows-lemonade-swap-wait.sh
+++ b/ods/tests/contracts/test-windows-lemonade-swap-wait.sh
@@ -43,6 +43,9 @@
 #
 #   8. Native Lemonade cleanup must also stop the per-user cached llama.cpp
 #      child process; it does not live under the Program Files Lemonade bin dir.
+#
+#   9. Hosts without GNU timeout must launch PowerShell without expanding an
+#      empty array under nounset (Bash 4.0-4.3 treats that as unbound).
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -147,15 +150,27 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 8b. Lemonade 10.7 removed the legacy launch flags and changed local GGUF
-#     request IDs. Bootstrap promotion must use the shared version-aware
-#     contract, resolve the live ID, and persist it for every downstream client.
+# 8a. The optional timeout command belongs in the always-populated env argv.
+# Expanding a separate empty array aborts under `set -u` on Bash < 4.4.
 # ---------------------------------------------------------------------------
 restart_block="$(awk '
     /^restart_windows_lemonade_with_full_model\(\)/ { in_block=1 }
     in_block { print }
     in_block && /^}/ { exit }
 ' "$SCRIPT" | grep -v '^[[:space:]]*#')"
+if ! grep -q 'ps_timeout_prefix' <<<"$restart_block" \
+   && grep -q 'ps_env_cmd+=(timeout --foreground' <<<"$restart_block" \
+   && grep -q 'if "${ps_env_cmd\[@\]}"' <<<"$restart_block"; then
+    pass "Windows Lemonade restart tolerates hosts without GNU timeout"
+else
+    fail "Windows Lemonade restart must not expand an optional empty timeout array"
+fi
+
+# ---------------------------------------------------------------------------
+# 8b. Lemonade 10.7 removed the legacy launch flags and changed local GGUF
+#     request IDs. Bootstrap promotion must use the shared version-aware
+#     contract, resolve the live ID, and persist it for every downstream client.
+# ---------------------------------------------------------------------------
 if grep -q 'Get-ODSLemonadeLaunchContract' <<<"$restart_block" \
    && grep -q 'New-ODSLemonadeScheduledTaskAction' <<<"$restart_block" \
    && grep -q 'Set-ODSLemonadeModernRuntimeConfig' <<<"$restart_block" \


### PR DESCRIPTION
## Summary
- remove the optional empty timeout argv from the Windows Lemonade restart command
- append GNU timeout to the always-populated environment command only when available
- retain the existing bounded restart behavior on hosts that provide timeout
- add the invariant to the Windows Lemonade swap contract

## Why this matters
Older Git Bash/MSYS releases can provide Bash 4.0-4.3 without GNU `timeout`. Under `set -u`, expanding the empty `ps_timeout_prefix` aborts before PowerShell starts, leaving Lemonade stopped after an otherwise successful model swap. The invariant is that timeout availability changes only the bound, never whether restart can launch.

Fixes #3136

## Overlap check
Searched open and closed PR titles for Windows Lemonade timeout/restart and PR bodies naming `ps_timeout_prefix`. No overlapping PR was found. Existing Lemonade swap PRs cover wait budgets, model identity, and rollback; this is independent command construction.

## Test plan
- [x] `bash -n scripts/bootstrap-upgrade.sh tests/contracts/test-windows-lemonade-swap-wait.sh`
- [x] `bash tests/contracts/test-windows-lemonade-swap-wait.sh` (13 passed)
- [x] `bash tests/test-bootstrap-upgrade-hotswap-contract.sh` (35 passed)
- [x] `git diff --check`

## Platform scope and validation gap
Windows native Lemonade via Git Bash. Static/behavioral shell contracts prove argv construction and transaction invariants; a live Bash 4.2 Windows host was not available.

## Rollback
Revert restores the separate optional timeout array and the Bash 4.0-4.3 failure.

Generated with Codex