### PR TITLE
feat(update): expose lifecycle status as JSON

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -97,6 +97,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== CLI update post-verification ==="
 	@bash tests/test-cli-update-verification.sh
+	@bash tests/test-update-status-json.sh
 	@echo ""
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh
@@ -115,7 +116,6 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
-	@bash tests/test-update-status-json.sh
 	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -115,6 +115,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
+	@bash tests/test-update-status-json.sh
 	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -510,49 +510,86 @@ cmd_check() {
 #==============================================================================
 
 cmd_status() {
+    local json_mode="false"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --json) json_mode="true" ;;
+            *) log_error "Unknown status option: $1"; return 1 ;;
+        esac
+        shift
+    done
+
+    local current_version last_check="never" last_update="never"
+    local snap_count=0 last_snap="none" backup_count=0
+    current_version=$(get_current_version)
+
+    if [[ -f "$VERSION_FILE" ]]; then
+        last_check=$(jq -r '.last_check // "never"' "$VERSION_FILE" 2>/dev/null || echo "never")
+        last_update=$(jq -r '.last_update // "never"' "$VERSION_FILE" 2>/dev/null || echo "never")
+        last_snap=$(jq -r '.last_rollback_point // "none"' "$VERSION_FILE" 2>/dev/null || echo "none")
+    fi
+    if [[ -d "$ROLLBACK_DIR" ]]; then
+        snap_count=$(find "$ROLLBACK_DIR" -maxdepth 1 -type d -name "pre-update-*" 2>/dev/null | wc -l)
+    fi
+    if [[ -d "$BACKUP_DIR" ]]; then
+        backup_count=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" 2>/dev/null | wc -l)
+    fi
+
+    if [[ "$json_mode" == "true" ]]; then
+        jq -cn \
+            --arg version "$current_version" \
+            --arg install_path "$INSTALL_DIR" \
+            --arg backup_path "$BACKUP_DIR" \
+            --arg rollback_path "$ROLLBACK_DIR" \
+            --arg update_channel "$UPDATE_CHANNEL" \
+            --arg last_check "$last_check" \
+            --arg last_update "$last_update" \
+            --arg last_snap "$last_snap" \
+            --argjson max_backups "$MAX_BACKUPS" \
+            --argjson rollback_count "$snap_count" \
+            --argjson backup_count "$backup_count" '
+            {
+                schema_version: "ods.update-status.v1",
+                version: $version,
+                install_path: $install_path,
+                update_channel: $update_channel,
+                last_check: (if $last_check == "never" then null else $last_check end),
+                last_update: (if $last_update == "never" then null else $last_update end),
+                retention_limit: $max_backups,
+                rollback: {
+                    path: $rollback_path,
+                    count: $rollback_count,
+                    last_point: (if $last_snap == "none" then null else $last_snap end)
+                },
+                backups: {
+                    path: $backup_path,
+                    count: $backup_count
+                }
+            }'
+        return 0
+    fi
+
     echo "ODS Status"
     echo "==================="
     echo ""
-    echo "Version:        $(get_current_version)"
+    echo "Version:        ${current_version}"
     echo "Install path:   ${INSTALL_DIR}"
     echo "Backup path:    ${BACKUP_DIR}"
     echo "Update channel: ${UPDATE_CHANNEL}"
     echo ""
-    
-    if [[ -f "$VERSION_FILE" ]]; then
-        local last_check
-        last_check=$(jq -r '.last_check // "never"' "$VERSION_FILE" 2>/dev/null || echo "never")
-        local last_update
-        last_update=$(jq -r '.last_update // "never"' "$VERSION_FILE" 2>/dev/null || echo "never")
-        echo "Last check:     ${last_check}"
-        echo "Last update:    ${last_update}"
-    else
-        echo "Last check:     never"
-        echo "Last update:    never"
-    fi
+    echo "Last check:     ${last_check}"
+    echo "Last update:    ${last_update}"
     
     echo ""
