### PR TITLE
fix(restore): confine backup IDs to backup root

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -116,6 +116,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@echo ""
+	@echo "=== restore backup ID boundary ==="
+	@bash tests/test-restore-backup-id-boundary.sh
+	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
 	@echo ""

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -25,6 +25,18 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*"; }
 log_step() { echo -e "${CYAN}[STEP]${NC} $*"; }
 
+# Backup IDs identify entries directly below BACKUP_ROOT; they are not paths.
+validate_backup_id() {
+    local backup_id="$1"
+
+    if [[ "$backup_id" == "." || "$backup_id" == ".." ||
+          "$backup_id" == */* || "$backup_id" == *\\* ||
+          "$backup_id" =~ [[:cntrl:]] ]]; then
+        log_error "Invalid backup ID: use a single path segment without slashes or control characters"
+        return 1
+    fi
+}
+
 # Source shared rsync utilities
 . "$ODS_DIR/lib/rsync.sh"
 
@@ -628,6 +640,10 @@ main() {
         if ! backup_id=$(select_backup); then
             exit 1
         fi
+    fi
+
+    if ! validate_backup_id "$backup_id"; then
+        exit 1
     fi
 
     # Check if running in ODS directory

--- a/ods/tests/test-restore-backup-id-boundary.sh
+++ b/ods/tests/test-restore-backup-id-boundary.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression coverage for explicit backup IDs at the restore CLI boundary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-restore-id.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+pass_count=0
+
+pass() {
+    echo "PASS: $1"
+    pass_count=$((pass_count + 1))
+}
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+mkdir -p "$FIXTURE/.backups" "$FIXTURE/data" "$FIXTURE/lib"
+cp "$ROOT_DIR/lib/rsync.sh" "$FIXTURE/lib/rsync.sh"
+
+write_manifest() {
+    local directory="$1"
+    local backup_id="$2"
+
+    mkdir -p "$directory"
+    cat > "$directory/manifest.json" <<JSON
+{
+  "manifest_version": "1.0",
+  "backup_date": "2026-08-30T00:00:00Z",
+  "backup_id": "$backup_id",
+  "backup_type": "user-data",
+  "ods_version": "test",
+  "hostname": "test",
+  "description": "boundary fixture",
+  "contents": {"user_data": true, "config": false, "cache": false}
+}
+JSON
+}
+
+run_restore() {
+    local output_file="$1"
+    shift
+
+    set +e
+    ODS_DIR="$FIXTURE" bash "$ROOT_DIR/ods-restore.sh" \
+        --dry-run --skip-verify "$@" >"$output_file" 2>&1
+    local status=$?
+    set -e
+    return "$status"
+}
+
+assert_rejected() {
+    local description="$1"
+    local backup_id="$2"
+    local output_file="$FIXTURE/output.log"
+
+    if run_restore "$output_file" "$backup_id"; then
+        fail "$description was accepted"
+    fi
+    grep -qF "Invalid backup ID" "$output_file" \
+        || fail "$description did not explain the backup-ID constraint"
+    pass "$description is rejected"
+}
+
+# This directory is a sibling of .backups. Before validation, ../external
+# passed extraction and manifest checks and became the restore source.
+write_manifest "$FIXTURE/external" "external"
+assert_rejected "parent-directory traversal" ../external
+
+assert_rejected "dot ID" .
+assert_rejected "backslash-separated ID" 'group\backup'
+assert_rejected "control-character ID" $'bad\nbackup'
+
+# Backup IDs produced by ods-backup.sh remain accepted.
+valid_id="20260830-120000"
+write_manifest "$FIXTURE/.backups/$valid_id" "$valid_id"
+if ! run_restore "$FIXTURE/valid.log" "$valid_id"; then
+    fail "valid generated backup ID was rejected"
+fi
+grep -qF "DRY RUN - Preview of restore operation" "$FIXTURE/valid.log" \
+    || fail "valid backup did not reach the restore preview"
+pass "valid generated backup ID reaches dry-run preview"
+
+echo "Result: $pass_count passed"


### PR DESCRIPTION
﻿## Summary
- validate explicit and interactively selected restore IDs before joining them to `.backups`
- reject path separators, dot segments, and control characters
- keep generated timestamp IDs working and wire the boundary regression into `make test`

## Why this matters
`ods-restore.sh --dry-run ../external` previously resolved `.backups/../external`, accepted a valid manifest from that sibling directory, and proceeded to the restore preview. A non-dry restore could therefore overwrite live ODS state from a directory the operator did not select from the backup store. Restore IDs must identify one direct child of `$ODS_DIR/.backups`.

## Root cause and invariant
`ensure_restore_space` and `extract_backup` joined a raw positional argument onto `BACKUP_ROOT`. Archive member validation did not constrain that outer identifier. The invariant is that a backup ID is one path segment; generated IDs such as `20260830-120000` remain unchanged.

## Overlap check
Searched open and closed PRs for `restore backup ID`, `backup identifier restore`, `restore path traversal`, `ods-restore validation`, and PRs changing `ods/ods-restore.sh`. No PR validates the outer backup ID. PRs #2720 (symlinked source entries), #2952 (empty config), #3094 (post-restore verification), #3250 (manifest member), and #3336 (status handling) address later, independent stages. Pairwise synthetic merges with all five plus #3372 were conflict-free. A synthetic head with tang-vu PR #3372 also passed both its restore safety UX suite and this boundary suite.

## Validation
- [x] Red repro on upstream main: `bash tests/test-restore-backup-id-boundary.sh` failed because `../external` reached dry-run preview
- [x] `bash tests/test-restore-backup-id-boundary.sh` ? 5 passed
- [x] `bash tests/test-backup-restore-cli.sh` ? 11 passed
- [x] synthetic merge with #3372: boundary 5/5; restore safety UX 2/2
- [x] `make lint`
- [x] `shellcheck --rcfile=/dev/null --severity=error ods-restore.sh tests/test-restore-backup-id-boundary.sh`
- [x] `git diff --check`

On the unmerged base, `tests/test-restore-safety-ux.sh` exits before restore because its fixture does not copy the newly required `lib/rsync.sh`; PR #3372 fixes that fixture, and the synthetic validation above proves this change composes with it. The batch-level `make gate` and all-files pre-commit limitations are the same pre-existing Windows CRLF/private-key-fixture failures recorded in PR #3540.

## Tradeoffs and rollback
The validator intentionally accepts legacy IDs containing spaces or punctuation as long as they are a single segment. Backslashes are rejected on every platform to keep the identifier portable across WSL and Windows. No backup contents or manifests change. Reverting restores permissive path joining.

Generated with Codex

## Batch compatibility update
A synthetic integration head built from `upstream/main` plus #3540, #3541, and #3542 merged without conflicts. It passed all three new boundary suites, the adjacent preset/backup/rollback suites, `make lint`, and `git diff --check`. The PRs change independent command boundaries; no merge order is required.



## CI receipt
Head `ccf72ed2c711310559190d550affe4a8fce69ae9` completed with 28 successful checks, 4 conditionally skipped Claude jobs, 0 pending checks, and 0 failures. GitHub reports the diff mergeable; branch protection is waiting only for required human review.

