### PR TITLE
fix(windows): refresh stale Hermes persona fallback

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -586,15 +586,13 @@ function Invoke-HermesSoulRefresh {
     }
 
     if (-not $rendered) {
-        if (Test-Path -LiteralPath $output -PathType Container) {
+        if (Test-Path -LiteralPath $output) {
             Remove-Item -LiteralPath $output -Recurse -Force
         }
-        if (-not (Test-Path -LiteralPath $output -PathType Leaf)) {
-            $content = Get-Content -LiteralPath $template -Raw
-            $content = $content -replace "(?m)^\s*<!-- INSTALLATION_CONTEXT -->\s*\r?\n?", ""
-            [System.IO.File]::WriteAllText($output, $content, (New-Object System.Text.UTF8Encoding($false)))
-            Write-AIWarn "Generated fallback Hermes SOUL.md without dynamic installation context"
-        }
+        $content = Get-Content -LiteralPath $template -Raw
+        $content = $content -replace "(?m)^\s*<!-- INSTALLATION_CONTEXT -->\s*\r?\n?", ""
+        [System.IO.File]::WriteAllText($output, $content, (New-Object System.Text.UTF8Encoding($false)))
+        Write-AIWarn "Generated fallback Hermes SOUL.md without dynamic installation context"
     }
 
     if ($SyncContainer) {

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -544,15 +544,13 @@ function Invoke-HermesSoulRefresh {
     }
 
     if (-not $_rendered) {
-        if (Test-Path -LiteralPath $_output -PathType Container) {
+        if (Test-Path -LiteralPath $_output) {
             Remove-Item -LiteralPath $_output -Recurse -Force
         }
-        if (-not (Test-Path -LiteralPath $_output -PathType Leaf)) {
-            $_content = Get-Content -LiteralPath $_template -Raw
-            $_content = $_content -replace "(?m)^\s*<!-- INSTALLATION_CONTEXT -->\s*\r?\n?", ""
-            Write-Utf8NoBom -Path $_output -Content $_content
-            Write-AIWarn "Generated fallback Hermes SOUL.md without dynamic installation context"
-        }
+        $_content = Get-Content -LiteralPath $_template -Raw
+        $_content = $_content -replace "(?m)^\s*<!-- INSTALLATION_CONTEXT -->\s*\r?\n?", ""
+        Write-Utf8NoBom -Path $_output -Content $_content
+        Write-AIWarn "Generated fallback Hermes SOUL.md without dynamic installation context"
     }
 
     if ($SyncContainer) {

--- a/ods/tests/test-windows-hermes-soul-refresh.ps1
+++ b/ods/tests/test-windows-hermes-soul-refresh.ps1
@@ -1,0 +1,63 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$targets = @(
+    @{ Path = "installers/windows/phases/06-directories.ps1"; Parameterized = $true },
+    @{ Path = "installers/windows/ods.ps1"; Parameterized = $false }
+)
+
+function Get-FunctionText {
+    param([string]$Path, [string]$Name)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $Path, [ref]$tokens, [ref]$errors
+    )
+    if ($errors.Count -ne 0) {
+        throw "PowerShell parse failed for ${Path}: $($errors[0].Message)"
+    }
+    $functionAst = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $Name
+    }, $true)
+    if (-not $functionAst) { throw "Function $Name not found in $Path" }
+    return $functionAst.Extent.Text
+}
+
+foreach ($target in $targets) {
+    $sandbox = Join-Path ([System.IO.Path]::GetTempPath()) ("ods-soul-" + [guid]::NewGuid())
+    try {
+        $hermesDir = Join-Path $sandbox "extensions/services/hermes"
+        $personaDir = Join-Path $sandbox "data/persona"
+        New-Item -ItemType Directory -Path $hermesDir, $personaDir -Force | Out-Null
+        Set-Content -LiteralPath (Join-Path $hermesDir "SOUL.md.template") -Value "fresh template" -NoNewline
+        Set-Content -LiteralPath (Join-Path $personaDir "SOUL.md") -Value "stale persona" -NoNewline
+
+        function Write-AIWarn { param([string]$Message) }
+        function Write-AISuccess { param([string]$Message) }
+        function Write-Utf8NoBom {
+            param([string]$Path, [string]$Content)
+            [System.IO.File]::WriteAllText($Path, $Content, [System.Text.UTF8Encoding]::new($false))
+        }
+
+        $script:ODS_LOG_FILE = Join-Path $sandbox "installer.log"
+        $InstallDir = $sandbox
+        Invoke-Expression (Get-FunctionText -Path (Join-Path $repoRoot $target.Path) -Name "Invoke-HermesSoulRefresh")
+
+        if ($target.Parameterized) {
+            Invoke-HermesSoulRefresh -InstallRoot $sandbox
+        } else {
+            Invoke-HermesSoulRefresh
+        }
+
+        $actual = Get-Content -LiteralPath (Join-Path $personaDir "SOUL.md") -Raw
+        if ($actual -ne "fresh template") {
+            throw "$($target.Path) preserved stale SOUL.md during fallback refresh"
+        }
+        Write-Host "PASS $($target.Path) refreshes stale SOUL.md without Python"
+    } finally {
+        Remove-Item -LiteralPath $sandbox -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary
- replace an existing generated `data/persona/SOUL.md` when Python rendering is unavailable
- keep the install phase and the Windows maintenance CLI behavior identical
- exercise both real PowerShell functions against a stale-file sandbox

## Why this matters
Windows install and refresh paths regenerate Hermes' install-owned persona after configuration/template changes. When every Python renderer candidate is unavailable, both paths only removed directories and silently retained an old regular file. The invariant is that a refresh always produces content from the current template, whether dynamic rendering succeeds or the fallback is used.

Closes #3334.
Closes #3343.

## Overlap check
Searched open and closed PRs for `Windows SOUL.md`, `Repair-HermesSoulMd`, `Invoke-HermesSoulRefresh`, and both issue numbers. No PR covers either production entry point. The two reports are intentionally combined because they implement the same refresh contract in the phase and maintenance CLI copies.

## Test plan
- [x] `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ods/tests/test-windows-hermes-soul-refresh.ps1` (both entry points passed)
- [x] PowerShell AST parsing occurs inside the regression test for both source files
- [x] `git diff --check`

## Tradeoffs and rollback
`SOUL.md` is installer-generated state, not a user-owned source template; fallback refresh now overwrites it just as successful dynamic rendering already does. No migration is needed. Reverting restores stale-file preservation when Python is unavailable.

Generated with Codex
## Follow-up overlap audit (2026-08-31)

#3489 opened later and fixes the same `Test-Path -PathType Container` mistake, but only in `installers/windows/ods.ps1`; it leaves the duplicated installer-phase implementation in `phases/06-directories.ps1` stale and provides no executable regression test.

#3346 remains the stronger canonical fix because it keeps both Windows production entry points behaviorally identical and runs each real function against a pre-existing stale `SOUL.md` with Python rendering unavailable. #3489's narrower `-PathType Leaf` check offers no independent advantage over #3346's removal of whatever conflicting node exists at the installer-owned output path, so no code was ported.