### PR TITLE
fix(ods-cli): use literal printf format for color diff markers (SC2059)

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3332,7 +3332,7 @@ META
             # Compare metadata
             echo -e "${BLUE}━━━ Metadata ━━━${NC}"
             if [[ -f "$dir1/meta.txt" ]] && [[ -f "$dir2/meta.txt" ]]; then
-                diff -u "$dir1/meta.txt" "$dir2/meta.txt" | tail -n +4 | sed "s/^-/$(printf "${RED}-${NC}")/" | sed "s/^+/$(printf "${GREEN}+${NC}")/" || true
+                diff -u "$dir1/meta.txt" "$dir2/meta.txt" | tail -n +4 | sed "s/^-/$(printf '%s' "${RED}-${NC}")/" | sed "s/^+/$(printf '%s' "${GREEN}+${NC}")/" || true
             fi
             echo ""
 


### PR DESCRIPTION
## Summary
In the metadata diff view (line 3335), the colored +/- markers were produced with:
```bash
sed "s/^-/$(printf "${RED}-${NC}")/" | sed "s/^+/$(printf "${GREEN}+${NC}")/"
```
ShellCheck **SC2059** flags this because the `printf` *format string* is itself a variable. If any of the color variables (`RED`, `GREEN`, `NC`) ever contained a `%` character, `printf` would interpret it as a format directive and mangle or truncate the output. Even today it is unsafe style.

## Fix
Use a literal `%s` format and pass the colored text as an argument, preserving the exact rendered output:
```bash
sed "s/^-/$(printf '%s' "${RED}-${NC}")/" | sed "s/^+/$(printf '%s' "${GREEN}+${NC}")/"
```

## Verification
- `bash -n ods/ods-cli` passes.
- `shellcheck ods/ods-cli` reports no SC2059 (was 2) and no new findings.