### PR TITLE
fix(wsl): trust working NVIDIA capability probe

### DIFF
--- a/ods/scripts/detect-hardware.sh
+++ b/ods/scripts/detect-hardware.sh
@@ -134,11 +134,16 @@ detect_platform() {
 detect_nvidia() {
     # Validate NVIDIA hardware present in sysfs before trusting nvidia-smi,
     # which may be installed without NVIDIA hardware (e.g. nvidia-container-toolkit
-    # on AMD-only systems).
+    # on AMD-only systems). WSL2 exposes the GPU through its paravirtualized
+    # driver without a PCI card entry, so a working nvidia-smi is the hardware
+    # witness there. Keep this in parity with installers/lib/detection.sh.
     local _has_nvidia=false
     for _v in /sys/class/drm/card*/device/vendor; do
         [[ "$(cat "$_v" 2>/dev/null)" == "0x10de" ]] && _has_nvidia=true && break
     done
+    if ! $_has_nvidia && is_wsl && command -v nvidia-smi &>/dev/null; then
+        _has_nvidia=true
+    fi
     $_has_nvidia || return 1
 
     # Works on bare metal Linux; on WSL2 it may be present via Docker Desktop GPU integration.

--- a/ods/tests/smoke/wsl-logic.sh
+++ b/ods/tests/smoke/wsl-logic.sh
@@ -9,4 +9,34 @@ grep -q "linux|wsl" installers/dispatch.sh
 grep -q "Windows (Docker Desktop + WSL2)" docs/SUPPORT-MATRIX.md
 grep -q 'install\.ps1' docs/SUPPORT-MATRIX.md
 
+echo "[smoke] WSL capability-profile NVIDIA detection"
+# Source the production detector without executing main, then emulate the WSL
+# kernel signal and its paravirtualized nvidia-smi surface. WSL commonly has no
+# /sys/class/drm/card*/device/vendor entry, so nvidia-smi itself is the witness.
+source scripts/detect-hardware.sh
+is_wsl() { return 0; }
+nvidia-smi() {
+    case "$*" in
+        *--query-gpu=name,memory.total*)
+            printf '%s\n' 'NVIDIA GeForce RTX 4090, 24564'
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+wsl_nvidia="$(detect_nvidia)"
+[[ "$wsl_nvidia" == "NVIDIA GeForce RTX 4090, 24564" ]] || {
+    echo "[smoke] WSL nvidia-smi was not accepted without PCI sysfs" >&2
+    exit 1
+}
+
+# Presence of the executable is not enough: a stale/broken nvidia-smi must
+# still fail so AMD and CPU detection can continue.
+nvidia-smi() { return 1; }
+if detect_nvidia >/dev/null; then
+    echo "[smoke] failed WSL nvidia-smi was accepted as hardware" >&2
+    exit 1
+fi
+
 echo "[smoke] PASS wsl-logic"


### PR DESCRIPTION
## Summary
- let the capability-profile detector use a working `nvidia-smi` as the NVIDIA hardware witness on WSL2
- preserve the PCI-vendor requirement on native Linux, where stale NVIDIA tooling can otherwise hide an AMD GPU
- extend the WSL smoke boundary with successful and failed paravirtualized probe cases

## Why this matters
The Linux installer first runs `scripts/build-capability-profile.sh`, which calls `scripts/detect-hardware.sh`. WSL2 exposes NVIDIA GPUs through its paravirtualized driver and commonly has no `/sys/class/drm/card*/device/vendor` entry. The installer-local detector already accounts for that, but the capability detector returned no NVIDIA GPU before invoking an otherwise working `nvidia-smi`. This can write a CPU capability profile and select the wrong backend before the later installer detector runs.

The invariant is platform-specific: native Linux requires the `0x10de` sysfs witness, while WSL2 may use a successful `nvidia-smi` query; a present but failing executable is never accepted.

## Overlap check
Searched open and closed PRs for `detect-hardware.sh`, `detect_nvidia`, WSL sysfs, and WSL `nvidia-smi`. Merged PR #917 introduced the native-Linux sysfs guard to prevent stale NVIDIA tooling from masking AMD hardware. Merged PR #1130 added Grace Blackwell handling. Neither covers WSL's missing PCI sysfs surface. Open PR #2614 only guards nonexistent glob paths. The matching exception already exists in `ods/installers/lib/detection.sh`; this PR repairs the drift in `ods/scripts/detect-hardware.sh` without weakening #917 on native Linux.

## Validation
- `bash tests/smoke/wsl-logic.sh` — pass
- `bash -n scripts/detect-hardware.sh tests/smoke/wsl-logic.sh` — pass
- `shellcheck --norc -S error scripts/detect-hardware.sh tests/smoke/wsl-logic.sh` — pass
- `git diff --check` — pass

The smoke test sources the real detector, emulates WSL, and proves both a successful `nvidia-smi` receipt and a failed executable fallback. No live Windows GPU host was available, so Docker Desktop/WSL GPU activation remains a reviewer/live-host gate.

## Tradeoffs and rollback
This intentionally trusts `nvidia-smi` only after its query succeeds and only on WSL. Native Linux behavior remains unchanged. Rollback restores the capability-profile false negative on WSL and requires no state migration.

Generated with Codex