### PR TITLE
fix(macos): drop unreachable */api/v1 branch in LLM base-url normalization

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -944,7 +944,7 @@ configure_perplexica() {
     local perplexica_url="http://localhost:${perplexica_port}"
 
     case "$llm_base_url" in
-        */v1|*/api/v1) ;;
+        */v1) ;;
         *) llm_base_url="${llm_base_url%/}/v1" ;;
     esac
 


### PR DESCRIPTION
shellcheck flagged SC2221/SC2222 in ods/installers/macos/lib/env-generator.sh.

The `case "$llm_base_url"` block uses the pattern `*/v1|*/api/v1`. Since the glob `*/v1` already matches `http://host/api/v1` (the `*` covers `http://host/api`), the `*/api/v1` alternative is shadowed and never executes.

Fix: keep only `*/v1`. A base URL that already ends in `/v1` (including `/api/v1`) still matches and is left untouched; only URLs without a `/v1` suffix get `/v1` appended. Behavior is identical.

Verified with `shellcheck -f gcc` (SC2221/SC2222 cleared, no new warning/error) and `bash -n`.