### PR TITLE
fix(gpu): validate topology before assignment

### DIFF
--- a/ods/scripts/assign_gpus.py
+++ b/ods/scripts/assign_gpus.py
@@ -71,6 +71,85 @@ class AssignmentResult:
     services: dict
 
 
+#  Input Validation
+
+def _require_finite_number(value, field: str, *, positive: bool = False) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be a number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} must be a number") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{field} must be finite")
+    if positive and number <= 0:
+        raise ValueError(f"{field} must be greater than zero")
+    return number
+
+
+def validate_topology(topology: object) -> None:
+    """Reject malformed topology input before assignment code indexes it."""
+    if not isinstance(topology, dict):
+        raise ValueError("topology root must be a JSON object")
+
+    gpu_count = topology.get("gpu_count")
+    if not isinstance(gpu_count, int) or isinstance(gpu_count, bool):
+        raise ValueError("gpu_count must be an integer")
+    gpus = topology.get("gpus")
+    if not isinstance(gpus, list):
+        raise ValueError("gpus must be an array")
+    if gpu_count != len(gpus):
+        raise ValueError(
+            f"gpu_count ({gpu_count}) does not match gpus length ({len(gpus)})"
+        )
+    if not gpus:
+        raise ValueError("no GPUs found in topology")
+
+    indices = set()
+    for position, gpu in enumerate(gpus):
+        field = f"gpus[{position}]"
+        if not isinstance(gpu, dict):
+            raise ValueError(f"{field} must be an object")
+        index = gpu.get("index")
+        if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+            raise ValueError(f"{field}.index must be a non-negative integer")
+        if index in indices:
+            raise ValueError(f"{field}.index duplicates GPU index {index}")
+        indices.add(index)
+        for key in ("uuid", "name"):
+            value = gpu.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field}.{key} must be a non-empty string")
+        _require_finite_number(gpu.get("memory_gb"), f"{field}.memory_gb", positive=True)
+        if gpu.get("memory_free_gb") is not None:
+            free_memory = _require_finite_number(
+                gpu["memory_free_gb"], f"{field}.memory_free_gb"
+            )
+            if free_memory < 0:
+                raise ValueError(f"{field}.memory_free_gb must not be negative")
+
+    links = topology.get("links", [])
+    if not isinstance(links, list):
+        raise ValueError("links must be an array")
+    for position, link in enumerate(links):
+        field = f"links[{position}]"
+        if not isinstance(link, dict):
+            raise ValueError(f"{field} must be an object")
+        for endpoint in ("gpu_a", "gpu_b"):
+            value = link.get(endpoint)
+            if not isinstance(value, int) or isinstance(value, bool) or value not in indices:
+                raise ValueError(f"{field}.{endpoint} must reference a known GPU index")
+        if link["gpu_a"] == link["gpu_b"]:
+            raise ValueError(f"{field} must connect two different GPUs")
+        for key in ("link_type", "link_label"):
+            value = link.get(key)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{field}.{key} must be a non-empty string")
+        rank = link.get("rank")
+        if not isinstance(rank, int) or isinstance(rank, bool) or rank < 0:
+            raise ValueError(f"{field}.rank must be a non-negative integer")
+
+
 #  Phase 1: Topology Analysis
 
 def parse_gpus(topology: dict) -> list:
@@ -450,7 +529,7 @@ def main():
 
     # Load topology
     try:
-        with open(args.topology) as f:
+        with open(args.topology, encoding="utf-8") as f:
             topology = json.load(f)
     except FileNotFoundError:
         print(f"ERROR: topology file not found: {args.topology}", file=sys.stderr)
@@ -458,14 +537,23 @@ def main():
     except json.JSONDecodeError as e:
         print(f"ERROR: invalid JSON in topology file: {e}", file=sys.stderr)
         sys.exit(1)
+    except (OSError, UnicodeError) as e:
+        print(f"ERROR: could not read topology file: {e}", file=sys.stderr)
+        sys.exit(1)
 
     enabled_services = [s.strip() for s in args.enabled_services.split(",")]
     model_size_mb    = args.model_size
-    gpu_count        = topology.get("gpu_count", 0)
-
-    if gpu_count == 0:
-        print("ERROR: no GPUs found in topology", file=sys.stderr)
+    try:
+        _require_finite_number(model_size_mb, "model size", positive=True)
+    except ValueError as e:
+        print(f"ERROR: invalid model size: {e}", file=sys.stderr)
         sys.exit(1)
+    try:
+        validate_topology(topology)
+    except ValueError as e:
+        print(f"ERROR: invalid topology input: {e}", file=sys.stderr)
+        sys.exit(1)
+    gpu_count = topology["gpu_count"]
 
     #  Early exit: single GPU
     if gpu_count == 1:

