### PR TITLE
feat(config): emit environment validation JSON

### DIFF
--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -25,8 +25,28 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INSTALL_DIR="${INSTALL_DIR:-$(dirname "$SCRIPT_DIR")}"
-ENV_FILE="${1:-${INSTALL_DIR}/.env}"
-SCHEMA_FILE="${2:-${INSTALL_DIR}/.env.schema.json}"
+JSON_OUTPUT=false
+POSITIONAL_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON_OUTPUT=true ;;
+    --help|-h)
+      SHOW_HELP=true
+      ;;
+    -*) echo "Unknown option: $1" >&2; exit 3 ;;
+    *) POSITIONAL_ARGS+=("$1") ;;
+  esac
+  shift
+done
+
+if (( ${#POSITIONAL_ARGS[@]} > 2 )); then
+  echo "Expected at most ENV_FILE and SCHEMA_FILE" >&2
+  exit 3
+fi
+
+ENV_FILE="${POSITIONAL_ARGS[0]:-${INSTALL_DIR}/.env}"
+SCHEMA_FILE="${POSITIONAL_ARGS[1]:-${INSTALL_DIR}/.env.schema.json}"
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -36,14 +56,32 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-log_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
-log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+VALIDATION_WARNINGS=()
+log_info() { $JSON_OUTPUT || echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { $JSON_OUTPUT || echo -e "${GREEN}[SUCCESS]${NC} $1"; }
+log_warn() { VALIDATION_WARNINGS+=("$1"); $JSON_OUTPUT || echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { $JSON_OUTPUT || echo -e "${RED}[ERROR]${NC} $1"; }
+
+json_escape() {
+  local value="${1-}"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '%s' "$value"
+}
+
+emit_input_error() {
+  printf '{"schema_version":"1","kind":"env-validation","valid":false,'
+  printf '"env_file":"%s","schema_file":"%s","error_code":"%s","message":"%s"}\n' \
+    "$(json_escape "$ENV_FILE")" "$(json_escape "$SCHEMA_FILE")" \
+    "$(json_escape "$1")" "$(json_escape "$2")"
+}
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [ENV_FILE] [SCHEMA_FILE]
+Usage: $(basename "$0") [--json] [ENV_FILE] [SCHEMA_FILE]
 
 Validates a ODS .env file against the JSON schema.
 
@@ -58,25 +96,27 @@ Tips:
 EOF
 }
 
-for arg in "$@"; do
-  case "$arg" in
-    --help|-h) usage; exit 0 ;;
-  esac
-done
+if [[ "${SHOW_HELP:-false}" == "true" ]]; then
+  usage
+  exit 0
+fi
 
 if [[ ! -f "$ENV_FILE" ]]; then
     log_error "Env file not found: $ENV_FILE"
+    $JSON_OUTPUT && emit_input_error "env_file_unreadable" "Env file not found"
     exit 3
 fi
 
 if [[ ! -f "$SCHEMA_FILE" ]]; then
     log_error "Schema file not found: $SCHEMA_FILE"
+    $JSON_OUTPUT && emit_input_error "schema_file_unreadable" "Schema file not found"
     exit 3
 fi
 
 if ! command -v jq >/dev/null 2>&1; then
     log_error "jq is required for schema validation"
     log_info "Install: sudo apt-get install -y jq  (or your distro equivalent)"
+    $JSON_OUTPUT && emit_input_error "jq_unavailable" "jq is required for schema validation"
     exit 3
 fi
 
@@ -147,7 +187,7 @@ while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
 
   # Must contain '='
   if [[ "$line" != *"="* ]]; then
-    log_warn "Ignoring line $line_no (not KEY=VALUE): $raw_line"
+    log_warn "Ignoring line $line_no (not KEY=VALUE)"
     continue
   fi
 
@@ -516,10 +556,92 @@ esac
 # Reporting
 # -----------------------------
 
+for key in "${!ENV_DUPLICATE_FROM[@]}"; do
+  from_to="${ENV_DUPLICATE_FROM[$key]}"
+  duplicate_errors+=("$key: duplicate assignment at lines $from_to")
+done
+
+secret_count=$(jq_raw '.properties | to_entries[] | select(.value.secret==true) | .key' "$SCHEMA_FILE" | wc -l | tr -d ' ')
+total_errors=$((
+  ${#missing[@]} + ${#unknown[@]} + ${#type_errors[@]} +
+  ${#enum_errors[@]} + ${#range_errors[@]} + ${#length_errors[@]} +
+  ${#contract_errors[@]} + ${#duplicate_errors[@]}
+))
+
 had_errors=false
+if (( total_errors > 0 )); then
+  had_errors=true
+fi
+
+array_json() {
+  if (( $# == 0 )); then
+    printf '[]'
+    return
+  fi
+  printf '%s\0' "$@" | jq -Rs 'split("\u0000")[:-1]'
+}
+
+emit_validation_json() {
+  local valid_json=false error_code="validation_failed"
+  if [[ "$had_errors" == "false" ]]; then
+    valid_json=true
+    error_code=""
+  fi
+  jq -n \
+    --arg env_file "$ENV_FILE" \
+    --arg schema_file "$SCHEMA_FILE" \
+    --arg error_code "$error_code" \
+    --argjson valid "$valid_json" \
+    --argjson missing "$(array_json "${missing[@]}")" \
+    --argjson unknown "$(array_json "${unknown[@]}")" \
+    --argjson type_errors "$(array_json "${type_errors[@]}")" \
+    --argjson enum_errors "$(array_json "${enum_errors[@]}")" \
+    --argjson range_errors "$(array_json "${range_errors[@]}")" \
+    --argjson length_errors "$(array_json "${length_errors[@]}")" \
+    --argjson contract_errors "$(array_json "${contract_errors[@]}")" \
+    --argjson duplicate_errors "$(array_json "${duplicate_errors[@]}")" \
+    --argjson warnings "$(array_json "${VALIDATION_WARNINGS[@]}")" \
+    --argjson env_keys "${#ENV_MAP[@]}" \
+    --argjson schema_keys "${#schema_keys[@]}" \
+    --argjson required_keys "${#required_keys[@]}" \
+    --argjson secret_keys "${secret_count:-0}" \
+    --argjson total_errors "$total_errors" \
+    '{
+      schema_version: "1",
+      kind: "env-validation",
+      valid: $valid,
+      env_file: $env_file,
+      schema_file: $schema_file,
+      error_code: $error_code,
+      errors: {
+        missing_required: $missing,
+        unknown_keys: $unknown,
+        type: $type_errors,
+        enum: $enum_errors,
+        range: $range_errors,
+        length: $length_errors,
+        runtime_contract: $contract_errors,
+        duplicate: $duplicate_errors
+      },
+      warnings: $warnings,
+      summary: {
+        env_keys: $env_keys,
+        schema_keys: $schema_keys,
+        required_keys: $required_keys,
+        secret_keys: $secret_keys,
+        total_errors: $total_errors,
+        total_warnings: ($warnings | length)
+      }
+    }'
+}
+
+if $JSON_OUTPUT; then
+  emit_validation_json
+  [[ "$had_errors" == "false" ]] && exit 0
+  exit 2
+fi
 
 if (( ${#missing[@]} > 0 )); then
-    had_errors=true
     log_error "Missing required keys:"
     for key in "${missing[@]}"; do
         echo "  - $key"
@@ -527,7 +649,6 @@ if (( ${#missing[@]} > 0 )); then
 fi
 
 if (( ${#unknown[@]} > 0 )); then
-    had_errors=true
     log_error "Unknown keys not defined in schema:"
     for key in "${unknown[@]}"; do
         echo "  - $key (line ${ENV_LINE[$key]:-?})"
@@ -535,7 +656,6 @@ if (( ${#unknown[@]} > 0 )); then
 fi
 
 if (( ${#type_errors[@]} > 0 )); then
-    had_errors=true
     log_error "Type validation errors:"
     for err in "${type_errors[@]}"; do
         echo "  - $err"
@@ -543,7 +663,6 @@ if (( ${#type_errors[@]} > 0 )); then
 fi
 
 if (( ${#enum_errors[@]} > 0 )); then
-    had_errors=true
     log_error "Enum validation errors:"
     for err in "${enum_errors[@]}"; do
         echo "  - $err"
@@ -551,7 +670,6 @@ if (( ${#enum_errors[@]} > 0 )); then
 fi
 
 if (( ${#range_errors[@]} > 0 )); then
-    had_errors=true
     log_error "Range validation errors:"
     for err in "${range_errors[@]}"; do
         echo "  - $err"
@@ -559,7 +677,6 @@ if (( ${#range_errors[@]} > 0 )); then
 fi
 
 if (( ${#length_errors[@]} > 0 )); then
-    had_errors=true
     log_error "Length validation errors (replace placeholder/default values):"
     for err in "${length_errors[@]}"; do
         echo "  - $err"
@@ -567,20 +684,13 @@ if (( ${#length_errors[@]} > 0 )); then
 fi
 
 if (( ${#contract_errors[@]} > 0 )); then
-    had_errors=true
     log_error "Runtime contract validation errors:"
     for err in "${contract_errors[@]}"; do
         echo "  - $err"
     done
 fi
 
-for key in "${!ENV_DUPLICATE_FROM[@]}"; do
-  from_to="${ENV_DUPLICATE_FROM[$key]}"
-  duplicate_errors+=("$key: duplicate assignment at lines $from_to")
-done
-
 if (( ${#duplicate_errors[@]} > 0 )); then
-    had_errors=true
     log_error "Duplicate key errors:"
     for err in "${duplicate_errors[@]}"; do
         echo "  - $err"
@@ -602,7 +712,6 @@ log_info "Keys in schema: ${#schema_keys[@]}"
 log_info "Required keys: ${#required_keys[@]}"
 
 # Optional: print helpful summary of secrets (without values)
-secret_count=$(jq_raw '.properties | to_entries[] | select(.value.secret==true) | .key' "$SCHEMA_FILE" | wc -l | tr -d ' ')
 if [[ "$secret_count" =~ ^[0-9]+$ ]] && (( secret_count > 0 )); then
   log_info "Schema marks ${secret_count} key(s) as secrets (values not printed)."
 fi

--- a/ods/tests/test-validate-env-json.sh
+++ b/ods/tests/test-validate-env-json.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATOR="$ROOT_DIR/scripts/validate-env.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-env-json.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cat > "$FIXTURE/schema.json" <<'JSON'
+{
+  "type": "object",
+  "required": ["SECRET", "COUNT", "MISSING"],
+  "properties": {
+    "SECRET": {"type": "string", "minLength": 3, "secret": true},
+    "COUNT": {"type": "integer"},
+    "MISSING": {"type": "string"}
+  }
+}
+JSON
+
+cat > "$FIXTURE/invalid.env" <<'ENV'
+SECRET=first-secret-value
+COUNT=not-a-number
+EXTRA=value
+SECRET=second-secret-value
+ENV
+
+set +e
+invalid_json="$(bash "$VALIDATOR" --json "$FIXTURE/invalid.env" "$FIXTURE/schema.json")"
+invalid_status=$?
+set -e
+[[ $invalid_status -eq 2 ]]
+[[ "$invalid_json" != *"first-secret-value"* ]]
+[[ "$invalid_json" != *"second-secret-value"* ]]
+JSON_REPORT="$invalid_json" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["schema_version"] == "1"
+assert report["kind"] == "env-validation"
+assert report["valid"] is False
+assert report["error_code"] == "validation_failed"
+assert report["errors"]["missing_required"] == ["MISSING"]
+assert report["errors"]["unknown_keys"] == ["EXTRA"]
+assert len(report["errors"]["type"]) == 1
+assert "COUNT" in report["errors"]["type"][0]
+assert len(report["errors"]["duplicate"]) == 1
+assert "SECRET" in report["errors"]["duplicate"][0]
+assert report["summary"] == {
+    "env_keys": 3,
+    "schema_keys": 3,
+    "required_keys": 3,
+    "secret_keys": 1,
+    "total_errors": 4,
+    "total_warnings": 0,
+}
+PY
+
+cat > "$FIXTURE/valid.env" <<'ENV'
+SECRET=valid-secret-value
+COUNT=7
+MISSING=present
+ENV
+valid_json="$(bash "$VALIDATOR" "$FIXTURE/valid.env" --json "$FIXTURE/schema.json")"
+JSON_REPORT="$valid_json" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["valid"] is True
+assert report["error_code"] == ""
+assert report["summary"]["total_errors"] == 0
+assert all(not values for values in report["errors"].values())
+PY
+
+set +e
+missing_json="$(bash "$VALIDATOR" --json "$FIXTURE/no.env" "$FIXTURE/schema.json")"
+missing_status=$?
+set -e
+[[ $missing_status -eq 3 ]]
+JSON_REPORT="$missing_json" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["valid"] is False
+assert report["error_code"] == "env_file_unreadable"
+PY
+
+echo "Environment validation JSON tests passed"


### PR DESCRIPTION
﻿?## Summary
- add order-independent `--json` to the shipped environment-schema validator
- categorize missing, unknown, type, enum, range, length, contract, and duplicate errors
- include stable counts and prerequisite error codes while preserving exit 0/2/3
- keep secret values out of the report and remove raw malformed-line content from warnings

## Why this matters
`validate-env.sh` gates generated installer configuration and is also an operator/CI boundary, but consumers currently have to scrape headings and bullets. Structured results let provisioning and release tooling identify the exact contract class that failed while retaining the validator's deterministic status codes.

Behavioral invariant: JSON and human modes run the same parsing, schema, and cross-service checks; no `.env` value marked secret is emitted.

## Overlap check
Searched open and closed PRs for `validate-env`, `validate env JSON`, and production file `ods/scripts/validate-env.sh`. PR #2197 expands schema/Compose parity and PR #2910 explains effective-value provenance. Neither exports validation outcomes. This PR changes no schema rule and remains independently useful with both.

## Test plan
- [x] `bash -n ods/scripts/validate-env.sh`
- [x] `bash ods/tests/test-validate-env-json.sh`
- [x] `bash ods/tests/test-validate-env.sh` (45 passed)
- [x] `git diff --check`

The regression fixture validates success, all major error categories, duplicate assignments, missing input status 3, argument-order independence, exact summary counts, valid JSON parsing, and absence of both fixture secret values.

## Security, portability, and rollback
JSON construction uses the validator's existing jq dependency and transmits arrays with NUL delimiters, avoiding shell re-parsing. Prerequisite failures have a Bash-only minimal receipt even when jq is missing. Linux/macOS/Homebrew Bash and Windows/WSL share the path. Rollback restores prose output without changing validation rules.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

