### PR TITLE
fix(update): migrate Hermes dashboard token before restart

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -235,6 +235,9 @@ jobs:
       - name: Update Rollback Contract
         run: bash tests/test-update-rollback-contract.sh
 
+      - name: Source Update Hermes Token Migration
+        run: bash tests/test-update-hermes-session-token.sh
+
       - name: Bootstrap Upgrade Compose Flags Recovery Tests
         run: bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -116,6 +116,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@echo ""
+	@echo "=== ods-update.sh Hermes token migration ==="
+	@bash tests/test-update-hermes-session-token.sh
+	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
 	@echo ""

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -71,6 +71,59 @@ env_file_value() {
     ' "${INSTALL_DIR}/.env" 2>/dev/null || true
 }
 
+ensure_hermes_dashboard_session_token() {
+    local env_file="${INSTALL_DIR}/.env"
+    [[ -f "$env_file" ]] || return 0
+
+    local current
+    current=$(awk -F= '
+        $1 == "HERMES_DASHBOARD_SESSION_TOKEN" {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/\r$/, "", value)
+            gsub(/^["'\'']|["'\'']$/, "", value)
+        }
+        END { print value }
+    ' "$env_file")
+    [[ -n "$current" ]] && return 0
+
+    local token=""
+    if command -v openssl >/dev/null 2>&1; then
+        token=$(openssl rand -hex 32 2>/dev/null || true)
+    fi
+    if [[ ! "$token" =~ ^[0-9a-f]{64}$ ]]; then
+        token=$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')
+    fi
+    [[ "$token" =~ ^[0-9a-f]{64}$ ]] || {
+        log_error "Could not generate HERMES_DASHBOARD_SESSION_TOKEN."
+        return 1
+    }
+
+    local tmp_env
+    if ! tmp_env=$(mktemp "${env_file}.tmp.XXXXXX"); then
+        log_error "Could not create a temporary file beside ${env_file}."
+        return 1
+    fi
+    if ! awk -v key="HERMES_DASHBOARD_SESSION_TOKEN" -v value="$token" '
+        index($0, key "=") == 1 {
+            if (!written) print key "=" value
+            written = 1
+            next
+        }
+        { print }
+        END { if (!written) print key "=" value }
+    ' "$env_file" > "$tmp_env"; then
+        rm -f "$tmp_env"
+        log_error "Could not update ${env_file} with the Hermes dashboard session token."
+        return 1
+    fi
+    if ! chmod 600 "$tmp_env" || ! mv -f "$tmp_env" "$env_file"; then
+        rm -f "$tmp_env"
+        log_error "Could not publish the updated ${env_file}."
+        return 1
+    fi
+    log_info "Added the Hermes dashboard session token required by the updated Compose stack."
+}
+
 compose_flags_files_exist() {
     local flags="$1"
     local prev="" tok
@@ -655,6 +708,15 @@ cmd_update() {
     git fetch origin
     if ! git pull origin main && ! git pull origin master; then
         _update_rollback "Git pull failed." "$snap_dir" "$compose_flags"
+        return 1
+    fi
+
+    # Source releases can add required Compose inputs before an existing
+    # checkout has them in .env. Migrate this installer-managed token after the
+    # pull but before Compose parses the updated Hermes service definition.
+    if ! ensure_hermes_dashboard_session_token; then
+        _update_rollback "Could not migrate the Hermes dashboard session token." \
+            "$snap_dir" "$compose_flags"
         return 1
     fi
 

--- a/ods/tests/test-update-hermes-session-token.sh
+++ b/ods/tests/test-update-hermes-session-token.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+REMOTE="$TEST_DIR/remote.git"
+SEED="$TEST_DIR/seed"
+INSTALL="$TEST_DIR/install"
+TEST_HOME="$TEST_DIR/home"
+mkdir -p "$SEED" "$TEST_HOME"
+
+git init --bare --quiet "$REMOTE"
+git -C "$SEED" init --quiet
+git -C "$SEED" config user.name "ODS Update Test"
+git -C "$SEED" config user.email "ods-update-test@example.invalid"
+git -C "$SEED" branch -M main
+git -C "$SEED" remote add origin "$REMOTE"
+
+cp "$ROOT_DIR/ods-update.sh" "$SEED/ods-update.sh"
+chmod +x "$SEED/ods-update.sh"
+cat > "$SEED/.env" <<'EOF'
+GPU_BACKEND=cpu
+GPU_COUNT=1
+TIER=1
+DASHBOARD_API_PORT=3002
+OLLAMA_PORT=8080
+EOF
+cat > "$SEED/.version" <<'EOF'
+{"version":"before-token-migration"}
+EOF
+cat > "$SEED/docker-compose.yml" <<'EOF'
+services:
+  hermes:
+    image: busybox:1.36
+EOF
+git -C "$SEED" add .
+git -C "$SEED" commit --quiet -m "old source checkout"
+git -C "$SEED" push --quiet -u origin main
+git --git-dir="$REMOTE" symbolic-ref HEAD refs/heads/main
+git clone --quiet "$REMOTE" "$INSTALL"
+
+# Simulate the source release that first makes the Hermes dashboard token a
+# required Compose input. The checked-out update manager must migrate .env
+# after pulling this commit and before it asks Compose to recreate services.
+cat > "$SEED/docker-compose.yml" <<'EOF'
+services:
+  hermes:
+    image: busybox:1.36
+    environment:
+      - HERMES_DASHBOARD_SESSION_TOKEN=${HERMES_DASHBOARD_SESSION_TOKEN:?source update must migrate the Hermes dashboard token}
+EOF
+git -C "$SEED" add docker-compose.yml
+git -C "$SEED" commit --quiet -m "require Hermes dashboard session token"
+git -C "$SEED" push --quiet
+
+STUB_BIN="$TEST_DIR/bin"
+DOCKER_LOG="$TEST_DIR/docker.log"
+mkdir -p "$STUB_BIN"
+export DOCKER_LOG
+
+cat > "$STUB_BIN/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+
+if [[ "${1:-}" == "info" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" ]]; then
+    shift
+fi
+
+command=""
+for argument in "$@"; do
+    case "$argument" in
+        down|up|ps)
+            command="$argument"
+            break
+            ;;
+    esac
+done
+
+case "$command" in
+    down)
+        exit 0
+        ;;
+    up)
+        token="$(awk -F= '$1 == "HERMES_DASHBOARD_SESSION_TOKEN" { value = $2 } END { print value }' .env)"
+        [[ "$token" =~ ^[0-9a-f]{64}$ ]]
+        ;;
+    ps)
+        if [[ " $* " == *" --services "* ]]; then
+            printf '%s\n' hermes
+        else
+            printf '%s\n' '{"State":"running"}'
+        fi
+        ;;
+    *)
+        exit 0
+        ;;
+esac
+SH
+chmod +x "$STUB_BIN/docker"
+
+cat > "$STUB_BIN/docker-compose" <<'SH'
+#!/usr/bin/env bash
+exec docker compose "$@"
+SH
+chmod +x "$STUB_BIN/docker-compose"
+
+cat > "$STUB_BIN/curl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$STUB_BIN/curl"
+
+UPDATE_OUTPUT="$TEST_DIR/update.out"
+if ! (
+    cd "$INSTALL"
+    HOME="$TEST_HOME" HEALTH_TIMEOUT=1 PATH="$STUB_BIN:$PATH" \
+        bash ./ods-update.sh update
+) > "$UPDATE_OUTPUT" 2>&1; then
+    cat "$UPDATE_OUTPUT" >&2
+    fail "source update did not migrate the required Hermes dashboard token"
+fi
+
+token="$(awk -F= '$1 == "HERMES_DASHBOARD_SESSION_TOKEN" { value = $2 } END { print value }' "$INSTALL/.env")"
+[[ "$token" =~ ^[0-9a-f]{64}$ ]] || fail "source update wrote an invalid Hermes dashboard token"
+[[ "$(grep -c '^HERMES_DASHBOARD_SESSION_TOKEN=' "$INSTALL/.env")" -eq 1 ]] \
+    || fail "source update left duplicate Hermes dashboard token assignments"
+grep -q 'compose .*up -d' "$DOCKER_LOG" || fail "updated stack was not recreated"
+pass "source update migrates the Hermes dashboard token before Compose restart"
+
+# A later source update must preserve the established browser-session token.
+printf 'next release\n' > "$SEED/release-marker"
+git -C "$SEED" add release-marker
+git -C "$SEED" commit --quiet -m "next source release"
+git -C "$SEED" push --quiet
+if ! (
+    cd "$INSTALL"
+    HOME="$TEST_HOME" HEALTH_TIMEOUT=1 PATH="$STUB_BIN:$PATH" \
+        bash ./ods-update.sh update
+) > "$UPDATE_OUTPUT" 2>&1; then
+    cat "$UPDATE_OUTPUT" >&2
+    fail "subsequent source update failed"
+fi
+
+token_after="$(awk -F= '$1 == "HERMES_DASHBOARD_SESSION_TOKEN" { value = $2 } END { print value }' "$INSTALL/.env")"
+[[ "$token_after" == "$token" ]] || fail "source update rotated an existing Hermes dashboard token"
+pass "subsequent source updates preserve the existing Hermes dashboard token"


