### PR TITLE
fix(extensions): gate installs on library dependencies

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1619,6 +1619,21 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
             raise HTTPException(
                 status_code=409, detail=f"Extension already installed: {service_id}",
             )
+
+    missing_deps = _get_missing_install_deps(service_id)
+    if missing_deps:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": (
+                    "Install or enable dependencies first: "
+                    f"{', '.join(missing_deps)}"
+                ),
+                "missing_dependencies": missing_deps,
+            },
+        )
+
+    if dest.exists():
         # Broken or failed directory — clean up before reinstall.
         logger.warning("Cleaning up extension directory before retry: %s", dest)
         shutil.rmtree(dest)
@@ -2064,10 +2079,12 @@ def _read_direct_deps(service_id: str) -> list[str]:
     """Return direct depends_on list for a service from its manifest.
 
     Checks user-extensions first, then built-in extensions — the same
-    shadowing order as _resolve_extension_dir. A user directory without a
-    manifest still shadows a built-in of the same id.
+    shadowing order as _resolve_extension_dir — and finally the installable
+    library source so dependencies can be checked before the target is copied.
+    A user directory without a manifest still shadows a built-in of the same
+    id.
     """
-    for base in (USER_EXTENSIONS_DIR, EXTENSIONS_DIR):
+    for base in (USER_EXTENSIONS_DIR, EXTENSIONS_DIR, EXTENSIONS_LIBRARY_DIR):
         ext_dir = base / service_id
         if not ext_dir.is_dir():
             continue
@@ -2088,6 +2105,26 @@ def _is_dep_satisfied(dep: str) -> bool:
     if (USER_EXTENSIONS_DIR / dep / "compose.yaml").exists():
         return True
     return False
