### PR TITLE
fix(dashboard-api): bound model performance history

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -188,6 +188,7 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
 _TOKEN_FILE = Path(DATA_DIR) / "token_counter.json"
 _PERF_FILE = Path(DATA_DIR) / "model_performance.json"
 MAX_SINGLE_REQUEST_TOKENS_PER_SECOND = 10_000.0
+MAX_MODEL_PERFORMANCE_SAMPLES = 512
 _prev_tokens = {"count": 0, "time": 0.0, "tps": 0.0}
 _token_counter_lock = threading.Lock()
 
@@ -293,6 +294,29 @@ def _performance_key(backend: str, gpu_name: str, model_name: str,
     return ":".join(parts)
 
 
+def _prune_model_performance_samples(samples: dict, protected_keys: set[str]) -> None:
+    """Discard the oldest observations while retaining the sample just recorded."""
+    excess = len(samples) - MAX_MODEL_PERFORMANCE_SAMPLES
+    if excess <= 0:
+        return
+
+    def updated_at(item: tuple[str, object]) -> float:
+        sample = item[1]
+        if not isinstance(sample, dict):
+            return 0.0
+        try:
+            return float(sample.get("updated_at", 0))
+        except (TypeError, ValueError):
+            return 0.0
+
+    candidates = sorted(
+        ((key, sample) for key, sample in samples.items() if key not in protected_keys),
+        key=updated_at,
+    )
+    for key, _sample in candidates[:excess]:
+        samples.pop(key, None)
+
+
 def record_model_performance(
     model_name: Optional[str],
     gpu_name: Optional[str],
@@ -350,7 +374,9 @@ def record_model_performance(
         "sample_count": previous_count + 1,
         "updated_at": int(time.time()),
     }
-    samples[_performance_key(backend, gpu_name, model_name)] = samples[key]
+    generic_key = _performance_key(backend, gpu_name, model_name)
+    samples[generic_key] = samples[key]
+    _prune_model_performance_samples(samples, {key, generic_key})
     _write_json_file(_PERF_FILE, data)
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1370,6 +1370,39 @@ def test_valid_sample_repairs_a_polluted_existing_average(data_dir):
     assert repaired["sample_count"] == 1
 
 
+def test_performance_recorder_prunes_oldest_samples(data_dir, monkeypatch):
+    import helpers
+
+    monkeypatch.setattr(helpers, "MAX_MODEL_PERFORMANCE_SAMPLES", 4)
+    helpers._PERF_FILE.write_text(json.dumps({
+        "schema_version": "ods.model-performance.v1",
+        "samples": {
+            f"old-{index}": {"tokens_per_second": 10, "updated_at": index}
+            for index in range(5)
+        },
+    }))
+
+    record_model_performance(
+        "qwen3.5-2b",
+        "AMD Radeon RX 9070 XT",
+        "lemonade",
+        240.5,
+        context_length=8192,
+    )
+
+    samples = json.loads(helpers._PERF_FILE.read_text())["samples"]
+    exact_key = helpers._performance_key(
+        "lemonade", "AMD Radeon RX 9070 XT", "qwen3.5-2b", 8192,
+    )
+    generic_key = helpers._performance_key(
+        "lemonade", "AMD Radeon RX 9070 XT", "qwen3.5-2b",
+    )
+    assert len(samples) == 4
+    assert exact_key in samples
+    assert generic_key in samples
+    assert "old-0" not in samples
+
+
 class TestServiceHealthReconciliation:
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- cap persisted model-performance samples at 512 entries
- prune the oldest observations using their `updated_at` timestamps
- preserve both the exact and generic keys for the measurement being recorded
- add a regression test covering pruning and retention of the current measurement

Without a bound, new model, GPU, context, and GGUF combinations continuously grow `model_performance.json` on long-running installations.

## AI Assistance

OpenAI Codex assisted with bug triage, implementation, test drafting, and PR preparation. I reviewed the diff and validation results and remain responsible for the contribution.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [x] Dashboard API / host agent

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
git diff --check
# passed

PYTHONPATH=ods/extensions/services/dashboard-api \
  python -m pytest -q ods/extensions/services/dashboard-api/tests/test_helpers.py
# 107 passed in 0.75s
```

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

The cap counts persisted lookup keys. A context-specific observation can occupy both an exact key and the generic fallback key; both keys for the newly recorded observation are protected during pruning.

