### PR TITLE
feat(cli): add machine-readable host-agent status

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -128,6 +128,9 @@ test: ## Run unit and contract tests
 	@echo "=== desktop host-agent environment contract ==="
 	@bash tests/test-desktop-agent-host-env.sh
 	@echo ""
+	@echo "=== host-agent status JSON output ==="
+	@bash tests/test-agent-status-json.sh
+	@echo ""
 	@echo "=== macOS model download retry contract ==="
 	@bash tests/test-macos-download-retries.sh
 	@echo ""

--- a/ods/docs/HOST-AGENT-API.md
+++ b/ods/docs/HOST-AGENT-API.md
@@ -6,6 +6,15 @@ The ODS Host Agent (`bin/ods-host-agent.py`) is a lightweight HTTP server that r
 
 The Dashboard API runs inside a Docker container and cannot directly run `docker compose` commands on the host. The host agent bridges this gap: it listens on `ODS_AGENT_BIND:ODS_AGENT_PORT`, accepts authenticated requests from the Dashboard API, and executes Docker Compose operations on its behalf. This avoids mounting the Docker socket into the container (a significant security risk).
 
+Operators can check the local agent without calling its HTTP endpoint directly:
+
+```bash
+ods agent status
+ods agent status --json
+```
+
+The JSON form reports `status`, `port`, `daemon_type`, and the validated health payload, making it suitable for monitoring and fleet automation.
+
 ## How It Runs
 
 | Platform | Mechanism |

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4780,12 +4780,26 @@ cmd_agent() {
         [[ -n "$command_line" && "$command_line" == *"$agent_script"* ]]
     }
 
-    _agent_health_ready() {
+    _agent_health_payload() {
         local bind_addr health_payload
         bind_addr="$(_agent_probe_host)"
-        health_payload=$(curl -sf --max-time 2 "http://${bind_addr}:${port}/health" 2>/dev/null) || return 1
-        grep -Eq '"status"[[:space:]]*:[[:space:]]*"ok"' <<<"$health_payload" && \
-            grep -Eq '"version"[[:space:]]*:' <<<"$health_payload"
+        health_payload=$(curl -sf --max-time 2 "http://${bind_addr}:${port}/health") || return 1
+        python3 - "$health_payload" <<'PYEOF'
+import json
+import sys
+
+try:
+    payload = json.loads(sys.argv[1])
+except json.JSONDecodeError:
+    raise SystemExit(1)
+if not isinstance(payload, dict) or payload.get("status") != "ok" or "version" not in payload:
+    raise SystemExit(1)
+json.dump(payload, sys.stdout, ensure_ascii=False, separators=(",", ":"))
+PYEOF
+    }
+
+    _agent_health_ready() {
+        _agent_health_payload >/dev/null
     }
 
     # Installer phases can explicitly request the per-session fallback when
@@ -4809,9 +4823,25 @@ cmd_agent() {
 
     case "$action" in
         status)
-            if _agent_health_ready; then
+            local json_mode="false"
+            [[ "${2:-}" == "--json" ]] && json_mode="true"
+            [[ -z "${2:-}" || "$json_mode" == "true" ]] || error "Usage: ods agent status [--json]"
+            [[ -z "${3:-}" ]] || error "Usage: ods agent status [--json]"
+
+            local health_payload=""
+            if health_payload=$(_agent_health_payload); then
+                if [[ "$json_mode" == "true" ]]; then
+                    printf '{"status":"running","port":"%s","daemon_type":"%s","health":%s}\n' \
+                        "$(_json_escape "$port")" "$(_json_escape "$daemon_type")" "$health_payload"
+                    return 0
+                fi
                 success "ODS host agent: running (port ${port}, ${daemon_type})"
             else
+                if [[ "$json_mode" == "true" ]]; then
+                    printf '{"status":"unreachable","port":"%s","daemon_type":"%s","health":null}\n' \
+                        "$(_json_escape "$port")" "$(_json_escape "$daemon_type")"
+                    return 0
+                fi
                 warn "ODS host agent: not responding (port ${port})"
             fi
             ;;
@@ -4913,7 +4943,7 @@ cmd_agent() {
             fi
             ;;
         *)
-            log "Usage: ods agent [status|start|stop|restart|logs]"
+            log "Usage: ods agent [status [--json]|start|stop|restart|logs]"
             ;;
     esac
 }
@@ -6444,7 +6474,7 @@ ${CYAN}Commands:${NC}
                       Repair voice services or prune leaked Hermes slash workers
   template [action]   Apply pre-built service templates (list|preview|apply)
   audit [extensions]  Audit extension manifests and compose contracts
