### PR TITLE
fix(windows): replace stale Hermes SOUL.md instead of guarding on Container

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -586,8 +586,8 @@ function Invoke-HermesSoulRefresh {
     }
 
     if (-not $rendered) {
-        if (Test-Path -LiteralPath $output -PathType Container) {
-            Remove-Item -LiteralPath $output -Recurse -Force
+        if (Test-Path -LiteralPath $output -PathType Leaf) {
+            Remove-Item -LiteralPath $output -Force
         }
         if (-not (Test-Path -LiteralPath $output -PathType Leaf)) {
             $content = Get-Content -LiteralPath $template -Raw


### PR DESCRIPTION
## Summary
`Invoke-HermesSoulRefresh` in the `ods` CLI guarded its stale-file cleanup with `Test-Path -LiteralPath $output -PathType Container`. `$output` is a **file** (`data/persona/SOUL.md`), so the Container check was always false — an existing SOUL.md was never removed and the fallback render was skipped. The stale template therefore persisted across refreshes.

## Fix
Check `-PathType Leaf` and remove the stale file before re-rendering.

## Verification
- `Test-Path -LiteralPath $output -PathType Leaf` is the correct test for a file path.
- Fallback render path now runs when the existing SOUL.md is present.

Closes #3334
