### PR TITLE
fix(talk): reuse the managed Hermes session pool

### DIFF
--- a/ods/extensions/services/dashboard-api/hermes_bridge.py
+++ b/ods/extensions/services/dashboard-api/hermes_bridge.py
@@ -556,33 +556,13 @@ async def submit_prompt(session_key: str, text: str) -> HermesReply:
     return HermesReply(session_id=session_id, text=final_text, status=status, warning=warning)
 
 
-# -------- legacy compat shims (kept so existing tests keep importing OK) --------
-
-_SESSION_IDS: dict[str, str] = {}
-
-
 async def ensure_session(session_key: str) -> str:
-    """Legacy: tests call this to seed _SESSION_IDS before invoking submit_prompt.
+    """Return the managed Hermes session for this Talk cookie.
 
-    The streaming bridge now creates a fresh Hermes session per call, so the
-    stored value is informational only. We still return *something* truthy so
-    tests that assert "ensure_session returned a non-empty string" pass.
+    Session ownership stays with the connection pool used by ``stream_prompt``
+    so the idle sweeper and application shutdown close the connection and evict
+    its cookie key together.
     """
-    existing = _SESSION_IDS.get(session_key)
-    if existing:
-        return existing
-    timeout_seconds = _request_timeout()
-    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
-    async with aiohttp.ClientSession(timeout=timeout) as http_session:
-        ws = await _connect_ws(http_session)
-        async with ws:
-            session_id = await _create_session_on_ws(ws, timeout=30)
-    _SESSION_IDS[session_key] = session_id
-    return session_id
-
-
-def clear_session_for_tests(session_key: str | None = None) -> None:
-    if session_key is None:
-        _SESSION_IDS.clear()
-    else:
-        _SESSION_IDS.pop(session_key, None)
+    _ensure_sweeper_running()
+    conn = await _get_connection(session_key)
+    return conn.session_id

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -481,6 +481,62 @@ def _run_with_one_loop(coro_factory):
         loop.close()
 
 
+def test_hermes_bridge_ensure_session_uses_managed_pool(monkeypatch):
+    """The session bootstrap endpoint must not keep a second, unbounded cache.
+
+    Its session ID should come from the same idle-evicted connection that later
+    chat prompts reuse, and normal pool shutdown must close that connection.
+    """
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._OPENING_LOCKS.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    class FakeWS:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    class FakeHTTP:
+        async def close(self):
+            pass
+
+    opened: list[hermes_bridge._HermesConnection] = []
+
+    async def fake_open(session_key):
+        conn = hermes_bridge._HermesConnection(
+            http_session=FakeHTTP(),
+            ws=FakeWS(),
+            session_id=f"sid-{session_key}",
+        )
+        opened.append(conn)
+        return conn
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
+
+    async def main():
+        first = await hermes_bridge.ensure_session("phone-key")
+        second = await hermes_bridge.ensure_session("phone-key")
+        return (
+            first,
+            second,
+            hermes_bridge._CONNECTION_POOL["phone-key"],
+            hermes_bridge._SWEEPER_TASK is not None,
+        )
+
+    first, second, pooled, sweeper_started = _run_with_one_loop(main)
+
+    assert first == second == "sid-phone-key"
+    assert opened == [pooled]
+    assert sweeper_started is True
+    assert hermes_bridge._CONNECTION_POOL == {}
+    assert pooled.closed is True
+    assert pooled.ws.closed is True
+
+
 def test_hermes_bridge_pool_serializes_same_key_parallels_different_keys(monkeypatch):
     """Connection-pool contract:
 


### PR DESCRIPTION
## Summary

- remove the legacy `_SESSION_IDS` dictionary that retained every ODS Talk cookie key for the lifetime of the dashboard API process
- have `/api/talk/session` obtain its session ID from the existing managed Hermes connection pool used by `stream_prompt`
- add regression coverage for same-key reuse, pool ownership, and shutdown cleanup

Previously, the session bootstrap endpoint opened a throwaway WebSocket, cached its returned ID in a second dictionary, and never evicted expired cookie keys. The ID was not the session later used for chat. Reusing the existing pool keeps one owner for per-cookie session state and gives it the pool's established idle eviction and application-shutdown cleanup.

## AI Assistance

OpenAI Codex assisted with bug analysis, implementation, test drafting, validation, and PR preparation. The final diff and validation evidence are included here for human review; merge and release decisions remain with the maintainers.

## Release Lane

- [x] Mainline change targeting `main`

Stable hotfix reason:

```text
Not applicable; this PR targets main.
```

## Changed Surface

- [x] Dashboard API / host agent
- [x] Model routing / Hermes / capabilities

## Risk And Validation

- Risk level: High, because this changes Hermes session lifecycle wiring
- Validation run:
  - [x] `git diff --check`
  - [x] Focused regression test
  - [x] Complete ODS Talk backend test file
  - [x] Complete dashboard API test directory

Commands/results:

```text
python -m pytest -q tests/test_talk.py::test_hermes_bridge_ensure_session_uses_managed_pool
# 1 passed

python -m pytest -q tests/test_talk.py
# 40 passed

python -m pytest -q tests
# 2118 passed, 1 skipped, 1 existing warning

python -m py_compile hermes_bridge.py tests/test_talk.py
# passed

git diff --check
# passed
```

Tests ran in a fresh virtual environment installed from the dashboard API `requirements.txt`, with pytest and pytest-asyncio added as test dependencies.

A hardware fleet was not run. The scoped equivalent is appropriate here because the patch does not change the Hermes protocol, request payloads, authentication, or response schema; it routes the bootstrap endpoint through the already-tested connection-pool path introduced for normal Talk prompts. The complete dashboard API suite was also run.

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

## Notes For Reviewers

- API response shape is unchanged: `/api/talk/session` still returns `session_id` and `expires_at`.
- Repeated calls with the same cookie reuse the same live pooled connection instead of a disconnected legacy ID.
- Idle eviction and graceful shutdown are handled by the existing pool; this PR does not add another cache or lifecycle mechanism.
- Rollback is a single-commit revert, restoring the prior bootstrap implementation and legacy dictionary.
