### PR TITLE
fix(egress): run provider probe off the asyncio event loop

### DIFF
--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, AsyncIterator, Mapping
 
+import asyncio
 import httpx
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -312,12 +313,18 @@ async def probe() -> Response:
         if route.get("transport") == "ssh":
             tunnel = await _ssh_tunnel_status()
         secret = read_provider_secret(SECRET_PATH)
-        payload = probe_route_response(
-            route,
-            provider_secret=secret,
-            verified_at=_iso_now(),
-            tunnel=tunnel,
-            timeout=PROBE_TIMEOUT_SECONDS,
+        # probe_route_response() makes a blocking urllib call; run it on a
+        # thread executor so the asyncio event loop stays free to serve
+        # concurrent inference requests during the probe.
+        payload = await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: probe_route_response(
+                route,
+                provider_secret=secret,
+                verified_at=_iso_now(),
+                tunnel=tunnel,
+                timeout=PROBE_TIMEOUT_SECONDS,
+            ),
         )
     except EgressError as exc:
         return _error_response(exc)


### PR DESCRIPTION
## Summary
`probe()` called `probe_route_response()` synchronously on the asyncio event loop. That function makes a blocking `urllib` HTTP call, so the loop froze for the full probe timeout (up to 10s), pausing all concurrent streaming inference.

## Fix
Offload the blocking probe to a thread executor (`run_in_executor(None, ...)`) so inference requests keep streaming while a probe runs.

Closes #2699
