### PR TITLE
fix(installer): preserve low-VRAM bootstrap context

### DIFF
--- a/ods/installers/lib/bootstrap-model.sh
+++ b/ods/installers/lib/bootstrap-model.sh
@@ -24,6 +24,28 @@ BOOTSTRAP_GGUF_SHA256="aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee91
 BOOTSTRAP_LLM_MODEL="qwen3.5-2b"
 BOOTSTRAP_MAX_CONTEXT=65536
 
+# Keep the selector's VRAM-fit context on sub-8GB discrete GPUs. Raising a
+# bootstrap model to 64K can consume the remaining VRAM in KV cache and kill
+# llama-server before the full-model download starts. Unified-memory and CPU
+# hosts retain the agent-capable 64K fast-start default.
+bootstrap_runtime_context() {
+    local selected_context="$1"
+    local vram_mb="${GPU_VRAM:-0}"
+
+    if [[ "${HERMES_CONTEXT_SIZE_EXPLICIT:-false}" != "true" \
+        && "${GPU_MEMORY_TYPE:-}" == "discrete" \
+        && "$vram_mb" =~ ^[0-9]+$ \
+        && "$vram_mb" -gt 0 \
+        && "$vram_mb" -lt 8192 \
+        && "$selected_context" =~ ^[0-9]+$ \
+        && "$selected_context" -lt "$BOOTSTRAP_MAX_CONTEXT" ]]; then
+        printf '%s\n' "$selected_context"
+        return
+    fi
+
+    printf '%s\n' "$BOOTSTRAP_MAX_CONTEXT"
+}
+
 # bootstrap_needed — Should we use the fast-start bootstrap pattern?
 #
 # Returns 0 (true) when ALL of these hold:

--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -90,8 +90,16 @@ if ! $INTERACTIVE && [[ "$ENABLE_COMFYUI" == "true" ]]; then
 fi
 
 if [[ "${ENABLE_HERMES:-false}" == "true" && "${ODS_MODE:-local}" != "cloud" ]]; then
+    HERMES_CONTEXT_SIZE_EXPLICIT=false
+    [[ -n "${HERMES_CONTEXT_SIZE+x}" ]] && HERMES_CONTEXT_SIZE_EXPLICIT=true
     HERMES_CONTEXT_SIZE="${HERMES_CONTEXT_SIZE:-65536}"
-    if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
+    if [[ "$HERMES_CONTEXT_SIZE_EXPLICIT" != "true" \
+        && "${GPU_MEMORY_TYPE:-}" == "discrete" \
+        && "${GPU_VRAM:-0}" =~ ^[0-9]+$ \
+        && "${GPU_VRAM:-0}" -gt 0 \
+        && "${GPU_VRAM:-0}" -lt 8192 ]]; then
+        ai_warn "Hermes context floor skipped on a ${GPU_VRAM}MB discrete GPU; preserving the ${MAX_CONTEXT}-token VRAM-fit context."
+    elif [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
         ai_warn "Hermes enabled: increasing llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (64K floor)."
         if [[ -n "${MODEL_RECOMMENDATION_REASON:-}" ]]; then
             MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON} Hermes requires at least 64K context, so runtime context was raised to ${HERMES_CONTEXT_SIZE}."

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -686,7 +686,7 @@ else
         GGUF_URL="$BOOTSTRAP_GGUF_URL"
         GGUF_SHA256="${BOOTSTRAP_GGUF_SHA256:-}"
         LLM_MODEL="$BOOTSTRAP_LLM_MODEL"
-        MAX_CONTEXT="$BOOTSTRAP_MAX_CONTEXT"
+        MAX_CONTEXT="$(bootstrap_runtime_context "$FULL_MAX_CONTEXT")"
         ai "Fast-start mode: downloading bootstrap model (~1.5GB) for instant chat."
         ai "Your full model ($FULL_LLM_MODEL) will download in the background."
     fi

