### PR TITLE
fix(scripts): check model download exit without $?

### DIFF
--- a/ods/scripts/pre-download.sh
+++ b/ods/scripts/pre-download.sh
@@ -159,7 +159,7 @@ download_model() {
     
     log "Downloading $label: $model"
     
-    "${ODS_PYTHON_CMD:-python3}" << EOF
+    if "${ODS_PYTHON_CMD:-python3}" << EOF
 from huggingface_hub import snapshot_download
 import sys
 
@@ -174,8 +174,7 @@ except Exception as e:
     print(f"Error: {e}", file=sys.stderr)
     sys.exit(1)
 EOF
-    
-    if [[ $? -eq 0 ]]; then
+    then
         success "Downloaded $label"
         return 0
     else


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2181** in `ods/scripts/pre-download.sh`: the success of the embedded Python download script is checked indirectly through `$?`.

## The warning
    "${ODS_PYTHON_CMD:-python3}" << EOF
    ...
    EOF

    if [[ $? -eq 0 ]]; then

The `$?` read after the heredoc is the indirect form ShellCheck discourages.

## Why it matters
Any statement inserted between the heredoc and the test would clobber `$?` and silently flip the result. Testing the command directly is robust and matches the repo's "let it crash" style.

## The fix
Put the heredoc invocation in the `if` condition so its exit status is what `if` evaluates:

    if "${ODS_PYTHON_CMD:-python3}" << EOF
    ...
    EOF
    then

The success/error branches are unchanged. `bash -n` passes and SC2181 no longer appears.