### PR TITLE
feat(cold-storage): export model placement inventory

### DIFF
--- a/ods/README.md
+++ b/ods/README.md
@@ -424,7 +424,8 @@ ods start                      # Start everything
 
 # Management scripts
 ./scripts/session-cleanup.sh             # Clean up bloated agent sessions
-./scripts/llm-cold-storage.sh --status   # Check model hot/cold storage
+./scripts/llm-cold-storage.sh --status          # Check model hot/cold storage
+./scripts/llm-cold-storage.sh --status --json   # Export model placement inventory
 ods mode                               # Show current mode
 ```
 

--- a/ods/scripts/llm-cold-storage.sh
+++ b/ods/scripts/llm-cold-storage.sh
@@ -14,6 +14,7 @@
 #   ./llm-cold-storage.sh --restore <name> # Restore a specific model
 #   ./llm-cold-storage.sh --restore-all    # Restore all archived models
 #   ./llm-cold-storage.sh --status         # Show archive status
+#   ./llm-cold-storage.sh --status --json  # Machine-readable inventory
 #
 set -uo pipefail
 
@@ -224,30 +225,143 @@ show_status() {
     echo "Cold storage total: $(du -sh "$COLD_DIR" 2>/dev/null | cut -f1)"
 }
 
-case "${1:-}" in
-    --execute)
+json_escape() {
+    local value="${1-}"
+    value=${value//\\/\\\\}
+    value=${value//\"/\\\"}
+    value=${value//$'\n'/\\n}
+    value=${value//$'\r'/\\r}
+    value=${value//$'\t'/\\t}
+    printf '%s' "$value"
+}
+
+du_size() {
+    local path="$1" output
+    if [[ ! -e "$path" ]]; then
+        printf '0'
+        return 0
+    fi
+    if ! output=$(du -sh "$path" 2>&1); then
+        echo "ERROR: could not measure $path: $output" >&2
+        return 1
+    fi
+    printf '%s' "${output%%$'\t'*}"
+}
+
+show_status_json() {
+    local hot=0 cold_links=0 cold=0 comma="" model_dir cold_model
+    local cache_total cold_total
+    cache_total="$(du_size "$HF_CACHE")" || return 1
+    cold_total="$(du_size "$COLD_DIR")" || return 1
+
+    printf '{"schema_version":"1","kind":"llm-cold-storage-status",'
+    printf '"paths":{"cache":"%s","cold_storage":"%s"},"models":[' \
+        "$(json_escape "$HF_CACHE")" "$(json_escape "$COLD_DIR")"
+
+    for model_dir in "$HF_CACHE"/models--*/; do
+        [[ -d "$model_dir" ]] || continue
+        local name size state idle_json protected=false in_use=false
+        name="$(basename "$model_dir")"
+        size="$(du_size "$model_dir")" || return 1
+        if [[ -L "${model_dir%/}" ]]; then
+            state="cold_link"
+            idle_json="null"
+            cold_links=$((cold_links + 1))
+        else
+            state="hot"
+            idle_json="$(get_last_access_days "$model_dir")"
+            is_protected "$name" && protected=true
+            is_model_in_use "$name" && in_use=true
+            hot=$((hot + 1))
+        fi
+        printf '%s{"name":"%s","state":"%s","size":"%s","idle_days":%s,' \
+            "$comma" "$(json_escape "$name")" "$state" "$(json_escape "$size")" "$idle_json"
+        printf '"protected":%s,"in_use":%s,"path":"%s"}' \
+            "$protected" "$in_use" "$(json_escape "${model_dir%/}")"
+        comma=","
+    done
+
+    for cold_model in "$COLD_DIR"/models--*/; do
+        [[ -d "$cold_model" ]] || continue
+        local name size
+        name="$(basename "$cold_model")"
+        size="$(du_size "$cold_model")" || return 1
+        printf '%s{"name":"%s","state":"cold","size":"%s","idle_days":null,' \
+            "$comma" "$(json_escape "$name")" "$(json_escape "$size")"
+        printf '"protected":false,"in_use":false,"path":"%s"}' \
+            "$(json_escape "${cold_model%/}")"
+        comma=","
+        cold=$((cold + 1))
+    done
+
+    printf '],"summary":{"hot":%d,"cold_links":%d,"cold":%d,' "$hot" "$cold_links" "$cold"
+    printf '"cache_size":"%s","cold_storage_size":"%s"}}\n' \
+        "$(json_escape "$cache_total")" "$(json_escape "$cold_total")"
+}
+
+ACTION=""
+RESTORE_NAME=""
+JSON_OUTPUT=false
+
+select_action() {
+    if [[ -n "$ACTION" && "$ACTION" != "$1" ]]; then
+        echo "ERROR: choose exactly one cold-storage action" >&2
+        exit 2
+    fi
+    ACTION="$1"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --execute) select_action "execute"; shift ;;
+        --restore)
+            select_action "restore"
+            RESTORE_NAME="${2:-}"
+            [[ -n "$RESTORE_NAME" ]] || { echo "Usage: $0 --restore <model-name>" >&2; exit 2; }
+            shift 2
+            ;;
+        --restore-all) select_action "restore_all"; shift ;;
+        --status) select_action "status"; shift ;;
+        --json) JSON_OUTPUT=true; shift ;;
+        --help|-h) select_action "help"; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -n "$ACTION" ]] || ACTION="dry_run"
+if [[ "$JSON_OUTPUT" == "true" && "$ACTION" != "status" ]]; then
+    echo "ERROR: --json is supported only with --status" >&2
+    exit 2
+fi
+
+case "$ACTION" in
+    execute)
         do_archive false
         ;;
-    --restore)
-        [[ -n "${2:-}" ]] || { echo "Usage: $0 --restore <model-name>"; exit 1; }
-        do_restore "$2"
+    restore)
+        do_restore "$RESTORE_NAME"
         ;;
-    --restore-all)
+    restore_all)
         do_restore_all
         ;;
-    --status)
-        show_status
+    status)
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            show_status_json
+        else
+            show_status
+        fi
         ;;
-    --help|-h)
-        echo "Usage: $0 [--execute|--restore <name>|--restore-all|--status|--help]"
+    help)
+        echo "Usage: $0 [--execute|--restore <name>|--restore-all|--status [--json]|--help]"
         echo ""
         echo "  (no args)            Dry-run: show what would be archived"
         echo "  --execute            Archive idle models (>$MAX_IDLE_DAYS days)"
         echo "  --restore <name>     Restore model from cold storage"
         echo "  --restore-all        Restore all archived models"
         echo "  --status             Show current hot/cold status"
+        echo "  --status --json      Emit machine-readable hot/cold inventory"
         ;;
-    *)
+    dry_run)
         do_archive true
         ;;
 esac

--- a/ods/tests/test-llm-cold-storage-json.sh
+++ b/ods/tests/test-llm-cold-storage-json.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOOL="$ROOT_DIR/scripts/llm-cold-storage.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-cold-status.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cache="$FIXTURE/cache"
+cold="$FIXTURE/cold"
+mkdir -p "$cache/models--Example--Hot" "$cold/models--Example--Archived"
+printf 'hot\n' > "$cache/models--Example--Hot/weights.gguf"
+printf 'cold\n' > "$cold/models--Example--Archived/weights.gguf"
+ln -s "$cold/models--Example--Archived" "$cache/models--Example--Archived"
+
+json_out="$(
+    HF_CACHE="$cache" COLD_DIR="$cold" LOG_FILE="$FIXTURE/tool.log" \
+        bash "$TOOL" --json --status
+)"
+JSON_REPORT="$json_out" CACHE_PATH="$cache" COLD_PATH="$cold" python3 - <<'PY'
+import json
+import os
+
+report = json.loads(os.environ["JSON_REPORT"])
+assert report["schema_version"] == "1"
+assert report["kind"] == "llm-cold-storage-status"
+assert report["paths"] == {
+    "cache": os.environ["CACHE_PATH"],
+    "cold_storage": os.environ["COLD_PATH"],
+}
+assert report["summary"]["hot"] == 1
+assert report["summary"]["cold_links"] == 1
+assert report["summary"]["cold"] == 1
+states = {(item["name"], item["state"]) for item in report["models"]}
+assert states == {
+    ("models--Example--Hot", "hot"),
+    ("models--Example--Archived", "cold_link"),
+    ("models--Example--Archived", "cold"),
+}
+hot = next(item for item in report["models"] if item["state"] == "hot")
+assert isinstance(hot["idle_days"], int)
+assert hot["protected"] is False
+assert hot["in_use"] is False
+PY
+
+set +e
+error_out="$(HF_CACHE="$cache" COLD_DIR="$cold" LOG_FILE="$FIXTURE/tool.log" bash "$TOOL" --json 2>&1)"
+status=$?
+set -e
+[[ $status -eq 2 ]]
+[[ "$error_out" == *"supported only with --status"* ]]
+
+echo "LLM cold-storage JSON tests passed"


### PR DESCRIPTION
﻿?## Summary
- add order-independent `--status --json` to LLM cold-storage tooling
- inventory hot directories, cold-storage symlinks, and archived physical copies
- report idle days, protection/in-use flags, paths, totals, and human-readable sizes
- replace the single-position command switch with validated mutually-exclusive actions

## Why this matters
Operators need to know which model artifacts occupy NVMe versus backup storage before capacity planning, moving disks, or restoring a model. The existing prose status is useful interactively but cannot feed dashboards, fleet inventory, or support evidence reliably.

Behavioral invariant: JSON status is read-only and classifies the same cache/cold directories, protected models, process usage, and access age as the human status path.

## Overlap check
Searched open and closed PRs for `llm-cold-storage`, `cold storage JSON`, and production file `ods/scripts/llm-cold-storage.sh`. PR #2627 configures retention age, #3638 adds a maximum storage limit, and #2365 repairs archive destination creation. None exports status. This PR does not change archive/restore policy and preserves each PR's independent advantage.

## Test plan
- [x] `bash -n ods/scripts/llm-cold-storage.sh`
- [x] `bash ods/tests/test-llm-cold-storage-json.sh`
- [x] `git diff --check`
- [ ] `bats ods/tests/bats-tests/macos-bsd-compat.bats` (BATS unavailable locally; CI remains the macOS contract gate)

The boundary fixture creates a hot model, archived model, and cache symlink; it parses the real status JSON, verifies the three physical/logical states and summary, and checks that JSON cannot select a mutating default action.

## Tradeoffs, portability, and rollback
Sizes remain human-readable `du` values rather than byte counts to preserve parity with the existing command. Linux and macOS retain their respective access-time probes; Windows uses WSL. No live archive/restore was performed. Rollback restores positional command parsing and prose-only status without moving data.

Generated with Codex

## Batch compatibility

This PR is independently mergeable. For the September feature batch, the tested order is #3647 ? #3656. All ten heads cherry-picked without conflict onto `upstream/main@6ff9b4fc`; the resulting synthetic integration head was `17e0791c`.

Combined validation: all focused boundary suites passed, `make lint` passed, and every GitHub Actions check on all ten PRs passed. `make test` reaches the pre-existing `Hermes template bounds each model turn` failure; the same command/failure was reproduced on a clean `upstream/main@6ff9b4fc` worktree. No live hardware, physical-print, archive/restore, or deployment claim is inferred from static/simulated validation.

