### PR TITLE
test(wsl): forward AMD contract fixtures to PowerShell

### DIFF
--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -342,7 +342,17 @@ elif command -v powershell.exe >/dev/null 2>&1; then
 fi
 if ((${#_lemonade_ps_cmd[@]} > 0)); then
     _ps_tmp="${TMPDIR:-/tmp}"
-    if ROOT_DIR="$ROOT_DIR" AMD_LEMONADE_IMAGE="$AMD_LEMONADE_IMAGE" TEMP="$_ps_tmp" ProgramFiles="$_ps_tmp" USERPROFILE="$_ps_tmp" "${_lemonade_ps_cmd[@]}" -Command '
+    if (
+        # WSL only forwards Linux environment variables named in WSLENV to a
+        # native powershell.exe process. Export the fixture environment from
+        # a subshell so Windows PowerShell receives the same contract as pwsh
+        # without leaking the overrides into later tests.
+        export ROOT_DIR AMD_LEMONADE_IMAGE
+        export TEMP="$_ps_tmp" ProgramFiles="$_ps_tmp" USERPROFILE="$_ps_tmp"
+        if [[ "${_lemonade_ps_cmd[0]}" == "powershell.exe" ]]; then
+            export WSLENV="${WSLENV:+${WSLENV}:}ROOT_DIR/p:AMD_LEMONADE_IMAGE:TEMP/p:ProgramFiles/p:USERPROFILE/p"
+        fi
+        "${_lemonade_ps_cmd[@]}" -Command '
         $ErrorActionPreference = "Stop"
         . (Join-Path $env:ROOT_DIR "installers/windows/lib/backend-contract.ps1")
         $runtime = Get-ODSAmdLemonadeRuntime -RootPath $env:ROOT_DIR
@@ -547,7 +557,8 @@ if ((${#_lemonade_ps_cmd[@]} > 0)); then
             $principal.RunLevel -ne "Limited") {
             throw "Interactive scheduled task principal did not preserve the resolved user and limited token"
         }
-    '; then
+        '
+    ); then
         pass "backend-contract.ps1: resolves Lemonade and enforces versioned secure launch/config contracts"
     else
         fail "backend-contract.ps1: PowerShell contract failed"


### PR DESCRIPTION
## Summary

- forward the AMD/Lemonade contract fixture environment across WSL interop with `WSLENV`
- isolate `ROOT_DIR`, image, and temporary Windows path overrides in a subshell
- preserve the existing native `pwsh` path while making the `powershell.exe` fallback executable from WSL

## Why this matters

`bash tests/contracts/test-amd-lemonade-contracts.sh` is part of the documented `make test` release gate. On WSL, Bash environment variables are not forwarded automatically to native Windows processes, so the fallback `powershell.exe` process received an empty `ROOT_DIR` and failed in `Join-Path`. That left the supported WSL development gate red even though the Windows backend contract itself was valid, and prevented the remaining suite from running.

Behavioral invariant: the real Windows PowerShell contract must receive its isolated fixture root, image pin, and temporary paths whether it is launched by Linux `pwsh` or through WSL interop, without leaking those overrides into later tests.

## Overlap check

Searched open and closed PRs for `test-amd-lemonade-contracts.sh WSLENV`, `PowerShell contract failed WSL`, `Windows backend contract helper WSL`, and `ROOT_DIR/p AMD`, plus remote branches and unmerged commits touching the contract. No PR covers this WSL environment-forwarding failure. #1219 introduced the backend helper but does not change WSL test transport; #2815 and #3158 fix earlier, independent `make test` blockers in the same full-gate run.

Changed file searched: `ods/tests/contracts/test-amd-lemonade-contracts.sh`.

## Regression test

The nearest public boundary is the existing AMD/Lemonade contract itself: it launches the real repository-owned `backend-contract.ps1` through native Windows PowerShell from WSL. Before this change it failed 64/65 with `$env:ROOT_DIR` null; after the change it passes 65/65.

## Validation

- Baseline at `upstream/main` (`6ff9b4fc`): `bash ods/tests/contracts/test-amd-lemonade-contracts.sh` — 64 passed, 1 failed (`Join-Path $env:ROOT_DIR` received null)
- Branch: `bash ods/tests/contracts/test-amd-lemonade-contracts.sh` — 65 passed, 0 failed
- `bash -n ods/tests/contracts/test-amd-lemonade-contracts.sh` — passed
- `shellcheck --rcfile=/dev/null --severity=error ods/tests/contracts/test-amd-lemonade-contracts.sh` — passed
- `git diff --check` — passed

The full WSL `make test` gate currently requires independent open fixes #2815 and #3158 to reach this contract. A synthetic head containing both reached this exact 64/65 failure; the focused real-PowerShell boundary is green after this change. Native Windows CI is left to GitHub Actions; no production installer files change.

## Platform impact and rollback

- WSL: adds the required variable names and path-conversion markers only while invoking `powershell.exe`.
- Linux with `pwsh`: retains ordinary exported environment propagation.
- Native Windows/Git Bash: the scoped exports remain compatible; `WSLENV` is inert outside WSL.

Rollback affects tests only, but restores the reproducible WSL release-gate failure.

Generated with Codex