### PR TITLE
fix(restore): clean invalid archive extraction before retry

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -484,6 +484,31 @@ verify_restore() {
     fi
 }
 
+# Remove only a newly extracted backup directory after validation fails.
+# Resolve both paths physically so a crafted id or symlink cannot turn cleanup
+# into a recursive delete outside BACKUP_ROOT.
+cleanup_failed_archive_extraction() {
+    local backup_dir="$1" backup_root_real backup_dir_real
+
+    if ! backup_root_real=$(cd "$BACKUP_ROOT" && pwd -P); then
+        log_error "Could not resolve backup root for failed extraction cleanup"
+        return 1
+    fi
+    if ! backup_dir_real=$(cd "$backup_dir" && pwd -P); then
+        log_error "Could not resolve extracted backup for cleanup: $backup_dir"
+        return 1
+    fi
+    if [[ "$backup_dir_real" != "$backup_root_real/"* ]]; then
+        log_error "Refusing to clean extracted backup outside backup root: $backup_dir_real"
+        return 1
+    fi
+    if ! rm -rf -- "$backup_dir_real"; then
+        log_error "Could not remove failed archive extraction: $backup_dir_real"
+        return 1
+    fi
+    log_info "Removed failed archive extraction: $backup_dir_real"
+}
+
 # Main restore function
 do_restore() {
     local backup_id="$1"
@@ -501,14 +526,23 @@ do_restore() {
         return 1
     fi
 
-    # Extract if compressed
-    local backup_dir
+    # Extract if compressed. Track only directories created by this invocation;
+    # an operator-managed uncompressed backup must survive validation failure.
+    local backup_dir extracted_for_restore="false"
+    if [[ ! -d "$BACKUP_ROOT/$backup_id" && -f "$BACKUP_ROOT/$backup_id.tar.gz" ]]; then
+        extracted_for_restore="true"
+    fi
     if ! backup_dir=$(extract_backup "$backup_id"); then
         return 1
     fi
 
     # Validate backup (with optional checksum verification)
     if ! validate_backup "$backup_dir" "$skip_verify"; then
+        if [[ "$extracted_for_restore" == "true" ]]; then
+            if ! cleanup_failed_archive_extraction "$backup_dir"; then
+                log_error "Failed archive extraction requires manual cleanup"
+            fi
+        fi
         log_error "Backup validation failed"
         return 1
     fi

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -106,6 +106,43 @@ ODS_DIR="$DST2" bash "$ODS_RESTORE" -f "$CBACKUP_ID" >/dev/null 2>&1 || fail "Co
 [[ "$(cat "$DST2/.env")" == "test-env-value" ]] || fail ".env content mismatch after compressed restore"
 pass "Compressed backup restores correctly"
 
+info "Rejecting a corrupt archive without retaining its extracted copy"
+CORRUPT_BUILD="$TMP/corrupt-build"
+mkdir -p "$CORRUPT_BUILD"
+tar xzf "$TARBALL" -C "$CORRUPT_BUILD"
+echo "tampered" >> "$CORRUPT_BUILD/$CBACKUP_ID/.env"
+
+DST3="$TMP/dst3"
+mkdir -p "$DST3/data" "$DST3/.backups" "$DST3/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$DST3/lib/"
+echo "compose-content" > "$DST3/docker-compose.yml"
+tar czf "$DST3/.backups/$CBACKUP_ID.tar.gz" -C "$CORRUPT_BUILD" "$CBACKUP_ID"
+
+set +e
+ODS_DIR="$DST3" bash "$ODS_RESTORE" -f "$CBACKUP_ID" >/dev/null 2>&1
+restore_rc=$?
+set -e
+[[ $restore_rc -ne 0 ]] || fail "Restore unexpectedly accepted a checksum-mismatched archive"
+[[ ! -e "$DST3/.backups/$CBACKUP_ID" ]] \
+    || fail "Failed restore retained the extracted corrupt backup"
+[[ -f "$DST3/.backups/$CBACKUP_ID.tar.gz" ]] \
+    || fail "Failed restore removed the source archive"
+
+cp "$TARBALL" "$DST3/.backups/$CBACKUP_ID.tar.gz"
+ODS_DIR="$DST3" bash "$ODS_RESTORE" -f "$CBACKUP_ID" >/dev/null 2>&1 \
+    || fail "A valid replacement archive could not be restored after cleanup"
+pass "Checksum failure cleans extraction and a corrected archive can be retried"
+
+echo "tampered-again" >> "$DST3/.backups/$CBACKUP_ID/.env"
+set +e
+ODS_DIR="$DST3" bash "$ODS_RESTORE" -f "$CBACKUP_ID" >/dev/null 2>&1
+restore_rc=$?
+set -e
+[[ $restore_rc -ne 0 ]] || fail "Restore accepted a corrupt pre-existing backup directory"
+[[ -d "$DST3/.backups/$CBACKUP_ID" ]] \
+    || fail "Validation failure deleted a pre-existing backup directory"
+pass "Validation failure preserves pre-existing uncompressed backups"
+
 # ── Interactive selection ─────────────────────────────────────────────
 # select_backup's stdout is command-substituted into backup_id, so the list
 # and prompt must print to stderr or the selection table is swallowed and


### PR DESCRIPTION
**Ready for independent review (2026-09-15).** Candidate `ffc10e100f4ec667edc5f02a4059199cfd7d379e` has a successful GitHub check rollup and no base-branch conflict at this review snapshot. This supersedes earlier draft-status wording only. All validation gaps, migration requirements, live gates and independent human review requirements below remain in force; this is not a merge-ready approval.

## Why this matters

Restoring a compressed backup extracts it to `.backups/<id>` before checksum validation. When validation fails, `do_restore` returns but leaves that newly created directory behind. Subsequent restores prefer the directory over `<id>.tar.gz`, so even replacing the damaged archive with a correct copy cannot recover without manual cleanup; the failed attempt also permanently doubles the archive's disk footprint and leaves extracted configuration/user data at rest.

The invariant is: a directory created by the current restore attempt must be removed if validation fails, while a pre-existing uncompressed backup and the source archive must never be deleted.

## What changed

- record whether this invocation is extracting a compressed archive into a previously absent directory
- on validation failure, physically resolve both the extraction and backup-root paths
- delete only when the resolved extraction remains a strict child of `BACKUP_ROOT`
- retain and report cleanup failures instead of swallowing them
- preserve pre-existing uncompressed backup directories and the original `.tar.gz`

## Overlap check

Searched open and closed upstream PRs for restore checksum cleanup, stale extracted backups, corrupt archive retries, `extract_backup`, `validate_backup`, and changes to `ods/ods-restore.sh`. No PR covers post-extraction validation cleanup. PR #2346 rejects archives whose top-level root does not match the backup ID before extraction; this PR handles a correctly rooted archive whose contents fail validation and changes a later `do_restore` boundary. PR #3541 validates backup IDs before path use, PR #3022 changes model coverage/container stopping, and PR #3554 cleans the separate `ods-backup.sh verify` temporary extraction. The behaviors and changed hunks are independent.

## Regression coverage

`tests/test-backup-restore-roundtrip.sh` now exercises the public restore command with real archives:

1. build a correctly rooted archive whose `.env` no longer matches `checksums.sha256`;
2. require restore to fail, remove only the new extracted directory, and retain the tarball;
3. replace the tarball with the valid original and require retry to succeed;
4. corrupt the now pre-existing uncompressed directory, require validation failure, and prove that directory is preserved.

The first cleanup assertion fails on upstream `main`; all four invariants pass with this change.

## Validation

- `bash tests/test-backup-restore-roundtrip.sh` — passed
- `bash tests/test-backup-integrity.sh` — passed
- `bash tests/test-backup-restore-cli.sh` — 11 passed
- `bash tests/test-update-rollback-contract.sh` — passed
- `bash -n ods-restore.sh tests/test-backup-restore-roundtrip.sh` — passed
- `pre-commit run --files ods/ods-restore.sh ods/tests/test-backup-restore-roundtrip.sh` — passed
- `git diff --check` — passed

`make` is unavailable on this Windows host; repository CI remains the full Linux validation gate.

## Tradeoffs, limitation, and rollback

The cleanup uses physical path containment because this PR must be safe independently of #3541's identifier validation. It intentionally does not delete a pre-existing directory, even when invalid, because that directory may be operator-managed evidence. A wrongly rooted archive is a separate pre-extraction contract handled by #2346; this PR neither duplicates nor depends on it.

This PR adds a guarded recursive delete. It is intentionally **not merge-ready until independent human review** confirms the extraction provenance and physical-containment guard. Rollback removes only automatic failed-extraction cleanup and reintroduces the stale-directory retry blocker.
## Combined compatibility validation

Synthetic integration was validated in both relevant merge orders:

- `175e2fa8`: #3554 → #3556 → #3557, then overlapping-file checks with #3540, #3541, and #2346
- `492ce800`: #3540 → #3556 and #3541 → #2346 → #3557, then #3554

Both orders merged without conflicts. The combined backup integrity/round-trip/CLI/update rollback, preset confinement, restore-ID confinement, remote-provider CLI contracts, Bash syntax, and `git diff --check` all passed. The three PRs in this batch have no required merge order.
## CI status

All GitHub Actions checks passed at head `ffc10e10`, including `integration-smoke` (4m09s), shell lint, Ruff, API/frontend, distro matrix, PowerShell lint, env validation, and secret scan. This PR still requires independent human review before merge because it introduces a guarded recursive deletion path.