### PR TITLE
fix(dashboard-api): bound runtime request state

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -32,6 +32,7 @@ TOKEN_SPY_KEY_FILE = Path(os.environ.get("TOKEN_SPY_KEY_FILE", "/data/token-spy/
 # buckets in memory and on the wire. The dashboard presets top out well
 # below a year; one full year is a generous ceiling.
 MAX_REPORT_RANGE_DAYS = 366
+MAX_LOCAL_RUNTIME_REQUEST_STATES = 128
 LLAMA_CPP_PROMETHEUS_METRICS = {
     "input_tokens": "llamacpp:prompt_tokens_total",
     "output_tokens": "llamacpp:tokens_predicted_total",
@@ -470,16 +471,26 @@ def _extract_llama_cpp_prometheus_counters(metrics_text: str, url: str) -> dict[
     }
 
 
+def _store_runtime_request_state(key: str, state: dict[str, Any]) -> None:
+    """Store the most recently observed runtime states with an LRU size bound."""
+    if key in _LOCAL_RUNTIME_REQUEST_STATE:
+        _LOCAL_RUNTIME_REQUEST_STATE.pop(key)
+    elif len(_LOCAL_RUNTIME_REQUEST_STATE) >= MAX_LOCAL_RUNTIME_REQUEST_STATES:
+        oldest_key = next(iter(_LOCAL_RUNTIME_REQUEST_STATE))
+        _LOCAL_RUNTIME_REQUEST_STATE.pop(oldest_key)
+    _LOCAL_RUNTIME_REQUEST_STATE[key] = state
+
+
 def _observe_runtime_request_delta(key: str, input_tokens: int, output_tokens: int) -> dict[str, Any]:
     total_tokens = input_tokens + output_tokens
     state = _LOCAL_RUNTIME_REQUEST_STATE.get(key)
     if state is None:
-        _LOCAL_RUNTIME_REQUEST_STATE[key] = {
+        _store_runtime_request_state(key, {
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
             "total_tokens": total_tokens,
             "requests": 0,
-        }
+        })
         return {
             "requests": 0,
             "source": "unavailable",
@@ -495,12 +506,12 @@ def _observe_runtime_request_delta(key: str, input_tokens: int, output_tokens: i
     elif total_tokens > previous_total:
         observed_requests += 1
 
-    _LOCAL_RUNTIME_REQUEST_STATE[key] = {
+    _store_runtime_request_state(key, {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": total_tokens,
         "requests": observed_requests,
-    }
+    })
     if observed_requests <= 0:
         return {
             "requests": 0,

--- a/ods/extensions/services/dashboard-api/tests/test_usage_runtime_metrics.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage_runtime_metrics.py
@@ -112,3 +112,16 @@ def test_distinct_keys_are_tracked_independently(clean_state):
     b = usage._observe_runtime_request_delta("b", input_tokens=100, output_tokens=0)
     assert a["requests"] == 1  # key "a" grew
     assert b["requests"] == 0  # key "b" unchanged, still at baseline
+
+
+def test_runtime_request_state_evicts_least_recently_used_key(clean_state, monkeypatch):
+    monkeypatch.setattr(usage, "MAX_LOCAL_RUNTIME_REQUEST_STATES", 2)
+    usage._observe_runtime_request_delta("a", input_tokens=10, output_tokens=0)
+    usage._observe_runtime_request_delta("b", input_tokens=20, output_tokens=0)
+
+    # Refresh "a", making "b" the least recently observed runtime.
+    usage._observe_runtime_request_delta("a", input_tokens=11, output_tokens=0)
+    usage._observe_runtime_request_delta("c", input_tokens=30, output_tokens=0)
+
+    assert list(usage._LOCAL_RUNTIME_REQUEST_STATE) == ["a", "c"]
+    assert usage._LOCAL_RUNTIME_REQUEST_STATE["a"]["requests"] == 1


### PR DESCRIPTION
## Summary

- cap the in-process local-runtime request observer at 128 keys
- refresh existing keys on observation and evict the least recently used key at capacity
- preserve accumulated request counts for active runtime/model combinations
- add regression coverage for eviction order and retained state

The observer key includes the runtime service and configured model. Without an eviction policy, repeatedly changing model identifiers causes `_LOCAL_RUNTIME_REQUEST_STATE` to grow for the lifetime of the Dashboard API process.

## AI Assistance

OpenAI Codex assisted with bug triage, implementation, test drafting, and PR preparation. I reviewed the diff and validation results and remain responsible for the contribution.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [x] Dashboard API / host agent

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
git diff --check
# passed

PYTHONPATH=ods/extensions/services/dashboard-api \
  python -m pytest -q \
  ods/extensions/services/dashboard-api/tests/test_usage_runtime_metrics.py \
  ods/extensions/services/dashboard-api/tests/test_usage.py
# 34 passed in 0.49s
```

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

The bound applies only to best-effort request-count inference used when llama.cpp does not expose `requests_total`. Evicted runtimes reinitialize their baseline if observed again; active keys keep their accumulated inferred count.

