### PR TITLE
feat(dashboard): add Privacy Shield monitoring

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/PrivacyMonitor.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PrivacyMonitor.jsx
@@ -1,0 +1,186 @@
+import {
+  Activity,
+  AlertTriangle,
+  Database,
+  ExternalLink,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  Users,
+} from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+
+const POLL_INTERVAL_MS = 10000
+
+const formatCount = (value) => {
+  const number = Number(value)
+  return Number.isFinite(number) && number >= 0 ? Math.round(number).toLocaleString() : '0'
+}
+
+export default function PrivacyMonitor() {
+  const [status, setStatus] = useState(null)
+  const [stats, setStats] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState(null)
+  const [statsError, setStatsError] = useState(null)
+  const controllerRef = useRef(null)
+
+  const loadPrivacy = useCallback(async ({ background = false } = {}) => {
+    controllerRef.current?.abort()
+    const controller = new AbortController()
+    controllerRef.current = controller
+    if (background) setRefreshing(true)
+    else setLoading(true)
+
+    try {
+      const statusResponse = await fetch('/api/privacy-shield/status', { signal: controller.signal })
+      if (!statusResponse.ok) throw new Error(`Privacy status request failed (${statusResponse.status})`)
+      const statusPayload = await statusResponse.json()
+      setStatus(statusPayload)
+      setError(null)
+
+      if (statusPayload.enabled) {
+        const statsResponse = await fetch('/api/privacy-shield/stats', { signal: controller.signal })
+        if (!statsResponse.ok) throw new Error(`Privacy stats request failed (${statsResponse.status})`)
+        const statsPayload = await statsResponse.json()
+        if (statsPayload.error) {
+          setStatsError(statsPayload.error)
+        } else {
+          setStats(statsPayload)
+          setStatsError(null)
+        }
+      } else {
+        setStats(null)
+        setStatsError(null)
+      }
+    } catch (err) {
+      if (err.name !== 'AbortError') setError(err.message || 'Privacy Shield status is unavailable')
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false)
+        setRefreshing(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    void loadPrivacy()
+    const timer = window.setInterval(() => void loadPrivacy({ background: true }), POLL_INTERVAL_MS)
+    return () => {
+      window.clearInterval(timer)
+      controllerRef.current?.abort()
+    }
+  }, [loadPrivacy])
+
+  if (loading && !status) return <PrivacyMonitorSkeleton />
+
+  const enabled = status?.enabled === true
+  const cacheEnabled = stats?.cache_enabled ?? status?.pii_cache_enabled
+
+  return (
+    <div className="min-h-full px-3 py-6 sm:px-4 lg:px-5 xl:px-6">
+      <header className="mb-7 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-[-0.01em] text-theme-text sm:text-4xl">Privacy Shield</h1>
+          <p className="mt-2 text-base text-theme-text-muted">Observe local PII scrubbing without exposing captured values.</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadPrivacy({ background: true })}
+          disabled={refreshing}
+          className="inline-flex h-11 items-center justify-center gap-2 rounded-lg border border-theme-border bg-theme-card px-4 text-sm font-medium text-theme-text hover:border-theme-accent/50 disabled:opacity-60"
+        >
+          <RefreshCw size={16} className={refreshing ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </header>
+
+      {error ? <WarningBanner>{error}. Showing the latest successful snapshot when available.</WarningBanner> : null}
+      {statsError ? <WarningBanner>Statistics unavailable: {statsError}. Shield health is reported independently.</WarningBanner> : null}
+
+      <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        <PrivacyMetric icon={ShieldCheck} label="Protection" value={enabled ? 'Active' : 'Inactive'} detail={status?.message || 'Status unavailable'} tone={enabled ? 'good' : 'muted'} />
+        <PrivacyMetric icon={Users} label="Active sessions" value={formatCount(stats?.active_sessions)} detail="Sessions with in-memory PII mappings" />
+        <PrivacyMetric icon={Activity} label="Active PII mappings" value={formatCount(stats?.total_pii_scrubbed)} detail="Current mappings, not a lifetime counter" />
+        <PrivacyMetric icon={Database} label="PII cache" value={cacheEnabled ? 'Enabled' : 'Disabled'} detail={stats?.cache_size ? `Configured capacity: ${formatCount(stats.cache_size)}` : 'Capacity unavailable'} />
+      </div>
+
+      <div className="mt-5 grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(20rem,0.7fr)]">
+        <section className="liquid-metal-frame liquid-metal-frame--soft rounded-lg border p-5">
+          <div className="flex items-start gap-3">
+            <Server size={20} className="mt-0.5 text-theme-accent-light" />
+            <div>
+              <h2 className="text-lg font-semibold text-theme-text">Runtime route</h2>
+              <p className="mt-1 text-sm text-theme-text-muted">Requests must use the shield endpoint to receive PII scrubbing.</p>
+            </div>
+          </div>
+          <dl className="mt-5 grid gap-4 sm:grid-cols-2">
+            <RouteValue label="Shield port" value={status?.port ? `:${status.port}` : 'Unavailable'} />
+            <RouteValue label="Target API" value={status?.target_api || 'Unavailable'} />
+            <RouteValue label="Container" value={status?.container_running ? 'Running' : 'Not running'} />
+            <RouteValue label="Session cache" value={cacheEnabled ? 'Enabled' : 'Disabled'} />
+          </dl>
+        </section>
+
+        <section className="liquid-metal-frame liquid-metal-frame--soft flex flex-col justify-between rounded-lg border p-5">
+          <div>
+            <h2 className="text-lg font-semibold text-theme-text">Configuration</h2>
+            <p className="mt-2 text-sm leading-6 text-theme-text-muted">
+              {enabled
+                ? 'Privacy Shield is healthy. Configuration and service lifecycle remain in the authenticated Extensions and Environment workflows.'
+                : 'Enable Privacy Shield from Extensions, then route supported LLM clients through its proxy endpoint.'}
+            </p>
+          </div>
+          <Link to="/extensions" className="mt-5 inline-flex items-center justify-between border-t border-theme-border pt-4 text-sm font-medium text-theme-accent-light">
+            Manage extension <ExternalLink size={15} />
+          </Link>
+        </section>
+      </div>
+    </div>
+  )
+}
+
+function PrivacyMetric({ icon: Icon, label, value, detail, tone = 'default' }) {
+  const valueClass = tone === 'good' ? 'text-emerald-300' : tone === 'muted' ? 'text-theme-text-muted' : 'text-theme-text'
+  return (
+    <section className="liquid-metal-frame liquid-metal-frame--soft rounded-lg border p-5">
+      <div className="flex items-center gap-2 text-theme-text-muted">
+        <Icon size={17} />
+        <h2 className="text-xs font-semibold uppercase tracking-[0.16em]">{label}</h2>
+      </div>
+      <p className={`mt-4 text-2xl font-semibold ${valueClass}`}>{value}</p>
+      <p className="mt-2 line-clamp-2 text-xs text-theme-text-muted" title={detail}>{detail}</p>
+    </section>
+  )
+}
+
+function RouteValue({ label, value }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-theme-border bg-theme-bg/25 p-4">
+      <dt className="text-xs text-theme-text-muted">{label}</dt>
+      <dd className="mt-1 truncate font-mono text-sm text-theme-text" title={value}>{value}</dd>
+    </div>
+  )
+}
+
+function WarningBanner({ children }) {
+  return (
+    <div role="alert" className="mb-5 flex items-center gap-3 rounded-lg border border-amber-400/25 bg-amber-400/10 p-4 text-sm text-amber-100">
+      <AlertTriangle size={18} className="shrink-0" />
+      <span>{children}</span>
+    </div>
+  )
+}
+
+function PrivacyMonitorSkeleton() {
+  return (
+    <div className="min-h-full animate-pulse px-5 py-7">
+      <div className="h-10 w-64 rounded-lg bg-theme-card" />
+      <div className="mt-8 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+        {[0, 1, 2, 3].map(item => <div key={item} className="h-32 rounded-lg bg-theme-card" />)}
+      </div>
+    </div>
+  )
+}

