### PR TITLE
fix(migrate): create unique backup directories

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -101,9 +101,11 @@ cmd_backup() {
     
     local backup_name backup_path
     backup_name="config-$(date +%Y%m%d-%H%M%S)"
-    backup_path="${BACKUP_DIR}/${backup_name}"
-    
-    mkdir -p "$backup_path"
+    mkdir -p "$BACKUP_DIR"
+    if ! backup_path="$(umask 077; mktemp -d "${BACKUP_DIR}/${backup_name}.XXXXXX")"; then
+        log_error "Could not create a unique configuration backup directory"
+        return 1
+    fi
     
     # Backup key config files
     local cp_exit=0

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -238,6 +238,31 @@ else
 fi
 
 # ============================================================================
+# Test 13: same-second backups use distinct directories
+# ============================================================================
+rm -rf "$DATA_DIR/backups"
+mock_bin="$TEMP_DIR/mock-bin"
+mkdir -p "$mock_bin"
+cat > "$mock_bin/date" <<'EOF'
+#!/bin/bash
+printf '%s\n' '20260827-123456'
+EOF
+chmod +x "$mock_bin/date"
+
+first_backup_output=$(PATH="$mock_bin:$PATH" bash "$MIGRATE_CONFIG_SCRIPT" backup 2>&1)
+second_backup_output=$(PATH="$mock_bin:$PATH" bash "$MIGRATE_CONFIG_SCRIPT" backup 2>&1)
+first_backup_path=$(printf '%s\n' "$first_backup_output" | tail -n 1)
+second_backup_path=$(printf '%s\n' "$second_backup_output" | tail -n 1)
+
+if [[ "$first_backup_path" != "$second_backup_path" \
+    && -d "$first_backup_path" \
+    && -d "$second_backup_path" ]]; then
+    pass "Behavioral test: same-second backups use distinct directories"
+else
+    fail "Behavioral test: same-second backups collided ($first_backup_path, $second_backup_path)"
+fi
+
+# ============================================================================
 # Summary
 # ============================================================================
 echo ""


### PR DESCRIPTION
## Summary

- replace second-resolution `mkdir -p` backup publication with exclusive `mktemp -d` creation
- retain the timestamp prefix while adding a portable six-character uniqueness suffix
- create backup directories under `umask 077` because configuration snapshots can contain secrets
- fail clearly if a unique directory cannot be created
- add a frozen-date regression proving two same-second backups receive different paths

Previously, two backup invocations within one second selected the same directory and silently merged or overwrote snapshot contents.

## AI Assistance

OpenAI Codex assisted with bug triage, implementation, test drafting, and PR preparation. I reviewed the diff and validation results and remain responsible for the contribution.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [x] Installer / bootstrap / lifecycle

## Risk And Validation

- Risk level: High (migration backup path)
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
bash -n ods/scripts/migrate-config.sh
bash -n ods/tests/test-migrate-config.sh
# passed

bash ods/tests/test-migrate-config.sh
# 15 passed, 0 failed

git diff --check
# passed
```

## Operational Change Check

- [x] This is an operational change and validation is intentionally deferred for: maintainer fleet validation; GNU/BSD-compatible creation and same-second behavior are covered by the real-script fixture.

## Notes For Reviewers

The output remains `config-YYYYmmdd-HHMMSS.*`, and no repository consumer parses the previous exact leaf name. Open PRs #2898 and #2954 change which data this same function copies but do not address directory uniqueness, so a small mechanical conflict is possible if either lands first.

