### PR TITLE
docs(edge): fix the repository-root install command

### DIFF
--- a/ods/EDGE-QUICKSTART.md
+++ b/ods/EDGE-QUICKSTART.md
@@ -9,7 +9,7 @@
 
 If you want a lightweight setup on CPU-only machines (no dedicated GPU), use **cloud mode**:
 
-- Install: `./install-core.sh --cloud` (from repo root)
+- Install from the repository root: `cd ods && ./install-core.sh --cloud`
 - Full install guide: [QUICKSTART.md](QUICKSTART.md)
 - macOS Apple Silicon: [docs/MACOS-QUICKSTART.md](docs/MACOS-QUICKSTART.md)
 - Documentation index: [docs/README.md](docs/README.md)

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -180,6 +180,11 @@ clone_docs=(
     "$ROOT_DIR/docs/INSTALLER_TRUST.md"
 )
 
+require_literal \
+    "$ROOT_DIR/EDGE-QUICKSTART.md" \
+    'cd ods && ./install-core.sh --cloud' \
+    "Edge quickstart repository-root install command"
+
 windows_copy_paste_docs=(
     "$REPO_ROOT/README.md"
     "$ROOT_DIR/README.md"


### PR DESCRIPTION
## Summary
- make the supported cloud-mode command runnable from the stated repository root
- add the edge quickstart command to the install-document contract gate

## Why this matters
The planned edge guide redirects current users to supported cloud mode, but its copy/paste command referenced `./install-core.sh` from the repository root even though the executable lives under `ods/`. Users following the fallback path failed before installer preflight. The invariant is that a command explicitly labeled repository-root-relative resolves to the shipped installer.

Closes #3226.

## Overlap check
Searched open and closed PRs for `EDGE-QUICKSTART`, `install-core`, `repository root`, issue #3226, and changes to the install docs. No existing PR corrects this command. Other documentation issues concern model names, architecture paths, and contribution workflow and are independent.

## Test plan
- [x] `cd ods && bash tests/test-install-docs.sh`
- [x] `cd ods && bash tests/test-doc-links.sh`
- [x] `git diff --check`

## Tradeoffs and rollback
The guide remains explicitly planned/not-yet-available; only its supported fallback command changes. The contract is a literal copy/paste guard tied to the actual repository layout. Reverting reintroduces the broken command and removes its regression guard.

Generated with Codex