### PR TITLE
feat(uninstall): add dry-run plans

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -136,6 +136,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== macOS uninstall LaunchAgent cleanup ==="
 	@bash tests/test-macos-uninstall-launchagents.sh
+	@bash tests/test-uninstall-dry-run.sh
 	@echo ""
 	@echo "=== token-spy session manager active-id extraction ==="
 	@bash tests/test-token-spy-session-manager.sh

--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # ods-uninstall.sh - ODS Clean Uninstaller
 # Removes all ODS components, data, and system modifications.
-# Usage: ./ods-uninstall.sh [--keep-models] [--keep-data] [--force]
+# Usage: ./ods-uninstall.sh [--keep-models] [--keep-data] [--force] [--dry-run [--json]]
 
 set -euo pipefail
 
@@ -48,15 +48,134 @@ resolve_compose_flags() {
     printf '%s\n' "$flags"
 }
 
+emit_uninstall_plan() {
+    local json_mode="$1"
+    local compose_flags containers="" volumes=""
+    local containers_json='[]' volumes_json='[]'
+    compose_flags=$(resolve_compose_flags)
+
+    if command -v docker &>/dev/null; then
+        containers=$(docker ps -a --format '{{.Names}}' 2>/dev/null \
+            | grep -E '^ods-' || true)
+        if [[ "$KEEP_DATA" != "true" ]]; then
+            volumes=$(docker volume ls --format '{{.Name}}' 2>/dev/null \
+                | grep -E '^ods[_-]' || true)
+        fi
+    fi
+    containers_json=$(printf '%s\n' "$containers" \
+        | jq -Rsc 'split("\n") | map(select(length > 0))')
+    volumes_json=$(printf '%s\n' "$volumes" \
+        | jq -Rsc 'split("\n") | map(select(length > 0))')
+
+    local install_action="remove" model_action="remove"
+    local preserved_data_path="" model_backup_path=""
+    if [[ "$KEEP_DATA" == "true" ]]; then
+        install_action="preserve-data"
+        preserved_data_path="$INSTALL_DIR/data"
+    fi
+    if [[ "$KEEP_MODELS" == "true" && -d "$INSTALL_DIR/data/models" ]]; then
+        model_action="preserve-separately"
+        model_backup_path="$HOME/.ods-models-backup"
+    elif [[ "$KEEP_DATA" == "true" ]]; then
+        model_action="preserve-with-data"
+    fi
+
+    local plan
+    plan=$(jq -cn \
+        --arg install_dir "$INSTALL_DIR" \
+        --arg compose_flags "$compose_flags" \
+        --argjson keep_data "$KEEP_DATA" \
+        --argjson keep_models "$KEEP_MODELS" \
+        --argjson containers "$containers_json" \
+        --argjson volumes "$volumes_json" \
+        --arg install_action "$install_action" \
+        --arg preserved_data_path "$preserved_data_path" \
+        --arg model_action "$model_action" \
+        --arg model_backup_path "$model_backup_path" \
+        --arg backup_dir "$HOME/.ods" '
+        {
+            schema_version: "ods.uninstall-plan.v1",
+            dry_run: true,
+            mutates: false,
+            install_dir: $install_dir,
+            options: {keep_data: $keep_data, keep_models: $keep_models},
+            compose: {
+                flags: $compose_flags,
+                containers: $containers,
+                volumes: $volumes,
+                remove_volumes: ($keep_data | not)
+            },
+            filesystem: {
+                install_action: $install_action,
+                preserved_data_path: (
+                    if $preserved_data_path == "" then null else $preserved_data_path end
+                ),
+                models: {
+                    action: $model_action,
+                    backup_path: (
+                        if $model_backup_path == "" then null else $model_backup_path end
+                    )
+                },
+                backup_dir: {path: $backup_dir, action: "remove"},
+                cli_symlink_candidates: [
+                    "/usr/local/bin/ods",
+                    ($ENV.HOME + "/.local/bin/ods"),
+                    "/usr/local/bin/ods-cli"
+                ],
+                desktop_file: ($ENV.HOME + "/.local/share/applications/ods.desktop"),
+                opencode_config: ($ENV.HOME + "/.config/opencode/opencode.json")
+            },
+            services: {
+                systemd_user_candidates: [
+                    "opencode-web.service",
+                    "openclaw-session-cleanup.timer",
+                    "memory-shepherd-workspace.timer",
+                    "memory-shepherd-memory.timer",
+                    "openclaw-session-cleanup.service",
+                    "memory-shepherd-workspace.service",
+                    "memory-shepherd-memory.service",
+                    "ods-host-agent.service"
+                ],
+                systemd_system_candidates: ["ods-host-agent.service"],
+                launch_agent_candidates: [
+                    "com.ods.llm-bridge",
+                    "com.ods.host-agent-bridge",
+                    "com.ods.host-agent",
+                    "com.ods.opencode-web",
+                    "com.ods.llama-server",
+                    "com.ods.full-model-download"
+                ]
+            }
+        }')
+
+    if [[ "$json_mode" == "true" ]]; then
+        printf '%s\n' "$plan"
+        return 0
+    fi
+
+    echo "ODS uninstall dry run"
+    echo "Install action:  $install_action ($INSTALL_DIR)"
+    echo "Containers:      $(jq -r '.compose.containers | length' <<< "$plan")"
+    echo "Volumes:         $(jq -r '.compose.volumes | length' <<< "$plan")"
+    echo "Keep data:       $KEEP_DATA"
+    echo "Keep models:     $KEEP_MODELS"
+    echo "Backup dir:      $HOME/.ods (remove)"
+    echo "No changes made. Re-run without --dry-run to uninstall."
+}
+
 KEEP_MODELS=false
 KEEP_DATA=false
 FORCE=false
+DRY_RUN=false
+JSON_MODE=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --keep-models) KEEP_MODELS=true; shift ;;
         --keep-data)   KEEP_DATA=true; shift ;;
         --force)       FORCE=true; shift ;;
