### PR TITLE
ci(windows): gate memory detection contracts

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -96,6 +96,16 @@ jobs:
         shell: pwsh
         run: ./tests/contracts/test-windows-runtime-recovery.ps1
 
+      - name: Windows AMD Memory Detection Contract
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./tests/test-windows-amd-memory-detection.ps1
+
+      - name: Windows NVIDIA Llama Memory Budget Contract
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./tests/test-windows-llama-memory-budget.ps1
+
       - name: Windows Installed Footprint Contract
         if: runner.os == 'Windows'
         shell: pwsh


### PR DESCRIPTION
## Why this matters

Windows installer memory behavior has dedicated tests for two hardware-critical paths, but neither is invoked by the PowerShell workflow. A change can misclassify an AMD APU as a discrete GPU or assign an NVIDIA container more memory than Docker Desktop exposes while CI remains green.

Root cause: the test files were added without corresponding native Windows workflow steps.

Invariant: AMD unified/dedicated memory classification and NVIDIA effective-container memory limits must be validated on every PowerShell change before merge.

## What changed

- run test-windows-amd-memory-detection.ps1 on windows-latest
- run test-windows-llama-memory-budget.ps1 on windows-latest
- keep them native-Windows-only because registry semantics and the shipped installer boundary are Windows-specific

## Overlap check

Searched open and closed PRs for Windows memory contracts CI, AMD memory detection workflow, NVIDIA llama memory budget workflow, and changes to .github/workflows/lint-powershell.yml. No open PR promotes these two tests. Existing memory/model PRs change runtime behavior, not CI reachability.

## Regression boundary

The activated tests exercise the public Windows installer libraries: adapter selection, WMI and registry VRAM conversion, unified-memory classification, Docker-vs-host memory selection, generated .env limits, and explicit override preservation.

## Validation

- test-windows-amd-memory-detection.ps1 under native Windows PowerShell: pass
- test-windows-llama-memory-budget.ps1 under native Windows PowerShell: pass
- workflow parsed with Python PyYAML safe_load: pass
- git diff --check: pass

## Tradeoffs and rollback

The two suites take about two seconds locally and add no dependencies. Restricting them to windows-latest avoids claiming Linux PowerShell as proof of Windows registry and path behavior. Rollback removes only the workflow steps; production code and persisted state are unchanged.