### PR TITLE
fix(dashboard-api): validate extension manifests against JSON schema at load time

### DIFF
--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -279,6 +279,20 @@ def _resolve_public_service_url(
     return ""
 
 
+# --- JSON Schema loading (guarded; optional dependency) ---
+# Validates extension manifests against service-manifest.v1.json when jsonschema
+# is available. Loaded here (not in the Templates section below) because
+# load_extension_manifests() runs at import time and needs these names defined first.
+_MANIFEST_SCHEMA = None
+try:
+    import jsonschema as _jsonschema_mod
+    _manifest_schema_path = Path(__file__).parent.parent.parent / "schema" / "service-manifest.v1.json"
+    if _manifest_schema_path.exists():
+        _MANIFEST_SCHEMA = json.loads(_manifest_schema_path.read_text(encoding="utf-8"))
+except ImportError:
+    _jsonschema_mod = None
+
+
 # --- Manifest Loading ---
 
 
@@ -338,6 +352,14 @@ def load_extension_manifests(
                 errors.append({"file": str(path), "error": "Unsupported schema_version"})
                 continue
 
+            if _MANIFEST_SCHEMA is not None and _jsonschema_mod is not None:
+                try:
+                    _jsonschema_mod.validate(manifest, _MANIFEST_SCHEMA)
+                except _jsonschema_mod.ValidationError as ve:
+                    logger.warning("Skipping manifest %s: schema validation failed: %s", path, ve.message)
+                    errors.append({"file": str(path), "error": f"Schema validation failed: {ve.message}"})
+                    continue
+
             service = manifest.get("service")
             if isinstance(service, dict):
                 service_id = service.get("id")
@@ -353,7 +375,7 @@ def load_extension_manifests(
                             compose_path,
                         )
                         continue
-                supported = service.get("gpu_backends", ["amd", "nvidia", "apple"])
+                supported = service.get("gpu_backends", [])
                 if gpu_backend == "apple":
                     if (
                         service.get("type") == "host-systemd"


### PR DESCRIPTION
## Summary
`load_extension_manifests()` only enforced `schema_version == "ods.services.v1"` and `service.id`; it never applied `service-manifest.v1.json`, so required fields (`type`/`category`/`port`) and enum constraints were unenforced at runtime and the schema file was effectively dead weight outside CI.

- Validate each manifest against `service-manifest.v1.json` at load time (guarded on the optional `jsonschema` dependency; load failure or a missing module is a no-op). Invalid manifests are skipped with a warning and recorded in the existing `errors` list.
- Stop defaulting `gpu_backends` to `["amd","nvidia","apple"]` when absent. An undeclared list now means "compatible with nothing" instead of universal, so a manifest that forgets `gpu_backends` is no longer silently advertised as installable on every backend. All bundled manifests already declare `gpu_backends`, so behavior is unchanged for them.

`jsonschema` is an optional dependency (mirrors the existing template-schema path); normal runtime does not require it.

## Test plan
- [ ] `python3 -m py_compile ods/extensions/services/dashboard-api/config.py`
- [ ] Validated all 60 current service/library manifests against the schema — 0 failures, so no service is dropped.
- [ ] `pytest extensions/services/dashboard-api/tests/` (config/manifest tests)

Fixes #3231
