### PR TITLE
docs(models): correct tier download workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,12 +354,17 @@ ods model list                 # Show all available tiers
 ods model swap T3              # Switch to a different tier
 ```
 
-If the new model isn't downloaded yet, pre-fetch it first:
+If the new model isn't downloaded yet, open **Dashboard → Models**, choose the
+catalog model for that tier, and use **Download**. After the download completes,
+the Dashboard can activate it directly, or you can run the tier swap:
 
 ```bash
-./scripts/pre-download.sh --tier 3    # Download before switching
-ods model swap T3                    # Then swap (restarts llama-server)
+ods model swap T3                    # Activate the downloaded tier model
 ```
+
+`ods model swap` deliberately does not download from the network. The legacy
+`scripts/pre-download.sh` caches Hugging Face Transformer snapshots for offline
+components; it does not populate the GGUF file required by a tier swap.
 
 Already have a GGUF you want to use? Drop the single `.gguf` file in
 `data/models/`, then open Dashboard -> Models and load the local entry. For

--- a/ods/FAQ.md
+++ b/ods/FAQ.md
@@ -101,10 +101,14 @@ ods model list                 # Show available tiers and models
 ods model swap T3              # Switch to Tier 3 (e.g., Qwen3 30B-A3B)
 ```
 
-The model file must already be downloaded. If it isn't, pre-fetch it first:
-```bash
-./scripts/pre-download.sh --tier 3
-```
+The model file must already be downloaded. If it isn't, open **Dashboard →
+Models**, choose the catalog model for that tier, and use **Download**. The
+Dashboard can activate it after the download, or you can rerun `ods model swap
+T3`.
+
+`ods model swap` deliberately does not download from the network. The legacy
+`scripts/pre-download.sh` caches Hugging Face Transformer snapshots for offline
+components; it does not populate the GGUF file required by a tier swap.
 
 ### Can I use my own GGUF model?
 Yes. Drop the single `.gguf` file into `data/models/`, then open Dashboard ->

--- a/ods/tests/test-install-docs.sh
+++ b/ods/tests/test-install-docs.sh
@@ -203,6 +203,19 @@ require_literal "$REPO_ROOT/README.md" '**Linux or macOS**' "Front-page Linux/ma
 require_literal "$REPO_ROOT/README.md" '**Windows PowerShell**' "Front-page Windows install label"
 require_literal "$REPO_ROOT/README.md" 'Docker must be installed and running' "Front-page Docker prerequisite"
 
+model_switch_docs=(
+    "$REPO_ROOT/README.md"
+    "$ROOT_DIR/FAQ.md"
+)
+
+for file in "${model_switch_docs[@]}"; do
+    require_literal "$file" 'Dashboard' "Model download workflow"
+    require_literal "$file" 'does not download from the network' "Model swap network contract"
+    if grep -qF './scripts/pre-download.sh --tier 3' "$file"; then
+        fail "Model switch guidance invokes an unsupported pre-download tier in ${file#"$REPO_ROOT"/}"
+    fi
+done
+
 for file in "${windows_copy_paste_docs[@]}"; do
     require_literal "$file" "$WINDOWS_SOURCE_ZIP_URL" "Windows no-Git source ZIP install"
     require_literal "$file" '[guid]::NewGuid().ToString("N")' "Windows collision-free temporary source directory"


### PR DESCRIPTION
## Summary
- replace the unsupported `pre-download.sh --tier 3` model-switch instructions in README and FAQ
- point operators to Dashboard → Models, the production catalog download and activation boundary
- document that `ods model swap` is intentionally network-free and requires a downloaded GGUF
- add an install-doc contract that rejects the broken command in both user-facing guides

## Why this matters
The published switching instructions tell operators to run `./scripts/pre-download.sh --tier 3`. That command accepts only `nano`, `edge`, `pro`, or `cluster`, so the copy/paste path fails. Even substituting one of those names would not satisfy `ods model swap T3`: the legacy helper caches Hugging Face Transformer snapshots, while the swap command checks for the catalog's exact GGUF under `data/models` before calling the host-agent transaction.

Dashboard → Models is the production path that downloads the catalog GGUF and can activate it through the same authenticated lifecycle. This change makes the external contract match the code instead of papering over the numeric argument mismatch.

## Overlap check
Searched open and closed PRs for `pre-download.sh`, tier 3, GGUF prefetch, and model switching. Open PRs #2641/#3092 cover Python packaging, #2632 proposes offline component selection, and #2865/#3360 cover exit-status handling; none corrects the user-facing tier-swap workflow. Searched both changed docs and the authoritative `ods model swap` implementation in `ods/ods-cli`.

## Validation
- `bash tests/test-install-docs.sh` — pass
- `bash -n tests/test-install-docs.sh` — pass
- `git diff --check` — pass
- `rg --fixed-strings './scripts/pre-download.sh --tier 3' README.md ods/FAQ.md` — no matches

This is a documentation-contract fix; it does not add a headless GGUF downloader. Headless operators must still place the catalog GGUF in `data/models` before `ods model swap`, as the CLI currently requires.

## Tradeoffs and rollback
The Dashboard is now the only documented built-in catalog download path. Rollback would restore a command that is both syntactically unsupported and artifact-incompatible; no runtime state or migration is involved.

Generated with Codex