### PR TITLE
fix(validate): quote inner expansion in trim() to avoid pattern matching

### DIFF
--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -98,8 +98,8 @@ declare -A ENV_DUPLICATE_FROM
 
 trim() {
   local s="$1"
-  s="${s#${s%%[![:space:]]*}}"
-  s="${s%${s##*[![:space:]]}}"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
   printf '%s' "$s"
 }
 


### PR DESCRIPTION
shellcheck reports SC2295 in `trim()` in ods/scripts/validate-env.sh.

The helper strips leading/trailing whitespace using:

    s="${s#${s%%[![:space:]]*}}"
    s="${s%${s##*[![:space:]]}}"

The inner `${s%%...}` / `${s##...}` expansions sit inside another `${...}` and are therefore interpreted as *patterns*, not literal strings. For values that contain glob metacharacters (notably `*`), the trim could match the wrong span of text.

Fix: double-quote the inner expansion so it is matched literally:

    s="${s#"${s%%[![:space:]]*}"}"
    s="${s%"${s##*[![:space:]]}"}"

This is the canonical shellcheck remedy and preserves the exact trimming behavior for ordinary values while making it correct for edge cases.

Verified with `shellcheck -f gcc` (SC2295 cleared) and `bash -n`.