### PR TITLE
fix(update): iterate compose services as an array to avoid word-splitting

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -929,10 +929,10 @@ cmd_health() {
         read -ra compose_args <<< "$compose_flags"
     fi
     
-    local services
-    services=$("${compose_cmd[@]}" "${compose_args[@]}" ps --services 2>/dev/null || echo "")
-    
-    if [[ -z "$services" ]]; then
+    local -a services=()
+    mapfile -t services < <("${compose_cmd[@]}" "${compose_args[@]}" ps --services 2>/dev/null || true)
+
+    if [[ ${#services[@]} -eq 0 ]]; then
         if [[ -n "$compose_flags" ]]; then
             log_warn "No services found for resolved compose stack: ${compose_flags}"
         else
@@ -941,7 +941,7 @@ cmd_health() {
         return 1
     fi
     
-    for service in $services; do
+    for service in "${services[@]}"; do
         local status
         status=$("${compose_cmd[@]}" "${compose_args[@]}" ps --format json "$service" 2>/dev/null \
             | jq -r 'if type == "array" then (.[0].State // "unknown") else (.State // "unknown") end' 2>/dev/null \


### PR DESCRIPTION
## Summary
`cmd_health` in `ods-update.sh` captured the output of `docker compose ps --services` in a scalar variable and iterated it with `for service in $services`. `docker compose ps --services` emits one service name per line, so the unquoted expansion word-splits on whitespace: any service whose name contains a space is torn into fragments and probed as a partial name, producing a false `unknown`/unhealthy report.

This change reads the service list into an array with `mapfile` and iterates over whole elements, so multi-word service names stay intact. The empty-case check now uses the array length.

## Test plan
- [ ] `bash -n ods/ods-update.sh`
- [ ] On a running stack, the health check reports each service correctly; add a service whose name contains a space and confirm it is no longer split.

Fixes #3339
