### PR TITLE
fix(session-cleanup): support an empty active-session index

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -146,12 +146,16 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
 
     # Check if this session is active
     IS_ACTIVE=false
-    for ID in "${ACTIVE_IDS[@]}"; do
-        if [ "$BASENAME" = "$ID" ]; then
-            IS_ACTIVE=true
-            break
-        fi
-    done
+    # Bash before 4.4 treats an initialized empty array as unset under
+    # `set -u`, so only expand it when the index contains active sessions.
+    if [[ ${#ACTIVE_IDS[@]} -gt 0 ]]; then
+        for ID in "${ACTIVE_IDS[@]}"; do
+            if [ "$BASENAME" = "$ID" ]; then
+                IS_ACTIVE=true
+                break
+            fi
+        done
+    fi
 
     if [ "$IS_ACTIVE" = false ]; then
         SIZE=$(du -h "$f" | cut -f1)

--- a/ods/tests/test-session-cleanup.sh
+++ b/ods/tests/test-session-cleanup.sh
@@ -99,6 +99,25 @@ else
 fi
 
 # ============================================================================
+# Test 4b: Empty active index still removes orphaned session files
+# ============================================================================
+EMPTY_INDEX_DIR="$TEMP_DIR/empty-active-index"
+mkdir -p "$EMPTY_INDEX_DIR"
+printf '{}\n' > "$EMPTY_INDEX_DIR/sessions.json"
+printf '{"orphaned":true}\n' > "$EMPTY_INDEX_DIR/orphaned.jsonl"
+
+empty_index_exit=0
+empty_index_output=$(SESSIONS_DIR="$EMPTY_INDEX_DIR" MAX_SIZE=100 \
+    bash "$SESSION_CLEANUP_SCRIPT" 2>&1) || empty_index_exit=$?
+if [[ $empty_index_exit -eq 0 ]] \
+    && [[ ! -f "$EMPTY_INDEX_DIR/orphaned.jsonl" ]] \
+    && echo "$empty_index_output" | grep -q "Active sessions found: 0"; then
+    pass "Empty active index removes orphaned sessions"
+else
+    fail "Empty active index cleanup failed (exit $empty_index_exit)"
+fi
+
+# ============================================================================
 # Test 5: Behavioral test - removes inactive sessions
 # ============================================================================
 # Create inactive session file (not in sessions.json)


### PR DESCRIPTION
## Summary
- avoid expanding an empty `ACTIVE_IDS` array under `set -u` on Bash before 4.4
- keep the existing active-session lookup unchanged when IDs are present
- add a public-script regression covering an empty index plus an orphaned session file

## Why this matters
The installed `openclaw-session-cleanup` systemd timer runs `scripts/session-cleanup.sh` once per minute. On Bash 3.2–4.3, a fresh or fully-cleared `sessions.json` leaves `ACTIVE_IDS` empty; expanding `${ACTIVE_IDS[@]}` then aborts with `unbound variable`. The timer therefore fails precisely when every `.jsonl` file is inactive, allowing stale session data to accumulate indefinitely.

The invariant is: an empty valid session index is a successful cleanup state, and every orphaned `.jsonl` file is removed.

Fixes #3132.

## Overlap check
Searched open and closed PR titles/bodies for `#3132`, `session-cleanup.sh`, `empty active index`, and `ACTIVE_IDS`, then inspected all local/upstream/fork branch commits touching `ods/scripts/session-cleanup.sh` and `ods/tests/test-session-cleanup.sh`. No competing fix or superset exists. Existing history covers transactional index updates and missing-Python handling, not empty-array compatibility.

## Production contract
- Producer: OpenClaw writes `sessions.json` and per-session `.jsonl` files.
- Consumer: the installed `openclaw-session-cleanup.service` invokes this script from its timer.
- Runtime effect: a zero-ID index now skips the unsafe array expansion and proceeds to classify every session file as inactive.
- Receipt: the script exits 0, logs `Active sessions found: 0`, removes orphaned files, and reports the remaining count.
- Rollback: revert this commit; no persisted format or configuration changes.

## Validation
- Bash 4.3 red/green boundary probe:
  - `upstream/main`: exits nonzero at line 149 with `ACTIVE_IDS[@]: unbound variable`; orphan remains.
  - this branch: exits 0; orphan is removed and summary reports zero remaining files.
- `bash tests/test-session-cleanup.sh` — 20 passed, 0 failed on current Bash.
- Same complete suite under GNU Bash 4.3.0 — 20 passed, 0 failed.
- `bash -n ods/scripts/session-cleanup.sh ods/tests/test-session-cleanup.sh`
- `shellcheck --rcfile=/dev/null --severity=error ...`
- `git diff --check`

## Platform impact
The fix targets Bash 3.2–4.3 compatibility and is behavior-neutral on Bash 4.4+. It changes no Windows PowerShell path. The primary deployed consumer is the Linux systemd timer; macOS's system Bash also benefits when the script is invoked manually.

Generated with Codex