--- a/ods/tests/test-hermes-context-floor.sh
+++ b/ods/tests/test-hermes-context-floor.sh
@@ -13,6 +13,8 @@ fail() { echo "  FAIL: $1" >&2; exit 1; }
 
 run_linux_phase_with_context() {
     local input_context="$1"
+    local memory_type="${2:-none}"
+    local vram_mb="${3:-0}"
     (
         set -euo pipefail
         INTERACTIVE=false
@@ -32,6 +34,8 @@ run_linux_phase_with_context() {
         SCRIPT_DIR="/tmp/ods-context-floor-no-compose"
         GPU_COUNT=1
         GPU_BACKEND=cpu
+        GPU_MEMORY_TYPE="$memory_type"
+        GPU_VRAM="$vram_mb"
         HOST_ARCH=x86_64
 
         ods_progress() { :; }
@@ -60,6 +64,24 @@ large_context="$(printf '%s\n' "$large" | sed -n '1p')"
 [[ "$large_context" == "131072" ]] \
     || fail "Linux Hermes floor should not reduce existing 128K context, got ${large_context}"
 pass "Linux Hermes floor preserves 128K-capable contexts"
+
+low_vram="$(run_linux_phase_with_context 16384 discrete 4096)"
+low_vram_context="$(printf '%s\n' "$low_vram" | sed -n '1p')"
+[[ "$low_vram_context" == "16384" ]] \
+    || fail "Linux must preserve selector context on sub-8GB discrete GPUs, got ${low_vram_context}"
+pass "Linux Hermes floor preserves the VRAM-fit context on a 4GB discrete GPU"
+
+source installers/lib/bootstrap-model.sh
+GPU_MEMORY_TYPE=discrete GPU_VRAM=4096 HERMES_CONTEXT_SIZE_EXPLICIT=false
+[[ "$(bootstrap_runtime_context 16384)" == "16384" ]] \
+    || fail "bootstrap must preserve the selector context on a 4GB discrete GPU"
+GPU_MEMORY_TYPE=unified GPU_VRAM=4096
+[[ "$(bootstrap_runtime_context 16384)" == "65536" ]] \
+    || fail "bootstrap must retain 64K on unified-memory hardware"
+GPU_MEMORY_TYPE=discrete GPU_VRAM=4096 HERMES_CONTEXT_SIZE_EXPLICIT=true
+[[ "$(bootstrap_runtime_context 16384)" == "65536" ]] \
+    || fail "an explicit Hermes context override must retain 64K"
+pass "Bootstrap context distinguishes low discrete VRAM from unified and explicit profiles"
 
 grep -Eq 'hermesContextSize[[:space:]]*=[[:space:]]*65536' installers/windows/phases/03-features.ps1 \
     || fail "Windows Hermes floor must be 64K"


### PR DESCRIPTION
## Why this matters
On discrete GPUs below 8 GB, forcing both Hermes and the fast-start model to a 64K context can exhaust VRAM and kill llama-server with exit 137 before ODS becomes usable. The installer now preserves the model selector's smaller, VRAM-fit context for that hardware class while retaining the 64K agent default on CPU/unified-memory hosts and honoring an explicit Hermes context override.

Closes #2927.

## Overlap check
Searched open and closed PRs for `bootstrap context`, `64K`, `low VRAM`, `exit 137`, issue #2927, and changes to the three installer files. No existing PR covers this defect. Existing context work establishes the 64K default but does not guard sub-8GB discrete GPUs.

## Regression test
`tests/test-hermes-context-floor.sh` exercises the sourced Linux feature phase and bootstrap selector at the public configuration boundary:
- 4GB discrete GPU preserves 16K
- 4GB unified memory retains 64K
- explicit context policy retains 64K
- ordinary 32K and 128K profiles keep their existing behavior

Focused validation: `bash tests/test-hermes-context-floor.sh`, `bash -n` for all touched installer scripts, and `git diff --check` pass. The broader context-parity script reaches a pre-existing unrelated Hermes token-bound assertion failure on current main; this change does not modify that path.

## Tradeoffs and rollback
Hermes may have less than its preferred 64K window only on auto-configured sub-8GB discrete GPUs; a running model is favored over an OOM-killed agent backend. Operators can still explicitly raise `HERMES_CONTEXT_SIZE`. Reverting restores the previous unconditional 64K behavior.