### PR TITLE
ci(macos): run behavioral installer contracts

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -227,6 +227,39 @@ jobs:
       - name: Atomic Environment Write Tests
         run: /bin/bash tests/test-atomic-env-writes.sh
 
+      - name: Resolve modern Bash for macOS runtime contracts
+        run: |
+          for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+            if [[ -x "$candidate" ]]; then
+              echo "ODS_TEST_BASH=$candidate" >> "$GITHUB_ENV"
+              exit 0
+            fi
+          done
+          brew install bash
+          candidate="$(brew --prefix)/bin/bash"
+          [[ -x "$candidate" ]]
+          echo "ODS_TEST_BASH=$candidate" >> "$GITHUB_ENV"
+
+      - name: macOS installer and CLI behavioral contracts
+        run: |
+          tests=(
+            tests/test-macos-bootstrap-resume.sh
+            tests/test-macos-cli-mode-routing.sh
+            tests/test-macos-cli-update-verification.sh
+            tests/test-macos-cloud-resolver.sh
+            tests/test-macos-compose-image-cache.sh
+            tests/test-macos-config-show-secret-mask.sh
+            tests/test-macos-direct-bind-bridge.sh
+            tests/test-macos-env-quote-strip.sh
+            tests/test-macos-host-agent-verification.sh
+            tests/test-macos-installer-transitions.sh
+            tests/test-macos-native-llama-launch-cwd.sh
+          )
+          for test_file in "${tests[@]}"; do
+            echo "=== ${test_file} ==="
+            "$ODS_TEST_BASH" "$test_file"
+          done
+
       - name: Bash 3.2 syntax check (catches declare -g, associative arrays, etc.)
         run: |
           echo "=== Checking installer scripts for Bash 3.2 compatibility ==="

--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -227,6 +227,14 @@ jobs:
       - name: Atomic Environment Write Tests
         run: /bin/bash tests/test-atomic-env-writes.sh
 
+      - name: Set up Python for Compose resolver contracts
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install Compose resolver dependencies
+        run: python3 -m pip install "PyYAML>=6.0,<7.0"
+
       - name: Resolve modern Bash for macOS runtime contracts
         run: |
           for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -272,75 +272,117 @@ assert data["agents"]["defaults"]["model"]["primary"] == "local-llama/local.gguf
 PY
 pass "OpenCode and OpenClaw routes transition without secret output"
 