--- a/ods/tests/test-assign-gpus.py
+++ b/ods/tests/test-assign-gpus.py
@@ -19,6 +19,13 @@ def run(topology_path, model_size_mb, enabled_services=None):
         output = json.loads(result.stdout)["gpu_assignment"]
     return result.returncode, output, result.stderr
 
+
+def run_payload(tmp_path, topology, model_size_mb=1000):
+    path = tmp_path / "topology.json"
+    path.write_text(json.dumps(topology), encoding="utf-8")
+    return run(str(path), model_size_mb)
+
+
 def all_assigned_uuids(output):
     uuids = set()
     for svc in output["services"].values():
@@ -30,6 +37,70 @@ def llama(output):
 
 def parallelism(output):
     return llama(output)["parallelism"]
+
+
+# ── Input validation ──────────────────────────────────────────────────────────
+
+class TestTopologyValidation:
+
+    def test_non_finite_model_size_returns_clean_error(self):
+        rc, output, stderr = run(
+            fixture_path("nvidia_smi_topo_matrix_1gpu_pcie.json"),
+            float("nan"),
+        )
+
+        assert rc == 1
+        assert output is None
+        assert "model size must be finite" in stderr
+        assert "Traceback" not in stderr
+
+    def test_gpu_count_mismatch_returns_clean_error(self, tmp_path):
+        rc, output, stderr = run_payload(
+            tmp_path,
+            {"vendor": "nvidia", "gpu_count": 1, "gpus": [], "links": []},
+        )
+
+        assert rc == 1
+        assert output is None
+        assert "gpu_count (1) does not match gpus length (0)" in stderr
+        assert "Traceback" not in stderr
+
+    def test_missing_gpu_fields_return_clean_error(self, tmp_path):
+        rc, output, stderr = run_payload(
+            tmp_path,
+            {"vendor": "nvidia", "gpu_count": 1, "gpus": [{}], "links": []},
+        )
+
+        assert rc == 1
+        assert output is None
+        assert "gpus[0].index" in stderr
+        assert "Traceback" not in stderr
+
+    def test_link_must_reference_known_gpu(self, tmp_path):
+        topology = {
+            "vendor": "nvidia",
+            "gpu_count": 1,
+            "gpus": [{
+                "index": 0,
+                "uuid": "GPU-0",
+                "name": "Test GPU",
+                "memory_gb": 24,
+            }],
+            "links": [{
+                "gpu_a": 0,
+                "gpu_b": 9,
+                "link_type": "SYS",
+                "link_label": "CrossNUMA",
+                "rank": 10,
+            }],
+        }
+
+        rc, output, stderr = run_payload(tmp_path, topology)
+
+        assert rc == 1
+        assert output is None
+        assert "links[0].gpu_b must reference a known GPU index" in stderr
+        assert "Traceback" not in stderr
 
 
 # ── 1 GPU — single ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- validate the topology root, GPU array, and `gpu_count` consistency before indexing GPU records
- validate required GPU identity, finite memory values, unique indices, and link endpoints
- reject non-finite or non-positive model sizes
- return concise `ERROR:` diagnostics instead of `IndexError`, `KeyError`, or type tracebacks
- add subprocess regressions for count mismatches, missing fields, invalid links, and non-finite sizes

For example, `{ "gpu_count": 1, "gpus": [] }` previously reached `parse_gpus(topology)[0]` and crashed with an uncaught `IndexError`.

## AI Assistance

OpenAI Codex assisted with bug triage, implementation, test drafting, and PR preparation. I reviewed the diff and validation results and remain responsible for the contribution.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this targets main.
```

## Changed Surface

- [x] Installer / bootstrap / lifecycle
- [x] Model routing / Hermes / capabilities

## Risk And Validation

- Risk level: High (GPU assignment input boundary)
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
python -m py_compile ods/scripts/assign_gpus.py ods/tests/test-assign-gpus.py
# passed

python -m pytest -q ods/tests/test-assign-gpus.py
# 89 passed

bash ods/tests/test-phase03-multigpu-tty.sh
# contract passed; optional PTY behavior skipped because util-linux script is unavailable

git diff --check
# passed
```

## Operational Change Check

- [x] This is an operational change and validation is intentionally deferred for: maintainer GPU fleet validation; valid fixture behavior is covered across 1, 2, 4, 5, and 8 GPU topologies.

## Notes For Reviewers

Valid topology behavior is unchanged. `test-gpu-reassign-manual.sh` could not run on the test Mac because only Apple Bash 3.2 is installed and `ods-cli` correctly requires Bash 4+; no alternate shell was available. The direct assignment suite exercises the real CLI in subprocesses.

