### PR TITLE
feat(models): preview pre-download artifact plans

### DIFF
--- a/ods/scripts/pre-download.sh
+++ b/ods/scripts/pre-download.sh
@@ -53,6 +53,8 @@ MODEL_SIZES_GB[cluster]="40"
 # Optional components
 STT_MODEL="Systran/faster-whisper-large-v3"
 TTS_MODEL="hexgrad/Kokoro-82M"
+STT_SIZE_GB="3"
+TTS_SIZE_GB="0.2"
 
 #=============================================================================
 # Utility Functions
@@ -74,6 +76,16 @@ log() { echo -e "${BLUE}[INFO]${NC} $1"; }
 success() { echo -e "${GREEN}[OK]${NC} $1"; }
 warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+json_escape() {
+    local value="${1-}"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
 
 check_dependencies() {
     local missing=()
@@ -208,6 +220,54 @@ EOF
 #=============================================================================
 # Main Functions
 #=============================================================================
+
+plan_download() {
+    local tier="$1"
+    local include_voice="$2"
+    local json_output="$3"
+    local selection="$4"
+
+    if [[ -z "${TIER_MODELS[$tier]:-}" ]]; then
+        error "Unknown tier: $tier"
+        echo "Available tiers: nano, edge, pro, cluster" >&2
+        return 1
+    fi
+
+    local model="${TIER_MODELS[$tier]}"
+    local size="${MODEL_SIZES_GB[$tier]}"
+    local ram vram total_size
+    ram=$(detect_ram_gb)
+    vram=$(detect_vram_gb)
+    total_size="$size"
+    if [[ "$include_voice" == "true" ]]; then
+        total_size=$(awk -v llm="$size" -v stt="$STT_SIZE_GB" -v tts="$TTS_SIZE_GB" \
+            'BEGIN { printf "%.1f", llm + stt + tts }')
+    fi
+
+    if [[ "$json_output" == "true" ]]; then
+        printf '{"schema_version":"1","kind":"model-download-plan","tier":"%s",' "$(json_escape "$tier")"
+        printf '"selection":"%s","include_voice":%s,"estimated_download_gb":%s,' \
+            "$(json_escape "$selection")" "$include_voice" "$total_size"
+        printf '"hardware":{"ram_gb":%s,"vram_gb":%s},"components":[' "$ram" "$vram"
+        printf '{"kind":"llm","model":"%s","size_gb":%s}' "$(json_escape "$model")" "$size"
+        if [[ "$include_voice" == "true" ]]; then
+            printf ',{"kind":"stt","model":"%s","size_gb":%s}' "$(json_escape "$STT_MODEL")" "$STT_SIZE_GB"
+            printf ',{"kind":"tts","model":"%s","size_gb":%s}' "$(json_escape "$TTS_MODEL")" "$TTS_SIZE_GB"
+        fi
+        printf ']}\n'
+        return 0
+    fi
+
+    echo "Model pre-download plan"
+    echo "  Tier: $tier ($selection)"
+    echo "  LLM:  $model (~${size}GB)"
+    if [[ "$include_voice" == "true" ]]; then
+        echo "  STT:  $STT_MODEL (~${STT_SIZE_GB}GB)"
+        echo "  TTS:  $TTS_MODEL (~${TTS_SIZE_GB}GB)"
+    fi
+    echo "  Estimated download: ~${total_size}GB"
+    echo "  Detected hardware: ${ram}GB RAM, ${vram}GB VRAM"
+}
 
 list_models() {
     echo -e "\n${BOLD}Available Models by Tier:${NC}\n"
@@ -353,6 +413,8 @@ Usage: $0 [options]
 Options:
   --tier TIER      Download models for specific tier (nano/edge/pro/cluster)
   --with-voice     Also download STT and TTS models
+  --plan           Preview the selected artifacts without downloading
+  --json           Emit --plan as machine-readable JSON
   --list           List available models and sizes
   --verify         Check which models are already cached
   --help           Show this help message
@@ -361,6 +423,7 @@ Examples:
   $0                      # Interactive mode (auto-detect tier)
   $0 --tier pro           # Download pro tier models
   $0 --tier edge --with-voice  # Download edge tier + voice models
+  $0 --plan --tier edge --with-voice --json
   $0 --verify             # Check cache status
 EOF
 }
@@ -369,16 +432,27 @@ main() {
     local tier=""
     local include_voice="false"
     local action="interactive"
+    local plan_mode="false"
+    local json_output="false"
     
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --tier)
-                tier="$2"
+                tier="${2:-}"
+                [[ -n "$tier" ]] || { error "--tier requires a value"; exit 2; }
                 action="download"
                 shift 2
                 ;;
             --with-voice)
                 include_voice="true"
+                shift
+                ;;
+            --plan)
+                plan_mode="true"
+                shift
+                ;;
+            --json)
+                json_output="true"
                 shift
                 ;;
             --list)
