### PR TITLE
feat(capability): stream profiles without writing

### DIFF
--- a/ods/docs/CAPABILITY-PROFILE.md
+++ b/ods/docs/CAPABILITY-PROFILE.md
@@ -15,6 +15,16 @@ ODS now exposes a normalized installer capability profile so platform and hardwa
 scripts/build-capability-profile.sh --output /tmp/ods-capabilities.json
 ```
 
+For read-only automation, stream the same profile without writing the default
+file:
+
+```bash
+scripts/build-capability-profile.sh --stdout
+```
+
+`--stdout` is intentionally exclusive with `--output` and `--env` so each
+invocation has one unambiguous output contract.
+
 For shell-driven installers:
 
 ```bash

--- a/ods/scripts/build-capability-profile.sh
+++ b/ods/scripts/build-capability-profile.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 OUTPUT_FILE=""
 ENV_MODE="false"
+STDOUT_MODE="false"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -16,12 +17,26 @@ while [[ $# -gt 0 ]]; do
             ENV_MODE="true"
             shift
             ;;
+        --stdout)
+            STDOUT_MODE="true"
+            shift
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
             ;;
     esac
 done
+
+if [[ "$STDOUT_MODE" == "true" && "$ENV_MODE" == "true" ]]; then
+    echo "--stdout and --env are mutually exclusive" >&2
+    exit 1
+fi
+
+if [[ "$STDOUT_MODE" == "true" && -n "$OUTPUT_FILE" ]]; then
+    echo "--stdout and --output are mutually exclusive" >&2
+    exit 1
+fi
 
 if [[ -z "$OUTPUT_FILE" ]]; then
     OUTPUT_FILE="${ROOT_DIR}/.capabilities.json"
@@ -67,7 +82,7 @@ fi
 _LLM_PORT="${SERVICE_PORTS[llama-server]:-11434}"
 _LLM_HEALTH="${SERVICE_HEALTH[llama-server]:-/health}"
 
-"$PYTHON_CMD" - "$HARDWARE_JSON" "$OUTPUT_FILE" "$ENV_MODE" "${HW_CLASS_ID:-unknown}" "${HW_CLASS_LABEL:-Unknown}" "${HW_REC_BACKEND:-cpu}" "${HW_REC_TIER:-T1}" "${HW_REC_COMPOSE_OVERLAYS:-}" "$_LLM_PORT" "$_LLM_HEALTH" <<'PY'
+"$PYTHON_CMD" - "$HARDWARE_JSON" "$OUTPUT_FILE" "$ENV_MODE" "${HW_CLASS_ID:-unknown}" "${HW_CLASS_LABEL:-Unknown}" "${HW_REC_BACKEND:-cpu}" "${HW_REC_TIER:-T1}" "${HW_REC_COMPOSE_OVERLAYS:-}" "$_LLM_PORT" "$_LLM_HEALTH" "$STDOUT_MODE" <<'PY'
 import json
 import os
 import pathlib
@@ -84,6 +99,7 @@ hw_rec_tier = sys.argv[7]
 hw_rec_overlays = [x for x in sys.argv[8].split(",") if x]
 llm_port = int(sys.argv[9]) if len(sys.argv) > 9 else 11434
 llm_health = sys.argv[10] if len(sys.argv) > 10 else "/health"
+stdout_mode = len(sys.argv) > 11 and sys.argv[11] == "true"
 
 os_name = (hardware.get("os") or "unknown").lower()
 if os_name in {"linux", "wsl"}:
@@ -171,20 +187,21 @@ profile = {
     }
 }
 
-output_path.parent.mkdir(parents=True, exist_ok=True)
-fd, tmp_path = tempfile.mkstemp(dir=str(output_path.parent), suffix=".tmp")
-try:
-    with os.fdopen(fd, "w", encoding="utf-8") as f:
-        f.write(json.dumps(profile, indent=2) + "\n")
-        f.flush()
-        os.fsync(f.fileno())
-    os.replace(tmp_path, str(output_path))
-except BaseException:
+if not stdout_mode:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(output_path.parent), suffix=".tmp")
     try:
