### PR TITLE
feat(cli): discover workflow templates from the catalog

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -152,6 +152,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
 	@echo ""
+	@echo "=== CLI workflow catalog discovery ==="
+	@bash tests/test-workflow-catalog-cli.sh
+	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
 

--- a/ods/docs/WORKFLOW-CATALOG.md
+++ b/ods/docs/WORKFLOW-CATALOG.md
@@ -1,0 +1,20 @@
+# Workflow Catalog CLI
+
+ODS ships an n8n workflow catalog under `config/n8n/catalog.json`. The dashboard
+uses that catalog to display and enable workflows; headless operators can inspect
+the same product-owned metadata through the `ods` CLI:
+
+```bash
+ods workflow list
+ods workflow list --category voice
+ods workflow search rag
+ods workflow show document-qa
+```
+
+Add `--json` to any command for automation. Search matches workflow IDs, names,
+descriptions, categories, and dependency service IDs.
+
+These commands are read-only. They report catalog metadata and do not claim that
+dependencies are healthy or that a workflow is installed in n8n. Runtime status
+and enable/disable operations remain owned by the authenticated dashboard API so
+they use its existing dependency checks and mutation lifecycle.

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -6209,6 +6209,18 @@ cmd_repair() {
 }
 
 #=============================================================================
+# Workflow catalog
+#=============================================================================
+cmd_workflow() {
+    check_install
+    local catalog="$INSTALL_DIR/config/n8n/catalog.json"
+    local query_script="$INSTALL_DIR/scripts/query-workflow-catalog.py"
+    [[ -f "$catalog" ]] || error "Workflow catalog not found: $catalog"
+    [[ -f "$query_script" ]] || error "Workflow catalog query tool not found: $query_script"
+    python3 "$query_script" "$catalog" "$@"
+}
+
+#=============================================================================
 # Templates
 #=============================================================================
 _template_list() {
@@ -6443,6 +6455,7 @@ ${CYAN}Commands:${NC}
   repair|fix [voice|hermes-workers]
                       Repair voice services or prune leaked Hermes slash workers
   template [action]   Apply pre-built service templates (list|preview|apply)
+  workflow [action]   Discover workflow templates (list|search|show)
   audit [extensions]  Audit extension manifests and compose contracts
   agent [action]      Manage ods host agent (status|start|stop|restart|logs)
   help                Show this help
@@ -6545,6 +6558,7 @@ ${CYAN}Examples:${NC}
                                   # Preview what a template will change
   ods template apply chat-playground
                                   # Apply a template (enables services)
+  ods workflow search rag --json  # Find workflow templates for RAG
   ods audit                     # Audit every extension contract
   ods audit --json whisper      # Audit one service as JSON
   ods agent status              # Check host agent health
@@ -6590,6 +6604,7 @@ case "${1:-help}" in
     benchmark|bench|b) cmd_benchmark ;;
     doctor|diag|d) shift; cmd_doctor "$@" ;;
     audit)        shift; cmd_audit "$@" ;;
+    workflow|wf)  shift; cmd_workflow "$@" ;;
     template|tmpl) shift; cmd_template "$@" ;;
     agent)        shift; cmd_agent "$@" ;;
     help|h|--help|-h) cmd_help ;;

