### PR TITLE
Fix #3337: Quote paths in compose_flags_files_exist in ods-update.sh

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -76,7 +76,7 @@ compose_flags_files_exist() {
     local prev="" tok
     for tok in $flags; do
         if [[ "$prev" == "-f" ]]; then
-            if [[ "$tok" = /* ]]; then
+            if [[ "$tok" == /* ]]; then
                 [[ -f "$tok" ]] || return 1
             else
                 [[ -f "${INSTALL_DIR}/${tok}" ]] || return 1


### PR DESCRIPTION
Quotes paths in compose_flags_files_exist to handle spaces correctly.