### PR TITLE
ci: exercise backup and restore safety contracts

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -235,6 +235,15 @@ jobs:
       - name: Update Rollback Contract
         run: bash tests/test-update-rollback-contract.sh
 
+      - name: Backup and Restore Safety Contracts
+        run: |
+          bash tests/test-backup-restore-cli.sh
+          bash tests/test-backup-restore-roundtrip.sh
+          bash tests/test-backup-integrity.sh
+          bash tests/test-restore-safety-ux.sh
+          bash tests/test-cli-preset-restore-user-extensions.sh
+          bash tests/test-update-script-backup.sh
+
       - name: Bootstrap Upgrade Compose Flags Recovery Tests
         run: bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
 

--- a/ods/tests/test-restore-safety-ux.sh
+++ b/ods/tests/test-restore-safety-ux.sh
@@ -21,7 +21,8 @@ TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
 FAKE_ODS="$TMP/ods"
-mkdir -p "$FAKE_ODS/.backups"
+mkdir -p "$FAKE_ODS/.backups" "$FAKE_ODS/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/rsync.sh"
 # minimal marker so 'is this a ODS dir' check passes
 mkdir -p "$FAKE_ODS/data"
 


### PR DESCRIPTION
## Why this matters
Backup and restore are data-safety boundaries, but six repository-owned contract suites were absent from GitHub Actions. Regressions could merge without exercising round trips, integrity checks, confirmation UX, preset restoration, or update backup rotation. This also repairs the dormant restore UX fixture so it carries the production `lib/rsync.sh` dependency when CI executes it.

Closes #3241.

## Overlap check
Searched open and closed PRs for `backup restore workflow`, each of the six test filenames, and changes to `.github/workflows/test-linux.yml`. No PR wires this exact data-safety suite into CI; existing backup/restore PRs change runtime behavior rather than CI coverage.

## Regression test
The `integration-smoke` job now runs:
- `tests/test-backup-restore-cli.sh`
- `tests/test-backup-restore-roundtrip.sh`
- `tests/test-backup-integrity.sh`
- `tests/test-restore-safety-ux.sh`
- `tests/test-cli-preset-restore-user-extensions.sh`
- `tests/test-update-script-backup.sh`

Focused local validation: all six scripts pass, workflow YAML parses, and `git diff --check` passes.

## Tradeoffs and rollback
This adds about six seconds locally to the existing integration job and requires no runtime or release behavior change. Reverting the workflow step removes the CI cost; the fixture correction remains independently safe.