--- a/ods/scripts/query-workflow-catalog.py
+++ b/ods/scripts/query-workflow-catalog.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Query the shipped ODS workflow catalog for CLI consumers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_workflows(path: Path) -> list[dict]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    workflows = document.get("workflows")
+    if not isinstance(workflows, list):
+        raise ValueError("workflow catalog must contain a workflows array")
+    return [item for item in workflows if isinstance(item, dict) and item.get("id")]
+
+
+def matches(workflow: dict, query: str, category: str) -> bool:
+    if category and workflow.get("category") != category:
+        return False
+    if not query:
+        return True
+    searchable = [
+        workflow.get("id", ""),
+        workflow.get("name", ""),
+        workflow.get("description", ""),
+        workflow.get("category", ""),
+        *workflow.get("dependencies", []),
+    ]
+    needle = query.casefold()
+    return any(needle in str(value).casefold() for value in searchable)
+
+
+def render_list(workflows: list[dict]) -> None:
+    if not workflows:
+        print("No matching workflows found.")
+        return
+    id_width = max(8, *(len(str(item["id"])) for item in workflows))
+    name_width = max(4, *(len(str(item.get("name", ""))) for item in workflows))
+    print(f"{'WORKFLOW':<{id_width}}  {'NAME':<{name_width}}  CATEGORY       DEPENDENCIES")
+    print(f"{'-' * id_width}  {'-' * name_width}  {'-' * 13}  {'-' * 12}")
+    for workflow in workflows:
+        dependencies = ",".join(workflow.get("dependencies", [])) or "none"
+        print(
+            f"{workflow['id']:<{id_width}}  {workflow.get('name', ''):<{name_width}}  "
+            f"{workflow.get('category', 'general'):<13}  {dependencies}"
+        )
+
+
+def render_detail(workflow: dict) -> None:
+    print(f"Workflow: {workflow.get('name', workflow['id'])}")
+    print(f"ID: {workflow['id']}")
+    print(f"Category: {workflow.get('category', 'general')}")
+    print(f"Description: {workflow.get('description', '-')}")
+    print(f"Dependencies: {', '.join(workflow.get('dependencies', [])) or 'none'}")
+    print(f"Setup time: {workflow.get('setupTime', 'unknown')}")
+    print(f"Definition: {workflow.get('file', 'unknown')}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("catalog", type=Path)
+    parser.add_argument("action", choices=("list", "search", "show"), nargs="?", default="list")
+    parser.add_argument("term", nargs="?")
+    parser.add_argument("--category", default="")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    if args.action in {"search", "show"} and not args.term:
+        parser.error(f"{args.action} requires a query or workflow ID")
+    if args.action == "list" and args.term:
+        parser.error("list does not accept a positional argument")
+
+    workflows = sorted(load_workflows(args.catalog), key=lambda item: str(item["id"]))
+    if args.action == "show":
+        workflow = next((item for item in workflows if item["id"] == args.term), None)
+        if workflow is None:
+            parser.error(f"workflow not found: {args.term}")
+        if args.category and workflow.get("category") != args.category:
+            parser.error(f"workflow {args.term} is not in category {args.category}")
+        if args.json:
+            print(json.dumps(workflow, ensure_ascii=False))
+        else:
+            render_detail(workflow)
+        return 0
+
+    query = args.term if args.action == "search" else ""
+    matches_list = [item for item in workflows if matches(item, query or "", args.category)]
+    if args.json:
+        print(json.dumps(matches_list, ensure_ascii=False))
+    else:
+        render_list(matches_list)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/contracts/test-ods-cli-contracts.py
+++ b/ods/tests/contracts/test-ods-cli-contracts.py
@@ -47,6 +47,7 @@ COMMANDS = {
     "benchmark": ("cmd_benchmark", "benchmark"),
     "doctor": ("cmd_doctor", "doctor [report|--json]"),
     "audit": ("cmd_audit", "audit [extensions]"),
+    "workflow": ("cmd_workflow", "workflow [action]"),
     "template": ("cmd_template", "template [action]"),
     "agent": ("cmd_agent", "agent [action]"),
 }

--- a/ods/tests/test-workflow-catalog-cli.sh
+++ b/ods/tests/test-workflow-catalog-cli.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Public CLI contract: workflow templates are discoverable without the dashboard.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$INSTALL_DIR/config/n8n" "$INSTALL_DIR/scripts"
+cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+cp "$ROOT_DIR/scripts/query-workflow-catalog.py" "$INSTALL_DIR/scripts/"
+cat > "$INSTALL_DIR/config/n8n/catalog.json" <<'EOF'
+{
+  "version": "2",
+  "workflows": [
+    {
+      "id": "document-qa",
+      "file": "document-qa.json",
+      "name": "Document Q&A",
+      "description": "Ask questions using local retrieval",
+      "category": "productivity",
+      "dependencies": ["qdrant", "llama-server"],
+      "setupTime": "2 minutes"
+    },
+    {
+      "id": "voice-memo",
+      "file": "voice-memo.json",
+      "name": "Voice Memo",
+      "description": "Transcribe personal notes",
+      "category": "voice",
+      "dependencies": ["whisper"]
+    }
+  ]
+}
+EOF
+
+search=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$ROOT_DIR/ods-cli" workflow search qdrant --json)
+python3 - "$search" <<'PYEOF'
+import json
+import sys
+
+workflows = json.loads(sys.argv[1])
+assert [item["id"] for item in workflows] == ["document-qa"]
+PYEOF
+
+detail=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$ROOT_DIR/ods-cli" workflow show voice-memo --json)
+python3 - "$detail" <<'PYEOF'
+import json
+import sys
+
+workflow = json.loads(sys.argv[1])
+assert workflow["id"] == "voice-memo"
+assert workflow["dependencies"] == ["whisper"]
+PYEOF
+
+table=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$ROOT_DIR/ods-cli" workflow list --category productivity)
+grep -q 'document-qa' <<<"$table"
+if grep -q 'voice-memo' <<<"$table"; then
+    echo "[FAIL] category filter leaked voice workflow" >&2
+    exit 1
+fi
+
+echo "[PASS] workflow catalog CLI discovery"


### PR DESCRIPTION
## Summary - add `ods workflow list`, `search`, and `show` for the shipped n8n workflow catalog - support category filtering and JSON output for every read-only action - document the boundary between catalog discovery and authenticated runtime mutation  ## Why this matters Headless operators currently need the Dashboard API/UI to discover ODS workflow templates. This feature exposes the same product-owned `config/n8n/catalog.json` through the host CLI, including dependency metadata needed to plan an installation.  ## Overlap check Searched open and closed upstream PR titles/bodies for `workflow catalog CLI` and `ods workflow list`, then inspected the workflow router, catalog loader, shipped catalog, and CLI dispatch. No equivalent or superset PR was found.  ## Behavioral invariant Results are deterministic by workflow ID, filters operate only on declared catalog metadata, and JSON returns the original matching objects. Read-only CLI discovery never claims runtime health or installed state and never bypasses the dashboard API's authenticated mutation lifecycle.  ## Test plan - [x] `bash ods/tests/test-workflow-catalog-cli.sh` - [x] `python ods/tests/contracts/test-ods-cli-contracts.py` - [x] `python -m py_compile ods/scripts/query-workflow-catalog.py` - [x] `bash -n ods/ods-cli` - [x] `git diff --check`  ## Scope and tradeoffs This intentionally does not enable/import workflows or probe n8n. Those operations require live dependency checks and stay with the existing API transaction boundary. Reverting removes only read-only discovery; no persisted state is affected.  Generated with Codex 
## Batch compatibility
Preferred merge order: #3481 → #3482 → #3483 → #3484 → #3485 → #3486. The combined result was validated on a local synthetic head (`2992ab11`) built from upstream `main` (`6ff9b4fc`). All six focused CLI tests, the static command contract, Bash syntax, the Windows log contract, and PowerShell parsing passed together.

Expected reconciliation: #3484 needs the earlier `Makefile` test entries retained; #3486 needs both catalog commands retained in `ods-cli`, `Makefile`, and the static command registry. These are additive shared-file conflicts, not behavioral incompatibilities. Each later PR should be rebased after its predecessors merge. Full local `make lint/test` was unavailable because GNU Make is not installed on this Windows host; each isolated PR's GitHub Actions matrix is the release validation source.