### PR TITLE
fix(test): isolate functional audio artifacts

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -175,6 +175,9 @@ jobs:
       - name: Mode Switch Tests
         run: bash tests/test-mode-switch-status.sh
 
+      - name: Functional Test Temp Isolation
+        run: bash tests/test-functional-temp-isolation.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -72,6 +72,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== mode switch status and switching ==="
 	@bash tests/test-mode-switch-status.sh
+	@echo "=== functional test temporary artifact isolation ==="
+	@bash tests/test-functional-temp-isolation.sh
 	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh

--- a/ods/scripts/ods-test-functional.sh
+++ b/ods/scripts/ods-test-functional.sh
@@ -47,6 +47,21 @@ WHISPER_URL="${WHISPER_URL:-http://localhost:${SERVICE_PORTS[whisper]:-9000}}"
 TTS_URL="${TTS_URL:-http://localhost:${SERVICE_PORTS[tts]:-8880}}"
 EMBEDDING_URL="${EMBEDDING_URL:-http://localhost:${SERVICE_PORTS[embeddings]:-9103}}"
 
+# Keep generated audio private to this invocation. Predictable files directly
+# under /tmp let concurrent runs overwrite or remove one another's fixtures.
+FUNCTIONAL_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ods-functional.XXXXXX")"
+TTS_OUTPUT_FILE="$FUNCTIONAL_TMP_DIR/tts-output.wav"
+WHISPER_TEST_AUDIO="$FUNCTIONAL_TMP_DIR/whisper-input.wav"
+
+cleanup_functional_artifacts() {
+    rm -f -- "$TTS_OUTPUT_FILE" "$WHISPER_TEST_AUDIO"
+    rmdir -- "$FUNCTIONAL_TMP_DIR"
+}
+trap cleanup_functional_artifacts EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # Test tracking
 TESTS_PASSED=0
 TESTS_FAILED=0
@@ -126,7 +141,7 @@ test_tts_functional() {
     echo "> Testing TTS Audio Generation"
     
     local test_text="Hello, this is a test."
-    local output_file="/tmp/test_tts_output.wav"
+    local output_file="$TTS_OUTPUT_FILE"
     
     local payload="{\"model\": \"kokoro\", \"input\": \"$test_text\", \"voice\": \"af_bella\", \"response_format\": \"wav\"}"
     
@@ -216,7 +231,7 @@ test_whisper_functional() {
     echo "> Testing Whisper Transcription"
     
     # Create a simple test audio file or use existing
-    local test_audio="/tmp/test_audio.wav"
+    local test_audio="$WHISPER_TEST_AUDIO"
     
     # Try to generate test audio with TTS first
     local tts_payload='{"model": "kokoro", "input": "Hello world", "voice": "af_bella", "response_format": "wav"}'

--- a/ods/tests/test-functional-temp-isolation.sh
+++ b/ods/tests/test-functional-temp-isolation.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Process-level regression for per-run ods-test-functional audio workspaces.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FUNCTIONAL_TEST="$ROOT_DIR/scripts/ods-test-functional.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; echo "       $2"; FAIL=$((FAIL + 1)); }
+
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+FAKE_BIN="$WORKDIR/bin"
+SCRATCH="$WORKDIR/scratch"
+CURL_LOG="$WORKDIR/curl-output-paths.log"
+mkdir -p "$FAKE_BIN" "$SCRATCH"
+
+cat > "$FAKE_BIN/curl" <<'FAKE_CURL'
+#!/usr/bin/env bash
+set -euo pipefail
+
+url=""
+output_file=""
+wants_status=0
+while (($#)); do
+    case "$1" in
+        http://*) url="$1" ;;
+        -o)
+            shift
+            output_file="$1"
+            ;;
+        -w) wants_status=1; shift ;;
+    esac
+    shift
+done
+
+case "$url" in
+    */v1/models)
+        printf '%s' '{"data":[{"id":"fixture"}]}'
+        ;;
+    */v1/chat/completions)
+        printf '%s' '{"choices":[{"message":{"content":"4"}}]}'
+        ;;
+    */embed|*/)
+        printf '%s' '[[0.1,0.2]]'
+        ;;
+    */v1/audio/speech)
+        printf '%s\n' "$output_file" >> "$CURL_LOG"
+        head -c 2048 /dev/zero > "$output_file"
+        if ((wants_status)); then
+            printf '%s' '200'
+        fi
+        ;;
+    */v1/audio/transcriptions)
+        printf '%s' '{"text":"hello world"}'
+        ;;
+    *)
+        printf 'unexpected URL: %s\n' "$url" >&2
+        exit 2
+        ;;
+esac
+FAKE_CURL
+
+cat > "$FAKE_BIN/file" <<'FAKE_FILE'
+#!/usr/bin/env bash
+printf '%s: RIFF (little-endian) data, WAVE audio\n' "$1"
+FAKE_FILE
+chmod +x "$FAKE_BIN/curl" "$FAKE_BIN/file"
+
+run_fixture() {
+    local output="$1"
+    TMPDIR="$SCRATCH" \
+        PATH="$FAKE_BIN:$PATH" \
+        CURL_LOG="$CURL_LOG" \
+        LLM_URL="http://llm.test" \
+        TTS_URL="http://tts.test" \
+        EMBEDDING_URL="http://embeddings.test" \
+        WHISPER_URL="http://whisper.test" \
+        bash "$FUNCTIONAL_TEST" > "$output" 2>&1
+}
+
+run_fixture "$WORKDIR/run-one.log" &
+pid_one=$!
+run_fixture "$WORKDIR/run-two.log" &
+pid_two=$!
+
+wait "$pid_one"
+rc_one=$?
+wait "$pid_two"
+rc_two=$?
+
+if [[ "$rc_one" -eq 0 && "$rc_two" -eq 0 ]]; then
+    pass "concurrent functional runs complete successfully"
+else
+    fail "concurrent functional runs complete successfully" \
+        "exit codes: $rc_one, $rc_two; logs: $WORKDIR/run-one.log $WORKDIR/run-two.log"
+fi
+
+mapfile -t output_paths < "$CURL_LOG"
+unique_count="$(printf '%s\n' "${output_paths[@]}" | sort -u | wc -l | tr -d ' ')"
+if [[ "${#output_paths[@]}" -eq 4 && "$unique_count" -eq 4 ]]; then
+    pass "each run uses distinct TTS and Whisper artifacts"
+else
+    fail "each run uses distinct TTS and Whisper artifacts" \
+        "expected 4 unique paths, got ${#output_paths[@]} paths / $unique_count unique"
+fi
+
+paths_are_scoped=1
+for output_path in "${output_paths[@]}"; do
+    if [[ "$output_path" != "$SCRATCH"/ods-functional.*/tts-output.wav &&
+          "$output_path" != "$SCRATCH"/ods-functional.*/whisper-input.wav ]]; then
+        paths_are_scoped=0
+    fi
+done
+if ((paths_are_scoped)); then
+    pass "generated audio stays inside per-run workspaces"
+else
+    fail "generated audio stays inside per-run workspaces" "paths: ${output_paths[*]}"
+fi
+
+leftovers="$(find "$SCRATCH" -mindepth 1 -print -quit)"
+if [[ -z "$leftovers" ]]; then
+    pass "exit traps remove functional-test artifacts"
+else
+    fail "exit traps remove functional-test artifacts" "left behind: $leftovers"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Why this matters

