### PR TITLE
fix(installer): rebuild AMD initramfs on Arch

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -51,6 +51,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
+	@bash tests/test-amd-initramfs-rebuild.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh
 	@bash tests/contracts/test-windows-strix-tier-map.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh

--- a/ods/installers/phases/10-amd-tuning.sh
+++ b/ods/installers/phases/10-amd-tuning.sh
@@ -29,6 +29,32 @@ elif [[ "$GPU_BACKEND" == "amd" ]] && ! $DRY_RUN; then
         ods_sudo "$@"
     }
 
+    _phase10_rebuild_initramfs() {
+        local rebuild_status=127
+        if command -v update-initramfs >/dev/null 2>&1; then
+            if _phase10_privileged update-initramfs -u; then
+                return 0
+            else
+                rebuild_status=$?
+            fi
+        fi
+        if command -v dracut >/dev/null 2>&1; then
+            if _phase10_privileged dracut --force; then
+                return 0
+            else
+                rebuild_status=$?
+            fi
+        fi
+        if command -v mkinitcpio >/dev/null 2>&1; then
+            if _phase10_privileged mkinitcpio -P; then
+                return 0
+            else
+                rebuild_status=$?
+            fi
+        fi
+        return "$rebuild_status"
+    }
+
     # Ensure user is in render and video groups for ROCm GPU access
     # Without these, containers can't access /dev/kfd and /dev/dri
     if ! groups "$USER" 2>/dev/null | grep -qw render || ! groups "$USER" 2>/dev/null | grep -qw video; then
@@ -170,10 +196,13 @@ options ttm page_pool_size=${page_pool_size}
 GTT_EOF
             if _phase10_privileged cp "$_gtt_tmp" /etc/modprobe.d/amdgpu_llm_optimized.conf 2>/dev/null; then
                 # Rebuild initramfs so the new modprobe config takes effect on next boot.
-                _phase10_privileged update-initramfs -u >> "$LOG_FILE" 2>&1 || \
-                    _phase10_privileged dracut --force >> "$LOG_FILE" 2>&1 || true
-                ai_ok "GTT memory tuning installed (gttsize=${gtt_size}MB of ${total_ram_mb}MB, ${gtt_pct}%)"
-                _amd_needs_reboot=true
+                if _phase10_rebuild_initramfs >> "$LOG_FILE" 2>&1; then
+                    ai_ok "GTT memory tuning installed (gttsize=${gtt_size}MB of ${total_ram_mb}MB, ${gtt_pct}%)"
+                    _amd_needs_reboot=true
+                else
+                    ai_warn "GTT memory config was installed, but initramfs could not be rebuilt."
+                    ai_warn "Rebuild it before rebooting (Arch: sudo mkinitcpio -P; Debian/Ubuntu: sudo update-initramfs -u; Fedora/RHEL: sudo dracut --force)."
+                fi
             else
                 ai_warn "Could not install GTT memory config (needs sudo)."
             fi

