### PR TITLE
ci: gate model catalog release contracts

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -188,7 +188,12 @@ jobs:
         run: python3 tests/test-dependency-pins.py
 
       - name: Offline Model Validation Tests
-        run: python3 tests/test-offline-model-validation.py
+        run: |
+          python3 tests/test-offline-model-validation.py
+          python3 tests/test-model-library-coverage.py
+          python3 tests/test-model-library-verdicts.py
+          python3 tests/test-gemma4-artifact-pins.py
+          python3 tests/test-gpu-layer-contract.py
 
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -91,6 +91,11 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
+	@echo "=== model catalog release contracts ==="
+	@python3 tests/test-model-library-coverage.py
+	@python3 tests/test-model-library-verdicts.py
+	@python3 tests/test-gemma4-artifact-pins.py
+	@python3 tests/test-gpu-layer-contract.py
 	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh


### PR DESCRIPTION
## Summary

- run model-library coverage and release-verdict contracts in make test and Linux CI
- gate the immutable Gemma 4 artifact revisions/checksums merged with the production fix
- gate GPU layer placement parity across platform generators

## Why this matters

Model catalog and tier-map edits directly select the artifacts users download and the GPU arguments their runtimes receive. These repository-owned release contracts already detect missing catalog coverage, unsupported release verdicts, mutable or mismatched Gemma artifacts, and cross-platform GPU-layer drift, but no standard local or CI gate invoked them. A later catalog change could therefore invalidate a shipped model path while the release checks remained green.

## Overlap check

Searched open and closed PRs for each test filename and model-catalog CI coverage. #2463 merged the Gemma artifact correction and added its regression test, but did not wire that test into a gate. #2292 similarly added the GPU-layer contract. Open model candidate PRs consume the coverage/verdict helpers but do not change Makefile or CI invocation. #3387 adds unrelated service Python suites in another job; #3370 changes workflow permissions only. No PR provides this combined release-model gate.

## Regression test

The nearest public boundaries are make test for contributors and the integration-smoke workflow for pull requests. Both now execute the same four repository contracts.

Validation:

- Linux: all four scripts passed; the macOS generator lifecycle exercised by test-gpu-layer-contract.py passed
- Windows: catalog coverage, verdict, and Gemma artifact contracts passed; platform-only GPU lifecycle checks skipped as designed
- workflow YAML parse passed
- git diff --check passed

## Tradeoffs and rollback

The contracts are pure repository checks and perform no network downloads. Keeping them beside offline model validation makes model release policy discoverable and avoids a separate CI job. Reverting removes only gate coverage and does not alter runtime state.