### PR TITLE
ci(extensions): gate hook and template contracts

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -115,6 +115,11 @@ jobs:
           bash tests/test-validate-manifests.sh
           bash tests/test-validate-manifest-schema.sh
 
+      - name: Extension Hook and Template Contracts
+        run: |
+          bash tests/test-hooks.sh
+          bash tests/test-templates.sh
+
       - name: Health Check Tests
         run: bash tests/test-health-check.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -103,6 +103,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
+	@echo "=== Extension hook and template contracts ==="
+	@bash tests/test-hooks.sh
+	@bash tests/test-templates.sh
 	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh

--- a/ods/tests/test-hooks.sh
+++ b/ods/tests/test-hooks.sh
@@ -91,8 +91,10 @@ touch "$EXT_DIR/old-setup.sh"
 mkdir -p "$EXT_DIR/hooks"
 touch "$EXT_DIR/hooks/new-setup.sh"
 
-export SCRIPT_DIR="$PROJECT_DIR"
-export EXTENSIONS_DIR="$TMPDIR_TEST/extensions/services"
+# service-registry.sh derives EXTENSIONS_DIR while it is sourced. Point its
+# public SCRIPT_DIR contract at the fixture root; exporting EXTENSIONS_DIR
+# directly is ineffective because the library initializes that variable.
+export SCRIPT_DIR="$TMPDIR_TEST"
 
 # Source registry and load
 # Reset loaded flag


### PR DESCRIPTION
## Why this matters

Extension lifecycle hooks and the 13 user-facing service templates are shipped release assets. Their contract suites existed, but neither `make test` nor any GitHub workflow ran them. A broken hook precedence rule, invalid template YAML, duplicate template ID, or reference to a missing service could therefore merge without a release signal.

The hook suite also could not serve as a gate as written: it exported an `EXTENSIONS_DIR` fixture that `service-registry.sh` immediately overwrites while loading. Against current `main`, the documented command reported 2 passed / 2 failed without exercising either hook-resolution path.

The preserved invariant is that `hooks.post_install` wins over legacy `setup_hook`, legacy-only manifests still resolve, traversal is rejected, and every shipped template parses with a unique ID and references real bundled/library services.

## What changed

- point the hook test's public `SCRIPT_DIR` input at its isolated fixture root so the real registry loader reads the fixture manifests
- add the hook and template contract suites to `make test`
- add both suites to the Linux manifest-validation job, where PyYAML is explicitly installed

No production runtime behavior or shipped manifest is changed.

## Overlap check

Searched open and closed PRs by `test-hooks.sh`, `test-templates.sh`, hook/template CI, and all changed files. The historical PRs that introduced these suites are closed; no open PR wires either suite into a release gate or repairs the fixture root. #2909 validates dependency graphs and #3387 runs Python service suites; neither changes these tests or their contracts.

## Regression boundary

Both tests execute the repository-owned public boundaries rather than inspecting implementation text:

- `test-hooks.sh` loads fixture manifests through `lib/service-registry.sh` and asserts the resolved hook paths
- `test-templates.sh` parses all shipped template YAML and service manifests, then checks IDs and references across bundled and library catalogs

## Validation

- pre-change `bash tests/test-hooks.sh` — reproduced 2 passed, 2 failed
- post-change `bash tests/test-hooks.sh` — 4 passed, 0 failed, 0 skipped
- `bash tests/test-templates.sh` — 27 passed, 0 failed
- `bash -n tests/test-hooks.sh tests/test-templates.sh` — passed
- parsed `.github/workflows/test-linux.yml` with PyYAML — passed
- `git diff --check` — passed

## Tradeoffs and rollback

The Linux gate already installs pinned PyYAML, so these checks run rather than skip there. On an ad-hoc host without Python/PyYAML, the suites retain their existing explicit skip behavior. Reverting this commit only removes the gate and restores the broken fixture input; it has no runtime state or migration impact.