--- a/ods/extensions/services/dashboard/src/pages/PrivacyMonitor.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PrivacyMonitor.test.jsx
@@ -1,0 +1,89 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import { coreRoutes } from '../plugins/core'
+import PrivacyMonitor from './PrivacyMonitor' // eslint-disable-line no-unused-vars
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const enabledStatus = {
+  enabled: true,
+  container_running: true,
+  port: 8085,
+  target_api: 'http://llama-server:8080/v1',
+  pii_cache_enabled: true,
+  message: 'Privacy Shield is active',
+}
+
+const stats = {
+  cache_enabled: true,
+  cache_size: 1000,
+  active_sessions: 4,
+  total_pii_scrubbed: 13,
+}
+
+describe('PrivacyMonitor', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  test('renders status and stats without displaying captured PII values', async () => {
+    const fetchMock = vi.fn(async (url) => (
+      url === '/api/privacy-shield/status' ? response(enabledStatus) : response(stats)
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<PrivacyMonitor />)
+
+    expect(await screen.findByRole('heading', { name: 'Privacy Shield' })).toBeInTheDocument()
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    expect(screen.getByText('4')).toBeInTheDocument()
+    expect(screen.getByText('13')).toBeInTheDocument()
+    expect(screen.getByText('Current mappings, not a lifetime counter')).toBeInTheDocument()
+    expect(screen.getByText('http://llama-server:8080/v1')).toBeInTheDocument()
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      '/api/privacy-shield/status',
+      '/api/privacy-shield/stats',
+    ])
+  })
+
+  test('does not request protected stats while the shield is disabled', async () => {
+    const fetchMock = vi.fn(async () => response({
+      enabled: false,
+      container_running: false,
+      port: 8085,
+      pii_cache_enabled: true,
+      message: 'Privacy Shield is not running',
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<PrivacyMonitor />)
+
+    expect(await screen.findByText('Inactive')).toBeInTheDocument()
+    expect(screen.getByText(/Enable Privacy Shield from Extensions/)).toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledWith('/api/privacy-shield/status', expect.objectContaining({ signal: expect.anything() }))
+  })
+
+  test('reports stats errors independently and can refresh', async () => {
+    const fetchMock = vi.fn(async (url) => (
+      url === '/api/privacy-shield/status'
+        ? response(enabledStatus)
+        : response({ error: 'SHIELD_API_KEY not configured', enabled: false })
+    ))
+    vi.stubGlobal('fetch', fetchMock)
+    render(<PrivacyMonitor />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Statistics unavailable: SHIELD_API_KEY not configured')
+    expect(screen.getByText('Active')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(4))
+  })
+
+  test('is registered as a sidebar route', () => {
+    expect(coreRoutes.find(route => route.id === 'privacy')).toMatchObject({
+      path: '/privacy',
+      label: 'Privacy',
+      sidebar: true,
+    })
+  })
+})

--- a/ods/extensions/services/dashboard/src/plugins/core.js
+++ b/ods/extensions/services/dashboard/src/plugins/core.js
@@ -10,6 +10,7 @@ import {
   UserPlus,
   CreditCard,
   Code,
+  Shield,
 } from 'lucide-react'
 
 const Dashboard = lazy(() => import('../pages/Dashboard'))
@@ -21,6 +22,7 @@ const RemoteProvider = lazy(() => import('../pages/RemoteProvider'))
 const ServiceMap = lazy(() => import('../pages/ServiceMap'))
 const Invites = lazy(() => import('../pages/Invites'))
 const Usage = lazy(() => import('../pages/Usage'))
+const PrivacyMonitor = lazy(() => import('../pages/PrivacyMonitor'))
 
 export const coreRoutes = [
   {
@@ -83,6 +85,16 @@ export const coreRoutes = [
     getProps: () => ({}),
     sidebar: true,
     order: 3.2,
+  },
+  {
+    id: 'privacy',
+    path: '/privacy',
+    label: 'Privacy',
+    icon: Shield,
+    component: PrivacyMonitor,
+    getProps: () => ({}),
+    sidebar: true,
+    order: 3.6,
   },
   // Usage + Setup / Owner are reachable from Settings rather than the top-level
   // sidebar. Setup / Owner is a factory/distributor/service-provider flow, not

--- a/ods/extensions/services/privacy-shield/README.md
+++ b/ods/extensions/services/privacy-shield/README.md
@@ -35,18 +35,27 @@ Privacy Shield sits between your applications and the LLM API, automatically scr
 
 Privacy Shield is included as a core service and starts automatically with the stack.
 
+The Dashboard's **Privacy** page shows shield health, active sessions, active
+PII mappings, cache configuration, and the current runtime route. It is
+read-only; service lifecycle remains in **Extensions**.
+
 **Via Dashboard API:**
 ```bash
+export DASHBOARD_API_KEY="your-dashboard-api-key"
+
 # Check status
-curl http://localhost:3002/api/privacy-shield/status
+curl -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
+  http://localhost:3002/api/privacy-shield/status
 
 # Enable
 curl -X POST http://localhost:3002/api/privacy-shield/toggle \
+  -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"enable": true}'
 
 # Get stats
-curl http://localhost:3002/api/privacy-shield/stats
+curl -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
+  http://localhost:3002/api/privacy-shield/stats
 ```
 
 ### Configuration


### PR DESCRIPTION
## Summary
- add a lazy-loaded Privacy Shield monitoring page and sidebar route
- show service health, active sessions, active PII mappings, cache configuration, and the runtime proxy route
- fetch protected statistics only while the shield reports enabled
- keep status and stats failures independent and preserve the latest successful snapshot
- correct the Privacy Shield README examples to include dashboard API Bearer authentication

## Why this matters
ODS advertises local PII protection and already ships authenticated status/statistics endpoints, but the dashboard has no consumer for them. Operators currently cannot verify from the product UI that requests are routed through a healthy shield or observe active mappings. The README's unauthenticated curl examples also fail against the production endpoint contract.

## Root cause and invariant
The Privacy Shield runtime was visible only through direct API calls and generic service health. The preserved invariant is that monitoring never exposes captured PII values and remains read-only: start/stop and environment changes stay in the existing authenticated lifecycle flows. Statistics are requested only after status proves the shield is enabled.

## Overlap check
Searched open and closed upstream PRs for `privacy shield dashboard`, `privacy monitor`, `privacy-shield/stats`, `plugins/core.js`, and `coreRoutes`. No PR adds a React consumer for the status/stats contract. Closed #1069 owns endpoint authentication, which this feature consumes and now documents correctly. #3193 adds generic registry tests, #2180 adds Workflows, and #3500 adds the independent Agent Monitor route; their `core.js` changes are additive and require only retaining both route entries.

## Validation
- `npm test -- --run src/pages/PrivacyMonitor.test.jsx` (4 passed)
- `npm test -- --run src/pages/PrivacyMonitor.test.jsx src/plugins/registry.test.js` (7 passed)
- `npm run lint -- --quiet`
- `npm run build`
- `git diff --check`

Regression tests exercise the dashboard boundary for enabled status/statistics, disabled status without an unnecessary stats request, independently reported stats configuration errors, manual refresh, and route registration. No live Privacy Shield container processed real PII in this Windows checkout; health/stat rendering is validated against the shipped service and router contracts.

## Compatibility, privacy, and rollback
This page displays counts and configuration metadata only—never source PII, mappings, prompts, or responses. It adds read-only requests only while `/privacy` is mounted. Reverting removes the route/page and documentation update without changing the service or persisted state. Merge after #3500 and retain both additive `core.js` route registrations during reconciliation.
## Batch compatibility
Preferred order for the two new dashboard routes is #3500 → #3501, retaining both additive imports and route objects in `src/plugins/core.js`. The full ten-PR batch was reconciled on synthetic head `f49ba48c` from upstream main `6ff9b4fc`. All six CLI feature tests, the CLI static contract, the Windows log contract, the 24-test support-bundle suite, 20 combined dashboard tests, ESLint, and the production dashboard build passed together. The synthetic branch is local validation evidence only and was not pushed.