+        --dry-run)     DRY_RUN=true; shift ;;
+        --json)        JSON_MODE=true; shift ;;
         -h|--help)
             cat << EOF
 ODS Uninstaller
@@ -67,6 +186,8 @@ Options:
     --keep-models   Keep downloaded AI models (saves re-download time)
     --keep-data     Keep user data (chat history, n8n workflows, etc.)
     --force         Skip confirmation prompts
+    --dry-run       Preview uninstall scope without changing the host
+    --json          Emit --dry-run as machine-readable JSON
     -h, --help      Show this help
 
 This will remove:
@@ -84,11 +205,18 @@ EOF
     esac
 done
 
-echo ""
-echo -e "${RED}╔══════════════════════════════════════════════════╗${NC}"
-echo -e "${RED}║         ODS UNINSTALLER                ║${NC}"
-echo -e "${RED}╚══════════════════════════════════════════════════╝${NC}"
-echo ""
+if [[ "$JSON_MODE" == "true" && "$DRY_RUN" != "true" ]]; then
+    log_error "--json requires --dry-run"
+    exit 1
+fi
+
+if [[ "$JSON_MODE" != "true" ]]; then
+    echo ""
+    echo -e "${RED}╔══════════════════════════════════════════════════╗${NC}"
+    echo -e "${RED}║         ODS UNINSTALLER                ║${NC}"
+    echo -e "${RED}╚══════════════════════════════════════════════════╝${NC}"
+    echo ""
+fi
 
 # Detect install dir
 if [[ -d "$SCRIPT_DIR" && -f "$SCRIPT_DIR/ods-cli" ]]; then
@@ -100,10 +228,12 @@ if [[ ! -d "$INSTALL_DIR" ]]; then
     exit 1
 fi
 
-log_info "Install directory: $INSTALL_DIR"
-$KEEP_MODELS && log_info "Keeping models (--keep-models)"
-$KEEP_DATA && log_info "Keeping user data (--keep-data)"
-echo ""
+if [[ "$JSON_MODE" != "true" ]]; then
+    log_info "Install directory: $INSTALL_DIR"
+    $KEEP_MODELS && log_info "Keeping models (--keep-models)"
+    $KEEP_DATA && log_info "Keeping user data (--keep-data)"
+    echo ""
+fi
 
 if [[ -f "$INSTALL_DIR/.env" ]]; then
     if [[ -f "$INSTALL_DIR/lib/safe-env.sh" ]]; then
