### PR TITLE
fix(installer): prefer specific GPU name matches

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Tier Map Unit Tests
         run: bash tests/test-tier-map.sh
 
+      - name: Hardware Name Specificity Tests
+        run: bash tests/test-hardware-name-specificity.sh
+
       - name: Service Registry Tests
         run: bash tests/test-service-registry.sh
 

--- a/ods/scripts/classify-hardware.sh
+++ b/ods/scripts/classify-hardware.sh
@@ -83,8 +83,9 @@ OVERLAY_MAP = {
 
 # --- Pass 1: Match known_gpus by device_id then name_patterns ---
 selected = None
-best_name_len = 0          # longest matching pattern wins (prevents "XT" matching "XTX")
-best_id_vram_diff = None   # closest VRAM wins for device_id-only fallback
+best_match_rank = 0        # exact id + name > exact id > name-only
+best_name_len = 0          # longest matching pattern wins (prevents broad aliases winning)
+best_id_vram_diff = None   # closest VRAM wins for otherwise-equal device-id matches
 combined_name = f"{gpu_name} {cpu_name}".strip().lower()
 
 for entry in db.get("known_gpus", []):
@@ -101,25 +102,37 @@ for entry in db.get("known_gpus", []):
     match_len = max((len(p) for p in matched_patterns), default=0)
 
     if id_matched and name_matched:
-        # Both match — prefer longest pattern to avoid "XT" matching "XTX"
-        if match_len > best_name_len:
-            selected = entry
-            best_name_len = match_len
-    elif id_matched and best_name_len == 0:
-        # Device ID matched but name didn't — use VRAM proximity as tiebreaker
-        entry_vram = entry.get("specs", {}).get("memory_mb", 0)
-        if vram_mb > 0:
-            diff = abs(entry_vram - vram_mb)
-        else:
-            # No VRAM info: prefer smallest card (under-provision is safe,
-            # over-provision crashes the model loader)
-            diff = entry_vram if entry_vram > 0 else float("inf")
-        if best_id_vram_diff is None or diff < best_id_vram_diff:
-            selected = entry
-            best_id_vram_diff = diff
-    elif name_matched and not selected:
+        match_rank = 3
+    elif id_matched:
+        match_rank = 2
+    elif name_matched:
+        match_rank = 1
+    else:
+        match_rank = 0
+    if match_rank == 0:
+        continue
+
+    entry_vram = entry.get("specs", {}).get("memory_mb", 0)
+    if vram_mb > 0:
+        id_vram_diff = abs(entry_vram - vram_mb)
+    else:
+        # No VRAM info: prefer the smallest device-id match. Under-provisioning
+        # is safer than selecting a model envelope the host cannot load.
+        id_vram_diff = entry_vram if entry_vram > 0 else float("inf")
+
+    better_match = match_rank > best_match_rank
+    if match_rank == best_match_rank == 3:
+        better_match = match_len > best_name_len
+    elif match_rank == best_match_rank == 2:
+        better_match = best_id_vram_diff is None or id_vram_diff < best_id_vram_diff
+    elif match_rank == best_match_rank == 1:
+        better_match = match_len > best_name_len
+
+    if better_match:
         selected = entry
+        best_match_rank = match_rank
         best_name_len = match_len
+        best_id_vram_diff = id_vram_diff if id_matched else None
 
 # --- Pass 2: Heuristic fallback (threshold-based, top-down) ---
 if not selected:

--- a/ods/tests/test-hardware-name-specificity.sh
+++ b/ods/tests/test-hardware-name-specificity.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+command -v jq >/dev/null 2>&1 || {
+    echo "[FAIL] jq is required"
+    exit 1
+}
+
+classify() {
+    bash scripts/classify-hardware.sh \
+        --platform-id linux \
+        --gpu-vendor nvidia \
+        --memory-type "$1" \
+        --vram-mb "$2" \
+        --ram-mb "$3" \
+        --gpu-name "$4"
+}
+
+# Device IDs are not always available (containers and restricted sysfs are
+# common examples), so the installer's production fallback is name matching.
+# "Grace Blackwell" also contains the earlier, generic "Blackwell" alias.
+grace_class="$(classify unified 0 131072 'NVIDIA Grace Blackwell')"
+jq -e '
+    .id == "nvidia_grace_blackwell_gb10"
+    and .memory_source == "ram"
+    and .bandwidth_gbps == 273
+' <<<"$grace_class" >/dev/null || {
+    echo "[FAIL] Grace Blackwell must beat the generic Blackwell alias"
+    exit 1
+}
+
+# The specificity rule must not redirect the workstation product whose name
+# owns the broad alias.
+workstation_class="$(classify discrete 98304 128000 'NVIDIA RTX PRO 6000 Blackwell')"
+jq -e '
+    .id == "rtx_pro_6000_blackwell"
+    and .memory_source == "vram"
+    and .bandwidth_gbps == 1792
+' <<<"$workstation_class" >/dev/null || {
+    echo "[FAIL] RTX PRO 6000 Blackwell classification changed unexpectedly"
+    exit 1
+}
+
+echo "[PASS] hardware name matching prefers the most specific shipped alias"


### PR DESCRIPTION
## Summary
- rank hardware database matches so exact device-id plus name wins over device-id-only, which wins over name-only
- choose the longest shipped name alias when PCI device IDs are unavailable
- add a CI boundary regression for the overlapping `Blackwell` / `Grace Blackwell` aliases

## Why this matters
`scripts/detect-hardware.sh` feeds name-only GPU data into `classify-hardware.sh` on hosts where a PCI device ID is unavailable. On `upstream/main`, `NVIDIA Grace Blackwell` stops at the earlier generic `Blackwell` alias and is reported as an RTX PRO 6000 workstation card. That changes the capability receipt from unified RAM / 273 GB/s to discrete VRAM / 1792 GB/s and gives operators the wrong hardware identity during installation.

The invariant is: higher-confidence matches always win, and equally confident name matches prefer the most specific alias. The regression invokes the shipped classifier with the shipped GPU database, rather than testing a copied helper.

## Overlap check
Searched open and closed PRs for `classify-hardware.sh`, `Grace Blackwell`, `longest pattern`, and hardware name specificity. Existing open PRs #3118, #2615, and #2750 cover CPU/RAM fallback, numeric parsing, and CLI help respectively; none changes match precedence or exercises the overlapping shipped aliases. Closed classifier PRs likewise cover low-VRAM fallback and platform overlays, not name specificity. Changed production file: `ods/scripts/classify-hardware.sh`.

## Validation
- `bash tests/test-hardware-name-specificity.sh` — pass
- `bash -n scripts/classify-hardware.sh tests/test-hardware-name-specificity.sh` — pass
- `shellcheck --norc -S error scripts/classify-hardware.sh tests/test-hardware-name-specificity.sh` — pass
- `git diff --check` — pass
- Baseline reproduction: the same Grace Blackwell CLI invocation on `upstream/main` returns `rtx_pro_6000_blackwell`, `memory_source=vram`, and `bandwidth_gbps=1792`.

The broad local `tests/contracts/test-installer-contracts.sh` run progressed through the new hardware assertion, then stopped at the existing Hermes context-template parity assertion. It is not counted as validation for this change; CI runs the new focused test as its own step.

## Tradeoffs and rollback
This keeps database order as the final tiebreaker when two aliases have equal confidence and equal length, preserving existing behavior for true ties. Rollback is a single commit and restores first-name-match behavior; no persisted state or migration is involved.

Generated with Codex