### PR TITLE
fix(context): log loaded-model probe failures

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import socket
 import subprocess
@@ -63,6 +64,7 @@ _SERVICE_CAPABILITIES: dict[str, tuple[str, str]] = {
 # Where the dynamic block gets inserted in SOUL.md.template. The template
 # has the literal marker line; this script replaces it.
 _INSERT_MARKER = "<!-- INSTALLATION_CONTEXT -->"
+logger = logging.getLogger("build-installation-context")
 
 
 def _read_env(env_path: Path) -> dict[str, str]:
@@ -172,19 +174,29 @@ def _loaded_model(llm_port: int = 8080) -> str | None:
     """Best-effort: ask llama-server / Lemonade what's currently loaded.
     Returns the model id, or None on any failure (network, no service)."""
     # Try Lemonade health first — has structured per-model state
+    failures: list[tuple[str, Exception]] = []
+    successful_probe = False
     for path in ("/api/v1/health", "/v1/models"):
         try:
             import urllib.request
             with urllib.request.urlopen(f"http://127.0.0.1:{llm_port}{path}", timeout=3) as resp:
                 data = json.load(resp)
-        except Exception:
+        except Exception as exc:
+            failures.append((path, exc))
+            logger.debug("Loaded-model probe failed for %s", path, exc_info=True)
             continue
+        successful_probe = True
         loaded = data.get("all_models_loaded") if isinstance(data, dict) else None
         if isinstance(loaded, list) and loaded:
             return loaded[0].get("model_name")
         models = data.get("data") if isinstance(data, dict) else None
         if isinstance(models, list) and models:
             return models[0].get("id")
+    if failures and not successful_probe:
+        detail = "; ".join(
+            f"{path}: {type(exc).__name__}: {exc}" for path, exc in failures
+        )
+        logger.warning("Could not probe the loaded model on port %s (%s)", llm_port, detail)
     return None
 
 

--- a/ods/tests/test_build_installation_context.py
+++ b/ods/tests/test_build_installation_context.py
@@ -1,0 +1,30 @@
+"""Tests for the installation-context builder's live model probe."""
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "build-installation-context.py"
+SPEC = importlib.util.spec_from_file_location("build_installation_context", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def test_loaded_model_logs_when_all_endpoints_fail(monkeypatch, caplog):
+    def unavailable(url, timeout):
+        raise OSError(f"unavailable: {url} after {timeout}s")
+
+    monkeypatch.setattr("urllib.request.urlopen", unavailable)
+
+    with caplog.at_level(logging.DEBUG, logger="build-installation-context"):
+        result = MODULE._loaded_model(18080)
+
+    assert result is None
+    assert caplog.text.count("Loaded-model probe failed") == 2
+    assert "Could not probe the loaded model on port 18080" in caplog.text
+    assert "/api/v1/health" in caplog.text
+    assert "/v1/models" in caplog.text


### PR DESCRIPTION
## Summary

- retain endpoint-specific diagnostics when the installation-context model probe fails
- emit one warning when neither Lemonade nor llama.cpp responds successfully
- avoid warning when at least one endpoint responds, including a valid no-model response
- add regression coverage for the all-endpoints-failed path

The probe previously swallowed every exception. A generated SOUL context could omit the live model with no indication that detection had failed.

## AI Assistance

OpenAI Codex assisted with bug triage, implementation, test drafting, and PR preparation. I reviewed the diff and validation results and remain responsible for the contribution.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [x] Installer / bootstrap / lifecycle

## Risk And Validation

- Risk level: High (installer/lifecycle utility)
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Not required because: this preserves probe results and fallback behavior and only adds diagnostics; unit, compile, and cross-platform SOUL contract checks pass.

Commands/results:

```text
python -m pytest -q ods/tests/test_build_installation_context.py
# 1 passed

python -m py_compile ods/scripts/build-installation-context.py
# passed

bash ods/tests/test-windows-hermes-soul.sh
# 31 passed, 0 failed

git diff --check
# passed
```

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

The broad catch remains because this is an explicitly best-effort snapshot generator. Individual failures are available with tracebacks at debug level; the warning contains a bounded summary only when every configured endpoint fails.

