### PR TITLE
feat(setup-card): generate vector print assets

### DIFF
--- a/ods/docs/SETUP-CARD.md
+++ b/ods/docs/SETUP-CARD.md
@@ -13,7 +13,10 @@ A portrait card with:
 3. **Plain-text fallback block** - SSID, password, and URL printed verbatim for phones that will not scan the QR.
 4. **Footer** - "ODS is open-source - osmantic.com", plus an optional per-unit serial number.
 
-Card is 1200x1800 px at 300 DPI = exactly 4x6 inches. PNG is the default output; PDF is available with `--format pdf` or a `.pdf` output path.
+Card is 1200x1800 px at 300 DPI = exactly 4x6 inches. PNG is the default output;
+PDF is available with `--format pdf` or a `.pdf` output path. SVG is available
+with `--format svg` or a `.svg` path for scalable vector print workflows; both
+QR codes remain crisp vector paths and operator-provided text is XML-escaped.
 
 ## Requirements
 
@@ -60,7 +63,7 @@ Flags:
 | `--owner-url` | factory-owner mode | Owner magic-link URL created from Setup / Owner. Treat it as a physical credential. |
 | `--device-name` | no | mDNS hostname printed on the card. Defaults to `ods.local`. |
 | `--serial` | no | Optional serial / batch ID printed in the footer right corner. |
-| `--format` | no | `png` or `pdf`. If omitted, `.pdf` output paths write PDF; everything else writes PNG. |
+| `--format` | no | `png`, `pdf`, or `svg`. If omitted, `.pdf`/`.svg` output paths select that format; everything else writes PNG. |
 | `--output` / `-o` | yes | Output path. Parent directory is created if missing. |
 
 Exit codes: `0` on success, `2` for missing dependencies or invalid flags.

--- a/ods/scripts/generate-setup-card.py
+++ b/ods/scripts/generate-setup-card.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import argparse
 import sys
 from pathlib import Path
+from xml.sax.saxutils import escape
 
 # Card geometry — 4×6 inches @ 300 DPI = 1200×1800px portrait.
 CARD_W = 1200
@@ -110,6 +111,128 @@ def render_qr(text: str, target_px: int):
     # antialiased version. NEAREST keeps every pixel pure black or pure
     # white, matching the source modules exactly.
     return img.resize((target_px, target_px), resample=Image.Resampling.NEAREST)
