### PR TITLE
fix(auth): harden magic-link hash lookup timing

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -331,10 +331,11 @@ def _prune(store: dict) -> dict:
 
 
 def _find_by_hash(store: dict, token_hash: str) -> Optional[dict]:
+    match = None
     for record in store.get("tokens", []):
-        if record["token_hash"] == token_hash:
-            return record
-    return None
+        if secrets.compare_digest(record["token_hash"], token_hash):
+            match = record
+    return match
 
 
 # --- Rate limiting ---

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -1073,6 +1073,29 @@ def test_owner_token_survives_pruning(magic_link_module):
     assert pruned["tokens"][0]["token_type"] == "owner"
 
 
+def test_token_lookup_compares_every_hash_in_constant_time(
+    magic_link_module, monkeypatch
+):
+    records = [{"token_hash": value} for value in ("a" * 64, "b" * 64, "c" * 64)]
+    compared = []
+    real_compare_digest = magic_link_module.secrets.compare_digest
+
+    def recording_compare_digest(stored, supplied):
+        compared.append((stored, supplied))
+        return real_compare_digest(stored, supplied)
+
+    monkeypatch.setattr(
+        magic_link_module.secrets, "compare_digest", recording_compare_digest
+    )
+
+    match = magic_link_module._find_by_hash(
+        {"tokens": records}, "a" * 64
+    )
+
+    assert match is records[0]
+    assert compared == [(record["token_hash"], "a" * 64) for record in records]
+
+
 # ---------------------------------------------------------------------------
 # Rate-limit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- compare persisted magic-link token hashes with `secrets.compare_digest`
- scan the complete token set so lookup work does not disclose a matching record's position
- add a regression test at the redemption lookup boundary

## Why this matters
`GET /auth/magic-link/{token}` hashes the bearer token and searches the persisted guest/owner token store. Short-circuit string equality made comparison timing depend on hash contents and record position. The invariant is that every stored SHA-256 hash receives the same constant-time comparison before lookup returns.

Closes #3342.

## Overlap check
Searched open and closed PR titles/bodies for `magic link`, `constant time`, `token hash`, issue #3342, and the changed `magic_link.py` production path. No existing PR implements this lookup hardening; existing magic-link work covers lifecycle behavior rather than hash comparison.

## Test plan
- [x] `cd ods/extensions/services/dashboard-api && python -m pytest tests/test_magic_link.py -q` (67 passed)
- [x] `git diff --check`

## Tradeoffs and rollback
The lookup remains synchronous and preserves the existing return contract. It now scans all token records instead of returning at the first match; stores are bounded by existing pruning, so the extra comparisons are negligible. Reverting the commit restores the previous timing behavior without a data migration.

Generated with Codex