### PR TITLE
fix(simulation): fail CI when installer scenarios fail

### DIFF
--- a/ods/scripts/simulate-installers.sh
+++ b/ods/scripts/simulate-installers.sh
@@ -28,14 +28,16 @@ chmod +x "${FAKEBIN}/curl"
 cd "$ROOT_DIR"
 
 # 1) Linux installer dry-run simulation
-LINUX_EXIT=0
-if ! PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1; then
+if PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1; then
+  LINUX_EXIT=0
+else
   LINUX_EXIT=$?
 fi
 
 # 2) macOS installer MVP simulation
-MACOS_EXIT=0
-if ! bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1; then
+if bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1; then
+  MACOS_EXIT=0
+else
   MACOS_EXIT=$?
 fi
 
@@ -54,8 +56,9 @@ scripts/preflight-engine.sh \
   --env >/dev/null
 
 # 4) Doctor snapshot for current machine context
-DOCTOR_EXIT=0
-if ! scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1; then
+if scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1; then
+  DOCTOR_EXIT=0
+else
   DOCTOR_EXIT=$?
 fi
 

--- a/ods/scripts/validate-sim-summary.py
+++ b/ods/scripts/validate-sim-summary.py
@@ -115,6 +115,12 @@ def _require_type(v: Validator, value: Any, path: str, expected: str) -> None:
         v.add(path, f"expected {expected}, got {_type_name(value)}")
 
 
+def _require_zero(v: Validator, value: Any, path: str) -> None:
+    _require_type(v, value, path, "int")
+    if _is_int(value) and value != 0:
+        v.add(path, "must be 0")
+
+
 def _optional_type(v: Validator, value: Any, path: str, expected: str) -> None:
     if value is None:
         return
@@ -158,7 +164,7 @@ def _require_iso8601ish(v: Validator, value: Any, path: str) -> None:
 
 def validate_linux_dryrun(v: Validator, linux: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, linux, path, "exit_code")
-    _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_zero(v, exit_code, f"{path}.exit_code")
 
     signals = _require_key(v, linux, path, "signals")
     _require_type(v, signals, f"{path}.signals", "object")
@@ -182,12 +188,15 @@ def validate_linux_dryrun(v: Validator, linux: Mapping[str, Any], path: str) -> 
             if s not in signals:
                 v.add(f"{path}.signals", f"missing required signal '{s}'")
             else:
-                _require_type(v, signals.get(s), f"{path}.signals.{s}", "bool")
+                signal = signals.get(s)
+                _require_type(v, signal, f"{path}.signals.{s}", "bool")
+                if isinstance(signal, bool) and not signal:
+                    v.add(f"{path}.signals.{s}", "must be true")
 
 
 def validate_macos_installer(v: Validator, mac: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, mac, path, "exit_code")
-    _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_zero(v, exit_code, f"{path}.exit_code")
 
     log_path = _require_key(v, mac, path, "log")
     _require_path_like(v, log_path, f"{path}.log")
@@ -205,7 +214,7 @@ def validate_macos_installer(v: Validator, mac: Mapping[str, Any], path: str) ->
         if isinstance(summary, Mapping):
             blockers = summary.get("blockers")
             warnings = summary.get("warnings")
-            _require_type(v, blockers, f"{path}.preflight.summary.blockers", "int")
+            _require_zero(v, blockers, f"{path}.preflight.summary.blockers")
             _require_type(v, warnings, f"{path}.preflight.summary.warnings", "int")
 
 
@@ -221,13 +230,13 @@ def validate_windows_scenario(v: Validator, win: Mapping[str, Any], path: str) -
     if isinstance(summary, Mapping):
         blockers = summary.get("blockers")
         warnings = summary.get("warnings")
-        _require_type(v, blockers, f"{path}.report.summary.blockers", "int")
+        _require_zero(v, blockers, f"{path}.report.summary.blockers")
         _require_type(v, warnings, f"{path}.report.summary.warnings", "int")
 
 
 def validate_doctor_snapshot(v: Validator, doctor: Mapping[str, Any], path: str) -> None:
     exit_code = _require_key(v, doctor, path, "exit_code")
-    _require_type(v, exit_code, f"{path}.exit_code", "int")
+    _require_zero(v, exit_code, f"{path}.exit_code")
 
     report = _require_key(v, doctor, path, "report")
     _require_type(v, report, f"{path}.report", "object")
@@ -265,6 +274,8 @@ def validate_golden_paths(v: Validator, golden: Mapping[str, Any], path: str) ->
         v.add(f"{path}.scenario_count", "must be greater than zero")
     if _is_int(pass_count) and _is_int(scenario_count) and pass_count > scenario_count:
         v.add(f"{path}.pass_count", "must be less than or equal to scenario_count")
+    if _is_int(pass_count) and _is_int(scenario_count) and pass_count < scenario_count:
+        v.add(f"{path}.pass_count", "must equal scenario_count")
 
 
 def validate_summary(v: Validator, data: Mapping[str, Any]) -> None:

--- a/ods/tests/test-validate-sim-summary.sh
+++ b/ods/tests/test-validate-sim-summary.sh
@@ -189,6 +189,74 @@ else
     fail "nested validation error should mention missing signal"
 fi
 