-        os.unlink(tmp_path)
-    except OSError:
-        pass
-    raise
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(json.dumps(profile, indent=2) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, str(output_path))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
 if env_mode:
     env = {
@@ -208,4 +225,6 @@ if env_mode:
     for key, value in env.items():
         safe = str(value).replace("\\", "\\\\").replace('"', '\\"')
         print(f'{key}="{safe}"')
+elif stdout_mode:
+    print(json.dumps(profile, indent=2))
 PY

--- a/ods/tests/test-capability-profile-stdout.sh
+++ b/ods/tests/test-capability-profile-stdout.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-capability-stdout.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/scripts" "$FIXTURE/lib"
+cp "$ROOT_DIR/scripts/build-capability-profile.sh" "$FIXTURE/scripts/"
+cp "$ROOT_DIR/lib/safe-env.sh" "$FIXTURE/lib/"
+cat > "$FIXTURE/lib/service-registry.sh" <<'SH'
+declare -A SERVICE_PORTS=([llama-server]=8080)
+declare -A SERVICE_HEALTH=([llama-server]=/health)
+sr_load() { :; }
+sr_resolve_ports() { :; }
+SH
+
+cat > "$FIXTURE/scripts/detect-hardware.sh" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' '{"os":"linux","cpu":"Fixture CPU","ram_gb":32,"tier":"T2","gpu":{"type":"nvidia","name":"Fixture GPU","memory_type":"discrete","vram_mb":16384,"count":1}}'
+SH
+cat > "$FIXTURE/scripts/classify-hardware.sh" <<'SH'
+#!/usr/bin/env bash
+cat <<'ENV'
+HW_CLASS_ID="fixture"
+HW_CLASS_LABEL="Fixture Host"
+HW_REC_BACKEND="nvidia"
+HW_REC_TIER="T2"
+HW_REC_COMPOSE_OVERLAYS="docker-compose.base.yml,docker-compose.nvidia.yml"
+ENV
+SH
+chmod +x "$FIXTURE/scripts/detect-hardware.sh" "$FIXTURE/scripts/classify-hardware.sh"
+
+json_out="$(bash "$FIXTURE/scripts/build-capability-profile.sh" --stdout)"
+[[ ! -e "$FIXTURE/.capabilities.json" ]]
+JSON_REPORT="$json_out" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["version"] == "1"
+assert report["hardware_class"] == {"id": "fixture", "label": "Fixture Host"}
+assert report["runtime"]["llm_backend"] == "nvidia"
+assert report["compose"]["overlays"] == [
+    "docker-compose.base.yml",
+    "docker-compose.nvidia.yml",
+]
+PY
+
+set +e
+error_out="$(bash "$FIXTURE/scripts/build-capability-profile.sh" --stdout --env 2>&1)"
+status=$?
+set -e
+[[ $status -eq 1 ]]
+[[ "$error_out" == *"mutually exclusive"* ]]
+
+echo "Capability profile stdout tests passed"


### PR DESCRIPTION
﻿?## Summary
- add `--stdout` to capability-profile generation
- stream the exact normalized JSON profile without creating `.capabilities.json`
- reject ambiguous `--stdout --output` and `--stdout --env` combinations
- document and test the read-only automation path

## Why this matters
Inventory collectors, CI probes, and installer simulations often need the normalized capability decision without mutating the checkout or installed state. Previously every JSON invocation wrote a persistent file; the new mode makes the producer usable as a pure read boundary.

Behavioral invariant: the streamed document is built by the same detection/classification path and has the same schema and values as the persisted profile.

## Overlap check
Searched open and closed PRs for `build-capability-profile`, `capability profile stdout`, and production file `ods/scripts/build-capability-profile.sh`. PR #2752 adds help text and PR #2229 improves atomic persistence. Neither provides a no-write JSON path. This implementation leaves both help and atomic-write behavior independently composable.

## Test plan
- [x] `bash -n ods/scripts/build-capability-profile.sh`
- [x] `bash ods/tests/test-capability-profile-stdout.sh`
- [x] `git diff --check`

The boundary fixture supplies deterministic hardware/classification producers, parses the real generator's stdout, verifies no default file was created, and checks mutually-exclusive output modes.

## Cross-platform and rollback
Profile assembly remains Python and therefore has identical Linux, macOS, and Windows/WSL semantics. Existing `--output` and `--env` callers are untouched. Rollback removes only the new read-only mode and documentation.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

