### PR TITLE
fix(lib): quote estimate expansion in format_duration call

### DIFF
--- a/ods/lib/progress.sh
+++ b/ods/lib/progress.sh
@@ -128,7 +128,7 @@ print_phase() {
     local desc=$2
     local estimate=${PHASE_ESTIMATES[$phase]:-0}
     local duration
-    duration=$(format_duration $estimate)
+    duration=$(format_duration "$estimate")
     
     echo -e "\n${BOLD}${BLUE}▶ $desc${NC} ${CYAN}(~$duration)${NC}"
 }


### PR DESCRIPTION
## Overview
ShellCheck (run by the `lint-shell` CI workflow) reports **SC2086** for an unquoted parameter expansion in `ods/lib/progress.sh`.

## The warning
`duration=$(format_duration $estimate)` leaves `$estimate` unquoted, so it is subject to word splitting and pathname expansion before being passed to `format_duration`.

## Why it matters
While `estimate` is normally a single numeric token, the unquoted form is exactly the pattern CI rejects and can misbehave if the value ever contains spaces or glob characters. Quoting is the canonical, safe form.

## The fix
Quote the expansion:

    duration=$(format_duration "$estimate")

Behavior is unchanged for normal inputs; `bash -n` passes and ShellCheck no longer emits SC2086 for this file.