### PR TITLE
feat(installer): support Docker Model Runner

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -94,11 +94,14 @@ OPEN_WEBUI_LLM_BASE_URL=
 OPEN_WEBUI_LLM_API_KEY=
 # LLM_URL=                  # Optional dashboard-api diagnostics override; normally follows LLM_API_URL
 
-# Reuse a host-managed Ollama or LM Studio model instead of downloading and
-# starting ODS's llama-server. Configure this through install.sh so the
+# Reuse a host-managed Ollama, LM Studio, or Docker Model Runner model instead
+# of starting ODS's llama-server. Configure this through install.sh so the
 # endpoint/model are validated and the Compose topology is updated atomically:
 #   ./install.sh --external-llm-url http://127.0.0.1:11434 \
 #     --external-llm-provider ollama --external-llm-model qwen3.5:9b
+# Docker Model Runner exposes its OpenAI API under /engines/v1:
+#   ./install.sh --external-llm-url http://127.0.0.1:12434 \
+#     --external-llm-provider docker-model-runner --external-llm-model ai/qwen2.5-coder
 # Interactive installs can discover a matching model and ask before reuse.
 # Non-interactive discovery is opt-in with --reuse-external-llm.
 # Use ./install.sh --no-external-llm to return a persisted install to managed

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -132,7 +132,7 @@
     },
     "EXTERNAL_LLM_URL": {
       "type": "string",
-      "description": "Host-facing base URL of an installer-validated Ollama or LM Studio runtime. Configure with install.sh rather than editing this field alone.",
+      "description": "Host-facing base URL of an installer-validated Ollama, LM Studio, or Docker Model Runner runtime. Configure with install.sh rather than editing this field alone.",
       "default": ""
     },
     "EXTERNAL_LLM_CONTAINER_URL": {
@@ -146,7 +146,8 @@
       "enum": [
         "",
         "ollama",
-        "lmstudio"
+        "lmstudio",
+        "docker-model-runner"
       ],
       "default": ""
     },
