### PR TITLE
feat(cli): add native Zsh completion

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: Zsh Completion Contract Tests
+        run: bash tests/test-zsh-completion.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -72,6 +72,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== mode switch status and switching ==="
 	@bash tests/test-mode-switch-status.sh
+	@echo "=== Zsh CLI completion ==="
+	@bash tests/test-zsh-completion.sh
 	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh

--- a/ods/completions/_ods
+++ b/ods/completions/_ods
@@ -1,0 +1,136 @@
+#compdef ods ods-cli
+
+# Zsh completion for the ODS CLI. Service, preset, and template candidates are
+# discovered from the active install so user extensions participate without a
+# generated completion file.
+
+_ods_services() {
+  local root="${ODS_HOME:-$HOME/ods}"
+  local -a service_dirs services
+  service_dirs=(
+    "$root"/extensions/services/*(N/)
+    "$root"/data/user-extensions/*(N/)
+  )
+  services=("${service_dirs[@]:t}")
+  _values 'service' "${services[@]}"
+}
+
+_ods_presets() {
+  local root="${ODS_HOME:-$HOME/ods}"
+  local -a preset_dirs presets
+  preset_dirs=("$root"/presets/*(N/))
+  presets=("${preset_dirs[@]:t}")
+  _values 'preset' "${presets[@]}"
+}
+
+_ods_templates() {
+  local root="${ODS_HOME:-$HOME/ods}"
+  local -a template_files templates
+  template_files=("$root"/templates/*.(yaml|yml)(N))
+  templates=("${template_files[@]:t:r}")
+  _values 'template' "${templates[@]}"
+}
+
+_ods() {
+  local -a commands
+  commands=(
+    'gpu:inspect and manage GPU configuration'
+    'status:show service and hardware health'
+    'status-json:emit machine-readable status'
+    'list:list available services'
+    'enable:enable an extension service'
+    'disable:disable an extension service'
+    'purge:delete disabled service data'
+    'preset:manage configuration presets'
+    'mode:switch local, cloud, or hybrid mode'
+    'model:view or change the local model tier'
+    'remote-provider:manage a remote inference provider'
+    'stt:manage the speech-to-text model'
+    'backup:create or verify backups'
+    'restore:restore a backup'
+    'rollback:restore pre-update state'
+    'logs:tail service logs'
+    'restart:restart services'
+    'repair:repair an operational subsystem'
+    'start:start services'
+    'stop:stop services'
+    'update:update ODS'
+    'shell:open a service container shell'
+    'config:view or edit configuration'
+    'chat:send a quick LLM prompt'
+    'benchmark:run an inference benchmark'
+    'doctor:run diagnostics'
+    'audit:audit extension contracts'
+    'template:list, preview, or apply templates'
+    'agent:manage the host agent'
+    'help:show CLI help'
+    'version:show the CLI version'
+  )
+
+  if (( CURRENT == 2 )); then
+    _describe -t commands 'ODS command' commands
+    return
+  fi
+
+  case "${words[2]}" in
+    enable|disable|purge|logs|log|restart|start|stop|shell|audit)
+      (( CURRENT == 3 )) && _ods_services
+      ;;
+    gpu|g)
+      (( CURRENT == 3 )) && _values 'GPU action' status topology assignment validate reassign help
+      (( CURRENT == 4 && words[3] == reassign )) && _values 'option' --auto --manual --dry-run
+      (( CURRENT == 4 && words[3] == topology )) && _values 'option' --force
+      ;;
+    preset|p)
+      if (( CURRENT == 3 )); then
+        _values 'preset action' save load list delete export import diff
+      elif (( CURRENT == 4 )); then
+        case "${words[3]}" in
+          save|load|delete|export|diff) _ods_presets ;;
+          import) _files -g '*.tar.gz' ;;
+        esac
+      fi
+      ;;
+    mode|m)
+      (( CURRENT == 3 )) && _values 'mode' local cloud hybrid
+      ;;
+    model)
+      (( CURRENT == 3 )) && _values 'model action' current list swap
+      (( CURRENT == 4 && words[3] == swap )) && _values 'tier' 0 1 2 3 4
+      ;;
+    remote-provider)
+      (( CURRENT == 3 )) && _values 'remote provider action' status plan configure test disable remove peer-models help
+      (( CURRENT == 4 && words[3] == peer-models )) && _values 'peer model action' list download-status cancel-download download load delete
+      ;;
+    stt)
+      (( CURRENT == 3 )) && _values 'STT action' current status download
+      ;;
+    backup)
+      (( CURRENT == 3 )) && _values 'backup option' verify --compress --list -c -l
+      ;;
+    config|cfg)
+      (( CURRENT == 3 )) && _values 'config action' show edit validate
+      ;;
+    repair|fix)
+      (( CURRENT == 3 )) && _values 'repair target' voice stt tts hermes-workers slash-workers rootless-ownership rootless
+      ;;
+    template|tmpl)
+      if (( CURRENT == 3 )); then
+        _values 'template action' list preview apply
+      elif (( CURRENT == 4 )) && [[ "${words[3]}" == preview || "${words[3]}" == apply ]]; then
+        _ods_templates
+      fi
+      ;;
+    agent)
+      (( CURRENT == 3 )) && _values 'agent action' status start stop restart logs
+      ;;
+    doctor|diag|d)
+      (( CURRENT == 3 )) && _values 'doctor option' report --json
+      ;;
+    update|u)
+      (( CURRENT == 3 )) && _values 'update option' --dry-run --force --rebuild-images
+      ;;
+  esac
+}
+
+_ods "$@"

--- a/ods/completions/install-zsh-completion.sh
+++ b/ods/completions/install-zsh-completion.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Install the ODS Zsh completion into a stable per-user fpath directory.
+
+set -euo pipefail
+
+install_dir="${1:?usage: install-zsh-completion.sh INSTALL_DIR}"
+source_file="${install_dir}/completions/_ods"
+completion_dir="$HOME/.zfunc"
+zshrc="${ODS_ZSHRC:-$HOME/.zshrc}"
+marker="# ODS CLI zsh completion"
+
+[[ -f "$source_file" ]] || {
+    echo "ODS Zsh completion source not found: $source_file" >&2
+    exit 1
+}
+
+mkdir -p "$completion_dir" "$(dirname "$zshrc")"
+tmp_file="$(mktemp "${completion_dir}/.ods-completion.XXXXXX")"
+trap 'rm -f "$tmp_file"' EXIT
+cp "$source_file" "$tmp_file"
+chmod 0644 "$tmp_file"
+mv -f "$tmp_file" "$completion_dir/_ods"
+trap - EXIT
+
+if ! grep -Fq "$marker" "$zshrc" 2>/dev/null; then
+    printf '\n%s\n' "$marker" >> "$zshrc"
+    printf 'fpath=("$HOME/.zfunc" $fpath)\n' >> "$zshrc"
+    printf 'autoload -Uz compinit && compinit\n' >> "$zshrc"
+fi

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1696,6 +1696,19 @@ else
         ai_ok "Installed ods-macos.sh CLI"
     fi
 
+    # Zsh is the default interactive shell on supported macOS releases. Install
+    # completion after the source tree is present, while keeping failure
+    # non-fatal because it only mutates the current user's shell profile.
+    _zsh_completion_installer="${INSTALL_DIR}/completions/install-zsh-completion.sh"
+    if command -v zsh >/dev/null 2>&1 && [[ -f "$_zsh_completion_installer" ]]; then
+        if bash "$_zsh_completion_installer" "$INSTALL_DIR"; then
+            ai_ok "Zsh completion enabled for ods-cli"
+        else
+            ai_warn "Could not install optional Zsh completion"
+        fi
+    fi
+    unset _zsh_completion_installer
+
     # The resolver treats compose.yaml as enabled and compose.yaml.disabled as
     # disabled. Persist every installer feature choice in that canonical form
     # so cache invalidation and later dashboard toggles cannot resurrect the

--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -255,7 +255,7 @@ DESKTOP_EOF
 fi
 
 #=============================================================================
-# Bash Completion Setup
+# Shell Completion Setup
 #=============================================================================
 if ! $DRY_RUN; then
     COMPLETION_FILE="$INSTALL_DIR/completions/ods-cli.bash"
@@ -267,6 +267,16 @@ if ! $DRY_RUN; then
 # ODS CLI bash completion
 if [[ -f "$HOME/ods/completions/ods-cli.bash" ]]; then
     . "$HOME/ods/completions/ods-cli.bash"
+fi
+
+if ! $DRY_RUN && command -v zsh >/dev/null 2>&1; then
+    ZSH_COMPLETION_INSTALLER="$INSTALL_DIR/completions/install-zsh-completion.sh"
+    if [[ -f "$ZSH_COMPLETION_INSTALLER" ]] \
+        && bash "$ZSH_COMPLETION_INSTALLER" "$INSTALL_DIR"; then
+        ai_ok "Zsh completion enabled for ods-cli"
+    else
+        warn "Could not install optional Zsh completion"
+    fi
 fi
 BASHRC_EOF
             ai_ok "Bash completion enabled for ods-cli"

--- a/ods/tests/test-zsh-completion.sh
+++ b/ods/tests/test-zsh-completion.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Public installation and command-parity contract for ODS Zsh completion.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI="$ROOT_DIR/ods-cli"
+COMPLETION="$ROOT_DIR/completions/_ods"
+INSTALLER="$ROOT_DIR/completions/install-zsh-completion.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+[[ -f "$COMPLETION" ]] || fail "Zsh completion file is missing"
+bash -n "$INSTALLER" || fail "completion installer has invalid Bash syntax"
+
+# Extract canonical first-level commands from the actual CLI dispatch table.
+while IFS= read -r command_name; do
+    grep -Fq "'${command_name}:" "$COMPLETION" \
+        || fail "Zsh completion is missing canonical command: $command_name"
+done < <(
+    sed -n '/^case "${1:-help}" in/,/^esac/p' "$CLI" \
+        | sed -n 's/^[[:space:]]*\([a-z][a-z0-9-]*\)[^)]*)[[:space:]].*/\1/p'
+)
+
+# Exercise the user-visible install boundary twice: the payload is copied and
+# the shell startup block remains idempotent.
+fixture="$TMP_DIR/ods"
+home_dir="$TMP_DIR/home"
+mkdir -p "$fixture/completions" "$home_dir"
+cp "$COMPLETION" "$fixture/completions/_ods"
+HOME="$home_dir" bash "$INSTALLER" "$fixture"
+HOME="$home_dir" bash "$INSTALLER" "$fixture"
+cmp "$COMPLETION" "$home_dir/.zfunc/_ods" \
+    || fail "installed completion differs from the shipped source"
+[[ "$(grep -Fc '# ODS CLI zsh completion' "$home_dir/.zshrc")" == "1" ]] \
+    || fail "Zsh startup hook is not idempotent"
+grep -Fq 'fpath=("$HOME/.zfunc" $fpath)' "$home_dir/.zshrc" \
+    || fail "Zsh startup hook does not register the completion directory"
+
+if command -v zsh >/dev/null 2>&1; then
+    zsh -n "$COMPLETION" || fail "completion has invalid Zsh syntax"
+fi
+
+echo "[PASS] Zsh completion command parity and installation"


### PR DESCRIPTION
## Why this matters

ODS ships Bash completion, but supported macOS releases default to Zsh. A normal macOS install therefore leaves ods commands, service IDs, presets, templates, and nested actions without completion unless the operator manually translates and configures the Bash-only asset.

Root cause: the completion distribution and installer hooks only cover Bash even though macOS installation is a first-class path.

Invariant: every canonical top-level ods command is completable, install hooks are idempotent, and runtime-owned candidates are discovered from the active ODS home rather than frozen into generated files.

## What changed

- add a native compdef completion for ods and ods-cli
- cover current nested GPU, preset, mode, model, remote-provider, STT, backup, config, repair, template, agent, doctor, and update actions
- discover built-in/user services, presets, and templates from ODS_HOME
- install the payload atomically into the stable per-user ~/.zfunc path
- add an idempotent .zshrc fpath/compinit hook from both core and standalone macOS installers
- gate command parity and the double-install boundary in Make and Linux CI

## Overlap check

Searched open and closed PRs for zsh completion, completions/_ods, macOS shell completion, and changes to the completion setup in phase 13. No PR provides Zsh completion. #2183 improves the existing Bash completion command parity; this PR uses a separate native asset and installer path and does not replace or modify that branch.

## Regression boundary

The new contract extracts canonical commands from the real ods-cli dispatch table, asserts each is exposed by the Zsh payload, installs the completion twice into an isolated HOME, compares the installed payload byte-for-byte, and proves the startup hook appears exactly once. On hosts with Zsh, it also runs zsh syntax validation.

## Validation

- bash tests/test-zsh-completion.sh: pass
- bash -n on installer/helper/touched shell files: pass
- test-linux workflow YAML parse: pass
- git diff --check: pass

Zsh itself is not installed in this Windows workspace; the added contract performs zsh -n on Linux/macOS CI hosts where it is available.

## Tradeoffs and rollback

The shell hook uses ~/.zfunc so custom ODS install roots do not leak into .zshrc and upgrades can replace one managed completion file. Optional completion installation warns but does not fail an otherwise healthy product install. Rollback removes the managed _ods file and the three-line marked .zshrc block; no runtime state changes.