### PR TITLE
fix(installer): drop unreachable ods-*:* glob in local-image check

### DIFF
--- a/ods/installers/lib/compose-images.sh
+++ b/ods/installers/lib/compose-images.sh
@@ -20,7 +20,7 @@ _ods_compose_python_cmd() {
 _ods_compose_is_local_image() {
     local image="${1:-}"
     case "$image" in
-        ""|ods-*|ods-*:*|docker.io/library/ods-*|localhost/*|localhost:*/*|127.0.0.1:*/*)
+        ""|ods-*|docker.io/library/ods-*|localhost/*|localhost:*/*|127.0.0.1:*/*)
             return 0
             ;;
     esac


### PR DESCRIPTION
shellcheck reports SC2221/SC2222 for `_ods_compose_is_local_image` in ods/installers/lib/compose-images.sh.

The `case` pattern lists `ods-*` followed by `ods-*:*`. Because the glob `ods-*` already matches every `ods-<name>:<tag>` string, the later `ods-*:*` alternative is dead code and is never reached.

Fix: remove the redundant `ods-*:*` alternative. Behavior is unchanged — `ods-*` continues to match both untagged and tagged ODS image names.

Verified with `shellcheck -f gcc` (warning gone) and `bash -n`.