### PR TITLE
fix(update): confine rollback targets to backup roots

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -98,6 +98,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI update post-verification ==="
 	@bash tests/test-cli-update-verification.sh
 	@echo ""
+	@echo "=== update rollback target boundary ==="
+	@bash tests/test-update-rollback-target-boundary.sh
+	@echo ""
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh
 	@echo ""

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -49,6 +49,17 @@ log_ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+validate_rollback_target() {
+    local target="$1"
+
+    if [[ "$target" == "." || "$target" == ".." ||
+          "$target" == */* || "$target" == *\\* ||
+          "$target" =~ [[:cntrl:]] ]]; then
+        log_error "Invalid rollback target: use a single path segment without slashes or control characters"
+        return 1
+    fi
+}
+
 get_current_version() {
     if [[ -f "$VERSION_FILE" ]]; then
         jq -r '.version // "0.0.0"' "$VERSION_FILE" 2>/dev/null || echo "0.0.0"
@@ -733,6 +744,10 @@ cmd_update() {
 cmd_rollback() {
     local target="${1:-}"
     local backup_path=""
+
+    if [[ -n "$target" ]] && ! validate_rollback_target "$target"; then
+        return 1
+    fi
 
     if [[ -n "$target" ]]; then
         # Explicit target: search rollback snapshots first, then general backups.

--- a/ods/tests/test-update-rollback-target-boundary.sh
+++ b/ods/tests/test-update-rollback-target-boundary.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Regression coverage for explicit ods-update rollback targets.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-update-rollback-id.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+INSTALL_DIR="$FIXTURE/install"
+HOME_DIR="$FIXTURE/home"
+BIN_DIR="$FIXTURE/bin"
+DOCKER_LOG="$FIXTURE/docker.log"
+mkdir -p "$INSTALL_DIR/data/backups" "$HOME_DIR/.ods/backups" "$BIN_DIR"
+cp "$ROOT_DIR/ods-update.sh" "$INSTALL_DIR/ods-update.sh"
+
+pass_count=0
+
+pass() {
+    echo "PASS: $1"
+    pass_count=$((pass_count + 1))
+}
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+cat > "$BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+
+if [[ "${1:-}" == "info" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" ]]; then
+    shift
+fi
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "ps" ]]; then
+        if [[ "${args[$((i + 1))]:-}" == "--services" ]]; then
+            printf '%s\n' dashboard-api
+            exit 0
+        fi
+        if [[ "${args[$((i + 1))]:-}" == "--format" ]]; then
+            printf '%s\n' '{"State":"running"}'
+            exit 0
+        fi
+    fi
+done
+
+exit 0
+SH
+chmod +x "$BIN_DIR/docker"
+
+cat > "$BIN_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$BIN_DIR/curl"
+
+cat > "$INSTALL_DIR/docker-compose.base.yml" <<'YAML'
+services:
+  dashboard-api:
+    image: example/dashboard:test
+YAML
+cat > "$INSTALL_DIR/docker-compose.nvidia.yml" <<'YAML'
+services:
+  llama-server:
+    image: example/llama:nvidia
+YAML
+cat > "$INSTALL_DIR/docker-compose.cpu.yml" <<'YAML'
+services:
+  llama-server:
+    image: example/llama:cpu
+YAML
+
+write_live_env() {
+    cat > "$INSTALL_DIR/.env" <<'EOF'
+MARKER=live
+ODS_MODE=local
+GPU_BACKEND=nvidia
+GPU_COUNT=1
+TIER=1
+EOF
+}
+
+write_legacy_backup() {
+    local directory="$1"
+    local marker="$2"
+    mkdir -p "$directory"
+    cat > "$directory/.env" <<EOF
+MARKER=$marker
+ODS_MODE=local
+GPU_BACKEND=cpu
+GPU_COUNT=1
+TIER=1
+EOF
+}
+
+run_rollback() {
+    local output_file="$1"
+    local target="$2"
+
+    set +e
+    HOME="$HOME_DIR" PATH="$BIN_DIR:$PATH" DOCKER_LOG="$DOCKER_LOG" \
+        HEALTH_TIMEOUT=2 bash "$INSTALL_DIR/ods-update.sh" rollback "$target" \
+        >"$output_file" 2>&1
+    local status=$?
+    set -e
+    return "$status"
+}
+
+assert_rejected() {
+    local description="$1"
+    local target="$2"
+    local output_file="$FIXTURE/output.log"
+
+    write_live_env
+    : > "$DOCKER_LOG"
+    if run_rollback "$output_file" "$target"; then
+        fail "$description was accepted"
+    fi
+    grep -qF "Invalid rollback target" "$output_file" \
+        || fail "$description did not explain the target constraint"
+    grep -qF "MARKER=live" "$INSTALL_DIR/.env" \
+        || fail "$description replaced live configuration"
+    [[ ! -s "$DOCKER_LOG" ]] \
+        || fail "$description touched Docker before validation"
+    pass "$description is rejected before state mutation"
+}
+
+# ROLLBACK_DIR is install/data/backups. This sibling was previously selected
+# through data/backups/../external and restored as a legacy backup.
+write_legacy_backup "$INSTALL_DIR/data/external" external
+assert_rejected "parent-directory traversal" ../external
+
+assert_rejected "dot target" .
+assert_rejected "backslash-separated target" 'group\backup'
+assert_rejected "control-character target" $'bad\ntarget'
+
+# Named general backups can contain spaces, so valid single segments must stay
+# compatible. Passing "team demo" selects backup-team demo below BACKUP_DIR.
+write_legacy_backup "$HOME_DIR/.ods/backups/backup-team demo" restored
+write_live_env
+: > "$DOCKER_LOG"
+if ! run_rollback "$FIXTURE/valid.log" "team demo"; then
+    cat "$FIXTURE/valid.log" >&2
+    fail "valid named backup target was rejected"
+fi
+grep -qF "MARKER=restored" "$INSTALL_DIR/.env" \
+    || fail "valid named backup did not restore configuration"
+[[ -s "$DOCKER_LOG" ]] || fail "valid rollback did not reach Docker lifecycle"
+pass "valid named backup target completes rollback"
+
+echo "Result: $pass_count passed"


### PR DESCRIPTION
﻿## Summary
- validate explicit `ods-update.sh rollback <target>` input before backup lookup
- reject path separators, dot segments, and control characters before any Docker or file mutation
- preserve named general backups containing spaces and wire the regression into `make test`

## Why this matters
`ods-update.sh rollback ../external` previously resolved `data/backups/../external`, treated that sibling directory as a legacy backup, stopped the live stack, copied its files into the install, and restarted services. A typo or path-like target could therefore replace live configuration from outside both supported backup roots. Explicit rollback targets must be identifiers, not paths.

## Root cause and invariant
`cmd_rollback` joined the raw target to `ROLLBACK_DIR` and `BACKUP_DIR` before validating its shape. The invariant is that an explicit target is one path segment and is rejected before lifecycle mutation. Automatic latest-snapshot selection is unchanged.

## Overlap check
Searched open and closed PRs for `rollback target`, `rollback path`, `rollback traversal`, `backup ID rollback`, and PRs changing `ods/ods-update.sh`. No PR constrains the explicit target. PRs #3338 (backup listing), #3347 (rotation path tokenization), #3379 (compose flag parsing), #3386 (Hermes token migration), and #3502 (health service iteration) are independent stages; #3504 changes the outer `ods-cli` rollback restart path. Pairwise synthetic merges with all of them plus #3247 were conflict-free. A combined synthetic head with tang-vu PRs #3347 and #3386 plus #3504 passed the new target suite and all affected backup/rollback/Hermes suites.

## Validation
- [x] Red repro on upstream main: boundary test failed because `../external` completed rollback
- [x] `bash tests/test-update-rollback-target-boundary.sh` ? 5 passed
- [x] `bash tests/test-rollback-compose-stack.sh` ? all 7 assertions passed
- [x] `bash tests/test-update-rollback-contract.sh` ? full backup?mutation?rollback contract passed
- [x] synthetic integration: boundary 5/5, rollback stack 7/7, update backup 6/6, Hermes migration 2/2
- [x] `make lint`
- [x] `shellcheck --rcfile=/dev/null --severity=error ods-update.sh tests/test-update-rollback-target-boundary.sh`
- [x] `git diff --check`

The batch-level `make gate`, dashboard lint/build, and all-files pre-commit results are recorded in PR #3540. The only gate blockers were pre-existing Windows checkout CRLF/private-key fixture/tool-environment issues; focused checks for this diff pass.

## Tradeoffs and rollback
Named general backups with spaces remain supported because spaces are valid inside one segment. Backslashes are rejected consistently for Windows/WSL portability. No snapshot format, lookup order, automatic selection, or Docker behavior changes for valid targets. Reverting restores permissive path joining.

Generated with Codex

## Batch compatibility update
A synthetic integration head built from `upstream/main` plus #3540, #3541, and #3542 merged without conflicts. It passed all three new boundary suites, the adjacent preset/backup/rollback suites, `make lint`, and `git diff --check`. The PRs change independent command boundaries; no merge order is required.



## CI receipt
Head `a44e79998f011377ce46826a869576b6e712bfd0` completed with 28 successful checks, 4 conditionally skipped Claude jobs, 0 pending checks, and 0 failures. GitHub reports the diff mergeable; branch protection is waiting only for required human review.

