### PR TITLE
fix(update): preserve backup paths during rotation

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -613,16 +613,14 @@ cmd_backup() {
     log_info "Files backed up: ${files_backed_up}"
     
     # Cleanup old backups
-    local backup_dirs
-    backup_dirs=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
     local count=0
-    for dir in $backup_dirs; do
+    while IFS= read -r dir; do
         count=$((count + 1))
         if ((count > MAX_BACKUPS)); then
             log_info "Removing old backup: $(basename "$dir")"
             rm -rf "$dir"
         fi
-    done
+    done < <(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
 }
 
 #==============================================================================

--- a/ods/tests/test-update-script-backup.sh
+++ b/ods/tests/test-update-script-backup.sh
@@ -36,18 +36,18 @@ FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-update-backup.XXXXXX")"
 trap 'rm -rf "$FIXTURE"' EXIT
 
 # INSTALL_DIR is the script's own directory; BACKUP_DIR is $HOME/.ods/backups
-mkdir -p "$FIXTURE/home"
+mkdir -p "$FIXTURE/home with space"
 cp "$ROOT_DIR/ods-update.sh" "$FIXTURE/ods-update.sh"
 : > "$FIXTURE/docker-compose.base.yml"
 : > "$FIXTURE/docker-compose.nvidia.yml"
 echo "GPU_BACKEND=nvidia" > "$FIXTURE/.env"
 echo '{"version": "2.0.0"}' > "$FIXTURE/.version"
 
-BACKUPS="$FIXTURE/home/.ods/backups"
+BACKUPS="$FIXTURE/home with space/.ods/backups"
 
 run_backup() {
     # Never let a non-zero exit kill the test; callers assert on output/state
-    HOME="$FIXTURE/home" bash "$FIXTURE/ods-update.sh" backup "$@" 2>&1 || true
+    HOME="$FIXTURE/home with space" bash "$FIXTURE/ods-update.sh" backup "$@" 2>&1 || true
 }
 
 echo ""


### PR DESCRIPTION
## Summary
- stream backup directory names through a quoted `read` loop during retention cleanup
- preserve the existing newest-first rotation and `MAX_BACKUPS` behavior
- run the real backup command with a HOME/backup path containing spaces

## Why this matters
`ods-update.sh backup` rotates snapshots under `$HOME/.ods/backups`. The previous `for dir in $backup_dirs` re-split each `find` result, so an operator whose home path contains spaces could delete unrelated path fragments or fail to prune the intended snapshots. The invariant is that each directory emitted by `find` is passed to `rm` as one exact pathname.

Closes #3330.

## Overlap check
Searched open and closed PRs for `backup cleanup`, `rotation`, `install path spaces`, `MAX_BACKUPS`, issue #3330, and changes to `ods-update.sh`. No existing PR covers retention-path tokenization. PR #2355 changes rsync restore semantics and is independent of update-manager rotation.

## Test plan
- [x] `cd ods && bash tests/test-update-script-backup.sh` (6 passed with HOME containing spaces)
- [x] `bash -n ods-update.sh tests/test-update-script-backup.sh`
- [x] `git diff --check`

## Tradeoffs and rollback
The newline-delimited `find` contract matches existing backup IDs, which cannot contain newlines through the CLI naming scheme. Sorting and retention order are unchanged. Reverting restores the word-splitting loop; no stored backup format changes.

Generated with Codex