### PR TITLE
feat(cli): expose support bundle command

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4694,6 +4694,13 @@ cmd_backup() {
     "$INSTALL_DIR/ods-backup.sh" "$@"
 }
 
+cmd_support_bundle() {
+    check_install
+    local bundle_script="$INSTALL_DIR/scripts/ods-support-bundle.sh"
+    [[ -x "$bundle_script" ]] || error "Support bundle generator not found or not executable: $bundle_script"
+    exec "$bundle_script" "$@"
+}
+
 cmd_restore() {
     check_install
     cd "$INSTALL_DIR"
@@ -6423,6 +6430,8 @@ ${CYAN}Commands:${NC}
                       View Whisper STT model, check cache, or trigger download
   backup [options]    Create a backup of user data and config
   backup verify <id>   Verify checksum integrity for a backup
+  support-bundle [options]
+                      Create a redacted diagnostics archive for support
   restore [backup_id] Restore from a backup
   rollback            Rollback to pre-update state (after failed update)
   logs <service>      Tail logs for a service
@@ -6533,6 +6542,7 @@ ${CYAN}Examples:${NC}
   ods backup -c                 # Create compressed backup
   ods backup -l                 # List all backups
   ods backup verify <id>        # Verify backup integrity
+  ods support-bundle --json     # Create a bundle and print its archive path as JSON
   ods restore                   # Interactive restore
   ods restore 20260309-120000   # Restore specific backup
   ods rollback                  # Rollback after failed update
@@ -6576,6 +6586,7 @@ case "${1:-help}" in
     remote-provider) shift; cmd_remote_provider "$@" ;;
     stt)         shift; cmd_stt "$@" ;;
     backup)      shift; cmd_backup "$@" ;;
+    support-bundle|support) shift; cmd_support_bundle "$@" ;;
     restore)     shift; cmd_restore "$@" ;;
     rollback)    cmd_rollback ;;
     logs|log|l)  shift; cmd_logs "$@" ;;

--- a/ods/tests/test-cli-support-bundle.sh
+++ b/ods/tests/test-cli-support-bundle.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-cli-support.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/lib" "$FIXTURE/scripts"
+cp "$ROOT_DIR/ods-cli" "$FIXTURE/ods-cli"
+cp "$ROOT_DIR"/lib/*.sh "$FIXTURE/lib/"
+: > "$FIXTURE/docker-compose.base.yml"
+
+cat > "$FIXTURE/scripts/ods-support-bundle.sh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "${SUPPORT_ARGS_LOG:?}"
+printf '{"archive":"fixture.tar.gz"}\n'
+exit "${SUPPORT_EXIT_CODE:-0}"
+SH
+chmod +x "$FIXTURE/scripts/ods-support-bundle.sh"
+
+args_log="$FIXTURE/args.log"
+output="$(
+    ODS_HOME="$FIXTURE" SUPPORT_ARGS_LOG="$args_log" \
+        bash "$FIXTURE/ods-cli" support-bundle --json --no-logs
+)"
+
+[[ "$output" == '{"archive":"fixture.tar.gz"}' ]]
+mapfile -t forwarded < "$args_log"
+[[ "${forwarded[*]}" == "--json --no-logs" ]]
+
+set +e
+ODS_HOME="$FIXTURE" SUPPORT_ARGS_LOG="$args_log" SUPPORT_EXIT_CODE=7 \
+    bash "$FIXTURE/ods-cli" support --json >/dev/null
+status=$?
+set -e
+[[ $status -eq 7 ]]
+
+rm "$FIXTURE/scripts/ods-support-bundle.sh"
+set +e
+missing_output="$(ODS_HOME="$FIXTURE" bash "$FIXTURE/ods-cli" support-bundle 2>&1)"
+status=$?
+set -e
+[[ $status -eq 1 ]]
+[[ "$missing_output" == *"Support bundle generator not found or not executable"* ]]
+
+echo "CLI support-bundle tests passed"


### PR DESCRIPTION
﻿?## Summary
- expose the existing redacted diagnostics generator as `ods support-bundle`
- keep `support` as a concise alias and forward all generator options unchanged
- preserve the generator's stdout and exit status for automation

## Why this matters
Operators are told to create support bundles with a repository-relative script, but installed users primarily interact through `ods`. The new command makes the shipped support workflow reachable from the public CLI while retaining `--json`, `--no-logs`, and output-directory behavior.

Behavioral invariant: invoking the CLI wrapper must pass arguments, stdout, and non-zero status through unchanged.

## Overlap check
Searched open and closed PRs for `support-bundle`, `support bundle CLI`, and production file `ods/ods-cli`. PR #3487 configures log windows inside `ods-support-bundle.sh`; merged PR #1042 introduced the generator. Neither exposes it through the CLI, and this PR does not modify their production file.

## Test plan
- [x] `bash -n ods/ods-cli`
- [x] `bash -n ods/tests/test-cli-support-bundle.sh`
- [x] `bash ods/tests/test-cli-support-bundle.sh`
- [x] `git diff --check`

The boundary test runs the real CLI against a fixture generator and verifies argument forwarding, JSON stdout, the `support` alias, failure status propagation, and the missing-generator diagnostic.

## Tradeoffs and rollback
This is a thin wrapper around the existing authenticated/local operator command and creates no new archive behavior. Rollback removes only the command registration; direct script usage remains unchanged.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