`ods-test-functional.sh` is the documented live-stack functional probe for LLM, TTS, embeddings, and Whisper. It wrote both generated audio fixtures to fixed names directly under `/tmp`. Two operators or CI jobs running the probe concurrently could overwrite or delete each other's files; a pre-existing filesystem entry at either predictable path could also receive curl's output.

Root cause: temporary artifact ownership was global rather than per process. The preserved invariant is that every functional-test invocation owns a private audio workspace and removes it on normal exit or interruption.

## What changed

- create a per-run directory with `mktemp -d` under `${TMPDIR:-/tmp}`
- keep the TTS and Whisper fixtures inside that directory
- clean the exact files and directory from an EXIT trap; HUP/INT/TERM exit through the same cleanup path
- add a process-level regression that launches two complete probes concurrently against fake HTTP/file boundaries
- run the regression from `make test` and Linux CI

## Overlap check

Searched open and closed PRs by `ods-test-functional`, `test_tts_output.wav`, temp/isolation keywords, and changed production file. #2651 changes JSON escaping for the discovered model ID in the same script, but touches an independent request-payload hunk. #2252 does not change `ods/scripts/ods-test-functional.sh`. No PR covers per-invocation audio ownership or concurrent execution.

## Regression boundary

`tests/test-functional-temp-isolation.sh` executes the public script twice concurrently, with fake service endpoints standing in for all four live services. It asserts:

- both end-to-end invocations succeed
- all four curl output destinations are unique
- every destination is scoped below a per-run `ods-functional.*` directory
- no generated workspace or artifact remains after process exit

## Validation

- `bash tests/test-functional-temp-isolation.sh` — 4 passed, 0 failed
- `bash -n scripts/ods-test-functional.sh tests/test-functional-temp-isolation.sh` — passed
- `git diff --check` — passed

## Tradeoffs and rollback

This intentionally requires `mktemp` before any service call, so a host unable to allocate a secure temporary directory fails visibly instead of falling back to a shared filename. The existing Bash 4+ requirement is unchanged. Reverting the commit restores the old fixed `/tmp` paths; no persisted user state or migration is involved.