### PR TITLE
feat(session-cleanup): preview cleanup plans

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -29,6 +29,7 @@ usage() {
     echo "sessions.json so the gateway creates a fresh session."
     echo ""
     echo "Options:"
+    echo "  --dry-run    Preview every cleanup action without changing files."
     echo "  -h, --help   Show this help and exit."
     echo ""
     echo "Environment:"
@@ -40,9 +41,15 @@ usage() {
     echo "      1 when Python or sessions.json validation fails before any session mutation."
 }
 
-case "${1:-}" in
-    -h|--help) usage; exit 0 ;;
-esac
+DRY_RUN=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+    esac
+    shift
+done
 
 # ── Preflight ──────────────────────────────────────────────────
 if [ ! -f "$SESSIONS_JSON" ]; then
@@ -119,19 +126,31 @@ echo "[$(date)] Active sessions found: ${#ACTIVE_IDS[@]}"
 
 # ── Clean up debris ────────────────────────────────────────────
 DELETED_EXIT=0
-DELETED_COUNT=$(find "$SESSIONS_DIR" -name '*.deleted.*' -delete -print 2>&1 | wc -l) || DELETED_EXIT=$?
+if $DRY_RUN; then
+    DELETED_COUNT=$(find "$SESSIONS_DIR" -name '*.deleted.*' -print 2>&1 | wc -l) || DELETED_EXIT=$?
+else
+    DELETED_COUNT=$(find "$SESSIONS_DIR" -name '*.deleted.*' -delete -print 2>&1 | wc -l) || DELETED_EXIT=$?
+fi
 if [[ $DELETED_EXIT -ne 0 ]]; then
     DELETED_COUNT=0
 fi
 
 BAK_EXIT=0
-BAK_COUNT=$(find "$SESSIONS_DIR" -name '*.bak*' -not -name '*.bak-cleanup' -delete -print 2>&1 | wc -l) || BAK_EXIT=$?
+if $DRY_RUN; then
+    BAK_COUNT=$(find "$SESSIONS_DIR" -name '*.bak*' -not -name '*.bak-cleanup' -print 2>&1 | wc -l) || BAK_EXIT=$?
+else
+    BAK_COUNT=$(find "$SESSIONS_DIR" -name '*.bak*' -not -name '*.bak-cleanup' -delete -print 2>&1 | wc -l) || BAK_EXIT=$?
+fi
 if [[ $BAK_EXIT -ne 0 ]]; then
     BAK_COUNT=0
 fi
 
 if [ "$DELETED_COUNT" -gt 0 ] || [ "$BAK_COUNT" -gt 0 ]; then
-    echo "[$(date)] Cleaned up $DELETED_COUNT .deleted files, $BAK_COUNT .bak files"
+    if $DRY_RUN; then
+        echo "[$(date)] Would clean up $DELETED_COUNT .deleted files, $BAK_COUNT .bak files"
+    else
+        echo "[$(date)] Cleaned up $DELETED_COUNT .deleted files, $BAK_COUNT .bak files"
+    fi
 fi
 
 # ── Process session files ──────────────────────────────────────
@@ -155,8 +174,12 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
 
     if [ "$IS_ACTIVE" = false ]; then
         SIZE=$(du -h "$f" | cut -f1)
-        echo "[$(date)] Removing inactive session: $BASENAME ($SIZE)"
-        rm -f "$f"
+        if $DRY_RUN; then
+            echo "[$(date)] Would remove inactive session: $BASENAME ($SIZE)"
+        else
+            echo "[$(date)] Removing inactive session: $BASENAME ($SIZE)"
+            rm -f "$f"
+        fi
         REMOVED_INACTIVE=$((REMOVED_INACTIVE + 1))
     else
         # Portable stat: Linux uses -c%s, macOS uses -f%z
