### PR TITLE
fix(update): preserve quoted compose file paths

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -71,18 +71,33 @@ env_file_value() {
     ' "${INSTALL_DIR}/.env" 2>/dev/null || true
 }
 
+COMPOSE_PARSED_ARGS=()
+
+compose_flags_parse() {
+    local flags="$1" parsed="" token
+    COMPOSE_PARSED_ARGS=()
+    [[ -n "$flags" ]] || return 0
+    # xargs tokenizes shell-style quotes without evaluating substitutions or
+    # commands. One token per output line preserves whitespace inside a path;
+    # compose filenames containing newlines are intentionally unsupported.
+    parsed="$(printf '%s\n' "$flags" | xargs -n 1 printf '%s\n')" || return 1
+    while IFS= read -r token; do
+        [[ -n "$token" ]] && COMPOSE_PARSED_ARGS+=("$token")
+    done <<< "$parsed"
+}
+
 compose_flags_files_exist() {
-    local flags="$1"
-    local prev="" tok
-    for tok in $flags; do
-        if [[ "$prev" == "-f" ]]; then
-            if [[ "$tok" = /* ]]; then
-                [[ -f "$tok" ]] || return 1
-            else
-                [[ -f "${INSTALL_DIR}/${tok}" ]] || return 1
-            fi
+    local flags="$1" index path
+    compose_flags_parse "$flags" || return 1
+    for ((index = 0; index < ${#COMPOSE_PARSED_ARGS[@]}; index++)); do
+        [[ "${COMPOSE_PARSED_ARGS[$index]}" == "-f" ]] || continue
+        ((index + 1 < ${#COMPOSE_PARSED_ARGS[@]})) || return 1
+        path="${COMPOSE_PARSED_ARGS[$((index + 1))]}"
+        if [[ "$path" = /* ]]; then
+            [[ -f "$path" ]] || return 1
+        else
+            [[ -f "${INSTALL_DIR}/${path}" ]] || return 1
         fi
-        prev="$tok"
     done
     return 0
 }
@@ -90,9 +105,9 @@ compose_flags_files_exist() {
 resolve_compose_flags() {
     local cached=""
     if [[ -f "${INSTALL_DIR}/.compose-flags" ]]; then
-        cached="$(tr '\n' ' ' < "${INSTALL_DIR}/.compose-flags" | xargs 2>/dev/null || true)"
+        cached="$(< "${INSTALL_DIR}/.compose-flags")"
         if [[ -n "$cached" ]] && compose_flags_files_exist "$cached"; then
-            echo "$cached"
+            printf '%s\n' "$cached"
             return 0
         fi
         log_warn "Cached compose flags are missing or stale; trying dynamic compose resolution." >&2
@@ -785,7 +800,11 @@ cmd_rollback() {
     local -a compose_args=()
     compose_flags=$(resolve_compose_flags 2>/dev/null || true)
     if [[ -n "$compose_flags" ]]; then
-        read -ra compose_args <<< "$compose_flags"
+        compose_flags_parse "$compose_flags" || {
+            log_error "Resolved compose flags are malformed."
+            return 1
+        }
+        compose_args=("${COMPOSE_PARSED_ARGS[@]}")
     fi
 
     # Stop services using the currently active compose stack.
@@ -838,7 +857,11 @@ cmd_rollback() {
     local -a restored_compose_args=()
     restored_compose_flags=$(resolve_compose_flags 2>/dev/null || true)
     if [[ -n "$restored_compose_flags" ]]; then
-        read -ra restored_compose_args <<< "$restored_compose_flags"
+        compose_flags_parse "$restored_compose_flags" || {
+            log_error "Restored compose flags are malformed."
+            return 1
+        }
+        restored_compose_args=("${COMPOSE_PARSED_ARGS[@]}")
     fi
 
     if [[ ${#restored_compose_args[@]} -gt 0 ]]; then
@@ -926,7 +949,11 @@ cmd_health() {
     local -a compose_args=()
     compose_flags=$(resolve_compose_flags 2>/dev/null || true)
     if [[ -n "$compose_flags" ]]; then
-        read -ra compose_args <<< "$compose_flags"
+        compose_flags_parse "$compose_flags" || {
+            log_error "Resolved compose flags are malformed."
+            return 1
+        }
+        compose_args=("${COMPOSE_PARSED_ARGS[@]}")
     fi
     
     local services

--- a/ods/tests/test-ods-update-runtime-compose.sh
+++ b/ods/tests/test-ods-update-runtime-compose.sh
@@ -51,10 +51,13 @@ EOF
 printf '%s\n' '-f docker-compose.base.yml -f docker-compose.cpu.yml' > "$INSTALL_DIR/.compose-flags"
 
 DOCKER_LOG="$TMP_DIR/docker-args.log"
+DOCKER_TOKEN_LOG="$TMP_DIR/docker-token-args.log"
 export DOCKER_LOG
+export DOCKER_TOKEN_LOG
 cat > "$BIN_DIR/docker" <<'SH'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+printf '<%s>\n' "$@" >> "${DOCKER_TOKEN_LOG:?}"
 
 if [[ "${1:-}" == "info" ]]; then
     exit 0
@@ -108,6 +111,17 @@ if grep -q "No services defined in docker-compose" "$TMP_DIR/health.out"; then
     fail "health emitted stale bare-compose warning"
 fi
 pass "ods-update health uses saved compose flags in runtime installs"
+
+mkdir -p "$INSTALL_DIR/custom stack"
+printf 'services: {}\n' > "$INSTALL_DIR/custom stack/compose.yaml"
+printf '%s\n' "-f docker-compose.base.yml -f 'custom stack/compose.yaml'" \
+    > "$INSTALL_DIR/.compose-flags"
+: > "$DOCKER_TOKEN_LOG"
+PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/ods-update.sh" health > "$TMP_DIR/spaced-health.out" 2>&1 \
+    || { cat "$TMP_DIR/spaced-health.out"; fail "health should preserve a quoted compose path containing spaces"; }
+grep -qF '<custom stack/compose.yaml>' "$DOCKER_TOKEN_LOG" \
+    || { cat "$DOCKER_TOKEN_LOG"; fail "quoted compose path was split into multiple Docker arguments"; }
+pass "ods-update health preserves quoted compose paths as single arguments"
 
 PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/ods-update.sh" backup runtime-smoke > "$TMP_DIR/backup.out" 2>&1 \
     || { cat "$TMP_DIR/backup.out"; fail "backup should not fail while counting copied files"; }


### PR DESCRIPTION
## Why this matters
`ods-update.sh` flattened cached compose flags and then split them with the default shell IFS. A valid quoted `-f` path containing whitespace became multiple Docker arguments; the cache was falsely marked stale and health/rollback commands targeted a malformed stack.

The updater now tokenizes shell-style quoting without evaluating shell code, validates complete `-f <path>` pairs, and reuses the resulting array for health plus both sides of rollback.

Closes #3332.
Closes #3337.

## Overlap check
Searched open and closed PRs for `ods-update`, `compose_flags_files_exist`, `read -ra compose_args`, quoted compose paths, and issues #3332/#3337. Closed #1024 implemented a resolver-side NUL contract and was later incorporated, but explicitly left installer/update legacy consumers out of scope. No open PR changes this updater parser. #3378 separately fixes the service-registry producer and does not touch this file.

## Regression test
The runtime updater test writes a real compose file at `custom stack/compose.yaml`, caches it as a quoted `-f` argument, invokes the public `health` command, and records every Docker argv element. It asserts the whitespace-bearing path reaches Docker as exactly one argument.

Validation: runtime compose test, full rollback compose-stack test, Bash syntax checks, and `git diff --check` pass.

## Tradeoffs and rollback
The parser supports ordinary shell quoting and escaping but intentionally rejects filenames containing literal newlines. It uses `xargs` only as a tokenizer—no shell evaluation occurs. Reverting restores whitespace splitting and stale-cache false positives; no persisted format migration is required.
## Follow-up overlap audit (2026-08-31)

#3543 opened later for #3337. Its updater patch replaces the stale-check loop with `xargs -n1`, but it leaves the `read -ra` consumers in health and rollback unchanged, so a quoted path can still be split before Docker receives it. It adds no boundary regression and its branch also carries changes across 32 unrelated files.

#3379 remains the stronger canonical fix: it uses one non-evaluating parser for validation and every consumer, checks complete `-f <path>` pairs, and proves the real health command passes the whitespace-bearing path as one Docker argv element. No implementation or test was ported from #3543 because it has no independent behavioral advantage.