### PR TITLE
fix(switchboard): enforce boolean phase receipts

### DIFF
--- a/ods/bin/model_switchboard/reconciler.py
+++ b/ods/bin/model_switchboard/reconciler.py
@@ -86,7 +86,14 @@ def run_runtime_activation(
                 "detail": "adapter returned a non-contract result",
                 **proof,
             }
-        if phase.startswith("verify_") and outcome.get("ok"):
+        if not isinstance(outcome["ok"], bool):
+            return {
+                "ok": False,
+                "phase": phase,
+                "detail": "adapter returned an invalid ok value",
+                **proof,
+            }
+        if phase.startswith("verify_") and outcome["ok"]:
             contract_error = _verification_error(outcome)
             if contract_error:
                 return {
@@ -126,7 +133,7 @@ def run_runtime_activation(
                     **proof,
                 }
             proof = outcome_proof
-        if not outcome.get("ok"):
+        if not outcome["ok"]:
             return {
                 "ok": False,
                 "phase": phase,

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -173,6 +173,22 @@ class TestReconcilerBoundaries:
         assert run["ok"] is False and run["phase"] == "stage"
         assert "non-contract" in run["detail"]
 
+    @pytest.mark.parametrize("phase", rc.PHASES)
+    @pytest.mark.parametrize("invalid_ok", ["false", 1, 0, None])
+    def test_non_boolean_ok_never_advances_activation(self, phase, invalid_ok):
+        plan = {phase: [{"ok": invalid_ok}]}
+        if phase == "verify_completion":
+            plan["verify_identity"] = [_proof_result()]
+        fake = ad.FakeAdapter(plan)
+
+        run = rc.run_runtime_activation(fake, {})
+
+        phase_index = rc.PHASES.index(phase)
+        assert run["ok"] is False
+        assert run["phase"] == phase
+        assert run["detail"] == "adapter returned an invalid ok value"
+        assert fake.calls == list(rc.PHASES[: phase_index + 1])
+
 
 class TestContainerLlamaAdapter:
     def test_delegates_with_expected_arguments(self):


### PR DESCRIPTION
## Summary

- require every model-switchboard phase receipt's `ok` field to be a real boolean
- reject truthy strings and integers before verification metadata is accepted or another phase runs
- exercise malformed receipts at stage, identity verification, and completion verification boundaries

## Why this matters

`run_runtime_activation` controls the production host agent sequence `stage -> verify_identity -> verify_completion`. It previously checked only that `ok` existed and then used Python truthiness, so receipts such as `{ok: false}` or `{ok: 1}` could advance activation and ultimately publish a model as proven.

The root cause is permissive truthiness at a transaction boundary. The invariant encoded here is that only JSON/Python booleans may control phase progression; malformed receipts fail closed at the phase that emitted them.

## Overlap check

Searched open and closed PR titles/bodies for model-switchboard adapter booleans, phase receipts, `contextVerified`, and `ods/bin/model_switchboard/reconciler.py`. PRs #3439 and #3451 mention the file but add unrelated synthetic rule/lock tests and do not modify this coordinator. PR #3033 applies the same contract principle to the separate remote-provider transaction in `ods/bin/remote_provider/reconciler.py`; it does not protect the model switchboard host-agent path.

Changed production file:
- `ods/bin/model_switchboard/reconciler.py`

## Regression boundary

The parameterized regression test calls the public runtime coordinator for all three phases with string, integer, zero, and null `ok` values. It verifies the returned failure phase and proves no later adapter method is invoked.

## Validation

- `python -m pytest tests/test_switchboard_reconciler.py` — 45 passed
- `python -m py_compile ods/bin/model_switchboard/reconciler.py ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py`
- `git diff --check`

## Compatibility and rollback

The bundled adapter `result()` helper already emits booleans, so conforming Linux/container, Windows-native, macOS-native, and Lemonade activation paths are unchanged. Custom adapters that returned non-booleans will now fail visibly instead of being coerced. Reverting restores permissive truthiness without changing persisted state formats.

Generated with Codex