+
+
+def _svg_qr(text: str, x: int, y: int, size: int) -> str:
+    """Return a crisp vector QR group sized to the card's viewBox."""
+    import qrcode  # noqa: PLC0415
+    from qrcode.constants import ERROR_CORRECT_M  # noqa: PLC0415
+
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=ERROR_CORRECT_M,
+        box_size=1,
+        border=4,
+    )
+    qr.add_data(text)
+    qr.make(fit=True)
+    matrix = qr.get_matrix()
+    module = size / len(matrix)
+    commands: list[str] = []
+    for row_index, row in enumerate(matrix):
+        for column_index, filled in enumerate(row):
+            if not filled:
+                continue
+            module_x = x + column_index * module
+            module_y = y + row_index * module
+            commands.append(
+                f"M{module_x:.3f},{module_y:.3f}h{module:.3f}v{module:.3f}"
+                f"h-{module:.3f}z"
+            )
+    return (
+        f'<g shape-rendering="crispEdges">'
+        f'<rect x="{x}" y="{y}" width="{size}" height="{size}" fill="#fff"/>'
+        f'<path d="{"".join(commands)}" fill="#000"/></g>'
+    )
+
+
+def _svg_value_text(value: str, x: int, y: int, max_width: int) -> str:
+    """Fit a fallback value into its column without raster font metrics."""
+    font_size = 36
+    estimated_width = len(value) * font_size * 0.62
+    while font_size > 18 and estimated_width > max_width:
+        font_size -= 2
+        estimated_width = len(value) * font_size * 0.62
+    fit = ""
+    if estimated_width > max_width:
+        fit = f' textLength="{max_width}" lengthAdjust="spacingAndGlyphs"'
+    return (
+        f'<text x="{x}" y="{y}" fill="#e4e4e7" font-size="{font_size}" '
+        f'font-family="DejaVu Sans Mono,Consolas,monospace"{fit}>'
+        f'{escape(value)}</text>'
+    )
+
+
+def render_svg_card(
+    ssid: str,
+    password: str,
+    setup_url: str | None,
+    device_name: str,
+    security: str = "WPA",
+    serial: str | None = None,
+    mode: str = "setup",
+    owner_url: str | None = None,
+) -> str:
+    """Compose a scalable 4x6 setup card as an SVG document."""
+    if mode not in {"setup", "factory-owner"}:
+        raise ValueError("mode must be setup or factory-owner")
+    right_url = owner_url if mode == "factory-owner" else setup_url
+    if not right_url:
+        raise ValueError(
+            "--owner-url is required for factory-owner mode"
+            if mode == "factory-owner"
+            else "--setup-url is required"
+        )
+
+    right_caption = "2. OPEN ODS TALK" if mode == "factory-owner" else "2. OPEN SETUP"
+    tagline = "Scan to join. Scan to talk." if mode == "factory-owner" else "Scan to set up. Scan to chat."
+    fallback_url_label = "owner url" if mode == "factory-owner" else "then visit"
+    qr_size = (CARD_W - MARGIN * 3) // 2
+    qr_y = 400
+    fallback_y = qr_y + qr_size + 130
+    value_x = MARGIN + 240
+    value_max_width = CARD_W - MARGIN - value_x
+
+    elements = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="4in" height="6in" viewBox="0 0 {CARD_W} {CARD_H}">',
+        f'<rect width="{CARD_W}" height="{CARD_H}" fill="#0f0f13"/>',
+        f'<text x="{MARGIN}" y="{MARGIN + 70}" fill="#a78bfa" font-size="80" font-weight="700" font-family="DejaVu Sans,Arial,sans-serif">ODS</text>',
+        f'<text x="{MARGIN}" y="{MARGIN + 140}" fill="#e4e4e7" font-size="42" font-weight="700" font-family="DejaVu Sans,Arial,sans-serif">{escape(device_name)}</text>',
+        f'<text x="{MARGIN}" y="{MARGIN + 200}" fill="#8c8c96" font-size="32" font-family="DejaVu Sans,Arial,sans-serif">{escape(tagline)}</text>',
+        _svg_qr(build_wifi_qr_payload(ssid, password, security), MARGIN, qr_y, qr_size),
+        _svg_qr(right_url, MARGIN * 2 + qr_size, qr_y, qr_size),
+        f'<text x="{MARGIN}" y="{qr_y + qr_size + 60}" fill="#a78bfa" font-size="42" font-weight="700" font-family="DejaVu Sans,Arial,sans-serif">1. JOIN WI-FI</text>',
+        f'<text x="{MARGIN * 2 + qr_size}" y="{qr_y + qr_size + 60}" fill="#a78bfa" font-size="42" font-weight="700" font-family="DejaVu Sans,Arial,sans-serif">{escape(right_caption)}</text>',
+        f'<text x="{MARGIN}" y="{fallback_y}" fill="#8c8c96" font-size="24" font-family="DejaVu Sans,Arial,sans-serif">if a QR won\'t scan:</text>',
+    ]
+
+    rows = [
+        ("network", ssid),
+        ("password", password if password else "(open)"),
+        (fallback_url_label, right_url),
+    ]
+    row_y = fallback_y + 70
+    for label, value in rows:
+        elements.append(
+            f'<text x="{MARGIN}" y="{row_y}" fill="#8c8c96" font-size="24" '
+            f'font-family="DejaVu Sans,Arial,sans-serif">{escape(label.upper())}</text>'
+        )
+        elements.append(_svg_value_text(value, value_x, row_y, value_max_width))
+        row_y += 70
+
+    footer_y = CARD_H - MARGIN - 10
+    elements.append(
+        f'<text x="{MARGIN}" y="{footer_y}" fill="#8c8c96" font-size="24" '
+        f'font-family="DejaVu Sans,Arial,sans-serif">ODS is open-source — osmantic.com</text>'
+    )
+    if serial:
+        elements.append(
+            f'<text x="{CARD_W - MARGIN}" y="{footer_y}" text-anchor="end" fill="#8c8c96" '
+            f'font-size="24" font-family="DejaVu Sans,Arial,sans-serif">{escape(serial)}</text>'
+        )
+    elements.append("</svg>")
+    return "\n".join(elements) + "\n"
 
 
 def render_card(
@@ -324,8 +447,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                         help="The mDNS name printed on the card (default ods.local)")
     parser.add_argument("--serial", default=None,
                         help="Optional serial / batch identifier printed in the footer")
