### PR TITLE
docs(installer): sync module and phase inventory

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,7 +167,7 @@ The LLM inference engine (`llama-server`) is the foundation. GPU overlays select
 
 ## Installer Architecture
 
-The installer is a 13-phase pipeline orchestrated by `install-core.sh`.
+The installer is a 14-phase pipeline orchestrated by `install-core.sh`.
 Installer libraries in `installers/lib/` are pure functions (no side effects);
 `lib/service-registry.sh` loads service manifests and port metadata; phases in
 `installers/phases/` execute sequentially.
@@ -189,7 +189,8 @@ graph LR
 
     subgraph Phases["installers/phases/ (sequential)"]
         P01["01 Preflight"] --> P02["02 Detection"]
-        P02 --> P03["03 Features"]
+        P02 --> P02B["02b External Services"]
+        P02B --> P03["03 Features"]
         P03 --> P04["04 Requirements"]
         P04 --> P05["05 Docker"]
         P05 --> P06["06 Directories"]
@@ -209,6 +210,7 @@ graph LR
 |-------|---------|
 | 01 Preflight | Root/OS/tools checks, existing install detection |
 | 02 Detection | GPU hardware detection, tier assignment, compose config selection |
+| 02b External Services | Validate and optionally reuse host Ollama or LM Studio |
 | 03 Features | Interactive feature selection (voice, workflows, RAG, images, etc.) |
 | 04 Requirements | RAM, disk, GPU, port availability checks |
 | 05 Docker | Install Docker, Compose, NVIDIA Container Toolkit |
@@ -251,7 +253,7 @@ graph TB
 
 ### 1. Installation Flow
 
-`install.sh` → `install-core.sh` → sources `installers/lib/*.sh` → sources `installers/phases/01..13.sh` sequentially. Each phase reads state set by prior phases via exported variables. Hardware detection (phase 02) drives all downstream decisions: tier assignment selects the model GGUF, context window, batch size, and compose overlays.
+`install.sh` → `install-core.sh` → sources `installers/lib/*.sh` → sources all 14 files under `installers/phases/` sequentially. Each phase reads state set by prior phases via exported variables. Hardware detection (phase 02) drives all downstream decisions: tier assignment selects the model GGUF, context window, batch size, and compose overlays.
 
 ### 2. Service Startup Flow
 

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ ods disable my-service    # Disable it
 ods list                  # See everything
 ```
 
-The installer itself is modular — 19 library modules, a shared service registry, and 13 ordered phases. Want to add a hardware tier, swap a default model, or skip a phase? Start with the installer architecture map so you update the Linux, macOS, Windows, upgrade, and host-agent writers together.
+The installer itself is modular — 24 library modules, a shared service registry, and 14 ordered phases. Want to add a hardware tier, swap a default model, or skip a phase? Start with the installer architecture map so you update the Linux, macOS, Windows, upgrade, and host-agent writers together.
 
 [Full extension guide](ods/docs/EXTENSIONS.md) | [Installer architecture](ods/docs/INSTALLER-ARCHITECTURE.md)
 

--- a/ods/README.md
+++ b/ods/README.md
@@ -315,8 +315,8 @@ Full guide: [docs/EXTENSIONS.md](docs/EXTENSIONS.md)
 
 ### Installer Architecture
 
-The installer is modular — 19 library modules, a shared service registry, and
-13 ordered phases. The architecture doc also maps the generated config writers
+The installer is modular — 24 library modules, a shared service registry, and
+14 ordered phases. The architecture doc also maps the generated config writers
 that have to stay in sync across Linux, macOS, Windows, bootstrap upgrades, and
 host-agent model activation.
 Want to add a hardware tier, swap the theme, or skip a phase? Start with the

--- a/ods/docs/INSTALLER-ARCHITECTURE.md
+++ b/ods/docs/INSTALLER-ARCHITECTURE.md
@@ -1,7 +1,7 @@
 # Installer Architecture
 
-The ODS installer is modular — 19 installer library modules, the
-shared service registry, and 13 ordered phases. This guide is the map for
+The ODS installer is modular — 24 installer library modules, the
+shared service registry, and 14 ordered phases. This guide is the map for
 understanding, changing, and reviewing install behavior without missing a
 parallel Linux/macOS/Windows or upgrade-time writer.
 
@@ -65,7 +65,7 @@ earlier phases (e.g., phase 04 checks the GPU tier assigned by phase 02).
 
 **The orchestrator is thin.** `install-core.sh` sets up interrupt traps, sources
 the library modules and `lib/service-registry.sh`, parses CLI arguments, then
-sources the 13 phases in order. All files share one global bash namespace —
+sources the 14 phases in order. All files share one global bash namespace —
 everything is sourced, not exec'd.
 
 ## File Header Convention

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -33,6 +33,17 @@ require_literal() {
         || fail "$description missing from ${file#"$REPO_ROOT"/}"
 }
 
+installer_lib_count="$(find "$ROOT_DIR/installers/lib" -maxdepth 1 -type f -name '*.sh' | wc -l | tr -d ' ')"
+installer_phase_count="$(find "$ROOT_DIR/installers/phases" -maxdepth 1 -type f -name '*.sh' | wc -l | tr -d ' ')"
+
+require_literal "$REPO_ROOT/README.md" "$installer_lib_count library modules" "Root README installer library count"
+require_literal "$REPO_ROOT/README.md" "$installer_phase_count ordered phases" "Root README installer phase count"
+require_literal "$ROOT_DIR/README.md" "$installer_lib_count library modules" "ODS README installer library count"
+require_literal "$ROOT_DIR/README.md" "$installer_phase_count ordered phases" "ODS README installer phase count"
+require_literal "$ROOT_DIR/docs/INSTALLER-ARCHITECTURE.md" "$installer_lib_count installer library modules" "Installer architecture library count"
+require_literal "$ROOT_DIR/docs/INSTALLER-ARCHITECTURE.md" "$installer_phase_count ordered phases" "Installer architecture phase count"
+require_literal "$REPO_ROOT/ARCHITECTURE.md" "02b External Services" "Root architecture external-services phase"
+
 assert_no_retired_names() {
     python3 - "$REPO_ROOT" <<'PY'
 import base64


### PR DESCRIPTION
## Summary
- update public installer inventory to the actual 24 libraries and 14 phase files
- add `02b-external-services.sh` to the architecture flow and phase table
- derive documentation assertions from the checked-out filesystem inventory

## Why this matters
Contributor docs undercounted five installer libraries and omitted the reachable external-provider phase between detection and feature selection. That gives maintainers an incomplete execution model and makes future additions easier to miss. The invariant is that documented counts match the shipped `.sh` inventory and every phase appears in the architecture flow.

Closes #3230.

## Overlap check
Searched open and closed PRs for `installer library modules`, `13 phases`, `02b external services`, issue #3230, and all changed docs. No existing PR updates the inventory. PR #3355 corrects repository-root path prefixes in `ARCHITECTURE.md`; this count/phase scope is behaviorally independent but touches the same document, so #3355 should merge first and this branch should then be updated if GitHub reports a text conflict.

## Test plan
- [x] `cd ods && bash tests/test-install-docs.sh`
- [x] `bash -n tests/test-install-docs.sh`
- [x] dynamic contract counted 24 library scripts and 14 phase scripts from the candidate tree
- [x] `git diff --check`

## Tradeoffs and rollback
Counts remain explicit for readability but are now protected by filesystem-derived assertions. Adding or removing modules will intentionally require docs updates. Reverting affects documentation/tests only.

Generated with Codex