### PR TITLE
fix(phase): remove redundant $ from array subscripts

### DIFF
--- a/ods/installers/phases/08-images.sh
+++ b/ods/installers/phases/08-images.sh
@@ -123,7 +123,7 @@ else
             fi
             if [[ "$_validated_llama_image" != "$_llama_image" ]]; then
                 LLAMA_SERVER_IMAGE="$_validated_llama_image"
-                PULL_LIST[$_llama_index]="${_validated_llama_image}|${_llama_label}"
+                PULL_LIST[_llama_index]="${_validated_llama_image}|${_llama_label}"
                 if [[ -f "$INSTALL_DIR/.env" ]]; then
                     if grep -q '^LLAMA_SERVER_IMAGE=' "$INSTALL_DIR/.env"; then
                         sed -i.bak "s|^LLAMA_SERVER_IMAGE=.*|LLAMA_SERVER_IMAGE=${_validated_llama_image}|" "$INSTALL_DIR/.env" && rm -f "$INSTALL_DIR/.env.bak"
@@ -167,7 +167,7 @@ else
             fi
             if [[ "$_validated_hermes_image" != "$_hermes_image" ]]; then
                 HERMES_AGENT_IMAGE="$_validated_hermes_image"
-                PULL_LIST[$_hermes_index]="${_validated_hermes_image}|${_hermes_label}"
+                PULL_LIST[_hermes_index]="${_validated_hermes_image}|${_hermes_label}"
                 if [[ -f "$INSTALL_DIR/.env" ]]; then
                     if grep -q '^HERMES_AGENT_IMAGE=' "$INSTALL_DIR/.env"; then
                         sed -i.bak "s|^HERMES_AGENT_IMAGE=.*|HERMES_AGENT_IMAGE=${_validated_hermes_image}|" "$INSTALL_DIR/.env" && rm -f "$INSTALL_DIR/.env.bak"


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2004** in `ods/installers/phases/08-images.sh`: a `$` is used on a variable inside an arithmetic context (array subscript), where it is unnecessary.

## The warning
    PULL_LIST[$_llama_index]="..."
    PULL_LIST[$_hermes_index]="..."

Inside `arr[...]` the subscript is already evaluated as an arithmetic expression, so `${_llama_index}` / `$_llama_index` should just be `_llama_index`.

## Why it matters
The `$` is redundant and trips the CI `lint-shell` job. More importantly, the same redundancy elsewhere can mask a genuine arithmetic-context mistake, so cleaning it up keeps the style consistent.

## The fix
Drop the `$` in the two subscripts:

    PULL_LIST[_llama_index]="..."
    PULL_LIST[_hermes_index]="..."

Behavior is unchanged — the index variable still resolves to the same integer. `bash -n` passes and SC2004 is gone.