### PR TITLE
feat(extensions): emit runtime checks as JSON

### DIFF
--- a/ods/scripts/extension-runtime-check.sh
+++ b/ods/scripts/extension-runtime-check.sh
@@ -4,7 +4,7 @@
 # HTTP health endpoints (same paths/timeouts as the installer health phase).
 #
 # Usage:
-#   scripts/extension-runtime-check.sh [ODS_ROOT]
+#   scripts/extension-runtime-check.sh [--json] [ODS_ROOT]
 #   ODS_ROOT defaults to the repository root (parent of scripts/).
 #
 # Environment:
@@ -16,7 +16,35 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-ODS_ROOT="$(cd "${1:-$ROOT_DIR}" && pwd)"
+JSON_OUTPUT=false
+REQUESTED_ROOT=""
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/extension-runtime-check.sh [--json] [ODS_ROOT]
+
+Check non-core extension container and HTTP health state.
+
+Options:
+  --json      Emit a stable machine-readable report.
+  -h, --help  Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json) JSON_OUTPUT=true ;;
+        -h|--help) usage; exit 0 ;;
+        -*) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)
+            [[ -z "$REQUESTED_ROOT" ]] || { echo "Only one ODS_ROOT may be provided" >&2; exit 2; }
+            REQUESTED_ROOT="$1"
+            ;;
+    esac
+    shift
+done
+
+ODS_ROOT="$(cd "${REQUESTED_ROOT:-$ROOT_DIR}" && pwd)"
 export SCRIPT_DIR="$ODS_ROOT"
 
 RED='\033[0;31m'
@@ -25,10 +53,58 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
 
-info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-ok_line() { echo -e "${GREEN}[OK]${NC} $1"; }
-bad_line() { echo -e "${RED}[BAD]${NC} $1"; }
+info() { $JSON_OUTPUT || echo -e "${BLUE}[INFO]${NC} $1"; }
+warn() { $JSON_OUTPUT || echo -e "${YELLOW}[WARN]${NC} $1"; }
+ok_line() { $JSON_OUTPUT || echo -e "${GREEN}[OK]${NC} $1"; }
+bad_line() { $JSON_OUTPUT || echo -e "${RED}[BAD]${NC} $1"; }
+
+declare -a CHECK_IDS=() CHECK_NAMES=() CHECK_STATUSES=() CHECK_CONTAINERS=() CHECK_URLS=() CHECK_MESSAGES=()
+DOCKER_STATUS="not_checked"
+HAVE_CURL=false
+
+record_check() {
+    CHECK_IDS+=("$1")
+    CHECK_NAMES+=("$2")
+    CHECK_STATUSES+=("$3")
+    CHECK_CONTAINERS+=("$4")
+    CHECK_URLS+=("$5")
+    CHECK_MESSAGES+=("$6")
+}
+
+json_escape() {
+    local value="${1-}"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
+
+emit_json() {
+    local healthy=0 unhealthy=0 skipped=0 i comma=""
+    for i in "${!CHECK_STATUSES[@]}"; do
+        case "${CHECK_STATUSES[$i]}" in
+            healthy|running) healthy=$((healthy + 1)) ;;
+            unhealthy|stopped) unhealthy=$((unhealthy + 1)) ;;
+            *) skipped=$((skipped + 1)) ;;
+        esac
+    done
+    printf '{"schema_version":"1","kind":"extension-runtime-check","root":"%s","strict":%s,' \
+        "$(json_escape "$ODS_ROOT")" "$([[ "${EXTENSION_RUNTIME_CHECK_STRICT:-0}" == "1" ]] && echo true || echo false)"
+    printf '"environment":{"docker":"%s","curl":"%s"},' \
+        "$DOCKER_STATUS" "$($HAVE_CURL && echo available || echo unavailable)"
+    printf '"checks":['
+    for i in "${!CHECK_IDS[@]}"; do
+        printf '%s{"service_id":"%s","name":"%s","status":"%s","container":"%s","url":"%s","message":"%s"}' \
+            "$comma" "$(json_escape "${CHECK_IDS[$i]}")" "$(json_escape "${CHECK_NAMES[$i]}")" \
+            "$(json_escape "${CHECK_STATUSES[$i]}")" "$(json_escape "${CHECK_CONTAINERS[$i]}")" \
+            "$(json_escape "${CHECK_URLS[$i]}")" "$(json_escape "${CHECK_MESSAGES[$i]}")"
+        comma=","
+    done
+    printf '],"summary":{"checked":%d,"healthy":%d,"unhealthy":%d,"skipped":%d}}\n' \
+        "${#CHECK_IDS[@]}" "$healthy" "$unhealthy" "$skipped"
+}
 
 if [[ ! -f "$ODS_ROOT/lib/service-registry.sh" ]]; then
     warn "ODS root missing lib/service-registry.sh — skipping ($ODS_ROOT)"
