### PR TITLE
fix(egress): bound provider connection pools

### DIFF
--- a/ods/extensions/services/remote-provider-egress/app/client_cache.py
+++ b/ods/extensions/services/remote-provider-egress/app/client_cache.py
@@ -1,0 +1,73 @@
+"""Bounded lifecycle management for asynchronously closable clients."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from collections.abc import Callable
+from typing import Protocol, TypeVar
+
+
+class AsyncClosable(Protocol):
+    is_closed: bool
+
+    async def aclose(self) -> None: ...
+
+
+ClientT = TypeVar("ClientT", bound=AsyncClosable)
+
+
+class AsyncClientCache:
+    """LRU cache that never closes a client while it is leased."""
+
+    def __init__(self, factory: Callable[[], ClientT], max_size: int) -> None:
+        if max_size < 1:
+            raise ValueError("max_size must be at least 1")
+        self._factory = factory
+        self._max_size = max_size
+        self._clients: OrderedDict[str, ClientT] = OrderedDict()
+        self._users: dict[str, int] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        return tuple(self._clients)
+
+    def __len__(self) -> int:
+        return len(self._clients)
+
+    async def acquire(self, key: str) -> ClientT:
+        async with self._lock:
+            client = self._clients.pop(key, None)
+            if client is None or client.is_closed:
+                client = self._factory()
+            self._clients[key] = client
+            self._users[key] = self._users.get(key, 0) + 1
+            await self._trim_locked()
+            return client
+
+    async def release(self, key: str) -> None:
+        async with self._lock:
+            current = self._users.get(key, 0)
+            self._users[key] = max(0, current - 1)
+            await self._trim_locked()
+
+    async def close(self) -> None:
+        async with self._lock:
+            clients = tuple(self._clients.values())
+            self._clients.clear()
+            self._users.clear()
+            for client in clients:
+                await client.aclose()
+
+    async def _trim_locked(self) -> None:
+        while len(self._clients) > self._max_size:
+            idle_key = next(
+                (key for key in self._clients if self._users.get(key, 0) == 0),
+                None,
+            )
+            if idle_key is None:
+                return
+            stale_client = self._clients.pop(idle_key)
+            self._users.pop(idle_key, None)
+            await stale_client.aclose()

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -7,7 +7,9 @@ injects provider credentials from a private file at the final egress boundary.
 
 from __future__ import annotations
 
+import asyncio
 import os
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
@@ -66,6 +68,10 @@ PROBE_TIMEOUT_SECONDS = float(
         str(DEFAULT_PROBE_TIMEOUT_SECONDS),
     )
 )
+DIRECT_HTTP_CLIENT_CACHE_SIZE = max(
+    1,
+    int(os.environ.get("ODS_REMOTE_PROVIDER_CLIENT_CACHE_SIZE", "4")),
+)
 app = FastAPI(title="ODS Remote Provider Egress", docs_url=None, redoc_url=None, openapi_url=None)
 
 _HOP_BY_HOP_RESPONSE_HEADERS = {
@@ -97,22 +103,62 @@ def _load_route() -> dict[str, Any]:
     return route_from_state(load_route_state(ROUTE_PATH), policy=policy)
 
 
-def _http_client(connection_key: str = "") -> httpx.AsyncClient:
+async def _http_client(connection_key: str = "") -> httpx.AsyncClient:
     if connection_key:
         clients = getattr(app.state, "direct_http_clients", None)
         if clients is None:
-            clients = {}
+            clients = OrderedDict()
             app.state.direct_http_clients = clients
-        client = clients.get(connection_key)
-        if client is None or client.is_closed:
+        if getattr(app.state, "direct_http_client_users", None) is None:
+            app.state.direct_http_client_users = {}
+        lock = getattr(app.state, "direct_http_clients_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            app.state.direct_http_clients_lock = lock
+        async with lock:
+            client = clients.pop(connection_key, None)
+            if client is not None and not client.is_closed:
+                clients[connection_key] = client
+                users = app.state.direct_http_client_users
+                users[connection_key] = users.get(connection_key, 0) + 1
+                return client
             client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
             clients[connection_key] = client
-        return client
+            users = app.state.direct_http_client_users
+            users[connection_key] = users.get(connection_key, 0) + 1
+            await _trim_direct_http_clients_locked()
+            return client
     client = getattr(app.state, "http", None)
     if client is None or client.is_closed:
         client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
         app.state.http = client
     return client
+
+
+async def _trim_direct_http_clients_locked() -> None:
+    clients = app.state.direct_http_clients
+    users = app.state.direct_http_client_users
+    while len(clients) > DIRECT_HTTP_CLIENT_CACHE_SIZE:
+        idle_key = next((key for key in clients if users.get(key, 0) == 0), None)
+        if idle_key is None:
+            return
+        stale_client = clients.pop(idle_key)
+        users.pop(idle_key, None)
+        await stale_client.aclose()
+
+
+async def _release_http_client(connection_key: str) -> None:
+    if not connection_key:
+        return
+    lock = app.state.direct_http_clients_lock
+    async with lock:
+        users = app.state.direct_http_client_users
+        current = users.get(connection_key, 0)
+        if current <= 1:
+            users[connection_key] = 0
+        else:
+            users[connection_key] = current - 1
+        await _trim_direct_http_clients_locked()
 
 
 def _error_response(exc: EgressError) -> JSONResponse:
@@ -171,7 +217,7 @@ def _safe_tunnel_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 
 async def _ssh_tunnel_status() -> dict[str, Any]:
-    client = _http_client()
+    client = await _http_client()
     try:
         response = await client.get(
             SSH_TUNNEL_HEALTH_URL,
@@ -356,7 +402,7 @@ async def forward(full_path: str, request: Request) -> Response:
     except EgressError as exc:
         return _error_response(exc)
 
-    client = _http_client(upstream_request.connection_key)
+    client = await _http_client(upstream_request.connection_key)
     headers = dict(upstream_request.headers)
     extensions = {}
     if upstream_request.tls_server_name:
@@ -386,6 +432,7 @@ async def forward(full_path: str, request: Request) -> Response:
                         yield chunk
                 finally:
                     await upstream.aclose()
+                    await _release_http_client(upstream_request.connection_key)
 
             return StreamingResponse(
                 stream_body(),
@@ -404,10 +451,12 @@ async def forward(full_path: str, request: Request) -> Response:
         )
         upstream = await client.send(req)
     except httpx.TimeoutException:
+        await _release_http_client(upstream_request.connection_key)
         return _error_response(
             EgressError(504, "upstream_timeout", "remote provider timed out")
         )
     except httpx.HTTPError as exc:
+        await _release_http_client(upstream_request.connection_key)
         return _error_response(
             EgressError(
                 502,
@@ -415,6 +464,7 @@ async def forward(full_path: str, request: Request) -> Response:
                 f"remote provider unavailable: {exc}",
             )
         )
+    await _release_http_client(upstream_request.connection_key)
     return Response(
         content=upstream.content,
         status_code=upstream.status_code,
@@ -426,7 +476,9 @@ async def forward(full_path: str, request: Request) -> Response:
 @app.on_event("startup")
 async def _startup() -> None:
     app.state.http = httpx.AsyncClient(follow_redirects=False, trust_env=False)
-    app.state.direct_http_clients = {}
+    app.state.direct_http_clients = OrderedDict()
+    app.state.direct_http_clients_lock = asyncio.Lock()
+    app.state.direct_http_client_users = {}
 
 
 @app.on_event("shutdown")
@@ -436,3 +488,4 @@ async def _shutdown() -> None:
     for client in clients.values():
         await client.aclose()
     clients.clear()
+    app.state.direct_http_client_users.clear()

--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -7,9 +7,7 @@ injects provider credentials from a private file at the final egress boundary.
 
 from __future__ import annotations
 
-import asyncio
 import os
-from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
@@ -18,6 +16,7 @@ import httpx
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 
+from .client_cache import AsyncClientCache
 from remote_provider.egress import (
     DEFAULT_MAX_BODY_BYTES,
     DEFAULT_SECRET_PATH,
@@ -105,29 +104,11 @@ def _load_route() -> dict[str, Any]:
 
 async def _http_client(connection_key: str = "") -> httpx.AsyncClient:
     if connection_key:
-        clients = getattr(app.state, "direct_http_clients", None)
-        if clients is None:
-            clients = OrderedDict()
-            app.state.direct_http_clients = clients
-        if getattr(app.state, "direct_http_client_users", None) is None:
-            app.state.direct_http_client_users = {}
-        lock = getattr(app.state, "direct_http_clients_lock", None)
-        if lock is None:
-            lock = asyncio.Lock()
-            app.state.direct_http_clients_lock = lock
-        async with lock:
-            client = clients.pop(connection_key, None)
-            if client is not None and not client.is_closed:
-                clients[connection_key] = client
-                users = app.state.direct_http_client_users
-                users[connection_key] = users.get(connection_key, 0) + 1
-                return client
-            client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
-            clients[connection_key] = client
-            users = app.state.direct_http_client_users
-            users[connection_key] = users.get(connection_key, 0) + 1
-            await _trim_direct_http_clients_locked()
-            return client
+        cache = getattr(app.state, "direct_http_client_cache", None)
+        if cache is None:
+            cache = _new_direct_http_client_cache()
+            app.state.direct_http_client_cache = cache
+        return await cache.acquire(connection_key)
     client = getattr(app.state, "http", None)
     if client is None or client.is_closed:
         client = httpx.AsyncClient(follow_redirects=False, trust_env=False)
@@ -135,30 +116,17 @@ async def _http_client(connection_key: str = "") -> httpx.AsyncClient:
     return client
 
 
-async def _trim_direct_http_clients_locked() -> None:
-    clients = app.state.direct_http_clients
-    users = app.state.direct_http_client_users
-    while len(clients) > DIRECT_HTTP_CLIENT_CACHE_SIZE:
-        idle_key = next((key for key in clients if users.get(key, 0) == 0), None)
-        if idle_key is None:
-            return
-        stale_client = clients.pop(idle_key)
-        users.pop(idle_key, None)
-        await stale_client.aclose()
+def _new_direct_http_client_cache() -> AsyncClientCache:
+    return AsyncClientCache(
+        lambda: httpx.AsyncClient(follow_redirects=False, trust_env=False),
+        DIRECT_HTTP_CLIENT_CACHE_SIZE,
+    )
 
 
 async def _release_http_client(connection_key: str) -> None:
     if not connection_key:
         return
-    lock = app.state.direct_http_clients_lock
-    async with lock:
-        users = app.state.direct_http_client_users
-        current = users.get(connection_key, 0)
-        if current <= 1:
-            users[connection_key] = 0
-        else:
-            users[connection_key] = current - 1
-        await _trim_direct_http_clients_locked()
+    await app.state.direct_http_client_cache.release(connection_key)
 
 
 def _error_response(exc: EgressError) -> JSONResponse:
@@ -476,16 +444,12 @@ async def forward(full_path: str, request: Request) -> Response:
 @app.on_event("startup")
 async def _startup() -> None:
     app.state.http = httpx.AsyncClient(follow_redirects=False, trust_env=False)
-    app.state.direct_http_clients = OrderedDict()
-    app.state.direct_http_clients_lock = asyncio.Lock()
-    app.state.direct_http_client_users = {}
+    app.state.direct_http_client_cache = _new_direct_http_client_cache()
 
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
     await app.state.http.aclose()
-    clients = getattr(app.state, "direct_http_clients", {})
-    for client in clients.values():
-        await client.aclose()
-    clients.clear()
-    app.state.direct_http_client_users.clear()
+    cache = getattr(app.state, "direct_http_client_cache", None)
+    if cache is not None:
+        await cache.close()

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -496,7 +496,7 @@ def test_direct_http_client_cache_evicts_and_closes_least_recent_origin() -> Non
         active_cache = module.AsyncClientCache(FakeClient, 2)
         active_first = await active_cache.acquire("https://active-first.example:443")
         active_second = await active_cache.acquire("https://active-second.example:443")
-        active_third = await active_cache.acquire("https://active-third.example:443")
+        await active_cache.acquire("https://active-third.example:443")
         assert_true(
             len(active_cache) == 3,
             "simultaneous active origins may temporarily exceed the idle cache bound",

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -33,6 +33,7 @@ BASE_COMPOSE = ROOT / "docker-compose.base.yml"
 MANIFEST = ROOT / "extensions" / "services" / "remote-provider-egress" / "manifest.yaml"
 DOCKERFILE = ROOT / "extensions" / "services" / "remote-provider-egress" / "Dockerfile"
 APP_MAIN = ROOT / "extensions" / "services" / "remote-provider-egress" / "app" / "main.py"
+CLIENT_CACHE = APP_MAIN.with_name("client_cache.py")
 POLICY = ROOT / "config" / "remote-provider-egress-policy.json"
 
 
@@ -455,67 +456,60 @@ def test_pinned_request_preserves_non_default_port_and_separates_tls_origins() -
 
 
 def test_direct_http_client_cache_evicts_and_closes_least_recent_origin() -> None:
-    spec = importlib.util.spec_from_file_location("ods_egress_app_cache_test", APP_MAIN)
-    assert_true(spec is not None and spec.loader is not None, "egress app must be importable")
+    spec = importlib.util.spec_from_file_location("ods_egress_client_cache_test", CLIENT_CACHE)
+    assert_true(spec is not None and spec.loader is not None, "client cache must be importable")
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 
     class FakeClient:
-        def __init__(self, **_kwargs):
+        def __init__(self):
             self.is_closed = False
 
         async def aclose(self):
             self.is_closed = True
 
     async def exercise_cache() -> None:
-        module.httpx.AsyncClient = FakeClient
-        module.DIRECT_HTTP_CLIENT_CACHE_SIZE = 2
-        module.app.state.direct_http_clients = module.OrderedDict()
-        module.app.state.direct_http_clients_lock = asyncio.Lock()
-        module.app.state.direct_http_client_users = {}
+        cache = module.AsyncClientCache(FakeClient, 2)
 
-        first = await module._http_client("https://first.example:443")
-        await module._release_http_client("https://first.example:443")
-        second = await module._http_client("https://second.example:443")
-        await module._release_http_client("https://second.example:443")
-        reused = await module._http_client("https://first.example:443")
-        await module._release_http_client("https://first.example:443")
-        third = await module._http_client("https://third.example:443")
+        first = await cache.acquire("https://first.example:443")
+        await cache.release("https://first.example:443")
+        second = await cache.acquire("https://second.example:443")
+        await cache.release("https://second.example:443")
+        reused = await cache.acquire("https://first.example:443")
+        await cache.release("https://first.example:443")
+        third = await cache.acquire("https://third.example:443")
 
         assert_true(reused is first, "cache hit must reuse the existing connection pool")
         assert_true(second.is_closed, "least-recently-used pool must be closed on eviction")
         assert_true(not first.is_closed and not third.is_closed, "active cached pools must remain open")
         assert_true(
-            list(module.app.state.direct_http_clients) == [
+            cache.keys == (
                 "https://first.example:443",
                 "https://third.example:443",
-            ],
+            ),
             "cache must retain only the two most recent provider origins",
         )
 
-        await module._release_http_client("https://third.example:443")
-        await first.aclose()
-        await third.aclose()
+        await cache.release("https://third.example:443")
+        await cache.close()
 
-        module.app.state.direct_http_clients = module.OrderedDict()
-        module.app.state.direct_http_client_users = {}
-        active_first = await module._http_client("https://active-first.example:443")
-        active_second = await module._http_client("https://active-second.example:443")
-        active_third = await module._http_client("https://active-third.example:443")
+        active_cache = module.AsyncClientCache(FakeClient, 2)
+        active_first = await active_cache.acquire("https://active-first.example:443")
+        active_second = await active_cache.acquire("https://active-second.example:443")
+        active_third = await active_cache.acquire("https://active-third.example:443")
         assert_true(
-            len(module.app.state.direct_http_clients) == 3,
+            len(active_cache) == 3,
             "simultaneous active origins may temporarily exceed the idle cache bound",
         )
         assert_true(
             not active_first.is_closed and not active_second.is_closed,
             "cache pressure must not close in-flight provider pools",
         )
-        await module._release_http_client("https://active-first.example:443")
+        await active_cache.release("https://active-first.example:443")
         assert_true(active_first.is_closed, "released least-recent active pool must be trimmed")
-        await module._release_http_client("https://active-second.example:443")
-        await module._release_http_client("https://active-third.example:443")
-        await active_second.aclose()
-        await active_third.aclose()
+        await active_cache.release("https://active-second.example:443")
+        await active_cache.release("https://active-third.example:443")
+        await active_cache.close()
 
     asyncio.run(exercise_cache())
 

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import importlib.util
 import json
 import socket
 import sys
@@ -452,6 +454,72 @@ def test_pinned_request_preserves_non_default_port_and_separates_tls_origins() -
     assert_true(first.connection_key == rotated_address.connection_key, "DNS address rotation for one TLS identity must use a bounded client pool")
 
 
+def test_direct_http_client_cache_evicts_and_closes_least_recent_origin() -> None:
+    spec = importlib.util.spec_from_file_location("ods_egress_app_cache_test", APP_MAIN)
+    assert_true(spec is not None and spec.loader is not None, "egress app must be importable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    class FakeClient:
+        def __init__(self, **_kwargs):
+            self.is_closed = False
+
+        async def aclose(self):
+            self.is_closed = True
+
+    async def exercise_cache() -> None:
+        module.httpx.AsyncClient = FakeClient
+        module.DIRECT_HTTP_CLIENT_CACHE_SIZE = 2
+        module.app.state.direct_http_clients = module.OrderedDict()
+        module.app.state.direct_http_clients_lock = asyncio.Lock()
+        module.app.state.direct_http_client_users = {}
+
+        first = await module._http_client("https://first.example:443")
+        await module._release_http_client("https://first.example:443")
+        second = await module._http_client("https://second.example:443")
+        await module._release_http_client("https://second.example:443")
+        reused = await module._http_client("https://first.example:443")
+        await module._release_http_client("https://first.example:443")
+        third = await module._http_client("https://third.example:443")
+
+        assert_true(reused is first, "cache hit must reuse the existing connection pool")
+        assert_true(second.is_closed, "least-recently-used pool must be closed on eviction")
+        assert_true(not first.is_closed and not third.is_closed, "active cached pools must remain open")
+        assert_true(
+            list(module.app.state.direct_http_clients) == [
+                "https://first.example:443",
+                "https://third.example:443",
+            ],
+            "cache must retain only the two most recent provider origins",
+        )
+
+        await module._release_http_client("https://third.example:443")
+        await first.aclose()
+        await third.aclose()
+
+        module.app.state.direct_http_clients = module.OrderedDict()
+        module.app.state.direct_http_client_users = {}
+        active_first = await module._http_client("https://active-first.example:443")
+        active_second = await module._http_client("https://active-second.example:443")
+        active_third = await module._http_client("https://active-third.example:443")
+        assert_true(
+            len(module.app.state.direct_http_clients) == 3,
+            "simultaneous active origins may temporarily exceed the idle cache bound",
+        )
+        assert_true(
+            not active_first.is_closed and not active_second.is_closed,
+            "cache pressure must not close in-flight provider pools",
+        )
+        await module._release_http_client("https://active-first.example:443")
+        assert_true(active_first.is_closed, "released least-recent active pool must be trimmed")
+        await module._release_http_client("https://active-second.example:443")
+        await module._release_http_client("https://active-third.example:443")
+        await active_second.aclose()
+        await active_third.aclose()
+
+    asyncio.run(exercise_cache())
+
+
 def main() -> int:
     tests = [
         test_compose_service_is_internal_only_and_hardened,
@@ -469,6 +537,7 @@ def main() -> int:
         test_prepare_upstream_request_with_resolved_addresses,
         test_prepare_upstream_request_with_resolved_ipv6_addresses,
         test_pinned_request_preserves_non_default_port_and_separates_tls_origins,
+        test_direct_http_client_cache_evicts_and_closes_least_recent_origin,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary - bound direct-provider AsyncClient pools with a configurable LRU cache (default 4) - close evicted idle pools immediately - lease pools to in-flight requests so cache pressure cannot terminate active JSON or streaming responses - allow temporary overflow only while every candidate is active, then trim on release - close and clear all cached pools and lease state at shutdown  ## Why this matters Every provider URL rotation creates a new AsyncClient and connection pool that remains until container restart. Long-running egress services accumulate sockets and memory without bound. A naive LRU close can also sever an active SSE stream, so the preserved invariant is: bounded when idle, never evict in-flight work.  Fixes #2701  ## Overlap check Searched open and closed PR titles for egress clients, provider connection pools, and cache eviction, plus PR bodies for `direct_http_clients`. No overlapping PR was found. Existing egress work covers DNS pinning, secret isolation, and transport policy, not pool lifecycle.  ## Test plan - [x] `python tests/contracts/test-remote-provider-egress-service.py` (16 passed) - [x] `python -m compileall -q extensions/services/remote-provider-egress/app` - [x] `git diff --check`  ## Production contract Provider origin identity -> acquired pool lease -> request/stream lifetime -> release -> idle LRU eviction -> shutdown cleanup. Concurrent active origins may briefly exceed the configured idle bound and are reconciled as soon as a lease ends.  ## Platform scope and rollback All Docker-supported platforms using remote-provider-egress. Revert restores unbounded per-origin caching. No route, credential, DNS, SNI, or response-header behavior changes.  Generated with Codex  ## CI follow-up  Commit `2f008c45` moves the cache lifecycle into a standard-library-only module after the integration runner exposed that its contract environment intentionally does not install the service's FastAPI/httpx dependencies. The production app now injects the `httpx.AsyncClient` factory, while the boundary contract directly exercises LRU reuse, idle eviction, in-flight lease protection, and shutdown closure without container-only imports.  Follow-up validation: - `python tests/contracts/test-remote-provider-egress-service.py` — 16 passed - `python -m compileall -q extensions/services/remote-provider-egress/app` — passed - `git diff --check` — passed 
Commit `900cd3a7` removes the unused test binding reported by Ruff; the exercised third lease remains unchanged. The focused 16-test contract suite, compile check, and diff check still pass locally. Ruff is verified by the repository CI runner because it is not installed in this Windows workspace.