@@ -181,8 +204,12 @@ done
 
 # ── Commit index first, then delete unreferenced session files ─
 if [[ ${#WIPE_IDS[@]} -gt 0 ]]; then
-    echo "[$(date)] Clearing ${#WIPE_IDS[@]} session reference(s) from sessions.json"
-    "$PYTHON_CMD" - "$SESSIONS_JSON" "${WIPE_IDS[@]}" <<'PY'
+    if $DRY_RUN; then
+        echo "[$(date)] Would clear ${#WIPE_IDS[@]} session reference(s) from sessions.json"
+        REMOVED_BLOATED=${#WIPE_IDS[@]}
+    else
+        echo "[$(date)] Clearing ${#WIPE_IDS[@]} session reference(s) from sessions.json"
+        "$PYTHON_CMD" - "$SESSIONS_JSON" "${WIPE_IDS[@]}" <<'PY'
 import json
 import os
 import stat
@@ -231,16 +258,21 @@ finally:
             pass
 PY
 
-    for f in "${WIPE_FILES[@]}"; do
-        if [[ -f "$f" ]]; then
-            rm -f "$f"
-            REMOVED_BLOATED=$((REMOVED_BLOATED + 1))
-        fi
-    done
+        for f in "${WIPE_FILES[@]}"; do
+            if [[ -f "$f" ]]; then
+                rm -f "$f"
+                REMOVED_BLOATED=$((REMOVED_BLOATED + 1))
+            fi
+        done
+    fi
 fi
 
 # ── Summary ────────────────────────────────────────────────────
-echo "[$(date)] Cleanup complete: removed $REMOVED_INACTIVE inactive, $REMOVED_BLOATED bloated"
+if $DRY_RUN; then
+    echo "[$(date)] Dry run complete: would remove $REMOVED_INACTIVE inactive, $REMOVED_BLOATED bloated"
+else
+    echo "[$(date)] Cleanup complete: removed $REMOVED_INACTIVE inactive, $REMOVED_BLOATED bloated"
+fi
 REMAINING_EXIT=0
 REMAINING=$(find "$SESSIONS_DIR" -maxdepth 1 -name '*.jsonl' 2>&1 | wc -l) || REMAINING_EXIT=$?
 if [[ $REMAINING_EXIT -ne 0 ]]; then

--- a/ods/tests/test-session-cleanup-dry-run.sh
+++ b/ods/tests/test-session-cleanup-dry-run.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLEANUP="$ROOT_DIR/scripts/session-cleanup.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-session-plan.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cat > "$FIXTURE/sessions.json" <<'JSON'
+{"agent:main:talk":{"sessionId":"active-bloated"}}
+JSON
+printf 'x%.0s' {1..100} > "$FIXTURE/active-bloated.jsonl"
+printf '{"inactive":true}\n' > "$FIXTURE/inactive.jsonl"
+printf 'debris\n' > "$FIXTURE/stale.deleted.1"
+printf 'backup\n' > "$FIXTURE/stale.bak"
+
+before_index="$(sha256sum "$FIXTURE/sessions.json" | cut -d' ' -f1)"
+output="$(SESSIONS_DIR="$FIXTURE" MAX_SIZE=10 bash "$CLEANUP" --dry-run)"
+after_index="$(sha256sum "$FIXTURE/sessions.json" | cut -d' ' -f1)"
+
+[[ "$before_index" == "$after_index" ]]
+[[ -f "$FIXTURE/active-bloated.jsonl" ]]
+[[ -f "$FIXTURE/inactive.jsonl" ]]
+[[ -f "$FIXTURE/stale.deleted.1" ]]
+[[ -f "$FIXTURE/stale.bak" ]]
+grep -q 'active-bloated' "$FIXTURE/sessions.json"
+
+[[ "$output" == *"Would clean up 1 .deleted files, 1 .bak files"* ]]
+[[ "$output" == *"Would remove inactive session: inactive"* ]]
+[[ "$output" == *"Would clear 1 session reference(s)"* ]]
+[[ "$output" == *"Dry run complete: would remove 1 inactive, 1 bloated"* ]]
+
+echo "Session cleanup dry-run tests passed"


### PR DESCRIPTION
﻿?## Summary
- add `--dry-run` to the OpenClaw session cleanup entrypoint
- inventory inactive, bloated, deleted, and backup artifacts without mutating them
- preview index-reference removals and report planned counts
- reject unknown flags instead of silently running a destructive cleanup

## Why this matters
Session cleanup removes files and atomically rewrites the live OpenClaw session index. Operators need to see the exact impact of threshold or path changes before enabling the timer or running cleanup manually, especially on installations with valuable long-running agent context.

Behavioral invariant: dry-run mode performs all validation and classification but never deletes debris/session files or changes `sessions.json`.

## Overlap check
Searched open and closed PRs for `session-cleanup`, `session cleanup dry run`, and production file `ods/scripts/session-cleanup.sh`. PR #3564 fixes the empty-active-set parser path; issue #2931 concerns a concurrent creation race. Neither provides a preview mode. This feature retains their transaction order and can compose with the parser fix.

## Test plan
- [x] `bash -n ods/scripts/session-cleanup.sh`
- [x] `bash ods/tests/test-session-cleanup-dry-run.sh`
- [x] `bash ods/tests/test-session-cleanup.sh` (19 passed, including injected interruption)
- [x] `git diff --check`

The boundary fixture creates active-bloated, inactive, deleted, and backup artifacts; it verifies the plan text, hashes the index before/after, and proves every file remains present.

## Safety, portability, and rollback
The new path is read-only. Normal cleanup retains its index-first transaction and interruption invariant. The shell logic uses existing Linux/macOS-compatible `find`, `stat`, and Bash constructs; Windows runs under WSL. Rollback removes only the option parser and dry-run branches.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

