### PR TITLE
feat(release): emit compatibility receipts as JSON

### DIFF
--- a/ods/scripts/check-compatibility.sh
+++ b/ods/scripts/check-compatibility.sh
@@ -5,21 +5,53 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST_FILE="${ROOT_DIR}/manifest.json"
+JSON_OUTPUT=false
+[[ "${1:-}" == "--json" ]] && JSON_OUTPUT=true
+CHECKS_JSON='[]'
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-fail() { echo -e "${RED}[FAIL]${NC} $1"; exit 1; }
-pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
-warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+record_check() {
+  local status="$1" name="$2"
+  command -v jq >/dev/null 2>&1 || return 0
+  CHECKS_JSON=$(jq -c --arg status "$status" --arg name "$name" \
+    '. + [{name: $name, status: $status}]' <<< "$CHECKS_JSON")
+}
+
+emit_json() {
+  local ok="$1"
+  jq -cn \
+    --argjson ok "$ok" \
+    --argjson checks "$CHECKS_JSON" \
+    --arg manifest_version "${MANIFEST_VERSION:-}" \
+    --arg release_version "${RELEASE_VERSION:-}" \
+    '{ok: $ok, manifest_version: $manifest_version, release_version: $release_version, checks: $checks}'
+}
+
+fail() {
+  record_check "fail" "$1"
+  if $JSON_OUTPUT; then emit_json false; else echo -e "${RED}[FAIL]${NC} $1"; fi
+  exit 1
+}
+pass() {
+  record_check "pass" "$1"
+  $JSON_OUTPUT || echo -e "${GREEN}[PASS]${NC} $1"
+}
+warn() {
+  record_check "warn" "$1"
+  $JSON_OUTPUT || echo -e "${YELLOW}[WARN]${NC} $1"
+}
 
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 test -f "$MANIFEST_FILE" || fail "manifest.json not found"
 
 jq -e '.manifestVersion and .release.version and .compatibility and .contracts' "$MANIFEST_FILE" >/dev/null \
   || fail "manifest.json missing required top-level fields"
+MANIFEST_VERSION="$(jq -r '.manifestVersion' "$MANIFEST_FILE")"
+RELEASE_VERSION="$(jq -r '.release.version' "$MANIFEST_FILE")"
 pass "manifest structure"
 
 # Compose contract files
@@ -55,3 +87,4 @@ if jq -e '.compatibility.os.macos.supported == false' "$MANIFEST_FILE" >/dev/nul
     || warn "manifest says macOS unsupported/preview but docs may be out of sync"
 fi
 pass "compatibility check complete"
+$JSON_OUTPUT && emit_json true

--- a/ods/scripts/check-compatibility.sh
+++ b/ods/scripts/check-compatibility.sh
@@ -87,4 +87,6 @@ if jq -e '.compatibility.os.macos.supported == false' "$MANIFEST_FILE" >/dev/nul
     || warn "manifest says macOS unsupported/preview but docs may be out of sync"
 fi
 pass "compatibility check complete"
-$JSON_OUTPUT && emit_json true
+if $JSON_OUTPUT; then
+  emit_json true
+fi

--- a/ods/tests/test-compatibility-json.sh
+++ b/ods/tests/test-compatibility-json.sh
@@ -21,7 +21,9 @@ assert all(item["status"] in {"pass", "warn"} for item in payload["checks"])
 assert payload["checks"][-1]["name"] == "compatibility check complete"
 PY
 
-human="$(bash "$SCRIPT")"
+human_rc=0
+human="$(bash "$SCRIPT")" || human_rc=$?
+[[ "$human_rc" -eq 0 ]]
 grep -qF "compatibility check complete" <<< "$human"
 
 echo "[PASS] compatibility validator emits a standalone JSON receipt"

--- a/ods/tests/test-compatibility-json.sh
+++ b/ods/tests/test-compatibility-json.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/check-compatibility.sh"
+
+output="$(bash "$SCRIPT" --json)"
+COMPAT_JSON="$output" python3 - "$ROOT_DIR/manifest.json" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+payload = json.loads(os.environ["COMPAT_JSON"])
+manifest = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["ok"] is True
+assert payload["manifest_version"] == str(manifest["manifestVersion"])
+assert payload["release_version"] == manifest["release"]["version"]
+assert len(payload["checks"]) >= 6
+assert all(item["status"] in {"pass", "warn"} for item in payload["checks"])
+assert payload["checks"][-1]["name"] == "compatibility check complete"
+PY
+
+human="$(bash "$SCRIPT")"
+grep -qF "compatibility check complete" <<< "$human"
+
+echo "[PASS] compatibility validator emits a standalone JSON receipt"


### PR DESCRIPTION
## Summary
- add `check-compatibility.sh --json` with release/manifest versions and ordered check results
- preserve warnings as structured non-failing results
- emit a partial receipt before exiting on the first failed contract
- keep the existing human release-gate output unchanged

## Why this matters
The compatibility validator is called by CI and the local release gate. Downstream release automation can now annotate the exact contract that failed without parsing ANSI-formatted console lines, while preserving the current fail-fast invariant.

## Overlap check
Searched open and closed PRs for `compatibility validator json` and PRs referencing `ods/scripts/check-compatibility.sh`. Open PR #2751 adds help, #2753 adds general test coverage, and #2618/#2575 harden path checks; none adds structured receipts. This PR leaves all compatibility rules unchanged.

## Test plan
- [x] `bash ods/tests/test-compatibility-json.sh`
- [x] `bash -n ods/scripts/check-compatibility.sh`
- [x] `bash -n ods/tests/test-compatibility-json.sh`
- [x] `git diff --check -- ods/scripts/check-compatibility.sh ods/tests/test-compatibility-json.sh`

## Tradeoffs and rollback
JSON construction reuses `jq`, already a mandatory dependency of this validator. The human path and fail-fast exit codes remain the default; rollback is removal of the optional reporter only.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.
- Integration follow-up `740f6bc1` preserves exit 0 in human mode and adds a regression assertion; focused tests were rerun.