### PR TITLE
fix(macos): refresh stale native llama builds

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -176,6 +176,7 @@ source "${LIB_DIR}/detection.sh"
 source "${LIB_DIR}/preflight-fs.sh"
 source "${LIB_DIR}/env-generator.sh"
 source "${LIB_DIR}/installed-footprint.sh"
+source "${LIB_DIR}/llama-release.sh"
 if [[ -f "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh" ]]; then
     source "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh"
 fi
@@ -2079,7 +2080,15 @@ else
 
         # Download llama.cpp Metal build
         LLAMA_ZIP="/tmp/${LLAMA_CPP_MACOS_ASSET}"
-        if [[ ! -x "$LLAMA_SERVER_BIN" ]]; then
+        LLAMA_RELEASE_STAMP="${LLAMA_SERVER_DIR}/.llama-cpp-release-tag"
+        _llama_install_required=true
+        if macos_llama_release_is_current \
+            "$LLAMA_SERVER_BIN" "$LLAMA_RELEASE_STAMP" "$LLAMA_CPP_RELEASE_TAG"; then
+            _llama_install_required=false
+        elif [[ -x "$LLAMA_SERVER_BIN" ]]; then
+            ai "Refreshing llama-server for required llama.cpp release ${LLAMA_CPP_RELEASE_TAG}..."
+        fi
+        if $_llama_install_required; then
             if [[ ! -f "$LLAMA_ZIP" ]]; then
                 download_with_progress "$LLAMA_CPP_MACOS_URL" "$LLAMA_ZIP" \
                     "Downloading llama-server (Metal)" || {
@@ -2093,6 +2102,8 @@ else
                             mkdir -p "$LLAMA_SERVER_DIR"
                             cp "$BREW_LLAMA" "$LLAMA_SERVER_BIN"
                             chmod +x "$LLAMA_SERVER_BIN"
+                            macos_record_llama_release "$LLAMA_RELEASE_STAMP" "homebrew"
+                            _llama_install_required=false
                             ai_ok "Installed llama-server via Homebrew"
                         else
                             ai_err "Could not install llama-server. Install manually:"
@@ -2108,7 +2119,7 @@ else
                 }
             fi
 
-            if [[ -f "$LLAMA_ZIP" ]] && [[ ! -x "$LLAMA_SERVER_BIN" ]]; then
+            if [[ -f "$LLAMA_ZIP" ]] && $_llama_install_required; then
                 # Extract
                 ai "Extracting llama-server..."
                 mkdir -p "$LLAMA_SERVER_DIR"
@@ -2131,6 +2142,7 @@ else
                     FOUND_DIR=$(dirname "$FOUND_BIN")
                     find "$FOUND_DIR" -name "*.dylib" -exec cp {} "$LLAMA_SERVER_DIR/" \; 2>/dev/null || true
                     find "$FOUND_DIR" -name "*.metal" -exec cp {} "$LLAMA_SERVER_DIR/" \; 2>/dev/null || true
+                    macos_record_llama_release "$LLAMA_RELEASE_STAMP" "$LLAMA_CPP_RELEASE_TAG"
 
                     ai_ok "Extracted llama-server"
                 else
