### PR TITLE
fix(showcase): route requests to live model

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: Showcase Live Model Routing Tests
+        run: bash tests/test-showcase-live-model.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -72,6 +72,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== mode switch status and switching ==="
 	@bash tests/test-mode-switch-status.sh
+	@echo "=== Showcase live model routing ==="
+	@bash tests/test-showcase-live-model.sh
 	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh

--- a/ods/scripts/showcase.sh
+++ b/ods/scripts/showcase.sh
@@ -67,7 +67,37 @@ check_service() {
     curl -sf "${url}${endpoint}" > /dev/null 2>&1
 }
 
+resolve_llm_model() {
+    if [[ -n "${SHOWCASE_MODEL:-}" ]]; then
+        printf '%s\n' "$SHOWCASE_MODEL"
+        return 0
+    fi
+
+    local models_json model_id
+    if ! models_json=$(curl -sf --max-time 10 "${LLM_URL}/v1/models"); then
+        echo "Unable to query ${LLM_URL}/v1/models" >&2
+        return 1
+    fi
+    if ! model_id=$(jq -er '.data[0].id | strings | select(length > 0)' <<< "$models_json"); then
+        echo "LLM model catalog did not contain a usable model id" >&2
+        return 1
+    fi
+    printf '%s\n' "$model_id"
+}
+
+request_llm_chat() {
+    local payload="$1" model_id routed_payload response
+    model_id=$(resolve_llm_model) || return 1
+    routed_payload=$(jq -c --arg model "$model_id" '.model = $model' <<< "$payload") \
+        || return 1
+    response=$(curl -sf --max-time 120 "${LLM_URL}/v1/chat/completions" \
+        -H "Content-Type: application/json" \
+        -d "$routed_payload") || return 1
+    jq -er '.choices[0].message.content | strings | select(length > 0)' <<< "$response"
+}
+
 demo_chat() {
+    local payload response
     clear_screen
     echo -e "${BOLD}${MAGENTA}💬 Chat with AI${NC}"
     echo -e "${DIM}────────────────────────────────────────${NC}"
@@ -96,16 +126,16 @@ demo_chat() {
         
         echo -ne "${CYAN}AI: ${NC}"
         
-        response=$(curl -sf "${LLM_URL}/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg msg "$user_input" '{
-                model: "local",
+        payload=$(jq -n --arg msg "$user_input" '{
                 messages: [{role: "user", content: $msg}],
                 max_tokens: 512,
                 temperature: 0.7
-            }')" 2>/dev/null | jq -r '.choices[0].message.content // "Error getting response"')
-        
-        echo "$response"
+            }')
+        if response=$(request_llm_chat "$payload"); then
+            echo "$response"
+        else
+            echo -e "${RED}Error getting response; check the LLM model catalog and logs.${NC}"
+        fi
         echo ""
     done
 }
@@ -160,6 +190,7 @@ demo_voice() {
 }
 
 demo_rag() {
+    local payload response
     clear_screen
     echo -e "${BOLD}${MAGENTA}📚 Document Q&A (RAG Demo)${NC}"
     echo -e "${DIM}────────────────────────────────────────${NC}"
@@ -216,24 +247,25 @@ demo_rag() {
         echo -ne "${CYAN}Answer: ${NC}"
         
         # Use document as context
-        response=$(curl -sf "${LLM_URL}/v1/chat/completions" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -n --arg doc "$DOC_CONTENT" --arg q "$question" '{
-                model: "local",
+        payload=$(jq -n --arg doc "$DOC_CONTENT" --arg q "$question" '{
                 messages: [
                     {role: "system", content: "Answer questions based on the provided document. Be concise and cite relevant parts."},
                     {role: "user", content: ("Document:\n" + $doc + "\n\nQuestion: " + $q)}
                 ],
                 max_tokens: 512,
                 temperature: 0.3
-            }')" 2>/dev/null | jq -r '.choices[0].message.content // "Error getting response"')
-        
-        echo "$response"
+            }')
+        if response=$(request_llm_chat "$payload"); then
+            echo "$response"
+        else
+            echo -e "${RED}Error getting response; check the LLM model catalog and logs.${NC}"
+        fi
         echo ""
     done
 }
 
 demo_code() {
+    local payload response
     clear_screen
     echo -e "${BOLD}${MAGENTA}💻 Code Assistant${NC}"
     echo -e "${DIM}────────────────────────────────────────${NC}"
@@ -288,20 +320,20 @@ demo_code() {
     
     prompt="Task: $task\n\nCode:\n\`\`\`\n$CODE\n\`\`\`"
     
-    response=$(curl -sf "${LLM_URL}/v1/chat/completions" \
-        -H "Content-Type: application/json" \
-        -d "$(jq -n --arg p "$prompt" '{
-            model: "local",
+    payload=$(jq -n --arg p "$prompt" '{
             messages: [
                 {role: "system", content: "You are an expert code reviewer. Provide clear, actionable feedback."},
                 {role: "user", content: $p}
             ],
             max_tokens: 2048,
             temperature: 0.3
-        }')" 2>/dev/null | jq -r '.choices[0].message.content // "Error getting response"')
-    
+        }')
     echo -e "${GREEN}Result:${NC}"
-    echo "$response"
+    if response=$(request_llm_chat "$payload"); then
+        echo "$response"
+    else
+        echo -e "${RED}Error getting response; check the LLM model catalog and logs.${NC}"
+    fi
     
     echo ""
     echo -e "${DIM}Press Enter to return to menu...${NC}"

--- a/ods/tests/test-showcase-live-model.sh
+++ b/ods/tests/test-showcase-live-model.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Boundary coverage for the interactive showcase's live model routing.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SHOWCASE="$ROOT_DIR/scripts/showcase.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+fake_bin="$TMP_DIR/bin"
+payload_log="$TMP_DIR/payload.json"
+mkdir -p "$fake_bin"
+cat > "$fake_bin/curl" <<'SH'
+#!/usr/bin/env bash
+url=""
+payload=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -d)
+            payload="${2:-}"
+            shift 2
+            ;;
+        http://*)
+            url="$1"
+            shift
+            ;;
+        *) shift ;;
+    esac
+done
+case "$url" in
+    */health)
+        printf '{"status":"ok"}\n'
+        ;;
+    */v1/models)
+        [[ "${SHOWCASE_TEST_FAIL_MODELS:-false}" != "true" ]] || exit 22
+        printf '{"data":[{"id":"live/model.gguf"}]}\n'
+        ;;
+    */v1/chat/completions)
+        printf '%s\n' "$payload" > "$SHOWCASE_TEST_PAYLOAD_LOG"
+        printf '{"choices":[{"message":{"content":"fixture answer"}}]}\n'
+        ;;
+    *) exit 22 ;;
+esac
+SH
+chmod +x "$fake_bin/curl"
+
+output="$({
+    printf '1\nhello\nback\nq\n' \
+        | PATH="$fake_bin:$PATH" \
+          LLM_URL="http://showcase.test" \
+          SHOWCASE_TEST_PAYLOAD_LOG="$payload_log" \
+          bash "$SHOWCASE"
+} 2>&1)"
+[[ "$output" == *"fixture answer"* ]] || fail "chat result did not reach the interactive boundary"
+jq -e '.model == "live/model.gguf"' "$payload_log" >/dev/null \
+    || fail "showcase did not post the live catalog model id"
+
+set +e
+failure_output="$({
+    printf '1\nhello\nback\nq\n' \
+        | PATH="$fake_bin:$PATH" \
+          LLM_URL="http://showcase.test" \
+          SHOWCASE_TEST_FAIL_MODELS="true" \
+          SHOWCASE_TEST_PAYLOAD_LOG="$payload_log" \
+          bash "$SHOWCASE"
+} 2>&1)"
+failure_rc=$?
+set -e
+[[ "$failure_rc" == "0" ]] || fail "catalog failure aborted the interactive showcase"
+[[ "$failure_output" == *"Error getting response"* ]] \
+    || fail "catalog failure was not explained at the menu boundary"
+[[ "$failure_output" == *"Thanks for trying ODS"* ]] \
+    || fail "showcase did not remain interactive after request failure"
+
+echo "[PASS] showcase discovers the live model and contains request failures"


