### PR TITLE
fix(macos): trust auto-capped voice CPU budgets

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1180,20 +1180,14 @@ if ! _ensure_colima_private_network; then
     exit 1
 fi
 
-# Pre-flight the docker daemon's CPU allocation. Trip early with a clear
-# message rather than letting compose fail after pulls/builds. If the user
-# already requested voice from CLI flags (for example --all), account for
-# Kokoro's 8-CPU pin now; interactive feature selection is checked again
-# after the user picks features.
+# Pre-flight the docker daemon's CPU allocation. Bundled service limits are
+# capped to the daemon's available CPUs by env-generator.sh, so optional
+# features must not raise this baseline requirement. ODS_MIN_DOCKER_CPUS stays
+# available for operators who intentionally enforce a larger local floor.
 _docker_cpu_override="${ODS_MIN_DOCKER_CPUS:-}"
 _docker_cpu_min="${_docker_cpu_override:-6}"
 _docker_cpu_max_pin=4
 _docker_cpu_workload="base compose stack"
-if $ENABLE_VOICE && [[ -z "$_docker_cpu_override" ]]; then
-    _docker_cpu_min=10
-    _docker_cpu_max_pin=8
-    _docker_cpu_workload="voice-enabled compose stack"
-fi
 _docker_cpu_preflight_min="$_docker_cpu_min"
 _require_docker_cpu_budget "$_docker_cpu_min" "$_docker_cpu_max_pin" "$_docker_cpu_workload"
 
@@ -1546,10 +1540,6 @@ info_box "  Langfuse:" "$(if $ENABLE_LANGFUSE; then echo enabled; else echo disa
 # Surface this to operators who passed --all so they aren't left wondering
 # why the dashboard shows no image-gen tile after install.
 info_box "  ComfyUI:" "not available on macOS (no MPS Docker image upstream)"
-
-if $ENABLE_VOICE && [[ -z "$_docker_cpu_override" ]] && [[ "${_docker_cpu_preflight_min:-0}" -lt 10 ]]; then
-    _require_docker_cpu_budget 10 8 "voice-enabled compose stack"
-fi
 
 # ============================================================================
 # PHASE 4 -- SETUP (directories, copy source, generate .env)

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -27,6 +27,21 @@ pass() {
     echo "[PASS] $*"
 }
 
+# Optional services are written with daemon-capped CPU limits. The installer
+# therefore has one baseline Docker CPU gate regardless of whether voice was
+# selected by --voice/--all or by the interactive prompt. A second feature
+# gate would reject an 8-core M1 even though the generated Compose plan is
+# valid for that daemon.
+cpu_gate_calls="$(grep -c '^_require_docker_cpu_budget ' "$INSTALLER")"
+[[ "$cpu_gate_calls" == "1" ]] \
+    || fail "macOS installer must apply exactly one baseline Docker CPU gate"
+if grep -q 'voice-enabled compose stack' "$INSTALLER"; then
+    fail "voice selection still raises the macOS Docker CPU floor"
+fi
+grep -Fq '_docker_cpu_min="${_docker_cpu_override:-6}"' "$INSTALLER" \
+    || fail "macOS installer lost the operator-overridable six-CPU baseline"
+pass "macOS optional services preserve the auto-capped Docker CPU baseline"
+
 extract_installer_function() {
     sed -n "/^${1}() {/,/^}$/p" "$INSTALLER"
 }


### PR DESCRIPTION
## Why this matters

On an 8-core M1, `install-macos.sh --all` aborts before setup because voice selection raises the Docker CPU floor from 6 to 10. That gate is obsolete: the shipped macOS env generator now caps TTS, Whisper, Hermes, and ComfyUI CPU limits to the daemon's actual CPU count. The installer therefore rejects a Compose plan it can generate and run safely (reported in #3600).

Root cause: the installer retained two feature-specific preflight checks from before bundled service CPU limits became daemon-capped in #1362.

Invariant: optional feature selection must not raise the baseline Docker CPU requirement when every optional service limit is capped to the detected daemon capacity. An explicit `ODS_MIN_DOCKER_CPUS` operator policy remains authoritative.

## What changed

- keep the existing six-CPU baseline and operator override
- remove both the CLI-time and post-prompt voice-specific 10-CPU gates
- document the env-generator contract next to the preflight

## Overlap check

Searched open and closed PRs for `macOS voice CPU budget`, `voice-enabled compose stack`, issue #3600, and changes to `ods/installers/macos/install-macos.sh`. #1362 is the merged producer-side CPU-cap change; it does not remove the now-stale consumer gate. No open PR covers this installer rejection.

## Regression boundary

`tests/test-macos-installer-transitions.sh` now asserts the public installer flow has exactly one baseline CPU gate, retains the six-CPU/operator-override contract, and cannot reintroduce a voice-specific floor. The existing generated-env smoke test separately proves TTS and all bundled service limits stay within the Docker CPU count.

## Validation

- `bash tests/test-macos-installer-transitions.sh` — pass
- `bash -n installers/macos/install-macos.sh tests/test-macos-installer-transitions.sh` — pass
- `git diff --check` — pass
- `bash tests/smoke/installer-env-smoke.sh` — CPU-cap assertions pass; suite later hits the existing unrelated `ai_err` undefined-function audit failure in `installers/phases/07-devtools.sh`

## Tradeoffs and rollback

This deliberately keeps the base six-CPU guard, so undersized daemon allocations still fail early. Operators who need a stricter policy can continue setting `ODS_MIN_DOCKER_CPUS`. Rollback is limited to restoring the two voice gates; no persisted state or Compose schema changes.

Closes #3600