### PR TITLE
fix(dashboard): explain model inventory timeouts

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -983,6 +983,31 @@ describe('useModels', () => {
     }
   })
 
+  test('turns a models timeout into actionable UI guidance', async () => {
+    vi.useFakeTimers()
+    fetch.mockImplementation((_url, options) => new Promise((_resolve, reject) => {
+      options.signal.addEventListener('abort', () => {
+        const error = new Error('signal is aborted without reason')
+        error.name = 'AbortError'
+        reject(error)
+      }, { once: true })
+    }))
+
+    try {
+      const { result } = renderHook(() => useModels())
+      setDocumentHidden(true)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000) })
+
+      expect(result.current.loading).toBe(false)
+      expect(result.current.error).toMatch(/timed out after 30 seconds/i)
+      expect(result.current.error).toMatch(/Dashboard API logs/i)
+      expect(result.current.error).not.toMatch(/aborted/i)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('does not let an older models response overwrite a newer snapshot', async () => {
     const firstRequest = deferred()
     const secondRequest = deferred()

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -145,6 +145,13 @@ function normalizeOdsMode(value) {
   return ODS_MODES.has(mode) ? mode : 'unknown'
 }
 
+function modelsFetchErrorMessage(error) {
+  if (error?.name === 'AbortError') {
+    return 'Model inventory timed out after 30 seconds. The model service may still be loading; retry shortly or check Dashboard API logs.'
+  }
+  return error?.message || 'Failed to fetch models'
+}
+
 function modelActivationModeError(effectiveMode, configuredMode, llmBackend) {
   if (llmBackend === 'external') {
     return 'ODS is using an external Ollama or LM Studio backend. Re-run the installer with --no-external-llm before activating a downloaded local model.'
@@ -258,7 +265,7 @@ export function useModels() {
     } catch (err) {
       if (requestId >= latestSettledModelsRequestRef.current) {
         latestSettledModelsRequestRef.current = requestId
-        setFetchError(err.message)
+        setFetchError(modelsFetchErrorMessage(err))
       }
       // No silent fallback - let error propagate to UI
     } finally {


### PR DESCRIPTION
Turn the model-inventory request deadline into actionable dashboard guidance.

## Why this matters
During a slow model-service startup, Models currently displays a raw browser abort error that does not explain whether loading or an operator action is needed.

Root cause: The hook copies AbortError.message directly into the model inventory error surface.

Behavioral invariant: An inventory deadline identifies the timed-out operation and its 30-second budget; other failures retain their actual message.

## Implementation and compatibility
Map abort failures to a concrete inventory timeout message with retry and Dashboard API log guidance. Preserve beta's operation deadlines, cancelled activation ownership and stale-request guards.

This updates the original canonical PR onto `public-beta` at `3c186f3f12ba21dad7b7266ec5449393529abb00`; it does not create a competing replacement. The shared browser code applies to Linux, macOS and Windows installations. There is no persisted schema migration. Rollback is a revert/rebuild of the dashboard; server lifecycle and authorization remain backend-owned.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and inspected the complete 1,010-entry public-beta changed-file index on 2026-09-16. Searched production paths: `ods/extensions/services/dashboard/src/hooks/useModels.js`.

Relevant same-file results: #4396 (open: feat(identity): make assistant naming generic and configurable), #5299 (merged: fix(models): honor runtime operation deadlines in the dashboard), #4962 (merged: fix(models): stop activation polling after leaving the page), #4557 (merged: fix(models): confirm activation with the current inventory)

#5299 handles runtime mutation deadlines, #4962 handles activation cleanup and #4557 proves activation from inventory. This canonical #3376 changes the read-timeout explanation, not those mutation contracts.

## Regression and validation
Candidate commit: `4f9cb520d93812c6653bdb17c79c6e2d9beb4267`.

- From `ods/extensions/services/dashboard`: `npx vitest run src/hooks/__tests__/useModels src/pages/Models` — **93 passed**.
- The timed-out inventory guidance assertion fails against baseline source; all 93 candidate inventory, model action and activation tests pass.
- Changed-file ESLint, `git diff --check`, and pre-commit secret/private-key/large-file checks pass. Existing lint warnings are not errors.
- Clean beta baseline: full dashboard **1,232 tests passed**, lint and production build passed on Windows Node 24.14.1. CI uses Node 20 and validates Linux/macOS/Windows. No browser-on-hardware or live GPU/model-service claim is made by these mocked HTTP/UI tests.
- Broad `make gate` on a Linux-native clean beta checkout stops at the existing no-sudo Docker fallback contract (2 failures under the root test environment). The Windows-mounted copy additionally exposed CRLF-sensitive Hermes fixture assertions. Full-tree pre-commit finds existing dummy private-key test fixtures and Windows lacks awk for the heredoc hook; the candidate's scoped secret/key/size hooks pass. These limitations are not represented as successful runtime validation.

## Review readiness and batch integration
Implementation and focused checks are complete; this PR is Ready for independent review. CI limits below remain visible and no upstream merge or deployment has been performed.

Exact-head CI at `2026-09-16T13:33:01.8060875Z` for `4f9cb520d93812c6653bdb17c79c6e2d9beb4267`: 37 successful checks; 0 failed; 0 pending; 4 skipped review/security jobs (not counted as passes).

All 37 executed current-head checks completed successfully; four review/security jobs were skipped. This establishes automated review readiness, not live hardware validation, an independent human review, or approval to merge.

All 20 exact candidate commits were merged into [synthetic integration `d3c05b74ddfa`](https://github.com/tang-vu/DreamServer/commit/d3c05b74ddfa7e7f1075b0f3e079c03cd55788b4) from beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. That exact head passed **1,279 tests across 167 files**, full ESLint (0 errors; 618 existing warnings), production build, scoped secret/private-key/large-file hooks and `git diff --check` on Windows Node 24.14.1. These are mocked browser/HTTP checks, not live GPU or deployment evidence.

Verified merge order: #3044 → #3046 → #3025 → #3038 → #3043 → #3050 → #3312 → #3313 → #3315 → #3316 → #3376 → #3041 → #3042 → #3051 → #3065 → #3062 → #3039 → #3040 → #3049 → #2780.

Merge guidance for this scope: The inventory hook message merges cleanly with the selected download-status UI changes.

The only textual conflicts inside the selected batch were #3316/#3040 (download hook plus tests) and #3046/#2780 (tests only). Use the linked integration commit as the reviewed resolution reference. Each PR remains independently based on beta; if merging them separately or squashing, reapply the relevant resolution and rerun affected suites. Outside-batch checks used `git merge-tree` only: #3846/#3848/#3841/#3843 merged textually, while #3803/#4356/#5276/#5125 conflicted. Textual compatibility alone does not establish runtime compatibility.

Additional clean-beta Linux checks: `make lint`, `make smoke`, and `make simulate` pass. `make bats` has five baseline environment failures (WSL classification, root permissions/preflight, and a 15 GB free-space boundary), in addition to the full-gate limitations described above. Installer/backend sources are unchanged by this batch. Rollback remains a revert and dashboard rebuild; no stored schema or backend lifecycle migration was introduced.