### PR DESCRIPTION
## Summary
- migrate a missing `HERMES_DASHBOARD_SESSION_TOKEN` immediately after a source update pulls new Compose definitions
- publish the generated 64-hex token through a same-directory, mode-600 atomic replacement while preserving an existing token
- exercise two complete `ods-update.sh update` runs against a local Git remote and gate the regression in `make test` and Linux CI

## Why this matters
`ods-update.sh update` is the documented source-checkout update path. PR #2293 made `HERMES_DASHBOARD_SESSION_TOKEN` a required input in `extensions/services/hermes/compose.yaml` and added migration coverage to the Linux, macOS, and Windows CLIs, but the standalone source updater still pulled the new Compose file and immediately restarted with the old `.env`.

An existing source checkout without the token therefore reaches Compose interpolation with `${HERMES_DASHBOARD_SESSION_TOKEN:?…}` unset. The updated Hermes stack cannot be recreated, and the source update can terminate after services have already been stopped.

Root cause: the producer/consumer handoff was incomplete for the documented `ods-update.sh update` entry point.

Invariant: after pulling a source release, every required installer-managed Compose token exists before Compose parses the updated stack; an established Hermes browser-session token is never rotated by later source updates.

The migration happens after the rollback snapshot and before repository migrations or service shutdown. Generation or atomic-publication failure invokes the existing snapshot rollback path. Rolling back restores the pre-update `.env`.