-  agent [action]      Manage ods host agent (status|start|stop|restart|logs)
+  agent [action]      Manage ods host agent (status [--json]|start|stop|restart|logs)
   help                Show this help
 
 ${CYAN}Preset Commands:${NC}
@@ -6547,7 +6577,7 @@ ${CYAN}Examples:${NC}
                                   # Apply a template (enables services)
   ods audit                     # Audit every extension contract
   ods audit --json whisper      # Audit one service as JSON
-  ods agent status              # Check host agent health
+  ods agent status [--json]     # Check host agent health
   ods agent restart             # Restart host agent
   ods repair voice              # Start voice services and cache STT model
   ods repair rootless-ownership # Repair active bind mounts for rootless Docker

--- a/ods/tests/test-agent-status-json.sh
+++ b/ods/tests/test-agent-status-json.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Public CLI contract: host-agent status is available as one JSON document.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+BIN_DIR="$TMP_DIR/bin"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+cat > "$INSTALL_DIR/.env" <<'EOF'
+ODS_AGENT_BIND=127.0.0.1
+ODS_AGENT_PORT=7788
+EOF
+cat > "$BIN_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${MOCK_AGENT_DOWN:-false}" == "true" ]]; then
+    exit 7
+fi
+printf '%s\n' '{"status":"ok","version":"2.6.0","operations":3}'
+EOF
+chmod +x "$BIN_DIR/curl"
+
+running=$(PATH="$BIN_DIR:$PATH" ODS_HOME="$INSTALL_DIR" NO_COLOR=1 \
+    "$ROOT_DIR/ods-cli" agent status --json)
+python3 - "$running" <<'PYEOF'
+import json
+import sys
+
+status = json.loads(sys.argv[1])
+assert status["status"] == "running"
+assert status["port"] == "7788"
+assert status["daemon_type"] in {"none", "systemd", "launchd"}
+assert status["health"] == {"status": "ok", "version": "2.6.0", "operations": 3}
+PYEOF
+
+unreachable=$(PATH="$BIN_DIR:$PATH" MOCK_AGENT_DOWN=true ODS_HOME="$INSTALL_DIR" NO_COLOR=1 \
+    "$ROOT_DIR/ods-cli" agent status --json)
+python3 - "$unreachable" <<'PYEOF'
+import json
+import sys
+
+status = json.loads(sys.argv[1])
+assert status["status"] == "unreachable"
+assert status["port"] == "7788"
+assert status["health"] is None
+PYEOF
+
+echo "[PASS] agent status JSON output"


### PR DESCRIPTION
## Summary - add `ods agent status --json` with stable status, port, daemon type, and validated health fields - preserve the existing human-readable status command and exit behavior - document and gate both reachable and unreachable agent states at the CLI boundary  ## Why this matters Monitoring and fleet automation need to distinguish a healthy host agent from an unreachable one without parsing icons or prose. This public command probes the same `/health` endpoint used before start/restart decisions, so it reflects the actual host-management path.  ## Overlap check Searched open and closed upstream PR titles/bodies for `agent status --json` and `machine-readable agent status`, then inspected `cmd_agent`, `_agent_health_ready`, host-agent documentation, and existing host-agent tests. No equivalent or superset PR was found.  ## Behavioral invariant Human output remains unchanged. JSON mode always emits one valid document; a healthy response is schema-checked before embedding, and failed/malformed probes produce `status: unreachable` with `health: null`.  ## Test plan - [x] `bash ods/tests/test-agent-status-json.sh` - [x] `python ods/tests/contracts/test-ods-cli-contracts.py` - [x] `bash -n ods/ods-cli` - [x] `git diff --check`  ## Scope and tradeoffs The status command remains observational and returns success for an unreachable agent, matching its pre-existing human-mode behavior. This PR does not change daemon lifecycle operations or authentication. Rollback has no state impact.  Generated with Codex 
## Batch compatibility
Preferred merge order: #3481 → #3482 → #3483 → #3484 → #3485 → #3486. The combined result was validated on a local synthetic head (`2992ab11`) built from upstream `main` (`6ff9b4fc`). All six focused CLI tests, the static command contract, Bash syntax, the Windows log contract, and PowerShell parsing passed together.

Expected reconciliation: #3484 needs the earlier `Makefile` test entries retained; #3486 needs both catalog commands retained in `ods-cli`, `Makefile`, and the static command registry. These are additive shared-file conflicts, not behavioral incompatibilities. Each later PR should be rebased after its predecessors merge. Full local `make lint/test` was unavailable because GNU Make is not installed on this Windows host; each isolated PR's GitHub Actions matrix is the release validation source.