### PR TITLE
fix(preflight): write preflight engine report JSON atomically in preflight-engine.sh

### DIFF
--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -344,7 +344,19 @@ report = {
 
 report_path = pathlib.Path(report_file)
 report_path.parent.mkdir(parents=True, exist_ok=True)
-report_path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+import os
+import pathlib
+import tempfile
+fd, tmp_str = tempfile.mkstemp(dir=str(report_path.parent), prefix=f".{report_path.name}.", suffix=".tmp")
+tmp_path = pathlib.Path(tmp_str)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(json.dumps(report, indent=2) + "\n")
+    os.replace(tmp_path, report_path)
+except Exception:
+    if tmp_path.exists():
+        tmp_path.unlink(missing_ok=True)
+    raise
 
 if env_mode:
     def out(key, value):


### PR DESCRIPTION
## Summary
fix(preflight): write preflight engine report JSON atomically in preflight-engine.sh

## Changes
- Updated implementation in `fix/preflight-engine-report-atomic` for resilience and error handling.
- Verified with standard linting and contract checks.

## Verification
- Passed `make lint` checks cleanly.
