### PR TITLE
feat(dashboard): show Tailscale remote-access status

### DIFF
--- a/ods/docs/TAILSCALE.md
+++ b/ods/docs/TAILSCALE.md
@@ -51,7 +51,7 @@ Joining the tailnet only gets the device a `100.x.y.z` IP and a `ods.tail-xxxxx.
 1. **`ods-proxy` is enabled.** It listens on port 80 and routes `/chat`, `/api/*`, `/auth/*` to the right backend. With it, tailnet clients browse to `http://ods.tail-xxxxx.ts.net` (no port). Without it, only the per-service ports work (`:3000`, `:3001`, `:3002`) and only if those are LAN-bound.
 2. **`BIND_ADDRESS=0.0.0.0` in `.env`.** The default `127.0.0.1` means the proxy / dashboard / chat only accept loopback connections — even though tailscaled is in the same namespace, an incoming tailnet packet looks like any other LAN packet, not loopback. Set `BIND_ADDRESS=0.0.0.0` so the host's listen sockets accept those connections.
 
-If you ship a fresh install with Tailscale enabled but neither of the above, `tailscale status` will show the device authed but `http://ods.tail-xxxxx.ts.net` will hang or refuse. Until the dashboard gets a dedicated Remote Access UI, verify those prerequisites with `.env`, `ods list`, and the status endpoint below.
+If you ship a fresh install with Tailscale enabled but neither of the above, `tailscale status` will show the device authed but `http://ods.tail-xxxxx.ts.net` will hang or refuse. Settings â†’ Remote Access shows the joined device, tailnet DNS name, and IP address; verify the proxy and bind prerequisites there before testing from another device.
 
 ## Setup
 

--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -179,6 +179,7 @@ export default function Settings() {
   const [envFollowUpPlan, setEnvFollowUpPlan] = useState(() => loadSettingsFollowUp())
   const [statusCache, setStatusCache] = useState(null)
   const [setupStatus, setSetupStatus] = useState(null)
+  const [remoteAccess, setRemoteAccess] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [notice, setNotice] = useState(null)
@@ -237,12 +238,13 @@ export default function Settings() {
       setError(null)
       setNotice(null)
       const today = todayKey()
-      const [summaryResult, storageResult, envResult, usageResult, setupResult] = await Promise.allSettled([
+      const [summaryResult, storageResult, envResult, usageResult, setupResult, remoteAccessResult] = await Promise.allSettled([
         fetchPayload('/api/settings/summary', 10000),
         fetchPayload('/api/storage', 12000),
         fetchPayload('/api/settings/env', 10000),
         fetchPayload(`/api/usage/report?start=${today}&end=${today}`, 10000),
         fetchPayload('/api/setup/status', 8000),
+        fetchPayload('/api/tailscale/status', 8000),
       ])
 
       if (summaryResult.status === 'fulfilled') {
@@ -270,6 +272,9 @@ export default function Settings() {
 
       if (setupResult.status === 'fulfilled') setSetupStatus(setupResult.value)
       else setSetupStatus(null)
+
+      if (remoteAccessResult.status === 'fulfilled') setRemoteAccess(remoteAccessResult.value)
+      else setRemoteAccess(null)
 
       if (failures.length === 3) setError(getErrorText(failures[0]))
       else if (failures.length > 0) setNotice({ type: 'warn', text: 'Some settings details are temporarily unavailable. Showing the data that loaded successfully.' })
@@ -415,6 +420,8 @@ export default function Settings() {
           expanded={routesExpanded}
           onToggleExpanded={() => setRoutesExpanded(current => !current)}
         />
+
+        <RemoteAccessCard remoteAccess={remoteAccess} onOpenEnvironment={handleOpenEnvironmentEditor} />
 
         <div className="grid items-stretch gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(22rem,0.85fr)]">
           <StorageCard storage={storage} />
@@ -590,6 +597,70 @@ function RemoteSetupCard({ setupStatus, className = '' }) {
         </span>
       </div>
     </PremiumCard>
+  )
+}
+
+function RemoteAccessCard({ remoteAccess, onOpenEnvironment }) {
+  const connected = remoteAccess?.running === true && remoteAccess?.authenticated === true
+  const needsAuthentication = remoteAccess?.running === true && remoteAccess?.authenticated !== true
+  const self = remoteAccess?.self || {}
+  const dnsName = String(self.dns_name || '').replace(/\.$/, '')
+  const addresses = Array.isArray(self.ips) ? self.ips.filter(Boolean) : []
+  const statusLabel = connected ? 'Connected' : needsAuthentication ? 'Needs authentication' : remoteAccess ? 'Not enabled' : 'Status unavailable'
+  const statusTone = connected ? 'bg-emerald-400' : needsAuthentication ? 'bg-amber-400' : 'bg-theme-text-muted'
+
+  return (
+    <UtilityCard icon={Network} title="Remote Access" description="Private Tailscale connectivity for this ODS device.">
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(18rem,0.7fr)]">
+        <div className="rounded-lg border border-theme-border bg-theme-bg/30 p-4">
+          <p className="flex items-center gap-2 text-sm font-semibold text-theme-text">
+            <span className={`h-2 w-2 rounded-full ${statusTone}`} />
+            {statusLabel}
+          </p>
+          {connected ? (
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              <RemoteAccessValue label="Tailnet DNS" value={dnsName || 'Unavailable'} />
+              <RemoteAccessValue label="Tailnet" value={remoteAccess.tailnet_name || remoteAccess.magic_dns_suffix || 'Unavailable'} />
+              <RemoteAccessValue label="Device" value={self.hostname || 'Unavailable'} />
+              <RemoteAccessValue label="Tailnet IP" value={addresses[0] || 'Unavailable'} />
+            </div>
+          ) : (
+            <p className="mt-3 text-sm leading-6 text-theme-text-muted">
+              {needsAuthentication
+                ? (remoteAccess.reason || 'Tailscale is running but has not joined a tailnet. Add an auth key in Environment, then apply the service change.')
+                : remoteAccess
+                  ? 'Enable the Tailscale extension to reach ODS privately from another device on your tailnet.'
+                  : 'The Tailscale status endpoint is temporarily unavailable. Other Settings data remains usable.'}
+            </p>
+          )}
+        </div>
+        <div className="flex flex-col justify-between rounded-lg border border-theme-border bg-theme-bg/20 p-4">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-theme-text-muted">Reachability prerequisites</p>
+            <p className="mt-2 text-sm leading-6 text-theme-text-muted">Remote HTTP access also requires the proxy extension and a LAN-visible bind address.</p>
+          </div>
+          <div className="mt-4 flex flex-wrap gap-2">
+            <Link to="/extensions/integrations" className="inline-flex items-center gap-2 rounded-lg border border-theme-border bg-theme-card px-3 py-2 text-sm text-theme-text hover:border-theme-accent/50">
+              Manage extension <ChevronRight size={15} />
+            </Link>
+            {needsAuthentication ? (
+              <button type="button" onClick={onOpenEnvironment} className="rounded-lg border border-theme-accent/40 bg-theme-accent/10 px-3 py-2 text-sm text-theme-accent-light hover:bg-theme-accent/20">
+                Open environment
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </UtilityCard>
+  )
+}
+
+function RemoteAccessValue({ label, value }) {
+  return (
+    <div className="min-w-0">
+      <p className="text-xs text-theme-text-muted">{label}</p>
+      <p className="mt-1 truncate font-mono text-sm text-theme-text" title={value}>{value}</p>
+    </div>
   )
 }
 

--- a/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
@@ -68,6 +68,15 @@ const payloadByUrl = (url) => {
     }
   }
   if (url === '/api/setup/status') return { first_run: false, persona: null }
+  if (url === '/api/tailscale/status') {
+    return {
+      running: true,
+      authenticated: true,
+      self: { hostname: 'ods-box', dns_name: 'ods-box.example.ts.net.', ips: ['100.64.0.42'], online: true },
+      magic_dns_suffix: 'example.ts.net',
+      tailnet_name: 'example.com',
+    }
+  }
   if (url === '/api/version') {
     return { current: '2.6.0', latest: '2.6.0', update_available: false, checked_at: '2026-07-23T12:00:00Z' }
   }
@@ -109,6 +118,30 @@ describe('Settings', () => {
     expect(within(accountCard).getByText('16.4k')).toBeInTheDocument()
     expect(within(accountCard).getByText('42')).toBeInTheDocument()
     expect(within(accountCard).getByText('2')).toBeInTheDocument()
+  })
+
+  test('renders authenticated Tailscale connection details from the status API', async () => {
+    const { fetchMock } = renderSettings()
+
+    const card = (await screen.findByRole('heading', { name: 'Remote Access' })).closest('.settings-premium-card')
+    expect(within(card).getByText('Connected')).toBeInTheDocument()
+    expect(within(card).getByText('ods-box.example.ts.net')).toBeInTheDocument()
+    expect(within(card).getByText('100.64.0.42')).toBeInTheDocument()
+    expect(within(card).getByText('example.com')).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledWith('/api/tailscale/status', expect.objectContaining({ signal: expect.anything() }))
+  })
+
+  test('keeps Settings usable when optional Tailscale status is unavailable', async () => {
+    renderSettings((url) => (
+      url === '/api/tailscale/status'
+        ? response({ detail: 'host agent unavailable' }, 503)
+        : null
+    ))
+
+    const card = (await screen.findByRole('heading', { name: 'Remote Access' })).closest('.settings-premium-card')
+    expect(within(card).getByText('Status unavailable')).toBeInTheDocument()
+    expect(within(card).getByText(/Other Settings data remains usable/)).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Storage' })).toBeInTheDocument()
   })
 
   test('clamps malformed storage values without rendering invalid widths', async () => {


### PR DESCRIPTION
## Summary
- add a Settings → Remote Access card backed by the authenticated `/api/tailscale/status` endpoint
- show joined device DNS, tailnet, hostname, and primary tailnet IP
- guide disabled and unauthenticated states to the existing Extensions and Environment workflows
- isolate optional status failures so the rest of Settings remains usable

## Why this matters
The merged Tailscale integration exposes a production status endpoint, but explicitly deferred its Settings UI in #1163. Operators currently have to use curl or the host CLI to discover whether the device joined its tailnet and which address to use. This closes that documented product gap without adding a new mutation path or handling auth keys in a new surface.

## Root cause and invariant
The API contract existed without a dashboard consumer. The preserved invariant is that Tailscale remains opt-in and read-only from this card: it reports lifecycle state and routes configuration through the existing authenticated Extensions and Environment flows. Failure of this optional endpoint must not fail the Settings page.

## Overlap check
Searched open and closed upstream PRs for `tailscale`, `tailscale status settings`, `Remote Access dashboard`, and changes related to `Settings.jsx`. The merged foundation PR #1163 explicitly lists “Remote Access Settings UI” as deferred. Open Tailscale PRs #2043, #2082, #2935, and #3221 change backend status/error handling rather than adding a dashboard consumer; this UI consumes their stable three-state response contract and does not overlap their files.

## Validation
- `npm test -- --run src/pages/Settings.test.jsx` (10 passed)
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

Regression tests exercise the Settings page boundary for both a joined tailnet payload and a 503 from the optional endpoint. No live Tailscale tailnet was available in this Windows checkout, so DNS/IP rendering and failure isolation are validated against the documented API contract rather than a physical remote connection.

## Compatibility and rollback
No backend, secret, extension-enable, or networking behavior changes. Existing Settings requests continue independently via `Promise.allSettled`. Reverting the commit removes only the new status request/card and restores the previous documentation wording.
## Batch compatibility
This PR is file-independent from the six CLI PRs #3481–#3486 and may merge before or after them. The complete eight-PR batch was reconciled and validated on synthetic head `3cbc6890` from upstream main `6ff9b4fc`. All focused CLI contracts, the 24-test support-bundle suite, Windows log contract, Settings tests, ESLint, and dashboard production build passed together. The only combined conflicts are the already-documented additive CLI registry/Makefile conflicts between #3484 and #3486.