### PR TITLE
fix(installer): reject invalid local-build metadata

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -52,22 +52,25 @@ _phase11_build_local_images() {
             # Cross-check that a successful build produced a tagged image. An
             # image left by an earlier install never overrides a non-zero build.
             if ! $build_failed; then
-                resolved_image=$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --format json 2>/dev/null \
+                if ! resolved_image=$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --format json 2>> "$build_log" \
                     | python3 -c "
 import json, sys
-try:
-    d = json.load(sys.stdin)
-    svc_name = '$svc'
-    svc_config = d.get('services', {}).get(svc_name, {})
-    image = svc_config.get('image', '') or ''
-    if not image and svc_config.get('build') is not None:
-        project = d.get('name') or 'ods'
-        image = f'{project}-{svc_name}'
-    print(image)
-except Exception:
-    pass
-" 2>/dev/null || echo "")
-                if [[ -n "$resolved_image" ]] && ! $DOCKER_CMD image inspect "$resolved_image" &>/dev/null; then
+d = json.load(sys.stdin)
+svc_name = '$svc'
+svc_config = d.get('services', {}).get(svc_name)
+if not isinstance(svc_config, dict):
+    raise SystemExit(f'Compose config has no service named {svc_name}')
+image = svc_config.get('image', '') or ''
+if not image and svc_config.get('build') is not None:
+    project = d.get('name') or 'ods'
+    image = f'{project}-{svc_name}'
+if not image:
+    raise SystemExit(f'Compose config has no image or build metadata for {svc_name}')
+print(image)
+" 2>> "$build_log"); then
+                    build_failed=true
+                    echo "Could not resolve the built image for '$svc' from Docker Compose metadata." >> "$build_log"
+                elif ! $DOCKER_CMD image inspect "$resolved_image" &>/dev/null; then
                     build_failed=true
                     echo "Built image '$resolved_image' was not found after build attempt $attempt." >> "$build_log"
                 fi

--- a/ods/tests/test-phase11-local-build-failure.sh
+++ b/ods/tests/test-phase11-local-build-failure.sh
@@ -53,6 +53,10 @@ case "$args" in
         exit 0
         ;;
     *" config --format json "*)
+        if [[ "${MOCK_CONFIG_INVALID:-false}" == "true" ]]; then
+            printf '%s\n' '{not-json'
+            exit 0
+        fi
         cat <<'JSON'
 {"name":"ods","services":{"comfyui":{"build":{"context":"extensions/services/comfyui"}}}}
 JSON
@@ -148,3 +152,23 @@ set -e
 grep -q 'WARN: comfyui build failed; retrying' "$LOG_FILE" \
     || fail "retry warning was not recorded"
 pass "phase 11 retries transient local image build failures"
+
+: > "$CALL_LOG"
+: > "$LOG_FILE"
+rm -f "$MOCK_COMFYUI_BUILD_COUNT"
+unset MOCK_COMFYUI_FAIL_BEFORE_SUCCESS
+export MOCK_CONFIG_INVALID=true
+export ODS_DOCKER_BUILD_MAX_ATTEMPTS=1
+
+set +e
+_phase11_build_local_images comfyui
+phase_rc=$?
+set -e
+
+[[ "$phase_rc" -ne 0 ]] \
+    || fail "invalid Compose build metadata was accepted as a verified image"
+! grep -q 'image inspect' "$CALL_LOG" \
+    || fail "installer inspected an image name parsed from invalid Compose metadata"
+grep -q "Could not resolve the built image for 'comfyui'" "$LOG_FILE" \
+    || fail "installer did not explain the Compose metadata failure"
+pass "invalid Compose build metadata fails closed"


### PR DESCRIPTION
## Summary

- fail a requested local image build when Docker Compose metadata cannot be parsed
- require the built service to resolve to an image or build entry before inspecting the tag
- record the Compose/parser error in the per-service build log

## Why this matters

Phase 11 builds required local services such as ComfyUI and model-router, then verifies that the expected image exists before starting the stack. The verifier caught every JSON/config error and returned an empty string; because image inspection was conditional on a non-empty result, the installer reported the service as built and continued without proving the artifact existed. An unsupported or failing docker compose config --format json path therefore bypassed the fail-closed guard added to prevent stale local images from masking build problems.

## Overlap check

Searched open and closed PRs for phase 11 build metadata, config --format json, resolved_image, and missing local images. Existing PR #3107 changes which active images the CLI rebuilds and does not touch installer phase 11. Merged PRs #1188, #1915, and #1918 established the local-build lifecycle; none handles metadata parse failure. No open PR changes this verifier or its boundary test.

## Regression test

The existing phase-11 behavioral harness now makes the public Docker shim return successful build status followed by malformed Compose JSON. It asserts the installer returns failure, never calls image inspect with fabricated metadata, and records an actionable reason. The same test retains coverage for stale images and transient build retries.

Validation:

- bash tests/test-phase11-local-build-failure.sh: all four behavioral checks passed
- bash -n on production and test scripts: passed
- ShellCheck error severity on both changed scripts: passed
- git diff --check: passed

## Tradeoffs and rollback

Metadata resolution now fails closed because the installer cannot verify which artifact a successful build produced. This can reject old Compose implementations without JSON output, but continuing would defeat the explicit stale-image safety invariant. Operators receive the underlying parser/Compose output in the existing build log. Reverting restores the silent verification bypass; no persisted state is changed.