--- a/ods/tests/test-amd-initramfs-rebuild.sh
+++ b/ods/tests/test-amd-initramfs-rebuild.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Regression contract for the AMD GTT initramfs rebuild path.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHASE="$ROOT_DIR/installers/phases/10-amd-tuning.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo "[PASS] $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo "[FAIL] $1"
+    FAIL=$((FAIL + 1))
+}
+
+extract_rebuild_helper() {
+    awk '
+        /^    _phase10_rebuild_initramfs\(\) \{/ { capture=1 }
+        capture {
+            line=$0
+            sub(/^    /, "", line)
+            print line
+            if ($0 == "    }") exit
+        }
+    ' "$PHASE"
+}
+
+HELPER_TEXT="$(extract_rebuild_helper)"
+if [[ -n "$HELPER_TEXT" ]]; then
+    pass "phase exposes the initramfs rebuild helper"
+else
+    fail "phase must expose _phase10_rebuild_initramfs"
+fi
+
+run_success_case() {
+    local tool="$1" expected="$2"
+    local case_dir="$TMP_DIR/$tool" call_log="$TMP_DIR/$tool.calls"
+    mkdir -p "$case_dir"
+    : > "$case_dir/$tool"
+    chmod +x "$case_dir/$tool"
+
+    if (
+        PATH="$case_dir"
+        _phase10_privileged() { printf '%s\n' "$*" >> "$call_log"; }
+        eval "$HELPER_TEXT"
+        _phase10_rebuild_initramfs
+    ); then
+        if [[ "$(< "$call_log")" == "$expected" ]]; then
+            pass "$tool is invoked with the distribution-specific arguments"
+        else
+            fail "$tool invocation mismatch: expected '$expected', got '$(< "$call_log")'"
+        fi
+    else
+        fail "$tool should be accepted as an initramfs generator"
+    fi
+}
+
+run_success_case update-initramfs "update-initramfs -u"
+run_success_case dracut "dracut --force"
+run_success_case mkinitcpio "mkinitcpio -P"
+
+fallback_dir="$TMP_DIR/fallback"
+fallback_log="$TMP_DIR/fallback.calls"
+mkdir -p "$fallback_dir"
+: > "$fallback_dir/update-initramfs"
+: > "$fallback_dir/dracut"
+chmod +x "$fallback_dir/update-initramfs" "$fallback_dir/dracut"
+if (
+    PATH="$fallback_dir"
+    _phase10_privileged() {
+        printf '%s\n' "$*" >> "$fallback_log"
+        [[ "$1" != "update-initramfs" ]]
+    }
+    eval "$HELPER_TEXT"
+    _phase10_rebuild_initramfs
+); then
+    if [[ "$(< "$fallback_log")" == $'update-initramfs -u\ndracut --force' ]]; then
+        pass "a failed generator falls through to the next available tool"
+    else
+        fail "generator fallback order was not preserved"
+    fi
+else
+    fail "dracut should recover a failed update-initramfs attempt"
+fi
+
+empty_path="$TMP_DIR/no-generator"
+mkdir -p "$empty_path"
+set +e
+(
+    PATH="$empty_path"
+    _phase10_privileged() { printf '%s\n' "$*" >> "$TMP_DIR/unexpected.calls"; }
+    eval "$HELPER_TEXT"
+    _phase10_rebuild_initramfs
+)
+no_generator_status=$?
+set -e
+if [[ "$no_generator_status" -ne 0 && ! -e "$TMP_DIR/unexpected.calls" ]]; then
+    pass "missing initramfs tooling fails without attempting a privileged command"
+else
+    fail "missing initramfs tooling must fail explicitly"
+fi
+
+failed_tool_dir="$TMP_DIR/failed-tool"
+mkdir -p "$failed_tool_dir"
+: > "$failed_tool_dir/mkinitcpio"
+chmod +x "$failed_tool_dir/mkinitcpio"
+set +e
+(
+    PATH="$failed_tool_dir"
+    _phase10_privileged() { return 23; }
+    eval "$HELPER_TEXT"
+    _phase10_rebuild_initramfs
+)
+failed_tool_status=$?
+set -e
+if [[ "$failed_tool_status" -ne 0 ]]; then
+    pass "initramfs generator failures propagate to the phase caller"
+else
+    fail "initramfs generator failure was hidden"
+fi
+
+gtt_block="$(awk '
+    /# Install GTT memory optimization/ { capture=1 }
+    capture { print }
+    /# Configure kernel boot parameters/ { exit }
+' "$PHASE")"
+if [[ "$gtt_block" == *'if _phase10_rebuild_initramfs'* \
+    && "$gtt_block" == *'GTT memory config was installed, but initramfs could not be rebuilt.'* ]]; then
+    pass "GTT install success is gated on a successful initramfs rebuild"
+else
+    fail "GTT block must warn instead of reporting success when initramfs rebuild fails"
+fi
+
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Why this matters

The Linux AMD tuning phase writes GTT-related `amdgpu`/`ttm` options into `/etc/modprobe.d`, rebuilds initramfs, and then tells the operator the tuning is installed and a reboot will activate it. On Arch Linux, the phase only tried Debian's `update-initramfs` and Fedora/RHEL's `dracut`; standard Arch hosts provide `mkinitcpio` instead. Both missing-command failures were swallowed, so the installer printed success and requested a reboot even though the new module options were never added to initramfs.

This is the independent Arch initramfs sub-defect documented in #2844. It does not claim to resolve or close the issue's separate gfx-target, `/dev/kfd`, restart-policy, or APU-gating concerns.

Root cause: the rebuild path treated a two-command `|| ... || true` chain as best effort, then unconditionally emitted the success receipt and set `_amd_needs_reboot=true`.

Behavioral invariant: GTT tuning may be reported as installed-and-ready for reboot only after an available distribution initramfs generator succeeds.

The dispatcher now preserves the existing `update-initramfs -u` then `dracut --force` fallback and adds `mkinitcpio -P`. Arch's official [`mkinitcpio(8)` manual](https://man.archlinux.org/man/mkinitcpio.8) defines `-P`/`--allpresets` as processing every preset under `/etc/mkinitcpio.d`.

## Overlap check

Searched open and closed PRs for `mkinitcpio`, `Arch initramfs`, `AMD tuning initramfs`, `update-initramfs dracut`, and the changed production file `ods/installers/phases/10-amd-tuning.sh`.

- Open #2312 changes secure temporary staging in the same GTT block. Current `main` already has a later secure `mktemp` implementation; #2312 does not add Arch generator dispatch or gate the success receipt and is currently conflicting.
- Closed #2966 fixes gfx-target detection and mentions this Arch gap as explicitly out of scope. It was closed without implementing suggestions 3-6 from #2844.
- No open or closed PR implements `mkinitcpio -P` or makes initramfs rebuild failure visible in this production path.

The scope is therefore independently useful and does not replace either PR.

## Regression test

`tests/test-amd-initramfs-rebuild.sh` extracts and executes the real phase helper with hermetic command fixtures. It proves:

- Debian/Ubuntu dispatches `update-initramfs -u`;
- Fedora/RHEL dispatches `dracut --force`;
- Arch dispatches `mkinitcpio -P`;
- a failed generator falls through to the next available tool;
- missing and failing generators return non-zero; and
- the GTT caller gates its success receipt on that result.

Against clean `upstream/main`, the final regression produced 2 passes and 6 failures. Against commit `59f3608b`, all 8 checks pass.

## Validation

- `bash tests/test-amd-initramfs-rebuild.sh` — 8 passed, 0 failed
- LF candidate archive: `make lint` — passed
- LF candidate archive: ShellCheck error severity on the phase and regression — passed
- `bash -n` on both changed shell files — passed
- `git diff --check` — passed

`tests/contracts/test-installer-hardening.sh` on current `main` stops earlier in the existing no-sudo fixture with `installers/lib/sudo.sh: nvidia-ctk: command not found`, before exercising this block. A real Arch AMD host and live initramfs/boot cycle were not available: the executable fixtures prove command selection, fallback, exit propagation, and operator receipt behavior, not successful booting of a regenerated image.

## Platform impact and rollback

Linux AMD only. Debian/Ubuntu and Fedora/RHEL retain their existing commands and fallback order; Arch gains its native generator. Windows and macOS paths are unchanged.

If every available generator fails, the config remains installed in `/etc/modprobe.d` and the installer gives distribution-specific manual rebuild commands, but it no longer claims the tuning is ready or asks for a misleading reboot. Reverting restores the silent Arch failure and unconditional success receipt.