-# Fake the pinned Perplexica provider/config API, including its fresh state with
-# no OpenAI provider, then exercise cloud -> local updates through production code.
-cat > "$TMP_DIR/perplexica-server.py" <<'PY'
-import json
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-
-values = {
-    "version": 1,
-    "setupComplete": False,
-    "preferences": {},
-    "modelProviders": [{
-        "id": "transformers-1", "name": "Transformers", "type": "transformers",
-        "config": {}, "chatModels": [],
-        "embeddingModels": [{"key": "Xenova/all-MiniLM-L6-v2", "name": "all-MiniLM-L6-v2"}],
-    }],
+# Fake the pinned Perplexica provider/config API at the Python HTTP boundary,
+# including its fresh state with no OpenAI provider. Hosted macOS runners do
+# not reliably allow an unsigned fixture process to bind a localhost listener;
+# sitecustomize keeps the production request code intact without that socket.
+PERPLEXICA_FIXTURE_STATE="$TMP_DIR/perplexica-state.json"
+PERPLEXICA_FIXTURE_PORT=39999
+mkdir -p "$TMP_DIR/perplexica-fixture"
+cat > "$PERPLEXICA_FIXTURE_STATE" <<'JSON'
+{
+  "version": 1,
+  "setupComplete": false,
+  "preferences": {},
+  "modelProviders": [{
+    "id": "transformers-1",
+    "name": "Transformers",
+    "type": "transformers",
+    "config": {},
+    "chatModels": [],
+    "embeddingModels": [{
+      "key": "Xenova/all-MiniLM-L6-v2",
+      "name": "all-MiniLM-L6-v2"
+    }]
+  }]
 }
+JSON
+cat > "$TMP_DIR/perplexica-fixture/sitecustomize.py" <<'PY'
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlsplit
+import urllib.request
 
-class Handler(BaseHTTPRequestHandler):
-    def log_message(self, *_):
-        pass
-    def send_json(self, value, status=200):
-        body = json.dumps(value).encode()
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-    def body(self):
-        return json.loads(self.rfile.read(int(self.headers.get("Content-Length", "0"))) or b"{}")
-    def do_GET(self):
-        if self.path == "/api/config":
-            self.send_json({"values": values, "fields": {}})
-        else:
-            self.send_json({}, 404)
-    def do_POST(self):
-        body = self.body()
-        if self.path == "/api/providers":
-            provider = {"id": "ods-openai-1", "chatModels": [], "embeddingModels": [], **body}
-            values["modelProviders"].append(provider)
-            self.send_json({"provider": provider})
-        elif self.path == "/api/config":
-            values[body["key"]] = body["value"]
-            self.send_json({"message": "ok"})
-        elif self.path == "/api/config/setup-complete":
-            values["setupComplete"] = True
-            self.send_json({"message": "ok"})
-        elif self.path.endswith("/models"):
-            provider = next(p for p in values["modelProviders"] if p["id"] in self.path)
-            provider["chatModels"].append({"key": body["key"], "name": body["name"]})
-            self.send_json({"message": "ok"})
-        else:
-            self.send_json({}, 404)
-    def do_PATCH(self):
-        body = self.body()
-        provider = next(p for p in values["modelProviders"] if p["id"] in self.path)
+_real_urlopen = urllib.request.urlopen
+_state_path = Path(os.environ["PERPLEXICA_FIXTURE_STATE"])
+_fixture_port = int(os.environ["PERPLEXICA_FIXTURE_PORT"])
+
+
+class FixtureResponse:
+    def __init__(self, value):
+        self._body = json.dumps(value).encode()
+        self.status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+    def read(self):
+        return self._body
+
+
+def fixture_urlopen(request, *args, **kwargs):
+    url = request.full_url if hasattr(request, "full_url") else str(request)
+    parsed = urlsplit(url)
+    if parsed.hostname != "localhost" or parsed.port != _fixture_port:
+        return _real_urlopen(request, *args, **kwargs)
+
+    values = json.loads(_state_path.read_text(encoding="utf-8"))
+    method = request.get_method()
+    body = json.loads(request.data or b"{}")
+    changed = False
+
+    if method == "GET" and parsed.path == "/api/config":
+        response = {"values": values, "fields": {}}
+    elif method == "POST" and parsed.path == "/api/providers":
+        provider = {
+            "id": "ods-openai-1",
+            "chatModels": [],
+            "embeddingModels": [],
+            **body,
+        }
+        values["modelProviders"].append(provider)
+        response = {"provider": provider}
+        changed = True
+    elif method == "POST" and parsed.path == "/api/config":
+        values[body["key"]] = body["value"]
+        response = {"message": "ok"}
+        changed = True
+    elif method == "POST" and parsed.path == "/api/config/setup-complete":
+        values["setupComplete"] = True
+        response = {"message": "ok"}
+        changed = True
+    elif method == "POST" and parsed.path.endswith("/models"):
+        provider_id = parsed.path.split("/")[3]
+        provider = next(p for p in values["modelProviders"] if p["id"] == provider_id)
+        provider["chatModels"].append({"key": body["key"], "name": body["name"]})
+        response = {"message": "ok"}
+        changed = True
+    elif method == "PATCH" and parsed.path.startswith("/api/providers/"):
+        provider_id = parsed.path.split("/")[3]
+        provider = next(p for p in values["modelProviders"] if p["id"] == provider_id)
         provider["name"] = body["name"]
         provider["config"] = body["config"]
-        self.send_json({"provider": provider})
+        response = {"provider": provider}
+        changed = True
+    else:
+        raise AssertionError(f"unexpected Perplexica request: {method} {parsed.path}")
 
-server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-print(server.server_port, flush=True)
-server.serve_forever()
+    if changed:
+        _state_path.write_text(json.dumps(values), encoding="utf-8")
+    return FixtureResponse(response)
+
+
+urllib.request.urlopen = fixture_urlopen
 PY
-coproc PERPLEXICA_FIXTURE { "$python_cmd" "$TMP_DIR/perplexica-server.py"; }
-SERVER_PID=$PERPLEXICA_FIXTURE_PID
-IFS= read -r -t 10 perplexica_port <&"${PERPLEXICA_FIXTURE[0]}" \
-    || fail "Perplexica fixture did not report its port"
-[[ "$perplexica_port" =~ ^[0-9]+$ ]] \
-    || fail "Perplexica fixture reported an invalid port"
+export PERPLEXICA_FIXTURE_STATE PERPLEXICA_FIXTURE_PORT
+export PYTHONPATH="$TMP_DIR/perplexica-fixture${PYTHONPATH:+:$PYTHONPATH}"
+perplexica_port="$PERPLEXICA_FIXTURE_PORT"
+
+# Exercise fresh cloud configuration followed by a local-model transition.
 perplexica_secret="sk-perplexica-transition-secret"
 perplexica_output="$(configure_perplexica "$perplexica_port" default \
     http://litellm:4000 "$perplexica_secret" 2>&1)" \
@@ -349,9 +391,9 @@ perplexica_output="$(configure_perplexica "$perplexica_port" default \
 configure_perplexica "$perplexica_port" local.gguf \
     http://host.docker.internal:8080 no-key >/dev/null \
     || fail "Perplexica cloud-to-local transition failed"
-"$python_cmd" - "$perplexica_port" <<'PY'
-import json, sys, urllib.request
-data = json.load(urllib.request.urlopen(f"http://127.0.0.1:{sys.argv[1]}/api/config"))["values"]
+"$python_cmd" - "$PERPLEXICA_FIXTURE_STATE" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
 providers = [p for p in data["modelProviders"] if p["type"] == "openai"]
 assert len(providers) == 1
 provider = providers[0]

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -275,7 +275,7 @@ pass "OpenCode and OpenClaw routes transition without secret output"
 # Fake the pinned Perplexica provider/config API, including its fresh state with
 # no OpenAI provider, then exercise cloud -> local updates through production code.
 cat > "$TMP_DIR/perplexica-server.py" <<'PY'
-import json, sys
+import json
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 values = {
@@ -332,14 +332,15 @@ class Handler(BaseHTTPRequestHandler):
         self.send_json({"provider": provider})
 
 server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-open(sys.argv[1], "w", encoding="ascii").write(str(server.server_port))
+print(server.server_port, flush=True)
 server.serve_forever()
 PY
-"$python_cmd" "$TMP_DIR/perplexica-server.py" "$TMP_DIR/perplexica.port" &
-SERVER_PID=$!
-for _ in $(seq 1 50); do [[ -s "$TMP_DIR/perplexica.port" ]] && break; sleep 0.1; done
-[[ -s "$TMP_DIR/perplexica.port" ]] || fail "Perplexica fixture did not start"
-perplexica_port="$(cat "$TMP_DIR/perplexica.port")"
+coproc PERPLEXICA_FIXTURE { "$python_cmd" "$TMP_DIR/perplexica-server.py"; }
+SERVER_PID=$PERPLEXICA_FIXTURE_PID
+IFS= read -r -t 10 perplexica_port <&"${PERPLEXICA_FIXTURE[0]}" \
+    || fail "Perplexica fixture did not report its port"
+[[ "$perplexica_port" =~ ^[0-9]+$ ]] \
+    || fail "Perplexica fixture reported an invalid port"
 perplexica_secret="sk-perplexica-transition-secret"
 perplexica_output="$(configure_perplexica "$perplexica_port" default \
     http://litellm:4000 "$perplexica_secret" 2>&1)" \


### PR DESCRIPTION
﻿## Why this matters

The macos-smoke job currently checks dispatch, one atomic-write suite, and Bash 3.2 parsing, but it never executes 11 shipped macOS behavioral suites. Regressions in cloud/local routing, image-cache platform selection, installer transitions, bootstrap resume, host-agent verification, secret masking, and native llama lifecycle can therefore merge while the macOS job remains green.

Root cause: macOS contracts accumulated under ods/tests without being wired to a native macOS CI runner.

Invariant: every stable, host-safe macOS installer and CLI contract must run on the platform whose BSD tools, paths, Homebrew layout, and system Bash it protects.

## What changed

- resolve an existing Homebrew Bash 4+ or install it when absent
- execute 11 installer and CLI behavioral suites in macos-smoke
- retain the separate system Bash 3.2 syntax gate for portable modules

The intentionally slow retry/backoff test and the currently failing uninstall warning test are not promoted here; this PR does not mask or relabel those gaps.

## Overlap check

Searched open and closed PRs for macOS behavioral tests CI, macOS runtime contracts, and changes to .github/workflows/matrix-smoke.yml. No open PR wires these suites into the native macOS job. #3161 concerns BATS host-state isolation, not this workflow or these scripts.

## Regression boundary

The workflow now invokes existing public-boundary tests that execute generated routing, installer transitions, CLI output, platform-aware image cache decisions, host-agent bootstrap verification, and native llama launch behavior.

## Validation

- exact 11-test set under modern Bash: pass
- workflow parsed with Python PyYAML safe_load: pass
- git diff --check: pass

Native runner execution remains the purpose of this PR's Actions check; local Linux/WSL execution cannot prove BSD tool and Homebrew-path behavior.

## Tradeoffs and rollback

This adds one Homebrew formula install only when the runner image lacks modern Bash; cached or preinstalled Bash skips that cost. Tests run serially for deterministic shared-fixture behavior. Rollback is deleting the two workflow steps; production artifacts are unchanged.
## CI follow-up

The first macOS run reached the newly enabled suite and failed at `test-macos-cli-mode-routing.sh` because the runner had no Python interpreter with PyYAML for the production Compose resolver. Follow-up commit `96721af9` provisions Python 3.12 and the same pinned PyYAML range used by the Linux manifest job before running the contracts. Workflow YAML parsing passes locally; the exact macOS rerun is the verification gate for this dependency fix.

The dependency fix let the suite reach `test-macos-installer-transitions.sh`, where the hosted ARM runner exposed a separate fixture race: the Python server had only five seconds to publish a port through a polled file. Follow-up `76bbf447` replaces that filesystem polling loop with a flushed coprocess pipe handshake and an explicit ten-second read bound. The full transition contract passes locally after the change; the macOS job remains the authoritative platform rerun.

The coprocess run proved the remaining failure was the hosted macOS listener boundary itself: even a flushed pipe received no port before the explicit timeout. Follow-up `effabaa8` keeps `configure_perplexica` and its embedded Python request/state/verification path unchanged, but injects a stateful `urllib.request.urlopen` fixture through `sitecustomize`. This exercises GET/POST/PATCH provider transitions at the HTTP-client boundary without requiring an unsigned localhost listener on the hosted runner. The full transition suite passes locally with no retry or polling loop.
