### PR TITLE
fix(cli): resolve compose flags after restore in rollback

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4747,6 +4747,12 @@ cmd_rollback() {
 
         # Restart services with restored configuration
         log "Restarting services with restored configuration..."
+        # Re-resolve compose flags from the restored .env/overlays so the restarted
+        # stack matches the backup rather than the failed update's flag selection.
+        load_env
+        flags_str=$(get_compose_flags)
+        flags=()
+        read -ra flags <<< "$flags_str"
         if docker compose "${flags[@]}" up -d; then
             success "Rollback complete"
             rm -f "$INSTALL_DIR/.last-backup-id"

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4709,20 +4709,12 @@ cmd_restore() {
 cmd_rollback() {
     check_install
     cd "$INSTALL_DIR"
-    load_env
-
-    if [[ ! -f "$INSTALL_DIR/.last-backup-id" ]]; then
-        error "No rollback point found. Rollback is only available after a failed update."
+    if [[ ! -x "$INSTALL_DIR/ods-update.sh" ]]; then
+        error "ods-update.sh not found or not executable"
     fi
 
-    local backup_id
-    backup_id=$(cat "$INSTALL_DIR/.last-backup-id")
-
-    if [[ -z "$backup_id" ]]; then
-        error "Invalid rollback point (empty backup ID)"
-    fi
-
-    log "Rolling back to pre-update state (backup: $backup_id)..."
+    local target="${1:-}"
+    log "Rolling back to pre-update state${target:+ (snapshot: $target)}..."
     echo ""
     warn "This will restore configuration from before the last update."
     read -p "Continue with rollback? [y/N] " -n 1 -r
@@ -4733,39 +4725,11 @@ cmd_rollback() {
         return 0
     fi
 
-    # Stop services before rollback
-    log "Stopping services..."
-    local flags_str
-    flags_str=$(get_compose_flags)
-    local -a flags
-    read -ra flags <<< "$flags_str"
-    docker compose "${flags[@]}" down 2>/dev/null || true
-
-    # Restore from backup
-    if "$INSTALL_DIR/ods-restore.sh" "$backup_id"; then
-        success "Configuration restored from backup: $backup_id"
-
-        # Restart services with restored configuration
-        log "Restarting services with restored configuration..."
-        # Re-resolve compose flags from the restored .env/overlays so the restarted
-        # stack matches the backup rather than the failed update's flag selection.
-        load_env
-        flags_str=$(get_compose_flags)
-        flags=()
-        read -ra flags <<< "$flags_str"
-        if docker compose "${flags[@]}" up -d; then
-            success "Rollback complete"
-            rm -f "$INSTALL_DIR/.last-backup-id"
-
-            log "Checking service health..."
-            sleep 5
-            cmd_status
-        else
-            error "Failed to restart services after rollback. Check 'docker compose logs' for details."
-        fi
-    else
-        error "Failed to restore from backup. Your system may be in an inconsistent state."
-    fi
+    # ods-update.sh owns pre-update snapshot discovery, integrity verification,
+    # compose-stack restoration, restart, and health proof. Keeping that
+    # transaction in one implementation avoids diverging backup roots and stale
+    # in-memory compose flags in this CLI wrapper.
+    bash "$INSTALL_DIR/ods-update.sh" rollback ${target:+"$target"}
 }
 
 cmd_agent() {
@@ -6430,7 +6394,7 @@ ${CYAN}Commands:${NC}
   backup [options]    Create a backup of user data and config
   backup verify <id>   Verify checksum integrity for a backup
   restore [backup_id] Restore from a backup
-  rollback            Rollback to pre-update state (after failed update)
+  rollback [snapshot] Rollback to pre-update state (after failed update)
   logs <service>      Tail logs for a service
   restart [service] [--rebuild-images]
                       Restart services (all if no service specified)
@@ -6583,7 +6547,7 @@ case "${1:-help}" in
     stt)         shift; cmd_stt "$@" ;;
     backup)      shift; cmd_backup "$@" ;;
     restore)     shift; cmd_restore "$@" ;;
-    rollback)    cmd_rollback ;;
+    rollback)    shift; cmd_rollback "$@" ;;
     logs|log|l)  shift; cmd_logs "$@" ;;
     restart|r)   shift; cmd_restart "$@" ;;
     repair|fix)  shift; cmd_repair "$@" ;;

--- a/ods/tests/test-ods-cli-rollback-delegation.sh
+++ b/ods/tests/test-ods-cli-rollback-delegation.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR/install"
+TRACE_FILE="$TMP_DIR/rollback.trace"
+mkdir -p "$INSTALL_DIR"
+touch "$INSTALL_DIR/docker-compose.base.yml"
+
+cat > "$INSTALL_DIR/ods-update.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$ROLLBACK_TRACE_FILE"
+SH
+chmod +x "$INSTALL_DIR/ods-update.sh"
+
+run_rollback() {
+    local output_file="$1"
+    shift
+    printf 'y\n' | ODS_HOME="$INSTALL_DIR" ROLLBACK_TRACE_FILE="$TRACE_FILE" \
+        bash "$ROOT_DIR/ods-cli" rollback "$@" >"$output_file" 2>&1
+}
+
+run_rollback "$TMP_DIR/latest.out"
+[[ "$(cat "$TRACE_FILE")" == "rollback" ]] || {
+    cat "$TMP_DIR/latest.out"
+    echo "FAIL: ods rollback did not delegate latest-snapshot recovery to ods-update.sh" >&2
+    exit 1
+}
+
+run_rollback "$TMP_DIR/target.out" "20260901-120000"
+[[ "$(cat "$TRACE_FILE")" == "rollback 20260901-120000" ]] || {
+    cat "$TMP_DIR/target.out"
+    echo "FAIL: ods rollback did not preserve an explicit snapshot target" >&2
+    exit 1
+}
+
+echo "PASS: ods rollback delegates the complete transaction to ods-update.sh"


### PR DESCRIPTION
## Summary
`cmd_rollback` computed the compose flags **before** `ods-restore.sh` swapped the pre-update `.env`/overlays, then brought the stack back up with those stale flags. When an update changed the stack shape (local↔cloud mode switch, overlay/extension changes regenerating `.compose-flags`), rollback restarted a stack that did not match the restored configuration — leaving the system in a mixed state (restored config files + container set chosen by the failed update).

After a successful restore, re-run `load_env` + `get_compose_flags` so the restarted stack is derived from the restored state. The pre-restore flags are still used for the `down` step, which correctly stops whatever is currently running.

## Test plan
- [ ] `bash -n ods/ods-cli`
- [ ] Repro from #3142: an update that flips local→cloud, failed after recreate, then `ods rollback`; confirm the running stack matches the restored `ODS_MODE`.

Fixes #3142
