### PR TITLE
fix(auth): preserve HTTPS session cookie policy

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/auth.py
+++ b/ods/extensions/services/dashboard-api/routers/auth.py
@@ -34,7 +34,7 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 import session_signer
-from security import verify_api_key
+from security import request_uses_https, verify_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -149,7 +149,7 @@ def admin_session(response: Response, request: Request) -> dict:
         )
 
     session_token = session_signer.issue(ttl_seconds=SESSION_TTL_SECONDS)
-    secure_cookie = request.url.scheme == "https"
+    secure_cookie = request_uses_https(request)
     cookie_domain = _cookie_domain()
 
     cookie_kwargs: dict = dict(

--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -69,7 +69,7 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 import session_signer
 from config import EXTENSIONS_DIR, GPU_BACKEND, SERVICES, _read_env_value, load_extension_manifests
-from security import verify_api_key
+from security import request_uses_https, verify_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -782,7 +782,7 @@ def redeem_magic_link(token: str, request: Request, response: Response) -> Redir
     # session_signer.issue() — guarded by is_configured() above so we
     # don't reach this line without a usable secret.
     session_token = session_signer.issue(ttl_seconds=SESSION_TTL_SECONDS)
-    secure_cookie = request.url.scheme == "https"
+    secure_cookie = request_uses_https(request)
     cookie_domain = _cookie_domain(record.get("url_mode", "auto"))
 
     logger.info(

--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -5,7 +5,7 @@ import os
 import secrets
 from pathlib import Path
 
-from fastapi import HTTPException, Security
+from fastapi import HTTPException, Request, Security
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 
 logger = logging.getLogger(__name__)
@@ -23,6 +23,15 @@ if not DASHBOARD_API_KEY:
     )
 
 security_scheme = HTTPBearer(auto_error=False)
+
+
+def request_uses_https(request: Request) -> bool:
+    """Return the original client scheme across the supported proxy hops."""
+    forwarded_proto = request.headers.get("x-forwarded-proto", "")
+    if forwarded_proto:
+        original_proto = forwarded_proto.split(",", 1)[0].strip().lower()
+        return original_proto == "https"
+    return request.url.scheme.lower() == "https"
 
 
 async def verify_api_key(credentials: HTTPAuthorizationCredentials = Security(security_scheme)):

--- a/ods/extensions/services/dashboard-api/tests/test_auth_router.py
+++ b/ods/extensions/services/dashboard-api/tests/test_auth_router.py
@@ -159,6 +159,25 @@ class TestAdminSession:
         assert b"ods-session=" in cookie_blob
         assert b"httponly" in cookie_blob
         assert b"samesite=lax" in cookie_blob
+        assert b"; secure" not in cookie_blob
+
+    def test_forwarded_https_sets_secure_cookie(self, test_client):
+        resp = test_client.post(
+            "/api/auth/admin-session",
+            headers={
+                **test_client.auth_headers,
+                "X-Forwarded-Proto": "https, http",
+            },
+        )
+
+        assert resp.status_code == 200
+        cookie_blob = b" ".join(
+            value
+            for key, value in resp.headers.raw
+            if key.lower() == b"set-cookie"
+        ).lower()
+        assert b"ods-session=" in cookie_blob
+        assert b"; secure" in cookie_blob
 
     def test_minted_cookie_verifies(self, test_client):
         """The cookie this endpoint mints must round-trip through

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -593,8 +593,35 @@ def test_redeem_sets_cookie_and_redirects(magic_link_client, magic_link_module):
     assert b"ods-session=" in cookie_blob
     assert b"httponly" in cookie_blob
     assert b"samesite=lax" in cookie_blob
+    assert b"; secure" not in cookie_blob
     # Username hint is readable by the chat UI's JS (not HttpOnly).
     assert b"ods-target-user=alice" in cookie_blob
+
+
+def test_redeem_sets_secure_cookies_for_forwarded_https(
+    magic_link_client, magic_link_module
+):
+    gen = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "alice", "scope": "chat"},
+        headers=magic_link_client.auth_headers,
+    )
+    token = gen.json()["token"]
+
+    resp = magic_link_client.get(
+        f"/auth/magic-link/{token}",
+        headers={"X-Forwarded-Proto": "HTTPS"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    set_cookies = [
+        value.lower()
+        for key, value in resp.headers.raw
+        if key.lower() == b"set-cookie"
+    ]
+    assert len(set_cookies) == 2
+    assert all(b"; secure" in cookie for cookie in set_cookies)
 
 
 def test_redeem_issues_signed_cookie_that_verifies(

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -1,3 +1,8 @@
+map $http_x_forwarded_proto $ods_forwarded_proto {
+    default $scheme;
+    ~*^https(?:,|$) https;
+}
+
 server {
     listen 3001;
     listen [::]:3001;  # IPv6 support for Docker healthcheck
@@ -33,7 +38,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $ods_forwarded_proto;
         proxy_set_header Connection "";
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
         proxy_read_timeout 600s;
@@ -52,7 +57,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $ods_forwarded_proto;
         proxy_set_header Connection "close";
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
         proxy_read_timeout 1800s;
@@ -69,7 +74,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $ods_forwarded_proto;
         proxy_set_header Connection "close";
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
         proxy_read_timeout 2700s;
@@ -85,7 +90,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $ods_forwarded_proto;
         proxy_set_header Connection "close";
         # B1 fix: Auth header injected by entrypoint.sh after reading key from file/env
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
@@ -101,7 +106,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Proto $ods_forwarded_proto;
         proxy_set_header Connection "close";
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
         proxy_read_timeout 1800s;

--- a/ods/tests/contracts/test-network-exposure-contracts.py
+++ b/ods/tests/contracts/test-network-exposure-contracts.py
@@ -207,6 +207,30 @@ def test_dashboard_pre_stages_hsts() -> None:
     )
 
 
+def test_dashboard_preserves_forwarded_https_for_api_cookies() -> None:
+    nginx_conf = read(SERVICES / "dashboard" / "nginx.conf")
+
+    assert_true(
+        "map $http_x_forwarded_proto $ods_forwarded_proto" in nginx_conf,
+        "dashboard nginx must derive the original client scheme",
+    )
+    assert_true(
+        "~*^https(?:,|$) https;" in nginx_conf,
+        "dashboard nginx must recognize HTTPS at the first proxy hop",
+    )
+    assert_true(
+        "proxy_set_header X-Forwarded-Proto $scheme;" not in nginx_conf,
+        "dashboard API routes must not overwrite the original HTTPS scheme",
+    )
+    assert_true(
+        nginx_conf.count(
+            "proxy_set_header X-Forwarded-Proto $ods_forwarded_proto;"
+        )
+        == 5,
+        "every dashboard API proxy location must forward the derived scheme",
+    )
+
+
 def test_openclaw_stays_deprecated_optional_and_token_gated() -> None:
     manifest = read(SERVICES / "openclaw" / "manifest.yaml")
     docs = read(ROOT / "docs" / "OPENCLAW-INTEGRATION.md")
@@ -240,6 +264,7 @@ def main() -> int:
         test_ods_proxy_caps_request_body_sizes,
         test_hermes_proxy_caps_request_body,
         test_dashboard_pre_stages_hsts,
+        test_dashboard_preserves_forwarded_https_for_api_cookies,
         test_openclaw_stays_deprecated_optional_and_token_gated,
         test_litellm_gateway_auth_is_enforced,
     ]


### PR DESCRIPTION
## Summary

- preserve an upstream HTTPS scheme through every dashboard nginx API location
- derive cookie security from the first `X-Forwarded-Proto` hop, falling back to the ASGI request scheme
- apply the same policy to admin-session, magic-link session, and magic-link username cookies
- retain non-Secure cookies for ODS's default plain-HTTP LAN mode

## Why this matters

ODS supports putting the dashboard behind a TLS terminator, but its runtime path lost that fact twice: dashboard nginx replaced the incoming `X-Forwarded-Proto=https` with its internal `$scheme` (`http`), and both cookie issuers looked only at the dashboard-api container socket scheme. As a result, sessions minted through an HTTPS deployment omitted the `Secure` attribute even though the browser-facing connection was encrypted.

The root cause spans the proxy handoff and both cookie consumers. The invariant is end-to-end: HTTPS at the first trusted proxy hop produces Secure session cookies; default HTTP LAN access remains functional with non-Secure cookies.

## Overlap check

Searched open and closed PR titles/bodies for dashboard nginx forwarded-proto handling, proxy-aware Secure cookies, magic-link cookie policy, and the changed auth router paths. No PR covers this producer-to-consumer contract. Open auth PRs #3302 and #2733 cover token parsing bounds and remote-provider egress authentication, not scheme propagation or cookie attributes.

Changed production files:
- `ods/extensions/services/dashboard/nginx.conf`
- `ods/extensions/services/dashboard-api/security.py`
- `ods/extensions/services/dashboard-api/routers/auth.py`
- `ods/extensions/services/dashboard-api/routers/magic_link.py`

## Regression boundary

API tests issue real admin and redeemed magic-link cookies over forwarded HTTPS and assert the serialized `Set-Cookie` attributes. The matching HTTP tests assert `Secure` stays absent. A network contract test covers all five nginx proxy locations and prevents future replacement with the internal scheme.

## Validation

- `python -m pytest tests/test_auth_router.py tests/test_magic_link.py -q` — 80 passed
- `python tests/contracts/test-network-exposure-contracts.py` — 12 contract checks passed
- `python -m py_compile extensions/services/dashboard-api/security.py extensions/services/dashboard-api/routers/auth.py extensions/services/dashboard-api/routers/magic_link.py`
- shipped `nginx:alpine` config validation after the runtime API-key substitution — syntax successful
- `git diff --check`

## Trust, compatibility, and rollback

The dashboard and ods-proxy remain the trusted header-setting boundaries; the dashboard API is loopback-bound by default. The nginx map only promotes the recognized first-hop `https` value and does not relay arbitrary scheme strings. Comma-separated proxy chains and mixed-case HTTPS are handled. Reverting restores the previous socket-scheme behavior without changing cookie format or persisted sessions.

Generated with Codex