### PR TITLE
feat(cli): support filtered log snapshots

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -89,6 +89,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
 	@echo ""
+	@echo "=== CLI log snapshot options ==="
+	@bash tests/test-cli-log-snapshots.sh
+	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py
 	@echo ""

--- a/ods/README.md
+++ b/ods/README.md
@@ -367,6 +367,7 @@ The `ods` CLI is the primary management tool. It's installed automatically at `~
 ods status              # Health checks + GPU status
 ods list                # Show all services and their state
 ods logs <service>      # Tail logs (accepts aliases: llm, stt, tts)
+ods logs <service> --since 30m --no-follow  # Print a bounded snapshot
 ods restart [service]   # Restart one or all services
 ods start / stop        # Start or stop the stack
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2339,10 +2339,14 @@ function Invoke-Restart {
 function Invoke-Logs {
     param(
         [string]$Service,
-        [int]$Lines = 100
+        [int]$Lines = 100,
+        [string]$Since = "",
+        [string]$Until = "",
+        [bool]$Follow = $true,
+        [switch]$Timestamps
     )
     if (-not $Service) {
-        Write-AI "Usage: .\ods.ps1 logs <service> [lines]"
+        Write-AI "Usage: .\ods.ps1 logs <service> [lines] [--since TIME] [--until TIME] [--no-follow] [--timestamps]"
         Write-AI "Services: llama-server, open-webui, dashboard-api, n8n, whisper, tts, ..."
         return
     }
@@ -2354,7 +2358,13 @@ function Invoke-Logs {
             Write-ODSMissingComposeServiceHint -ComposeFlags $flags -Service $Service
             exit 1
         }
-        & docker compose @flags logs -f --tail $Lines $Service
+        $logArgs = @("logs")
+        if ($Follow) { $logArgs += "-f" }
+        if ($Since) { $logArgs += @("--since", $Since) }
+        if ($Until) { $logArgs += @("--until", $Until) }
+        if ($Timestamps) { $logArgs += "--timestamps" }
+        $logArgs += @("--tail", $Lines, $Service)
+        & docker compose @flags @logArgs
     } finally {
         Pop-Location
     }
@@ -3504,8 +3514,8 @@ function Show-Help {
     Write-Host "Stop all or one service" -ForegroundColor DarkGray
     Write-Host "    restart [service]   " -ForegroundColor Cyan -NoNewline
     Write-Host "Restart all or one service" -ForegroundColor DarkGray
-    Write-Host "    logs <svc> [lines]  " -ForegroundColor Cyan -NoNewline
-    Write-Host "Tail logs (default 100)" -ForegroundColor DarkGray
+    Write-Host "    logs <svc> [lines] [--since TIME] [--no-follow]" -ForegroundColor Cyan -NoNewline
+    Write-Host "  Stream or snapshot logs" -ForegroundColor DarkGray
     Write-Host "    config show         " -ForegroundColor Cyan -NoNewline
     Write-Host "View .env (secrets masked)" -ForegroundColor DarkGray
     Write-Host "    config edit         " -ForegroundColor Cyan -NoNewline
@@ -3590,21 +3600,47 @@ switch ($Command.ToLower()) {
     "restart" { Invoke-Restart -Service ($Arguments | Select-Object -First 1) }
     "logs"    {
         $svc = $Arguments | Select-Object -First 1
-        # Validate the optional line count instead of a bare [int] cast, which
-        # throws an unhandled .NET conversion error on non-numeric input
-        # (e.g. `ods logs llama-server 5m`). Mirrors the [int]::TryParse guard
-        # used elsewhere in this script; the Unix CLIs pass the value straight
-        # to `docker compose --tail`, which rejects bad input gracefully too.
         $n = 100
-        if ($Arguments.Count -ge 2) {
-            $parsedLines = 0
-            if ([int]::TryParse([string]$Arguments[1], [ref]$parsedLines) -and $parsedLines -gt 0) {
-                $n = $parsedLines
-            } else {
-                Write-AIWarn "Invalid line count '$($Arguments[1])'; using $n."
+        $lineCountSet = $false
+        $since = ""
+        $until = ""
+        $follow = $true
+        $timestamps = $false
+        for ($i = 1; $i -lt $Arguments.Count; $i++) {
+            $arg = [string]$Arguments[$i]
+            switch ($arg) {
+                "--since" {
+                    if ($i + 1 -ge $Arguments.Count) { Write-AIError "--since requires a value"; exit 1 }
+                    $i++; $since = [string]$Arguments[$i]
+                }
+                "--until" {
+                    if ($i + 1 -ge $Arguments.Count) { Write-AIError "--until requires a value"; exit 1 }
+                    $i++; $until = [string]$Arguments[$i]
+                }
+                "--no-follow" { $follow = $false }
+                "--timestamps" { $timestamps = $true }
+                "--tail" {
+                    if ($i + 1 -ge $Arguments.Count) { Write-AIError "--tail requires a value"; exit 1 }
+                    if ($lineCountSet) { Write-AIError "Only one log line count may be specified"; exit 1 }
+                    $i++
+                    $parsedLines = 0
+                    if (-not [int]::TryParse([string]$Arguments[$i], [ref]$parsedLines) -or $parsedLines -le 0) {
+                        Write-AIError "Log line count must be a positive integer: $($Arguments[$i])"
+                        exit 1
+                    }
+                    $n = $parsedLines; $lineCountSet = $true
+                }
+                default {
+                    $parsedLines = 0
+                    if ($lineCountSet -or -not [int]::TryParse($arg, [ref]$parsedLines) -or $parsedLines -le 0) {
+                        Write-AIError "Unknown logs argument: $arg"
+                        exit 1
+                    }
+                    $n = $parsedLines; $lineCountSet = $true
+                }
             }
         }
-        Invoke-Logs -Service $svc -Lines $n
+        Invoke-Logs -Service $svc -Lines $n -Since $since -Until $until -Follow $follow -Timestamps:$timestamps
     }
     "config"  {
         $action = ($Arguments | Select-Object -First 1)

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1503,20 +1503,58 @@ cmd_logs() {
     load_env
 
     local service="${1:-}"
-    local lines="${2:-100}"
-
     if [[ -z "$service" ]]; then
-        log "Usage: ods logs <service> [lines]"
+        log "Usage: ods logs <service> [lines] [--since TIME] [--until TIME] [--no-follow] [--timestamps]"
         log "Run 'ods list' to see available services."
         exit 1
     fi
+    shift
+
+    local lines="100"
+    local lines_set="false"
+    local since=""
+    local until=""
+    local follow="true"
+    local timestamps="false"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --since|--until)
+                [[ -n "${2:-}" ]] || error "$1 requires a timestamp or duration"
+                if [[ "$1" == "--since" ]]; then since="$2"; else until="$2"; fi
+                shift 2
+                ;;
+            --no-follow) follow="false"; shift ;;
+            --timestamps) timestamps="true"; shift ;;
+            --tail)
+                [[ -n "${2:-}" ]] || error "--tail requires a positive line count"
+                [[ "$lines_set" == "false" ]] || error "Only one log line count may be specified"
+                lines="$2"
+                lines_set="true"
+                shift 2
+                ;;
+            -*) error "Unknown logs option: $1" ;;
+            *)
+                [[ "$lines_set" == "false" ]] || error "Only one log line count may be specified"
+                lines="$1"
+                lines_set="true"
+                shift
+                ;;
+        esac
+    done
+    [[ "$lines" =~ ^[1-9][0-9]*$ ]] || error "Log line count must be a positive integer: $lines"
 
     service=$(resolve_service "$service")
     local flags_str
     flags_str=$(get_compose_flags)
     local -a flags
     read -ra flags <<< "$flags_str"
-    docker compose "${flags[@]}" logs -f --tail "$lines" "$service"
+    local -a log_args=(logs)
+    [[ "$follow" == "false" ]] || log_args+=(-f)
+    [[ -z "$since" ]] || log_args+=(--since "$since")
+    [[ -z "$until" ]] || log_args+=(--until "$until")
+    [[ "$timestamps" == "false" ]] || log_args+=(--timestamps)
+    log_args+=(--tail "$lines" "$service")
+    docker compose "${flags[@]}" "${log_args[@]}"
 }
 
 cmd_restart() {
@@ -6425,7 +6463,8 @@ ${CYAN}Commands:${NC}
   backup verify <id>   Verify checksum integrity for a backup
   restore [backup_id] Restore from a backup
   rollback            Rollback to pre-update state (after failed update)
-  logs <service>      Tail logs for a service
+  logs <service> [lines] [--since TIME] [--until TIME] [--no-follow] [--timestamps]
+                      Stream logs or print a bounded snapshot
   restart [service] [--rebuild-images]
                       Restart services (all if no service specified)
   start [service] [--rebuild-images]

--- a/ods/tests/contracts/test-windows-log-snapshots.ps1
+++ b/ods/tests/contracts/test-windows-log-snapshots.ps1
@@ -1,0 +1,22 @@
+$ErrorActionPreference = "Stop"
+
+$root = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$cli = Get-Content -Raw (Join-Path $root "installers\windows\ods.ps1")
+
+$required = @(
+    '[string]$Since = ""',
+    '[string]$Until = ""',
+    '[bool]$Follow = $true',
+    'if ($Follow) { $logArgs += "-f" }',
+    '$logArgs += @("--since", $Since)',
+    '$logArgs += @("--until", $Until)',
+    'Invoke-Logs -Service $svc -Lines $n -Since $since -Until $until -Follow $follow'
+)
+
+foreach ($snippet in $required) {
+    if (-not $cli.Contains($snippet)) {
+        throw "Missing Windows log snapshot contract: $snippet"
+    }
+}
+
+Write-Host "[PASS] Windows log snapshot argument contract"

--- a/ods/tests/test-cli-log-snapshots.sh
+++ b/ods/tests/test-cli-log-snapshots.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Public CLI contract: log snapshots forward filters without forcing follow mode.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+BIN_DIR="$TMP_DIR/bin"
+ARGS_FILE="$TMP_DIR/docker-args"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$INSTALL_DIR" "$BIN_DIR"
+cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+: > "$INSTALL_DIR/.env"
+cat > "$BIN_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "$MOCK_DOCKER_ARGS"
+EOF
+chmod +x "$BIN_DIR/docker"
+
+PATH="$BIN_DIR:$PATH" MOCK_DOCKER_ARGS="$ARGS_FILE" ODS_HOME="$INSTALL_DIR" NO_COLOR=1 \
+    "$ROOT_DIR/ods-cli" logs llama-server 25 --since 30m --until 5m --timestamps --no-follow
+
+grep -qx -- 'logs' "$ARGS_FILE"
+grep -qx -- '--since' "$ARGS_FILE"
+grep -qx -- '30m' "$ARGS_FILE"
+grep -qx -- '--until' "$ARGS_FILE"
+grep -qx -- '5m' "$ARGS_FILE"
+grep -qx -- '--timestamps' "$ARGS_FILE"
+grep -qx -- '--tail' "$ARGS_FILE"
+grep -qx -- '25' "$ARGS_FILE"
+grep -qx -- 'llama-server' "$ARGS_FILE"
+if awk '$0 == "logs" { after_logs = 1; next } after_logs && $0 == "-f" { found = 1 } END { exit !found }' "$ARGS_FILE"; then
+    echo "[FAIL] --no-follow still passed -f" >&2
+    exit 1
+fi
+
+PATH="$BIN_DIR:$PATH" MOCK_DOCKER_ARGS="$ARGS_FILE" ODS_HOME="$INSTALL_DIR" NO_COLOR=1 \
+    "$ROOT_DIR/ods-cli" logs llama-server
+awk '$0 == "logs" { after_logs = 1; next } after_logs && $0 == "-f" { found = 1 } END { exit !found }' "$ARGS_FILE"
+grep -qx -- '100' "$ARGS_FILE"
+
+if PATH="$BIN_DIR:$PATH" MOCK_DOCKER_ARGS="$ARGS_FILE" ODS_HOME="$INSTALL_DIR" NO_COLOR=1 \
+    "$ROOT_DIR/ods-cli" logs llama-server invalid --no-follow >/dev/null 2>&1; then
+    echo "[FAIL] invalid line count was accepted" >&2
+    exit 1
+fi
+
+echo "[PASS] CLI log snapshots and default follow mode"


### PR DESCRIPTION
## Summary - add `--since`, `--until`, `--timestamps`, `--tail`, and `--no-follow` to service logs - preserve the existing `<service> [lines]` form and default live-follow behavior - implement parity in the Bash CLI (Linux/macOS) and PowerShell CLI (Windows)  ## Why this matters Support scripts and operators need bounded log snapshots that terminate, especially for incident attachments and fleet automation. Previously `ods logs` always forced `-f`, so every call remained attached. The options map directly to the shipped Docker Compose logs contract: https://docs.docker.com/reference/cli/docker/compose/logs/  ## Overlap check Searched open and closed upstream PR titles/bodies for `logs --since`, `no-follow logs CLI`, and `log snapshot CLI`, then inspected both production CLI implementations and their tests. No equivalent or superset PR was found.  ## Behavioral invariant Existing `ods logs SERVICE [LINES]` calls still follow with a 100-line default. Snapshot mode omits only `-f`; filters and timestamps are forwarded as distinct argv entries, and invalid or duplicate line counts fail before Docker is invoked.  ## Test plan - [x] `bash ods/tests/test-cli-log-snapshots.sh` - [x] `powershell.exe -NoProfile -ExecutionPolicy Bypass -File ods/tests/contracts/test-windows-log-snapshots.ps1` - [x] PowerShell parser validation for `ods/installers/windows/ods.ps1` - [x] `python ods/tests/contracts/test-ods-cli-contracts.py` - [x] `bash -n ods/ods-cli` - [x] `git diff --check`  ## Scope, validation gaps, and rollback The Bash public boundary was exercised with exact Docker argv assertions. Windows parsing and parity were statically validated on PowerShell 5.1, but a live Docker Desktop log stream was not available. The feature does not change containers or persisted state; rollback is a clean revert.  Generated with Codex 
## Batch compatibility
Preferred merge order: #3481 → #3482 → #3483 → #3484 → #3485 → #3486. The combined result was validated on a local synthetic head (`2992ab11`) built from upstream `main` (`6ff9b4fc`). All six focused CLI tests, the static command contract, Bash syntax, the Windows log contract, and PowerShell parsing passed together.

Expected reconciliation: #3484 needs the earlier `Makefile` test entries retained; #3486 needs both catalog commands retained in `ods-cli`, `Makefile`, and the static command registry. These are additive shared-file conflicts, not behavioral incompatibilities. Each later PR should be rebased after its predecessors merge. Full local `make lint/test` was unavailable because GNU Make is not installed on this Windows host; each isolated PR's GitHub Actions matrix is the release validation source.