### PR TITLE
feat(preflight): emit runtime readiness JSON

### DIFF
--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -2,7 +2,7 @@
 # ODS Pre-flight Check
 # Validates all services start correctly before user interaction
 # Backend-aware: detects AMD vs NVIDIA (both use llama-server)
-# Usage: ./ods-preflight.sh
+# Usage: ./ods-preflight.sh [--json]
 #        ./ods-preflight.sh --install-env   # Linux install environment report (JSON: see scripts/linux-install-preflight.sh --help)
 
 set -euo pipefail
@@ -16,6 +16,20 @@ case "${1:-}" in
         exec "$SCRIPT_DIR/scripts/linux-install-preflight.sh" "$@"
         ;;
 esac
+
+JSON_OUTPUT=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --json) JSON_OUTPUT=true ;;
+        -h|--help)
+            echo "Usage: ./ods-preflight.sh [--json]"
+            echo "       ./ods-preflight.sh --install-env [OPTIONS]"
+            exit 0
+            ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
 LOG_FILE="$ODS_DIR/preflight-$(date +%Y%m%d-%H%M%S).log"
 
 # Safe .env loading (no eval; use lib/safe-env.sh)
@@ -88,14 +102,45 @@ NC='\033[0m' # No Color
 PASS=0
 FAIL=0
 WARN=0
+COLLECT_RESULTS=true
+RESULT_STATUSES=()
+RESULT_MESSAGES=()
 
 log() {
-    echo -e "$1"
+    $JSON_OUTPUT || echo -e "$1"
     echo -e "$1" | sed $'s/\033\\[[0-9;]*m//g' >> "$LOG_FILE"
 }
-pass() { log "${GREEN}✓${NC} $1"; PASS=$((PASS+1)); }
-fail() { log "${RED}✗${NC} $1"; FAIL=$((FAIL+1)); }
-warn() { log "${YELLOW}⚠${NC} $1"; WARN=$((WARN+1)); }
+record_result() {
+    $COLLECT_RESULTS || return 0
+    RESULT_STATUSES+=("$1")
+    RESULT_MESSAGES+=("$2")
+}
+pass() { log "${GREEN}✓${NC} $1"; PASS=$((PASS+1)); record_result "pass" "$1"; }
+fail() { log "${RED}✗${NC} $1"; FAIL=$((FAIL+1)); record_result "fail" "$1"; }
+warn() { log "${YELLOW}⚠${NC} $1"; WARN=$((WARN+1)); record_result "warn" "$1"; }
+
+json_escape() {
+    local value="${1-}"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
+
+emit_json() {
+    local i comma=""
+    printf '{"schema_version":"1","kind":"runtime-preflight","backend":"%s","ready":%s,' \
+        "$(json_escape "$BACKEND")" "$([[ "$FAIL" -eq 0 ]] && echo true || echo false)"
+    printf '"log_file":"%s","checks":[' "$(json_escape "$LOG_FILE")"
+    for i in "${!RESULT_STATUSES[@]}"; do
+        printf '%s{"status":"%s","message":"%s"}' "$comma" \
+            "${RESULT_STATUSES[$i]}" "$(json_escape "${RESULT_MESSAGES[$i]}")"
+        comma=","
+    done
+    printf '],"summary":{"passed":%d,"failed":%d,"warnings":%d}}\n' "$PASS" "$FAIL" "$WARN"
+}
 
 echo "" > "$LOG_FILE"
 log "========================================"
@@ -310,6 +355,7 @@ fi
 log ""
 
 # Summary
+COLLECT_RESULTS=false
 log "========================================"
 log "Pre-flight Summary"
 log "========================================"
@@ -319,14 +365,16 @@ log "$(printf "${YELLOW}⚠${NC} Warnings: %d" "$WARN")"
 log ""
 
 if [ $FAIL -eq 0 ]; then
-    pass "Pre-flight PASSED — ODS is ready!"
+    log "${GREEN}✓${NC} Pre-flight PASSED — ODS is ready!"
     EXIT_CODE=0
 else
-    fail "Pre-flight FAILED — fix issues above before proceeding"
+    log "${RED}✗${NC} Pre-flight FAILED — fix issues above before proceeding"
     EXIT_CODE=1
 fi
 
 log ""
 log "Full log: $LOG_FILE"
+
+$JSON_OUTPUT && emit_json
 
 exit $EXIT_CODE

--- a/ods/tests/test-runtime-preflight-json.sh
+++ b/ods/tests/test-runtime-preflight-json.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-runtime-preflight.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/lib" "$FIXTURE/bin" "$FIXTURE/scripts"
+cp "$ROOT_DIR/ods-preflight.sh" "$FIXTURE/ods-preflight.sh"
+cp "$ROOT_DIR/lib/safe-env.sh" "$FIXTURE/lib/safe-env.sh"
+cp "$ROOT_DIR/scripts/linux-install-preflight.sh" "$FIXTURE/scripts/linux-install-preflight.sh"
+printf 'GPU_BACKEND=cpu\n' > "$FIXTURE/.env"
+
+cat > "$FIXTURE/bin/docker" <<'SH'
+#!/usr/bin/env bash
+case "${1:-}" in
+    --version) echo 'Docker version 28.0.0, build fixture' ;;
+    info) exit 0 ;;
+    compose)
+        [[ "${2:-}" == "version" ]] && echo 'Docker Compose version v2.35.0'
+        ;;
+    port|ps) exit 0 ;;
+esac
+SH
+cat > "$FIXTURE/bin/curl" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "$FIXTURE/bin/docker" "$FIXTURE/bin/curl"
+
+set +e
+json_out="$(PATH="$FIXTURE/bin:$PATH" bash "$FIXTURE/ods-preflight.sh" --json)"
+status=$?
+set -e
+
+[[ $status -eq 1 ]]
+JSON_REPORT="$json_out" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["schema_version"] == "1"
+assert report["kind"] == "runtime-preflight"
+assert report["backend"] == "cpu"
+assert report["ready"] is False
+assert report["summary"]["failed"] == 1
+assert report["summary"]["passed"] >= 3
+assert report["summary"]["warnings"] >= 4
+assert len(report["checks"]) == sum(report["summary"].values())
+assert any(item["status"] == "fail" and "LLM endpoint" in item["message"] for item in report["checks"])
+assert Path(report["log_file"]).is_file()
+PY
+
+[[ "$json_out" != *"ODS Pre-flight Check"* ]]
+echo "Runtime preflight JSON tests passed"


