### PR TITLE
fix(workflows): reject non-runnable n8n stubs

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -26,6 +26,67 @@ def _validate_workflow_id(workflow_id: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid workflow ID format")
 
 
+def _workflow_template_is_runnable(workflow_data: object) -> bool:
+    """Return whether a trigger reaches at least one executable node."""
+    if not isinstance(workflow_data, dict):
+        return False
+    nodes = workflow_data.get("nodes")
+    connections = workflow_data.get("connections")
+    if not isinstance(nodes, list) or not isinstance(connections, dict):
+        return False
+
+    node_types = {
+        node.get("name"): node.get("type", "")
+        for node in nodes
+        if isinstance(node, dict) and isinstance(node.get("name"), str)
+    }
+    trigger_names = {
+        name
+        for name, node_type in node_types.items()
+        if node_type.lower().endswith("trigger")
+        or node_type in {
+            "n8n-nodes-base.webhook",
+            "n8n-nodes-base.emailReadImap",
+        }
+    }
+    if not trigger_names:
+        return False
+
+    adjacency: dict[str, set[str]] = {}
+    for source, output_groups in connections.items():
+        if source not in node_types or not isinstance(output_groups, dict):
+            continue
+        targets = adjacency.setdefault(source, set())
+        for outputs in output_groups.values():
+            if not isinstance(outputs, list):
+                continue
+            for output in outputs:
+                if not isinstance(output, list):
+                    continue
+                for link in output:
+                    if not isinstance(link, dict):
+                        continue
+                    target = link.get("node")
+                    if target in node_types:
+                        targets.add(target)
+
+    visited = set(trigger_names)
+    pending = list(trigger_names)
+    while pending:
+        source = pending.pop()
+        for target in adjacency.get(source, set()):
+            if target in visited:
+                continue
+            if (
+                target not in trigger_names
+                and node_types[target] != "n8n-nodes-base.stickyNote"
+            ):
+                return True
+            visited.add(target)
+            pending.append(target)
+    return False
+
+
 def load_workflow_catalog() -> dict:
     """Load workflow catalog from JSON file."""
     if not WORKFLOW_CATALOG_FILE.exists():
@@ -199,6 +260,12 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
             workflow_data = json.load(f)
     except (OSError, json.JSONDecodeError) as e:
         raise HTTPException(status_code=500, detail=f"Failed to read workflow: {e}")
+
+    if not _workflow_template_is_runnable(workflow_data):
+        raise HTTPException(
+            status_code=422,
+            detail="Workflow template is a non-runnable starter stub; no workflow was imported",
+        )
 
     try:
         headers = {"Content-Type": "application/json"}

--- a/ods/extensions/services/dashboard-api/tests/test_workflow_stub_gate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflow_stub_gate.py
@@ -1,0 +1,84 @@
+"""Regression tests for rejecting non-runnable n8n catalog templates."""
+
+import json
+from unittest.mock import patch
+
+
+def _catalog(tmp_path, monkeypatch, workflow):
+    import routers.workflows as workflows
+
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps({
+        "workflows": [{
+            "id": "starter",
+            "name": "Starter",
+            "description": "test",
+            "file": "starter.json",
+            "dependencies": [],
+        }],
+        "categories": {},
+    }))
+    workflow_dir = tmp_path / "workflows"
+    workflow_dir.mkdir()
+    (workflow_dir / "starter.json").write_text(json.dumps(workflow))
+    monkeypatch.setattr(workflows, "WORKFLOW_CATALOG_FILE", catalog_file)
+    monkeypatch.setattr(workflows, "WORKFLOW_DIR", workflow_dir)
+
+
+def test_enable_rejects_disconnected_manual_starter_before_contacting_n8n(
+    test_client, tmp_path, monkeypatch,
+):
+    _catalog(tmp_path, monkeypatch, {
+        "name": "Starter",
+        "nodes": [
+            {
+                "name": "Start",
+                "type": "n8n-nodes-base.manualTrigger",
+            },
+            {
+                "name": "Setup Instructions",
+                "type": "n8n-nodes-base.stickyNote",
+            },
+        ],
+        "connections": {},
+    })
+
+    with patch("routers.workflows.aiohttp.ClientSession") as session:
+        response = test_client.post(
+            "/api/workflows/starter/enable",
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 422
+    assert response.json() == {
+        "detail": (
+            "Workflow template is a non-runnable starter stub; "
+            "no workflow was imported"
+        )
+    }
+    session.assert_not_called()
+
+
+def test_runnable_check_requires_a_trigger_connected_to_work(
+    test_client, tmp_path, monkeypatch,
+):
+    _catalog(tmp_path, monkeypatch, {
+        "name": "Starter",
+        "nodes": [
+            {"name": "Start", "type": "n8n-nodes-base.manualTrigger"},
+            {"name": "One", "type": "n8n-nodes-base.set"},
+            {"name": "Two", "type": "n8n-nodes-base.set"},
+        ],
+        "connections": {
+            "One": {"main": [[{"node": "Two", "type": "main", "index": 0}]]}
+        },
+    })
+
+    with patch("routers.workflows.aiohttp.ClientSession") as session:
+        response = test_client.post(
+            "/api/workflows/starter/enable",
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 422
+    session.assert_not_called()

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -661,7 +661,16 @@ def test_workflow_enable_success(test_client, tmp_path, monkeypatch):
 
     workflow_dir = tmp_path / "workflows"
     workflow_dir.mkdir()
-    (workflow_dir / "ok-wf.json").write_text(json.dumps({"name": "OK Workflow", "nodes": []}))
+    (workflow_dir / "ok-wf.json").write_text(json.dumps({
+        "name": "OK Workflow",
+        "nodes": [
+            {"name": "Start", "type": "n8n-nodes-base.manualTrigger"},
+            {"name": "Do Work", "type": "n8n-nodes-base.set"},
+        ],
+        "connections": {
+            "Start": {"main": [[{"node": "Do Work", "type": "main", "index": 0}]]}
+        },
+    }))
     monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
 
     # Mock n8n POST (create) → 201 with id
@@ -717,7 +726,16 @@ def test_workflow_enable_n8n_error(test_client, tmp_path, monkeypatch):
 
     workflow_dir = tmp_path / "workflows"
     workflow_dir.mkdir()
-    (workflow_dir / "err-wf.json").write_text(json.dumps({"name": "Err"}))
+    (workflow_dir / "err-wf.json").write_text(json.dumps({
+        "name": "Err",
+        "nodes": [
+            {"name": "Start", "type": "n8n-nodes-base.manualTrigger"},
+            {"name": "Do Work", "type": "n8n-nodes-base.set"},
+        ],
+        "connections": {
+            "Start": {"main": [[{"node": "Do Work", "type": "main", "index": 0}]]}
+        },
+    }))
     monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
 
     create_resp = AsyncMock()
@@ -759,7 +777,16 @@ def test_workflow_enable_n8n_unreachable(test_client, tmp_path, monkeypatch):
 
     workflow_dir = tmp_path / "workflows"
     workflow_dir.mkdir()
-    (workflow_dir / "net-wf.json").write_text(json.dumps({"name": "Net"}))
+    (workflow_dir / "net-wf.json").write_text(json.dumps({
+        "name": "Net",
+        "nodes": [
+            {"name": "Start", "type": "n8n-nodes-base.manualTrigger"},
+            {"name": "Do Work", "type": "n8n-nodes-base.set"},
+        ],
+        "connections": {
+            "Start": {"main": [[{"node": "Do Work", "type": "main", "index": 0}]]}
+        },
+    }))
     monkeypatch.setattr(wf_mod, "WORKFLOW_DIR", workflow_dir)
 
     session_mock = AsyncMock()


### PR DESCRIPTION
## Why this matters

The dashboard currently imports every catalog JSON into n8n and can report success even when the template is only a disconnected manual trigger plus a sticky note. Operators receive an installed workflow that cannot execute any advertised behavior. Issue #3587 reproduces this across the shipped catalog.

Root cause: the enable boundary validates the catalog id, dependencies, path, and JSON syntax, but never validates that the n8n graph has an executable path.

This change preserves the invariant that a catalog template is importable only when a trigger reaches at least one non-trigger executable node. Invalid starter stubs return HTTP 422 before any n8n request, with an explicit no-import message.

## Overlap check

Searched open and closed PRs for n8n stub templates, workflow enable, activation failure, routers/workflows.py, and test_workflows.py. PR #2964 fixes n8n v1 create/activate response semantics after a workflow has been imported; this PR acts earlier and rejects a non-runnable graph before import. PR #2495 validates catalog metadata and dependency aliases, but deliberately checks only JSON shape and connection references, not trigger reachability. PR #2114 concerns installed-workflow name matching. None covers this invariant.

## Regression coverage

- API-boundary test proves a disconnected manual-trigger/sticky-note template returns 422 and never constructs an n8n client.
- A second boundary test proves unrelated connected nodes do not make an orphaned trigger runnable.
- Existing success, n8n rejection, and unreachable-n8n fixtures now use minimally runnable graphs so their original boundaries remain exercised.

Validation:

- python -m pytest ods/extensions/services/dashboard-api/tests/test_workflow_stub_gate.py ods/extensions/services/dashboard-api/tests/test_workflows.py -q — 47 passed
- python -m compileall -q ods/extensions/services/dashboard-api/routers/workflows.py ods/extensions/services/dashboard-api/tests/test_workflow_stub_gate.py — passed
- git diff --check — passed

## Tradeoffs and rollback

This intentionally blocks importing starter-only templates instead of silently treating them as useful workflows. Manual demos remain supported when their manual trigger connects to real work. Static validation proves graph reachability, not that external credentials or services will succeed at runtime; dependency checks and n8n activation still own those gates. Reverting the commit restores the former permissive import behavior without changing stored workflows.

Local Ruff was unavailable in this checkout; the repository Python-lint workflow remains the authoritative lint gate.