### PR TITLE
docs(contributing): fix dashboard API working directory

### DIFF
--- a/ods/CONTRIBUTING.md
+++ b/ods/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The short version: the dashboard-api `Dockerfile` copies the Python source into 
 The recommended workflow is to run uvicorn natively on the host with `--reload`:
 
 ```bash
-cd ods/extensions/services/dashboard-api
+cd extensions/services/dashboard-api
 pip install -r requirements.txt
 ODS_INSTALL_DIR=/path/to/ods \
   uvicorn main:app --host 127.0.0.1 --port 3002 --reload

--- a/ods/tests/test-doc-links.sh
+++ b/ods/tests/test-doc-links.sh
@@ -106,6 +106,18 @@ check_markdown_file() {
   done < "$file"
 }
 
+check_contributing_workdirs() {
+  local command workdir
+  while IFS= read -r command; do
+    workdir="${command#cd }"
+    workdir="${workdir%% &&*}"
+    [[ -d "$ROOT_DIR/$workdir" ]] || {
+      echo "[FAIL] CONTRIBUTING.md uses a missing working directory: $workdir"
+      return 1
+    }
+  done < <(grep -E '^cd [^/~$]+' "$ROOT_DIR/CONTRIBUTING.md")
+}
+
 main() {
   local failures=0
 
@@ -133,6 +145,10 @@ main() {
       failures=$((failures + 1))
     fi
   done
+
+  if ! check_contributing_workdirs; then
+    failures=$((failures + 1))
+  fi
 
   if [[ $failures -gt 0 ]]; then
     fail "$failures markdown file(s) contain broken local links"


### PR DESCRIPTION
## Why this matters
`ods/CONTRIBUTING.md` is read from the `ods/` project root, but its dashboard API command added another `ods/` segment and failed with a nonexistent `ods/ods/extensions/...` path. Contributors following the documented local-development path could not start the backend.

Closes #3229.

## Overlap check
Searched open and closed PRs for `CONTRIBUTING`, `dashboard-api`, `double ods`, the incorrect command text, and changes to `ods/CONTRIBUTING.md`. No existing PR covers this path defect.

## Regression test
`tests/test-doc-links.sh` now validates relative `cd` working directories documented in `CONTRIBUTING.md`, so the command is checked against the repository layout rather than protected by a text-only assertion.

Validation: `bash tests/test-doc-links.sh`, `bash -n tests/test-doc-links.sh`, and `git diff --check` pass.

## Tradeoffs and rollback
The contract intentionally checks only relative `cd` commands in the contributor guide; absolute, home-relative, and variable-based operator examples are outside its scope. Reverting restores the broken command and removes that executable documentation guard.