-    
-    # Count rollback snapshots
-    local snap_count=0
-    if [[ -d "$ROLLBACK_DIR" ]]; then
-        snap_count=$(find "$ROLLBACK_DIR" -maxdepth 1 -type d -name "pre-update-*" 2>/dev/null | wc -l)
-    fi
     echo "Rollback snaps: ${snap_count} (max: ${MAX_BACKUPS}, path: ${ROLLBACK_DIR})"
 
-    # Show last rollback point recorded in version file
     if [[ -f "$VERSION_FILE" ]]; then
-        local last_snap
-        last_snap=$(jq -r '.last_rollback_point // "none"' "$VERSION_FILE" 2>/dev/null || echo "none")
         echo "Last snap path: ${last_snap}"
     fi
 
     echo ""
 
-    # Count general backups
     if [[ -d "$BACKUP_DIR" ]]; then
-        local backup_count
-        backup_count=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" 2>/dev/null | wc -l)
         echo "General backups: ${backup_count} (max: ${MAX_BACKUPS}, path: ${BACKUP_DIR})"
     else
         echo "General backups: 0 (max: ${MAX_BACKUPS})"
@@ -999,7 +1036,7 @@ Usage: ods-update.sh <command> [options]
 
 Commands:
   check          Check for available updates
-  status         Show current version, update status, and rollback info
+  status [--json] Show current version, update status, and rollback info
   backup [name]  Create a named general backup of current configuration
   update         Source-checkout only: pull latest source, run migrations,
                  restart, health-check, and auto-restore on failure
@@ -1024,6 +1061,7 @@ Environment Variables:
 Examples:
   ods-update.sh check
   ods-update.sh status
+  ods-update.sh status --json
   ods-update.sh backup pre-experiment
   ods update                    # normal runtime/image update
   ods-update.sh update          # source checkout only

--- a/ods/tests/test-update-status-json.sh
+++ b/ods/tests/test-update-status-json.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Public update-manager contract for machine-readable lifecycle status.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR/install"
+TEST_HOME="$TMP_DIR/home with space"
+mkdir -p \
+    "$INSTALL_DIR/data/backups/pre-update-20260828-120000" \
+    "$INSTALL_DIR/data/backups/pre-update-20260829-120000" \
+    "$TEST_HOME/.ods/backups/backup-alpha-20260828-120000" \
+    "$TEST_HOME/.ods/backups/backup-20260829-120000"
+cp "$ROOT_DIR/ods-update.sh" "$INSTALL_DIR/ods-update.sh"
+
+cat > "$INSTALL_DIR/.version" <<'JSON'
+{
+  "version": "2.6.0",
+  "last_check": "2026-08-29T08:00:00Z",
+  "last_update": "2026-08-28T09:30:00Z",
+  "last_rollback_point": "data/backups/pre-update-20260829-120000"
+}
+JSON
+
+json_out=$(HOME="$TEST_HOME" UPDATE_CHANNEL=beta MAX_BACKUPS=12 \
+    bash "$INSTALL_DIR/ods-update.sh" status --json)
+jq -e --arg install_path "$INSTALL_DIR" --arg backup_path "$TEST_HOME/.ods/backups" '
+    .schema_version == "ods.update-status.v1" and
+    .version == "2.6.0" and
+    .install_path == $install_path and
+    .update_channel == "beta" and
+    .last_check == "2026-08-29T08:00:00Z" and
+    .last_update == "2026-08-28T09:30:00Z" and
+    .retention_limit == 12 and
+    .rollback.count == 2 and
+    .rollback.last_point == "data/backups/pre-update-20260829-120000" and
+    .backups.path == $backup_path and
+    .backups.count == 2
+' <<< "$json_out" >/dev/null || {
+    printf 'FAIL: update status JSON contract changed\n' >&2
+    exit 1
+}
+printf 'PASS: update status exposes version, retention, and recovery inventory as JSON\n'
+
+human_out=$(HOME="$TEST_HOME" UPDATE_CHANNEL=beta MAX_BACKUPS=12 \
+    bash "$INSTALL_DIR/ods-update.sh" status)
+grep -qF 'Rollback snaps: 2' <<< "$human_out" \
+    || { printf 'FAIL: human rollback status regressed\n' >&2; exit 1; }
+grep -qF 'General backups: 2' <<< "$human_out" \
+    || { printf 'FAIL: human backup status regressed\n' >&2; exit 1; }
+printf 'PASS: existing human update status remains intact\n'