@@ -113,6 +243,11 @@ if [[ -f "$INSTALL_DIR/.env" ]]; then
     else
         log_warn "safe-env.sh not found; using uninstall defaults without loading .env"
     fi
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    emit_uninstall_plan "$JSON_MODE"
+    exit 0
 fi
 
 if [[ "$FORCE" != "true" ]]; then

--- a/ods/tests/test-uninstall-dry-run.sh
+++ b/ods/tests/test-uninstall-dry-run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Public dry-run contract: enumerate uninstall scope without mutating the host.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR/ODS install"
+TEST_HOME="$TMP_DIR/home"
+STUB_BIN="$TMP_DIR/bin"
+DOCKER_LOG="$TMP_DIR/docker.log"
+mkdir -p "$INSTALL_DIR/lib" "$INSTALL_DIR/data/models" "$TEST_HOME/.ods" "$STUB_BIN"
+cp "$ROOT_DIR/ods-uninstall.sh" "$INSTALL_DIR/ods-uninstall.sh"
+touch "$INSTALL_DIR/ods-cli" "$INSTALL_DIR/data/models/model.gguf"
+printf '%s\n' '-f docker-compose.base.yml' > "$INSTALL_DIR/.compose-flags"
+printf '%s\n' 'GPU_BACKEND=nvidia' > "$INSTALL_DIR/.env"
+
+cat > "$INSTALL_DIR/lib/safe-env.sh" <<'STUB'
+load_env_file() { return 0; }
+STUB
+
+cat > "$STUB_BIN/docker" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$DOCKER_LOG"
+case "$*" in
+    'ps -a --format {{.Names}}') printf '%s\n' ods-dashboard unrelated ods-llama-server ;;
+    'volume ls --format {{.Name}}') printf '%s\n' ods_data unrelated ods-models ;;
+esac
+STUB
+chmod +x "$STUB_BIN/docker"
+
+run_plan() {
+    HOME="$TEST_HOME" PATH="$STUB_BIN:$PATH" DOCKER_LOG="$DOCKER_LOG" \
+        bash "$INSTALL_DIR/ods-uninstall.sh" "$@"
+}
+
+default_json=$(run_plan --dry-run --json)
+jq -e --arg install_dir "$INSTALL_DIR" '
+    .schema_version == "ods.uninstall-plan.v1" and
+    .dry_run == true and
+    .mutates == false and
+    .install_dir == $install_dir and
+    .options == {keep_data: false, keep_models: false} and
+    .compose.flags == "-f docker-compose.base.yml" and
+    .compose.containers == ["ods-dashboard", "ods-llama-server"] and
+    .compose.volumes == ["ods_data", "ods-models"] and
+    .compose.remove_volumes == true and
+    .filesystem.install_action == "remove" and
+    .filesystem.backup_dir.action == "remove"
+' <<< "$default_json" >/dev/null || {
+    printf 'FAIL: default uninstall plan contract changed\n' >&2
+    exit 1
+}
+printf 'PASS: default uninstall plan exposes destructive scope\n'
+
+preserve_json=$(run_plan --keep-data --keep-models --dry-run --json)
+jq -e --arg data_path "$INSTALL_DIR/data" --arg model_path "$TEST_HOME/.ods-models-backup" '
+    .options == {keep_data: true, keep_models: true} and
+    .compose.volumes == [] and
+    .compose.remove_volumes == false and
+    .filesystem.install_action == "preserve-data" and
+    .filesystem.preserved_data_path == $data_path and
+    .filesystem.models == {action: "preserve-separately", backup_path: $model_path}
+' <<< "$preserve_json" >/dev/null || {
+    printf 'FAIL: preservation options were not reflected in uninstall plan\n' >&2
+    exit 1
+}
+printf 'PASS: preservation options change the plan without changing host state\n'
+
+data_only_json=$(run_plan --keep-data --dry-run --json)
+jq -e '
+    .filesystem.models == {action: "preserve-with-data", backup_path: null}
+' <<< "$data_only_json" >/dev/null || {
+    printf 'FAIL: data preservation did not account for the model directory\n' >&2
+    exit 1
+}
+printf 'PASS: keep-data reports models preserved in place\n'
+
+[[ -f "$INSTALL_DIR/data/models/model.gguf" ]] \
+    || { printf 'FAIL: dry run removed model data\n' >&2; exit 1; }
+[[ -d "$TEST_HOME/.ods" ]] \
+    || { printf 'FAIL: dry run removed backup data\n' >&2; exit 1; }
+if grep -Eq 'compose .*down|volume rm|rm -f' "$DOCKER_LOG"; then
+    printf 'FAIL: dry run invoked a destructive Docker command\n' >&2
+    exit 1
+fi
+printf 'PASS: dry run performs discovery only\n'
+
+human_out=$(run_plan --dry-run)
+grep -qF 'No changes made.' <<< "$human_out" \
+    || { printf 'FAIL: human dry run omitted the no-mutation receipt\n' >&2; exit 1; }
+printf 'PASS: human dry run reports that no changes were made\n'


