### PR TITLE
fix(whisper): patch VAD per transcribe call

### DIFF
--- a/ods/extensions/services/whisper/docker-entrypoint.sh
+++ b/ods/extensions/services/whisper/docker-entrypoint.sh
@@ -22,87 +22,83 @@ import sys
 import re
 
 def patch_transcribe_call(source_code):
-    """Safely patch transcribe() calls to add VAD parameters."""
-    # Newer speaches commits (post mid-2025) include vad_filter= directly in
-    # the upstream transcribe() call. Skip patching anywhere in the file
-    # already containing those kwargs — the per-call check below only sees
-    # the first line of a multi-line call and misses kwargs on continuation
-    # lines, which produced "SyntaxError: keyword argument repeated".
-    if 'vad_filter=' in source_code or 'vad_parameters=' in source_code:
-        return source_code, False
+    """Patch every transcribe() call without duplicating existing VAD kwargs."""
     try:
         # Parse the AST to find function calls
         tree = ast.parse(source_code)
 
-        # Track line numbers of transcribe calls
-        transcribe_lines = []
+        calls = []
         for node in ast.walk(tree):
             if (isinstance(node, ast.Call) and
                 isinstance(node.func, ast.Attribute) and
                 node.func.attr == 'transcribe'):
-                transcribe_lines.append(node.lineno)
+                present = {keyword.arg for keyword in node.keywords}
+                missing = []
+                if 'vad_filter' not in present:
+                    missing.append('vad_filter=True')
+                if 'vad_parameters' not in present:
+                    missing.append('vad_parameters={"threshold": 0.5}')
+                if missing:
+                    calls.append((node, missing))
 
-        if not transcribe_lines:
+        if not calls:
             return source_code, False
 
-        lines = source_code.splitlines()
-        modified = False
+        lines = source_code.splitlines(keepends=True)
+        line_starts = []
+        offset = 0
+        for line in lines:
+            line_starts.append(offset)
+            offset += len(line)
 
-        for line_num in transcribe_lines:
-            # Convert to 0-based index
-            idx = line_num - 1
-            if idx >= len(lines):
+        def absolute_offset(line_number, byte_column):
+            line = lines[line_number - 1]
+            char_column = len(
+                line.encode('utf-8')[:byte_column].decode('utf-8')
+            )
+            return line_starts[line_number - 1] + char_column
+
+        edits = []
+        for node, missing in calls:
+            close_offset = absolute_offset(node.end_lineno, node.end_col_offset) - 1
+            close_line = lines[node.end_lineno - 1]
+            close_column = close_offset - line_starts[node.end_lineno - 1]
+            before_close = close_line[:close_column]
+            call_items = [*node.args, *node.keywords]
+
+            if node.lineno == node.end_lineno or before_close.strip():
+                separator = ', ' if call_items else ''
+                edits.append((close_offset, separator + ', '.join(missing)))
                 continue
 
-            line = lines[idx]
+            if call_items:
+                last_item = max(
+                    call_items,
+                    key=lambda item: (item.end_lineno, item.end_col_offset),
+                )
+                item_end = absolute_offset(
+                    last_item.end_lineno, last_item.end_col_offset
+                )
+                between = source_code[item_end:close_offset]
+                if not between.lstrip().startswith(','):
+                    edits.append((item_end, ','))
+                item_line = lines[last_item.lineno - 1]
+                indentation = re.match(r'[ \t]*', item_line).group(0)
+            else:
+                indentation = before_close + '    '
 
-            # Check if VAD parameters already exist
-            if 'vad_filter=' in line or 'vad_parameters=' in line:
-                continue
+            keyword_lines = ''.join(
+                f'{indentation}{keyword},\n' for keyword in missing
+            )
+            edits.append((line_starts[node.end_lineno - 1], keyword_lines))
 
-            # Find the transcribe call and add VAD parameters
-            # Handle both single-line and multi-line calls
-            if 'transcribe(' in line:
-                # Simple single-line case
-                if line.strip().endswith(')'):
-                    # Insert VAD parameters before the LAST closing paren only
-                    # Use rfind to replace only the rightmost ')' to avoid breaking nested calls
-                    last_paren_idx = line.rfind(')')
-                    if last_paren_idx != -1:
-                        new_line = line[:last_paren_idx] + ', vad_filter=True, vad_parameters={"threshold": 0.5}' + line[last_paren_idx:]
-                        lines[idx] = new_line
-                        modified = True
-                else:
-                    # Multi-line call - find the closing parenthesis
-                    paren_count = line.count('(') - line.count(')')
-                    search_idx = idx + 1
-
-                    while search_idx < len(lines) and paren_count > 0:
-                        search_line = lines[search_idx]
-                        paren_count += search_line.count('(') - search_line.count(')')
-
-                        if paren_count == 0:
-                            # Found the closing line
-                            if search_line.strip() == ')':
-                                # Closing paren on its own line
-                                lines.insert(search_idx, '    vad_filter=True,')
-                                lines.insert(search_idx + 1, '    vad_parameters={"threshold": 0.5},')
-                            else:
-                                # Closing paren with other content - replace only the last ')'
-                                last_paren_idx = search_line.rfind(')')
-                                if last_paren_idx != -1:
-                                    lines[search_idx] = search_line[:last_paren_idx] + ', vad_filter=True, vad_parameters={"threshold": 0.5}' + search_line[last_paren_idx:]
-                            modified = True
-                            break
-                        search_idx += 1
-
-        return '\n'.join(lines), modified
+        patched = source_code
+        for edit_offset, replacement in sorted(edits, reverse=True):
+            patched = patched[:edit_offset] + replacement + patched[edit_offset:]
+        return patched, True
 
     except SyntaxError as e:
         print(f"Syntax error in source file: {e}", file=sys.stderr)
