### PR TITLE
fix(persona): catch OSError and UnicodeDecodeError in _running_services in build-installation-context.py

### DIFF
--- a/ods/scripts/build-installation-context.py
+++ b/ods/scripts/build-installation-context.py
@@ -141,7 +141,7 @@ def _running_services(repo_root: Path) -> set[str]:
             ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=ods-"],
             capture_output=True, text=True, timeout=10,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError, UnicodeDecodeError):
         return set()
 
     cmap = _container_to_service_map(repo_root)


### PR DESCRIPTION
## Summary
fix(persona): catch OSError and UnicodeDecodeError in _running_services in build-installation-context.py

## Changes
- Updated implementation in `fix/build-installation-context-running-services-exceptions` for resilience and error handling.
- Verified with standard linting and contract checks.

## Verification
- Passed `make lint` checks cleanly.