@@ -400,6 +474,20 @@ main() {
                 ;;
         esac
     done
+
+    if [[ "$json_output" == "true" && "$plan_mode" != "true" ]]; then
+        error "--json requires --plan"
+        exit 2
+    fi
+
+    local selection="requested"
+    if [[ "$plan_mode" == "true" ]]; then
+        action="plan"
+        if [[ -z "$tier" ]]; then
+            tier=$(recommend_tier)
+            selection="auto"
+        fi
+    fi
     
     case "$action" in
         interactive)
@@ -418,6 +506,9 @@ main() {
             print_banner
             check_dependencies
             verify_cache
+            ;;
+        plan)
+            plan_download "$tier" "$include_voice" "$json_output" "$selection"
             ;;
     esac
 }

--- a/ods/tests/test-model-download-plan.sh
+++ b/ods/tests/test-model-download-plan.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLANNER="$ROOT_DIR/scripts/pre-download.sh"
+
+json_out="$(bash "$PLANNER" --plan --tier pro --with-voice --json)"
+JSON_REPORT="$json_out" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["schema_version"] == "1"
+assert report["kind"] == "model-download-plan"
+assert report["tier"] == "pro"
+assert report["selection"] == "requested"
+assert report["include_voice"] is True
+assert report["estimated_download_gb"] == 21.2
+assert report["components"] == [
+    {"kind": "llm", "model": "Qwen/Qwen2.5-32B-Instruct-AWQ", "size_gb": 18},
+    {"kind": "stt", "model": "Systran/faster-whisper-large-v3", "size_gb": 3},
+    {"kind": "tts", "model": "hexgrad/Kokoro-82M", "size_gb": 0.2},
+]
+assert set(report["hardware"]) == {"ram_gb", "vram_gb"}
+PY
+
+human_out="$(bash "$PLANNER" --plan --tier nano)"
+[[ "$human_out" == *"Model pre-download plan"* ]]
+[[ "$human_out" == *"Qwen/Qwen2.5-1.5B-Instruct"* ]]
+
+set +e
+error_out="$(bash "$PLANNER" --json --tier nano 2>&1)"
+status=$?
+set -e
+[[ $status -eq 2 ]]
+[[ "$error_out" == *"--json requires --plan"* ]]
+
+echo "Model download plan tests passed"


### PR DESCRIPTION
﻿?## Summary
- add non-mutating `--plan` mode to model pre-download tooling
- select an explicit tier or reuse the existing hardware recommendation
- include optional STT/TTS artifacts and estimated total transfer size
- expose the plan as stable JSON for provisioning automation

## Why this matters
Pre-download currently asks for confirmation only after selecting artifacts and preparing download dependencies. Operators on slow or metered links need an auditable artifact/size plan before network activity, and fleet provisioning needs the same decision without scraping the interactive menu.

Behavioral invariant: planning uses the exact tier/model/size tables and recommendation function used by the downloader, while never installing dependencies or calling Hugging Face.

## Overlap check
Searched open and closed PRs for `pre-download`, `pre-download JSON`, `model download plan`, and production file `ods/scripts/pre-download.sh`. PR #2585 emits offline *readiness* from `validate-models.py`; PR #2631 exposes legacy model inventory. Neither previews the artifacts this downloader will fetch, so this is an independent producer boundary.

## Test plan
- [x] `bash -n ods/scripts/pre-download.sh`
- [x] `bash ods/tests/test-model-download-plan.sh`
- [x] `bash ods/tests/test-bash32-guards.sh` (10 passed)
- [x] `git diff --check`

The boundary test invokes the real script, validates the exact pro+voice JSON artifact list and total size, checks human planning, and ensures `--json` cannot accidentally fall through to a download action.

## Tradeoffs and rollback
Sizes remain the existing documented estimates, not live registry measurements. The plan intentionally reports the current catalog unchanged. Linux/macOS hardware probes are preserved and Windows runs through WSL. Rollback removes planning without affecting downloads or cache verification.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

