### PR TITLE
fix(restore): act on subshell exit directly, drop $? indirection (SC2181)

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -296,10 +296,7 @@ validate_backup() {
                         log_error "Use --skip-verify to restore anyway (NOT RECOMMENDED)"
                         return 1
                     fi
-                )
-                if [[ $? -ne 0 ]]; then
-                    return 1
-                fi
+                ) || return 1
             fi
         else
             log_warn "No checksums.sha256 found in backup (older backup format)"


### PR DESCRIPTION
## Summary
`ods-restore.sh`'s checksum verification runs a verification subshell and then checks its result indirectly:
```bash
                )
                if [[ $? -ne 0 ]]; then
                    return 1
                fi
```
ShellCheck **SC2181** flags this: reading `$?` after the fact is fragile because any command inserted between the subshell and the test would overwrite `$?`, silently defeating the failure check. It also breaks under `set -e` assumptions.

## Fix
Test the subshell's exit status directly:
```bash
                ) || return 1
```
This returns from the enclosing function whenever the verification subshell fails, preserving the original behavior while removing the `$?` indirection.

## Verification
- `bash -n ods/ods-restore.sh` passes.
- `shellcheck ods/ods-restore.sh` reports no SC2181 (was 1) and no new findings.