### PR TITLE
fix(dashboard-api): guard null nodes payload in cluster status refresh

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -60,12 +60,20 @@ class ClusterStatus:
 
             if proc.returncode == 0:
                 data = json.loads(stdout.decode())
-                self.nodes = data.get("nodes", [])
-                self.total_gpus = len(self.nodes)
-                self.active_gpus = sum(1 for n in self.nodes if n.get("healthy", False))
-                self.failover_ready = self.active_gpus > 1
-                logger.debug("Cluster status: %d/%d GPUs active, failover_ready=%s",
-                           self.active_gpus, self.total_gpus, self.failover_ready)
+                if isinstance(data, dict):
+                    nodes_data = data.get("nodes")
+                    self.nodes = nodes_data if isinstance(nodes_data, list) else []
+                    self.total_gpus = len(self.nodes)
+                    self.active_gpus = sum(
+                        1 for n in self.nodes if isinstance(n, dict) and n.get("healthy", False)
+                    )
+                    self.failover_ready = self.active_gpus > 1
+                    logger.debug(
+                        "Cluster status: %d/%d GPUs active, failover_ready=%s",
+                        self.active_gpus,
+                        self.total_gpus,
+                        self.failover_ready,
+                    )
         except FileNotFoundError:
             logger.debug("Cluster proxy not available: curl command not found")
         except asyncio.TimeoutError:

--- a/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -295,6 +295,24 @@ class TestClusterStatusRefresh:
 
         assert cs.total_gpus == 0
 
+    @pytest.mark.asyncio
+    async def test_refresh_handles_null_nodes_payload(self):
+        """ClusterStatus.refresh handles {"nodes": null} without TypeError."""
+        cs = ClusterStatus()
+
+        async def _fake_subprocess(*args, **kwargs):
+            proc = MagicMock()
+            proc.communicate = AsyncMock(return_value=(b'{"nodes": null}', b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+            await cs.refresh()
+
+        assert cs.nodes == []
+        assert cs.total_gpus == 0
+        assert cs.active_gpus == 0
+
 
 class TestGetFullAgentMetrics:
 


### PR DESCRIPTION
## Summary
fix(dashboard-api): guard null nodes payload in cluster status refresh

## Changes
- Updated implementation in `fix/agent-monitor-null-nodes-guard` for resilience and error handling.
- Verified with standard linting and contract checks.

## Verification
- Passed `make lint` checks cleanly.
