### PR TITLE
fix(installer): continue port detection fallbacks

### DIFF
--- a/ods/installers/phases/04-requirements.sh
+++ b/ods/installers/phases/04-requirements.sh
@@ -156,17 +156,23 @@ check_port_conflict() {
     PORT_CONFLICT=false
     PORT_CONFLICT_PID=""
     PORT_CONFLICT_PROC=""
+    local port_tool_found=false
 
     # Try lsof first (most reliable for getting process info)
     if command -v lsof &> /dev/null; then
+        port_tool_found=true
         if lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1; then
             PORT_CONFLICT_PID=$(lsof -t -i ":${port}" -sTCP:LISTEN 2>/dev/null | head -1)
             PORT_CONFLICT_PROC=$(ps -p "$PORT_CONFLICT_PID" -o comm= 2>/dev/null || echo "unknown")
             PORT_CONFLICT=true
             return 0
         fi
-    # Fallback to ss (faster but less detailed)
-    elif command -v ss &> /dev/null; then
+    fi
+
+    # Fallback to ss (faster but less detailed). Keep trying when lsof exists
+    # but cannot observe the listener, which can happen under restricted users.
+    if command -v ss &> /dev/null; then
+        port_tool_found=true
         if ss -tln 2>/dev/null | grep -qE ":${port}(\s|$)"; then
             # Try to extract PID from ss output (format: users:(("process",pid=1234,fd=5)))
             local ss_line
@@ -180,8 +186,11 @@ check_port_conflict() {
             PORT_CONFLICT=true
             return 0
         fi
-    # Fallback to netstat
-    elif command -v netstat &> /dev/null; then
+    fi
+
+    # Last fallback to netstat.
+    if command -v netstat &> /dev/null; then
+        port_tool_found=true
         if netstat -tln 2>/dev/null | grep -qE ":${port}(\s|$)"; then
             # netstat -tlnp requires root, so we may not get PID
             local netstat_line
@@ -195,14 +204,15 @@ check_port_conflict() {
             PORT_CONFLICT=true
             return 0
         fi
-    else
+    fi
+
+    if [[ "$port_tool_found" != "true" ]]; then
         # No tools available
         if [[ "${_port_check_warned}" != "true" ]]; then
             _port_check_warned=true
             warn "Neither 'lsof', 'ss', nor 'netstat' found — cannot verify port availability"
             warn "Install lsof, iproute2 (for ss), or net-tools (for netstat) to enable port checks"
         fi
-        return 1
     fi
 
     return 1

--- a/ods/tests/test-port-ollama-detection.sh
+++ b/ods/tests/test-port-ollama-detection.sh
@@ -40,6 +40,23 @@ warn() { :; }
 # Default warn-once guard expected by the function.
 _port_check_warned=false
 
+# Reproduce a restricted host where lsof is installed but misses a listener
+# that remains visible through ss.
+FALLBACK_BIN="$(mktemp -d "${TMPDIR:-/tmp}/ods-port-fallback.XXXXXX")"
+trap 'rm -rf "$FALLBACK_BIN"; [[ -z "${TEST_SERVER_PID:-}" ]] || kill "$TEST_SERVER_PID" 2>/dev/null || true' EXIT
+printf '#!/bin/sh\nexit 1\n' > "$FALLBACK_BIN/lsof"
+printf '#!/bin/sh\nprintf "LISTEN 0 4096 127.0.0.1:59876 0.0.0.0:*\\n"\n' > "$FALLBACK_BIN/ss"
+chmod +x "$FALLBACK_BIN/lsof" "$FALLBACK_BIN/ss"
+
+printf "  %-50s " "ss fallback runs when lsof misses listener..."
+if PATH="$FALLBACK_BIN:$PATH" check_port_conflict 59876 && [[ "$PORT_CONFLICT" == "true" ]]; then
+    echo -e "${GREEN}âœ“ PASS${NC}"
+    PASSED=$((PASSED + 1))
+else
+    echo -e "${RED}âœ— FAIL${NC}"
+    FAILED=$((FAILED + 1))
+fi
+
 echo "1. Function Existence Tests"
 echo "────────────────────────────"
 


### PR DESCRIPTION
﻿## Summary
- try `ss` and `netstat` when an installed `lsof` cannot see a listener
- retain process details and warn-once behavior
- add a command-level fixture where `lsof` misses a port and `ss` detects it

## Why this matters
Installer preflight uses `check_port_conflict` before assigning ODS ports. On restricted hosts, `lsof` can be installed but return no rows while `ss` still reports the listener; the old `elif` chain stopped after the first executable and allowed installation to continue into a real bind conflict. The invariant is that a negative result from one available detector does not suppress later detectors.

Closes #3335.

## Overlap check
Searched open and closed PRs for `port conflict`, `lsof`, `ss fallback`, `netstat fallback`, issue #3335, and the changed phase function. No existing PR changes this detector chain. macOS' dedicated detector is separate and continues using its platform-provided `lsof` path.

## Test plan
- [x] `cd ods && bash tests/test-port-ollama-detection.sh` (14/14 passed)
- [x] fixture installs fake `lsof` and `ss` commands and exercises the sourced production function
- [x] `bash -n installers/phases/04-requirements.sh tests/test-port-ollama-detection.sh`
- [x] `git diff --check`

## Tradeoffs and rollback
Hosts with multiple tools may execute one or two extra local inspection commands only after an earlier detector returns negative. Positive results still return immediately. Reverting restores executable-presence precedence; no persisted state changes.

Generated with Codex

## CI status
All repository-owned validation passed. The sole failed job is openSUSE Tumbleweed package setup: its OSS mirror timed out repeatedly and zypper could not install jq/rsync before the changed test ran. Upstream denied a failed-job rerun because the author lacks Actions admin rights; no no-op commit was added.
