### PR TITLE
fix(ods-cli): rename GPU-validate counter to dodge array name clash (SC2178)

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -5397,17 +5397,17 @@ _gpu_validate() {
                 live_uuids=$(nvidia-smi --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | tr -d ' ' || true)
             fi
             live_uuids="${live_uuids:-}"
-            local missing=0
+            local missing_count=0
             while IFS= read -r uuid; do
                 [[ -z "$uuid" ]] && continue
                 if ! echo "$live_uuids" | grep -qF "$uuid"; then
                     warn "UUID ${uuid} not found in current system"
                     echo "    Fix: run 'ods gpu reassign'"
-                    ((missing++)) || true
+                    ((missing_count++)) || true
                     ((fail++)) || true
                 fi
             done < <(echo "$assignment_json" | jq -r '.gpu_assignment.services[].gpus[]' 2>/dev/null)
-            if [[ "$missing" -eq 0 ]]; then
+            if [[ "$missing_count" -eq 0 ]]; then
                 success "All assigned GPU UUIDs are present in system"
                 ((pass++)) || true
             fi


### PR DESCRIPTION
## Summary
`ods/ods-cli`'s `_gpu_validate()` declared `local missing=0` and used it as an integer counter (`((missing++))`, `[[ "$missing" -eq 0 ]]`). ShellCheck **SC2178** ("variable was used as an array but is now assigned a string") fired because `missing` is already used as an *array* in a sourced helper (`ods/installers/lib/detection.sh`), so the name carries array typing into this scope. The scalar assignment therefore looks like an array being clobbered with a string.

## Fix
Rename the local counter to `missing_count` so it no longer shadows the array-typed name. All three references in the function are updated; the increment/threshold logic is unchanged:
```bash
local missing_count=0
((missing_count++)) || true
if [[ "$missing_count" -eq 0 ]]; then
```

## Verification
- `bash -n ods/ods-cli` passes.
- `shellcheck ods/ods-cli` reports no SC2178 (was 1) and no new findings.