### PR TITLE
fix(models): size KV cache from GGUF architecture

### DIFF
--- a/ods/CONTRIBUTING.md
+++ b/ods/CONTRIBUTING.md
@@ -26,7 +26,7 @@ The short version: the dashboard-api `Dockerfile` copies the Python source into 
 The recommended workflow is to run uvicorn natively on the host with `--reload`:
 
 ```bash
-cd ods/extensions/services/dashboard-api
+cd extensions/services/dashboard-api
 pip install -r requirements.txt
 ODS_INSTALL_DIR=/path/to/ods \
   uvicorn main:app --host 127.0.0.1 --port 3002 --reload

--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -170,6 +170,21 @@ def _first_int(metadata: dict[str, Any], suffixes: tuple[str, ...]) -> int | Non
     return None
 
 
+def _first_int_or_list(
+    metadata: dict[str, Any], suffixes: tuple[str, ...]
+) -> int | list[int] | None:
+    for key, value in metadata.items():
+        if not key.endswith(suffixes):
+            continue
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        if isinstance(value, list) and all(
+            isinstance(item, int) and not isinstance(item, bool) for item in value
+        ):
+            return value
+    return None
+
+
 def _first_value(metadata: dict[str, Any], suffixes: tuple[str, ...]) -> Any:
     for key, value in metadata.items():
         if key.endswith(suffixes):
@@ -223,7 +238,16 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
             "block_count": _first_int(metadata, (".block_count",)),
             "embedding_length": _first_int(metadata, (".embedding_length",)),
             "attention_head_count": _first_int(metadata, (".attention.head_count",)),
-            "attention_head_count_kv": _first_int(metadata, (".attention.head_count_kv",)),
+            "attention_head_count_kv": _first_int_or_list(
+                metadata, (".attention.head_count_kv",)
+            ),
+            "attention_key_length": _first_int(
+                metadata, (".attention.key_length",)
+            ),
+            "attention_value_length": _first_int(
+                metadata, (".attention.value_length",)
+            ),
+            "rope_dimension_count": _first_int(metadata, (".rope.dimension_count",)),
             "expert_count": _first_int(metadata, (".expert_count", ".expert.count")),
             "expert_used_count": _first_int(metadata, (".expert_used_count", ".expert.used_count")),
             "model_name": _first_value(metadata, ("general.name",)),

--- a/ods/extensions/services/dashboard-api/model_memory.py
+++ b/ods/extensions/services/dashboard-api/model_memory.py
@@ -62,6 +62,31 @@ def estimated_context_kv_gb(
     except (TypeError, ValueError):
         context = 0
     context = max(context, 8192)
+    block_count = _positive_number(model.get("block_count"))
+    kv_heads = _positive_number(
+        model.get("attention_head_count_kv") or model.get("head_count_kv")
+    )
+    embedding_length = _positive_number(model.get("embedding_length"))
+    head_count = _positive_number(
+        model.get("attention_head_count") or model.get("head_count")
+    )
+    head_dimension = _positive_number(
+        model.get("attention_head_dimension")
+        or model.get("head_dimension")
+        or model.get("rope_dimension_count")
+    )
+    if not head_dimension and embedding_length and head_count:
+        head_dimension = embedding_length / head_count
+
+    if block_count and kv_heads and head_dimension:
+        # llama.cpp's default f16 KV cache stores one key and one value for
+        # every layer/head/token: 2 * layers * KV heads * head dimension *
+        # 2-byte elements. Architecture metadata is authoritative here;
+        # parameter count is especially misleading for MoE models.
+        element_bytes = _positive_number(model.get("kv_cache_element_bytes")) or 2.0
+        kv_bytes = 2.0 * block_count * kv_heads * head_dimension * element_bytes * context
+        return round(kv_bytes / (1024.0 ** 3), 2)
+
     params_b = estimated_param_billions(model)
     kv_per_32k_gb = min(max(params_b * 0.12, 0.35), 3.5)
     return round(kv_per_32k_gb * (context / 32768.0), 2)

--- a/ods/extensions/services/dashboard-api/model_memory.py
+++ b/ods/extensions/services/dashboard-api/model_memory.py
@@ -63,9 +63,7 @@ def estimated_context_kv_gb(
         context = 0
     context = max(context, 8192)
     block_count = _positive_number(model.get("block_count"))
-    kv_heads = _positive_number(
-        model.get("attention_head_count_kv") or model.get("head_count_kv")
-    )
+    kv_heads_raw = model.get("attention_head_count_kv") or model.get("head_count_kv")
     embedding_length = _positive_number(model.get("embedding_length"))
     head_count = _positive_number(
         model.get("attention_head_count") or model.get("head_count")
@@ -73,18 +71,39 @@ def estimated_context_kv_gb(
     head_dimension = _positive_number(
         model.get("attention_head_dimension")
         or model.get("head_dimension")
-        or model.get("rope_dimension_count")
     )
-    if not head_dimension and embedding_length and head_count:
-        head_dimension = embedding_length / head_count
+    derived_head_dimension = (
+        embedding_length / head_count if embedding_length and head_count else 0.0
+    )
+    key_dimension = _positive_number(model.get("attention_key_length"))
+    value_dimension = _positive_number(model.get("attention_value_length"))
+    key_dimension = key_dimension or head_dimension or derived_head_dimension
+    value_dimension = value_dimension or head_dimension or derived_head_dimension
 
-    if block_count and kv_heads and head_dimension:
+    layer_kv_heads = 0.0
+    if isinstance(kv_heads_raw, (list, tuple)):
+        kv_heads_by_layer = [_positive_number(value) for value in kv_heads_raw]
+        # Per-layer arrays are authoritative only when complete. The GGUF
+        # inspector deliberately samples very large arrays, so an incomplete
+        # list must fall back instead of under-counting omitted layers.
+        if block_count and len(kv_heads_by_layer) == int(block_count):
+            layer_kv_heads = sum(kv_heads_by_layer)
+    else:
+        kv_heads = _positive_number(kv_heads_raw)
+        if block_count and kv_heads:
+            layer_kv_heads = block_count * kv_heads
+
+    if layer_kv_heads and key_dimension and value_dimension:
         # llama.cpp's default f16 KV cache stores one key and one value for
-        # every layer/head/token: 2 * layers * KV heads * head dimension *
-        # 2-byte elements. Architecture metadata is authoritative here;
-        # parameter count is especially misleading for MoE models.
+        # every KV head/token. Key and value dimensions can differ, and newer
+        # hybrid architectures expose a per-layer KV-head array.
         element_bytes = _positive_number(model.get("kv_cache_element_bytes")) or 2.0
-        kv_bytes = 2.0 * block_count * kv_heads * head_dimension * element_bytes * context
+        kv_bytes = (
+            layer_kv_heads
+            * (key_dimension + value_dimension)
+            * element_bytes
+            * context
+        )
         return round(kv_bytes / (1024.0 ** 3), 2)
 
     params_b = estimated_param_billions(model)

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -1362,13 +1362,16 @@ def build_models_payload(gpu_info: Optional[GPUInfo], loaded_model: Optional[str
                 else 0
             )
         )
+        memory_model = {**model, **metadata}
         context_model = {
-            **model,
+            **memory_model,
             "max_context_length": max_context_length,
             "context_limit_known": context_limit_known,
         }
         vram_required = float(model["vram_required_gb"])
-        selector_required = _effective_required_memory_gb({**model, "context_length": actual_context}, runtime_profile)
+        selector_required = _effective_required_memory_gb(
+            {**memory_model, "context_length": actual_context}, runtime_profile
+        )
         if gpu_info:
             capacity_gb = _usable_model_memory_gb(gpu_info)
             fits_total = bool(_fits_declared_vram(selector_required, capacity_gb) or is_loaded)

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -80,6 +80,9 @@ def test_full_metadata_is_normalized(tmp_path):
         ("llama.embedding_length", U32, 4096),
         ("llama.attention.head_count", U32, 32),
         ("llama.attention.head_count_kv", U32, 8),
+        ("llama.attention.key_length", U32, 128),
+        ("llama.attention.value_length", U32, 96),
+        ("llama.rope.dimension_count", U32, 64),
     ]
     path = _write(tmp_path, "model.gguf", build_gguf(kvs, tensor_count=291))
 
@@ -99,7 +102,21 @@ def test_full_metadata_is_normalized(tmp_path):
     assert result["embedding_length"] == 4096
     assert result["attention_head_count"] == 32
     assert result["attention_head_count_kv"] == 8
+    assert result["attention_key_length"] == 128
+    assert result["attention_value_length"] == 96
+    assert result["rope_dimension_count"] == 64
     assert result["size_bytes"] == path.stat().st_size
+
+
+def test_per_layer_kv_head_counts_are_preserved(tmp_path):
+    path = _write(tmp_path, "hybrid.gguf", build_gguf([
+        ("general.architecture", STR, "qwen35"),
+        ("qwen35.attention.head_count_kv", ARR, (U32, [0, 2, 0, 2])),
+    ]))
+
+    result = inspect_gguf(path)
+
+    assert result["attention_head_count_kv"] == [0, 2, 0, 2]
 
 
 def test_expert_count_accepts_alternate_suffix(tmp_path):

--- a/ods/extensions/services/dashboard-api/tests/test_model_memory.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_memory.py
@@ -78,6 +78,31 @@ class TestParamScaleSources:
         assert estimated_context_kv_gb(model) < estimated_context_kv_gb(without_filename)
 
 
+class TestArchitectureAwareKvCache:
+
+    def test_dense_qwen_metadata_matches_llama_allocation(self):
+        model = {
+            "block_count": 36,
+            "attention_head_count_kv": 8,
+            "embedding_length": 4096,
+            "attention_head_count": 32,
+        }
+        assert estimated_context_kv_gb(model, 32768) == 4.5
+        assert estimated_context_kv_gb(model, 262144) == 36.0
+
+    def test_explicit_head_dimension_supports_grouped_attention(self):
+        model = {
+            "block_count": 10,
+            "attention_head_count_kv": 4,
+            "rope_dimension_count": 64,
+        }
+        assert estimated_context_kv_gb(model, 32768) == 0.31
+
+    def test_incomplete_metadata_keeps_catalog_fallback(self):
+        model = {"params_b": 4, "block_count": 36}
+        assert estimated_context_kv_gb(model, 32768) == 0.48
+
+
 @pytest.mark.skipif(
     not CATALOG_PATH.exists() or not SELECT_MODEL_PATH.exists(),
     reason="repo checkout required",

--- a/ods/extensions/services/dashboard-api/tests/test_model_memory.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_memory.py
@@ -90,13 +90,43 @@ class TestArchitectureAwareKvCache:
         assert estimated_context_kv_gb(model, 32768) == 4.5
         assert estimated_context_kv_gb(model, 262144) == 36.0
 
-    def test_explicit_head_dimension_supports_grouped_attention(self):
+    def test_explicit_key_and_value_lengths_support_grouped_attention(self):
         model = {
             "block_count": 10,
             "attention_head_count_kv": 4,
-            "rope_dimension_count": 64,
+            "attention_key_length": 64,
+            "attention_value_length": 64,
         }
         assert estimated_context_kv_gb(model, 32768) == 0.31
+
+    def test_partial_rope_dimension_does_not_undercount_phi3_heads(self):
+        model = {
+            "block_count": 32,
+            "attention_head_count_kv": 8,
+            "embedding_length": 3072,
+            "attention_head_count": 24,
+            "rope_dimension_count": 96,
+        }
+        assert estimated_context_kv_gb(model, 32768) == 4.0
+
+    def test_per_layer_kv_heads_cover_hybrid_attention(self):
+        model = {
+            "block_count": 4,
+            "attention_head_count_kv": [0, 2, 0, 2],
+            "attention_key_length": 256,
+            "attention_value_length": 256,
+        }
+        assert estimated_context_kv_gb(model, 32768) == 0.12
+
+    def test_incomplete_per_layer_metadata_falls_back(self):
+        model = {
+            "params_b": 4,
+            "block_count": 80,
+            "attention_head_count_kv": [8] * 64,
+            "attention_key_length": 128,
+            "attention_value_length": 128,
+        }
+        assert estimated_context_kv_gb(model, 32768) == 0.48
 
     def test_incomplete_metadata_keeps_catalog_fallback(self):
         model = {"params_b": 4, "block_count": 36}

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -1143,6 +1143,10 @@ def test_downloaded_gguf_header_replaces_stale_hub_context(
             "readable": True,
             "context_length": 131072,
             "quantization": "Q4_K_M",
+            "block_count": 36,
+            "attention_head_count_kv": 8,
+            "embedding_length": 4096,
+            "attention_head_count": 32,
         },
     )
 
@@ -1162,6 +1166,8 @@ def test_downloaded_gguf_header_replaces_stale_hub_context(
     assert model["metadata"]["contextSource"] == "gguf_file"
     assert model["contextOptions"][-1]["contextLength"] == 131072
     assert model["contextOptions"][-1]["fullContext"] is True
+    assert model["estimatedRequired"] == 1.61
+    assert model["contextOptions"][-1]["estimatedRequired"] == 18.49
 
 
 def test_configured_model_prefers_env_file_over_stale_process_env(data_dir, tmp_path, monkeypatch):

--- a/ods/tests/test-doc-links.sh
+++ b/ods/tests/test-doc-links.sh
@@ -106,6 +106,18 @@ check_markdown_file() {
   done < "$file"
 }
 
+check_contributing_workdirs() {
+  local command workdir
+  while IFS= read -r command; do
+    workdir="${command#cd }"
+    workdir="${workdir%% &&*}"
+    [[ -d "$ROOT_DIR/$workdir" ]] || {
+      echo "[FAIL] CONTRIBUTING.md uses a missing working directory: $workdir"
+      return 1
+    }
+  done < <(grep -E '^cd [^/~$]+' "$ROOT_DIR/CONTRIBUTING.md")
+}
+
 main() {
   local failures=0
 
@@ -133,6 +145,10 @@ main() {
       failures=$((failures + 1))
     fi
   done
+
+  if ! check_contributing_workdirs; then
+    failures=$((failures + 1))
+  fi
 
   if [[ $failures -gt 0 ]]; then
     fail "$failures markdown file(s) contain broken local links"


### PR DESCRIPTION
## Why this matters
The dashboard estimated llama.cpp KV cache from parameter count, which substantially under-counts some dense models and over-counts MoE models. Those estimates drive context options, `estimatedRequired`, and `fitsVram`, so users could be encouraged to activate contexts whose KV allocation alone exceeds GPU memory.

When a downloaded GGUF exposes architecture metadata, ODS now calculates f16 KV memory from layers, KV heads, head dimension, and tokens. Catalog entries without readable GGUF metadata retain the existing conservative fallback.

Closes #3324.

## Overlap check
Searched open and closed PRs for `KV cache`, `estimated_context_kv_gb`, `head_count_kv`, `block_count`, issue #3324, and both production files. No existing PR covers architecture-aware KV sizing.

## Regression test
Boundary coverage includes:
- the reported 36-layer/8-KV-head dense shape: 4.5 GiB at 32K and 36 GiB at 256K
- explicit GGUF head-dimension metadata
- incomplete metadata falling back without behavior change
- downloaded GGUF metadata flowing through `/api/models` estimates and context options

Validation: `python -m pytest tests/test_model_memory.py tests/test_performance_oracle.py -q` (61 passed), Python compile checks, and `git diff --check`.

## Tradeoffs and rollback
The exact path assumes llama.cpp's default f16 K/V elements; `kv_cache_element_bytes` allows a caller to describe quantized cache storage. Pre-download catalog models still use the legacy heuristic until architecture metadata is available. Reverting restores parameter-count estimates without changing persisted state.