@@ -176,12 +177,12 @@
     },
     "LLM_API_BASE_PATH": {
       "type": "string",
-      "description": "Base API path for the inference backend",
+      "description": "Base API path for the inference backend, including /engines/v1 for Docker Model Runner",
       "default": "/v1"
     },
     "ODS_TALK_VISION_URL": {
       "type": "string",
-      "description": "Optional OpenAI-compatible base URL for ODS Talk image attachments. Accepts either a host root or a base path ending in /v1 or /api/v1.",
+      "description": "Optional OpenAI-compatible base URL for ODS Talk image attachments. Accepts either a host root or a provider path such as /v1, /api/v1, or /engines/v1.",
       "default": ""
     },
     "ODS_TALK_VISION_KEY": {

--- a/ods/docker-compose.external-llm.yml
+++ b/ods/docker-compose.external-llm.yml
@@ -1,4 +1,4 @@
-# Host-managed Ollama / LM Studio overlay.
+# Host-managed Ollama, LM Studio, or Docker Model Runner overlay.
 #
 # The selected endpoint is reached through host.docker.internal. The explicit
 # host-gateway mappings make that name available on plain Linux Docker Engine
@@ -25,8 +25,8 @@ services:
       - "host.docker.internal:host-gateway"
     environment:
       LLM_BACKEND: external
-      LLM_API_BASE_PATH: /v1
-      ODS_TALK_VISION_URL: "${EXTERNAL_LLM_CONTAINER_URL}/v1"
+      LLM_API_BASE_PATH: "${LLM_API_BASE_PATH:-/v1}"
+      ODS_TALK_VISION_URL: "${EXTERNAL_LLM_CONTAINER_URL}${LLM_API_BASE_PATH:-/v1}"
       AMD_INFERENCE_RUNTIME: ""
       AMD_INFERENCE_BACKEND: ""
       AMD_INFERENCE_LOCATION: ""

--- a/ods/docs/FAQ.md
+++ b/ods/docs/FAQ.md
@@ -307,7 +307,7 @@ Applying a template only enables services — it doesn't disable anything you've
 
 ---
 
-### Can ODS reuse a model already running in Ollama or LM Studio?
+### Can ODS reuse a model already running in Ollama, LM Studio, or Docker Model Runner?
 
 The Linux installer can reuse a host-managed text/chat model instead of
 downloading and starting a duplicate GGUF with ODS's llama-server.
@@ -328,6 +328,21 @@ Or configure the endpoint and exact provider model directly:
   --external-llm-model qwen3.5:9b
 ```
 
+Docker Model Runner uses a different OpenAI-compatible base path. Enable its
+host TCP endpoint first, pull a model, then select the exact namespaced id:
+
+```bash
+docker model pull ai/qwen2.5-coder
+./install.sh \
+  --external-llm-url http://127.0.0.1:12434 \
+  --external-llm-provider docker-model-runner \
+  --external-llm-model ai/qwen2.5-coder
+```
+
+Docker Desktop requires host-side TCP support for port 12434. Docker Engine
+enables that port by default. Keep the endpoint local: Docker Model Runner's
+API does not authenticate callers.
+
 The installer verifies the model and a real completion before changing the
 Compose topology. Open WebUI, ODS Talk, Hermes, Perplexica, Privacy Shield, and
 Token Spy then use the container-safe external endpoint. ODS does not stop the
@@ -341,7 +356,7 @@ To return an existing installation to ODS-managed llama-server:
 ```
 
 This integration routes text/chat inference; it does not import or synchronize
-Ollama/LM Studio model files, VLMs, embedding models, or rerankers. The
+external provider's model files, VLMs, embedding models, or rerankers. The
 installer flags in this release are Linux-only. Windows Lemonade and macOS
 native llama-server keep their existing platform lifecycle.
 

--- a/ods/docs/INSTALLER-ARCHITECTURE.md
+++ b/ods/docs/INSTALLER-ARCHITECTURE.md
@@ -35,7 +35,7 @@ installers/
   phases/                     # Sequential install steps — execute on source
     01-preflight.sh           #   Root/OS/tools checks, existing installation check
     02-detection.sh           #   Hardware detection → tier assignment → compose config
-    02b-external-services.sh  #   Validate/offer host Ollama or LM Studio reuse
+    02b-external-services.sh  #   Validate/offer host model runtime reuse
     03-features.sh            #   Interactive feature selection menu
     04-requirements.sh        #   RAM, disk, GPU, and port availability checks
     05-docker.sh              #   Install Docker, Docker Compose, NVIDIA Container Toolkit
@@ -137,7 +137,8 @@ Perplexica's persisted `defaultChatModel` must be refreshed after bootstrap
 hot-swap.
 
 Linux external-LLM reuse is an explicit topology choice, not ambient discovery
-state. Interactive installs may offer a matching Ollama or LM Studio model;
+state. Interactive installs may offer a matching Ollama, LM Studio, or Docker
+Model Runner model;
 non-interactive installs adopt one only with `--reuse-external-llm` or an
 explicit URL/provider/model tuple. Phase 02b validates the host endpoint, phase
 06 writes both host-facing and container-facing routes, phase 11 omits managed

--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -159,7 +159,7 @@ def _apply_external_llm_service_override(
     services: dict[str, dict[str, Any]],
     environment: Mapping[str, str] | None = None,
 ) -> None:
-    """Route dashboard LLM probes to a validated external Ollama/LM Studio endpoint."""
+    """Route dashboard LLM probes to a validated external model endpoint."""
     env = environment if environment is not None else os.environ
     if str(env.get("LLM_BACKEND", "")).strip().lower() != "external":
         return
@@ -186,6 +186,7 @@ def _apply_external_llm_service_override(
     health_paths = {
         "ollama": "/api/tags",
         "lmstudio": "/v1/models",
+        "docker-model-runner": "/engines/v1/models",
     }
     service["host"] = parsed.hostname
     service["port"] = port
@@ -193,6 +194,7 @@ def _apply_external_llm_service_override(
     service["name"] = {
         "ollama": "Ollama (External LLM)",
         "lmstudio": "LM Studio (External LLM)",
+        "docker-model-runner": "Docker Model Runner (External LLM)",
     }.get(provider, "External LLM")
     logger.info(
         "External %s inference detected; routing LLM probes to %s:%d%s",

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -61,8 +61,12 @@ class _DirSizeCache:
 
 _dir_size_cache = _DirSizeCache()
 
-# Lemonade serves at /api/v1 instead of llama.cpp's /v1
-_LLM_API_PREFIX = "/api/v1" if LLM_BACKEND == "lemonade" else "/v1"
+def _llm_api_prefix() -> str:
+    """Return the configured OpenAI API prefix for the active runtime."""
+    configured = (os.environ.get("LLM_API_BASE_PATH") or "").strip()
+    if configured:
+        return "/" + configured.strip("/")
+    return "/api/v1" if LLM_BACKEND == "lemonade" else "/v1"
 
 logger = logging.getLogger(__name__)
 
@@ -539,12 +543,12 @@ async def get_loaded_model() -> Optional[str]:
         # field, so the first entry is arbitrary.  The health endpoint is the
         # authoritative source for which model is actually loaded.
         if LLM_BACKEND == "lemonade":
-            resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/health")
+            resp = await client.get(f"http://{host}:{port}{_llm_api_prefix()}/health")
             loaded = resp.json().get("model_loaded")
             return loaded if loaded else None
 
         # llama.cpp: /v1/models returns the loaded model with status info.
-        resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/models")
+        resp = await client.get(f"http://{host}:{port}{_llm_api_prefix()}/models")
         models = resp.json().get("data", [])
         for m in models:
             status = m.get("status", {})

--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -159,7 +159,7 @@ def _model_activation_mode_denial(
         reason = "external_backend_selected"
         message = (
             "Local model activation is unavailable while ODS is using an "
-            "external Ollama or LM Studio backend. Re-run the installer with "
+            "external host-managed model backend. Re-run the installer with "
             "--no-external-llm before activating a downloaded local model."
         )
     elif "unknown" in {effective_mode, configured_mode}:

--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -144,7 +144,7 @@ def _vision_backend_base_url() -> str:
 
     ``ODS_TALK_VISION_URL`` accepts either a host root
     (``http://host:8080``) or a full OpenAI-compatible base
-    (``http://host:8080/v1`` / ``http://host:8080/api/v1``). Normalising here
+    (for example ``/v1``, ``/api/v1``, or ``/engines/v1``). Normalising here
     keeps Linux container, Windows host, llama-server, and Lemonade paths from
     accidentally becoming ``/v1/v1`` or ``/api/v1/v1``.
     """

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -190,6 +190,13 @@ class TestExternalLlmResolution:
         [
             ("ollama", "http://host.docker.internal:11434", 11434, "/api/tags", "Ollama (External LLM)"),
             ("lmstudio", "http://host.docker.internal:1234", 1234, "/v1/models", "LM Studio (External LLM)"),
+            (
+                "docker-model-runner",
+                "http://host.docker.internal:12434",
+                12434,
+                "/engines/v1/models",
+                "Docker Model Runner (External LLM)",
+            ),
             ("", "https://llm.example.test", 443, "/v1/models", "External LLM"),
         ],
     )

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -736,6 +736,28 @@ class TestGetLoadedModel:
         assert result == "only-model"
 
     @pytest.mark.asyncio
+    async def test_uses_configured_external_provider_api_prefix(self, monkeypatch):
+        fake_services = {
+            "llama-server": {"host": "host.docker.internal", "port": 12434, "health": "/engines/v1/models"},
+        }
+        monkeypatch.setattr("helpers.SERVICES", fake_services)
+        monkeypatch.setattr("helpers.LLM_BACKEND", "external")
+        monkeypatch.setenv("LLM_API_BASE_PATH", "/engines/v1")
+
+        mock_response = MagicMock()
+        mock_response.json = MagicMock(return_value={"data": [{"id": "ai/qwen2.5-coder"}]})
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        result = await get_loaded_model()
+
+        assert result == "ai/qwen2.5-coder"
+        mock_client.get.assert_awaited_once_with(
+            "http://host.docker.internal:12434/engines/v1/models",
+        )
+
+    @pytest.mark.asyncio
     async def test_returns_none_on_failure(self, monkeypatch):
         fake_services = {
             "llama-server": {"host": "localhost", "port": 8080, "health": "/health", "name": "llama-server"},

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -1518,7 +1518,7 @@ def test_model_activation_mode_policy_rejects_external_backend():
         "reason": "external_backend_selected",
         "message": (
             "Local model activation is unavailable while ODS is using an "
-            "external Ollama or LM Studio backend. Re-run the installer with "
+            "external host-managed model backend. Re-run the installer with "
             "--no-external-llm before activating a downloaded local model."
         ),
         "effectiveMode": "local",

--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -175,7 +175,7 @@ describe('useModels', () => {
 
     const activationPosts = fetch.mock.calls.filter(([, options]) => options?.method === 'POST')
     expect(activationPosts).toHaveLength(0)
-    expect(result.current.error).toContain('external Ollama or LM Studio backend')
+    expect(result.current.error).toContain('external host-managed model backend')
   })
 
   test('does not activate when effective and configured modes differ', async () => {

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -147,7 +147,7 @@ function normalizeOdsMode(value) {
 
 function modelActivationModeError(effectiveMode, configuredMode, llmBackend) {
   if (llmBackend === 'external') {
-    return 'ODS is using an external Ollama or LM Studio backend. Re-run the installer with --no-external-llm before activating a downloaded local model.'
+    return 'ODS is using an external host-managed model backend. Re-run the installer with --no-external-llm before activating a downloaded local model.'
   }
   if (effectiveMode === 'unknown' || configuredMode === 'unknown') {
     return 'ODS could not verify the active runtime mode. Repair or restart ODS before running a local model.'

--- a/ods/extensions/services/privacy-shield/compose.yaml
+++ b/ods/extensions/services/privacy-shield/compose.yaml
@@ -11,7 +11,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - TARGET_API_URL=${LLM_API_URL:-http://llama-server:8080}/v1
+      - TARGET_API_URL=${LLM_API_URL:-http://llama-server:8080}${LLM_API_BASE_PATH:-/v1}
       - TARGET_API_KEY=${LITELLM_KEY:-${TARGET_API_KEY:-not-needed}}
       - SHIELD_PORT=${SHIELD_PORT:-8085}
       - SHIELD_API_KEY_PATH=${SHIELD_API_KEY_PATH:-/data/shield_api_key}

--- a/ods/extensions/services/privacy-shield/compose.yaml
+++ b/ods/extensions/services/privacy-shield/compose.yaml
@@ -11,7 +11,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - TARGET_API_URL=${LLM_API_URL:-http://llama-server:8080}${LLM_API_BASE_PATH:-/v1}
+      - TARGET_API_URL=${OPEN_WEBUI_LLM_BASE_URL:-${LLM_API_URL:-http://llama-server:8080}/v1}
       - TARGET_API_KEY=${LITELLM_KEY:-${TARGET_API_KEY:-not-needed}}
       - SHIELD_PORT=${SHIELD_PORT:-8085}
       - SHIELD_API_KEY_PATH=${SHIELD_API_KEY_PATH:-/data/shield_api_key}

--- a/ods/extensions/services/token-spy/compose.yaml
+++ b/ods/extensions/services/token-spy/compose.yaml
@@ -16,6 +16,9 @@ services:
       - ./data/token-spy:/app/data:z
     environment:
       - OLLAMA_URL=${LLM_API_URL:-http://llama-server:8080}
+      - API_PROVIDER=local
+      - UPSTREAM_BASE_URL=${LLM_API_URL:-http://llama-server:8080}${LLM_API_BASE_PATH:-/v1}
+      - OPENAI_UPSTREAM=${LLM_API_URL:-http://llama-server:8080}${LLM_API_BASE_PATH:-/v1}
       - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
     deploy:
       resources:

--- a/ods/extensions/services/token-spy/compose.yaml
+++ b/ods/extensions/services/token-spy/compose.yaml
@@ -17,8 +17,8 @@ services:
     environment:
       - OLLAMA_URL=${LLM_API_URL:-http://llama-server:8080}
       - API_PROVIDER=local
-      - UPSTREAM_BASE_URL=${LLM_API_URL:-http://llama-server:8080}${LLM_API_BASE_PATH:-/v1}
-      - OPENAI_UPSTREAM=${LLM_API_URL:-http://llama-server:8080}${LLM_API_BASE_PATH:-/v1}
+      - UPSTREAM_BASE_URL=${OPEN_WEBUI_LLM_BASE_URL:-${LLM_API_URL:-http://llama-server:8080}/v1}
+      - OPENAI_UPSTREAM=${OPEN_WEBUI_LLM_BASE_URL:-${LLM_API_URL:-http://llama-server:8080}/v1}
       - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
     deploy:
       resources:

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -31,6 +31,7 @@ from routed_telemetry import (
     routed_event_to_usage,
     validate_routed_event,
 )
+from upstream_url import openai_api_base_url
 
 # Database backend selection: sqlite (default) or postgres
 DB_BACKEND = os.environ.get("DB_BACKEND", "sqlite").lower()
@@ -75,6 +76,8 @@ if not OPENAI_UPSTREAM:
         OPENAI_UPSTREAM = UPSTREAM_BASE_URL
     else:
         OPENAI_UPSTREAM = UPSTREAM_BASE_URL  # fallback: same upstream
+
+OPENAI_UPSTREAM = openai_api_base_url(OPENAI_UPSTREAM)
 
 LOCAL_PROVIDER_NAMES = {"local", "ollama", "llama", "llama.cpp", "llama-server", "vllm"}
 LOCAL_UPSTREAM_HOSTS = {"localhost", "127.0.0.1", "::1", "host.docker.internal", "llama-server", "ollama"}
@@ -339,7 +342,7 @@ def get_moonshot_client() -> httpx.AsyncClient:
     global _openai_client
     if _openai_client is None or _openai_client.is_closed:
         _openai_client = httpx.AsyncClient(
-            base_url=OPENAI_UPSTREAM,
+            base_url=f"{OPENAI_UPSTREAM.rstrip('/')}/",
             timeout=_CLIENT_TIMEOUT,
             limits=_CLIENT_LIMITS,
         )
@@ -942,7 +945,7 @@ async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysi
         logged = False
         try:
             async with client.stream(
-                "POST", "/v1/chat/completions",
+                "POST", "chat/completions",
                 content=raw_body,
                 headers=headers,
             ) as upstream:
@@ -1013,7 +1016,7 @@ async def _handle_openai_non_streaming(client, raw_body, headers, model, sys_ana
     """Handle non-streaming OpenAI-format requests."""
     try:
         resp = await client.request(
-            "POST", "/v1/chat/completions",
+            "POST", "chat/completions",
             content=raw_body,
             headers=headers,
         )

--- a/ods/extensions/services/token-spy/upstream_url.py
+++ b/ods/extensions/services/token-spy/upstream_url.py
@@ -1,0 +1,15 @@
+"""OpenAI-compatible upstream URL helpers."""
+
+from urllib.parse import urlsplit
+
+
+_API_BASE_SUFFIXES = ("/v1", "/api/v1", "/engines/v1")
+
+
+def openai_api_base_url(url: str) -> str:
+    """Return a complete OpenAI-compatible API base without changing providers."""
+    candidate = url.strip().rstrip("/")
+    path = urlsplit(candidate).path.rstrip("/")
+    if path.endswith(_API_BASE_SUFFIXES):
+        return candidate
+    return f"{candidate}/v1"

--- a/ods/install-core.sh
+++ b/ods/install-core.sh
@@ -159,9 +159,9 @@ Options:
     --lemonade-api-key K
                       API key LiteLLM should send to the existing Lemonade server
     --external-llm-url U
-                      Reuse an OpenAI-compatible Ollama or LM Studio endpoint
+                      Reuse an OpenAI-compatible host model endpoint
     --external-llm-provider P
-                      External provider: auto, ollama, or lmstudio
+                      Provider: auto, ollama, lmstudio, or docker-model-runner
     --external-llm-model M
                       Exact model id exposed by the external provider
     --reuse-external-llm

--- a/ods/installers/lib/external-services.sh
+++ b/ods/installers/lib/external-services.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# External Ollama / LM Studio discovery and validation helpers.
+# External Ollama, LM Studio, and Docker Model Runner discovery helpers.
 
 external_llm_normalize_model_name() {
     local value="${1:-}"
@@ -37,6 +37,7 @@ external_llm_strip_url() {
     local url="${1:-}"
     url="${url%/}"
     case "$url" in
+        */engines/v1) url="${url%/engines/v1}" ;;
         */api/v1) url="${url%/api/v1}" ;;
         */v1) url="${url%/v1}" ;;
     esac
@@ -63,10 +64,17 @@ if (
     or parsed.password is not None
     or parsed.query
     or parsed.fragment
-    or parsed.path.rstrip("/") not in {"", "/v1", "/api/v1"}
+    or parsed.path.rstrip("/") not in {"", "/v1", "/api/v1", "/engines/v1"}
 ):
     sys.exit(1)
 PY
+}
+
+external_llm_api_base_path() {
+    case "${1:-}" in
+        docker-model-runner) printf '/engines/v1\n' ;;
+        *) printf '/v1\n' ;;
+    esac
 }
 
 external_llm_host_url() {
@@ -94,6 +102,9 @@ external_llm_models() {
             ;;
         lmstudio)
             response="$(curl -fsS --max-time 5 "${url}/v1/models" 2>/dev/null)" || return 1
+            ;;
+        docker-model-runner)
+            response="$(curl -fsS --max-time 5 "${url}/engines/v1/models" 2>/dev/null)" || return 1
             ;;
         *)
             return 2
@@ -126,6 +137,10 @@ external_llm_detect_provider() {
         printf 'lmstudio\n'
         return 0
     fi
+    if external_llm_models docker-model-runner "$url" >/dev/null 2>&1; then
+        printf 'docker-model-runner\n'
+        return 0
+    fi
     return 1
 }
 
@@ -144,8 +159,9 @@ external_llm_resolve_model() {
 }
 
 external_llm_probe_completion() {
-    local url="${1:-}" model="${2:-}" body
+    local url="${1:-}" model="${2:-}" provider="${3:-}" body base_path
     url="$(external_llm_host_url "$url")"
+    base_path="$(external_llm_api_base_path "$provider")"
     body="$(
         EXTERNAL_LLM_MODEL_VALUE="$model" python3 - <<'PY'
 import json
@@ -163,7 +179,7 @@ PY
     curl -fsS --max-time "${EXTERNAL_LLM_PROBE_TIMEOUT:-60}" \
         -H "Content-Type: application/json" \
         -d "$body" \
-        "${url}/v1/chat/completions" >/dev/null
+        "${url}${base_path}/chat/completions" >/dev/null
 }
 
 external_llm_env_value() {

--- a/ods/installers/phases/02b-external-services.sh
+++ b/ods/installers/phases/02b-external-services.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Detect or validate an explicitly selected host Ollama / LM Studio runtime.
+# Detect or validate an explicitly selected host local model runtime.
 
 ods_progress 15 "detection" "Checking external LLM services"
 
@@ -34,7 +34,10 @@ if [[ -z "$_external_url" && "${ODS_MODE:-local}" == "local" && "${LEMONADE_EXTE
     _detected_provider=""
     _detected_url=""
     _detected_model=""
-    for _candidate in "ollama|http://127.0.0.1:11434" "lmstudio|http://127.0.0.1:1234"; do
+    for _candidate in \
+        "ollama|http://127.0.0.1:11434" \
+        "lmstudio|http://127.0.0.1:1234" \
+        "docker-model-runner|http://127.0.0.1:12434"; do
         _candidate_provider="${_candidate%%|*}"
         _candidate_url="${_candidate#*|}"
         _candidate_model="$(external_llm_resolve_model \
@@ -80,12 +83,12 @@ if [[ -z "$_external_url" ]]; then
 fi
 
 if [[ "${ODS_MODE:-local}" != "local" ]]; then
-    ai_bad "External Ollama / LM Studio reuse is only supported in local mode."
+    ai_bad "External local model reuse is only supported in local mode."
     ai "Use --no-external-llm before selecting cloud or hybrid mode."
     return 1
 fi
 if [[ "${LEMONADE_EXTERNAL:-false}" == "true" ]]; then
-    ai_bad "External Ollama / LM Studio reuse cannot be combined with external Lemonade."
+    ai_bad "External local model reuse cannot be combined with external Lemonade."
     ai "Select one host-managed inference backend, or use --no-external-llm."
     return 1
 fi
@@ -100,10 +103,10 @@ if [[ -z "$_external_provider" || "$_external_provider" == "auto" ]]; then
     _external_provider="$(external_llm_detect_provider "$_external_url" || true)"
 fi
 case "$_external_provider" in
-    ollama|lmstudio) ;;
+    ollama|lmstudio|docker-model-runner) ;;
     *)
         ai_bad "Could not identify the external LLM provider at ${_external_url}"
-        ai "Use --external-llm-provider ollama|lmstudio and verify the service is running."
+        ai "Use --external-llm-provider ollama|lmstudio|docker-model-runner and verify the service is running."
         return 1
         ;;
 esac

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -546,6 +546,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     EXTERNAL_LLM_CONTAINER_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL:-}"
     EXTERNAL_LLM_PROVIDER_VALUE="${EXTERNAL_LLM_PROVIDER:-}"
     EXTERNAL_SELECTED_MODEL="${EXTERNAL_LLM_MODEL:-}"
+    EXTERNAL_LLM_API_BASE_PATH_VALUE="$(external_llm_api_base_path "$EXTERNAL_LLM_PROVIDER_VALUE")"
     EXTERNAL_LLM_ACTIVE=false
     if [[ -n "$EXTERNAL_LLM_URL_VALUE" ]]; then
         if [[ -z "$EXTERNAL_LLM_CONTAINER_URL_VALUE" || -z "$EXTERNAL_LLM_PROVIDER_VALUE" || -z "$EXTERNAL_SELECTED_MODEL" ]]; then
@@ -575,7 +576,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     _default_llm_api_url="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "http://litellm:4000"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "http://litellm:4000"; elif [[ "${ODS_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)"
     if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then
         LLM_API_URL_VALUE="$EXTERNAL_LLM_CONTAINER_URL_VALUE"
-        OPEN_WEBUI_LLM_BASE_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL_VALUE}/v1"
+        OPEN_WEBUI_LLM_BASE_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL_VALUE}${EXTERNAL_LLM_API_BASE_PATH_VALUE}"
         OPEN_WEBUI_LLM_API_KEY_VALUE=""
     elif [[ "${EXTERNAL_LLM_RESET:-false}" == "true" ]]; then
         LLM_API_URL_VALUE="$_default_llm_api_url"
@@ -606,7 +607,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
         _default_hermes_api_key="${LITELLM_KEY}"
     fi
     if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then
-        HERMES_LLM_BASE_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL_VALUE}/v1"
+        HERMES_LLM_BASE_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL_VALUE}${EXTERNAL_LLM_API_BASE_PATH_VALUE}"
         HERMES_LLM_API_KEY_VALUE="not-needed"
     elif [[ "${EXTERNAL_LLM_RESET:-false}" == "true" ]]; then
         HERMES_LLM_BASE_URL_VALUE="$_default_hermes_base_url"
@@ -825,7 +826,7 @@ LLM_API_URL=${LLM_API_URL_VALUE}
 OPEN_WEBUI_LLM_BASE_URL=${OPEN_WEBUI_LLM_BASE_URL_VALUE}
 OPEN_WEBUI_LLM_API_KEY=${OPEN_WEBUI_LLM_API_KEY_VALUE}
 LLM_BACKEND=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo "external"; elif [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; else echo "llama-server"; fi)
-LLM_API_BASE_PATH=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "${LEMONADE_API_BASE_PATH_VALUE}"; else echo "/v1"; fi)
+LLM_API_BASE_PATH=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo "${EXTERNAL_LLM_API_BASE_PATH_VALUE}"; elif [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "${LEMONADE_API_BASE_PATH_VALUE}"; else echo "/v1"; fi)
 EXTERNAL_LLM_URL=${EXTERNAL_LLM_URL_VALUE}
 EXTERNAL_LLM_CONTAINER_URL=${EXTERNAL_LLM_CONTAINER_URL_VALUE}
 EXTERNAL_LLM_PROVIDER=${EXTERNAL_LLM_PROVIDER_VALUE}

--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -210,7 +210,7 @@ _phase12_verify_external_llm_completion() {
         ai "Restore the model/service, or re-run the installer with --no-external-llm."
         return 1
     fi
-    if ! external_llm_probe_completion "$host_url" "$model"; then
+    if ! external_llm_probe_completion "$host_url" "$model" "$provider"; then
         ai_bad "External ${provider} accepted discovery but failed a real completion for ${model}."
         ai "Check the provider logs and model readiness, then re-run the installer."
         return 1
@@ -225,6 +225,7 @@ import urllib.request
 
 base = sys.argv[1].rstrip("/")
 model = sys.argv[2]
+api_base_path = sys.argv[3]
 payload = json.dumps({
     "model": model,
     "messages": [{"role": "user", "content": "Reply with OK."}],
@@ -233,7 +234,7 @@ payload = json.dumps({
     "stream": False,
 }).encode()
 request = urllib.request.Request(
-    base + "/v1/chat/completions",
+    base + api_base_path + "/chat/completions",
     data=payload,
     headers={"Content-Type": "application/json"},
 )
@@ -242,7 +243,7 @@ with urllib.request.urlopen(request, timeout=90) as result:
 content = body.get("choices", [{}])[0].get("message", {}).get("content")
 if content is None:
     raise SystemExit("completion response did not contain assistant content")
-' "$container_url" "$model" 2>&1
+' "$container_url" "$model" "$(external_llm_api_base_path "$provider")" 2>&1
     )" || {
         ai_bad "ODS containers cannot use external ${provider} at ${container_url}."
         ai "On Linux, bind the provider to a container-reachable interface (for example 0.0.0.0 on a trusted host) and allow the ODS Docker subnet through the firewall."

--- a/ods/tests/test-external-services.sh
+++ b/ods/tests/test-external-services.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# External Ollama / LM Studio discovery and installer-selection contracts.
+# External host-managed model discovery and installer-selection contracts.
 
 set -euo pipefail
 
@@ -47,10 +47,18 @@ assert_eq "$(external_llm_container_url 'http://localhost:11434/v1')" \
     "http://host.docker.internal:11434" "normalizes localhost for containers"
 assert_eq "$(external_llm_container_url 'http://[::1]:1234/api/v1')" \
     "http://host.docker.internal:1234" "normalizes IPv6 loopback for containers"
+assert_eq "$(external_llm_strip_url 'http://127.0.0.1:12434/engines/v1')" \
+    "http://127.0.0.1:12434" "strips the Docker Model Runner OpenAI base path"
+assert_eq "$(external_llm_api_base_path docker-model-runner)" \
+    "/engines/v1" "selects the Docker Model Runner OpenAI base path"
+assert_eq "$(external_llm_api_base_path lmstudio)" \
+    "/v1" "keeps the standard OpenAI base path for LM Studio"
 assert_eq "$(external_llm_host_url 'http://host.docker.internal:11434/v1')" \
     "http://127.0.0.1:11434" "normalizes the Docker host alias for host probes"
 assert_true "accepts a supported external base URL" \
     external_llm_validate_url "http://127.0.0.1:11434/v1"
+assert_true "accepts a Docker Model Runner OpenAI base URL" \
+    external_llm_validate_url "http://127.0.0.1:12434/engines/v1"
 if external_llm_validate_url "file:///tmp/models"; then
     fail "rejects non-HTTP external URLs"
 else
@@ -74,6 +82,16 @@ else
     pass "rejects unrelated model families"
 fi
 
+probe_docker_model_runner_completion() (
+    curl() {
+        [[ "${*: -1}" == "http://127.0.0.1:12434/engines/v1/chat/completions" ]]
+    }
+    external_llm_probe_completion \
+        "http://127.0.0.1:12434" "ai/qwen3.5-9b" "docker-model-runner"
+)
+assert_true "probes Docker Model Runner through its OpenAI completion path" \
+    probe_docker_model_runner_completion
+
 run_phase_case() {
     set -euo pipefail
 
@@ -94,11 +112,15 @@ run_phase_case() {
                 [[ "${MOCK_OLLAMA:-down}" == "up" ]] || return 22
                 printf '{"models":[{"name":"qwen3.5:9b"},{"name":"llama3.2:3b"}]}'
                 ;;
+            */engines/v1/models)
+                [[ "${MOCK_DOCKER_MODEL_RUNNER:-down}" == "up" ]] || return 22
+                printf '{"data":[{"id":"ai/qwen3.5-9b"},{"id":"ai/smollm2"}]}'
+                ;;
             */v1/models)
                 [[ "${MOCK_LMSTUDIO:-down}" == "up" ]] || return 22
                 printf '{"data":[{"id":"qwen3.5-9b"},{"id":"local-model"}]}'
                 ;;
-            */v1/chat/completions)
+            */v1/chat/completions|*/engines/v1/chat/completions)
                 printf '{"choices":[{"message":{"content":"OK"}}]}'
                 ;;
             *)
@@ -141,6 +163,12 @@ run_phase_case() {
             EXTERNAL_LLM_URL="http://127.0.0.1:11434"
             EXTERNAL_LLM_PROVIDER="ollama"
             EXTERNAL_LLM_MODEL="qwen3.5:9b"
+            ;;
+        docker-model-runner)
+            MOCK_DOCKER_MODEL_RUNNER=up
+            EXTERNAL_LLM_URL="http://127.0.0.1:12434/engines/v1"
+            EXTERNAL_LLM_PROVIDER="docker-model-runner"
+            EXTERNAL_LLM_MODEL="ai/qwen3.5-9b"
             ;;
         explicit-cloud)
             MOCK_OLLAMA=up
@@ -189,6 +217,17 @@ if output="$(run_phase_case auto "$TEMP_DIR/auto"; printf '%s|%s|%s|%s\n' \
         "explicit auto-reuse validates and persists an exact external route"
 else
     fail "opt-in auto-reuse phase completes"
+fi
+
+if output="$(run_phase_case docker-model-runner "$TEMP_DIR/docker-model-runner"; printf '%s|%s|%s|%s|%s\n' \
+    "${EXTERNAL_LLM_PROVIDER:-}" "${EXTERNAL_LLM_MODEL:-}" \
+    "${EXTERNAL_LLM_URL:-}" "${EXTERNAL_LLM_CONTAINER_URL:-}" \
+    "$(external_llm_api_base_path "${EXTERNAL_LLM_PROVIDER:-}")")"; then
+    assert_eq "$output" \
+        "docker-model-runner|ai/qwen3.5-9b|http://127.0.0.1:12434|http://host.docker.internal:12434|/engines/v1" \
+        "explicit Docker Model Runner selection preserves its provider API contract"
+else
+    fail "Docker Model Runner selection phase completes"
 fi
 
 mkdir -p "$TEMP_DIR/persisted"
@@ -323,6 +362,20 @@ run_phase06_env_cycle() (
     grep -qx 'EXTERNAL_LLM_PROVIDER=ollama' "$install_dir/.env"
     grep -qx 'SKIP_MODEL_DOWNLOAD=true' "$install_dir/.env"
     grep -qx 'MODEL_RECOMMENDED_MODEL=qwen3-1.7b' "$install_dir/.env"
+
+    export LLM_MODEL=qwen3-1.7b
+    export EXTERNAL_LLM_URL=http://127.0.0.1:12434
+    export EXTERNAL_LLM_CONTAINER_URL=http://host.docker.internal:12434
+    export EXTERNAL_LLM_PROVIDER=docker-model-runner
+    export EXTERNAL_LLM_MODEL=ai/qwen3.5-9b
+
+    source "$install_dir/installers/phases/06-directories.sh"
+
+    grep -qx 'LLM_API_BASE_PATH=/engines/v1' "$install_dir/.env"
+    grep -qx 'LLM_MODEL=ai/qwen3.5-9b' "$install_dir/.env"
+    grep -qx 'OPEN_WEBUI_LLM_BASE_URL=http://host.docker.internal:12434/engines/v1' "$install_dir/.env"
+    grep -qx 'HERMES_LLM_BASE_URL=http://host.docker.internal:12434/engines/v1' "$install_dir/.env"
+    grep -qx 'EXTERNAL_LLM_PROVIDER=docker-model-runner' "$install_dir/.env"
 
     export LLM_MODEL=qwen3-1.7b
     export GGUF_FILE=Qwen3-1.7B-Q4_K_M.gguf

--- a/ods/tests/test-resolve-compose-resilient.sh
+++ b/ods/tests/test-resolve-compose-resilient.sh
@@ -676,12 +676,13 @@ if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; 
     # shellcheck disable=SC2086
     if (
         cd "$ROOT_DIR"
-        export EXTERNAL_LLM_URL="http://127.0.0.1:11434"
-        export EXTERNAL_LLM_CONTAINER_URL="http://host.docker.internal:11434"
-        export EXTERNAL_LLM_PROVIDER="ollama"
-        export EXTERNAL_LLM_MODEL="qwen3.5:9b"
+        export EXTERNAL_LLM_URL="http://127.0.0.1:12434"
+        export EXTERNAL_LLM_CONTAINER_URL="http://host.docker.internal:12434"
+        export EXTERNAL_LLM_PROVIDER="docker-model-runner"
+        export EXTERNAL_LLM_MODEL="ai/qwen3.5-9b"
+        export LLM_API_BASE_PATH="/engines/v1"
         export LLM_API_URL="$EXTERNAL_LLM_CONTAINER_URL"
-        export HERMES_LLM_BASE_URL="${EXTERNAL_LLM_CONTAINER_URL}/v1"
+        export HERMES_LLM_BASE_URL="${EXTERNAL_LLM_CONTAINER_URL}${LLM_API_BASE_PATH}"
         export HERMES_DASHBOARD_SESSION_TOKEN="external-llm-hermes-dashboard-session-token"
         export WEBUI_SECRET="external-llm-compose-test"
         export DASHBOARD_API_KEY="external-llm-compose-test"
@@ -696,10 +697,16 @@ if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; 
             fail "Rendered external-LLM stack still contains managed llama-server"
         elif grep -Eq '^[[:space:]]+model-router:$' "$compose_config_file"; then
             fail "Rendered external-LLM stack still contains model-router"
-        elif ! grep -Fq 'ODS_TALK_VISION_URL: http://host.docker.internal:11434/v1' "$compose_config_file"; then
-            fail "Rendered external-LLM stack does not route ODS Talk vision to the external backend"
+        elif ! grep -Fq 'LLM_API_BASE_PATH: /engines/v1' "$compose_config_file"; then
+            fail "Rendered external-LLM stack loses the provider API base path"
+        elif ! grep -Fq 'ODS_TALK_VISION_URL: http://host.docker.internal:12434/engines/v1' "$compose_config_file"; then
+            fail "Rendered external-LLM stack does not route ODS Talk vision to Docker Model Runner"
+        elif ! grep -Fq 'TARGET_API_URL: http://host.docker.internal:12434/engines/v1' "$compose_config_file"; then
+            fail "Rendered external-LLM stack does not route Privacy Shield to Docker Model Runner"
+        elif ! grep -Fq 'OPENAI_UPSTREAM: http://host.docker.internal:12434/engines/v1' "$compose_config_file"; then
+            fail "Rendered external-LLM stack does not route Token Spy to Docker Model Runner"
         else
-            pass "Real external-LLM Compose stack renders without managed inference and routes ODS Talk externally"
+            pass "Real Docker Model Runner stack renders without managed inference and preserves its OpenAI base path"
         fi
     else
         fail "Real external-LLM Compose stack failed docker compose config"

--- a/ods/tests/test-resolve-compose-resilient.sh
+++ b/ods/tests/test-resolve-compose-resilient.sh
@@ -656,6 +656,25 @@ if $consumer_routes_ok; then
     pass "All direct external-LLM consumers define a Linux host-gateway route"
 fi
 
+if ROOT_DIR="$ROOT_DIR" python3 - <<'PY'
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.environ["ROOT_DIR"], "extensions", "services", "token-spy"))
+from upstream_url import openai_api_base_url
+
+assert openai_api_base_url("http://llama-server:8080") == "http://llama-server:8080/v1"
+assert openai_api_base_url("http://lemonade:8000/api/v1") == "http://lemonade:8000/api/v1"
+assert openai_api_base_url("http://host.docker.internal:12434/engines/v1") == (
+    "http://host.docker.internal:12434/engines/v1"
+)
+PY
+then
+    pass "Token Spy preserves provider-specific OpenAI API roots"
+else
+    fail "Token Spy provider-specific OpenAI API root contract"
+fi
+
 # ============================================================================
 # 26. The real external-LLM stack renders without local inference dependencies
 # ============================================================================
@@ -682,6 +701,7 @@ if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; 
         export EXTERNAL_LLM_MODEL="ai/qwen3.5-9b"
         export LLM_API_BASE_PATH="/engines/v1"
         export LLM_API_URL="$EXTERNAL_LLM_CONTAINER_URL"
+        export OPEN_WEBUI_LLM_BASE_URL="${EXTERNAL_LLM_CONTAINER_URL}${LLM_API_BASE_PATH}"
         export HERMES_LLM_BASE_URL="${EXTERNAL_LLM_CONTAINER_URL}${LLM_API_BASE_PATH}"
         export HERMES_DASHBOARD_SESSION_TOKEN="external-llm-hermes-dashboard-session-token"
         export WEBUI_SECRET="external-llm-compose-test"
@@ -753,6 +773,28 @@ if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; 
         fi
     else
         fail "Real AMD external-LLM stack failed docker compose config"
+    fi
+
+    managed_amd_consumers="$TEMP_DIR/managed-amd-consumers.yml"
+    if (
+        cd "$ROOT_DIR"
+        export LLM_API_URL="http://litellm:4000"
+        export LLM_API_BASE_PATH="/api/v1"
+        export OPEN_WEBUI_LLM_BASE_URL=""
+        docker compose \
+            -f extensions/services/privacy-shield/compose.yaml \
+            -f extensions/services/token-spy/compose.yaml \
+            config > "$managed_amd_consumers"
+    ); then
+        if ! grep -Fq 'TARGET_API_URL: http://litellm:4000/v1' "$managed_amd_consumers"; then
+            fail "Managed AMD Privacy Shield route inherited Lemonade's private /api/v1 path"
+        elif ! grep -Fq 'OPENAI_UPSTREAM: http://litellm:4000/v1' "$managed_amd_consumers"; then
+            fail "Managed AMD Token Spy route inherited Lemonade's private /api/v1 path"
+        else
+            pass "Managed AMD OpenAI consumers retain the LiteLLM /v1 route"
+        fi
+    else
+        fail "Managed AMD consumer Compose stack failed to render"
     fi
 else
     skip "Docker Compose unavailable; real external-LLM render skipped"


### PR DESCRIPTION
## Summary - add `docker-model-runner` as an installer-validated external local inference provider - preserve Docker Model Runner's `/engines/v1` OpenAI base path through discovery, generated `.env`, Compose consumers, dashboard probes, and host/container completion receipts - route Open WebUI, ODS Talk, Hermes/Perplexica, Privacy Shield, and Token Spy to the same provider-specific endpoint - document the exact `docker model` setup, namespaced model ids, TCP requirement, and unauthenticated-API limitation  ## Why this matters Docker Model Runner now provides a supported cross-platform local model runtime and publishes GGUF/Safetensors models as OCI artifacts, but its OpenAI-compatible API lives under `/engines/v1`, not `/v1`. ODS previously rejected `docker-model-runner` as a provider and would either start a duplicate managed GGUF runtime or misroute consumers and health probes.  The reachable production contract is:  1. An operator enables Docker Model Runner TCP access, pulls a model, and passes `--external-llm-url`, `--external-llm-provider docker-model-runner`, and the exact namespaced model id. 2. Phase 02b lists `/engines/v1/models`, validates the selected id, and records a container-safe host route. 3. Phase 06 persists the root URL separately from `LLM_API_BASE_PATH=/engines/v1`; every OpenAI consumer receives the composed base URL. 4. Phase 12 proves both host-side and ODS-network chat completions against `/engines/v1/chat/completions` before installation succeeds. 5. `./install.sh --no-external-llm` remains the rollback path and restores ODS-managed inference.  Official provider contract: https://docs.docker.com/ai/model-runner/api-reference/  ## Overlap check Searched open and closed PR titles/bodies for `Docker Model Runner`, `docker-model-runner`, `external LLM provider`, `privacy-shield TARGET_API_URL`, `token-spy OPENAI_UPSTREAM`, plus the changed production files. No PR implements Docker Model Runner or its `/engines/v1` contract.  Three open fixes touch the shared external-service helper/test:  - #2314 fixes `.env` parsing; its production change auto-merges with this feature. - #2512 fixes Ollama tag normalization; its production change auto-merges with this feature. - #2873 is a strict CRLF-only subset of #2314, so #2314 is the compatibility target.  Synthetic compatibility head `c243f4da3e9e2360dfd98e1eb6a49d60c5cc4bdd` combines this PR with #2314 and #2512. The combined external-runtime suite passes 40/40; the CRLF/leading-space parser invariant and Ollama `:latest`/quantization-tag invariants also pass. The only merge conflict is additive assertions occupying the same test-file location, not production code.  #2517 mentions Privacy Shield settings routing but changes only dashboard settings code; it does not overlap the provider URL composition in this PR.  ## Behavioral invariant A validated external provider's API root must remain unchanged from model discovery through every runtime consumer and both completion receipts. In particular, Docker Model Runner must never be normalized from `/engines/v1` to `/v1`.  ## Test plan - [x] `bash tests/test-external-services.sh` — 28 passed - [x] `bash tests/test-resolve-compose-resilient.sh` — 38 passed - [x] dashboard API focused suite (`test_config.py`, `test_helpers.py`, `test_models.py`, `test_talk.py`) — 302 passed, 2 skipped - [x] dashboard model hook — 34 passed - [x] dashboard ESLint and production build - [x] platform smoke suite — Linux AMD, Linux NVIDIA, WSL logic, macOS dispatch passed - [x] shell syntax and `.env.schema.json` parse - [x] `git diff --check` - [x] gitleaks and large-file pre-commit hooks  ## Validation gaps - Live Docker Model Runner was not available on this host; the nearest public boundaries are exercised with provider-shaped `/engines/v1/models` and completion fixtures plus a real rendered Compose plan. - `make gate` stops on `tests/test-installer-context-parity.sh` at the pre-existing `Hermes template bounds each model turn` assertion; the same assertion fails on a clean `main` snapshot. - BATS, installer simulation, and the all-files ShellCheck hook cannot execute from this Windows checkout because Git-converted CRLF shebangs resolve as `bash\r`/`python3\r`; ShellCheck likewise rejects the CRLF `.shellcheckrc`. CI checks out LF files and remains the authoritative gate. - The all-files private-key hook flags two existing test fixtures (`test_host_agent.py` and `test-remote-provider-egress-policy.py`); gitleaks passes and this PR adds no key material.  ## Tradeoffs and rollback This extends the existing transactional external-provider path instead of adopting Compose's newer top-level `models` feature, preserving ODS's current Docker Compose compatibility floor and rollback behavior. Docker Model Runner's API is unauthenticated, so documentation requires a local TCP endpoint; ODS does not expose or manage that endpoint.  Rollback is `./install.sh --no-external-llm`, which clears the persisted external route and restores managed llama-server/model-router selection.  Generated with Codex
## Review follow-up (2026-08-30)

Commit `95baa2ba` fixes two consumer-path regressions found during direct review:

- Privacy Shield and Token Spy now consume the generated `OPEN_WEBUI_LLM_BASE_URL` when an external runtime is selected, while managed LiteLLM deployments retain their `/v1` API root. This prevents managed AMD's private Lemonade `/api/v1` path from leaking into LiteLLM consumers.
- Token Spy normalizes OpenAI-compatible roots once and sends the relative `chat/completions` path. This preserves Docker Model Runner's `/engines/v1` prefix instead of replacing it with `/v1`.

### Added regression boundary

`tests/test-resolve-compose-resilient.sh` now renders both Docker Model Runner and managed AMD consumer configurations and asserts the final URLs presented to Privacy Shield and Token Spy. The Token Spy unit suite also exercises root, existing `/api/v1`, and Docker Model Runner `/engines/v1` normalization.

Focused validation after the follow-up:

- `bash tests/test-resolve-compose-resilient.sh` — 40 passed, 0 failed
- `python -m pytest tests -q` in Token Spy — 20 passed, 1 skipped
- direct `httpx` request construction — `/engines/v1/chat/completions` and `/v1/chat/completions` both preserved as intended
- Python compile, `bash -n`, and `git diff --check` — passed

### Expanded overlap and merge-order check

Semantic and changed-file comparison covered #2990, #3172, #2970, #2971, and #2692. This branch auto-merges cleanly with #2990, #3172, #2971, and #2692. PR #2970 touches the same streaming request construction and therefore needs one semantic reconciliation: retain #2970's early-open/status-propagation flow, but build its request with relative `chat/completions` on this PR's normalized base URL.

A synthetic merge implementing that reconciliation passed the combined Token Spy suite (22 passed, 1 skipped) and direct Docker Model Runner/LiteLLM URL assertions at integration SHA `14df98045c1ae5684615bff629d12a49327748cf`. Recommended order: merge #2970 first, then resolve #3509 with that one-line relative-path rule. No code or tests from #2970 are duplicated in this branch.