### PR TITLE
feat(mode): emit routing status as JSON

### DIFF
--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -2,7 +2,7 @@
 # ============================================================================
 # ODS Mode Switch
 # ============================================================================
-# Usage: ./mode-switch.sh <local|cloud|hybrid> [--status]
+# Usage: ./mode-switch.sh <local|cloud|hybrid> | --status [--json]
 #
 # Switches ODS between local/cloud/hybrid modes by updating .env.
 # This is the backend for `ods mode <mode>`.
@@ -39,16 +39,34 @@ env_set() {
 }
 
 show_status() {
+    local json_output="${1:-false}"
     local current=""
+    local source="default"
     if [[ -f "$ENV_FILE" ]]; then
         # `grep` exits 1 when the key is absent and the script runs under
         # `set -euo pipefail`, so a bare pipeline here aborted the whole script
         # before the default below could apply — status printed nothing at all.
         current=$(grep -m1 "^ODS_MODE=" "$ENV_FILE" | cut -d= -f2- | tr -d '"\047\r' || true)
+        [[ -n "$current" ]] && source="configured"
     else
-        warn ".env not found at $ENV_FILE — showing defaults"
+        [[ "$json_output" == "true" ]] || warn ".env not found at $ENV_FILE — showing defaults"
     fi
-    echo "Current mode: ${current:-local}"
+
+    current="${current:-local}"
+    if [[ "$json_output" == "true" ]]; then
+        MODE_STATUS="$current" MODE_SOURCE="$source" MODE_ENV_FILE="$ENV_FILE" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "mode": os.environ["MODE_STATUS"],
+    "source": os.environ["MODE_SOURCE"],
+    "env_file": os.environ["MODE_ENV_FILE"],
+}, separators=(",", ":")))
+PY
+        return
+    fi
+    echo "Current mode: $current"
     echo ""
     echo "Available modes:"
     echo "  local   — Local inference via llama-server (requires GPU/CPU)"
@@ -96,9 +114,15 @@ switch_mode() {
 # Called directly or sourced
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     case "${1:---status}" in
-        --status|-s|status) show_status ;;
+        --status|-s|status)
+            case "${2:-}" in
+                "") show_status ;;
+                --json) show_status true ;;
+                *) error "Unknown status option: $2. Use: --json" ;;
+            esac
+            ;;
         --help|-h|help)
-            echo "Usage: mode-switch.sh <local|cloud|hybrid|--status>"
+            echo "Usage: mode-switch.sh <local|cloud|hybrid|--status [--json]>"
             ;;
         *) switch_mode "${1:-}" ;;
     esac

--- a/ods/tests/test-mode-switch-status.sh
+++ b/ods/tests/test-mode-switch-status.sh
@@ -37,6 +37,11 @@ check_contains() {
     fi
 }
 
+json_field() {
+    local field="$1"
+    python3 -c 'import json,sys; print(json.load(sys.stdin)[sys.argv[1]])' "$field"
+}
+
 WORKDIR="$(mktemp -d)"
 trap 'rm -rf "$WORKDIR"' EXIT
 
@@ -99,6 +104,21 @@ check_eq "quoted mode is reported unquoted" "Current mode: hybrid" "$(current_mo
 ROOT="$(new_root)"
 printf 'ODS_MODE=cloud\r\n' > "$ROOT/.env"
 check_eq "CRLF .env does not leak a carriage return" "Current mode: cloud" "$(current_mode_line "$(run_mode "$ROOT" --status)")"
+
+# ── 4. Machine-readable status ──────────────────────────────────────────────
+
+ROOT="$(new_root)"
+printf 'ODS_MODE=hybrid\n' > "$ROOT/.env"
+OUT="$(run_mode "$ROOT" --status --json)"
+check_eq "JSON status exits 0" "0" "$(run_rc "$ROOT" --status --json)"
+check_eq "JSON status reports configured mode" "hybrid" "$(json_field mode <<< "$OUT")"
+check_eq "JSON status identifies configured source" "configured" "$(json_field source <<< "$OUT")"
+
+ROOT="$(new_root)"
+OUT="$(run_mode "$ROOT" --status --json)"
+check_eq "JSON status remains standalone without .env" "local" "$(json_field mode <<< "$OUT")"
+check_eq "JSON status identifies default source" "default" "$(json_field source <<< "$OUT")"
+check_eq "unknown JSON status option is rejected" "1" "$(run_rc "$ROOT" --status --yaml)"
 
 # ── 4. Bare invocation defaults to status ─────────────────────────────────
 


### PR DESCRIPTION
## Summary
- add `mode-switch.sh --status --json` for a stable routing-mode receipt
- distinguish configured values from the local default and include the resolved env path
- preserve the existing human-readable status and switching behavior
- reject unsupported status-output options

## Why this matters
`mode-switch.sh --status` is the documented read-only backend used before changing local, cloud, or hybrid routing. Automation can now determine the active source of truth without scraping colored prose or mutating `.env`.

## Overlap check
Searched open and closed PRs for `mode status json` and PRs referencing `ods/scripts/mode-switch.sh`. Open PR #2626 adds switch previews, while #2616/#2767/#2864/#3076 change atomic writes; none adds a machine-readable status boundary. This PR changes only status reporting and its regression test.

## Test plan
- [x] `bash ods/tests/test-mode-switch-status.sh` (26 assertions)
- [x] `bash -n ods/scripts/mode-switch.sh`
- [x] `git diff --check -- ods/scripts/mode-switch.sh ods/tests/test-mode-switch-status.sh`

## Tradeoffs and rollback
JSON mode uses the Python runtime already required by ODS to guarantee correct escaping. Removing the new optional flag fully restores the prior interface; switching semantics and `.env` writes are unchanged.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.