### PR TITLE
fix(hermes): stop mangling config values that contain '$'

### DIFF
--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -387,6 +387,12 @@ function Update-HermesConfigFile {
 
     if (-not (Test-Path $Path)) { return $false }
 
+    # The -replace operator treats '$' in the replacement string as a .NET
+    # substitution token (e.g. '$1', '$$'). Literal '$' characters in the model
+    # id or base URL would otherwise be mangled, so escape them first.
+    $Model = $Model.Replace('$', '$$')
+    $BaseUrl = $BaseUrl.Replace('$', '$$')
+
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     $content = [System.IO.File]::ReadAllText($Path, $utf8NoBom)
     $content = $content -replace '(?m)^  default: ".*"\r?$', "  default: `"$Model`""


### PR DESCRIPTION
## Summary
`Update-HermesConfigFile` injects the model id and base URL into PowerShell `-replace` replacement strings. The .NET regex engine treats `$` as a substitution token (`$1`, `$$`, …), so any value containing `$` was silently mangled in the generated Hermes config.

## Fix
Escape `$` → `$$` on `$Model` and `$BaseUrl` before substitution. The written file then contains the literal value, and the existing post-write verification still matches.

Closes #2928
