### PR TITLE
fix(cli): remove remote-provider secret temp files on failure

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4505,10 +4505,10 @@ cmd_remote_provider() {
             local payload_file response_file http_code curl_status
             payload_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-payload.XXXXXX") || \
                 error "Could not create a remote-provider request file"
+            trap 'rm -f "$payload_file" "${response_file:-}"' EXIT INT TERM HUP
             response_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-plan.XXXXXX") || \
                 error "Could not create a remote-provider response file"
             chmod 600 "$payload_file" "$response_file"
-            trap 'rm -f "$payload_file" "$response_file"' INT TERM HUP
             _remote_provider_write_payload "$action" "$payload_file" "$@"
             if http_code="$(_remote_provider_request POST /api/remote-provider/plan "$response_file" "$payload_file" 15)"; then
                 curl_status=0
@@ -4517,17 +4517,17 @@ cmd_remote_provider() {
             fi
             rm -f "$payload_file"
             if [[ $curl_status -ne 0 ]]; then
-                rm -f "$response_file"; trap - INT TERM HUP
+                rm -f "$response_file"; trap - EXIT INT TERM HUP
                 error "Remote-provider plan request failed before Dashboard API completed"
             fi
             if [[ "$http_code" != "200" ]]; then
                 local detail
                 detail="$(_remote_provider_response_error "$response_file")"
-                rm -f "$response_file"; trap - INT TERM HUP
+                rm -f "$response_file"; trap - EXIT INT TERM HUP
                 error "Remote-provider plan failed (HTTP $http_code): $detail"
             fi
             jq . "$response_file"
-            rm -f "$response_file"; trap - INT TERM HUP
+            rm -f "$response_file"; trap - EXIT INT TERM HUP
             ;;
         configure|test|disable|remove)
             if [[ "$subcmd" == "test" ]]; then
@@ -4560,10 +4560,10 @@ cmd_remote_provider() {
             local payload_file response_file http_code curl_status
             payload_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-payload.XXXXXX") || \
                 error "Could not create a remote-provider request file"
+            trap 'rm -f "$payload_file" "${response_file:-}"' EXIT INT TERM HUP
             response_file=$(mktemp "${TMPDIR:-/tmp}/ods-remote-provider-apply.XXXXXX") || \
                 error "Could not create a remote-provider response file"
             chmod 600 "$payload_file" "$response_file"
-            trap 'rm -f "$payload_file" "$response_file"' INT TERM HUP
             REMOTE_PROVIDER_JSON_MODE="false"
             _remote_provider_write_payload "$subcmd" "$payload_file" "$@"
             if http_code="$(_remote_provider_request POST /api/remote-provider/apply "$response_file" "$payload_file" 20)"; then
@@ -4573,13 +4573,13 @@ cmd_remote_provider() {
             fi
             rm -f "$payload_file"
             if [[ $curl_status -ne 0 ]]; then
-                rm -f "$response_file"; trap - INT TERM HUP
+                rm -f "$response_file"; trap - EXIT INT TERM HUP
                 error "Remote-provider $subcmd request failed before Dashboard API completed"
             fi
             if [[ "$http_code" != "200" ]]; then
                 local detail
                 detail="$(_remote_provider_response_error "$response_file")"
-                rm -f "$response_file"; trap - INT TERM HUP
+                rm -f "$response_file"; trap - EXIT INT TERM HUP
                 error "Remote-provider $subcmd failed (HTTP $http_code): $detail"
             fi
             if [[ "${REMOTE_PROVIDER_JSON_MODE:-false}" == "true" ]]; then
@@ -4587,7 +4587,7 @@ cmd_remote_provider() {
             else
                 _remote_provider_print_apply_result "$response_file"
             fi
-            rm -f "$response_file"; trap - INT TERM HUP
+            rm -f "$response_file"; trap - EXIT INT TERM HUP
             ;;
         help|--help|-h)
             _remote_provider_usage

--- a/ods/tests/contracts/test-remote-provider-cli.py
+++ b/ods/tests/contracts/test-remote-provider-cli.py
@@ -3,7 +3,11 @@
 
 from __future__ import annotations
 
+import os
 import re
+import shlex
+import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -19,6 +23,81 @@ def fail(message: str) -> None:
 def require(pattern: str, text: str, message: str) -> None:
     if not re.search(pattern, text, flags=re.MULTILINE):
         fail(message)
+
+
+def bash_path(path: Path) -> str:
+    """Return a path usable by the Bash process on native or WSL hosts."""
+    posix_path = path.resolve().as_posix()
+    if os.name == "nt" and len(posix_path) > 2 and posix_path[1] == ":":
+        return f"/mnt/{posix_path[0].lower()}{posix_path[2:]}"
+    return posix_path
+
+
+def check_secret_temp_cleanup() -> None:
+    """A payload-construction failure must not retain streamed secrets."""
+    with tempfile.TemporaryDirectory() as root:
+        root_path = Path(root)
+        install_dir = root_path / "ods"
+        request_tmp = root_path / "request-tmp"
+        stub_bin = root_path / "bin"
+        install_dir.mkdir()
+        request_tmp.mkdir()
+        stub_bin.mkdir()
+        (install_dir / "docker-compose.base.yml").write_text(
+            "services: {}\n", encoding="utf-8"
+        )
+        (install_dir / ".env").write_text(
+            "DASHBOARD_API_KEY=test-dashboard-key\n", encoding="utf-8"
+        )
+        secret_file = root_path / "provider-key"
+        secret_file.write_text("provider-secret-marker\n", encoding="utf-8")
+
+        jq_stub = stub_bin / "jq"
+        jq_stub.write_text("#!/usr/bin/env bash\ncat\nexit 1\n", encoding="utf-8")
+        jq_stub.chmod(0o755)
+        curl_stub = stub_bin / "curl"
+        curl_stub.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
+        curl_stub.chmod(0o755)
+
+        stub_path = bash_path(stub_bin)
+        command_path = (
+            f"{stub_path}:"
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
+        provider_args = [
+            "--base-url", "https://provider.example/v1",
+            "--model", "remote-model",
+            "--api-key-file", bash_path(secret_file),
+        ]
+        invocations = {
+            "apply": ["remote-provider", "configure", *provider_args],
+            "plan": ["remote-provider", "plan", "configure", *provider_args],
+        }
+        for label, cli_args in invocations.items():
+            command = " ".join([
+                "exec", "env",
+                f"ODS_HOME={shlex.quote(bash_path(install_dir))}",
+                f"TMPDIR={shlex.quote(bash_path(request_tmp))}",
+                f"PATH={shlex.quote(command_path)}",
+                "bash", shlex.quote(bash_path(ODS_CLI)),
+                *(shlex.quote(arg) for arg in cli_args),
+            ])
+            result = subprocess.run(
+                ["bash", "-c", command],
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            if result.returncode == 0:
+                fail(f"remote-provider {label} must surface payload construction failure")
+            output = result.stdout + result.stderr
+            if "Could not build remote-provider lifecycle request" not in output:
+                fail(f"remote-provider {label} did not reach payload construction: {output}")
+            if "provider-secret-marker" in output:
+                fail(f"remote-provider {label} failure output printed the provider API key")
+            leftovers = list(request_tmp.glob("ods-remote-provider-*"))
+            if leftovers:
+                fail(f"remote-provider {label} retained temporary request data: {leftovers}")
 
 
 def main() -> int:
@@ -218,6 +297,8 @@ def main() -> int:
         body,
         "remote-provider test must treat SSH options as one-shot lifecycle probes",
     )
+
+    check_secret_temp_cleanup()
 
     print("[PASS] remote-provider CLI static contract")
     return 0


### PR DESCRIPTION
## Why this matters

The `ods remote-provider plan ...` and `configure|test ...` paths stream provider API keys and optional SSH credentials into owner-only temporary payload files. Cleanup was registered only for `INT`, `TERM`, and `HUP`, and only after both request and response files existed. Under the CLI's `set -euo pipefail`, a payload-construction/I/O failure exits normally without a signal, leaving the secret-bearing payload in `TMPDIR`; failure of the second `mktemp` also leaked the first file.

The invariant is: secret request material must be removed on every terminal path and must never be printed.

## What changed

- register cleanup immediately after the first request file is created
- include `EXIT` so `set -e`, `jq`, chmod, allocation, and rendering failures remove both files
- use a nounset-safe optional response path before the second `mktemp` has completed
- clear the scoped `EXIT`/signal trap after every explicit cleanup path
- preserve existing HTTP handling, response rendering, exit statuses, and signal cleanup

## Overlap check

Searched open and closed upstream PRs for remote-provider payload cleanup, secret temp leaks, `ods-remote-provider-payload`, `payload_file`, and traps in `ods/ods-cli`. No PR covers this lifecycle failure. PR #3327 changes quoting on two unrelated `RETURN` traps for status/GPU temporary directories; it does not touch remote-provider files or `EXIT` behavior. PR #2145 introduced the CLI surface, #2710 bounds peer responses in dashboard-api, and #3540 changes preset path confinement in a distant `ods-cli` function.

## Regression coverage

`tests/contracts/test-remote-provider-cli.py` now executes both public boundaries:

- `ods remote-provider configure ...`
- `ods remote-provider plan configure ...`

A fake `jq` copies the streamed provider key into the payload and then exits non-zero. The test requires the CLI to surface the construction failure, keep the key out of stdout/stderr, and leave no `ods-remote-provider-*` files in a dedicated `TMPDIR`. Both invocations fail the cleanup assertion on upstream `main` and pass with this change. The harness supports native POSIX and Windows-hosted WSL Bash paths.

## Validation

- `python tests/contracts/test-remote-provider-cli.py` — passed
- `python tests/contracts/test-ods-cli-contracts.py` — passed
- `bash -n ods-cli` — passed
- `python -m py_compile tests/contracts/test-remote-provider-cli.py` — passed
- `pre-commit run --files ods/ods-cli ods/tests/contracts/test-remote-provider-cli.py` — passed
- `git diff --check` — passed

`make` and Ruff are unavailable on this Windows host; repository CI remains the full Linux lint/test gate.

## Tradeoffs and rollback

The trap is intentionally installed inside the existing CLI command flow and cleared before normal return, so it does not alter later commands or caller state. Rollback restores the previous signal-only cleanup but reintroduces retained credential files on ordinary error exits.
## Combined compatibility validation

Synthetic integration was validated in both relevant merge orders:

- `175e2fa8`: #3554 → #3556 → #3557, then overlapping-file checks with #3540, #3541, and #2346
- `492ce800`: #3540 → #3556 and #3541 → #2346 → #3557, then #3554

Both orders merged without conflicts. The combined backup integrity/round-trip/CLI/update rollback, preset confinement, restore-ID confinement, remote-provider CLI contracts, Bash syntax, and `git diff --check` all passed. The three PRs in this batch have no required merge order.