### PR TITLE
fix(doctor): check docker inspect exit status without $?

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -402,8 +402,7 @@ collect_extension_diagnostics() {
         # Check container state
         if [[ "$DOCKER_DAEMON" == "true" && -n "$container" ]]; then
             local inspect_output
-            inspect_output=$(docker inspect --format '{{.State.Status}}' "$container" 2>&1)
-            if [[ $? -eq 0 ]]; then
+            if inspect_output=$(docker inspect --format '{{.State.Status}}' "$container" 2>&1); then
                 container_state="$inspect_output"
             else
                 container_state="not_found"


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2181** in `ods/scripts/ods-doctor.sh`: the exit status of `docker inspect` is examined indirectly through `$?` instead of being tested directly.

## The warning
    inspect_output=$(docker inspect --format '{{.State.Status}}' "$container" 2>&1)
    if [[ $? -eq 0 ]]; then

Reading `$?` after the assignment is the indirect form ShellCheck discourages.

## Why it matters
The indirection is fragile — any command slipped between the assignment and the test would clobber `$?`. Testing the command directly is clearer and matches the repo's "let it crash" style.

## The fix
Assign inside the condition so the command's exit code is what `if` evaluates:

    if inspect_output=$(docker inspect --format '{{.State.Status}}' "$container" 2>&1); then

`inspect_output` is still populated for the success branch. `bash -n` passes and SC2181 no longer appears.