### PR TITLE
fix(doctor): use unquoted regex for GPU backend match

### DIFF
--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -436,9 +436,10 @@ collect_extension_diagnostics() {
         # manifest-level concern, not a runtime doctor warning.
         if [[ "$backend" != "apple" ]] && declare -p SERVICE_GPU_BACKENDS &>/dev/null; then
             local gpu_backends="${SERVICE_GPU_BACKENDS[$sid]:-}"
+            local backend_re=" $backend "
             if [[ -n "$gpu_backends" \
                 && ! " $gpu_backends " =~ " all " \
-                && ! " $gpu_backends " =~ " $backend " ]]; then
+                && ! " $gpu_backends " =~ $backend_re ]]; then
                 issues+=("gpu_backend_incompatible")
             fi
         fi


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2076** in `ods/scripts/ods-doctor.sh`: the right-hand side of a `=~` test is quoted, so Bash performs a literal string match instead of a regex match.

## The warning
    && ! " $gpu_backends " =~ " $backend " ]]; then

The quoted RHS makes `=~` compare literally. The intent is a space-bounded substring test (` all ` / ` cuda `), which a literal quoted match happens to satisfy — but ShellCheck correctly flags the quoted form as fragile.

## Why it matters
A quoted RHS silently changes `=~` semantics. If the pattern ever gained regex meaning the behavior would differ from intent, and CI's `lint-shell` job fails on it.

## The fix
Move the pattern into an unquoted variable so the match is explicit and ShellCheck-clean while keeping the exact space-bounded behavior:

    local backend_re=" $backend "
    ...
    && ! " $gpu_backends " =~ $backend_re ]]; then

`bash -n` passes and SC2076 is resolved.