### PR TITLE
feat(cli): discover extensions from the catalog

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -152,6 +152,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
 	@echo ""
+	@echo "=== CLI extension catalog discovery ==="
+	@bash tests/test-extension-catalog-cli.sh
+	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
 

--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -418,6 +418,16 @@ This section describes the end-to-end flow of how extensions are discovered, ins
 
 At startup, the Dashboard API (`config.py:load_extension_catalog()`) loads `config/extensions-catalog.json` — a static JSON file listing all available extensions. This catalog is served via `GET /api/extensions/catalog` and enriched at request time with live status (enabled, disabled, not_installed, incompatible) by checking the filesystem and service health (`routers/extensions.py:_compute_extension_status()`).
 
+The same product-owned catalog is discoverable from the host CLI:
+
+```bash
+ods catalog list
+ods catalog list --backend apple --json
+ods catalog search rag --backend nvidia
+```
+
+Search matches extension IDs, names, descriptions, and tags. Backend filtering uses the catalog's declared `gpu_backends`; it does not probe the current host or mutate extension state.
+
 ### 2. Manifest Loading
 
 The Dashboard API loads manifests from `extensions/services/*/manifest.yaml` at startup (`config.py:load_extension_manifests()`). This populates the `SERVICES` dict (used for health checks) and `FEATURES` list (used by the features endpoint). Disabled extensions (those with `compose.yaml.disabled` instead of `compose.yaml`) are skipped during manifest loading — they do not appear in service health checks or feature recommendations.

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -6209,6 +6209,51 @@ cmd_repair() {
 }
 
 #=============================================================================
+# Extension catalog
+#=============================================================================
+cmd_catalog() {
+    check_install
+
+    local action="${1:-list}"
+    shift || true
+    local query=""
+    case "$action" in
+        list) ;;
+        search)
+            query="${1:-}"
+            [[ -n "$query" ]] || error "Usage: ods catalog search <query> [--backend BACKEND] [--json]"
+            shift
+            ;;
+        *) error "Usage: ods catalog <list|search> [query] [--backend BACKEND] [--json]" ;;
+    esac
+
+    local backend=""
+    local json_mode="false"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --backend)
+                [[ -n "${2:-}" ]] || error "--backend requires a value"
+                backend="$2"
+                shift 2
+                ;;
+            --json) json_mode="true"; shift ;;
+            *) error "Unknown catalog argument: $1" ;;
+        esac
+    done
+
+    local catalog="$INSTALL_DIR/config/extensions-catalog.json"
+    local query_script="$INSTALL_DIR/scripts/query-extensions-catalog.py"
+    [[ -f "$catalog" ]] || error "Extension catalog not found: $catalog"
+    [[ -f "$query_script" ]] || error "Extension catalog query tool not found: $query_script"
+
+    local -a args=("$query_script" "$catalog")
+    [[ -z "$query" ]] || args+=(--query "$query")
+    [[ -z "$backend" ]] || args+=(--backend "$backend")
+    [[ "$json_mode" == "false" ]] || args+=(--json)
+    python3 "${args[@]}"
+}
+
+#=============================================================================
 # Templates
 #=============================================================================
 _template_list() {
@@ -6443,6 +6488,7 @@ ${CYAN}Commands:${NC}
   repair|fix [voice|hermes-workers]
                       Repair voice services or prune leaked Hermes slash workers
   template [action]   Apply pre-built service templates (list|preview|apply)
+  catalog [action]    Discover extension-library services (list|search)
   audit [extensions]  Audit extension manifests and compose contracts
   agent [action]      Manage ods host agent (status|start|stop|restart|logs)
   help                Show this help
@@ -6545,6 +6591,8 @@ ${CYAN}Examples:${NC}
                                   # Preview what a template will change
   ods template apply chat-playground
                                   # Apply a template (enables services)
+  ods catalog search rag --backend nvidia
+                                  # Find compatible library extensions
   ods audit                     # Audit every extension contract
   ods audit --json whisper      # Audit one service as JSON
   ods agent status              # Check host agent health
@@ -6590,6 +6638,7 @@ case "${1:-help}" in
     benchmark|bench|b) cmd_benchmark ;;
     doctor|diag|d) shift; cmd_doctor "$@" ;;
     audit)        shift; cmd_audit "$@" ;;
+    catalog)      shift; cmd_catalog "$@" ;;
     template|tmpl) shift; cmd_template "$@" ;;
     agent)        shift; cmd_agent "$@" ;;
     help|h|--help|-h) cmd_help ;;

