### PR TITLE
fix(registry): relativize extension compose paths

### DIFF
--- a/ods/lib/service-registry.sh
+++ b/ods/lib/service-registry.sh
@@ -327,10 +327,19 @@ sr_compose_flags() {
 
     # Cache miss: rebuild flags
     ((_SR_CACHE_MISSES++))
-    local flags=""
+    local flags="" compose_path registry_root
+    registry_root="${INSTALL_DIR:-${SCRIPT_DIR:-}}"
     for sid in "${SERVICE_IDS[@]}"; do
-        local cf="${SERVICE_COMPOSE[$sid]}"
-        [[ -n "$cf" && -f "$cf" ]] && flags="$flags -f $cf"
+        compose_path="${SERVICE_COMPOSE[$sid]}"
+        [[ -n "$compose_path" && -f "$compose_path" ]] || continue
+        # Registry manifests live below the install root. Emit those paths
+        # relative to the compose working directory so an install directory
+        # containing whitespace never becomes part of the flat legacy flags
+        # string consumed by ods-cli.
+        if [[ -n "$registry_root" && "$compose_path" == "$registry_root/"* ]]; then
+            compose_path="${compose_path#"$registry_root/"}"
+        fi
+        flags="$flags -f $compose_path"
     done
 
     # Store in cache

--- a/ods/tests/test-service-registry.sh
+++ b/ods/tests/test-service-registry.sh
@@ -447,6 +447,35 @@ else
 fi
 
 # ============================================
+# TEST 8: Compose flags under a spaced install root
+# ============================================
+header "8/8" "Path-safe Compose Flags"
+
+if (
+    spaced_root="$(mktemp -d)/ODS Install"
+    trap 'rm -rf "${spaced_root%/ODS Install}"' EXIT
+    compose_file="$spaced_root/extensions/services/fixture/compose.yaml"
+    mkdir -p "$(dirname "$compose_file")"
+    printf 'services: {}\n' > "$compose_file"
+
+    INSTALL_DIR="$spaced_root"
+    SERVICE_IDS=(fixture)
+    SERVICE_COMPOSE[fixture]="$compose_file"
+    _SR_LOADED=true
+    _SR_COMPOSE_FLAGS_CACHED=false
+    flags="$(sr_compose_flags)"
+    [[ "$flags" == " -f extensions/services/fixture/compose.yaml" ]]
+
+    cd "$INSTALL_DIR"
+    read -ra args <<< "$flags"
+    [[ "${args[0]}" == "-f" && -f "${args[1]}" ]]
+); then
+    pass "Registry compose flags survive an install root containing spaces"
+else
+    fail "Registry compose flags must be relative to a spaced install root"
+fi
+
+# ============================================
 # Summary
 # ============================================
 echo ""


### PR DESCRIPTION
## Why this matters
The service-registry fallback appended absolute extension compose paths to a whitespace-delimited flags string. If ODS was installed below a directory such as `/opt/My ODS`, downstream `read -ra` consumers split one `-f` path into multiple arguments and silently omitted extension services.

Registry-owned compose files are always below the install root, so the fallback now emits them relative to Docker Compose's install-directory working directory. The legacy scalar never contains the whitespace-bearing root and existing callers remain compatible.

Closes #3331.

## Overlap check
Searched open and closed PRs for `service-registry`, `compose flags`, `path spaces`, and the changed files. Closed #1024 introduced a NUL contract elsewhere and was later closed as incorporated upstream; it did not change `sr_compose_flags`, which is the remaining reachable fallback reported here. No open PR covers this production function.

## Regression test
The public registry function is exercised with a real compose file below a synthetic `ODS Install` directory. The test asserts the emitted pair is relative, round-trips through the actual legacy `read -ra` consumer shape, and resolves to an existing file after changing to the install working directory.

Validation: `bash tests/test-service-registry.sh` (241 passed), Bash syntax checks, and `git diff --check`.

## Tradeoffs and rollback
Only registry paths within `INSTALL_DIR` are relativized; an unusual external compose path keeps its previous representation rather than being silently rewritten. Docker Compose already runs from `INSTALL_DIR`, so behavior for ordinary paths is unchanged. Reverting restores absolute fallback paths.
## Follow-up overlap audit (2026-08-31)

#3545 opened later for #3331. It wraps the absolute compose path in literal double quotes inside the legacy scalar, but the downstream `read -ra` consumers do not interpret shell quoting: they still split on the path's spaces and pass quote characters through as data. It adds no regression for this behavior and its branch also carries changes across 33 unrelated files.

#3378 remains the stronger canonical fix because registry-owned files are made relative to the install working directory, keeping whitespace out of the legacy scalar altogether. Its regression round-trips the result through the real `read -ra` consumer shape and verifies the resolved file. No code was ported from #3545 because its one-line change does not satisfy the reported contract.