### PR TITLE
fix(update): parse version into array via read -ra, not split (SC2206)

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -180,7 +180,10 @@ semver_compare() {
     fi
     
     local IFS='.'
-    local i v1_parts=($v1) v2_parts=($v2)
+    local i
+    local -a v1_parts v2_parts
+    IFS='.' read -ra v1_parts <<< "$v1"
+    IFS='.' read -ra v2_parts <<< "$v2"
     
     for ((i=0; i<3; i++)); do
         local n1="${v1_parts[$i]:-0}"


### PR DESCRIPTION
## Summary
`semver_compare()` in `ods-update.sh` built arrays with:
```bash
local i v1_parts=($v1) v2_parts=($v2)
```
(with `IFS='.'` set in the function). ShellCheck **SC2206** flags this: unquoted `$(...)`/variable expansion word-splits *and* applies pathname expansion, so a version component containing a glob character (e.g. `1.2.*`) would be expanded against the filesystem and corrupt the comparison.

## Fix
Build the arrays with `read -ra`, which splits on `IFS` without any globbing:
```bash
local i
local -a v1_parts v2_parts
IFS='.' read -ra v1_parts <<< "$v1"
IFS='.' read -ra v2_parts <<< "$v2"
```
Each dotted component becomes a clean array element, identical for normal numeric versions but safe for unusual input. The downstream `${v1_parts[$i]:-0}` indexing is unchanged.

## Verification
- `bash -n ods/ods-update.sh` passes.
- `shellcheck ods/ods-update.sh` reports no SC2206 (was 2) and no new findings.