### PR TITLE
docs(models): align FAQ with the tier selector

### DIFF
--- a/ods/FAQ.md
+++ b/ods/FAQ.md
@@ -130,12 +130,14 @@ The installer auto-selects based on your GPU, but you can switch between any tie
 
 | Tier | Model | Min VRAM |
 |------|-------|----------|
+| T0 | Qwen3.5 2B | CPU fallback (8 GB RAM) |
 | T1 | Qwen3.5 9B | 8 GB |
-| T2 | Qwen3.5 9B | 12 GB |
-| T3 | Qwen3 30B-A3B | 20 GB |
-| T4 | Qwen3 30B-A3B (MoE) | 40 GB |
-| SH_COMPACT | Qwen3 30B-A3B (MoE) | 64 GB unified |
-| SH_LARGE | Qwen3 Coder Next 80B (MoE) | 90 GB unified |
+| T2 | Phi-4 14B | 12 GB |
+| T3 | Qwen3.5 27B | 24 GB |
+| T4 | DeepSeek R1 Distill Llama 70B | 48 GB |
+| SH_COMPACT | Qwen3.6 35B-A3B | 64 GB unified |
+| SH_LARGE | DeepSeek R1 Distill Llama 70B | 96 GB unified |
+| SH_LARGE | Qwen3.6 35B-A3B | 124 GB unified |
 
 Run `ods model list` for the full list on your system.
 

--- a/ods/tests/test-tier-map.sh
+++ b/ods/tests/test-tier-map.sh
@@ -520,6 +520,33 @@ else
 fi
 echo ""
 
+if python3 - "$SCRIPT_DIR/FAQ.md" <<'PY'
+from pathlib import Path
+import sys
+
+faq = Path(sys.argv[1]).read_text(encoding="utf-8")
+expected = (
+    "| T0 | Qwen3.5 2B | CPU fallback (8 GB RAM) |",
+    "| T1 | Qwen3.5 9B | 8 GB |",
+    "| T2 | Phi-4 14B | 12 GB |",
+    "| T3 | Qwen3.5 27B | 24 GB |",
+    "| T4 | DeepSeek R1 Distill Llama 70B | 48 GB |",
+    "| SH_COMPACT | Qwen3.6 35B-A3B | 64 GB unified |",
+    "| SH_LARGE | DeepSeek R1 Distill Llama 70B | 96 GB unified |",
+    "| SH_LARGE | Qwen3.6 35B-A3B | 124 GB unified |",
+)
+missing = [row for row in expected if row not in faq]
+if missing:
+    raise SystemExit("FAQ tier table is stale:\n" + "\n".join(missing))
+print("[PASS] FAQ tier table matches current selector examples")
+PY
+then
+    ((PASS++))
+else
+    ((FAIL++))
+fi
+echo ""
+
 # --- Summary ---
 echo "==============================="
 echo "Results: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
- align FAQ T0–T4 and Strix Halo examples with the current canonical selector outputs
- remove Qwen3 Coder Next from unified-memory guidance
- make the tier-map gate assert every documented row

## Why this matters
The public FAQ sent operators to models and VRAM envelopes that no longer match installation selection, including a model explicitly excluded from Strix Halo by current correctness policy. The invariant is that quick-reference tier guidance matches the current selector examples used by the canonical READMEs.

Closes #3225.

## Overlap check
Searched open and closed PRs for `FAQ tier`, `VRAM table`, `SH_LARGE`, issue #3225, and the FAQ/tier-map files. No PR covers table parity. PR #3353 removes stale prose defaults elsewhere in the FAQ; it does not modify this table or tier assertions.

## Test plan
- [x] `cd ods && bash tests/test-tier-map.sh` (130 passed)
- [x] `bash -n tests/test-tier-map.sh`
- [x] `git diff --check`

## Tradeoffs and rollback
SH_LARGE has two rows because the selector differs between 96GB and 124GB unified-memory envelopes. The regression uses exact current examples, so future selector changes intentionally require the FAQ to move with them. Documentation/test-only rollback.

Generated with Codex