-    parser.add_argument("--format", choices=["png", "pdf"], default=None,
-                        help="Output format. Defaults to PNG unless the output path ends in .pdf")
+    parser.add_argument("--format", choices=["png", "pdf", "svg"], default=None,
+                        help="Output format. Defaults from a .pdf/.svg suffix, otherwise PNG")
     parser.add_argument("--output", "-o", required=True,
                         help="Output path")
     return parser.parse_args(argv)
@@ -344,33 +467,54 @@ def main(argv: list[str] | None = None) -> int:
         print("error: --owner-url is required in factory-owner mode", file=sys.stderr)
         return 2
 
+    out_path = Path(args.output)
+    out_format = args.format or (
+        "pdf" if out_path.suffix.lower() == ".pdf"
+        else "svg" if out_path.suffix.lower() == ".svg"
+        else "png"
+    )
+
     try:
-        import PIL  # noqa: F401, PLC0415
         import qrcode  # noqa: F401, PLC0415
+        if out_format != "svg":
+            import PIL  # noqa: F401, PLC0415
     except ImportError as exc:
         print(f"error: missing dependency: {exc.name}. "
               "Install with: pip install 'qrcode[pil]'", file=sys.stderr)
         return 2
 
-    card = render_card(
-        ssid=args.ssid,
-        password=args.password,
-        setup_url=args.setup_url,
-        device_name=args.device_name,
-        security=args.security,
-        serial=args.serial,
-        mode=args.mode,
-        owner_url=args.owner_url,
-    )
-
-    out_path = Path(args.output)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_format = args.format or ("pdf" if out_path.suffix.lower() == ".pdf" else "png")
-    if out_format == "pdf":
-        card.save(out_path, format="PDF", resolution=300.0)
+    if out_format == "svg":
+        out_path.write_text(
+            render_svg_card(
+                ssid=args.ssid,
+                password=args.password,
+                setup_url=args.setup_url,
+                device_name=args.device_name,
+                security=args.security,
+                serial=args.serial,
+                mode=args.mode,
+                owner_url=args.owner_url,
+            ),
+            encoding="utf-8",
+        )
     else:
-        card.save(out_path, format="PNG", dpi=(300, 300))
-    print(f"wrote {out_path} ({CARD_W}×{CARD_H} @ 300 DPI = 4×6 inches)")
+        card = render_card(
+            ssid=args.ssid,
+            password=args.password,
+            setup_url=args.setup_url,
+            device_name=args.device_name,
+            security=args.security,
+            serial=args.serial,
+            mode=args.mode,
+            owner_url=args.owner_url,
+        )
+        if out_format == "pdf":
+            card.save(out_path, format="PDF", resolution=300.0)
+        else:
+            card.save(out_path, format="PNG", dpi=(300, 300))
+    detail = "4×6-inch vector" if out_format == "svg" else f"{CARD_W}×{CARD_H} @ 300 DPI = 4×6 inches"
+    print(f"wrote {out_path} ({detail})")
     return 0
 
 

