### PR TITLE
fix(backup): clean extracted data after verification failure

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -567,20 +567,18 @@ verify_backup() {
     fi
 
     if [[ -f "$target" && "$target" == *.tar.gz ]]; then
-        local tmpdir
-        tmpdir=$(mktemp -d)
-        trap 'rm -rf "$tmpdir"' RETURN
-
-        # Extract checksums first (fast fail if missing)
-        local archive_name="${backup_id%.tar.gz}"
-        if ! tar xzf "$target" -C "$tmpdir" "${archive_name}/checksums.sha256" >/dev/null 2>&1; then
-            log_error "checksums.sha256 not found in archive: $backup_id"
-            return 1
-        fi
-
-        tar xzf "$target" -C "$tmpdir"
-
+        local tmpdir archive_name="${backup_id%.tar.gz}"
         (
+            tmpdir=$(mktemp -d)
+            trap 'rm -rf "$tmpdir"' EXIT
+
+            # Extract checksums first (fast fail if missing)
+            if ! tar xzf "$target" -C "$tmpdir" "${archive_name}/checksums.sha256" >/dev/null 2>&1; then
+                log_error "checksums.sha256 not found in archive: $backup_id"
+                exit 1
+            fi
+
+            tar xzf "$target" -C "$tmpdir"
             cd "$tmpdir/$archive_name"
             if command -v sha256sum >/dev/null 2>&1; then
                 sha256sum -c "checksums.sha256"

--- a/ods/tests/test-backup-integrity.sh
+++ b/ods/tests/test-backup-integrity.sh
@@ -67,6 +67,26 @@ fi
 
 pass "verify fails after tampering"
 
+info "Verifying a corrupt archive cleans extracted temporary data"
+(cd "$BACKUPS_DIR" && tar czf "$backup_id.tar.gz" "$backup_id")
+rm -rf "$BACKUPS_DIR/$backup_id"
+VERIFY_TMP="$TMP_ROOT/verify-tmp"
+mkdir -p "$VERIFY_TMP"
+
+set +e
+TMPDIR="$VERIFY_TMP" ODS_DIR="$FAKE_ODS" \
+  "$ODS_BACKUP" --output "$BACKUPS_DIR" verify "$backup_id.tar.gz" >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  fail "archive verify unexpectedly succeeded with a checksum mismatch"
+fi
+if find "$VERIFY_TMP" -mindepth 1 -print -quit | grep -q .; then
+  fail "archive verify left extracted backup data in TMPDIR after failure"
+fi
+pass "archive verify removes extracted data after checksum failure"
+
 # ── Lifecycle: list, retention, and delete must see the script's own IDs ──
 # Backup IDs are YYYYMMDD-HHMMSS (one hyphen); a glob requiring two hyphens
 # regressed list/retention into ignoring every backup this script creates.


### PR DESCRIPTION
## Why this matters

`ods-backup.sh verify <archive>.tar.gz` extracts the full backup into `TMPDIR` before checking its hashes. The function protected that directory with a Bash `RETURN` trap, but `set -e` exits the shell directly when `sha256sum -c` reports a mismatch, so the function never returns and the trap never fires. A damaged archive therefore leaves the entire extracted backup—potentially configuration and user data—on disk after verification fails.

The invariant is: archive verification must remove extracted data on every terminal path, including checksum failure.

## What changed

- isolate compressed-archive verification in a subshell
- install an `EXIT` cleanup trap inside that subshell, so normal completion and `set -e` failure both remove the extraction directory
- preserve the existing failure status, checksum output, archive layout, and successful verification behavior

## Overlap check

Searched open and closed upstream PRs for backup archive verification, checksum-failure cleanup, `verify_backup`, backup temp leaks, `RETURN` traps, and changes to `ods/ods-backup.sh`. No PR covers failed archive-verification cleanup. PR #3022 changes only the full-backup model source paths in this file; PR #3066 changes update snapshot publication; PR #3541 confines restore backup IDs. None touches this function or behavior.

## Regression coverage

`tests/test-backup-integrity.sh` now drives the public `ods-backup.sh ... verify <id>.tar.gz` boundary with a real archive whose payload no longer matches `checksums.sha256`, assigns a dedicated `TMPDIR`, requires a non-zero verification result, and asserts that no extracted files remain. The assertion fails on upstream `main` and passes with this change.

## Validation

- `bash tests/test-backup-integrity.sh` — passed
- `bash tests/test-backup-restore-roundtrip.sh` — passed, including compressed restore
- `bash tests/test-backup-restore-cli.sh` — 11 passed
- `bash tests/test-update-rollback-contract.sh` — passed
- `bash -n ods/ods-backup.sh tests/test-backup-integrity.sh` — passed
- `pre-commit run --files ods/ods-backup.sh ods/tests/test-backup-integrity.sh` — passed
- `git diff --check` — passed

`make` is unavailable on this Windows host; repository CI remains the full Linux validation gate.

## Tradeoffs and rollback

The subshell intentionally isolates both the temporary working directory and its `EXIT` trap, so it cannot replace a caller trap or change the parent shell's working directory. Rollback simply restores the previous `RETURN` trap, but would reintroduce data retention on `set -e` failures.
## Combined compatibility validation

Synthetic integration was validated in both relevant merge orders:

- `175e2fa8`: #3554 → #3556 → #3557, then overlapping-file checks with #3540, #3541, and #2346
- `492ce800`: #3540 → #3556 and #3541 → #2346 → #3557, then #3554

Both orders merged without conflicts. The combined backup integrity/round-trip/CLI/update rollback, preset confinement, restore-ID confinement, remote-provider CLI contracts, Bash syntax, and `git diff --check` all passed. The three PRs in this batch have no required merge order.