### PR TITLE
ci: run service Python test suites

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -8,6 +8,34 @@ on:
       - master
 
 jobs:
+  service-python-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ods
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install service test dependencies
+        run: |
+          python -m pip install "pytest>=8,<9" "pytest-asyncio>=0.21,<2"
+          python -m pip install -r extensions/services/ape/requirements.txt
+          python -m pip install -r extensions/services/model-router/requirements.txt
+          python -m pip install -r extensions/services/privacy-shield/requirements.txt
+
+      - name: Test service Python boundaries
+        run: |
+          python -m pytest extensions/services/ape/tests -v
+          python -m pytest extensions/services/litellm/tests -v
+          python -m pytest extensions/services/model-router/tests -v
+          python -m pytest extensions/services/privacy-shield/tests -v
+
   token-spy-postgres:
     runs-on: ubuntu-latest
     services:

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -585,7 +585,7 @@ class TestModelsAndEvidence:
         ):
             read_errors = stream_error.subgroup(httpx.ReadError)
             assert read_errors is not None
-            assert "truncated stream" in str(read_errors)
+            assert "truncated stream" in repr(read_errors)
         else:
             assert "truncated stream" in str(stream_error)
         ev = client.get(

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import base64
 import asyncio
+import builtins
 import hashlib
 import hmac
 import importlib
@@ -567,7 +568,10 @@ class TestModelsAndEvidence:
             [b'data: {"model":"Concrete.gguf"}\n\n'],
             model_error=httpx.ReadError("truncated stream"),
         )
-        with pytest.raises((httpx.ReadError, BaseExceptionGroup)) as exc_info:
+        exception_group_type = getattr(
+            builtins, "BaseExceptionGroup", httpx.ReadError
+        )
+        with pytest.raises((httpx.ReadError, exception_group_type)) as exc_info:
             client.post("/v1/chat/completions", json={
                 "model": "ods/current", "stream": True,
                 "messages": [
@@ -575,7 +579,10 @@ class TestModelsAndEvidence:
                 ],
             })
         stream_error = exc_info.value
-        if isinstance(stream_error, BaseExceptionGroup):
+        if (
+            exception_group_type is not httpx.ReadError
+            and isinstance(stream_error, exception_group_type)
+        ):
             read_errors = stream_error.subgroup(httpx.ReadError)
             assert read_errors is not None
             assert "truncated stream" in str(read_errors)

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -567,13 +567,20 @@ class TestModelsAndEvidence:
             [b'data: {"model":"Concrete.gguf"}\n\n'],
             model_error=httpx.ReadError("truncated stream"),
         )
-        with pytest.raises(httpx.ReadError, match="truncated stream"):
+        with pytest.raises((httpx.ReadError, BaseExceptionGroup)) as exc_info:
             client.post("/v1/chat/completions", json={
                 "model": "ods/current", "stream": True,
                 "messages": [
                     {"role": "user", "content": _signed_marker(probe_id)}
                 ],
             })
+        stream_error = exc_info.value
+        if isinstance(stream_error, BaseExceptionGroup):
+            read_errors = stream_error.subgroup(httpx.ReadError)
+            assert read_errors is not None
+            assert "truncated stream" in str(read_errors)
+        else:
+            assert "truncated stream" in str(stream_error)
         ev = client.get(
             f"/internal/route-evidence/{probe_id}",
             headers={"Authorization": "Bearer internal-secret"},


### PR DESCRIPTION
## Summary

- add a Linux CI job for the existing APE, LiteLLM, model-router, and privacy-shield Python suites
- install each service's shipped runtime dependencies plus the shared test runner
- run all four suites at their service boundary on Python 3.12

Closes #3237.

## Why this matters

These suites cover governance decisions, routed telemetry, model routing, authentication, key handling, PII scrubbing, and streaming proxy behavior. They already contain 148 tests, but no GitHub Actions workflow invoked them, so regressions in those production services could merge without running their nearest boundary tests.

## Overlap check

Searched open and closed PRs for the four service test directories, pytest CI jobs, and issue #3237. No PR runs these suites. #3349 expands the separate token-spy job, while #3370 adds least-privilege permissions to this workflow; neither covers these test commands. This PR keeps the four missing suites together as one release gate instead of splitting one behavioral invariant into micro-PRs.

## Regression test

The workflow itself is the release-boundary regression: a failure in any existing service suite now fails the service-python-tests check.

Local validation:

- py -m pytest extensions/services/ape/tests extensions/services/litellm/tests extensions/services/model-router/tests extensions/services/privacy-shield/tests -q: 148 passed
- parsed .github/workflows/test-linux.yml with PyYAML: passed
- git diff --check: passed

## Tradeoffs and rollback

The job installs the exact runtime requirement files ODS ships, plus bounded pytest dependencies. Running the suites serially avoids cross-service module-name collisions and makes the failing service obvious in CI logs. Reverting removes only the release gate; it does not change runtime behavior.

## CI-discovered compatibility fix

The first Linux run exposed that Starlette versions allowed by the shipped FastAPI range may wrap an upstream httpx.ReadError in BaseExceptionGroup. The model-router regression now verifies the same ReadError leaf in both direct and grouped forms, then continues to assert that failed streams record no evidence and release admission. A clean virtualenv using the shipped model-router requirements passes all 48 router tests.