--- a/ods/tests/test_setup_card.py
+++ b/ods/tests/test_setup_card.py
@@ -11,6 +11,7 @@ import importlib.util
 import subprocess
 import sys
 import struct
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
@@ -76,9 +77,21 @@ def _have_pillow_and_qrcode():
         return False
 
 
+def _have_qrcode():
+    try:
+        import qrcode  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
 pillow_required = pytest.mark.skipif(
     not _have_pillow_and_qrcode(),
     reason="Pillow + qrcode not installed; setup-card requires them",
+)
+qrcode_required = pytest.mark.skipif(
+    not _have_qrcode(),
+    reason="qrcode not installed; SVG setup-card requires it",
 )
 
 
@@ -146,6 +159,38 @@ def test_cli_writes_factory_owner_pdf(tmp_path):
     assert out.exists()
     with open(out, "rb") as f:
         assert f.read(4) == b"%PDF"
+
+
+@qrcode_required
+def test_cli_writes_scalable_svg_with_vector_qr_paths(tmp_path):
+    out = tmp_path / "card.svg"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--ssid", "ODS & Friends",
+            "--password", "a<secure>password",
+            "--setup-url", "http://192.168.7.1/setup?a=1&b=2",
+            "--device-name", "ods<vector>.local",
+            "--serial", "TEST&SVG",
+            "--output", str(out),
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.exists()
+    assert out.read_bytes().startswith(b'<?xml version="1.0"')
+
+    root = ET.parse(out).getroot()
+    assert root.attrib["width"] == "4in"
+    assert root.attrib["height"] == "6in"
+    assert root.attrib["viewBox"] == "0 0 1200 1800"
+    namespace = {"svg": "http://www.w3.org/2000/svg"}
+    paths = root.findall(".//svg:path", namespace)
+    assert len(paths) == 2
+    assert all(len(path.attrib["d"]) > 1000 for path in paths)
+    text = out.read_text(encoding="utf-8")
+    assert "ods&lt;vector&gt;.local" in text
+    assert "TEST&amp;SVG" in text
 
 
 @pillow_required


### PR DESCRIPTION
﻿?## Summary
- add SVG as an inferred or explicit setup-card output format
- render both QR codes as crisp vector paths with the required four-module quiet zone
- preserve the 4x6-inch card contract and fit long fallback values to the printable column
- XML-escape device credentials, URLs, and fulfillment identifiers

## Why this matters
Factory and fulfillment teams often send setup cards through vector print/cutting workflows where a 1200x1800 raster source can be resampled or softened. Native SVG keeps QR module edges sharp at any output resolution and remains editable without changing the existing PNG/PDF path.

Behavioral invariant: SVG encodes the same Wi-Fi payload, onboarding/owner URL, labels, dimensions, and physical credential text as the raster card.

## Overlap check
Searched open and closed PRs for `generate-setup-card`, `setup card SVG`, and production file `ods/scripts/generate-setup-card.py`. PR #3589 wraps long raster owner URLs; PRs #2447/#2387 make raster writes atomic; merged PR #1160 introduced PNG. None adds vector output. This implementation keeps raster rendering untouched and gives the other fixes independent value.

## Test plan
- [x] `python -m py_compile ods/scripts/generate-setup-card.py`
- [x] `python -m pytest ods/tests/test_setup_card.py -q` (17 passed)
- [x] `git diff --check`

The CLI regression test generates a real SVG, parses it as XML, checks physical dimensions/viewBox, verifies exactly two non-trivial QR paths, and proves special characters are escaped.

## Validation limits and rollback
Static tests prove SVG structure and QR matrix generation; a physical printer/scanner pass was not available, so real-media contrast and scanner behavior remain a release validation step. SVG uses generic font fallbacks rather than embedding fonts. Rollback removes SVG only; PNG/PDF behavior is unchanged.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

