### PR TITLE
feat(cli): expose saved presets as JSON

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -110,6 +110,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI preset restore user extensions ==="
 	@bash tests/test-cli-preset-restore-user-extensions.sh
 	@echo ""
+	@echo "=== CLI preset list JSON output ==="
+	@bash tests/test-preset-list-json.sh
+	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh
 	@echo ""

--- a/ods/README.md
+++ b/ods/README.md
@@ -390,6 +390,7 @@ ods config show         # View .env (secrets masked)
 ods config edit         # Open .env in editor
 ods preset save <name>  # Snapshot current config
 ods preset load <name>  # Restore a saved preset
+ods preset list --json  # Export preset metadata for automation
 ```
 
 Full mode-switching documentation: [docs/MODE-SWITCH.md](docs/MODE-SWITCH.md)

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3194,6 +3194,55 @@ META
             ;;
 
         list|ls)
+            if [[ "$name" == "--json" ]]; then
+                python3 - "$PRESETS_DIR" <<'PYEOF'
+import json
+import sys
+from pathlib import Path
+
+presets_dir = Path(sys.argv[1])
+presets = []
+if presets_dir.is_dir():
+    for preset_dir in sorted(path for path in presets_dir.iterdir() if path.is_dir()):
+        metadata = {}
+        metadata_path = preset_dir / "meta.txt"
+        if metadata_path.is_file():
+            for line in metadata_path.read_text(encoding="utf-8").splitlines():
+                if "=" not in line or line.startswith("#"):
+                    continue
+                key, value = line.split("=", 1)
+                metadata[key] = value
+
+        enabled_services = []
+        disabled_services = []
+        extensions_path = preset_dir / "extensions.list"
+        if extensions_path.is_file():
+            for line in extensions_path.read_text(encoding="utf-8").splitlines():
+                state, separator, service = line.partition(":")
+                if not separator or not service:
+                    continue
+                if state == "enabled":
+                    enabled_services.append(service)
+                elif state == "disabled":
+                    disabled_services.append(service)
+
+        presets.append(
+            {
+                "name": preset_dir.name,
+                "created": metadata.get("created"),
+                "gpu_backend": metadata.get("gpu_backend"),
+                "tier": metadata.get("tier"),
+                "enabled_services": enabled_services,
+                "disabled_services": disabled_services,
+            }
+        )
+
+json.dump(presets, sys.stdout, ensure_ascii=False)
+sys.stdout.write("\n")
+PYEOF
+                return
+            fi
+            [[ -z "$name" ]] || error "Usage: ods preset list [--json]"
             echo -e "${BLUE}━━━ Saved Presets ━━━${NC}"
             if [[ ! -d "$PRESETS_DIR" ]] || [[ -z "$(ls -A "$PRESETS_DIR" 2>/dev/null)" ]]; then
                 echo "  No presets saved yet."
@@ -3443,7 +3492,7 @@ Usage: ods preset <command> [args]
 Commands:
   save <name>              Save current configuration as a preset
   load <name>              Load a preset (restores .env and service state)
-  list                     List all saved presets
+  list [--json]            List all saved presets
   delete <name>            Delete a preset
   export <name> <file>     Export preset to .tar.gz archive
   import <file>            Import preset from .tar.gz archive
@@ -3452,6 +3501,7 @@ Commands:
 Examples:
   ods preset save gaming
   ods preset load gaming
+  ods preset list --json
   ods preset diff gaming production
   ods preset export gaming ~/gaming-preset.tar.gz
 EOF
@@ -6450,7 +6500,7 @@ ${CYAN}Commands:${NC}
 ${CYAN}Preset Commands:${NC}
   preset save <name>     Snapshot current config (env, mode, extensions)
   preset load <name>     Restore a saved preset
-  preset list            Show all saved presets
+  preset list [--json]   Show all saved presets
   preset delete <name>   Delete a saved preset
   preset export <name> <file.tar.gz>
                          Export preset to shareable archive

--- a/ods/tests/test-preset-list-json.sh
+++ b/ods/tests/test-preset-list-json.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Public CLI contract: saved presets can be enumerated without parsing tables.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$INSTALL_DIR/presets/creative"
+cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+cat > "$INSTALL_DIR/presets/creative/meta.txt" <<'EOF'
+name=creative
+created=2026-08-29T12:34:56Z
+gpu_backend=nvidia
+tier=T3
+EOF
+cat > "$INSTALL_DIR/presets/creative/extensions.list" <<'EOF'
+enabled:comfyui
+enabled:whisper
+disabled:langfuse
+EOF
+
+output=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$ROOT_DIR/ods-cli" preset list --json)
+python3 - "$output" <<'PYEOF'
+import json
+import sys
+
+presets = json.loads(sys.argv[1])
+assert presets == [
+    {
+        "name": "creative",
+        "created": "2026-08-29T12:34:56Z",
+        "gpu_backend": "nvidia",
+        "tier": "T3",
+        "enabled_services": ["comfyui", "whisper"],
+        "disabled_services": ["langfuse"],
+    }
+]
+PYEOF
+
+echo "[PASS] preset list JSON output"


### PR DESCRIPTION
## Summary - add `ods preset list --json` for machine-readable saved-preset discovery - include persisted metadata plus enabled and disabled service inventories - document the command and add it to the repository test gate  ## Why this matters Backup tooling, fleet scripts, and support workflows can inventory saved configurations without scraping the human table. The production path reads the same `presets/<name>/meta.txt` and `extensions.list` state used by `ods preset load`.  ## Overlap check Searched open and closed upstream PR titles/bodies for `preset list --json` and `machine-readable presets`, then inspected `cmd_preset` and tests referencing its persisted files. No equivalent or superset PR was found; existing preset work covers restore/import correctness rather than an inventory API.  ## Behavioral invariant `ods preset list` keeps its existing human output. JSON mode emits one deterministic array, preserves full timestamps, partitions known extension states, and represents absent metadata as JSON null.  ## Test plan - [x] `bash ods/tests/test-preset-list-json.sh` - [x] `python ods/tests/contracts/test-ods-cli-contracts.py` - [x] `bash -n ods/ods-cli` - [x] `git diff --check`  ## Scope and tradeoffs The feature is read-only and uses Python already required by ODS. Unknown extension-state lines are ignored just as the load path only acts on `enabled` and `disabled`; malformed file I/O remains visible. Reverting removes the output mode without changing persisted presets.  Generated with Codex 
## Batch compatibility
Preferred merge order: #3481 → #3482 → #3483 → #3484 → #3485 → #3486. The combined result was validated on a local synthetic head (`2992ab11`) built from upstream `main` (`6ff9b4fc`). All six focused CLI tests, the static command contract, Bash syntax, the Windows log contract, and PowerShell parsing passed together.

Expected reconciliation: #3484 needs the earlier `Makefile` test entries retained; #3486 needs both catalog commands retained in `ods-cli`, `Makefile`, and the static command registry. These are additive shared-file conflicts, not behavioral incompatibilities. Each later PR should be rebased after its predecessors merge. Full local `make lint/test` was unavailable because GNU Make is not installed on this Windows host; each isolated PR's GitHub Actions matrix is the release validation source.