### PR TITLE
fix(hermes): resolve host UID/GID for data/hermes ownership

### DIFF
--- a/ods/extensions/services/hermes/compose.yaml
+++ b/ods/extensions/services/hermes/compose.yaml
@@ -15,8 +15,8 @@ services:
     environment:
       # User remapping: match the host user so files written into the volume
       # are owned by the user, not container-root. Same pattern as n8n.
-      - HERMES_UID=${UID:-10000}
-      - HERMES_GID=${GID:-10000}
+      - HERMES_UID=${ODS_UID:-10000}
+      - HERMES_GID=${ODS_GID:-10000}
       # Point Hermes at the local LLM. provider=custom is the documented
       # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
       # The actual provider/model wiring lives in cli-config.yaml (mounted below).

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -814,6 +814,13 @@ ODS_VERSION=${VERSION:-2.6.0}
 # 127.0.0.1 = localhost only (secure default)
 # 0.0.0.0   = accessible from LAN (install with --lan or set manually)
 BIND_ADDRESS=${BIND_ADDRESS}
+#=== Host User Mapping ===
+# Real host UID/GID, written to .env so Docker Compose (which interpolates from
+# the environment, not shell state) can remap volume ownership for Hermes/n8n.
+# ${UID}/${GID} are read-only shell vars and are never exported, so they always
+# fall back to the default inside compose; ODS_UID/ODS_GID carry the real value.
+ODS_UID=$(id -u 2>/dev/null || echo 10000)
+ODS_GID=$(id -g 2>/dev/null || echo 10000)
 # Host LAN IP (populated when BIND_ADDRESS=0.0.0.0; empty otherwise).
 # Containers like openclaw read this to advertise the host's LAN address.
 HOST_LAN_IP=${HOST_LAN_IP}


### PR DESCRIPTION
## Summary
Hermes compose used `${UID:-10000}`/`${GID:-10000}`, but `UID`/`GID` are read-only shell variables and are never exported into the environment, so Docker Compose (which interpolates from the environment) always saw the fallback. Files in `data/hermes` ended up owned by uid 10000.

## Fix
- Write `ODS_UID`/`ODS_GID` (from `id -u`/`id -g`) into `.env` during install.
- Reference `${ODS_UID:-10000}`/`${ODS_GID:-10000}` in the Hermes compose file so volume ownership matches the real host user.

Closes #2303