+assert_invalid_outcome() {
+    local fixture="$1"
+    local expected_path="$2"
+    local description="$3"
+    local output
+    local status
+
+    set +e
+    output=$(python3 "$ROOT_DIR/scripts/validate-sim-summary.py" "$fixture" 2>&1)
+    status=$?
+    set -e
+
+    if [[ $status -eq 2 ]]; then
+        pass "$description exits 2"
+    else
+        fail "$description should exit 2, got $status"
+    fi
+    if echo "$output" | grep -q "$expected_path"; then
+        pass "$description identifies $expected_path"
+    else
+        fail "$description should identify $expected_path"
+    fi
+}
+
+python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR"
+import copy
+import json
+import pathlib
+import sys
+
+source, output_dir = sys.argv[1:]
+with open(source, encoding="utf-8") as handle:
+    valid = json.load(handle)
+
+fixtures = {}
+
+fixtures["failed-linux-exit.json"] = copy.deepcopy(valid)
+fixtures["failed-linux-exit.json"]["runs"]["linux_dryrun"]["exit_code"] = 17
+
+fixtures["missing-linux-signal.json"] = copy.deepcopy(valid)
+fixtures["missing-linux-signal.json"]["runs"]["linux_dryrun"]["signals"]["capability_loaded"] = False
+
+fixtures["macos-blocker.json"] = copy.deepcopy(valid)
+fixtures["macos-blocker.json"]["runs"]["macos_installer_mvp"]["preflight"] = {
+    "summary": {"blockers": 1, "warnings": 0}
+}
+
+fixtures["windows-blocker.json"] = copy.deepcopy(valid)
+fixtures["windows-blocker.json"]["runs"]["windows_scenario_preflight"]["report"]["summary"]["blockers"] = 1
+
+fixtures["failed-doctor-exit.json"] = copy.deepcopy(valid)
+fixtures["failed-doctor-exit.json"]["runs"]["doctor_snapshot"]["exit_code"] = 3
+
+fixtures["incomplete-golden-paths.json"] = copy.deepcopy(valid)
+fixtures["incomplete-golden-paths.json"]["golden_paths"]["pass_count"] = 3
+
+for name, data in fixtures.items():
+    path = pathlib.Path(output_dir, name)
+    path.write_text(json.dumps(data), encoding="utf-8")
+PY
+
+assert_invalid_outcome "$TMP_DIR/failed-linux-exit.json" "linux_dryrun.exit_code" "failed Linux simulation"
+assert_invalid_outcome "$TMP_DIR/missing-linux-signal.json" "capability_loaded" "false Linux success signal"
+assert_invalid_outcome "$TMP_DIR/macos-blocker.json" "macos_installer_mvp.preflight.summary.blockers" "macOS blocker"
+assert_invalid_outcome "$TMP_DIR/windows-blocker.json" "windows_scenario_preflight.report.summary.blockers" "Windows blocker"
+assert_invalid_outcome "$TMP_DIR/failed-doctor-exit.json" "doctor_snapshot.exit_code" "failed doctor snapshot"
+assert_invalid_outcome "$TMP_DIR/incomplete-golden-paths.json" "golden_paths.pass_count" "incomplete golden paths"
+
 python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR/no-generated-at.json"
 import json
 import sys


### PR DESCRIPTION
## Summary
- preserve real Linux, macOS, and doctor exit codes instead of reading the status of a negated command
- make simulation-summary validation reject failed runs, false required signals, preflight blockers, and incomplete golden-path coverage
- add boundary-level summary fixtures for every failure outcome

## Why this matters
`scripts/simulate-installers.sh` used `if ! command; then status=$?`, so every failed command was recorded as exit code 0. The CI and release-gate validator then checked only types, allowing a crashed installer scenario to produce a green gate. The invariant is that every required simulated run succeeds and every declared golden path passes before the release gate can succeed.

This fixes #2999.

## Overlap check
Searched open and closed PR titles/bodies for `#2999`, `simulate-installers.sh`, `validate-sim-summary`, `installer simulation exit code`, and the affected production files. No overlapping PR or superset was found. Current `upstream/main` still contains the negated-status capture in `ods/scripts/simulate-installers.sh` and type-only outcome checks in `ods/scripts/validate-sim-summary.py`.

## Production contract
- Producer: Linux/macOS installer simulations and the doctor snapshot return an exit status and reports.
- Persisted state: `artifacts/installer-sim/summary.json` and `golden-paths.json`.
- Consumers: `scripts/validate-sim-summary.py`, `.github/workflows/test-linux.yml`, and `scripts/release-gate.sh`.
- Runtime effect: a nonzero run, false required signal, blocker, or incomplete scenario set now fails validation with JSON-path diagnostics.
- Rollback: revert this commit to restore schema-only validation; no persisted user state or compatibility surface changes.

## Validation
- `bash -n scripts/simulate-installers.sh tests/test-validate-sim-summary.sh`
- `python -m py_compile scripts/validate-sim-summary.py`
- `bash tests/test-validate-sim-summary.sh` — 24 passed, 0 failed
- `git diff --check`
- Full harness negative probe under the current root WSL session: Linux install correctly returned 1 (`Do not run as root`), the summary recorded 1, validation failed, and golden coverage reported 3/4. A non-root full success run remains delegated to CI.

## Platform impact
The shared simulation gate covers Linux, macOS, Windows-preflight, and doctor outcomes. No installer implementation or platform selection behavior changes.

Generated with Codex