### PR TITLE
ci(token-spy): run the complete test suite

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -45,8 +45,8 @@ jobs:
       - name: Install test dependencies
         run: python -m pip install "psycopg2-binary>=2.9.9,<3.0.0" "pytest>=8,<9"
 
-      - name: Test Postgres SSE cursor
-        run: python -m pytest tests/test_recent_events_cursor_postgres.py -v
+      - name: Test Token Spy
+        run: python -m pytest tests/ -v
 
   integration-smoke:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run every Token Spy pytest module in the Postgres-backed Linux job
- keep the existing real PostgreSQL service and dependency setup
- bring routed-telemetry privacy contracts and usage-report aggregation into the required CI gate

## Why this matters
Token Spy ships three test modules, but `test-linux.yml` named only the Postgres cursor file. Changes could regress metadata-only telemetry validation or usage aggregation while required CI stayed green. The invariant is that every test under Token Spy's owned `tests/` directory participates in the repository gate.

Closes #3232.

## Overlap check
Searched open and closed PRs for `token-spy tests`, `routed telemetry`, `usage report`, issue #3232, and changes to `test-linux.yml`. No existing PR expands this job. Dependency/type-check PRs are separate from runtime pytest coverage.

## Test plan
- [x] `cd ods/extensions/services/token-spy && python -m pytest tests/test_routed_telemetry.py tests/test_usage_report.py -q` (20 passed)
- [x] parsed `.github/workflows/test-linux.yml` with PyYAML
- [ ] full three-file suite with PostgreSQL (executed by this PR's `token-spy-postgres` CI job)
- [x] `git diff --check`

## Tradeoffs and rollback
This adds 20 fast tests to an existing job; it does not create another runner or change production dependencies. Local validation cannot reproduce the hosted PostgreSQL service, so the existing cursor module is deferred to CI. Reverting narrows CI coverage again without runtime changes.

Generated with Codex