### PR TITLE
feat(token-spy): price routed cloud usage

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -1556,7 +1556,8 @@ async def ingest_routed_telemetry(request: Request):
     if not _db_available:
         raise HTTPException(status_code=503, detail="Usage database is unavailable.")
 
-    await asyncio.to_thread(log_usage, routed_event_to_usage(event))
+    usage = routed_event_to_usage(event, cost_estimator=estimate_cost)
+    await asyncio.to_thread(log_usage, usage)
     return JSONResponse({"status": "accepted"}, status_code=202)
 
 

--- a/ods/extensions/services/token-spy/routed_telemetry.py
+++ b/ods/extensions/services/token-spy/routed_telemetry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any
 
 
@@ -98,7 +99,13 @@ def validate_routed_event(payload: Any) -> dict[str, Any]:
     return normalized
 
 
-def routed_event_to_usage(event: dict[str, Any]) -> dict[str, Any]:
+CostEstimator = Callable[[str, int, int, int, int, str], float]
+
+
+def routed_event_to_usage(
+    event: dict[str, Any],
+    cost_estimator: CostEstimator | None = None,
+) -> dict[str, Any]:
     """Map validated metadata into the existing Token Spy usage schema."""
     provider = event["provider_name"].lower()
     is_local = provider in _LOCAL_PROVIDERS
@@ -108,11 +115,29 @@ def routed_event_to_usage(event: dict[str, Any]) -> dict[str, Any]:
     # namespace, not part of the physical model identity.
     if is_local and model.startswith("extra."):
         model = model.removeprefix("extra.")
+
+    estimated_cost = 0.0
+    if not is_local and cost_estimator is not None:
+        estimated_cost = cost_estimator(
+            model,
+            event["input_tokens"],
+            event["output_tokens"],
+            event["cache_read_tokens"],
+            event["cache_write_tokens"],
+            provider,
+        )
+    if is_local:
+        cost_source = "local_zero_cost"
+    elif estimated_cost > 0:
+        cost_source = "priced_from_tokens"
+    else:
+        cost_source = "untracked"
+
     return {
         "agent": event["agent"],
         "model": model,
         "provider_name": "local" if is_local else provider,
-        "cost_source": "local_zero_cost" if is_local else "untracked",
+        "cost_source": cost_source,
         "request_body_bytes": event["request_body_bytes"],
         "message_count": event["message_count"],
         "user_message_count": event["user_message_count"],
@@ -133,7 +158,7 @@ def routed_event_to_usage(event: dict[str, Any]) -> dict[str, Any]:
         "output_tokens": event["output_tokens"],
         "cache_read_tokens": event["cache_read_tokens"],
         "cache_write_tokens": event["cache_write_tokens"],
-        "estimated_cost_usd": 0,
+        "estimated_cost_usd": round(estimated_cost, 6),
         "duration_ms": event["duration_ms"],
         "stop_reason": event["stop_reason"] or None,
         "filter_chars_saved": 0,

--- a/ods/extensions/services/token-spy/tests/test_routed_telemetry.py
+++ b/ods/extensions/services/token-spy/tests/test_routed_telemetry.py
@@ -111,6 +111,69 @@ def test_routed_event_appears_in_usage_report(tmp_path, monkeypatch):
     }]
 
 
+def test_remote_routed_event_records_priced_usage_in_report(tmp_path, monkeypatch):
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+    db = _load(TOKEN_SPY_DIR / "db.py", "token_spy_db")
+    monkeypatch.setattr(db, "DB_PATH", str(tmp_path / "usage.db"))
+    db._local.conn = None
+    db.init_db()
+    estimator_calls = []
+
+    def estimate(
+        model,
+        input_tokens,
+        output_tokens,
+        cache_read,
+        cache_write,
+        provider,
+    ):
+        estimator_calls.append(
+            (model, input_tokens, output_tokens, cache_read, cache_write, provider)
+        )
+        return 0.003125
+
+    normalized = telemetry.validate_routed_event(
+        _event(
+            provider_name="OpenAI",
+            model="gpt-4o-mini",
+            input_tokens=10_000,
+            output_tokens=2_000,
+            cache_read_tokens=500,
+        )
+    )
+    db.log_usage(
+        telemetry.routed_event_to_usage(normalized, cost_estimator=estimate)
+    )
+    today = datetime.now(timezone.utc).date().isoformat()
+    report = db.query_report(today, today)
+
+    assert estimator_calls == [
+        ("gpt-4o-mini", 10_000, 2_000, 500, 0, "openai")
+    ]
+    assert report["summary"]["paid_cost_usd"] == 0.003125
+    assert report["summary"]["billing_providers"] == 1
+    assert report["models"][0]["cost_source"] == "priced_from_tokens"
+    assert report["models"][0]["cost_usd"] == 0.003125
+
+
+def test_unknown_remote_routed_model_remains_untracked():
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+
+    usage = telemetry.routed_event_to_usage(
+        telemetry.validate_routed_event(
+            _event(provider_name="custom-cloud", model="unpriced-model")
+        ),
+        cost_estimator=lambda *_args: 0.0,
+    )
+
+    assert usage["estimated_cost_usd"] == 0
+    assert usage["cost_source"] == "untracked"
+
+
 def test_local_lemonade_namespace_maps_to_one_physical_model():
     telemetry = _load(
         TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"


### PR DESCRIPTION
## Summary

- reuse Token Spy's provider pricing registry for metadata-only routed events
- classify priced remote rows as `priced_from_tokens` while preserving local zero-cost and unknown-model `untracked` semantics
- cover the routed-event-to-SQLite-report boundary, including estimator inputs and billing aggregates

## Why this matters

The model router sends token counts and provider/model identity to `/api/ingest/routed`, but Token Spy currently stores every non-local routed event at $0 with `cost_source=untracked`. Operators therefore undercount spend whenever OpenAI- or Anthropic-backed traffic takes the router path even though Token Spy already ships rates for those models.

The root cause is that the ingest path maps telemetry directly to the usage schema without invoking the existing `estimate_cost` boundary. This change injects that estimator during ingestion. The preserved invariant is explicit: local runtimes stay zero-cost, known remote models are priced from tokens, and unknown remote models are never guessed.

## Overlap check

Searched open and closed PR titles/bodies for `routed telemetry cost`, `routed_telemetry.py`, and `estimated_cost_usd`. No PR covers pricing at the routed telemetry ingest path. Existing Token Spy work around reports and provider pricing does not connect `/api/ingest/routed` to the estimator.

Changed production files:
- `ods/extensions/services/token-spy/main.py`
- `ods/extensions/services/token-spy/routed_telemetry.py`

## Regression boundary

The regression test validates a normalized remote routed event through cost estimation, usage persistence, and `query_report` billing aggregates. It also asserts the exact estimator handoff and the unknown-model fallback.

## Validation

- `python -m pytest tests/test_routed_telemetry.py tests/test_usage_report.py` — 22 passed
- `python -m py_compile ods/extensions/services/token-spy/main.py ods/extensions/services/token-spy/routed_telemetry.py`
- `git diff --check`

## Tradeoffs and rollback

Pricing remains an estimate based on the versioned provider tables Token Spy already uses for proxied requests; zero-price unknown models remain visibly untracked. Reverting this commit restores the previous routed-event accounting without a schema or data migration.

Generated with Codex