### PR TITLE
docs(models): replace stale FAQ default guidance

### DIFF
--- a/ods/FAQ.md
+++ b/ods/FAQ.md
@@ -10,7 +10,7 @@ Frequently asked questions about installing, running, and troubleshooting ODS.
 
 ### What is ODS?
 ODS is a turnkey local AI stack that runs entirely on your own hardware. It includes:
-- LLM inference via llama-server (qwen2.5-32b-instruct)
+- LLM inference via llama-server (hardware-appropriate model selected automatically)
 - Web dashboard for chat and model management
 - Voice capabilities (STT via Whisper, TTS via Kokoro)
 - Workflow automation via n8n
@@ -161,7 +161,7 @@ sudo systemctl restart docker
 
 ### "CUDA out of memory" errors
 Your GPU doesn't have enough VRAM. Options:
-1. Use a smaller model (qwen2.5-7b-instruct instead of 32b)
+1. Switch to a lower hardware tier (for example, `ods model swap T1`)
 2. All models use GGUF Q4_K_M quantization by default
 3. Reduce `CTX_SIZE` in `.env` (try 4096)
 4. Run on CPU only (slower but works)

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -189,6 +189,14 @@ windows_copy_paste_docs=(
     "$ROOT_DIR/docs/WINDOWS-INSTALL-WALKTHROUGH.md"
 )
 
+require_literal \
+    "$ROOT_DIR/FAQ.md" \
+    'ods model swap T1' \
+    "FAQ low-VRAM recovery command"
+if grep -qE 'qwen2\.5-(32b|7b)-instruct' "$ROOT_DIR/FAQ.md"; then
+    fail "FAQ must not present retired default model names as current guidance"
+fi
+
 for file in "${install_docs[@]}"; do
     [[ -f "$file" ]] || fail "Expected install document missing: $file"
     require_literal "$file" "$CANONICAL_ENDPOINT" "Canonical install endpoint"


### PR DESCRIPTION
## Summary
- describe automatic model selection without naming a retired default
- replace the stale 32B-to-7B advice with the supported tier-swap command
- guard the public FAQ against reintroducing those obsolete defaults

## Why this matters
The root FAQ advertised `qwen2.5-32b-instruct` as the bundled inference model and recommended a hard-coded 7B downgrade, while current ODS selects profiles from the tier/model catalog. Operators could search for a nonexistent default or manually edit configuration instead of using the supported model lifecycle. The invariant is that evergreen FAQ guidance points to the public selector rather than a transient catalog entry.

Closes #3227.

## Overlap check
Searched open and closed PRs for `FAQ`, `qwen2.5`, `model names`, issue #3227, and the changed documentation. No PR covers these stale statements. The issue's claim that Qwen 2.5 7B is absent from the full library is inaccurate—it remains an optional catalog entry—but it is not the current default, so this PR fixes the confirmed guidance defect without deleting supported catalog data.

## Test plan
- [x] `cd ods && bash tests/test-install-docs.sh`
- [x] contract requires the runnable `ods model swap T1` recovery command and rejects the retired default statements
- [x] `git diff --check`

## Tradeoffs and rollback
Provider-neutral wording stays correct as catalog defaults evolve, while the tier command remains a public CLI boundary. No model configuration changes. Reverting affects documentation only and reintroduces stale operator guidance.

Generated with Codex