-        return source_code, False
-    except Exception as e:
-        print(f"Error patching transcribe call: {e}", file=sys.stderr)
         return source_code, False
 
 if __name__ == "__main__":

--- a/ods/tests/test_todo_fixes.py
+++ b/ods/tests/test_todo_fixes.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 
@@ -55,12 +56,17 @@ def transcribe_audio(model, file):
     assert modified is True
     assert "vad_filter=True" in patched
     assert 'vad_parameters={"threshold": 0.5}' in patched
+    compile(patched, "<patched-whisper>", "exec")
 
 
 def test_vad_patch_is_idempotent_when_kwargs_already_exist() -> None:
     source = """
 def transcribe_audio(model, file):
-    return model.transcribe(file, vad_filter=True)
+    return model.transcribe(
+        file,
+        vad_filter=True,
+        vad_parameters={"threshold": 0.2},
+    )
 """.strip()
 
     patched, modified = patch_source(source)
@@ -82,12 +88,47 @@ def transcribe_audio(model, path):
     assert 'load_audio(path), vad_filter=True, vad_parameters={"threshold": 0.5})' in patched
 
 
+def test_vad_patch_updates_each_unpatched_call_independently() -> None:
+    source = """
+def transcribe_audio(primary, fallback, file):
+    first = primary.transcribe(file, vad_filter=False)
+    second = fallback.transcribe(
+        file,
+        language="en"
+    )
+    return first, second
+""".strip()
+
+    patched, modified = patch_source(source)
+
+    assert modified is True
+    tree = ast.parse(patched)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "transcribe"
+    ]
+    assert len(calls) == 2
+    assert patched.count("vad_filter=False") == 1
+    for call in calls:
+        keyword_names = [keyword.arg for keyword in call.keywords]
+        assert keyword_names.count("vad_filter") == 1
+        assert keyword_names.count("vad_parameters") == 1
+
+    patched_again, modified_again = patch_source(patched)
+    assert modified_again is False
+    assert patched_again == patched
+
+
 if __name__ == "__main__":
     tests = [
         test_vad_patch_single_line_transcribe_call,
         test_vad_patch_multiline_transcribe_call,
         test_vad_patch_is_idempotent_when_kwargs_already_exist,
         test_vad_patch_uses_rightmost_paren_for_nested_single_line_call,
+        test_vad_patch_updates_each_unpatched_call_independently,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary

- inspect VAD kwargs per AST call instead of skipping an entire Speaches module when any call is already patched
- apply source edits from AST end positions so every unpatched single- or multi-line `transcribe()` call receives exactly the missing kwargs
- preserve existing VAD choices, repair missing trailing commas in multiline calls, and keep the patch idempotent

## Why this matters

The Whisper container patches Speaches at startup to enable VAD. The old global guard returned as soon as `vad_filter=` or `vad_parameters=` appeared anywhere in the module. If an upstream Speaches version contained multiple `transcribe()` paths and only one was VAD-aware, every other path silently ran without ODS's VAD settings. Its multiline insertion also failed to add a separator after a final argument without a trailing comma, producing invalid Python.

The root cause is file-level text detection plus parenthesis counting rather than per-call syntax metadata. The invariant is now: every attribute `transcribe()` call has each VAD keyword exactly once, existing values are preserved, and applying the patch twice makes no further edit.

## Overlap check

Searched open and closed PRs for Whisper VAD multi-call handling, `vad_filter transcribe`, and `ods/extensions/services/whisper/docker-entrypoint.sh`. Open PR #2368 touches the entrypoint only to route Python discovery through a shared resolver; it does not change the VAD patcher. Closed PRs #294, #776, and #1130 cover the original TODO, POSIX shell compatibility, and arm64 support respectively, not mixed patched/unpatched calls.

Changed production file:
- `ods/extensions/services/whisper/docker-entrypoint.sh`

## Regression boundary

The tests execute the Python patcher extracted from the shipped container entrypoint. They compile multiline output, parse all resulting calls, assert both keywords occur exactly once, prove an existing `vad_filter=False` is retained, and verify a second patch is byte-for-byte idempotent.

## Validation

- `python -m pytest tests/test_todo_fixes.py -q` — 5 passed
- `python tests/test_todo_fixes.py` — PASS
- `bash -n extensions/services/whisper/docker-entrypoint.sh`
- `git diff --check`

## Compatibility and rollback

The patch still targets attribute calls named `transcribe`, matching existing behavior. AST byte columns are translated back to Unicode-safe character offsets, and no upstream content is rewritten beyond inserted commas/kwargs. A source file that cannot be parsed remains unchanged and logs the syntax error. Reverting restores the prior file-level skip behavior; no persistent data migration is involved.

Generated with Codex