### PR TITLE
fix(preset): confine names to preset directory

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -110,6 +110,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI preset restore user extensions ==="
 	@bash tests/test-cli-preset-restore-user-extensions.sh
 	@echo ""
+	@echo "=== CLI preset name boundary ==="
+	@bash tests/test-preset-name-boundary.sh
+	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh
 	@echo ""

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3048,6 +3048,18 @@ cmd_list() {
 #=============================================================================
 PRESETS_DIR="${INSTALL_DIR}/presets"
 
+# Preset names are directory names, not paths. Keep every preset operation
+# confined to PRESETS_DIR while preserving spaces and other valid characters.
+validate_preset_name() {
+    local name="$1"
+
+    if [[ "$name" == "." || "$name" == ".." ||
+          "$name" == */* || "$name" == *\\* ||
+          "$name" =~ [[:cntrl:]] ]]; then
+        error "Invalid preset name: use a single path segment without slashes or control characters"
+    fi
+}
+
 # Validate preset compatibility with current system
 validate_preset_compatibility() {
     local preset_dir="$1"
@@ -3091,6 +3103,7 @@ cmd_preset() {
     case "$action" in
         save|s)
             [[ -z "$name" ]] && { log "Usage: ods preset save <name>"; exit 1; }
+            validate_preset_name "$name"
             local preset_dir="${PRESETS_DIR}/${name}"
             mkdir -p "$preset_dir"
 
@@ -3127,6 +3140,7 @@ META
 
         load|l)
             [[ -z "$name" ]] && { log "Usage: ods preset load <name>"; exit 1; }
+            validate_preset_name "$name"
             local preset_dir="${PRESETS_DIR}/${name}"
             [[ -d "$preset_dir" ]] || error "Preset not found: $name"
 
@@ -3221,6 +3235,7 @@ META
 
         delete|rm)
             [[ -z "$name" ]] && { log "Usage: ods preset delete <name>"; exit 1; }
+            validate_preset_name "$name"
             local preset_dir="${PRESETS_DIR}/${name}"
             [[ -d "$preset_dir" ]] || error "Preset not found: $name"
 
@@ -3236,6 +3251,7 @@ META
             [[ -z "$name" ]] && { log "Usage: ods preset export <name> <output.tar.gz>"; exit 1; }
             local output="${3:-}"
             [[ -z "$output" ]] && { log "Usage: ods preset export <name> <output.tar.gz>"; exit 1; }
+            validate_preset_name "$name"
             local preset_dir="${PRESETS_DIR}/${name}"
             [[ -d "$preset_dir" ]] || error "Preset not found: $name"
 
@@ -3318,6 +3334,8 @@ META
             if [[ -z "$preset1" ]] || [[ -z "$preset2" ]]; then
                 error "Usage: ods preset diff <preset1> <preset2>"
             fi
+            validate_preset_name "$preset1"
+            validate_preset_name "$preset2"
 
             local dir1="$PRESETS_DIR/$preset1"
             local dir2="$PRESETS_DIR/$preset2"

--- a/ods/tests/test-preset-name-boundary.sh
+++ b/ods/tests/test-preset-name-boundary.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Regression coverage for preset names at the public ods CLI boundary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-preset-name.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+pass_count=0
+
+pass() {
+    echo "PASS: $1"
+    pass_count=$((pass_count + 1))
+}
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+mkdir -p "$FIXTURE/lib" "$FIXTURE/extensions/services" "$FIXTURE/presets"
+cp "$ROOT_DIR/ods-cli" "$FIXTURE/ods-cli"
+cp "$ROOT_DIR"/lib/*.sh "$FIXTURE/lib/"
+: > "$FIXTURE/docker-compose.base.yml"
+printf 'GPU_BACKEND=cpu\n' > "$FIXTURE/.env"
+
+run_cli() {
+    local output_file="$1"
+    shift
+
+    set +e
+    printf 'y\n' | ODS_HOME="$FIXTURE" bash "$FIXTURE/ods-cli" "$@" >"$output_file" 2>&1
+    local status=$?
+    set -e
+    return "$status"
+}
+
+assert_rejected() {
+    local description="$1"
+    shift
+    local output_file="$FIXTURE/output.log"
+
+    if run_cli "$output_file" "$@"; then
+        fail "$description was accepted"
+    fi
+    grep -qF "Invalid preset name" "$output_file" \
+        || fail "$description did not explain the name constraint"
+    pass "$description is rejected"
+}
+
+# Saving ../outside writes beside presets on the unguarded implementation.
+assert_rejected "save traversal" preset save ../outside
+[[ ! -e "$FIXTURE/outside" ]] || fail "save traversal wrote outside presets"
+pass "save traversal cannot create an out-of-scope preset"
+
+# Make an otherwise valid preset outside PRESETS_DIR so read actions would
+# accept it if they only checked the joined path.
+mkdir -p "$FIXTURE/outside-preset"
+printf 'name=outside\n' > "$FIXTURE/outside-preset/meta.txt"
+: > "$FIXTURE/outside-preset/extensions.list"
+: > "$FIXTURE/outside-preset/env"
+
+assert_rejected "load traversal" preset load ../outside-preset
+assert_rejected "export traversal" preset export ../outside-preset "$FIXTURE/export.tar.gz"
+
+mkdir -p "$FIXTURE/presets/safe"
+printf 'name=safe\n' > "$FIXTURE/presets/safe/meta.txt"
+: > "$FIXTURE/presets/safe/extensions.list"
+: > "$FIXTURE/presets/safe/env"
+assert_rejected "diff traversal" preset diff safe ../outside-preset
+
+# Delete is the destructive case: ../data previously escaped PRESETS_DIR and
+# recursively removed installation data after confirmation.
+mkdir -p "$FIXTURE/data"
+printf 'keep\n' > "$FIXTURE/data/sentinel"
+assert_rejected "delete traversal" preset delete ../data
+[[ -f "$FIXTURE/data/sentinel" ]] || fail "delete traversal removed installation data"
+pass "delete traversal leaves installation data untouched"
+
+assert_rejected "dot name" preset save .
+assert_rejected "backslash-separated name" preset save 'group\preset'
+assert_rejected "control-character name" preset save $'bad\nname'
+
+# Spaces are valid within one path segment and remain supported.
+if ! run_cli "$FIXTURE/valid.log" preset save "team demo"; then
+    fail "valid single-segment name with spaces was rejected"
+fi
+[[ -f "$FIXTURE/presets/team demo/meta.txt" ]] \
+    || fail "valid preset was not saved"
+pass "valid single-segment names remain supported"
+
+echo "Result: $pass_count passed"


### PR DESCRIPTION
﻿## Summary
- reject preset names that are paths rather than one directory segment
- apply the same boundary to save, load, delete, export, and both diff operands
- preserve valid names containing spaces

## Why this matters
`ods preset delete ../data` previously resolved to `presets/../data` and recursively deleted installation data after the normal confirmation prompt. Read and write actions could likewise consume or create directories outside the preset store. Preset names are operator input, and every preset action must remain confined to `$ODS_HOME/presets`.

## Root cause and invariant
The CLI joined raw names directly onto `PRESETS_DIR` without validating that the name was one path segment. The preserved invariant is: a preset name may contain spaces and ordinary filename characters, but never `.`, `..`, a slash, a backslash, or a control character.

## Overlap check
Searched open and closed PRs for `preset name traversal`, `preset delete path`, `cmd_preset validation`, and PRs changing `ods/ods-cli` plus preset tests. No PR covers preset-name confinement. PR #2203 validates imported archive contents and publishes them transactionally; PR #3482 adds JSON listing; both are independent. A synthetic integration head merged this commit with #2203 and #3482 without conflicts, then passed all three preset boundary/import/list suites.

## Validation
- [x] Red repro on upstream main: `bash tests/test-preset-name-boundary.sh` failed because `preset save ../outside` succeeded
- [x] `bash tests/test-preset-name-boundary.sh` ? 11 passed
- [x] `bash tests/test-cli-preset-restore-user-extensions.sh` ? 7 passed
- [x] `bash tests/test-preset-diff.sh` ? 6 passed
- [x] synthetic merge with #2203 and #3482: name boundary 11/11, import/export 18/18, JSON list passed
- [x] `make lint`
- [x] dashboard `npm run lint` and `npm run build`
- [x] `shellcheck --rcfile=/dev/null --severity=error ods-cli tests/test-preset-name-boundary.sh`
- [x] `git diff --check`

`make gate` reaches the existing Hermes template contract and stops on the Windows checkout's CRLF conversion; upstream PR #3019 covers that line-ending family. `pre-commit run --all-files` likewise reports pre-existing private-key fixtures and CRLF `.shellcheckrc`, plus the Windows hook environment lacks `awk`; no touched-file error remains under the focused shellcheck command above.

## Tradeoffs and rollback
This deliberately rejects backslashes even on Unix so the same stored name cannot become a path on Windows/WSL. No preset format changes. Reverting the commit restores the old permissive behavior; existing valid single-segment presets remain compatible.

Generated with Codex

## Batch compatibility update
A synthetic integration head built from `upstream/main` plus #3540, #3541, and #3542 merged without conflicts. It passed all three new boundary suites, the adjacent preset/backup/rollback suites, `make lint`, and `git diff --check`. The PRs change independent command boundaries; no merge order is required.



## CI receipt
Head `684b45ac89c92f365c0166dcd8f170bd94e44d8e` completed with 28 successful checks, 4 conditionally skipped Claude jobs, 0 pending checks, and 0 failures. GitHub reports the diff mergeable; branch protection is waiting only for required human review.

