### PR TITLE
fix(dashboard): refresh links on topology changes

### DIFF
--- a/ods/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/ods/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -31,17 +31,42 @@ export default function Sidebar({ status, collapsed, onToggle }) {
   const [apiLinks, setApiLinks] = useState([])
   const [showAllQuickLinks, setShowAllQuickLinks] = useState(false)
 
-  useEffect(() => {
-    fetch('/api/service-tokens')
-      .then(r => r.ok ? r.json() : {})
-      .then(setServiceTokens)
-      .catch(() => {})
+  // Link metadata only needs refreshing when services are added, removed, or
+  // move across the deployed/not-deployed boundary. Health changes are already
+  // reflected from `status` below and must not create an extra request every
+  // five-second status poll.
+  const serviceTopology = useMemo(() => (status?.services || [])
+    .map(service => {
+      const id = service.id || service.name || ''
+      const deployed = service.status === 'not_deployed' ? 'absent' : 'present'
+      return `${id}:${deployed}`
+    })
+    .sort()
+    .join('|'), [status?.services])
 
-    fetch('/api/external-links')
-      .then(r => r.ok ? r.json() : [])
-      .then(setApiLinks)
-      .catch(() => {})
-  }, [])
+  useEffect(() => {
+    const controller = new AbortController()
+
+    const refreshLinks = async () => {
+      const [tokensResponse, linksResponse] = await Promise.all([
+        fetch('/api/service-tokens', { signal: controller.signal }),
+        fetch('/api/external-links', { signal: controller.signal }),
+      ])
+
+      // Preserve the last known-good launcher data during a transient API
+      // failure; replacing it with empty data makes healthy links disappear.
+      if (tokensResponse.ok) setServiceTokens(await tokensResponse.json())
+      if (linksResponse.ok) setApiLinks(await linksResponse.json())
+    }
+
+    refreshLinks().catch(error => {
+      if (error.name !== 'AbortError') {
+        console.warn('Sidebar quick-link refresh failed:', error)
+      }
+    })
+
+    return () => controller.abort()
+  }, [serviceTopology])
 
   const navItems = useMemo(
     () => getSidebarNavItems({ status }),

--- a/ods/extensions/services/dashboard/src/components/__tests__/Sidebar.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/Sidebar.test.jsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { screen, waitFor } from '@testing-library/react'
 import { render } from '../../test/test-utils'
 import Sidebar from '../Sidebar' // eslint-disable-line no-unused-vars
 import { getSidebarExternalLinks } from '../../plugins/registry'
@@ -85,5 +85,51 @@ describe('Sidebar', () => {
     expect(screen.getByText('OpenCode')).toBeInTheDocument()
     expect(screen.getByText('OFFLINE')).toBeInTheDocument()
     expect(screen.getByText('OpenCode').closest('a')).not.toHaveAttribute('href')
+  })
+
+  test('refreshes quick-link metadata when the deployed service topology changes', async () => {
+    const { rerender } = render(
+      <Sidebar status={defaultStatus} collapsed={false} onToggle={() => {}} />
+    )
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    const enabledStatus = {
+      ...defaultStatus,
+      services: [
+        ...defaultStatus.services,
+        { id: 'perplexica', name: 'Perplexica', status: 'healthy', port: 3001 },
+      ],
+    }
+    rerender(<Sidebar status={enabledStatus} collapsed={false} onToggle={() => {}} />)
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(4)
+    })
+    expect(fetch.mock.calls.filter(([url]) => url === '/api/external-links')).toHaveLength(2)
+    expect(fetch.mock.calls.filter(([url]) => url === '/api/service-tokens')).toHaveLength(2)
+  })
+
+  test('does not refetch link metadata for an ordinary health transition', async () => {
+    const { rerender } = render(
+      <Sidebar status={defaultStatus} collapsed={false} onToggle={() => {}} />
+    )
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    const unhealthyStatus = {
+      ...defaultStatus,
+      services: defaultStatus.services.map(service => (
+        service.name === 'n8n' ? { ...service, status: 'healthy' } : service
+      )),
+    }
+    rerender(<Sidebar status={unhealthyStatus} collapsed={false} onToggle={() => {}} />)
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(fetch).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
## Why this matters

The dashboard fetches Sidebar launcher metadata and service tokens only once when the SPA mounts. Installing, enabling, disabling, or removing an extension changes the service topology while the dashboard stays mounted, so Quick Links can remain stale until a full browser reload.

Root cause: `Sidebar` had a mount-only effect even though its API-derived link catalog is consumed together with the continuously polled `/api/status` topology.

Invariant: launcher metadata refreshes when the deployed service set changes, while ordinary health polling updates link availability locally and does not add API traffic.

## What changed

- derive a stable topology signature from service identity plus deployed/not-deployed state
- refetch `/api/external-links` and `/api/service-tokens` only when that signature changes
- abort superseded requests and preserve last-known-good data on non-2xx responses
- surface unexpected request failures in the console instead of silently swallowing them

## Overlap check

Searched open and closed PRs for `Sidebar external links refresh`, `quick links stale`, `service topology`, and references to `ods/extensions/services/dashboard/src/components/Sidebar.jsx`. No PR covers topology-triggered Sidebar metadata refresh. The existing OpenClaw URL/query work changes launcher URL construction, not catalog lifecycle.

## Regression boundary

Component tests render the real Sidebar, rerender it with an added deployed extension, and assert both public metadata endpoints are fetched again. A second test changes only service health and asserts the five-second status-poll path does not refetch metadata.

## Validation

- `npm test -- --run src/components/__tests__/Sidebar.test.jsx` — 9/9 pass
- `npm run lint -- --quiet` — pass
- `npm run build` — pass
- `git diff --check` — pass

## Tradeoffs and rollback

Topology refresh makes two small authenticated GET requests only on install/deploy boundary changes, not on every status poll. Retaining the last good catalog avoids launcher flicker during a transient API restart. Rollback is UI-only and requires no state migration.