### PR TITLE
fix(bootstrap): trim whitespace from media_type in verify-hosted-bootstrap.sh

### DIFF
--- a/ods/scripts/verify-hosted-bootstrap.sh
+++ b/ods/scripts/verify-hosted-bootstrap.sh
@@ -119,7 +119,7 @@ for endpoint in "$@"; do
     [[ "$presentation" == "script" ]] \
         || fail "$endpoint reports presentation '${presentation:-missing}'; expected script."
 
-    media_type="$(printf '%s' "${content_type%%;*}" | tr '[:upper:]' '[:lower:]')"
+    media_type="$(printf '%s' "${content_type%%;*}" | tr '[:upper:]' '[:lower:]' | xargs)"
     case "$media_type" in
         text/plain) ;;
         *) fail "$endpoint returned content type '${content_type:-missing}'; expected text/plain." ;;


### PR DESCRIPTION
## Summary
fix(bootstrap): trim whitespace from media_type in verify-hosted-bootstrap.sh

## Changes
- Updated implementation in `fix/verify-hosted-bootstrap-media-type-trim` for resilience and error handling.
- Verified with standard linting and contract checks.

## Verification
- Passed `make lint` checks cleanly.
