### PR TITLE
fix(ssh-tunnel): log the ValueError that disables a tunnel plan

### DIFF
--- a/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
+++ b/ods/extensions/services/remote-provider-ssh-tunnel/app/main.py
@@ -301,7 +301,8 @@ class SshProcessSupervisor:
             self._notice_exited_locked(now)
             try:
                 argv = _combined_ssh_argv(plan)
-            except ValueError:
+            except ValueError as exc:
+                LOGGER.warning("ssh plan argv invalid: %s", exc)
                 self._stop_process_locked()
                 self._last_payload = _health_from_plan(
                     _error_plan("ssh_plan_unavailable", secret_dir=self.secret_dir),


### PR DESCRIPTION
## Summary
`SshProcessSupervisor.reconcile()` caught the `ValueError` raised by `_combined_ssh_argv()` and silently stopped the tunnel, so a broken/misconfigured routing state (e.g. a truncated `routing-state.json`) left the `remote-provider-ssh-tunnel` container in `error` with no explanation.

## Fix
Bind the exception as `exc` and log it at WARNING before stopping the process, giving operators an actionable log line.

## Verification
`LOGGER.warning("ssh plan argv invalid: %s", exc)` runs whenever `_combined_ssh_argv` raises.

Closes #2338
