### PR TITLE
fix(host-agent): log optional import failures

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -42,6 +42,8 @@ from socketserver import ThreadingMixIn
 from urllib import error as urllib_error, request as urllib_request
 from urllib.parse import parse_qs, unquote, urlparse
 
+logger = logging.getLogger("ods-host-agent")
+
 # Model Switchboard (PR 1, observe mode): stdlib-only sibling package. The
 # import is fail-open — a missing/broken package disables state recording but
 # never the agent itself.
@@ -51,11 +53,19 @@ if _SWITCHBOARD_BIN_DIR not in sys.path:
 try:
     from model_switchboard import state as _switchboard_state
 except Exception:  # pragma: no cover - import environment dependent
+    logger.warning(
+        "Model switchboard state import failed; state recording is disabled",
+        exc_info=True,
+    )
     _switchboard_state = None
 try:
     from model_switchboard import adapters as _switchboard_adapters
     from model_switchboard import reconciler as _switchboard_reconciler
 except Exception:  # pragma: no cover - import environment dependent
+    logger.warning(
+        "Model switchboard reconciler import failed; reconciliation is disabled",
+        exc_info=True,
+    )
     _switchboard_adapters = None
     _switchboard_reconciler = None
 try:
@@ -78,6 +88,10 @@ try:
         ssh_supervisor_plan as _remote_provider_ssh_supervisor_plan,
     )
 except Exception:  # pragma: no cover - import environment dependent
+    logger.warning(
+        "Remote-provider import failed; remote-provider operations are disabled",
+        exc_info=True,
+    )
     _RemoteProviderLifecycleError = ValueError
     _RemoteProviderPolicyError = ValueError
     _RemoteProviderProbeError = RuntimeError
@@ -122,8 +136,6 @@ VALID_HOOK_NAMES = frozenset({
     "pre_install", "post_install", "pre_start", "post_start",
     "pre_uninstall", "post_uninstall",
 })
-logger = logging.getLogger("ods-host-agent")
-
 _MACOS_LLM_BRIDGE_LABEL = "com.ods.llm-bridge"
 _MACOS_HOST_AGENT_BRIDGE_LABEL = "com.ods.host-agent-bridge"
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1,5 +1,6 @@
 """Tests for ods-host-agent.py — _parse_mem_value and _iso_now."""
 
+import builtins
 import hashlib
 import importlib.util
 import io
@@ -56,6 +57,35 @@ def can_create_symlinks(tmp_path: Path) -> bool:
     except (OSError, NotImplementedError):
         return False
     return link.is_symlink()
+
+
+def test_optional_component_import_failures_are_logged(monkeypatch, caplog):
+    real_import = builtins.__import__
+
+    def fail_optional_import(name, *args, **kwargs):
+        if name == "model_switchboard" or name.startswith("remote_provider"):
+            raise RuntimeError(f"broken optional component: {name}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fail_optional_import)
+    module_name = "ods_host_agent_import_failure_test"
+    spec = importlib.util.spec_from_file_location(module_name, _agent_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        with caplog.at_level(logging.WARNING, logger="ods-host-agent"):
+            spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+
+    assert module._switchboard_state is None
+    assert module._switchboard_adapters is None
+    assert module._switchboard_reconciler is None
+    assert module._plan_remote_provider_lifecycle_operation is None
+    assert "Model switchboard state import failed" in caplog.text
+    assert "Model switchboard reconciler import failed" in caplog.text
+    assert "Remote-provider import failed" in caplog.text
+    assert "broken optional component" in caplog.text
 
 
 def test_host_agent_model_library_accepts_only_integrity_pinned_hub_imports(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- log warning-level tracebacks when model-switchboard state cannot be imported
- distinguish switchboard reconciler failures from state-recording failures
- log when remote-provider imports fail and their operations are disabled
- keep all existing fail-open fallback assignments unchanged
- add regression coverage that forces each optional import path to fail

These imports previously caught every exception silently. A broken or missing optional component therefore disabled host-agent functionality without leaving an actionable diagnostic.

## AI Assistance

OpenAI Codex assisted with bug triage, implementation, test drafting, and PR preparation. I reviewed the diff and validation results and remain responsible for the contribution.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [x] Dashboard API / host agent

## Risk And Validation

- Risk level: High (host-agent startup surface)
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Not required because: the runtime behavior remains fail-open and only warning diagnostics are added; the complete host-agent unit/wire suite was run.

Commands/results:

```text
git diff --check
# passed

PYTHONPATH=ods/extensions/services/dashboard-api \
  python -m pytest -q ods/extensions/services/dashboard-api/tests/test_host_agent.py
# 262 passed in 14.70s
```

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

The logger is initialized before the optional imports so failures are observable during module startup. Each broad catch and its existing fallback values remain in place, so an optional-component failure still cannot prevent the host agent from starting.

