### PR TITLE
fix(scripts): quote TIMEOUT expansion in health-check curl

### DIFF
--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -102,7 +102,7 @@ test_llm() {
     # running instead of failing on every Lemonade install.
     local base_path="${LLM_API_BASE_PATH:-/v1}"
     local response
-    response=$(curl -sf --max-time $TIMEOUT \
+    response=$(curl -sf --max-time "$TIMEOUT" \
         -H "Content-Type: application/json" \
         -d '{"model":"default","prompt":"Hi","max_tokens":1}' \
         "http://${LLM_HOST}:${LLM_PORT}${base_path}/completions" 2>/dev/null)


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2086** for an unquoted expansion in `ods/scripts/health-check.sh`.

## The warning
`response=$(curl -sf --max-time $TIMEOUT \` passes `$TIMEOUT` unquoted to `curl --max-time`, exposing it to word splitting and pathname expansion.

## Why it matters
`TIMEOUT` is a numeric seconds value, but the unquoted form is the exact pattern the `lint-shell` CI rejects and would break if the value ever contained spaces or glob characters.

## The fix
Quote the expansion:

    response=$(curl -sf --max-time "$TIMEOUT" \

`bash -n` passes and ShellCheck no longer reports SC2086 for this file. Behavior is identical for normal inputs.