### PR DESCRIPTION
## Why this matters

scripts/showcase.sh is advertised from the product README, but all three LLM demos post model local. The shipped direct llama-server does not define that alias; it exposes the active model ID through /v1/models, which changes by tier and after model swaps. Chat, RAG, and code demos can therefore fail with model-not-found even while the health endpoint is green.

A curl or response-parse failure also occurs inside an assignment under set -e, terminating the entire interactive showcase instead of returning the user to its menu.

Invariant: every showcase completion uses the model ID currently advertised by the target endpoint, and a failed inference request remains a contained demo failure rather than ending the interactive process.

## What changed

- resolve the first usable live ID from /v1/models, with SHOWCASE_MODEL as an explicit override
- centralize model injection, bounded transport, and response validation in one request boundary
- route chat, RAG, and code-assistant demos through that boundary
- keep the menu alive and print an actionable error when discovery, transport, or parsing fails
- gate the behavior in Make and Linux CI

## Overlap check

Searched open and closed PRs for showcase model discovery, scripts/showcase.sh plus model local, live model routing, and interactive showcase failures. No PR covers this behavior. Existing showcase-related history only checks file/menu presence or script-directory handling.

## Regression boundary

The new test runs the real interactive script with piped menu input and a fake HTTP boundary. It returns live/model.gguf from /v1/models, captures the posted completion JSON, and asserts the exact discovered ID plus rendered answer. A second run fails catalog discovery and proves the script explains the failure, accepts back/quit input, and exits successfully.

## Validation

- bash tests/test-showcase-live-model.sh: pass
- bash -n scripts/showcase.sh tests/test-showcase-live-model.sh: pass
- test-linux workflow YAML parse: pass
- git diff --check: pass

A live model was not loaded in this workspace; the regression exercises the full process/menu/HTTP contract deterministically.

## Tradeoffs and rollback

The showcase now adds one bounded model-catalog request per completion, so a model swap during a long-running session is reflected immediately. SHOWCASE_MODEL avoids that query for controlled demos. Rollback restores the hardcoded alias and set-e termination behavior; no persistent state changes.