### PR DESCRIPTION
﻿?## Summary
- add `--json` to the post-install `ods-preflight.sh` runtime check
- expose backend, readiness, log receipt, individual outcomes, and summary counts
- keep the existing human report and `--install-env` delegation unchanged
- reject unknown runtime-preflight arguments with an explicit usage error

## Why this matters
ODS already provides machine-readable install-environment preflight, but the public post-install preflight only prints colorized prose. Operators and fleet automation need a stable receipt for Docker, Compose, GPU, LLM, voice, embeddings, and dashboard readiness after activation.

Behavioral invariant: JSON and human modes execute the same checks and return 0 only when no blocking runtime failure is recorded.

## Overlap check
Searched open and closed PRs for `ods-preflight`, `preflight JSON runtime`, and production file `ods/ods-preflight.sh`. PR #2652 changes Compose-flag expansion in the separate `ods/scripts/ods-preflight.sh`; rootless preflight PRs #1720/#1722 add checks but do not expose the root runtime report as JSON. This PR is independent and preserves `--install-env --json` routing.

## Test plan
- [x] `bash -n ods/ods-preflight.sh`
- [x] `bash ods/tests/test-runtime-preflight-json.sh`
- [x] `bash ods/tests/test-preflight.sh` (22 passed)
- [x] `bash ods/tests/test-linux-install-preflight.sh` (15 passed)
- [x] `git diff --check`

The boundary fixture invokes the real preflight with Docker/curl shims, parses stdout as JSON, checks summary/result parity, validates the log receipt, and confirms failure status propagation.

## Cross-platform and rollback
The code uses indexed arrays supported by the script's current Bash targets. Linux runs it natively; Windows uses WSL; macOS behavior remains the existing runtime path. Rollback removes structured output without changing the default report or checks.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