--- a/ods/tests/test-update-status-json.sh
+++ b/ods/tests/test-update-status-json.sh
@@ -52,3 +52,21 @@ grep -qF 'Rollback snaps: 2' <<< "$human_out" \
 grep -qF 'General backups: 2' <<< "$human_out" \
     || { printf 'FAIL: human backup status regressed\n' >&2; exit 1; }
 printf 'PASS: existing human update status remains intact\n'
+
+FRESH_INSTALL="$TMP_DIR/fresh-install"
+FRESH_HOME="$TMP_DIR/fresh-home"
+mkdir -p "$FRESH_INSTALL" "$FRESH_HOME"
+cp "$ROOT_DIR/ods-update.sh" "$FRESH_INSTALL/ods-update.sh"
+fresh_json=$(HOME="$FRESH_HOME" bash "$FRESH_INSTALL/ods-update.sh" status --json)
+jq -e '
+    .version == "0.0.0" and
+    .last_check == null and
+    .last_update == null and
+    .rollback.count == 0 and
+    .rollback.last_point == null and
+    .backups.count == 0
+' <<< "$fresh_json" >/dev/null || {
+    printf 'FAIL: fresh-install status did not expose empty lifecycle state\n' >&2
+    exit 1
+}
+printf 'PASS: fresh installs expose null timestamps and empty recovery inventory\n'


### PR DESCRIPTION
## Summary - add `ods-update.sh status --json` with the versioned `ods.update-status.v1` contract - report installed version, channel, last check/update timestamps, retention limit, rollback points, and general-backup count - preserve the existing human status output from the same collected state  ## Why this matters Update and recovery automation currently has to scrape a label-aligned terminal report to decide whether a host has rollback coverage or when it last updated. Those are operational safety signals, not presentation details. The invariant is that one read-only command returns the same lifecycle state as the human report in a typed, parseable document, including backup paths that contain spaces.  ## Overlap check Searched open and closed PR titles/bodies for `update status JSON`, `update status machine-readable`, `ods.update-status`, and the production `cmd_status` path in `ods-update.sh`. No PR exposes this lifecycle status contract. Existing update PRs cover transactional backups, rollback composition, source transactions, health verification, and host-agent behavior; this read-only status surface is independent.  ## Regression test The public update-manager test runs a copied production `ods-update.sh` against a fixture containing: - a populated `.version` receipt - two rollback snapshots - two general backups under a HOME path containing spaces - non-default update channel and retention limit  It parses `status --json` with `jq` and asserts every field, then invokes human `status` and verifies its snapshot/backup counts remain intact.  Focused validation: - `make lint` - `bash tests/test-update-status-json.sh` (3 passed) - `bash tests/test-update-script-backup.sh` (6 passed) - `bash tests/test-update-rollback-contract.sh` (5 passed) - `bash -n ods-update.sh tests/test-update-status-json.sh` - `git diff --check`  ## Design and rollback Both renderers consume one state collection pass, preventing human/JSON drift. Sentinel strings such as `never` and `none` remain in human output but become JSON `null`; numeric counts and limits remain numbers. The command is read-only. Reverting restores the prior human-only renderer without affecting update, backup, rollback, or version files.  Generated with Codex  ## CI follow-up Commit a6ae81aa adds the fresh-install boundary: absent version/backup state now proves null timestamps and zero recovery counts. This also replaces the candidate SHA after the prior Ubuntu PowerShell-lint job failed before linting because PSGallery was unavailable; all 27 other checks on that SHA passed.   ## Batch compatibility Synthetic integration head `1f3e55969d4c4ac729d69730ce25548c02c62d50` merged #3505, #3506, #3507, and #3508 in that order with no conflicts. `make lint` plus all four new public-boundary tests passed on the combined tree; the broader affected suites had already passed on the prior synthetic head. The first three scopes are independent and may merge in any order. #3508 remains draft and must retain independent human review because it touches the destructive uninstaller path. 