### PR TITLE
fix(workflows): follow n8n activation API contract

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -214,7 +214,12 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
                     if n8n_id:
                         async with session.patch(f"{N8N_URL}/api/v1/workflows/{n8n_id}", headers=headers, json={"active": True}) as activate_resp:
                             activated = activate_resp.status == 200
-                    return {"status": "success", "workflowId": workflow_id, "n8nId": n8n_id, "activated": activated, "message": f"{wf_info['name']} is now active!"}
+                    message = (
+                        f"{wf_info['name']} is now active!"
+                        if activated
+                        else f"{wf_info['name']} was imported but could not be activated."
+                    )
+                    return {"status": "success", "workflowId": workflow_id, "n8nId": n8n_id, "activated": activated, "message": message}
                 else:
                     error_text = await resp.text()
                     raise HTTPException(status_code=resp.status, detail=f"n8n API error: {error_text}")

--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -209,10 +209,11 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
             async with session.post(f"{N8N_URL}/api/v1/workflows", headers=headers, json=workflow_data) as resp:
                 if resp.status in (200, 201):
                     result = await resp.json()
-                    n8n_id = result.get("data", {}).get("id")
+                    n8n_id = result.get("id")
                     activated = False
                     if n8n_id:
-                        async with session.patch(f"{N8N_URL}/api/v1/workflows/{n8n_id}", headers=headers, json={"active": True}) as activate_resp:
+                        activate_url = f"{N8N_URL}/api/v1/workflows/{n8n_id}/activate"
+                        async with session.post(activate_url, headers=headers) as activate_resp:
                             activated = activate_resp.status == 200
                     message = (
                         f"{wf_info['name']} is now active!"

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -698,6 +698,65 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     assert data["status"] == "success"
     assert data["n8nId"] == "n8n-99"
     assert data["activated"] is True
+    assert data["message"] == "OK Workflow is now active!"
+
+
+def test_workflow_enable_reports_activation_rejection(test_client, tmp_path, monkeypatch):
+    """A successful import must not claim a rejected activation succeeded."""
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "manual-wf", "name": "Manual Workflow", "description": "test",
+             "file": "manual-wf.json", "dependencies": []}
+        ],
+        "categories": {}
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "manual-wf.json").write_text(json.dumps({
+        "name": "Manual Workflow",
+        "nodes": [{"type": "n8n-nodes-base.manualTrigger"}],
+    }))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
+
+    create_resp = AsyncMock()
+    create_resp.status = 201
+    create_resp.json = AsyncMock(return_value={"data": {"id": "n8n-manual"}})
+
+    activate_resp = AsyncMock()
+    activate_resp.status = 400
+
+    create_ctx = AsyncMock()
+    create_ctx.__aenter__ = AsyncMock(return_value=create_resp)
+    create_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    activate_ctx = AsyncMock()
+    activate_ctx.__aenter__ = AsyncMock(return_value=activate_resp)
+    activate_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    session_mock = AsyncMock()
+    session_mock.post = MagicMock(return_value=create_ctx)
+    session_mock.patch = MagicMock(return_value=activate_ctx)
+    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+    session_mock.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+        resp = test_client.post(
+            "/api/workflows/manual-wf/enable",
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "success"
+    assert data["n8nId"] == "n8n-manual"
+    assert data["activated"] is False
+    assert data["message"] == "Manual Workflow was imported but could not be activated."
 
 
 def test_workflow_enable_n8n_error(test_client, tmp_path, monkeypatch):

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -667,9 +667,9 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     # Mock n8n POST (create) → 201 with id
     create_resp = AsyncMock()
     create_resp.status = 201
-    create_resp.json = AsyncMock(return_value={"data": {"id": "n8n-99"}})
+    create_resp.json = AsyncMock(return_value={"id": "n8n-99"})
 
-    # Mock n8n PATCH (activate) → 200
+    # Mock n8n POST (activate) → 200
     activate_resp = AsyncMock()
     activate_resp.status = 200
 
@@ -682,8 +682,7 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     activate_ctx.__aexit__ = AsyncMock(return_value=False)
 
     session_mock = AsyncMock()
-    session_mock.post = MagicMock(return_value=create_ctx)
-    session_mock.patch = MagicMock(return_value=activate_ctx)
+    session_mock.post = MagicMock(side_effect=[create_ctx, activate_ctx])
     session_mock.__aenter__ = AsyncMock(return_value=session_mock)
     session_mock.__aexit__ = AsyncMock(return_value=False)
 
@@ -699,6 +698,9 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
     assert data["n8nId"] == "n8n-99"
     assert data["activated"] is True
     assert data["message"] == "OK Workflow is now active!"
+    assert session_mock.post.call_args_list[1].args[0].endswith(
+        "/api/v1/workflows/n8n-99/activate"
+    )
 
 
 def test_workflow_enable_reports_activation_rejection(test_client, tmp_path, monkeypatch):
@@ -726,7 +728,7 @@ def test_workflow_enable_reports_activation_rejection(test_client, tmp_path, mon
 
     create_resp = AsyncMock()
     create_resp.status = 201
-    create_resp.json = AsyncMock(return_value={"data": {"id": "n8n-manual"}})
+    create_resp.json = AsyncMock(return_value={"id": "n8n-manual"})
 
     activate_resp = AsyncMock()
     activate_resp.status = 400
@@ -740,8 +742,7 @@ def test_workflow_enable_reports_activation_rejection(test_client, tmp_path, mon
     activate_ctx.__aexit__ = AsyncMock(return_value=False)
 
     session_mock = AsyncMock()
-    session_mock.post = MagicMock(return_value=create_ctx)
-    session_mock.patch = MagicMock(return_value=activate_ctx)
+    session_mock.post = MagicMock(side_effect=[create_ctx, activate_ctx])
     session_mock.__aenter__ = AsyncMock(return_value=session_mock)
     session_mock.__aexit__ = AsyncMock(return_value=False)
 


### PR DESCRIPTION
## Summary
- read the created workflow ID from n8n's documented workflow response
- activate through POST /api/v1/workflows/{id}/activate instead of PATCHing a read-only active field
- make the user-facing message agree with the activation receipt
- cover accepted and rejected activation paths through the dashboard API boundary

## Why this matters
The workflow enable endpoint did not follow the public API contract of the pinned n8n runtime: create returns the workflow object with a top-level id, and activation uses a dedicated POST route. The old code expected data.id and attempted a PATCH with active: true, so real imports could never produce a reliable activation receipt. It then compounded the failure by always claiming the workflow was active.

The preserved invariant is end-to-end: a successful create receipt supplies the exact ID used by the activation request, and activated plus the displayed message reflect the activation response. Manual-trigger-only templates remain imported when n8n rejects activation, but operators are told the truth.

## Overlap check
Searched open and closed ODS PRs for workflow enable, activation failure/rejection, n8n create response, /activate, and changes to routers/workflows.py plus test_workflows.py. No PR covers this endpoint contract. Model-activation and setup-readiness PRs returned by broader searches operate on different services and state machines. This resolves #3585 and corrects the underlying public-API mismatch exposed while reproducing it.

## Validation
- python -m pytest tests/test_workflows.py -q (46 passed)
- git diff --check

The regression exercises POST /api/workflows/{id}/enable through FastAPI TestClient. It asserts the create response's top-level id is carried into the documented /activate URL, then separately verifies activation 200 and 400 receipts.

## Tradeoffs and rollback
A workflow that imports but does not activate remains HTTP 200 with status success because the import succeeded and callers already consume activated as the second-stage receipt. Only a 200 activation response produces an active claim. Rollback affects no persisted workflow data; it restores the previous API calls and response wording.