--- a/ods/scripts/query-extensions-catalog.py
+++ b/ods/scripts/query-extensions-catalog.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Query the shipped ODS extension catalog for CLI consumers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_catalog(path: Path) -> list[dict]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    extensions = document.get("extensions")
+    if not isinstance(extensions, list):
+        raise ValueError("extension catalog must contain an extensions array")
+    return extensions
+
+
+def matches(extension: dict, query: str, backend: str) -> bool:
+    backends = extension.get("gpu_backends", [])
+    if backend and backend not in backends:
+        return False
+    if not query:
+        return True
+    searchable = [
+        extension.get("id", ""),
+        extension.get("name", ""),
+        extension.get("description", ""),
+        *extension.get("tags", []),
+    ]
+    needle = query.casefold()
+    return any(needle in str(value).casefold() for value in searchable)
+
+
+def render_table(extensions: list[dict]) -> None:
+    if not extensions:
+        print("No matching extensions found.")
+        return
+
+    id_width = max(9, *(len(str(item.get("id", ""))) for item in extensions))
+    name_width = max(4, *(len(str(item.get("name", ""))) for item in extensions))
+    print(f"{'EXTENSION':<{id_width}}  {'NAME':<{name_width}}  BACKENDS")
+    print(f"{'-' * id_width}  {'-' * name_width}  {'-' * 12}")
+    for extension in extensions:
+        backends = ",".join(extension.get("gpu_backends", [])) or "none"
+        print(
+            f"{extension.get('id', ''):<{id_width}}  "
+            f"{extension.get('name', ''):<{name_width}}  {backends}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("catalog", type=Path)
+    parser.add_argument("--query", default="")
+    parser.add_argument("--backend", default="")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    extensions = [
+        extension
+        for extension in load_catalog(args.catalog)
+        if isinstance(extension, dict)
+        and extension.get("id")
+        and matches(extension, args.query, args.backend)
+    ]
+    extensions.sort(key=lambda item: str(item["id"]))
+    if args.json:
+        print(json.dumps(extensions, ensure_ascii=False))
+    else:
+        render_table(extensions)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/contracts/test-ods-cli-contracts.py
+++ b/ods/tests/contracts/test-ods-cli-contracts.py
@@ -47,6 +47,7 @@ COMMANDS = {
     "benchmark": ("cmd_benchmark", "benchmark"),
     "doctor": ("cmd_doctor", "doctor [report|--json]"),
     "audit": ("cmd_audit", "audit [extensions]"),
+    "catalog": ("cmd_catalog", "catalog [action]"),
     "template": ("cmd_template", "template [action]"),
     "agent": ("cmd_agent", "agent [action]"),
 }

--- a/ods/tests/test-extension-catalog-cli.sh
+++ b/ods/tests/test-extension-catalog-cli.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Public CLI contract: operators can search the shipped extension catalog.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$INSTALL_DIR/config" "$INSTALL_DIR/scripts"
+cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+cp "$ROOT_DIR/scripts/query-extensions-catalog.py" "$INSTALL_DIR/scripts/"
+cat > "$INSTALL_DIR/config/extensions-catalog.json" <<'EOF'
+{
+  "schema_version": "1.0.0",
+  "extensions": [
+    {
+      "id": "vector-local",
+      "name": "Vector Local",
+      "description": "Private vector search",
+      "tags": ["rag"],
+      "gpu_backends": ["amd", "nvidia"]
+    },
+    {
+      "id": "music-cuda",
+      "name": "Music CUDA",
+      "description": "Generate audio",
+      "tags": ["music"],
+      "gpu_backends": ["nvidia"]
+    }
+  ]
+}
+EOF
+
+output=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$ROOT_DIR/ods-cli" \
+    catalog search rag --backend amd --json)
+python3 - "$output" <<'PYEOF'
+import json
+import sys
+
+extensions = json.loads(sys.argv[1])
+assert [item["id"] for item in extensions] == ["vector-local"]
+assert extensions[0]["gpu_backends"] == ["amd", "nvidia"]
+PYEOF
+
+table=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$ROOT_DIR/ods-cli" catalog list --backend nvidia)
+grep -q 'vector-local' <<<"$table"
+grep -q 'music-cuda' <<<"$table"
+
+echo "[PASS] extension catalog CLI discovery"


### PR DESCRIPTION
## Summary - add `ods catalog list` and `ods catalog search` for the shipped extension library - support backend compatibility filters and full JSON output - document the discovery contract and gate it with a public CLI regression test  ## Why this matters Headless operators currently see library extensions only through the Dashboard API/UI. The new read-only CLI exposes the same shipped `config/extensions-catalog.json`, allowing users to find relevant, backend-compatible extensions before deciding what to install.  ## Overlap check Searched open and closed upstream PR titles/bodies for `extension catalog CLI`, `ods catalog search`, and `discover extensions CLI`. Inspected the Dashboard catalog loader, catalog generator, `ods list`, and extension documentation. No equivalent or superset PR was found; existing catalog paths serve the dashboard but provide no host CLI discovery command.  ## Behavioral invariant Catalog discovery is read-only, deterministic by extension ID, and filters only declared catalog metadata. Human output stays concise while `--json` returns the complete matching catalog objects without inventing live installation status.  ## Test plan - [x] `bash ods/tests/test-extension-catalog-cli.sh` - [x] `python ods/tests/contracts/test-ods-cli-contracts.py` - [x] `python -m py_compile ods/scripts/query-extensions-catalog.py` - [x] `bash -n ods/ods-cli` - [x] `git diff --check`  ## Scope and tradeoffs Backend filtering reflects declared compatibility and deliberately does not probe hardware. Installation remains owned by the authenticated dashboard/host-agent lifecycle, so this PR introduces no new mutation path. Revert removes only the CLI wrapper and query helper.  Generated with Codex 
## Batch compatibility
Preferred merge order: #3481 → #3482 → #3483 → #3484 → #3485 → #3486. The combined result was validated on a local synthetic head (`2992ab11`) built from upstream `main` (`6ff9b4fc`). All six focused CLI tests, the static command contract, Bash syntax, the Windows log contract, and PowerShell parsing passed together.

Expected reconciliation: #3484 needs the earlier `Makefile` test entries retained; #3486 needs both catalog commands retained in `ods-cli`, `Makefile`, and the static command registry. These are additive shared-file conflicts, not behavioral incompatibilities. Each later PR should be rebased after its predecessors merge. Full local `make lint/test` was unavailable because GNU Make is not installed on this Windows host; each isolated PR's GitHub Actions matrix is the release validation source.