+
+
+def _get_missing_install_deps(service_id: str) -> list[str]:
+    """Resolve dependencies from the authoritative library source pre-copy."""
+    source_dir = EXTENSIONS_LIBRARY_DIR / service_id
+    direct_deps: list[str] = []
+    for name in ("manifest.yaml", "manifest.yml"):
+        candidate = source_dir / name
+        if candidate.exists():
+            direct_deps = _parse_manifest_deps(candidate)
+            break
+
+    order: list[str] = []
+    visiting = {service_id}
+    for dep in direct_deps:
+        if _is_dep_satisfied(dep) or dep in order:
+            continue
+        _get_missing_deps_transitive(dep, _visiting=visiting, _order=order)
+        order.append(dep)
+    return order
 
 
 def _get_missing_deps_transitive(

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -400,7 +400,9 @@ class TestUserExtensionStatus:
 _SAFE_COMPOSE = "services:\n  svc:\n    image: test:latest\n"
 
 
-def _setup_library_ext(tmp_path, service_id, compose_content=None):
+def _setup_library_ext(
+    tmp_path, service_id, compose_content=None, depends_on=None
+):
     """Create a library extension directory with compose.yaml and manifest."""
     lib_dir = tmp_path / "lib"
     lib_dir.mkdir(exist_ok=True)
@@ -409,7 +411,11 @@ def _setup_library_ext(tmp_path, service_id, compose_content=None):
     (ext_dir / "compose.yaml").write_text(compose_content or _SAFE_COMPOSE)
     (ext_dir / "manifest.yaml").write_text(yaml.dump({
         "schema_version": "ods.services.v1",
-        "service": {"id": service_id, "name": service_id},
+        "service": {
+            "id": service_id,
+            "name": service_id,
+            "depends_on": depends_on or [],
+        },
     }))
     return lib_dir
 
@@ -448,6 +454,91 @@ def _patch_mutation_config(monkeypatch, tmp_path, lib_dir=None, user_dir=None):
 
 
 class TestInstallExtension:
+
+    def test_install_rejects_transitive_library_dependencies_before_copy(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        lib_dir = _setup_library_ext(tmp_path, "vector-db")
+        _setup_library_ext(
+            tmp_path,
+            "embedding-api",
+            depends_on=["vector-db"],
+        )
+        _setup_library_ext(
+            tmp_path,
+            "document-chat",
+            depends_on=["embedding-api"],
+        )
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
+
+        resp = test_client.post(
+            "/api/extensions/document-chat/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        assert detail["missing_dependencies"] == [
+            "vector-db",
+            "embedding-api",
+        ]
+        assert "Install or enable dependencies first" in detail["message"]
+        assert not (tmp_path / "user" / "document-chat").exists()
+
+    def test_dependency_failure_preserves_broken_retry_directory(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        lib_dir = _setup_library_ext(tmp_path, "dependency")
+        _setup_library_ext(
+            tmp_path,
+            "my-ext",
+            depends_on=["dependency"],
+        )
+        user_dir = tmp_path / "user"
+        broken_dir = user_dir / "my-ext"
+        broken_dir.mkdir(parents=True)
+        marker = broken_dir / "operator-note.txt"
+        marker.write_text("keep until install can proceed")
+        _patch_mutation_config(
+            monkeypatch,
+            tmp_path,
+            lib_dir=lib_dir,
+            user_dir=user_dir,
+        )
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        assert marker.read_text() == "keep until install can proceed"
+
+    def test_install_proceeds_when_library_dependency_is_enabled(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        lib_dir = _setup_library_ext(tmp_path, "dependency")
+        _setup_library_ext(
+            tmp_path,
+            "my-ext",
+            depends_on=["dependency"],
+        )
+        user_dir = _setup_user_ext(tmp_path, "dependency", enabled=True)
+        _patch_mutation_config(
+            monkeypatch,
+            tmp_path,
+            lib_dir=lib_dir,
+            user_dir=user_dir,
+        )
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "installed"
+        assert (user_dir / "my-ext" / "compose.yaml").exists()
 
     def test_install_copies_and_enables(self, test_client, monkeypatch, tmp_path):
         """Install copies from library and keeps compose.yaml enabled."""


### PR DESCRIPTION
## Summary

- resolve install-time dependencies from the authoritative library manifest before copying an extension
- follow transitive dependencies through installed, built-in, and library manifests in leaf-first order
- reject an install before any filesystem mutation when a dependency is absent or disabled
- preserve broken/retry directories until the dependency precondition is satisfied

## Why this matters

A catalog extension can declare another catalog extension in `service.depends_on` (AnythingLLM → Ollama). The catalog endpoint can display that relationship, but `POST /api/extensions/{id}/install` previously copied the target and asked the host agent to start it without checking the dependency. Docker Compose then sees `depends_on: ollama` with no installed Ollama service, leaving an extension reported as installed but unable to form a valid stack.

The root cause is that dependency resolution only begins after a manifest has been copied into user extensions; the install boundary never consults the bundled source. The invariant is now: install/start is attempted only when every transitive dependency is present in the active Compose set.

## Overlap check

Searched open and closed PRs for extension install dependencies, catalog dependency installation, `_install_from_library`, and missing-dependency handling in `routers/extensions.py`. No PR covers the install boundary.

Issue #3244 identifies the visible `unknown` dependency symptom, but its example is partly inaccurate: `ollama` is a real library service on current main. The confirmed failure is that the install endpoint ignores that library relationship before copying and starting AnythingLLM. This PR fixes the reachable contract violation rather than renaming the valid dependency to `llama-server`.

Changed production file:
- `ods/extensions/services/dashboard-api/routers/extensions.py`

## Regression boundary

The API regression tests POST to the real install endpoint. They prove a two-level dependency chain is returned leaf-first, the target is not copied, an operator's broken retry directory is preserved, and installation proceeds once the dependency has an enabled Compose definition.

## Validation

- `python -m pytest tests/test_extensions.py tests/test_extensions_deps.py -q` — 266 passed, 5 skipped
- `python -m pytest tests/test_extensions.py::TestInstallExtension -q` — 19 passed
- `python -m py_compile routers/extensions.py tests/test_extensions.py`
- `git diff --check`

## Operator behavior and rollback

The endpoint returns HTTP 400 with `missing_dependencies` and a direct “Install or enable dependencies first” message. Already-installed extensions retain the existing 409 behavior; always-on core services and enabled built-in/user dependencies remain satisfied. This change does not auto-install or auto-start extra software without the operator choosing it. Reverting restores eager target installation and requires no state migration.

Generated with Codex