### PR TITLE
fix(egress): keep provider probes off the event loop

### DIFF
--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -7,6 +7,7 @@ injects provider credentials from a private file at the final egress boundary.
 
 from __future__ import annotations
 
+import asyncio
 import os
 from datetime import datetime, timezone
 from pathlib import Path
@@ -312,7 +313,8 @@ async def probe() -> Response:
         if route.get("transport") == "ssh":
             tunnel = await _ssh_tunnel_status()
         secret = read_provider_secret(SECRET_PATH)
-        payload = probe_route_response(
+        payload = await asyncio.to_thread(
+            probe_route_response,
             route,
             provider_secret=secret,
             verified_at=_iso_now(),

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import asyncio
+import importlib.util
 import json
 import socket
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 
@@ -370,6 +373,34 @@ def test_service_source_avoids_public_env_secret_names() -> None:
     assert_true(POLICY.exists(), "policy document must exist for mounted service config")
 
 
+def test_probe_does_not_block_the_event_loop() -> None:
+    spec = importlib.util.spec_from_file_location("ods_egress_app", APP_MAIN)
+    assert_true(spec is not None and spec.loader is not None, "egress app must be importable")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    module._load_route = lambda: {"transport": "direct"}
+    module.read_provider_secret = lambda _path: "provider-token"
+
+    def slow_probe(*_args, **_kwargs):
+        time.sleep(0.15)
+        return {"ok": True}
+
+    module.probe_route_response = slow_probe
+
+    async def exercise() -> None:
+        task = asyncio.create_task(module.probe())
+        await asyncio.sleep(0.02)
+        assert_true(
+            not task.done(),
+            "probe must yield to the event loop while synchronous provider I/O runs",
+        )
+        response = await task
+        assert_true(response.status_code == 200, "offloaded probe must preserve response behavior")
+
+    asyncio.run(exercise())
+
+
 def test_prepare_upstream_request_with_resolved_addresses() -> None:
     route = route_from_state(route_state())
     upstream = prepare_upstream_request(
@@ -466,6 +497,7 @@ def main() -> int:
         test_probe_response_returns_redacted_ssh_receipt_through_tunnel_boundary,
         test_probe_response_fails_closed_when_ssh_tunnel_is_not_ready,
         test_service_source_avoids_public_env_secret_names,
+        test_probe_does_not_block_the_event_loop,
         test_prepare_upstream_request_with_resolved_addresses,
         test_prepare_upstream_request_with_resolved_ipv6_addresses,
         test_pinned_request_preserves_non_default_port_and_separates_tls_origins,

--- a/ods/tests/contracts/test-remote-provider-egress-service.py
+++ b/ods/tests/contracts/test-remote-provider-egress-service.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import asyncio
-import importlib.util
+import ast
 import json
 import socket
 import sys
@@ -374,22 +374,44 @@ def test_service_source_avoids_public_env_secret_names() -> None:
 
 
 def test_probe_does_not_block_the_event_loop() -> None:
-    spec = importlib.util.spec_from_file_location("ods_egress_app", APP_MAIN)
-    assert_true(spec is not None and spec.loader is not None, "egress app must be importable")
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    module._load_route = lambda: {"transport": "direct"}
-    module.read_provider_secret = lambda _path: "provider-token"
-
     def slow_probe(*_args, **_kwargs):
         time.sleep(0.15)
         return {"ok": True}
 
-    module.probe_route_response = slow_probe
+    class StubResponse:
+        def __init__(self, content):
+            self.content = content
+            self.status_code = 200
+
+    tree = ast.parse(read(APP_MAIN), filename=str(APP_MAIN))
+    handler = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "probe"
+    )
+    handler.decorator_list = []
+    handler_module = ast.fix_missing_locations(ast.Module(body=[handler], type_ignores=[]))
+    namespace = {
+        "asyncio": asyncio,
+        "Response": object,
+        "_load_route": lambda: {"transport": "direct"},
+        "_ssh_tunnel_status": lambda: None,
+        "read_provider_secret": lambda _path: "provider-token",
+        "SECRET_PATH": object(),
+        "probe_route_response": slow_probe,
+        "_iso_now": lambda: "2026-08-27T00:00:00+00:00",
+        "PROBE_TIMEOUT_SECONDS": 10.0,
+        "EgressError": EgressError,
+        "ProbeError": Exception,
+        "_error_response": lambda exc: exc,
+        "_probe_error_response": lambda exc: exc,
+        "JSONResponse": StubResponse,
+    }
+    exec(compile(handler_module, str(APP_MAIN), "exec"), namespace)
+    probe_handler = namespace["probe"]
 
     async def exercise() -> None:
-        task = asyncio.create_task(module.probe())
+        task = asyncio.create_task(probe_handler())
         await asyncio.sleep(0.02)
         assert_true(
             not task.done(),
@@ -397,6 +419,7 @@ def test_probe_does_not_block_the_event_loop() -> None:
         )
         response = await task
         assert_true(response.status_code == 200, "offloaded probe must preserve response behavior")
+        assert_true(response.content == {"ok": True}, "offloaded probe must preserve payload")
 
     asyncio.run(exercise())
 


### PR DESCRIPTION
﻿## Summary
- run the synchronous provider probe in `asyncio.to_thread`
- preserve route loading, tunnel status, error mapping, and JSON response contracts
- add a dependency-isolated concurrency regression against the production handler

## Why this matters
`POST /probe` calls an urllib-based provider check that may block for the configured timeout. Calling it directly from the async FastAPI handler stopped the egress event loop, pausing concurrent streaming inference and health traffic. The invariant is that provider I/O may remain synchronous internally but must yield the service event loop at the HTTP boundary.

Closes #2699.

## Overlap check
Searched open and closed PRs for `remote provider`, `egress probe`, `event loop`, `urllib`, issue #2699, and the egress app path. No existing PR offloads this handler. PR #3322 addresses client-pool lifecycle in the forwarding path and is independent.

## Test plan
- [x] `cd ods && python tests/contracts/test-remote-provider-egress-service.py` (16 boundary contracts passed)
- [x] concurrency regression executes the production `/probe` AST around a 150ms blocking probe and proves the event loop remains responsive without requiring service dependencies
- [x] `python -m py_compile ...`
- [x] `git diff --check`

## CI follow-up
The first integration run exposed that importing the whole FastAPI module pulled `httpx` into the dependency-minimal contract job. Commit `b94988d4` now executes the production handler AST with standard-library stubs; the focused 16-contract suite passes again.

## Tradeoffs and rollback
The default asyncio worker pool now owns probe execution; probes are infrequent operator actions and no retry or background lifecycle is added. Exceptions still propagate to the existing narrow handlers. Reverting restores in-loop execution; no data or configuration migration is involved.

Generated with Codex
