### PR TITLE
fix(ap-mode): roll back failed activation

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: AP Mode Activation Transaction Tests
+        run: bash tests/test-ap-mode.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -72,6 +72,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== mode switch status and switching ==="
 	@bash tests/test-mode-switch-status.sh
+	@echo "=== AP mode activation transaction ==="
+	@bash tests/test-ap-mode.sh
 	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh

--- a/ods/scripts/ap-mode.sh
+++ b/ods/scripts/ap-mode.sh
@@ -285,6 +285,13 @@ HEREDOC
   chmod 0644 "${STATE_FILE}"
 }
 
+rollback_failed_up() {
+  local stage="$1"
+  err "AP activation failed while ${stage}; rolling back interface and firewall state"
+  cmd_down
+  return 1
+}
+
 cmd_up() {
   require_linux
   require_root
@@ -297,11 +304,23 @@ cmd_up() {
   # Snapshot the original state so we can recover on teardown.
   log "bringing up AP on ${ODS_AP_INTERFACE} as '${ODS_AP_SSID}'"
   release_interface_from_nm
-  bring_up_interface
+  if ! bring_up_interface; then
+    rollback_failed_up "configuring ${ODS_AP_INTERFACE}"
+    return 1
+  fi
 
-  write_hostapd_conf
-  write_dnsmasq_conf
-  install_iptables_rules
+  if ! write_hostapd_conf; then
+    rollback_failed_up "writing hostapd configuration"
+    return 1
+  fi
+  if ! write_dnsmasq_conf; then
+    rollback_failed_up "writing dnsmasq configuration"
+    return 1
+  fi
+  if ! install_iptables_rules; then
+    rollback_failed_up "installing captive-portal firewall rules"
+    return 1
+  fi
 
   # Start daemons directly and track them with PID files so teardown can
   # cleanly stop only the processes started for AP mode.
@@ -314,7 +333,10 @@ cmd_up() {
       || { err "dnsmasq failed to start — check ${RUN_DIR}/dnsmasq.log"; cmd_down; return 1; }
   fi
 
-  write_state "active"
+  if ! write_state "active"; then
+    rollback_failed_up "publishing active state"
+    return 1
+  fi
   log "AP up: SSID=${ODS_AP_SSID} gateway=${ODS_AP_GATEWAY_IP}"
   log "  any hostname resolves to ${ODS_AP_GATEWAY_IP} (captive portal)"
   log "  HTTP/HTTPS on ${ODS_AP_INTERFACE} redirected to the gateway"

--- a/ods/tests/test-ap-mode.sh
+++ b/ods/tests/test-ap-mode.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/scripts/ap-mode.sh"
+source "${ROOT_DIR}/scripts/ap-mode.sh"
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -40,5 +40,72 @@ assert_fails "short AP password" require_password
 
 ODS_AP_PASSWORD="unique-device-pass"
 require_password >/dev/null
+
+# Execute the public `up` command with a controlled command boundary. Failure
+# after NetworkManager releases the interface must reclaim it and remove every
+# partial runtime artifact before returning non-zero.
+work_dir="$(mktemp -d)"
+trap 'rm -rf "$work_dir"' EXIT
+fake_bin="$work_dir/bin"
+run_dir="$work_dir/run"
+command_log="$work_dir/commands.log"
+mkdir -p "$fake_bin" "$run_dir"
+
+for binary in hostapd dnsmasq pgrep pkill; do
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$fake_bin/$binary"
+  chmod +x "$fake_bin/$binary"
+done
+cat > "$fake_bin/id" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "-u" ]] && { echo 0; exit 0; }
+[[ "${1:-}" == "-un" ]] && { echo root; exit 0; }
+exit 1
+SH
+cat > "$fake_bin/uname" <<'SH'
+#!/usr/bin/env bash
+echo Linux
+SH
+cat > "$fake_bin/iw" <<'SH'
+#!/usr/bin/env bash
+printf 'Supported interface modes:\n\t * AP\n'
+SH
+cat > "$fake_bin/nmcli" <<'SH'
+#!/usr/bin/env bash
+printf 'nmcli %s\n' "$*" >> "$ODS_AP_TEST_LOG"
+SH
+cat > "$fake_bin/iptables" <<'SH'
+#!/usr/bin/env bash
+printf 'iptables %s\n' "$*" >> "$ODS_AP_TEST_LOG"
+exit 1
+SH
+cat > "$fake_bin/ip" <<'SH'
+#!/usr/bin/env bash
+printf 'ip %s\n' "$*" >> "$ODS_AP_TEST_LOG"
+[[ "$*" == *"addr add"* ]] && exit 42
+exit 0
+SH
+chmod +x "$fake_bin"/*
+
+set +e
+up_output="$({
+  PATH="$fake_bin:$PATH" \
+  ODS_AP_TEST_LOG="$command_log" \
+  ODS_AP_RUN_DIR="$run_dir" \
+  ODS_AP_CONF_DIR="$work_dir/conf" \
+  ODS_AP_PASSWORD="unique-device-pass" \
+  bash "${ROOT_DIR}/scripts/ap-mode.sh" up
+} 2>&1)"
+up_rc=$?
+set -e
+
+[[ "$up_rc" -ne 0 ]] || fail "failed interface configuration reported success"
+[[ "$up_output" == *"rolling back interface and firewall state"* ]] \
+  || fail "failed activation did not report rollback"
+grep -Fq 'nmcli device set wlan0 managed no' "$command_log" \
+  || fail "activation never released the interface"
+grep -Fq 'nmcli device set wlan0 managed yes' "$command_log" \
+  || fail "rollback did not reclaim the interface"
+[[ ! -e "$run_dir/state.json" && ! -e "$run_dir/hostapd.conf" && ! -e "$run_dir/dnsmasq.conf" ]] \
+  || fail "rollback left partial AP runtime files"
 
 printf 'AP mode helper checks passed\n'


### PR DESCRIPTION
## Why this matters

ap-mode.sh up takes the selected Wi-Fi interface away from NetworkManager before configuring its address, writing daemon configs, and adding captive-portal firewall rules. With set -e, a failure in any of those middle stages exits immediately without cmd_down, leaving the host Wi-Fi unmanaged and the AP partially configured. This is a reachable operator and systemd activation path documented in AP-MODE.md.

Root cause: only hostapd and dnsmasq startup failures had explicit rollback; earlier mutations and the final state write relied on global strict-mode exit.

Invariant: after NetworkManager releases the interface, every non-successful activation returns the interface to NetworkManager, removes ODS firewall state, and deletes partial runtime files before reporting failure.

## What changed

- add one explicit failed-activation rollback boundary
- route interface, hostapd config, dnsmasq config, iptables, and state-publication failures through it
- retain the existing daemon-start rollback paths
- wire the AP-mode behavioral test into Make and Linux CI

## Overlap check

Searched open and closed PRs for AP mode rollback, ap-mode transaction, and changes to ods/scripts/ap-mode.sh. #2406 changes only write_state to atomically publish JSON; it does not clean up failed activation. This PR deliberately leaves write_state unchanged so #2406 remains canonical and the branches touch independent hunks. The combined behavior is compatible: an atomic write failure will now trigger rollback.

## Regression boundary

The test executes the public ap-mode.sh up command with controlled Linux/root/network command boundaries. It forces ip addr add to fail after NetworkManager has accepted managed no, then asserts a non-zero result, an explicit rollback receipt, managed yes reclamation, and absence of state, hostapd, and dnsmasq artifacts.

## Validation

- bash tests/test-ap-mode.sh: pass
- bash -n scripts/ap-mode.sh tests/test-ap-mode.sh: pass
- test-linux workflow YAML parse: pass
- git diff --check: pass

No real Wi-Fi interface or host firewall was mutated; the boundary test uses isolated fake commands and runtime directories.

## Tradeoffs and rollback

Rollback is intentionally best-effort through the existing idempotent cmd_down implementation. If OS cleanup commands themselves fail, their current teardown semantics remain unchanged and the original activation still returns non-zero. Rollback restores the former strict-mode behavior but risks leaving NetworkManager ownership lost again; no persisted migration is involved.