### PR TITLE
feat(gpu): expose topology as JSON

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -88,6 +88,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
+	@bash tests/test-gpu-topology-json.sh
 	@echo ""
 	@echo "=== offline model validation ==="
 	@python3 tests/test-offline-model-validation.py

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -5146,21 +5146,59 @@ _gpu_status() {
 }
 
 _gpu_topology() {
-    local force=0
+    local force=0 json_mode=0
     while [[ $# -gt 0 ]]; do
-        case "$1" in --force|-f) force=1 ;; esac
+        case "$1" in
+            --force|-f) force=1 ;;
+            --json) json_mode=1 ;;
+            *) error "Unknown gpu topology option: $1" ;;
+        esac
         shift
     done
 
     check_install
     load_env
 
-    echo -e "${BLUE}━━━ GPU Topology ━━━${NC}"
-    echo ""
-
     if [[ "${GPU_BACKEND:-}" == "apple" ]]; then
+        if [[ "$json_mode" -eq 1 ]]; then
+            command -v jq &>/dev/null || error "jq not found — required for JSON output"
+            local chip memory_bytes gpu_cores
+            chip=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "Apple Silicon")
+            memory_bytes=$(sysctl -n hw.memsize 2>/dev/null || echo 0)
+            [[ "$memory_bytes" =~ ^[0-9]+$ ]] || memory_bytes=0
+            gpu_cores=$(system_profiler SPDisplaysDataType -json 2>/dev/null \
+                | jq -r '.SPDisplaysDataType[0].sppci_cores // empty') || gpu_cores=""
+            jq -cn \
+                --arg chip "$chip" \
+                --argjson memory_bytes "$memory_bytes" \
+                --arg gpu_cores "$gpu_cores" '
+                {
+                    schema_version: "ods.gpu-topology.v1",
+                    backend: "apple",
+                    source: "live",
+                    gpu_count: 1,
+                    integrated: true,
+                    driver_version: null,
+                    gpus: [{
+                        index: 0,
+                        name: $chip,
+                        memory_bytes: $memory_bytes,
+                        gpu_cores: ($gpu_cores | tonumber? // null)
+                    }],
+                    links: [],
+                    numa: {nodes: 1}
+                }'
+            return 0
+        fi
+        echo -e "${BLUE}━━━ GPU Topology ━━━${NC}"
+        echo ""
         echo "  Single integrated GPU (Apple Silicon, unified memory) — no multi-GPU topology to display."
         return 0
+    fi
+
+    if [[ "$json_mode" -eq 0 ]]; then
+        echo -e "${BLUE}━━━ GPU Topology ━━━${NC}"
+        echo ""
     fi
 
     if ! command -v jq &>/dev/null; then
@@ -5178,28 +5216,49 @@ _gpu_topology() {
         topo_lib="$SCRIPT_DIR/installers/lib/nvidia-topo.sh"
         topo_detect_fn="detect_nvidia_topo"
         if ! command -v nvidia-smi &>/dev/null; then
+            [[ "$json_mode" -eq 1 ]] && error "nvidia-smi not found — topology unavailable"
             warn "nvidia-smi not found — topology unavailable"
             return
         fi
     fi
 
     if [[ ! -f "$topo_lib" ]]; then
+        [[ "$json_mode" -eq 1 ]] && error "Topology library not found: $topo_lib"
         warn "Topology library not found: $topo_lib"
         return
     fi
 
     local topo_file="$INSTALL_DIR/config/gpu-topology.json"
-    local topo_json
+    local topo_json source="detected"
 
     if [[ "$force" -eq 0 && -f "$topo_file" ]]; then
         topo_json=$(cat "$topo_file")
+        source="cache"
     else
-        [[ "$force" -eq 1 && -f "$topo_file" ]] && log "Re-detecting topology (--force)..."
+        if [[ "$json_mode" -eq 0 && "$force" -eq 1 && -f "$topo_file" ]]; then
+            log "Re-detecting topology (--force)..."
+        fi
         . "$topo_lib"
-        topo_json=$($topo_detect_fn 2>&1) || { warn "Failed to detect GPU topology"; return; }
+        if ! topo_json=$($topo_detect_fn 2>&1); then
+            [[ "$json_mode" -eq 1 ]] && error "Failed to detect GPU topology"
+            warn "Failed to detect GPU topology"
+            return
+        fi
         echo "$topo_json" > "$topo_file"
         chmod 644 "$topo_file"
-        log "Topology saved to $topo_file"
+        [[ "$json_mode" -eq 0 ]] && log "Topology saved to $topo_file"
+    fi
+
+    if [[ "$json_mode" -eq 1 ]]; then
+        printf '%s\n' "$topo_json" | jq \
+            --arg backend "$backend" \
+            --arg source "$source" \
+            '. + {
+                schema_version: "ods.gpu-topology.v1",
+                backend: $backend,
+                source: $source
+            }'
+        return 0
     fi
 
     local gpu_count driver
@@ -6107,7 +6166,7 @@ cmd_gpu() {
             echo ""
             echo "Subcommands:"
             echo "  status       Per-GPU metrics table with VRAM, util, temp, power"
-            echo "  topology     Show GPU interconnect topology (NVLink, PCIe, NUMA)"
+            echo "  topology     Show GPU interconnect topology (add --json for automation)"
             echo "  assignment   Show current service→GPU mapping from .env"
             echo "  validate     Check GPU config is consistent with live system"
             echo "  reassign     Re-run GPU assignment algorithm and update .env"
@@ -6508,6 +6567,7 @@ EOF
 ${CYAN}Examples:${NC}
   ods gpu status                # Per-GPU metrics (VRAM, util, temp, power)
   ods gpu topology              # Show GPU interconnect topology
+  ods gpu topology --json       # Machine-readable cached/live topology
   ods gpu assignment            # Show service→GPU mapping
   ods gpu validate              # Validate GPU configuration
   ods gpu reassign --auto       # Auto-reassign GPUs after hardware change

--- a/ods/tests/test-gpu-topology-json.sh
+++ b/ods/tests/test-gpu-topology-json.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Public CLI contract for machine-readable NVIDIA, AMD, and Apple topology.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR/install"
+STUB_BIN="$TMP_DIR/bin"
+mkdir -p "$INSTALL_DIR/config" "$STUB_BIN"
+touch "$INSTALL_DIR/docker-compose.base.yml"
+
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+pass() { printf 'PASS: %s\n' "$1"; }
+
+cat > "$STUB_BIN/nvidia-smi" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--list-gpus" ]]; then
+    printf '%s\n' 'GPU 0: Example NVIDIA GPU (UUID: GPU-example)'
+fi
+STUB
+
+cat > "$STUB_BIN/sysctl" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+    *machdep.cpu.brand_string*) printf '%s\n' 'Apple M3 Max' ;;
+    *hw.memsize*) printf '%s\n' '68719476736' ;;
+esac
+STUB
+
+cat > "$STUB_BIN/system_profiler" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' '{"SPDisplaysDataType":[{"sppci_cores":"40"}]}'
+STUB
+chmod +x "$STUB_BIN"/*
+
+run_cli() {
+    ODS_HOME="$INSTALL_DIR" PATH="$STUB_BIN:$PATH" \
+        bash "$ROOT_DIR/ods-cli" gpu topology --json
+}
+
+cat > "$INSTALL_DIR/config/gpu-topology.json" <<'JSON'
+{"gpu_count":1,"driver_version":"600.1","gpus":[{"index":0,"name":"NVIDIA Test"}],"links":[],"numa":{"nodes":1}}
+JSON
+printf '%s\n' 'GPU_BACKEND=nvidia' > "$INSTALL_DIR/.env"
+nvidia_json=$(run_cli)
+jq -e '
+    .schema_version == "ods.gpu-topology.v1" and
+    .backend == "nvidia" and
+    .source == "cache" and
+    .gpu_count == 1 and
+    .gpus[0].name == "NVIDIA Test"
+' <<< "$nvidia_json" >/dev/null || fail "NVIDIA topology JSON contract changed"
+pass "NVIDIA cached topology is exposed as JSON"
+
+cat > "$INSTALL_DIR/config/gpu-topology.json" <<'JSON'
+{"vendor":"amd","gpu_count":2,"driver_version":"7.0","gpus":[{"index":0,"name":"AMD A"},{"index":1,"name":"AMD B"}],"links":[],"numa":{"nodes":1}}
+JSON
+printf '%s\n' 'GPU_BACKEND=amd' > "$INSTALL_DIR/.env"
+amd_json=$(run_cli)
+jq -e '
+    .schema_version == "ods.gpu-topology.v1" and
+    .backend == "amd" and
+    .source == "cache" and
+    .gpu_count == 2 and
+    [.gpus[].name] == ["AMD A", "AMD B"]
+' <<< "$amd_json" >/dev/null || fail "AMD topology JSON contract changed"
+pass "AMD cached topology is exposed as JSON"
+
+printf '%s\n' 'GPU_BACKEND=apple' > "$INSTALL_DIR/.env"
+apple_json=$(run_cli)
+jq -e '
+    .schema_version == "ods.gpu-topology.v1" and
+    .backend == "apple" and
+    .source == "live" and
+    .integrated == true and
+    .gpu_count == 1 and
+    .gpus[0].name == "Apple M3 Max" and
+    .gpus[0].memory_bytes == 68719476736 and
+    .gpus[0].gpu_cores == 40 and
+    .links == [] and
+    .numa.nodes == 1
+' <<< "$apple_json" >/dev/null || fail "Apple topology JSON contract changed"
+pass "Apple integrated topology is exposed as JSON"
+
+cat > "$STUB_BIN/nvidia-smi" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$STUB_BIN/nvidia-smi"
+rm -f "$INSTALL_DIR/config/gpu-topology.json"
+printf '%s\n' 'GPU_BACKEND=nvidia' > "$INSTALL_DIR/.env"
+if broken_json=$(run_cli 2>/dev/null); then
+    fail "JSON mode succeeded without the NVIDIA telemetry boundary"
+fi
+[[ -z "$broken_json" ]] || fail "JSON failure polluted stdout with non-JSON output"
+pass "topology JSON fails cleanly when live NVIDIA detection is unavailable"


### PR DESCRIPTION
## Summary - add `ods gpu topology --json` with the versioned `ods.gpu-topology.v1` contract - preserve native NVIDIA/AMD detector fields while adding backend and cache/live provenance - model Apple Silicon as one integrated GPU with unified-memory bytes and GPU-core metadata - fail JSON mode non-zero without polluting stdout when live detection cannot produce a report  ## Why this matters The topology command currently renders only a terminal matrix, so provisioning systems and support tools must scrape spacing, Unicode separators, and backend-specific prose. ODS already computes a structured topology for assignment and the dashboard; this change exposes that production contract directly. The invariant is that automation receives either one valid JSON document covering the selected backend or a non-zero result with clean stdout.  ## Overlap check Searched open and closed PR titles/bodies for `gpu topology JSON`, `machine-readable GPU topology`, `ods.gpu-topology`, and the `_gpu_topology` production function. #2389 makes installer writes of `gpu-topology.json` atomic, and #2013 enriches AMD PCIe fields; neither exposes the topology through the CLI. This PR preserves and forwards those detector fields, so both changes compose without duplicating them.  ## Regression test A public CLI contract invokes `ods gpu topology --json` through real argument dispatch with hermetic host-command doubles. It covers: - cached NVIDIA topology and provenance - cached AMD multi-GPU topology and provenance - live Apple integrated topology, unified memory, and core count - clean non-zero failure when NVIDIA live detection is unavailable  Focused validation: - `make lint` - `bash tests/test-gpu-topology-json.sh` (4 passed) - `bash tests/test-nvidia-topo.sh` (7 passed) - `bash tests/test-gpu-reassign-manual.sh` (passed) - `bash -n ods-cli tests/test-gpu-topology-json.sh` - `git diff --check`  The older `test-gpu-apple.sh` reached 20/21 assertions; its sole failure is an existing hermeticity assumption that `nvidia-smi` is absent from the host PATH. This Windows/WSL host exposes a real `nvidia-smi`, so its negative NVIDIA case observes a real GPU instead of the expected missing-tool warning. The Apple topology assertions touched here pass.  ## Platform scope, tradeoffs, and rollback NVIDIA and AMD output forwards the same cached or freshly detected object used by the human renderer, augmented with schema/backend/source keys. Apple has no discrete topology file, so it reports a live one-node integrated topology. Human output is unchanged. Reverting removes the JSON mode and test wiring without changing detection, cache contents, assignment, or GPU runtime settings.  Generated with Codex ## Batch compatibility Synthetic integration head `1f3e55969d4c4ac729d69730ce25548c02c62d50` merged #3505, #3506, #3507, and #3508 in that order with no conflicts. `make lint` plus all four new public-boundary tests passed on the combined tree; the broader affected suites had already passed on the prior synthetic head. The first three scopes are independent and may merge in any order. #3508 remains draft and must retain independent human review because it touches the destructive uninstaller path. 