### PR TITLE
ci: default core workflows to read-only tokens

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   powershell-lint:
     strategy:

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   token-spy-postgres:
     runs-on: ubuntu-latest
@@ -219,6 +222,7 @@ jobs:
           python3 tests/contracts/test-network-exposure-contracts.py
           python3 tests/contracts/test-remote-provider-egress-policy.py
           python3 tests/contracts/test-remote-provider-egress-service.py
+          python3 tests/contracts/test-workflow-permissions.py
 
       - name: Linux install preflight tests
         run: |

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   env-schema:
     runs-on: ubuntu-latest

--- a/ods/tests/contracts/test-workflow-permissions.py
+++ b/ods/tests/contracts/test-workflow-permissions.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Required CI workflows must declare a read-only default token."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOWS = (
+    "dashboard.yml",
+    "lint-powershell.yml",
+    "test-linux.yml",
+    "validate-env.yml",
+)
+
+
+def main() -> None:
+    expected = "\npermissions:\n  contents: read\n"
+    for name in WORKFLOWS:
+        path = REPO_ROOT / ".github" / "workflows" / name
+        text = path.read_text(encoding="utf-8")
+        if expected not in text:
+            raise AssertionError(f"{name} must default GITHUB_TOKEN to contents: read")
+        print(f"[PASS] {name} uses a read-only default token")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- set the default GITHUB_TOKEN to `contents: read` in four required CI workflows
- cover dashboard, PowerShell lint, environment validation, and Linux integration/artifact upload
- add a repository contract that prevents those defaults from becoming implicit again

## Why this matters
These pull-request workflows only check out source and upload runner-produced artifacts, but inherited GitHub's mutable default token permissions. Explicit read-only defaults keep routine validation from gaining repository write access when organization settings change. This is CI least-privilege hardening; it does not claim an untrusted runtime boundary.

Closes #3228.
Closes #3238.

## Overlap check
Searched open and closed PRs for `workflow permissions`, `dashboard`, `lint-powershell`, `validate-env`, `test-linux`, and both issue numbers. No existing PR covers these four workflows. Workflows with intentional job-level write permissions remain unchanged.

## Test plan
- [x] `python ods/tests/contracts/test-workflow-permissions.py` (4 workflows passed)
- [x] parsed all four YAML files with PyYAML
- [x] wired the contract into the Linux integration gate
- [x] `git diff --check`

## Tradeoffs and rollback
`actions/upload-artifact` uploads through the Actions service and does not require repository write permission. If a future step needs another scope, grant it narrowly at the job level. Reverting restores implicit platform defaults.

Generated with Codex