### PR TITLE
fix(phase): match IPv6 loopback literally in case pattern

### DIFF
--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -471,7 +471,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
             case "$LEMONADE_BASE_URL_VALUE" in
                 http://localhost:*) LEMONADE_CONTAINER_BASE_URL_VALUE="${LEMONADE_BASE_URL_VALUE/http:\/\/localhost:/http:\/\/host.docker.internal:}" ;;
                 http://127.0.0.1:*) LEMONADE_CONTAINER_BASE_URL_VALUE="${LEMONADE_BASE_URL_VALUE/http:\/\/127.0.0.1:/http:\/\/host.docker.internal:}" ;;
-                http://[::1]:*) LEMONADE_CONTAINER_BASE_URL_VALUE="${LEMONADE_BASE_URL_VALUE/http:\/\/[::1]:/http:\/\/host.docker.internal:}" ;;
+                http://\[::1]:*) LEMONADE_CONTAINER_BASE_URL_VALUE="${LEMONADE_BASE_URL_VALUE/http:\/\/[::1]:/http:\/\/host.docker.internal:}" ;;
                 *) LEMONADE_CONTAINER_BASE_URL_VALUE="$LEMONADE_BASE_URL_VALUE" ;;
             esac
         fi


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2102** in `ods/installers/phases/06-directories.sh`: the `http://[::1]:*` case branch treats `[::1]` as a glob bracket expression rather than the literal IPv6 loopback address.

## The warning
    http://[::1]:*) ...

In a `case` pattern, `[::1]` is a bracket expression matching a single character from the set `:` / `1`, so it matches `http://:` or `http://1` — never the real `http://[::1]:` IPv6 localhost URL. That branch is effectively dead.

## Why it matters
When Lemonade is bound to the IPv6 loopback, ODS never rewrites the container URL to `host.docker.internal`, so the container cannot reach Lemonade. This is a genuine (if rare) bug, not just a lint nit.

## The fix
Escape the brackets so they are matched literally:

    http://\[::1]:*) ...

`bash -n` passes and SC2102 is resolved; the IPv6 loopback branch now actually matches.