### PR TITLE
fix(config): preserve generated YAML scalar values

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -829,9 +829,9 @@ class TestWriteLemonadeConfig:
         _write_lemonade_config(tmp_path, "Qwen3.5-9B-Q4_K_M.gguf")
 
         content = (litellm_dir / "lemonade.yaml").read_text()
-        assert "model: openai/extra.Qwen3.5-9B-Q4_K_M.gguf" in content
-        assert "api_base: http://llama-server:8080/api/v1" in content
-        assert "api_key: sk-lemonade" in content
+        assert 'model: "openai/extra.Qwen3.5-9B-Q4_K_M.gguf"' in content
+        assert 'api_base: "http://llama-server:8080/api/v1"' in content
+        assert 'api_key: "sk-lemonade"' in content
         assert "extra_body:" in content
         assert "chat_template_kwargs:" in content
         assert "enable_thinking: false" in content
@@ -870,8 +870,8 @@ class TestWriteLemonadeConfig:
         _write_lemonade_config(tmp_path, "Qwen3.5-9B-Q4_K_M.gguf")
 
         content = (litellm_dir / "lemonade.yaml").read_text()
-        assert "api_key: sk-from-env-file-12345" in content
-        assert "api_key: sk-lemonade" not in content
+        assert 'api_key: "sk-from-env-file-12345"' in content
+        assert 'api_key: "sk-lemonade"' not in content
 
     def test_prefers_persisted_exact_model_id(self, tmp_path):
         litellm_dir = tmp_path / "config" / "litellm"
@@ -884,7 +884,7 @@ class TestWriteLemonadeConfig:
         _write_lemonade_config(tmp_path, "Modern-Model.gguf")
 
         content = (litellm_dir / "lemonade.yaml").read_text(encoding="utf-8")
-        assert "model: openai/Modern-Model" in content
+        assert 'model: "openai/Modern-Model"' in content
         assert "extra.Modern-Model.gguf" not in content
 
     def test_overwrites_previous(self, tmp_path):
@@ -896,7 +896,7 @@ class TestWriteLemonadeConfig:
 
         content = (litellm_dir / "lemonade.yaml").read_text()
         assert "old-model.gguf" not in content
-        assert "model: openai/extra.new-model.gguf" in content
+        assert 'model: "openai/extra.new-model.gguf"' in content
 
     def test_file_path(self, tmp_path):
         litellm_dir = tmp_path / "config" / "litellm"
@@ -4265,8 +4265,8 @@ class TestModelActivateRollback:
 
         assert handler.response_code == 200
         content = lemonade_yaml.read_text(encoding="utf-8")
-        assert "api_key: sk-inline-from-env-file-67890" in content
-        assert "api_key: sk-lemonade" not in content
+        assert 'api_key: "sk-inline-from-env-file-67890"' in content
+        assert 'api_key: "sk-lemonade"' not in content
         assert "enable_thinking: false" in content
         env = _mod.load_env(env_path)
         assert env["LEMONADE_MODEL"] == "extra.new-model.gguf"
@@ -4383,7 +4383,7 @@ class TestModelActivateRollback:
         assert state["active"]["runtimeModelId"] == "Modern-Model"
         assert state["active"]["contextLength"] == 4096
         assert "LEMONADE_MODEL=Modern-Model" in env_path.read_text(encoding="utf-8")
-        assert "model: openai/Modern-Model" in lemonade_yaml.read_text(encoding="utf-8")
+        assert 'model: "openai/Modern-Model"' in lemonade_yaml.read_text(encoding="utf-8")
         assert 'default: "Modern-Model"' in hermes_live.read_text(encoding="utf-8")
         assert 'default: "Modern-Model"' in hermes_template.read_text(encoding="utf-8")
         for path in (opencode_config, opencode_compat):
@@ -4642,7 +4642,7 @@ class TestModelActivateRollback:
 
         assert handler.response_code == 200
         content = lemonade_yaml.read_text(encoding="utf-8")
