### PR TITLE
fix(migration): write migration version state atomically in migrate-config.sh

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -65,7 +65,10 @@ get_last_migrated_version() {
 set_last_migrated_version() {
     local version="$1"
     mkdir -p "$(dirname "$MIGRATION_STATE")"
-    echo "$version" > "$MIGRATION_STATE"
+    local tmp_state
+    tmp_state="$(mktemp "${MIGRATION_STATE}.XXXXXX.tmp")"
+    echo "$version" > "$tmp_state"
+    mv -f "$tmp_state" "$MIGRATION_STATE"
 }
 
 # Compare semantic versions


### PR DESCRIPTION
## Summary
fix(migration): write migration version state atomically in migrate-config.sh

## Changes
- Updated implementation in `fix/migration-version-state-atomic` for resilience and error handling.
- Verified with standard linting and contract checks.

## Verification
- Passed `make lint` checks cleanly.
