### PR TITLE
fix(backup): declare backup dir separately from assignment (SC2155)

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -339,7 +339,8 @@ backup_user_data() {
     for path in "${user_data_paths[@]}"; do
         local full_path="$ODS_DIR/$path"
         if [[ -d "$full_path" ]]; then
-            local dest_dir="$backup_dir/$(dirname "$path")"
+            local dest_dir
+            dest_dir="$backup_dir/$(dirname "$path")"
             mkdir -p "$dest_dir"
             rsync_with_progress "$full_path" "$dest_dir/" "Backing up $path"
             log_success "Backed up: $path"
@@ -422,7 +423,8 @@ backup_cache() {
 
     for path in "${cache_paths[@]}"; do
         if [[ -d "$ODS_DIR/$path" ]]; then
-            local dest_dir="$backup_dir/$(dirname "$path")"
+            local dest_dir
+            dest_dir="$backup_dir/$(dirname "$path")"
             mkdir -p "$dest_dir"
             rsync_with_progress "$ODS_DIR/$path" "$dest_dir/" "Backing up $path"
             log_success "Backed up: $path"


### PR DESCRIPTION
## Summary
`ods/ods-backup.sh` uses `local dest_dir="$backup_dir/$(dirname "$path")"` at lines 342 and 425. ShellCheck **SC2155** warns that combining `local` with a command substitution masks the substitution's exit status — a failed `dirname`/expansion would be invisible under `set -e`.

## Fix
Split into two statements at both sites:
```bash
local dest_dir
dest_dir="$backup_dir/$(dirname "$path")"
```
No behavioral change; the computed path is identical.

## Verification
- `bash -n ods/ods-backup.sh` passes.
- `shellcheck ods/ods-backup.sh` shows no SC2155 (was 2) and no new findings.