-        assert "model: openai/extra.new-model.gguf" in content
+        assert 'model: "openai/extra.new-model.gguf"' in content
         assert ["docker", "restart", "ods-litellm"] in calls
 
     def test_windows_lemonade_runtime_ensure_persists_config_without_dependents(
@@ -4706,7 +4706,7 @@ class TestModelActivateRollback:
         assert "GGUF_FILE=new-model.gguf" in updated_env
         assert "LLM_MODEL=target-model" in updated_env
         assert "LEMONADE_MODEL=Modern-Model" in updated_env
-        assert "model: openai/Modern-Model" in lemonade_yaml.read_text(encoding="utf-8")
+        assert 'model: "openai/Modern-Model"' in lemonade_yaml.read_text(encoding="utf-8")
 
     def test_windows_lemonade_runtime_ensure_rolls_back_renderer_failure(
         self, tmp_path, monkeypatch,

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -177,8 +177,8 @@ def render_litellm_local_native(inputs: RenderInputs) -> RenderedFile:
     content = f"""model_list:
   - model_name: default
     litellm_params:
-      model: openai/{model}
-      api_base: {api_base}
+      model: {yaml_scalar(f"openai/{model}")}
+      api_base: {yaml_scalar(api_base)}
       api_key: not-needed
       extra_body:
         chat_template_kwargs:
@@ -187,7 +187,7 @@ def render_litellm_local_native(inputs: RenderInputs) -> RenderedFile:
   - model_name: "*"
     litellm_params:
       model: openai/*
-      api_base: {api_base}
+      api_base: {yaml_scalar(api_base)}
       api_key: not-needed
       extra_body:
         chat_template_kwargs:
@@ -351,18 +351,18 @@ def render_litellm_lemonade(inputs: RenderInputs) -> RenderedFile:
     content = f"""model_list:
   - model_name: default
     litellm_params:
-      model: openai/{model}
-      api_base: {api_base}
-      api_key: {inputs.litellm_key}
+      model: {yaml_scalar(f"openai/{model}")}
+      api_base: {yaml_scalar(api_base)}
+      api_key: {yaml_scalar(inputs.litellm_key)}
       extra_body:
         chat_template_kwargs:
           enable_thinking: false
 
   - model_name: "*"
     litellm_params:
-      model: openai/{model}
-      api_base: {api_base}
-      api_key: {inputs.litellm_key}
+      model: {yaml_scalar(f"openai/{model}")}
+      api_base: {yaml_scalar(api_base)}
+      api_key: {yaml_scalar(inputs.litellm_key)}
       extra_body:
         chat_template_kwargs:
           enable_thinking: false
@@ -384,9 +384,9 @@ def render_hermes(inputs: RenderInputs) -> RenderedFile:
         else inputs.llm_base_url
     )
     content = f"""model:
-  default: "{model}"
+  default: {yaml_scalar(model)}
   provider: "custom"
-  base_url: "{base_url}"
+  base_url: {yaml_scalar(base_url)}
   context_length: {inputs.context_length}
   max_tokens: {DEFAULT_HERMES_MAX_TOKENS}
 

--- a/ods/tests/contracts/test-windows-runtime-recovery.ps1
+++ b/ods/tests/contracts/test-windows-runtime-recovery.ps1
@@ -174,7 +174,7 @@ try {
         }
     }
     $lemonadeConfig = Get-Content -LiteralPath (Join-Path $generatedInstall "config/litellm/lemonade.yaml") -Raw
-    if (-not $lemonadeConfig.Contains("api_base: http://host.docker.internal:18080/api/v1")) {
+    if (-not $lemonadeConfig.Contains('api_base: "http://host.docker.internal:18080/api/v1"')) {
         throw "LiteLLM Lemonade config ignored AMD_INFERENCE_PORT"
     }
     $routerConfig = Get-Content -LiteralPath (Join-Path $generatedInstall "config/model-router/endpoints.json") -Raw

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -12,6 +12,8 @@ import tempfile
 from pathlib import Path
 from types import ModuleType
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "render-runtime-configs.py"
@@ -261,8 +263,8 @@ def test_native_local_projection_uses_host_route_and_concrete_model() -> None:
         "http://host.docker.internal:13306/v1",
     )
     content = file_by_surface(payload, "litellm-local-native")["content"]
-    assert "model: openai/Native-Model.gguf" in content
-    assert "api_base: http://host.docker.internal:13306/v1" in content
+    assert 'model: "openai/Native-Model.gguf"' in content
+    assert 'api_base: "http://host.docker.internal:13306/v1"' in content
     assert "enable_thinking: false" in content
     assert "request_timeout: 900" in content
     assert "stream_timeout: 900" in content
@@ -376,8 +378,8 @@ def test_lemonade_disables_thinking_and_uses_extra_alias() -> None:
         "sk-test",
     )
     content = file_by_surface(payload, "litellm-lemonade")["content"]
-    assert "model: openai/extra.Model.gguf" in content
-    assert "api_key: sk-test" in content
+    assert 'model: "openai/extra.Model.gguf"' in content
+    assert 'api_key: "sk-test"' in content
     assert "enable_thinking: false" in content
 
 
@@ -397,9 +399,42 @@ def test_external_lemonade_uses_supplied_model_and_api_base() -> None:
         "lemonade-secret",
     )
     content = file_by_surface(payload, "litellm-lemonade")["content"]
-    assert "model: openai/Qwen3-0.6B-GGUF" in content
-    assert "api_base: http://host.docker.internal:13305/api/v1" in content
-    assert "api_key: lemonade-secret" in content
+    assert 'model: "openai/Qwen3-0.6B-GGUF"' in content
+    assert 'api_base: "http://host.docker.internal:13305/api/v1"' in content
+    assert 'api_key: "lemonade-secret"' in content
+
+
+def test_dynamic_yaml_values_round_trip_as_scalars() -> None:
+    model = 'vendor/model"quoted'
+    api_base = "http://[::1]:13305/api/v1?route=blue#primary"
+    api_key = "1234567890"
+    payload = run_renderer(
+        "--surface",
+        "all",
+        "--ods-mode",
+        "lemonade",
+        "--gpu-backend",
+        "amd",
+        "--lemonade-model-id",
+        model,
+        "--lemonade-api-base",
+        api_base,
+        "--llm-base-url",
+        api_base,
+        "--litellm-key",
+        api_key,
+    )
+
+    litellm = yaml.safe_load(file_by_surface(payload, "litellm-lemonade")["content"])
+    for route in litellm["model_list"]:
+        params = route["litellm_params"]
+        assert params["model"] == f"openai/{model}"
+        assert params["api_base"] == api_base
+        assert params["api_key"] == api_key
+
+    hermes = yaml.safe_load(file_by_surface(payload, "hermes")["content"])
+    assert hermes["model"]["default"] == model
+    assert hermes["model"]["base_url"] == api_base
 
 
 def test_exact_lemonade_id_propagates_to_every_runtime_surface() -> None:
@@ -423,7 +458,7 @@ def test_exact_lemonade_id_propagates_to_every_runtime_surface() -> None:
     perplexica = json.loads(file_by_surface(payload, "perplexica")["content"])
 
     assert "LEMONADE_MODEL=Modern-Model" in env_content
-    assert "model: openai/Modern-Model" in litellm_content
+    assert 'model: "openai/Modern-Model"' in litellm_content
     assert 'default: "Modern-Model"' in hermes_content
     assert opencode["model"] == "Modern-Model"
     assert perplexica["preferences"]["defaultChatModel"] == "Modern-Model"
@@ -566,6 +601,7 @@ def main() -> int:
         test_enabled_opencode_uses_stable_switchboard_alias,
         test_lemonade_disables_thinking_and_uses_extra_alias,
         test_external_lemonade_uses_supplied_model_and_api_base,
+        test_dynamic_yaml_values_round_trip_as_scalars,
         test_exact_lemonade_id_propagates_to_every_runtime_surface,
         test_amd_local_env_does_not_invent_a_lemonade_model,
         test_hermes_uses_lemonade_model_id_for_amd,


### PR DESCRIPTION
## Why this matters

The runtime renderer accepts operator-provided Lemonade credentials and model identifiers, then writes them into LiteLLM and Hermes YAML. Those values were interpolated as raw YAML. A schema-valid numeric 10-character API key was parsed as an integer, and a model identifier containing a double quote made Hermes config unparsable. Either outcome prevents the generated route from preserving the configured runtime contract and can break service startup or authentication.

Root cause: the renderer already had a JSON-compatible YAML scalar encoder, but only the cloud route used it. Native-local, Lemonade, and Hermes dynamic fields bypassed that boundary.

This change applies the existing scalar encoder to every dynamic value in those YAML surfaces. The preserved invariant is: every accepted dynamic renderer value must round-trip through a YAML parser with the same string value.

## Overlap check

Searched open and closed PRs for `runtime config`, `YAML escaping`, `LiteLLM Lemonade API key`, and `Hermes config YAML`, then compared PRs changing `ods/scripts/render-runtime-configs.py` and `ods/tests/test-render-runtime-configs.py`.

The closest open work is #1944/#1927 (atomic file replacement tests), #2934 (OrcaRouter cloud provider), #2843 (MLX runtime), #1787 (Hipfire routing), #2719 (model-router internal-key enforcement), and #2568 (OpenCode small-model field). None preserves scalar typing/escaping in the native-local, Lemonade, or Hermes YAML writers, so this scope is independent.

## Regression coverage

`test_dynamic_yaml_values_round_trip_as_scalars` invokes the public renderer CLI for a Lemonade install, parses the generated LiteLLM and Hermes documents with PyYAML, and asserts the exact model, URL, and numeric-looking API-key strings survive. Existing projection assertions were updated to make the now-explicit quoting contract visible.

## Validation

- `python ods/tests/test-render-runtime-configs.py` — 24/24 passed
- `python ods/scripts/validate-generated-configs.py` — passed
- `python -m compileall -q ods/scripts/render-runtime-configs.py ods/tests/test-render-runtime-configs.py` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

JSON string syntax is valid YAML and gives deterministic escaping without introducing another serializer or changing document structure. Static values remain unchanged. Rolling back restores the previous human-readable unquoted values but also restores YAML type coercion and parse failures for accepted dynamic input. Live container startup was not exercised locally; parser-level validation proves generated document validity and exact scalar preservation, not LiteLLM/Hermes process startup.
## Validation follow-up

Follow-up `6afdfcb0` updates the API and Windows projection contracts to assert the new explicit YAML quoting instead of the obsolete raw-scalar representation. Focused validation after that commit: 24/24 renderer tests, 238 model-activation tests passed with 1 skip, and the Windows native-runtime recovery contract passed. GitHub reports 27 successful checks and no hard failures; five optional Claude review jobs on the superseded run were cancelled.