### PR TITLE
fix(litellm): close Token Spy AsyncClient on worker exit

### DIFF
--- a/ods/extensions/services/litellm/ods_token_spy_callback.py
+++ b/ods/extensions/services/litellm/ods_token_spy_callback.py
@@ -164,6 +164,7 @@ class ODSTokenSpyCallback(CustomLogger):
             )
         )
         self.worker: asyncio.Task[None] | None = None
+        self._client: httpx.AsyncClient | None = None
         self.last_warning = 0.0
 
     async def async_log_success_event(
@@ -195,9 +196,12 @@ class ODSTokenSpyCallback(CustomLogger):
         timeout = max(
             0.1, float(os.environ.get("ODS_LITELLM_TELEMETRY_TIMEOUT", "3"))
         )
-        async with httpx.AsyncClient(
-            follow_redirects=False, timeout=timeout
-        ) as client:
+        # Hold the client on the instance and close it in a finally so a
+        # cancelled/restarted worker task never leaks TCP sockets or fds
+        # (the previous async-with form could leave __aexit__ unawaited).
+        client = httpx.AsyncClient(follow_redirects=False, timeout=timeout)
+        self._client = client
+        try:
             while True:
                 event = await self.queue.get()
                 try:
@@ -215,6 +219,10 @@ class ODSTokenSpyCallback(CustomLogger):
                     self._warn(f"Token Spy telemetry unavailable: {exc}")
                 finally:
                     self.queue.task_done()
+        finally:
+            await client.aclose()
+            if self._client is client:
+                self._client = None
 
     def _warn(self, message: str) -> None:
         now = time.monotonic()


### PR DESCRIPTION
## Summary
The Token Spy background worker created its `httpx.AsyncClient` with `async with`. If the worker task is cancelled (LiteLLM model swap, gunicorn recycle, shutdown race), `__aexit__` could be left unawaited, leaking TCP sockets and fds until the process hit `EMFILE`.

## Fix
Hold the client on the instance (`self._client`) and `await client.aclose()` in a `finally` so every task exit — including cancellation — releases the connections.

Closes #2336