### PR DESCRIPTION
**Ready for independent review (2026-09-15).** Candidate `a32796a203b674263be0bb18da28e5b12bc3cac9` has a successful GitHub check rollup and no base-branch conflict at this review snapshot. This supersedes earlier draft-status wording only. All validation gaps, migration requirements, live gates and independent human review requirements below remain in force; this is not a merge-ready approval.

## Summary - add read-only `ods-uninstall.sh --dry-run` and `--dry-run --json` - enumerate resolved Compose flags, discovered ODS containers/volumes, filesystem cleanup, preservation behavior, and service-definition candidates - return before confirmation and before every destructive host operation  ## Why this matters Uninstall is ODS's broadest destructive workflow, but operators currently cannot inspect its resolved scope before confirming. In particular, `--keep-data` changes volume removal and install-directory cleanup, while `--keep-models` moves model data to a separate path. The invariant is that dry-run performs discovery only, accurately reflects those preservation choices, emits an explicit `mutates: false` receipt, and never reaches Docker cleanup or filesystem deletion.  ## Overlap check Searched open and closed PR titles/bodies for `uninstall dry run`, `uninstall plan`, `ods.uninstall-plan`, and the production `ods-uninstall.sh` path. No PR adds a preview mode. Existing uninstall PRs scope Docker discovery, protect the source checkout, handle unavailable sudo, and remove host-service remnants; this feature reports the targets produced by those behaviors without replacing them.  ## Regression test The public uninstaller test runs a copied production script from an install path containing spaces with hermetic Docker discovery. It asserts: - the versioned `ods.uninstall-plan.v1` document - exact resolved Compose flags and filtered ODS container/volume discovery - default destructive scope - `--keep-data` and `--keep-models` preservation semantics - model and backup files remain present - Docker receives discovery calls only, never `compose down`, `volume rm`, or container removal - human dry-run emits a no-mutation receipt  Focused validation: - `make lint` - `bash tests/test-uninstall-dry-run.sh` (5 passed) - `bash tests/test-uninstall-compose-flags.sh` (7 passed) - `bash tests/test-windows-uninstall-command.sh` (passed) - `bash -n ods-uninstall.sh tests/test-uninstall-dry-run.sh` - `git diff --check`  `test-macos-uninstall-launchagents.sh` passed its first three scenarios, then its existing permission-failure fixture failed because this environment runs as root: root can remove a plist from a `chmod 555` directory, so the fixture cannot induce the expected warning. The changed normal uninstall path is not reached by dry-run, and the preceding LaunchAgent cleanup scenarios passed.  ## Safety, tradeoffs, and rollback The JSON plan distinguishes discovered Docker targets from static service/file candidates and never includes secrets. `--json` is rejected unless paired with `--dry-run`. Because this touches the destructive uninstaller control flow, this PR is Ready for review and still requires independent human review before merge even if CI is green. Reverting removes only the early preview path; existing confirmation and uninstall behavior remain unchanged.  Generated with Codex ## Batch compatibility Synthetic integration head `1f3e55969d4c4ac729d69730ce25548c02c62d50` merged #3505, #3506, #3507, and #3508 in that order with no conflicts. `make lint` plus all four new public-boundary tests passed on the combined tree; the broader affected suites had already passed on the prior synthetic head. The first three scopes are independent and may merge in any order. #3508 remains subject to independent human review because it touches the destructive uninstaller path. 