### PR TITLE
fix(phase): remove no-op self-assignment of BIND_ADDRESS

### DIFF
--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -678,7 +678,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     # Network binding (--lan or exported BIND_ADDRESS wins over a stale .env;
     # otherwise preserve the existing .env value and default to localhost-only).
     if [[ "${BIND_ADDRESS_EXPLICIT:-false}" == "true" && -n "${BIND_ADDRESS:-}" ]]; then
-        BIND_ADDRESS="${BIND_ADDRESS}"
+        :
     else
         BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
     fi


### PR DESCRIPTION
## Overview
ShellCheck reports **SC2269** in `ods/installers/phases/06-directories.sh`: `BIND_ADDRESS` is assigned to itself, which has no effect.

## The warning
    if [[ "${BIND_ADDRESS_EXPLICIT:-false}" == "true" && -n "${BIND_ADDRESS:-}" ]]; then
        BIND_ADDRESS="${BIND_ADDRESS}"
    else
        ...
    fi

The `BIND_ADDRESS="${BIND_ADDRESS}"` line is a no-op — it just re-reads the variable into itself.

## Why it matters
The branch's intent is "when an explicit bind address is set, keep it." The self-assignment is dead code that adds noise and fails the CI `lint-shell` check. It is a leftover from an earlier refactor.

## The fix
Replace the no-op assignment with a explicit no-op so the value is preserved without a dead self-assignment:

    if [[ ... ]]; then
        :
    else
        BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
    fi

Behavior is identical (an explicit, non-empty BIND_ADDRESS is left untouched). `bash -n` passes and SC2269 is gone.