### PR TITLE
fix(repair): drop unreachable */api/v1 branch in base-url normalization

### DIFF
--- a/ods/scripts/repair/repair-perplexica.sh
+++ b/ods/scripts/repair/repair-perplexica.sh
@@ -16,7 +16,7 @@ if [[ "$_perplexica_switchboard_mode" == "enabled" ]]; then
     PERPLEXICA_API_KEY="${LITELLM_KEY:-${OPENAI_API_KEY:-no-key}}"
 fi
 case "$PERPLEXICA_LLM_BASE_URL" in
-    */v1|*/api/v1) ;;
+    */v1) ;;
     *) PERPLEXICA_LLM_BASE_URL="${PERPLEXICA_LLM_BASE_URL%/}/v1" ;;
 esac
 


### PR DESCRIPTION
shellcheck flagged SC2221/SC2222 in ods/scripts/repair/repair-perplexica.sh.

The `case "$PERPLEXICA_LLM_BASE_URL"` block uses the pattern `*/v1|*/api/v1`. Since the glob `*/v1` already matches `.../api/v1` (the `*` absorbs `.../api`), the `*/api/v1` alternative is shadowed and never executes.

Fix: keep only `*/v1`. A base URL like `http://host/v1` or `http://host/api/v1` still matches and is left untouched; only URLs without a `/v1` suffix get `/v1` appended. No behavioral change.

Checked with `shellcheck -f gcc` (warning cleared) and `bash -n`.