### PR TITLE
feat(api): expose Hermes over A2A v1

### DIFF
--- a/ods/docs/HERMES.md
+++ b/ods/docs/HERMES.md
@@ -131,6 +131,43 @@ To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthrop
 
 For local backends, keep `model.context_length` and `auxiliary.compression.context_length` aligned with `.env`'s `CTX_SIZE` / `MAX_CONTEXT`. Values below 64000 will make Hermes reject prompts; values above the server's real context can produce `context length exceeded` / `max compression attempts reached` loops.
 
+### A2A v1 interoperability
+
+The dashboard API exposes Hermes through the A2A v1 HTTP+JSON binding. Agent
+discovery is public and contains no credentials:
+
+```bash
+curl http://127.0.0.1:3002/.well-known/agent-card.json
+```
+
+Message execution uses the same bearer token as the protected dashboard API:
+
+```bash
+curl -X POST http://127.0.0.1:3002/a2a/v1/message:send \
+  -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
+  -H "A2A-Version: 1.0" \
+  -H "Content-Type: application/a2a+json" \
+  -d '{
+    "message": {
+      "messageId": "example-1",
+      "role": "ROLE_USER",
+      "parts": [{"text": "Summarize the health of this ODS node"}]
+    },
+    "configuration": {"acceptedOutputModes": ["text/plain"]}
+  }'
+```
+
+ODS currently returns the A2A direct `Message` response variant and accepts
+text only. Reusing the returned `contextId` keeps later messages on the same
+Hermes conversation while its bridge connection remains alive. Streaming,
+push notifications, durable tasks, and task cancellation are deliberately not
+advertised: the pinned Hermes API cannot yet cancel a submitted prompt safely.
+The adapter rejects those requests instead of reporting a false terminal state.
+
+The default local URLs use HTTP. Put `api.<device>.local` behind an HTTPS/TLS
+endpoint before exposing A2A outside the trusted local network; the A2A v1
+production security contract requires HTTPS.
+
 ## Security posture
 
 - **`--insecure` is enabled inside the container.** Hermes's dashboard refuses non-loopback binds without it. ODS accepts that trade-off only because port 9119 is not host-bound in the default stack; the LAN-facing entry is the magic-link-gated proxy on port 9120. Do not add a public 9119 host binding.

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -72,6 +72,7 @@ from routers import (
     tailscale,
     usage,
     node,
+    a2a,
 )
 from settings import (
     _ENV_ASSIGNMENT_RE, _ENV_COMMENTED_ASSIGNMENT_RE, _SETTINGS_APPLY_ALLOWED_SERVICES, _parse_env_text, _read_env_map_from_path,
@@ -1114,6 +1115,7 @@ app.include_router(talk.router)
 app.include_router(tailscale.router)
 app.include_router(usage.router)
 app.include_router(node.router)
+app.include_router(a2a.router)
 
 
 # ================================================================

--- a/ods/extensions/services/dashboard-api/routers/a2a.py
+++ b/ods/extensions/services/dashboard-api/routers/a2a.py
@@ -1,0 +1,421 @@
+"""A2A v1 HTTP+JSON adapter for the ODS Hermes agent.
+
+The pinned Hermes dashboard exposes a blocking prompt bridge, but it does not
+expose durable tasks or safe cancellation.  This adapter therefore uses A2A's
+direct ``Message`` response form and advertises no streaming or push support.
+That keeps discovery truthful while making the existing agent reachable by
+standards-aware clients.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from collections.abc import Mapping
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, Security
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials
+
+import hermes_bridge
+from security import security_scheme, verify_api_key
+
+router = APIRouter(tags=["a2a"])
+
+A2A_MEDIA_TYPE = "application/a2a+json"
+A2A_VERSION = "1.0"
+MAX_MESSAGE_CHARS = 8000
+MAX_REQUEST_BYTES = 64 * 1024
+MAX_ID_CHARS = 256
+MAX_PARTS = 64
+
+
+def _interface_url(request: Request) -> str:
+    return f"{str(request.base_url).rstrip('/')}/a2a/v1"
+
+
+def _agent_card(request: Request) -> dict[str, Any]:
+    return {
+        "name": "ODS Hermes Agent",
+        "description": "A private, locally hosted general-purpose agent powered by ODS and Hermes.",
+        "supportedInterfaces": [
+            {
+                "url": _interface_url(request),
+                "protocolBinding": "HTTP+JSON",
+                "protocolVersion": A2A_VERSION,
+            }
+        ],
+        "provider": {
+            "url": "https://github.com/Osmantic/ODS",
+            "organization": "Osmantic",
+        },
+        "version": "1.0.0",
+        "documentationUrl": "https://github.com/Osmantic/ODS/blob/main/ods/docs/HERMES.md",
+        "capabilities": {
+            "streaming": False,
+            "pushNotifications": False,
+            "extendedAgentCard": False,
+        },
+        "securitySchemes": {
+            "dashboardBearer": {
+                "httpAuthSecurityScheme": {
+                    "description": "ODS Dashboard API bearer token",
+                    "scheme": "Bearer",
+                    "bearerFormat": "opaque",
+                }
+            }
+        },
+        "securityRequirements": [
+            {"schemes": {"dashboardBearer": {"list": []}}}
+        ],
+        "defaultInputModes": ["text/plain"],
+        "defaultOutputModes": ["text/plain"],
+        "skills": [
+            {
+                "id": "general-assistance",
+                "name": "General assistance",
+                "description": "Answer questions and perform locally configured Hermes agent workflows.",
+                "tags": ["assistant", "local-ai", "tools"],
+                "examples": ["Summarize this topic", "Research a technical question"],
+            }
+        ],
+    }
+
+
+def _message_text(payload: Any) -> tuple[str, str, str]:
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="message must be an object.")
+
+    message_id = payload.get("messageId")
+    if not isinstance(message_id, str) or not message_id.strip():
+        raise HTTPException(status_code=400, detail="message.messageId is required.")
+    if len(message_id.strip()) > MAX_ID_CHARS:
+        raise HTTPException(status_code=400, detail="message.messageId exceeds 256 characters.")
+    if payload.get("role") != "ROLE_USER":
+        raise HTTPException(status_code=400, detail="message.role must be ROLE_USER.")
+    if payload.get("taskId"):
+        raise HTTPException(
+            status_code=409,
+            detail="ODS does not expose an A2A task lifecycle yet; send a direct message without taskId.",
+        )
+
+    parts = payload.get("parts")
+    if not isinstance(parts, list) or not parts:
+        raise HTTPException(status_code=400, detail="message.parts must contain at least one text part.")
+    if len(parts) > MAX_PARTS:
+        raise HTTPException(status_code=413, detail="message.parts exceeds the 64-part limit.")
+
+    text_parts: list[str] = []
+    for part in parts:
+        content_fields = {"text", "raw", "url", "data"}.intersection(part) if isinstance(part, dict) else set()
+        if content_fields != {"text"} or not isinstance(part.get("text"), str):
+            raise HTTPException(status_code=415, detail="ODS A2A currently accepts text parts only.")
+        media_type = part.get("mediaType")
+        if media_type not in (None, "", "text/plain"):
+            raise HTTPException(status_code=415, detail="ODS A2A currently accepts text/plain parts only.")
+        if part["text"].strip():
+            text_parts.append(part["text"].strip())
+
+    text = "\n\n".join(text_parts)
+    if not text:
+        raise HTTPException(status_code=400, detail="message text cannot be empty.")
+    if len(text) > MAX_MESSAGE_CHARS:
+        raise HTTPException(
+            status_code=413,
+            detail=f"message text exceeds the {MAX_MESSAGE_CHARS}-character limit.",
+        )
+
+    context_id = payload.get("contextId")
+    if context_id is not None and (not isinstance(context_id, str) or not context_id.strip()):
+        raise HTTPException(status_code=400, detail="message.contextId must be a non-empty string.")
+    if isinstance(context_id, str) and len(context_id.strip()) > MAX_ID_CHARS:
+        raise HTTPException(status_code=400, detail="message.contextId exceeds 256 characters.")
+    return message_id.strip(), (context_id or str(uuid.uuid4())).strip(), text
+
+
+def _session_key(api_key: str, context_id: str) -> str:
+    identity = f"a2a:{api_key}:{context_id}".encode("utf-8")
+    return hashlib.sha256(identity).hexdigest()
+
+
+def _error_response(
+    status_code: int,
+    message: str,
+    *,
+    reason: str | None = None,
+    headers: Mapping[str, str] | None = None,
+) -> JSONResponse:
+    details: list[dict[str, Any]] = []
+    if reason:
+        details.append(
+            {
+                "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+                "reason": reason,
+                "domain": "a2a-protocol.org",
+            }
+        )
+    status_name = {
+        400: "INVALID_ARGUMENT",
+        401: "UNAUTHENTICATED",
+        403: "PERMISSION_DENIED",
+        404: "NOT_FOUND",
+        413: "RESOURCE_EXHAUSTED",
+        502: "UNAVAILABLE",
+        503: "UNAVAILABLE",
+    }.get(status_code, "UNKNOWN")
+    if reason in {
+        "PUSH_NOTIFICATION_NOT_SUPPORTED",
+        "UNSUPPORTED_OPERATION",
+        "VERSION_NOT_SUPPORTED",
+    }:
+        status_name = "FAILED_PRECONDITION"
+    return JSONResponse(
+        {
+            "error": {
+                "code": status_code,
+                "status": status_name,
+                "message": message,
+                "details": details,
+            }
+        },
+        status_code=status_code,
+        media_type=A2A_MEDIA_TYPE,
+        headers=headers,
+    )
+
+
+async def _authorize_request(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials,
+) -> tuple[str | None, JSONResponse | None]:
+    try:
+        api_key = await verify_api_key(credentials)
+    except HTTPException as exc:
+        return None, _error_response(
+            exc.status_code,
+            str(exc.detail),
+            headers=exc.headers,
+        )
+
+    version = (request.headers.get("A2A-Version") or "0.3").strip()
+    if version != A2A_VERSION:
+        return None, _error_response(
+            400,
+            f"A2A protocol version {version!r} is not supported; use {A2A_VERSION}.",
+            reason="VERSION_NOT_SUPPORTED",
+        )
+    return api_key, None
+
+
+@router.get("/.well-known/agent-card.json")
+async def agent_card(request: Request) -> JSONResponse:
+    """Public A2A discovery document; it never contains credentials."""
+    return JSONResponse(_agent_card(request), media_type=A2A_MEDIA_TYPE)
+
+
+@router.post("/a2a/v1/message:send")
+async def send_message(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    """Run one blocking A2A text turn through the existing Hermes bridge."""
+    api_key, auth_error = await _authorize_request(request, credentials)
+    if auth_error is not None:
+        return auth_error
+    assert api_key is not None
+
+    body = await request.body()
+    if len(body) > MAX_REQUEST_BYTES:
+        return _error_response(413, "Request body exceeds the 64 KiB limit.")
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return _error_response(400, "Request body must be valid JSON.")
+    if not isinstance(payload, dict):
+        return _error_response(400, "Request body must be a JSON object.")
+
+    try:
+        message_id, context_id, text = _message_text(payload.get("message"))
+
+        if payload.get("tenant") not in (None, ""):
+            raise HTTPException(status_code=400, detail="tenant is not configured for this A2A interface.")
+        configuration = payload.get("configuration") or {}
+        if not isinstance(configuration, dict):
+            raise HTTPException(status_code=400, detail="configuration must be an object.")
+        accepted_modes = configuration.get("acceptedOutputModes") or []
+        if not isinstance(accepted_modes, list):
+            raise HTTPException(status_code=400, detail="acceptedOutputModes must be a list.")
+        if len(accepted_modes) > 16 or not all(isinstance(mode, str) for mode in accepted_modes):
+            raise HTTPException(status_code=400, detail="acceptedOutputModes must contain at most 16 strings.")
+        if accepted_modes and "text/plain" not in accepted_modes:
+            return _error_response(
+                400,
+                "ODS A2A produces text/plain output only.",
+                reason="CONTENT_TYPE_NOT_SUPPORTED",
+            )
+        if "taskPushNotificationConfig" in configuration:
+            return _error_response(
+                400,
+                "ODS A2A does not support push notifications.",
+                reason="PUSH_NOTIFICATION_NOT_SUPPORTED",
+            )
+    except HTTPException as exc:
+        reason = None
+        status_code = exc.status_code
+        if status_code == 409:
+            status_code = 400
+            reason = "UNSUPPORTED_OPERATION"
+        elif status_code == 415:
+            status_code = 400
+            reason = "CONTENT_TYPE_NOT_SUPPORTED"
+        return _error_response(status_code, str(exc.detail), reason=reason)
+
+    try:
+        reply = await hermes_bridge.submit_prompt(_session_key(api_key, context_id), text)
+    except hermes_bridge.HermesUnavailable:
+        return _error_response(503, "Hermes Agent is unavailable.")
+    except hermes_bridge.HermesBridgeError:
+        return _error_response(502, "Hermes Agent could not complete the message.")
+
+    response_message: dict[str, Any] = {
+        "messageId": str(uuid.uuid4()),
+        "contextId": context_id,
+        "role": "ROLE_AGENT",
+        "parts": [{"text": reply.text, "mediaType": "text/plain"}],
+        "metadata": {"inReplyTo": message_id},
+    }
+    if reply.warning:
+        response_message["metadata"]["warning"] = reply.warning
+    return JSONResponse({"message": response_message}, media_type=A2A_MEDIA_TYPE)
+
+
+@router.post("/a2a/v1/message:stream")
+async def send_streaming_message(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    _, auth_error = await _authorize_request(request, credentials)
+    if auth_error is not None:
+        return auth_error
+    return _error_response(
+        400,
+        "ODS A2A does not support streaming messages.",
+        reason="UNSUPPORTED_OPERATION",
+    )
+
+
+async def _unsupported_capability(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials,
+    *,
+    message: str,
+    reason: str,
+) -> JSONResponse:
+    _, auth_error = await _authorize_request(request, credentials)
+    if auth_error is not None:
+        return auth_error
+    return _error_response(400, message, reason=reason)
+
+
+@router.get("/a2a/v1/tasks")
+async def list_tasks(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    _, auth_error = await _authorize_request(request, credentials)
+    if auth_error is not None:
+        return auth_error
+    raw_page_size = request.query_params.get("pageSize", "50")
+    try:
+        page_size = int(raw_page_size)
+    except ValueError:
+        return _error_response(400, "pageSize must be an integer from 1 to 100.")
+    if not 1 <= page_size <= 100:
+        return _error_response(400, "pageSize must be an integer from 1 to 100.")
+    return JSONResponse(
+        {"tasks": [], "nextPageToken": "", "pageSize": page_size, "totalSize": 0},
+        media_type=A2A_MEDIA_TYPE,
+    )
+
+
+def _task_not_found(task_id: str) -> JSONResponse:
+    return _error_response(
+        404,
+        f"Task with ID {task_id!r} was not found; ODS currently returns direct messages.",
+        reason="TASK_NOT_FOUND",
+    )
+
+
+@router.get("/a2a/v1/tasks/{task_id}")
+async def get_task(
+    task_id: str,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    _, auth_error = await _authorize_request(request, credentials)
+    if auth_error is not None:
+        return auth_error
+    return _task_not_found(task_id)
+
+
+@router.post("/a2a/v1/tasks/{task_id}:cancel")
+async def cancel_task(
+    task_id: str,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    _, auth_error = await _authorize_request(request, credentials)
+    if auth_error is not None:
+        return auth_error
+    return _task_not_found(task_id)
+
+
+@router.post("/a2a/v1/tasks/{task_id}:subscribe")
+async def subscribe_to_task(
+    task_id: str,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    return await _unsupported_capability(
+        request,
+        credentials,
+        message=f"ODS A2A does not support streaming task {task_id!r}.",
+        reason="UNSUPPORTED_OPERATION",
+    )
+
+
+@router.api_route(
+    "/a2a/v1/tasks/{task_id}/pushNotificationConfigs",
+    methods=["GET", "POST"],
+)
+@router.api_route(
+    "/a2a/v1/tasks/{task_id}/pushNotificationConfigs/{config_id}",
+    methods=["GET", "DELETE"],
+)
+async def task_push_notifications_not_supported(
+    task_id: str,
+    request: Request,
+    config_id: str | None = None,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    return await _unsupported_capability(
+        request,
+        credentials,
+        message=f"ODS A2A does not support push notifications for task {task_id!r}.",
+        reason="PUSH_NOTIFICATION_NOT_SUPPORTED",
+    )
+
+
+@router.get("/a2a/v1/extendedAgentCard")
+async def extended_agent_card_not_supported(
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    return await _unsupported_capability(
+        request,
+        credentials,
+        message="ODS A2A does not expose an extended Agent Card.",
+        reason="UNSUPPORTED_OPERATION",
+    )

--- a/ods/extensions/services/dashboard-api/routers/a2a.py
+++ b/ods/extensions/services/dashboard-api/routers/a2a.py
@@ -199,7 +199,11 @@ async def _authorize_request(
             headers=exc.headers,
         )
 
-    version = (request.headers.get("A2A-Version") or "0.3").strip()
+    version = (
+        request.headers.get("A2A-Version")
+        or request.query_params.get("A2A-Version")
+        or "0.3"
+    ).strip()
     if version != A2A_VERSION:
         return None, _error_response(
             400,
@@ -348,6 +352,20 @@ def _task_not_found(task_id: str) -> JSONResponse:
     )
 
 
+@router.get("/a2a/v1/tasks/{task_id}:subscribe")
+async def subscribe_to_task(
+    task_id: str,
+    request: Request,
+    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
+) -> JSONResponse:
+    return await _unsupported_capability(
+        request,
+        credentials,
+        message=f"ODS A2A does not support streaming task {task_id!r}.",
+        reason="UNSUPPORTED_OPERATION",
+    )
+
+
 @router.get("/a2a/v1/tasks/{task_id}")
 async def get_task(
     task_id: str,
@@ -370,20 +388,6 @@ async def cancel_task(
     if auth_error is not None:
         return auth_error
     return _task_not_found(task_id)
-
-
-@router.post("/a2a/v1/tasks/{task_id}:subscribe")
-async def subscribe_to_task(
-    task_id: str,
-    request: Request,
-    credentials: HTTPAuthorizationCredentials = Security(security_scheme),
-) -> JSONResponse:
-    return await _unsupported_capability(
-        request,
-        credentials,
-        message=f"ODS A2A does not support streaming task {task_id!r}.",
-        reason="UNSUPPORTED_OPERATION",
-    )
 
 
 @router.api_route(

--- a/ods/extensions/services/dashboard-api/tests/test_a2a.py
+++ b/ods/extensions/services/dashboard-api/tests/test_a2a.py
@@ -1,0 +1,276 @@
+"""Boundary tests for the A2A v1 HTTP+JSON adapter."""
+
+from unittest.mock import AsyncMock
+
+from hermes_bridge import HermesReply, HermesUnavailable
+
+
+def _a2a_headers(test_client):
+    return {**test_client.auth_headers, "A2A-Version": "1.0"}
+
+
+def test_agent_card_advertises_only_implemented_capabilities(test_client):
+    response = test_client.get(
+        "/.well-known/agent-card.json",
+        headers={"host": "api.ods.local"},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/a2a+json")
+    card = response.json()
+    assert card["supportedInterfaces"] == [
+        {
+            "url": "http://api.ods.local/a2a/v1",
+            "protocolBinding": "HTTP+JSON",
+            "protocolVersion": "1.0",
+        }
+    ]
+    assert card["capabilities"] == {
+        "streaming": False,
+        "pushNotifications": False,
+        "extendedAgentCard": False,
+    }
+    assert card["securitySchemes"]["dashboardBearer"]["httpAuthSecurityScheme"]["scheme"] == "Bearer"
+    assert card["securityRequirements"] == [
+        {"schemes": {"dashboardBearer": {"list": []}}}
+    ]
+
+
+def test_send_message_requires_dashboard_bearer_token(test_client):
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        json={
+            "message": {
+                "messageId": "msg-unauthorized",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}],
+            }
+        },
+    )
+
+    assert response.status_code == 401
+    assert response.headers["www-authenticate"] == "Bearer"
+
+
+def test_send_message_maps_text_to_hermes_and_returns_direct_message(test_client, monkeypatch):
+    submit = AsyncMock(return_value=HermesReply(session_id="hermes-1", text="Hello from ODS"))
+    monkeypatch.setattr("routers.a2a.hermes_bridge.submit_prompt", submit)
+
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers=_a2a_headers(test_client),
+        json={
+            "message": {
+                "messageId": "msg-1",
+                "contextId": "context-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "Research local inference"}],
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/a2a+json")
+    payload = response.json()
+    assert set(payload) == {"message"}
+    assert payload["message"]["role"] == "ROLE_AGENT"
+    assert payload["message"]["contextId"] == "context-1"
+    assert payload["message"]["parts"] == [{"text": "Hello from ODS", "mediaType": "text/plain"}]
+    session_key, prompt = submit.await_args.args
+    assert len(session_key) == 64
+    assert prompt == "Research local inference"
+
+
+def test_send_message_keeps_context_on_the_same_hermes_session(test_client, monkeypatch):
+    submit = AsyncMock(return_value=HermesReply(session_id="hermes-1", text="ok"))
+    monkeypatch.setattr("routers.a2a.hermes_bridge.submit_prompt", submit)
+    base_message = {
+        "contextId": "shared-context",
+        "role": "ROLE_USER",
+        "parts": [{"text": "hello"}],
+    }
+
+    for message_id in ("msg-1", "msg-2"):
+        response = test_client.post(
+            "/a2a/v1/message:send",
+            headers=_a2a_headers(test_client),
+            json={"message": {**base_message, "messageId": message_id}},
+        )
+        assert response.status_code == 200
+
+    assert submit.await_args_list[0].args[0] == submit.await_args_list[1].args[0]
+
+
+def test_send_message_generates_context_when_client_omits_it(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "routers.a2a.hermes_bridge.submit_prompt",
+        AsyncMock(return_value=HermesReply(session_id="hermes-1", text="ok")),
+    )
+
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers=_a2a_headers(test_client),
+        json={
+            "message": {
+                "messageId": "msg-new-context",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}],
+            }
+        },
+    )
+
+    context_id = response.json()["message"]["contextId"]
+    assert response.status_code == 200
+    assert isinstance(context_id, str) and context_id
+
+
+def test_send_message_rejects_task_continuation_until_task_lifecycle_exists(test_client):
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers=_a2a_headers(test_client),
+        json={
+            "message": {
+                "messageId": "msg-task",
+                "taskId": "task-1",
+                "role": "ROLE_USER",
+                "parts": [{"text": "continue"}],
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/a2a+json")
+    assert response.json()["error"]["details"][0]["reason"] == "UNSUPPORTED_OPERATION"
+    assert "task lifecycle" in response.json()["error"]["message"].lower()
+
+
+def test_send_message_rejects_non_text_parts_at_the_public_boundary(test_client):
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers=_a2a_headers(test_client),
+        json={
+            "message": {
+                "messageId": "msg-file",
+                "role": "ROLE_USER",
+                "parts": [{"url": "https://example.test/file.pdf"}],
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["details"][0]["reason"] == "CONTENT_TYPE_NOT_SUPPORTED"
+    assert "text" in response.json()["error"]["message"].lower()
+
+
+def test_send_message_rejects_oversized_request_before_hermes(test_client, monkeypatch):
+    submit = AsyncMock(return_value=HermesReply(session_id="hermes-1", text="unused"))
+    monkeypatch.setattr("routers.a2a.hermes_bridge.submit_prompt", submit)
+
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers=_a2a_headers(test_client),
+        json={
+            "message": {
+                "messageId": "msg-large",
+                "role": "ROLE_USER",
+                "parts": [{"text": "x" * 70_000}],
+            }
+        },
+    )
+
+    assert response.status_code == 413
+    assert response.json()["error"]["status"] == "RESOURCE_EXHAUSTED"
+    submit.assert_not_awaited()
+
+
+def test_send_message_surfaces_hermes_unavailability(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "routers.a2a.hermes_bridge.submit_prompt",
+        AsyncMock(side_effect=HermesUnavailable("offline")),
+    )
+
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers=_a2a_headers(test_client),
+        json={
+            "message": {
+                "messageId": "msg-offline",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}],
+            }
+        },
+    )
+
+    assert response.status_code == 503
+    assert response.json()["error"]["message"] == "Hermes Agent is unavailable."
+
+
+def test_send_message_rejects_unsupported_protocol_version(test_client):
+    response = test_client.post(
+        "/a2a/v1/message:send",
+        headers={**test_client.auth_headers, "A2A-Version": "0.3"},
+        json={
+            "message": {
+                "messageId": "msg-old-version",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}],
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.headers["content-type"].startswith("application/a2a+json")
+    assert response.json()["error"]["details"][0]["reason"] == "VERSION_NOT_SUPPORTED"
+
+
+def test_task_operations_are_truthful_for_a_direct_message_agent(test_client):
+    headers = _a2a_headers(test_client)
+
+    listed = test_client.get("/a2a/v1/tasks", headers=headers)
+    missing = test_client.get("/a2a/v1/tasks/task-1", headers=headers)
+    canceled = test_client.post("/a2a/v1/tasks/task-1:cancel", headers=headers)
+
+    assert listed.status_code == 200
+    assert listed.json() == {
+        "tasks": [],
+        "nextPageToken": "",
+        "pageSize": 50,
+        "totalSize": 0,
+    }
+    for response in (missing, canceled):
+        assert response.status_code == 404
+        assert response.json()["error"]["status"] == "NOT_FOUND"
+        assert response.json()["error"]["details"][0]["reason"] == "TASK_NOT_FOUND"
+
+
+def test_streaming_operation_matches_the_agent_card_capability(test_client):
+    response = test_client.post(
+        "/a2a/v1/message:stream",
+        headers=_a2a_headers(test_client),
+        json={},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["status"] == "FAILED_PRECONDITION"
+    assert response.json()["error"]["details"][0]["reason"] == "UNSUPPORTED_OPERATION"
+
+
+def test_optional_capability_routes_return_protocol_errors(test_client):
+    headers = _a2a_headers(test_client)
+    responses = (
+        test_client.post("/a2a/v1/tasks/task-1:subscribe", headers=headers),
+        test_client.post(
+            "/a2a/v1/tasks/task-1/pushNotificationConfigs",
+            headers=headers,
+            json={},
+        ),
+        test_client.get("/a2a/v1/extendedAgentCard", headers=headers),
+    )
+
+    assert [response.status_code for response in responses] == [400, 400, 400]
+    reasons = [response.json()["error"]["details"][0]["reason"] for response in responses]
+    assert reasons == [
+        "UNSUPPORTED_OPERATION",
+        "PUSH_NOTIFICATION_NOT_SUPPORTED",
+        "UNSUPPORTED_OPERATION",
+    ]

--- a/ods/extensions/services/dashboard-api/tests/test_a2a.py
+++ b/ods/extensions/services/dashboard-api/tests/test_a2a.py
@@ -223,6 +223,28 @@ def test_send_message_rejects_unsupported_protocol_version(test_client):
     assert response.json()["error"]["details"][0]["reason"] == "VERSION_NOT_SUPPORTED"
 
 
+def test_send_message_accepts_protocol_version_query_parameter(test_client, monkeypatch):
+    monkeypatch.setattr(
+        "routers.a2a.hermes_bridge.submit_prompt",
+        AsyncMock(return_value=HermesReply(session_id="hermes-1", text="ok")),
+    )
+
+    response = test_client.post(
+        "/a2a/v1/message:send?A2A-Version=1.0",
+        headers=test_client.auth_headers,
+        json={
+            "message": {
+                "messageId": "msg-query-version",
+                "role": "ROLE_USER",
+                "parts": [{"text": "hello"}],
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"]["parts"][0]["text"] == "ok"
+
+
 def test_task_operations_are_truthful_for_a_direct_message_agent(test_client):
     headers = _a2a_headers(test_client)
 
@@ -258,7 +280,7 @@ def test_streaming_operation_matches_the_agent_card_capability(test_client):
 def test_optional_capability_routes_return_protocol_errors(test_client):
     headers = _a2a_headers(test_client)
     responses = (
-        test_client.post("/a2a/v1/tasks/task-1:subscribe", headers=headers),
+        test_client.get("/a2a/v1/tasks/task-1:subscribe", headers=headers),
         test_client.post(
             "/a2a/v1/tasks/task-1/pushNotificationConfigs",
             headers=headers,


### PR DESCRIPTION
## Summary - publish an A2A v1 Agent Card at `/.well-known/agent-card.json` - expose the HTTP+JSON `message:send` operation through the existing authenticated Hermes bridge - preserve A2A `contextId` continuity while returning the protocol's direct `Message` response variant - return A2A `google.rpc.Status`-shaped errors for version, content, task, streaming, push, and availability failures - document discovery, authentication, limitations, and an operator curl receipt  ## Why this matters ODS already ships a production-reachable agent path: an authenticated dashboard API calls the internal Hermes JSON-RPC WebSocket and Hermes executes against the selected local model. Until this change, external agent clients had to understand ODS Talk's private API instead of a standard agent contract.  A2A v1 defines public Agent Card discovery, authenticated HTTP+JSON operations, context identifiers, direct `Message` responses, capability negotiation, and standard error envelopes. This adapter makes the existing Hermes path interoperable without inventing a second agent runtime or exposing Hermes's internal dashboard token.  Production contract: 1. an A2A client discovers the card through the dashboard API host; 2. the card declares HTTP+JSON v1.0, text modes, Dashboard bearer auth, and only capabilities ODS implements; 3. `message:send` validates auth, `A2A-Version`, body size, identifiers, media type, and request complexity; 4. the caller's bearer identity plus `contextId` maps to an opaque Hermes bridge session key; 5. the existing bridge submits the prompt on Hermes's internal authenticated WebSocket; 6. ODS returns a schema-valid direct A2A `Message`, or an `application/a2a+json` error receipt.  The upstream contract is the released A2A v1 specification: https://github.com/a2aproject/A2A/blob/main/docs/specification.md  ## Behavioral invariant The Agent Card must never advertise a capability that the runtime cannot complete safely. The pinned Hermes dashboard has no durable task store or safe prompt cancellation, so ODS returns direct messages, reports an empty task collection, and explicitly rejects streaming/push/extended-card operations. It does not mark a task canceled while Hermes could still be executing tools.  ## Overlap check Searched open and closed PR titles/bodies for `A2A`, `Agent Card`, `agent protocol`, `Hermes bridge`, and `dashboard API`, then scanned the file lists of all 347 open PRs for `main.py`, `HERMES.md`, `hermes_bridge.py`, and `routers/a2a.py`. No PR adds A2A discovery or message operations.  Relevant shared-file work is independent: - #1976 adds optional Basic Auth inside `hermes_bridge.py`; this adapter consumes the public bridge API. - #2731 adds cross-site browser request rejection; non-browser A2A calls omit `Origin` and remain allowed. - #3099 closes partial Hermes connections on cancellation; it strengthens the same bridge without changing its public contract. - #3385 adds Pixel while retaining Hermes as a rollback path. The only merge conflicts are additive `a2a`/`pixel` import and router-registration lines.  Synthetic integration head `ee361c3c034a58c2d66f6859f1f8fb7433202d0a` combines this commit with #3099, #2731, and #3385. After preserving both router registrations, the A2A, Talk, CSRF, Pixel, Main, and Security suites passed 168 tests.  ## Validation - `pytest -q tests/test_a2a.py tests/test_talk.py tests/test_main.py tests/test_security.py` — 132 passed - full dashboard API suite — 2,114 passed, 14 skipped; one unchanged Windows symlink test could not create a symlink without SeCreateSymbolicLink privilege - official `a2a-sdk==1.1.2` protobuf parsing — Agent Card parsed as protocol 1.0 and response parsed with the `message` payload discriminator - Ruff E/F/W on changed Python — passed - Python compile + `git diff --check` — passed - dashboard ESLint + Vite production build — passed - `make gate` — lint and 129 tier assertions passed, then stopped at the unchanged `Hermes template bounds each model turn` failure also present on clean `main` - pre-commit — gitleaks and large-file checks passed; existing private-key fixtures were flagged, all-files ShellCheck hit the Windows CRLF `.shellcheckrc`, and the heredoc hook could not find `awk`  ## Design, limitations, and rollback - Input/output is text-only and each request is capped at 64 KiB, 64 parts, and 8,000 joined text characters. - Context continuity uses the existing in-process Hermes connection pool and therefore expires on idle eviction or dashboard API restart; no durability is claimed. - The local stack serves HTTP. A2A must be placed behind HTTPS before exposure outside the trusted LAN, as documented. - A live Hermes/A2A turn was not available on this development host; mocked boundary tests prove the HTTP-to-bridge handoff and the official SDK proves wire-schema compatibility, not live model/tool execution. - Rollback is the single feature commit. It removes only the new router registration, adapter, tests, and documentation; Hermes and ODS Talk behavior remain unchanged.
## Review follow-up (2026-08-30)

Commit `e8a89f44` aligns the HTTP binding with the normative A2A v1 proto after review:
- accepts `A2A-Version=1.0` as a query parameter as permitted by the version-negotiation contract;
- exposes task subscription at `GET /tasks/{id}:subscribe` and registers that specific route before `GET /tasks/{id}`, preventing FastAPI's dynamic route from swallowing it;
- adds public-boundary regressions for both cases.

Revalidation: `python -m pytest tests/test_a2a.py tests/test_talk.py tests/test_main.py tests/test_security.py -q` — 133 passed. Python compile and `git diff --check` passed. Ruff was unavailable in the local Python environment; GitHub CI remains the lint gate.