### PR TITLE
fix(ods-cli): defer trap variable expansion with single quotes (SC2064)

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1291,7 +1291,7 @@ cmd_status() {
     # Create temp directory for health check results
     local tmpdir
     tmpdir=$(mktemp -d)
-    trap "rm -rf '$tmpdir'" RETURN
+    trap 'rm -rf "$tmpdir"' RETURN
 
     # Array to track background job PIDs
     local -a pids=()
@@ -5569,7 +5569,7 @@ _gpu_reassign() {
     # Write topology to tmpfile and run assignment
     local tmpdir
     tmpdir=$(mktemp -d)
-    trap "rm -rf '$tmpdir'" RETURN
+    trap 'rm -rf "$tmpdir"' RETURN
     echo "$topo_json" > "$tmpdir/topo.json"
     local env_backup="$tmpdir/env.before"
     cp "$INSTALL_DIR/.env" "$env_backup"


### PR DESCRIPTION
## Summary
At lines 1294 and 5572, `ods/ods-cli` registers a cleanup trap as:
```bash
trap "rm -rf '$tmpdir'" RETURN
```
Because the body is double-quoted, `$tmpdir` is expanded at the moment the trap is *registered*, not when the function returns. ShellCheck flags this as **SC2064**. In practice `tmpdir` is already set by the time the trap fires, so today it happens to work — but it is a latent bug: any trap whose body depends on a variable assigned after registration would clean up the wrong thing, and the pattern is exactly what SC2064 exists to prevent.

## Fix
Rewrap the trap body in single quotes so expansion is deferred to signal time. The path is quoted with double quotes inside the single-quoted body:
```bash
trap 'rm -rf "$tmpdir"' RETURN
```
This keeps the cleanup correct even if `$tmpdir` were reassigned later, and satisfies the linter.

## Verification
- `bash -n ods/ods-cli` passes.
- `shellcheck ods/ods-cli` reports no SC2064 (was 2) and introduces no new findings.