### PR TITLE
feat(migrations): emit pending plans as JSON

### DIFF
--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -165,14 +165,18 @@ cmd_diff() {
 
 # Check if migration is needed
 cmd_check() {
+    local output_format="${1:-human}"
     local current_version
     local last_migrated
+    local pending_json='[]'
     
     current_version=$(get_current_version)
     last_migrated=$(get_last_migrated_version)
     
-    log_info "Current version: $current_version"
-    log_info "Last migrated: $last_migrated"
+    if [[ "$output_format" == "human" ]]; then
+        log_info "Current version: $current_version"
+        log_info "Last migrated: $last_migrated"
+    fi
     
     # compare_versions returns a non-zero *ordering* status, so capture it with
     # `|| result=$?`. A bare call would trip `set -e` and abort before $? is
@@ -183,27 +187,53 @@ cmd_check() {
     compare_versions "$current_version" "$last_migrated" || result=$?
 
     if [[ $result -eq 1 ]]; then
-        log_warn "Migration needed: $last_migrated → $current_version"
+        [[ "$output_format" == "human" ]] && log_warn "Migration needed: $last_migrated → $current_version"
         
         # List pending migrations
-        echo ""
-        echo "Pending migrations:"
+        if [[ "$output_format" == "human" ]]; then
+            echo ""
+            echo "Pending migrations:"
+        fi
         for migration in "$MIGRATIONS_DIR"/migrate-v*.sh; do
             if [[ -f "$migration" ]]; then
-                local migration_version
+                local migration_version description
                 migration_version=$(basename "$migration" | sed 's/migrate-v//;s/.sh//')
                 
                 local mig_cmp=0
                 compare_versions "$migration_version" "$last_migrated" || mig_cmp=$?
                 if [[ $mig_cmp -eq 1 ]]; then
-                    echo "  - $migration_version: $(head -5 "$migration" | grep '^# Description:' | sed 's/# Description://')"
+                    description=$(awk '/^# Description:/ {sub(/^# Description:[[:space:]]*/, ""); print; exit}' "$migration")
+                    if [[ "$output_format" == "json" ]]; then
+                        pending_json=$(jq -c \
+                            --arg version "$migration_version" \
+                            --arg description "$description" \
+                            '. + [{version: $version, description: $description}]' \
+                            <<< "$pending_json")
+                    else
+                        echo "  - $migration_version: $description"
+                    fi
                 fi
             fi
         done
+
+        if [[ "$output_format" == "json" ]]; then
+            jq -cn \
+                --arg current_version "$current_version" \
+                --arg last_migrated "$last_migrated" \
+                --argjson pending_migrations "$pending_json" \
+                '{migration_needed: true, current_version: $current_version, last_migrated: $last_migrated, pending_migrations: $pending_migrations}'
+        fi
         
         return 2
     else
-        log_success "No migration needed (already at $current_version)"
+        if [[ "$output_format" == "json" ]]; then
+            jq -cn \
+                --arg current_version "$current_version" \
+                --arg last_migrated "$last_migrated" \
+                '{migration_needed: false, current_version: $current_version, last_migrated: $last_migrated, pending_migrations: []}'
+        else
+            log_success "No migration needed (already at $current_version)"
+        fi
         return 0
     fi
 }
@@ -303,7 +333,8 @@ ODS Config Migration Manager
 Usage: ./migrate-config.sh [command]
 
 Commands:
-  check       Check if migration is needed
+  check [--json]
+              Check if migration is needed; optionally emit a JSON plan
   migrate     Run pending migrations (with backup)
   diff        Show configuration differences
   backup      Backup current configuration
@@ -311,7 +342,7 @@ Commands:
   help        Show this help message
 
 Examples:
-  ./migrate-config.sh check
+  ./migrate-config.sh check --json
   ./migrate-config.sh migrate
   ./migrate-config.sh diff
   ./migrate-config.sh validate
@@ -325,7 +356,14 @@ EOF
 # Main
 case "${1:-help}" in
     check)
-        cmd_check
+        case "${2:-}" in
+            "") cmd_check ;;
+            --json)
+                command -v jq >/dev/null 2>&1 || { log_error "jq is required for --json"; exit 1; }
+                cmd_check json
+                ;;
+            *) log_error "Unknown check option: $2"; exit 1 ;;
+        esac
         ;;
     migrate)
         cmd_migrate

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -227,6 +227,16 @@ else
     fail "Behavioral test: check missed pending migration (exit $check_exit): $check_output"
 fi
 
+json_exit=0
+json_output=$(bash "$MIGRATE_CONFIG_SCRIPT" check --json) || json_exit=$?
+json_needed=$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["migration_needed"]).lower())' <<< "$json_output")
+json_pending=$(python3 -c 'import json,sys; print(len(json.load(sys.stdin)["pending_migrations"]))' <<< "$json_output")
+if [[ $json_exit -eq 2 && "$json_needed" == "true" && "$json_pending" -ge 1 ]]; then
+    pass "Behavioral test: JSON check reports the pending migration plan"
+else
+    fail "Behavioral test: JSON pending plan is invalid" "exit $json_exit: $json_output"
+fi
+
 # Test 12: with last-migrated equal to current, no migration is reported.
 echo "2.4.1" > "$DATA_DIR/.migration-state"
 check_exit=0
@@ -235,6 +245,15 @@ if [[ $check_exit -eq 0 ]] && echo "$check_output" | grep -q "No migration neede
     pass "Behavioral test: check reports up-to-date when versions match"
 else
     fail "Behavioral test: check misreported up-to-date state (exit $check_exit): $check_output"
+fi
+
+json_exit=0
+json_output=$(bash "$MIGRATE_CONFIG_SCRIPT" check --json) || json_exit=$?
+json_needed=$(python3 -c 'import json,sys; print(str(json.load(sys.stdin)["migration_needed"]).lower())' <<< "$json_output")
+if [[ $json_exit -eq 0 && "$json_needed" == "false" ]]; then
+    pass "Behavioral test: JSON check reports an up-to-date installation"
+else
+    fail "Behavioral test: JSON current plan is invalid" "exit $json_exit: $json_output"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- add `migrate-config.sh check --json` with current and last-migrated versions
- include ordered pending migration versions and descriptions
- preserve exit code 2 when a migration is required and exit 0 when current
- keep existing human output unchanged

## Why this matters
Upgrade orchestration already calls the read-only migration check before applying configuration changes. A structured plan lets installers and fleet tooling display exactly what is pending without scraping ANSI-formatted output or performing a backup/mutation.

## Overlap check
Searched open and closed PRs for `migration check json` and PRs referencing `ods/scripts/migrate-config.sh`. Open PRs #3548/#2830/#3533/#2449/#2393/#2954/#2478/#3382/#3075/#1949 address quoting, semver, backup, or atomic state writes; none exposes a JSON check plan. This PR does not change migration execution or persistence.

## Test plan
- [x] `bash ods/tests/test-migrate-config.sh` (16 checks)
- [x] `bash -n ods/scripts/migrate-config.sh`
- [x] `git diff --check -- ods/scripts/migrate-config.sh ods/tests/test-migrate-config.sh`

## Tradeoffs and rollback
The JSON option requires `jq`, which is already used by version parsing in this tool. Removing the optional reporting branch restores the previous CLI; migration selection and exit-code semantics remain intact.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.