### PR TITLE
fix(backup): include Hermes sessions and persona SOUL.md in backups

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -66,6 +66,8 @@ estimate_backup_bytes() {
             "data/litellm"
             "data/livekit"
             "data/ollama"
+            "data/hermes"
+            "data/persona"
         )
 
         for p in "${user_data_paths[@]}"; do
@@ -334,6 +336,8 @@ backup_user_data() {
         "data/litellm"
         "data/livekit"
         "data/ollama"
+        "data/hermes"
+        "data/persona"
     )
 
     for path in "${user_data_paths[@]}"; do


### PR DESCRIPTION
## Summary
`ods-backup.sh` enumerated user-data volumes for size estimation and rsync copy, but omitted `data/hermes` (sessions, memories, cron jobs) and `data/persona` (SOUL.md). A full or user-data restore therefore destroyed that state.

## Fix
Add both paths to the size-estimate list and the rsync copy list.

Closes #3145
