### PR TITLE
feat(support): configure support-bundle log windows

### DIFF
--- a/ods/docs/SUPPORT-BUNDLE.md
+++ b/ods/docs/SUPPORT-BUNDLE.md
@@ -16,6 +16,9 @@ scripts/ods-support-bundle.sh --output /tmp/ods-support
 # Skip container logs
 scripts/ods-support-bundle.sh --no-logs
 
+# Capture a bounded incident window instead of only the default 200-line tail
+scripts/ods-support-bundle.sh --logs-since 30m --log-tail 1000
+
 # Print machine-readable result JSON
 scripts/ods-support-bundle.sh --json
 ```
@@ -25,7 +28,7 @@ scripts/ods-support-bundle.sh --json
 - ODS Doctor output, when `scripts/ods-doctor.sh` can run
 - Extension audit JSON from `scripts/audit-extensions.py`
 - Compose resolution and compose validation output, when Docker Compose is available
-- Docker version, daemon info, container summary, and short ODS container log tails
+- Docker version, daemon info, container summary, and bounded ODS container logs
 - Platform, git, disk, memory, listening port, manifest, env schema, and redacted `.env` details
 
 The command is best-effort. Missing Docker, an unreachable daemon, or a failing

--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -5,6 +5,8 @@ TOOL_VERSION="1"
 REDACTION_VERSION="1"
 DEFAULT_LOG_TAIL=200
 MAX_LOG_CONTAINERS=25
+LOG_TAIL="$DEFAULT_LOG_TAIL"
+LOG_SINCE=""
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -24,6 +26,8 @@ Options:
   --output DIR   Write bundle directory/archive under DIR
   --json         Print machine-readable result JSON
   --no-logs      Skip Docker container log collection
+  --log-tail N   Include the last N lines per container (default: 200)
+  --logs-since T Include only logs since an RFC3339 timestamp or duration (for example 30m)
   -h, --help     Show this help
 
 The generated archive is safe-by-default, but review it before posting to a
@@ -45,6 +49,16 @@ while [[ $# -gt 0 ]]; do
         --no-logs)
             INCLUDE_LOGS=false
             shift
+            ;;
+        --log-tail)
+            LOG_TAIL="${2:-}"
+            [[ "$LOG_TAIL" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: --log-tail requires a positive integer" >&2; exit 2; }
+            shift 2
+            ;;
+        --logs-since)
+            LOG_SINCE="${2:-}"
+            [[ -n "$LOG_SINCE" ]] || { echo "ERROR: --logs-since requires a timestamp or duration" >&2; exit 2; }
+            shift 2
             ;;
         -h|--help)
             usage
@@ -511,7 +525,11 @@ collect_docker() {
         [[ "$count" -le "$MAX_LOG_CONTAINERS" ]] || break
         local safe
         safe="$(safe_filename "$container")"
-        collect_shell "logs/${safe}.log" "docker-logs:${container}" "$(shell_quote "$DOCKER_BIN") logs --tail ${DEFAULT_LOG_TAIL} $(shell_quote "$container")"
+        local log_command
+        log_command="$(shell_quote "$DOCKER_BIN") logs --tail $(shell_quote "$LOG_TAIL")"
+        [[ -z "$LOG_SINCE" ]] || log_command="${log_command} --since $(shell_quote "$LOG_SINCE")"
+        log_command="${log_command} $(shell_quote "$container")"
+        collect_shell "logs/${safe}.log" "docker-logs:${container}" "$log_command"
     done < "$names_file"
 
     if [[ "$count" -eq 0 ]]; then
@@ -520,7 +538,7 @@ collect_docker() {
 }
 
 write_manifest() {
-    "$PYTHON_CMD" - "$BUNDLE_DIR" "$ARCHIVE_PATH" "$TOOL_VERSION" "$REDACTION_VERSION" "$INCLUDE_LOGS" <<'PY'
+    "$PYTHON_CMD" - "$BUNDLE_DIR" "$ARCHIVE_PATH" "$TOOL_VERSION" "$REDACTION_VERSION" "$INCLUDE_LOGS" "$LOG_TAIL" "$LOG_SINCE" <<'PY'
 import json
 import os
 import sys
@@ -532,6 +550,8 @@ archive_path = sys.argv[2]
 tool_version = sys.argv[3]
 redaction_version = sys.argv[4]
 include_logs = sys.argv[5].lower() == "true"
+log_tail = int(sys.argv[6])
+logs_since = sys.argv[7] or None
 status_path = bundle_dir / "manifest" / "command-status.tsv"
 
 commands = []
@@ -567,6 +587,8 @@ manifest = {
     "generated_at": datetime.now(timezone.utc).isoformat(),
     "archive_path": archive_path,
     "logs_included": include_logs,
+    "log_tail": log_tail,
+    "logs_since": logs_since,
     "files": files,
     "commands": commands,
 }

--- a/ods/tests/test-support-bundle.sh
+++ b/ods/tests/test-support-bundle.sh
@@ -247,11 +247,66 @@ assert isinstance(manifest["files"], list) and manifest["files"]
 assert isinstance(manifest["commands"], list) and manifest["commands"]
 assert any(command["label"] == "docker-version" for command in manifest["commands"])
 assert any(item["path"] == "manifest/evidence.json" for item in manifest["files"])
+assert manifest["log_tail"] == 200
+assert manifest["logs_since"] is None
 PY
 then
     pass "manifest records files and command exit codes"
 else
     fail "manifest is missing expected file/command metadata"
+fi
+
+MOCK_DOCKER="$TMP_DIR/mock-docker"
+MOCK_DOCKER_LOG="$TMP_DIR/mock-docker.log"
+cat > "$MOCK_DOCKER" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MOCK_DOCKER_LOG"
+if [[ "$1" == "ps" && "$*" != *" -a "* && "$*" != *" -a"* ]]; then
+    printf '%s\n' 'ods-window-test'
+fi
+EOF
+chmod +x "$MOCK_DOCKER"
+
+WINDOW_OUTPUT="$TMP_DIR/window-out"
+WINDOW_JSON="$TMP_DIR/window-result.json"
+if MOCK_DOCKER_LOG="$MOCK_DOCKER_LOG" ODS_SUPPORT_BUNDLE_DOCKER="$MOCK_DOCKER" \
+    ODS_SUPPORT_BUNDLE_BASH="$BASH_WRAPPER" \
+    bash "$SUPPORT_SCRIPT" --output "$WINDOW_OUTPUT" --logs-since 45m --log-tail 750 --json > "$WINDOW_JSON"; then
+    pass "support bundle accepts a bounded Docker log window"
+else
+    fail "support bundle rejected a valid Docker log window"
+fi
+
+WINDOW_MANIFEST="$(python3 - "$WINDOW_JSON" <<'PY'
+import json
+import sys
+print(json.load(open(sys.argv[1], encoding="utf-8"))["manifest"])
+PY
+)"
+if grep -q 'logs --tail 750 --since 45m ods-window-test' "$MOCK_DOCKER_LOG"; then
+    pass "bounded log options reach Docker as distinct arguments"
+else
+    fail "bounded log options were not forwarded to Docker"
+fi
+
+if python3 - "$WINDOW_MANIFEST" <<'PY'
+import json
+import sys
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+assert manifest["logs_included"] is True
+assert manifest["log_tail"] == 750
+assert manifest["logs_since"] == "45m"
+PY
+then
+    pass "manifest records the selected Docker log window"
+else
+    fail "manifest omitted the selected Docker log window"
+fi
+
+if bash "$SUPPORT_SCRIPT" --log-tail invalid >/dev/null 2>&1; then
+    fail "support bundle accepted an invalid log tail"
+else
+    pass "support bundle rejects invalid log tail values"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- add `--log-tail` and `--logs-since` controls to support-bundle collection
- forward each option to Docker as a separately quoted argument
- record the selected window in `manifest.json` for reproducibility
- document the incident-window workflow

## Why this matters
The support bundle previously hard-coded a 200-line tail. That can omit the beginning of a failure during noisy incidents, while collecting a larger unbounded history would make bundles unnecessarily large. Operators can now choose a bounded time-and-line window without changing the safe default.

## Root cause and invariant
The Docker log window was an implementation constant rather than an operator input. The preserved invariant is that every container log capture remains bounded, defaults to 200 lines, and the exact capture policy is recorded in the bundle manifest.

## Overlap check
Searched open and closed upstream PRs for `support bundle log tail`, `logs since`, `ods-support-bundle`, and changes to `ods/scripts/ods-support-bundle.sh`. No PR implements configurable Docker log windows. The scope is independent of the current support-bundle and diagnostic work.

Docker Compose documents both `--tail` and `--since`, including relative durations: https://docs.docker.com/reference/cli/docker/compose/logs/

## Validation
- `bash -n ods/scripts/ods-support-bundle.sh`
- `bash ods/tests/test-support-bundle.sh` (24 passed)
- `git diff --check`

The regression test exercises the public CLI boundary with a mock Docker executable and verifies exact argument forwarding plus generated manifest metadata. A live Docker daemon was not used in this Windows checkout; the test proves CLI composition, validation, and bundle receipt behavior, not daemon-specific log rendering.

## Compatibility and rollback
Existing invocations retain the 200-line default. `--no-logs` behavior is unchanged. Reverting this commit restores the fixed window without changing bundle layout beyond removing the two new manifest fields.
## Batch compatibility
This PR is file-independent from the six CLI PRs #3481–#3486 and may merge before or after them. The complete eight-PR batch was reconciled and validated on synthetic head `3cbc6890` from upstream main `6ff9b4fc`. All focused CLI contracts, the 24-test support-bundle suite, Windows log contract, Settings tests, ESLint, and dashboard production build passed together. The only combined conflicts are the already-documented additive CLI registry/Makefile conflicts between #3484 and #3486.