### PR TITLE
fix(update): pass compose flags as array elements to docker compose (SC2086)

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -398,6 +398,10 @@ _update_rollback() {
     local reason="$1"
     local snap_dir_arg="$2"
     local compose_flags_arg="${3:-}"
+    local -a compose_args=()
+    if [[ -n "${compose_flags_arg}" ]]; then
+        read -ra compose_args <<< "${compose_flags_arg}"
+    fi
 
     log_error "${reason}"
     log_warn "Auto-restoring rollback snapshot and restarting services..."
@@ -412,14 +416,14 @@ _update_rollback() {
     fi
 
     cd "$INSTALL_DIR"
-    if [[ -n "${compose_flags_arg}" ]]; then
-        if ! docker compose ${compose_flags_arg} down --remove-orphans; then
+    if [[ ${#compose_args[@]} -gt 0 ]]; then
+        if ! docker compose "${compose_args[@]}" down --remove-orphans; then
             log_warn "docker compose v2 down failed, trying v1..."
-            docker-compose ${compose_flags_arg} down --remove-orphans
+            docker-compose "${compose_args[@]}" down --remove-orphans
         fi
-        if ! docker compose ${compose_flags_arg} up -d; then
+        if ! docker compose "${compose_args[@]}" up -d; then
             log_warn "docker compose v2 up failed, trying v1..."
-            docker-compose ${compose_flags_arg} up -d
+            docker-compose "${compose_args[@]}" up -d
         fi
     else
         if ! docker compose down --remove-orphans; then
@@ -648,6 +652,10 @@ cmd_update() {
     # Resolve compose flags once — used in restart and rollback paths.
     local compose_flags=""
     compose_flags=$(resolve_compose_flags 2>/dev/null || true)
+    local -a compose_args=()
+    if [[ -n "$compose_flags" ]]; then
+        read -ra compose_args <<< "$compose_flags"
+    fi
 
     # ── Step 2: pull latest changes ───────────────────────────────────────────
     log_info "Pulling latest changes..."
@@ -677,14 +685,14 @@ cmd_update() {
     # ── Step 4: restart services ──────────────────────────────────────────────
     log_info "Restarting services..."
     cd "$INSTALL_DIR"
-    if [[ -n "${compose_flags}" ]]; then
-        if ! docker compose ${compose_flags} down --remove-orphans; then
+    if [[ ${#compose_args[@]} -gt 0 ]]; then
+        if ! docker compose "${compose_args[@]}" down --remove-orphans; then
             log_warn "docker compose v2 down failed, trying v1..."
-            docker-compose ${compose_flags} down --remove-orphans
+            docker-compose "${compose_args[@]}" down --remove-orphans
         fi
-        if ! docker compose ${compose_flags} up -d; then
+        if ! docker compose "${compose_args[@]}" up -d; then
             log_warn "docker compose v2 up failed, trying v1..."
-            docker-compose ${compose_flags} up -d
+            docker-compose "${compose_args[@]}" up -d
         fi
     elif [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
         if ! docker compose down --remove-orphans; then


### PR DESCRIPTION
## Summary
`ods-update.sh` built the compose invocation with the unquoted flag string:
```bash
docker compose ${compose_flags} down --remove-orphans
docker-compose ${compose_flags} up -d
```
ShellCheck **SC2086** warns the expansion is subject to word splitting/globbing.

## Why not just double-quote
The variable holds the output of `resolve_compose_flags` — several space-separated `-f` flags (base + GPU overlay + extensions). Double-quoting would collapse them into a *single* argument and break any multi-file compose stack, so that is not a safe fix here.

## Fix
Follow the convention already used elsewhere in this file (e.g. lines 788/841/929): keep the flags as a string, split them into a `compose_args` array with `read -ra`, guard on `${#compose_args[@]}`, and expand with `"${compose_args[@]}"`:
```bash
local -a compose_args=()
if [[ -n "$compose_flags" ]]; then
    read -ra compose_args <<< "$compose_flags"
fi
...
if ! docker compose "${compose_args[@]}" down --remove-orphans; then
```
The same treatment is applied to the `_update_rollback` flags argument. Behavior is identical for single-flag and multi-flag stacks.

## Verification
- `bash -n ods/ods-update.sh` passes.
- `shellcheck ods/ods-update.sh` reports no SC2086 (was 8) and no new findings.