### PR TITLE
feat(models): preview legacy model upgrades

### DIFF
--- a/ods/scripts/upgrade-model.sh
+++ b/ods/scripts/upgrade-model.sh
@@ -12,6 +12,7 @@
 #   ./upgrade-model.sh --rollback            # Rollback to previous model
 #   ./upgrade-model.sh --list                # List available models
 #   ./upgrade-model.sh --current             # Show current model
+#   ./upgrade-model.sh --dry-run <model>     # Preview without changing state
 #
 #=============================================================================
 
@@ -428,6 +429,42 @@ cmd_current() {
     fi
 }
 
+cmd_preview() {
+    local new_model="$1"
+    local model_path="$MODELS_DIR/$new_model"
+
+    if [[ ! -d "$model_path" || ! -f "$model_path/config.json" ]]; then
+        if [[ -d "$new_model" && -f "$new_model/config.json" ]]; then
+            model_path="$new_model"
+            new_model=$(basename "$new_model")
+        else
+            echo "[ERROR] Model not found: $new_model" >&2
+            return 1
+        fi
+    fi
+
+    local current_model
+    current_model=$(get_current_model)
+
+    echo "Model upgrade preview (no changes will be made)"
+    echo "  Current model: ${current_model:-<none>}"
+    echo "  Target model:  $new_model"
+    echo "  Model path:    $model_path"
+    if [[ "$current_model" == "$new_model" ]]; then
+        echo "  Action:        none (target is already active)"
+        return 0
+    fi
+
+    cat <<EOF
+  Lifecycle:
+    1. Stop llama-server
+    2. Save current/previous model state
+    3. Set LLM_MODEL=$model_path in $ODS_DIR/.env
+    4. Start llama-server
+    5. Verify health and inference; roll back on failure
+EOF
+}
+
 cmd_upgrade() {
     local new_model="$1"
     
@@ -546,12 +583,17 @@ main() {
         --rollback|-r)
             cmd_rollback
             ;;
+        --dry-run)
+            [[ $# -eq 2 ]] || { echo "Usage: $0 --dry-run <model-name>" >&2; exit 2; }
+            cmd_preview "$2"
+            ;;
         --help|-h)
             cat << EOF
 ODS Model Upgrade
 
 Usage:
   $0 <model-name>        Upgrade to specified model
+  $0 --dry-run <model>   Preview the upgrade lifecycle without changes
   $0 --list              List available models
   $0 --current           Show current model
   $0 --rollback          Rollback to previous model
@@ -564,6 +606,7 @@ Note:
 
 Examples:
   $0 Qwen2.5-32B-Instruct-AWQ
+  $0 --dry-run Qwen2.5-32B-Instruct-AWQ
   $0 /path/to/model
   $0 --rollback
 
@@ -585,7 +628,11 @@ EOF
             exit 1
             ;;
         *)
-            cmd_upgrade "$1"
+            if [[ "${2:-}" == "--dry-run" && $# -eq 2 ]]; then
+                cmd_preview "$1"
+            else
+                cmd_upgrade "$1"
+            fi
             ;;
     esac
 }

--- a/ods/tests/test-upgrade-model-preview.sh
+++ b/ods/tests/test-upgrade-model-preview.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/upgrade-model.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+install_root="$TMP_DIR/install"
+models_root="$install_root/data/models"
+mkdir -p "$models_root/current-model" "$models_root/next-model"
+printf '{}\n' > "$models_root/current-model/config.json"
+printf '{}\n' > "$models_root/next-model/config.json"
+printf 'LLM_MODEL=current-model\n' > "$install_root/.env"
+printf '{"current":"current-model","previous":""}\n' > "$install_root/model-state.json"
+
+before="$(find "$install_root" -type f -exec cksum {} + | sort)"
+output="$(ODS_DIR="$install_root" MODELS_DIR="$models_root" bash "$SCRIPT" --dry-run next-model)"
+after="$(find "$install_root" -type f -exec cksum {} + | sort)"
+
+[[ "$before" == "$after" ]] || fail "preview changed installation files"
+grep -qF "Current model: current-model" <<< "$output" || fail "preview omitted current model"
+grep -qF "Target model:  next-model" <<< "$output" || fail "preview omitted target model"
+grep -qF "1. Stop llama-server" <<< "$output" || fail "preview omitted stop phase"
+grep -qF "5. Verify health and inference; roll back on failure" <<< "$output" \
+    || fail "preview omitted verification and rollback phase"
+
+alternate="$(ODS_DIR="$install_root" MODELS_DIR="$models_root" bash "$SCRIPT" next-model --dry-run)"
+[[ "$alternate" == "$output" ]] || fail "trailing --dry-run form changed the plan"
+
+if ODS_DIR="$install_root" MODELS_DIR="$models_root" \
+    bash "$SCRIPT" --dry-run missing-model >"$TMP_DIR/missing.log" 2>&1; then
+    fail "preview accepted a missing model"
+fi
+grep -qF "Model not found: missing-model" "$TMP_DIR/missing.log" \
+    || fail "missing-model failure was not actionable"
+
+same="$(ODS_DIR="$install_root" MODELS_DIR="$models_root" bash "$SCRIPT" --dry-run current-model)"
+grep -qF "none (target is already active)" <<< "$same" \
+    || fail "preview did not identify a no-op upgrade"
+
+echo "[PASS] model upgrade preview is complete and read-only"


### PR DESCRIPTION
## Summary
- add a read-only `upgrade-model.sh --dry-run <model>` lifecycle preview
- show current and target models, the resolved model path, configuration handoff, restart, health verification, and rollback intent
- accept both `--dry-run <model>` and `<model> --dry-run`
- detect missing targets and already-active no-op upgrades before any mutation

## Why this matters
Legacy directory-based installations still use this documented production helper, and a real upgrade stops inference and rewrites model state. Operators can now verify the exact target and lifecycle before disrupting a running stack.

## Overlap check
Searched open and closed PRs for `model upgrade dry run preview` and PRs referencing `ods/scripts/upgrade-model.sh`. Open PR #2631 adds read-only inventory JSON; #2404/#3121/#2613/#2871/#3074 change state, validation, or compose behavior. None previews the upgrade lifecycle. This PR does not alter the apply or rollback paths.

## Test plan
- [x] `bash ods/tests/test-upgrade-model-preview.sh`
- [x] `bash -n ods/scripts/upgrade-model.sh`
- [x] `bash -n ods/tests/test-upgrade-model-preview.sh`
- [x] `git diff --check -- ods/scripts/upgrade-model.sh ods/tests/test-upgrade-model-preview.sh`

## Tradeoffs and rollback
The preview validates local model artifacts but intentionally performs no Docker or live health probes; those remain apply-time checks. Removing the optional command restores the old interface with no state migration required.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.