@@ -49,20 +125,25 @@ sr_resolve_ports
 
 if [[ ${#SERVICE_IDS[@]} -eq 0 ]]; then
     info "No services in registry — nothing to check"
+    $JSON_OUTPUT && emit_json
     exit 0
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
+    DOCKER_STATUS="unavailable"
     info "Extension runtime check — docker not in PATH (skipping)"
+    $JSON_OUTPUT && emit_json
     exit 0
 fi
 
 if ! docker info >/dev/null 2>&1; then
+    DOCKER_STATUS="unreachable"
     info "Extension runtime check — Docker daemon not reachable (skipping)"
+    $JSON_OUTPUT && emit_json
     exit 0
 fi
 
-HAVE_CURL=false
+DOCKER_STATUS="available"
 command -v curl >/dev/null 2>&1 && HAVE_CURL=true
 
 strict="${EXTENSION_RUNTIME_CHECK_STRICT:-0}"
@@ -82,12 +163,14 @@ for sid in "${SERVICE_IDS[@]}"; do
 
     if ! docker inspect "$cname" >/dev/null 2>&1; then
         info "[$sid] $disp — no container '$cname' (not in current compose stack or not started)"
+        record_check "$sid" "$disp" "not_started" "$cname" "" "container is not present"
         continue
     fi
 
     status="$(docker inspect -f '{{.State.Status}}' "$cname" 2>/dev/null || echo unknown)"
     if [[ "$status" != "running" ]]; then
         warn "[$sid] $disp — container exists but status=$status (try: docker logs $cname)"
+        record_check "$sid" "$disp" "stopped" "$cname" "" "container status: $status"
         continue
     fi
 
@@ -97,27 +180,34 @@ for sid in "${SERVICE_IDS[@]}"; do
 
     if [[ ! "$port" =~ ^[0-9]+$ ]] || [[ "$port" -le 0 ]]; then
         ok_line "[$sid] $disp — running (no external port to probe)"
+        record_check "$sid" "$disp" "running" "$cname" "" "no external port to probe"
         continue
     fi
 
     if [[ -z "$health" ]]; then
         ok_line "[$sid] $disp — running (no health path in manifest)"
+        record_check "$sid" "$disp" "running" "$cname" "" "no health path in manifest"
         continue
     fi
 
     if ! $HAVE_CURL; then
         warn "[$sid] $disp — running; curl missing, cannot probe http://127.0.0.1:${port}${health}"
+        record_check "$sid" "$disp" "unprobed" "$cname" "http://127.0.0.1:${port}${health}" "curl is unavailable"
         continue
     fi
 
     url="http://127.0.0.1:${port}${health}"
     if curl -sf --max-time "$timeout_sec" "$url" >/dev/null; then
         ok_line "[$sid] $disp — running, health OK ($url)"
+        record_check "$sid" "$disp" "healthy" "$cname" "$url" "HTTP health probe passed"
     else
         bad_line "[$sid] $disp — running but health failed ($url) — try: docker compose logs $sid"
+        record_check "$sid" "$disp" "unhealthy" "$cname" "$url" "HTTP health probe failed"
         had_health_fail=1
     fi
 done
+
+$JSON_OUTPUT && emit_json
 
 if [[ "$strict" == "1" && "$had_health_fail" -ne 0 ]]; then
     exit 1

--- a/ods/tests/test-extension-runtime-check.sh
+++ b/ods/tests/test-extension-runtime-check.sh
@@ -193,6 +193,48 @@ else
     fail "STRICT=1: expected [BAD] line in output, got: $(echo "$out_strict" | tail -5)"
 fi
 
+# JSON mode keeps stdout parseable and reports the same failing probe.
+set +e
+json_out=$(PATH="$MOCK_BIN:$PATH" EXTENSION_RUNTIME_CHECK_STRICT=1 bash "$CHK" --json "$FIXTURE_DIR")
+json_code=$?
+set -e
+
+if [[ $json_code -eq 1 ]]; then
+    pass "JSON + STRICT=1 preserves the health-failure exit code"
+else
+    fail "JSON + STRICT=1: expected exit 1, got $json_code"
+fi
+
+if JSON_REPORT="$json_out" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["schema_version"] == "1"
+assert report["kind"] == "extension-runtime-check"
+assert report["strict"] is True
+assert report["environment"] == {"docker": "available", "curl": "available"}
+assert report["summary"] == {
+    "checked": 1,
+    "healthy": 0,
+    "unhealthy": 1,
+    "skipped": 0,
+}
+assert report["checks"] == [{
+    "service_id": "test-svc",
+    "name": "Test Service",
+    "status": "unhealthy",
+    "container": "ods-test-svc",
+    "url": "http://127.0.0.1:19999/health",
+    "message": "HTTP health probe failed",
+}]
+PY
+then
+    pass "JSON mode emits the documented service-level report"
+else
+    fail "JSON mode emitted an invalid report: $json_out"
+fi
+
 rm -rf "$MOCK_BIN"
 
 echo ""


### PR DESCRIPTION
﻿?## Summary
- add `--json` to `extension-runtime-check.sh`
- report Docker/curl availability plus normalized per-service runtime states
- include stable summary counts while preserving strict-mode exit semantics
- validate options and retain the existing optional positional ODS root

## Why this matters
The extension runtime checker is a documented operator boundary, but its colorized prose cannot be consumed reliably by CI, fleet automation, or support tooling. The new report exposes container and HTTP readiness without changing the default human output.

Behavioral invariant: `EXTENSION_RUNTIME_CHECK_STRICT=1` still fails exactly when a running extension fails its HTTP health probe, including in JSON mode.

## Overlap check
Searched open and closed PRs for `extension-runtime-check`, `extension runtime JSON`, and production file `ods/scripts/extension-runtime-check.sh`. PR #2634 adds service targeting and PR #2738 adds a curl connect timeout. Neither provides structured output. This scope is independent and its option parser is compatible with a future `--service` option; no existing feature PR is replaced.

## Test plan
- [x] `bash -n ods/scripts/extension-runtime-check.sh`
- [x] `bash ods/tests/test-extension-runtime-check.sh` (11 passed)
- [x] `git diff --check`

The boundary fixture runs the real script against a registry manifest plus Docker/curl shims, parses stdout as JSON, verifies every field, and asserts strict-mode status 1.

## Cross-platform and tradeoffs
The implementation uses Bash 4 arrays, matching the script's existing registry requirement on Linux and macOS/Homebrew Bash. Windows reaches this tool through WSL. JSON is generated without adding a jq dependency. Rollback restores prose-only output; default behavior is otherwise unchanged.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

