### PR TITLE
fix(ui): use literal printf format strings instead of variable-in-format

### DIFF
--- a/ods/installers/lib/ui.sh
+++ b/ods/installers/lib/ui.sh
@@ -320,7 +320,7 @@ pull_with_progress() {
     if [[ $attempt -gt 1 ]]; then
       local backoff
       backoff="$(_docker_pull_retry_delay "$((attempt - 1))")"
-      printf "  ${AMB}⟳${NC} [$count/$total] Retry attempt $attempt of $max_attempts for $label (waiting ${backoff}s)\n"
+      printf '  %s⟳%s [%s/%s] Retry attempt %s of %s for %s (waiting %ss)\n' "${AMB}" "${NC}" "$count" "$total" "$attempt" "$max_attempts" "$label" "${backoff}"
       sleep "$backoff"
     fi
 
@@ -367,7 +367,7 @@ pull_with_progress() {
   done
 
   # All attempts failed
-  printf "  ${RED}✗${NC} [$count/$total] Failed after $max_attempts attempts: $label\n"
+  printf '  %s✗%s [%s/%s] Failed after %s attempts: %s\n' "${RED}" "${NC}" "$count" "$total" "$max_attempts" "$label"
   return 1
 }
 


### PR DESCRIPTION
shellcheck reports SC2059 for two `printf` calls in ods/installers/lib/ui.sh.

Both format strings embedded shell variables directly, e.g.:

    printf "  ${AMB}⟳${NC} [$count/$total] Retry attempt $attempt of $max_attempts for $label (waiting ${backoff}s)\n"

When a value passed to `printf` appears in the *format* argument, it is interpreted by printf itself rather than substituted beforehand, which is fragile (especially if a value ever contains `%`). The canonical fix is a literal format string plus `%s` placeholders, with the dynamic values passed as separate arguments:

    printf '  %s⟳%s [%s/%s] Retry attempt %s of %s for %s (waiting %ss)\n' \
        "${AMB}" "${NC}" "$count" "$total" "$attempt" "$max_attempts" "$label" "${backoff}"

The second call (the "Failed after N attempts" line) is handled the same way. Rendered output is identical.

Verified with `shellcheck -f gcc` (SC2059 cleared, no new error/warning) and `bash -n`.