### PR TITLE
fix(installer): --tier override now bounds catalog model selection

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -677,6 +677,7 @@ if [[ "${ODS_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_TIE
                 --ram-gb "${SYSTEM_RAM_GB:-0}" \
                 --profile "${MODEL_PROFILE_EFFECTIVE:-${MODEL_PROFILE:-qwen}}" \
                 --tier "$SELECTED_TIER" \
+                --max-size-mb "${LLM_MODEL_SIZE_MB:-0}" \
                 --host-arch "$(uname -m 2>/dev/null || echo unknown)" \
                 --installable-only \
                 --env 2>>"$ODS_LOG_FILE" || true)"

--- a/ods/installers/phases/02-detection.sh
+++ b/ods/installers/phases/02-detection.sh
@@ -551,6 +551,7 @@ if [[ "${ODS_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "${TIER:-}" !=
                 --ram-gb "${RAM_GB:-0}" \
                 --profile "${MODEL_PROFILE_EFFECTIVE:-${MODEL_PROFILE:-qwen}}" \
                 --tier "${TIER:-1}" \
+                --max-size-mb "${LLM_MODEL_SIZE_MB:-0}" \
                 --host-arch "${HOST_ARCH:-unknown}" \
                 --installable-only \
                 --env 2>>"$LOG_FILE" || true)"

--- a/ods/scripts/select-model.py
+++ b/ods/scripts/select-model.py
@@ -249,14 +249,33 @@ def score_model(model: dict[str, Any], capacity_gb: float, profile: str) -> floa
     return specialty_weight + family_bonus + context_bonus + capability - headroom_penalty
 
 
+def size_within_ceiling(model: dict[str, Any], max_size_mb: float) -> bool:
+    """True if `model` respects an optional tier size ceiling.
+
+    `max_size_mb` <= 0 means "no ceiling" (unbounded, current behavior).
+    A small tolerance absorbs rounding differences between the tier map's
+    declared LLM_MODEL_SIZE_MB and the catalog's size_mb for the same
+    model, so the tier's own designated model is never excluded by its
+    own ceiling.
+    """
+    if max_size_mb <= 0:
+        return True
+    size_mb = float(model.get("size_mb") or 0)
+    tolerance_mb = max(max_size_mb * 0.02, 64.0)
+    return size_mb <= max_size_mb + tolerance_mb
+
+
 def rank_models(catalog: list[dict[str, Any]], capacity_gb: float, profile: str,
                 installable_only: bool, backend: str, memory_type: str,
-                vram_mb: int, ram_gb: int, host_arch: str) -> list[dict[str, Any]]:
+                vram_mb: int, ram_gb: int, host_arch: str,
+                max_size_mb: float = 0) -> list[dict[str, Any]]:
     candidates = []
     for model in catalog:
         if installable_only and not model.get("gguf_url"):
             continue
         if not family_allowed(model, profile):
+            continue
+        if not size_within_ceiling(model, max_size_mb):
             continue
         runtime_profile = matching_runtime_profile(model, backend, memory_type, vram_mb, ram_gb, host_arch)
         candidate_model = {**model, "_runtime_profile": runtime_profile} if runtime_profile else model
@@ -266,6 +285,11 @@ def rank_models(catalog: list[dict[str, Any]], capacity_gb: float, profile: str,
         candidates.append((score_model(candidate_model, capacity_gb, profile), candidate_model))
     if not candidates:
         fallback_pool = [
+            model for model in catalog
+            if (not installable_only or model.get("gguf_url"))
+            and family_allowed(model, profile)
+            and size_within_ceiling(model, max_size_mb)
+        ] or [
             model for model in catalog
             if (not installable_only or model.get("gguf_url")) and family_allowed(model, profile)
         ] or catalog
@@ -398,6 +422,12 @@ def main() -> int:
     parser.add_argument("--ram-gb", type=int, default=0)
     parser.add_argument("--profile", default="qwen")
     parser.add_argument("--tier", default="1")
+    parser.add_argument(
+        "--max-size-mb", type=float, default=0,
+        help="Optional ceiling on selected model size_mb, e.g. the tier map's "
+             "LLM_MODEL_SIZE_MB. 0 (default) leaves selection unbounded, "
+             "picking the largest catalog model that fits available memory.",
+    )
     parser.add_argument("--host-arch", default="unknown")
     parser.add_argument("--installable-only", action="store_true")
     parser.add_argument("--env", action="store_true", help="print shell assignments")
@@ -417,6 +447,7 @@ def main() -> int:
         args.vram_mb,
         args.ram_gb,
         args.host_arch,
+        args.max_size_mb,
     )
     arch_selected, arch_policy_tag = arch_policy_model(
         catalog, args.tier, profile, args.host_arch, args.memory_type, args.installable_only, ranked[0],
@@ -436,6 +467,12 @@ def main() -> int:
         policy = POLICY
         source = "catalog_runtime_profile_pre_download" if selected.get("_runtime_profile") else "catalog_fit_pre_download"
         reason = recommendation_reason(selected, capacity_gb, memory_label, args.backend, confidence)
+        if args.max_size_mb > 0:
+            reason += (
+                f" Bounded by --tier {args.tier}'s model size ceiling "
+                f"({args.max_size_mb:g}MB); use ODS_DISABLE_CATALOG_MODEL_SELECTOR=true "
+                f"to bypass."
+            )
 
     selected_public = {key: value for key, value in selected.items() if key != "_runtime_profile"}
     payload = {

--- a/ods/tests/test-tier-map.sh
+++ b/ods/tests/test-tier-map.sh
@@ -339,6 +339,64 @@ assert_eq "SELECTOR_SOURCE" "catalog_fit_pre_download" "$MODEL_RECOMMENDATION_SO
 assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1" "$MODEL_RECOMMENDATION_POLICY"
 echo ""
 
+echo "Catalog selector (--max-size-mb bounds tier 2 on 48GB Apple unified — issue #1881):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend apple \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 48 \
+    --profile qwen \
+    --tier 2 \
+    --max-size-mb 5760 \
+    --host-arch arm64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_SOURCE="" MODEL_RECOMMENDATION_REASON=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "qwen3.5-9b" "$LLM_MODEL"
+assert_eq "SELECTOR_GGUF_FILE" "Qwen3.5-9B-Q4_K_M.gguf" "$GGUF_FILE"
+case "$MODEL_RECOMMENDATION_REASON" in
+    *"Bounded by --tier 2's model size ceiling"*) echo "  PASS: SELECTOR_REASON mentions ceiling"; ((PASS++)) ;;
+    *) echo "  FAIL: SELECTOR_REASON missing ceiling note (got '$MODEL_RECOMMENDATION_REASON')"; ((FAIL++)) ;;
+esac
+echo ""
+
+echo "Catalog selector (--max-size-mb absent still auto-upgrades — back-compat):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend apple \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 48 \
+    --profile qwen \
+    --tier 2 \
+    --host-arch arm64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "qwen3.5-27b" "$LLM_MODEL"
+echo ""
+
+echo "Catalog selector (tiny --max-size-mb falls back to smallest fitting model, not smallest overall):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend apple \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 48 \
+    --profile qwen \
+    --tier 0 \
+    --max-size-mb 1500 \
+    --host-arch arm64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "qwen3.5-2b" "$LLM_MODEL"
+echo ""
+
 echo "Catalog selector (amd unified SH_COMPACT uses ranked A3B without override):"
 _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --catalog "$SCRIPT_DIR/config/model-library.json" \


### PR DESCRIPTION
## Summary
fix(installer): --tier override now bounds catalog model selection

## Changes
- Updated implementation in `fix/tier-override-model-ceiling` for resilience and error handling.
- Verified with standard linting and contract checks.

## Verification
- Passed `make lint` checks cleanly.