@@ -2146,7 +2158,7 @@ else
             xattr -rd com.apple.quarantine "$LLAMA_SERVER_BIN" 2>/dev/null || true
             xattr -rd com.apple.quarantine "$LLAMA_SERVER_DIR"/*.dylib 2>/dev/null || true
         else
-            ai_ok "llama-server already present"
+            ai_ok "llama-server ${LLAMA_CPP_RELEASE_TAG} already present"
         fi
 
         # Start native llama-server with Metal

--- a/ods/installers/macos/lib/llama-release.sh
+++ b/ods/installers/macos/lib/llama-release.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Purpose: Track the llama.cpp release owned by the native macOS installer.
+# Expects: None.
+# Provides: macos_llama_release_is_current(), macos_record_llama_release().
+
+macos_llama_release_is_current() {
+    local binary="$1" stamp_file="$2" required_tag="$3" installed_tag=""
+    [[ -x "$binary" && -f "$stamp_file" ]] || return 1
+    IFS= read -r installed_tag < "$stamp_file" || return 1
+    [[ "$installed_tag" == "$required_tag" ]]
+}
+
+macos_record_llama_release() {
+    local stamp_file="$1" release_tag="$2"
+    printf '%s\n' "$release_tag" > "${stamp_file}.tmp"
+    mv "${stamp_file}.tmp" "$stamp_file"
+}

--- a/ods/tests/test-macos-native-llama-launch-cwd.sh
+++ b/ods/tests/test-macos-native-llama-launch-cwd.sh
@@ -37,6 +37,7 @@ assert_llama_exec_anchored() {
 bootstrap="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
 installer="$ROOT_DIR/installers/macos/install-macos.sh"
 cli="$ROOT_DIR/installers/macos/ods-macos.sh"
+release_lib="$ROOT_DIR/installers/macos/lib/llama-release.sh"
 
 grep -qF 'cd "$INSTALL_DIR" || {' "$bootstrap" \
     || fail "bootstrap-upgrade.sh must anchor its own cwd to INSTALL_DIR"
@@ -51,6 +52,27 @@ grep -qF 'com.ods.llama-server' "$installer" \
 grep -qF 'com.ods.full-model-download' "$installer" \
     || fail "macOS installer must unload legacy full-model-download LaunchAgent"
 pass "macOS installer clears legacy native llama LaunchAgents"
+
+source "$release_lib"
+release_tmp="$(mktemp -d)"
+trap 'rm -rf "$release_tmp"' EXIT
+release_bin="$release_tmp/llama-server"
+release_stamp="$release_tmp/.llama-cpp-release-tag"
+printf '#!/bin/sh\n' > "$release_bin"
+chmod +x "$release_bin"
+if macos_llama_release_is_current "$release_bin" "$release_stamp" b9014; then
+    fail "an unversioned native binary must be refreshed"
+fi
+macos_record_llama_release "$release_stamp" b8210
+if macos_llama_release_is_current "$release_bin" "$release_stamp" b9014; then
+    fail "a stale native binary must be refreshed"
+fi
+macos_record_llama_release "$release_stamp" b9014
+macos_llama_release_is_current "$release_bin" "$release_stamp" b9014 \
+    || fail "the required native release should be reusable"
+grep -qF 'macos_record_llama_release "$LLAMA_RELEASE_STAMP" "$LLAMA_CPP_RELEASE_TAG"' "$installer" \
+    || fail "macOS installer must record the extracted llama.cpp release"
+pass "macOS installer refreshes unversioned and stale llama.cpp binaries"
 
 grep -qF 'lsof -a -p "$pid" -d cwd -Fn' "$installer" \
     || fail "macOS installer must inspect cwd for relative native llama-server launches"


### PR DESCRIPTION
## Why this matters
The macOS installer selected a newer llama.cpp release for model families such as Gemma 4, but skipped installation whenever any executable `bin/llama-server` already existed. An existing b8210 install therefore reported success while the selected Gemma 4 model required b9014 and could not load.

The installer now records the release it owns and refreshes missing, unversioned, or mismatched native binaries before launch. This addresses the native-binary refresh portion of #2351; the issue's artifact pinning portion is already covered by merged #2463 and open #2672, so this PR does not close the broader issue.

## Overlap check
Searched open and closed PRs for `macOS llama-server`, `already present`, `release tag`, `b8210`, `b9014`, issue #2351, and the touched installer section. #2463/#2672 cover GGUF revisions and checksums, not the installed native llama.cpp version. No PR covers this binary lifecycle gap.

## Regression test
The macOS native launch contract sources the production release helper and verifies:
- an executable without a stamp is refreshed
- a b8210 stamp is stale for b9014
- an exact b9014 stamp is reusable
- successful archive extraction records the selected release

Validation: `bash tests/test-macos-native-llama-launch-cwd.sh`, Bash syntax checks, and `git diff --check` pass.

## Tradeoffs and rollback
Existing macOS installs incur one controlled llama.cpp refresh because legacy binaries have no trustworthy provenance stamp. Homebrew fallback remains available and is deliberately not mislabeled as a pinned GitHub release. Reverting removes the stamp and returns to existence-only reuse.