### PR TITLE
fix(installer): refresh stale Hermes SOUL.md during install phase

### DIFF
--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -544,8 +544,8 @@ function Invoke-HermesSoulRefresh {
     }
 
     if (-not $_rendered) {
-        if (Test-Path -LiteralPath $_output -PathType Container) {
-            Remove-Item -LiteralPath $_output -Recurse -Force
+        if (Test-Path -LiteralPath $_output -PathType Leaf) {
+            Remove-Item -LiteralPath $_output -Force
         }
         if (-not (Test-Path -LiteralPath $_output -PathType Leaf)) {
             $_content = Get-Content -LiteralPath $_template -Raw


### PR DESCRIPTION
## Summary
The install-phase `Invoke-HermesSoulRefresh` (used during `ods` setup) guarded cleanup on `-PathType Container` for a file path, so an existing `data/persona/SOUL.md` was never replaced and the fallback render was skipped.

## Fix
Test `-PathType Leaf` and remove the stale file before re-rendering, mirroring the corrected CLI refresh path.

Closes #3343