## Overlap check
Searched open and closed upstream PRs by `Hermes dashboard token update`, `ods-update Hermes session token`, `HERMES_DASHBOARD_SESSION_TOKEN`, and PRs changing `ods/ods-update.sh`.

- Merged #2293 introduced the required token and covers installer/CLI generation, but does not touch `ods-update.sh`.
- Open file-adjacent update PRs including #2709, #3159, #3341, #3344, #3347, and #3379 address source transactions, host-agent refresh, version parsing, Compose argument handling, backup rotation, and quoted paths respectively; none migrates this required Compose input.
- Open Hermes PRs #1976, #2962, and #3255 concern auth integration or Windows config escaping and do not cover the source-update handoff.

This scope is independent: one production update entry point, one required state migration, and one boundary regression.

## Regression test
`tests/test-update-hermes-session-token.sh` creates a real local Git remote and old source checkout, publishes a new release whose Compose file requires the token, and runs the public `ods-update.sh update` command with deterministic Docker/health shims. It proves the token exists before `compose up`, is valid and unique, and remains stable through a second source release.

Before the fix the first update fails at the Compose restart. After the fix both releases complete.

## Validation
- [x] `make lint` — passed
- [x] `bash tests/test-update-hermes-session-token.sh` — 2 passed
- [x] `bash tests/test-update-script-backup.sh` — 6 passed
- [x] `bash tests/test-update-rollback-contract.sh` — 5 boundary checks passed
- [x] `py -m pytest ods/tests/test-hermes-dashboard-session-token.py -q` — 3 passed, 3 platform skips
- [x] `bash -n ods-update.sh tests/test-update-hermes-session-token.sh`
- [x] ShellCheck severity `error` on both changed shell files
- [x] `git diff --check`

A full `make test` from a clean Linux clone reached the existing `test-installer-noninteractive-sudo.sh` check and stopped with 3 passed / 2 failed because this WSL shell runs as UID 0. The same focused test fails identically on untouched `upstream/main` (`6ff9b4fc`); this branch does not modify sudo behavior. All suites reached before that baseline/environment failure passed, including the new regression.

## Design tradeoffs and rollback
The updater owns this narrow migration because it is the only path that observes the transition from an old source tree to a new required Compose contract. Existing installers and platform CLIs keep their current token provisioning. No new dependency is introduced: OpenSSL is preferred and the same `/dev/urandom` + `od` fallback used by the Linux CLI is retained.

Rollback is one commit. Reverting it restores the preexisting source-update failure for checkouts whose `.env` predates #2293; it does not invalidate tokens already generated.

Generated with Codex