### PR TITLE
feat(cli): add machine-readable template discovery

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -152,6 +152,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
 	@echo ""
+	@echo "=== CLI template JSON output ==="
+	@bash tests/test-template-json-output.sh
+	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
 

--- a/ods/docs/FAQ.md
+++ b/ods/docs/FAQ.md
@@ -291,11 +291,17 @@ Templates are curated presets that enable a group of extensions suited to a spec
 **List available templates:**
 ```bash
 ods template list
+
+# Machine-readable catalog for scripts and integrations
+ods template list --json
 ```
 
 **Preview what a template will change before applying:**
 ```bash
 ods template preview <template-id>
+
+# Machine-readable preview, including already_enabled and to_enable services
+ods template preview <template-id> --json
 ```
 
 **Apply a template (enables the template's services):**

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -6212,10 +6212,40 @@ cmd_repair() {
 # Templates
 #=============================================================================
 _template_list() {
+    local json_mode="${1:-false}"
     local templates_dir="$INSTALL_DIR/templates"
     if [[ ! -d "$templates_dir" ]]; then
+        if [[ "$json_mode" == "true" ]]; then
+            printf '[]\n'
+            return 0
+        fi
         warn "No templates directory found at $templates_dir"
         return 0
+    fi
+
+    if [[ "$json_mode" == "true" ]]; then
+        python3 - "$templates_dir" <<'PYEOF'
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+templates = []
+templates_dir = Path(sys.argv[1])
+for path in sorted(templates_dir.glob("*.yaml")) + sorted(templates_dir.glob("*.yml")):
+    with path.open(encoding="utf-8") as fh:
+        document = yaml.safe_load(fh)
+    if not isinstance(document, dict) or document.get("schema_version") != "ods.templates.v1":
+        continue
+    template = document.get("template", {})
+    if isinstance(template, dict) and template.get("id"):
+        templates.append(template)
+
+json.dump(templates, sys.stdout, ensure_ascii=False)
+sys.stdout.write("\n")
+PYEOF
+        return
     fi
 
     # First pass: collect template rows and compute max ID width so the
@@ -6269,7 +6299,8 @@ PYEOF
 
 _template_preview() {
     local template_id="${1:-}"
-    [[ -z "$template_id" ]] && { log "Usage: ods template preview <template-id>"; exit 1; }
+    local json_mode="${2:-false}"
+    [[ -z "$template_id" ]] && { log "Usage: ods template preview <template-id> [--json]"; exit 1; }
 
     local templates_dir="$INSTALL_DIR/templates"
     local tmpl_file=""
@@ -6294,20 +6325,18 @@ PYEOF
 
     [[ -z "$tmpl_file" ]] && error "Template not found: $template_id"
 
-    python3 - "$tmpl_file" "$INSTALL_DIR" <<'PYEOF'
-import yaml, sys
+    python3 - "$tmpl_file" "$INSTALL_DIR" "$json_mode" <<'PYEOF'
+import json
+import sys
 from pathlib import Path
+
+import yaml
 
 with open(sys.argv[1]) as fh:
     d = yaml.safe_load(fh)
 t = d.get("template", {})
 install_dir = Path(sys.argv[2])
-
-print(f"Template: {t.get('name', t.get('id', ''))}")
-print(f"Description: {t.get('description', '-')}")
-if t.get("estimated_disk_gb"):
-    print(f"Estimated disk: ~{t['estimated_disk_gb']}GB")
-print()
+json_mode = sys.argv[3] == "true"
 
 services = t.get("services", [])
 ext_dir = install_dir / "extensions" / "services"
@@ -6322,6 +6351,20 @@ for svc in services:
         already.append(svc)
     else:
         to_enable.append(svc)
+
+if json_mode:
+    result = dict(t)
+    result["already_enabled"] = already
+    result["to_enable"] = to_enable
+    json.dump(result, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    raise SystemExit(0)
+
+print(f"Template: {t.get('name', t.get('id', ''))}")
+print(f"Description: {t.get('description', '-')}")
+if t.get("estimated_disk_gb"):
+    print(f"Estimated disk: ~{t['estimated_disk_gb']}GB")
+print()
 
 if already:
     print(f"Already enabled: {', '.join(already)}")
@@ -6389,10 +6432,22 @@ cmd_template() {
     local subcmd="${1:-list}"
     shift || true
     case "$subcmd" in
-        list)    _template_list ;;
-        preview) _template_preview "$@" ;;
+        list)
+            local list_json="false"
+            [[ "${1:-}" == "--json" ]] && { list_json="true"; shift; }
+            [[ $# -eq 0 ]] || error "Usage: ods template list [--json]"
+            _template_list "$list_json"
+            ;;
+        preview)
+            local template_id="${1:-}"
+            shift || true
+            local preview_json="false"
+            [[ "${1:-}" == "--json" ]] && { preview_json="true"; shift; }
+            [[ $# -eq 0 ]] || error "Usage: ods template preview <template-id> [--json]"
+            _template_preview "$template_id" "$preview_json"
+            ;;
         apply)   _template_apply "$@" ;;
-        *)       log "Usage: ods template [list|preview|apply] [template-id]"; exit 1 ;;
+        *)       log "Usage: ods template [list [--json]|preview <template-id> [--json]|apply <template-id>]"; exit 1 ;;
     esac
 }
 
@@ -6540,8 +6595,8 @@ ${CYAN}Examples:${NC}
   ods restart stt               # Restart Whisper (via alias)
   ods chat "What is 2+2?"      # Quick LLM test
   ods config edit               # Edit .env file
-  ods template list              # List available templates
-  ods template preview creative-studio
+  ods template list [--json]     # List available templates
+  ods template preview creative-studio [--json]
                                   # Preview what a template will change
   ods template apply chat-playground
                                   # Apply a template (enables services)

--- a/ods/tests/test-template-json-output.sh
+++ b/ods/tests/test-template-json-output.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Public CLI contract: template discovery and preview expose parseable JSON.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI="$ROOT_DIR/ods-cli"
+
+list_output=$(ODS_HOME="$ROOT_DIR" NO_COLOR=1 "$CLI" template list --json)
+python3 - "$list_output" <<'PYEOF'
+import json
+import sys
+
+templates = json.loads(sys.argv[1])
+assert isinstance(templates, list)
+creative = next(item for item in templates if item["id"] == "creative-studio")
+assert creative["name"] == "Creative Studio"
+assert creative["tier_minimum"] == "T3"
+assert "comfyui" in creative["services"]
+PYEOF
+
+preview_output=$(ODS_HOME="$ROOT_DIR" NO_COLOR=1 "$CLI" template preview creative-studio --json)
+python3 - "$preview_output" <<'PYEOF'
+import json
+import sys
+
+preview = json.loads(sys.argv[1])
+assert preview["id"] == "creative-studio"
+assert isinstance(preview["already_enabled"], list)
+assert isinstance(preview["to_enable"], list)
+assert sorted(preview["already_enabled"] + preview["to_enable"]) == sorted(preview["services"])
+PYEOF
+
+echo "[PASS] template list and preview JSON output"


### PR DESCRIPTION
## Summary - add `--json` output to `ods template list` - add machine-readable template change previews with `already_enabled` and `to_enable` - document the automation interface and run its CLI-boundary regression test from `make test`  ## Why this matters Operators and dashboard integrations can discover template metadata and preview the exact service changes without scraping colorized, width-dependent terminal tables. The reachable public path is `ods template list|preview`, backed by the shipped `templates/*.yaml` catalog.  ## Overlap check Searched open and closed upstream PR titles/bodies for `template --json` and `machine-readable template`, plus production callers of `_template_list` and `_template_preview`. PR #3309 concerns template rendering validation and parameter substitution, not CLI discovery or preview output; no equivalent or superset PR was found.  ## Behavioral invariant Human-readable template commands remain unchanged by default, while JSON mode emits one valid JSON document whose preview service partitions exactly reconstruct the template service list.  ## Test plan - [x] `bash ods/tests/test-template-json-output.sh` - [x] `python ods/tests/contracts/test-ods-cli-contracts.py` - [x] `bash -n ods/ods-cli` - [x] `git diff --check`  ## Scope and tradeoffs This adds JSON only to read-only list and preview operations; applying templates remains explicitly interactive/operational. It relies on PyYAML, which the existing template CLI already requires. Rollback is a clean revert with no persisted-state migration.  Generated with Codex 
## Batch compatibility
Preferred merge order: #3481 → #3482 → #3483 → #3484 → #3485 → #3486. The combined result was validated on a local synthetic head (`2992ab11`) built from upstream `main` (`6ff9b4fc`). All six focused CLI tests, the static command contract, Bash syntax, the Windows log contract, and PowerShell parsing passed together.

Expected reconciliation: #3484 needs the earlier `Makefile` test entries retained; #3486 needs both catalog commands retained in `ods-cli`, `Makefile`, and the static command registry. These are additive shared-file conflicts, not behavioral incompatibilities. Each later PR should be rebased after its predecessors merge. Full local `make lint/test` was unavailable because GNU Make is not installed on this Windows host; each isolated PR's GitHub Actions matrix is the release validation source.