### PR TITLE
feat(compose): emit validation receipts as JSON

### DIFF
--- a/ods/scripts/validate-compose-stack.sh
+++ b/ods/scripts/validate-compose-stack.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Validate resolved Docker Compose stack for syntax errors
-# Usage: validate-compose-stack.sh --compose-flags "-f file1.yml -f file2.yml" [--env-file /path/to/.env]
+# Usage: validate-compose-stack.sh --compose-flags "-f file1.yml -f file2.yml" [--env-file /path/to/.env] [--json]
 #
 # Returns:
 #   0 - Valid compose stack
@@ -11,6 +11,36 @@ set -euo pipefail
 COMPOSE_FLAGS=""
 ENV_FILE=""
 QUIET=false
+JSON_OUTPUT=false
+
+usage() {
+    cat <<'EOF'
+Usage: validate-compose-stack.sh --compose-flags FLAGS [OPTIONS]
+
+Options:
+  --env-file FILE  Supply an environment file to Docker Compose.
+  --quiet          Suppress the human success report.
+  --json           Emit a machine-readable validation receipt.
+  -h, --help       Show this help.
+EOF
+}
+
+json_escape() {
+    local value="${1-}"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
+
+emit_json() {
+    local valid="$1" engine="$2" service_count="$3" error_code="$4"
+    printf '{"schema_version":"1","kind":"compose-validation","valid":%s,' "$valid"
+    printf '"engine":"%s","service_count":%d,"error_code":"%s"}\n' \
+        "$(json_escape "$engine")" "$service_count" "$(json_escape "$error_code")"
+}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -26,6 +56,15 @@ while [[ $# -gt 0 ]]; do
             QUIET=true
             shift
             ;;
+        --json)
+            JSON_OUTPUT=true
+            QUIET=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
@@ -35,6 +74,7 @@ done
 
 if [[ -z "$COMPOSE_FLAGS" ]]; then
     echo "ERROR: --compose-flags required" >&2
+    $JSON_OUTPUT && emit_json false "" 0 "missing_compose_flags"
     exit 1
 fi
 
@@ -51,6 +91,7 @@ elif command -v docker-compose &>/dev/null; then
     DOCKER_COMPOSE_CMD="docker-compose"
 else
     echo "ERROR: docker compose not found" >&2
+    $JSON_OUTPUT && emit_json false "" 0 "compose_unavailable"
     exit 1
 fi
 
@@ -68,12 +109,13 @@ fi
 # - Invalid environment variable references
 validation_output=$(mktemp)
 if $DOCKER_COMPOSE_CMD $ENV_FILE_FLAG $COMPOSE_FLAGS config > "$validation_output" 2>&1; then
+    service_count=$(grep -c "^  [a-z]" "$validation_output" || echo "0")
     if ! $QUIET; then
         echo "Compose stack validation passed"
         # Show summary of services
-        service_count=$(grep -c "^  [a-z]" "$validation_output" || echo "0")
         echo "  Services defined: $service_count"
     fi
+    $JSON_OUTPUT && emit_json true "$DOCKER_COMPOSE_CMD" "$service_count" ""
     rm -f "$validation_output"
     exit 0
 else
@@ -83,6 +125,7 @@ else
     cat "$validation_output" >&2
     echo "" >&2
     echo "Compose flags: $COMPOSE_FLAGS" >&2
+    $JSON_OUTPUT && emit_json false "$DOCKER_COMPOSE_CMD" 0 "compose_config_failed"
     rm -f "$validation_output"
     exit 1
 fi

--- a/ods/tests/test-validate-compose-json.sh
+++ b/ods/tests/test-validate-compose-json.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/validate-compose-stack.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-compose-json.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/bin"
+cat > "$FIXTURE/bin/docker" <<'SH'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" && " $* " == *" config "* ]]; then
+    if [[ "${COMPOSE_FIXTURE_FAIL:-0}" == "1" ]]; then
+        echo "fixture compose error" >&2
+        exit 17
+    fi
+    cat <<'YAML'
+services:
+  api:
+    image: fixture/api
+  web:
+    image: fixture/web
+YAML
+    exit 0
+fi
+exit 2
+SH
+chmod +x "$FIXTURE/bin/docker"
+
+success_json="$(PATH="$FIXTURE/bin:$PATH" bash "$VALIDATOR" --compose-flags '-f fixture.yml' --json)"
+JSON_REPORT="$success_json" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report == {
+    "schema_version": "1",
+    "kind": "compose-validation",
+    "valid": True,
+    "engine": "docker compose",
+    "service_count": 2,
+    "error_code": "",
+}
+PY
+
+set +e
+failure_json="$(
+    PATH="$FIXTURE/bin:$PATH" COMPOSE_FIXTURE_FAIL=1 \
+        bash "$VALIDATOR" --compose-flags '-f broken.yml' --json 2>"$FIXTURE/error.log"
+)"
+failure_status=$?
+set -e
+[[ $failure_status -eq 1 ]]
+[[ "$(cat "$FIXTURE/error.log")" == *"fixture compose error"* ]]
+JSON_REPORT="$failure_json" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["valid"] is False
+assert report["engine"] == "docker compose"
+assert report["service_count"] == 0
+assert report["error_code"] == "compose_config_failed"
+PY
+
+echo "Compose validation JSON tests passed"


### PR DESCRIPTION
﻿?## Summary
- add `--json` to the shipped Compose stack validator
- report a stable validity receipt, selected Compose engine, service count, and error code
- keep detailed Compose diagnostics on stderr so stdout remains parseable
- add explicit help without changing default or quiet output

## Why this matters
Installers and CI already call `validate-compose-stack.sh` at the point where layered Compose files become a deployable stack. Machine-readable receipts let automation distinguish missing Compose, invalid input, and invalid merged configuration without scraping prose or storing the fully rendered Compose document.

Behavioral invariant: validation still delegates to the exact shipped Compose engine and returns non-zero whenever `compose config` fails.

## Overlap check
Searched open and closed PRs for `validate-compose-stack`, `validate compose JSON`, `compose stack JSON`, and the production file. PR #2630 adds structured *resolution* plans to `resolve-compose-stack.sh`; PR #3259 adds deployed-stack drift attestation. Neither exposes the validation result from `validate-compose-stack.sh`, so this is a separate handoff boundary.

## Test plan
- [x] `bash -n ods/scripts/validate-compose-stack.sh`
- [x] `bash ods/tests/test-validate-compose-json.sh`
- [x] `bash ods/tests/test-extension-integration.sh` (39 passed, 1 environment skip)
- [x] `git diff --check`

The boundary test invokes the real validator with a Docker Compose shim, validates exact success JSON, then forces `compose config` failure and verifies stderr detail, stable error code, and exit 1.

## Security, portability, and rollback
Rendered Compose output may contain expanded configuration, so JSON intentionally carries only a normalized error code; diagnostic text stays on stderr under the existing operator policy. Linux/macOS use the same Bash path and Windows uses WSL. Removing `--json` cleanly restores the prior interface.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

