### PR TITLE
feat(manifests): emit schema summaries as JSON

### DIFF
--- a/ods/scripts/validate-manifest-schema.sh
+++ b/ods/scripts/validate-manifest-schema.sh
@@ -16,6 +16,7 @@ SCHEMA_PATH=""
 
 STRICT_MODE=false
 VERBOSE=false
+JSON_OUTPUT=false
 ERRORS=0
 WARNINGS=0
 
@@ -36,6 +37,7 @@ OPTIONS:
     -h, --help      Show this help message
     -s, --strict    Treat warnings as errors
     -v, --verbose   Show detailed validation output
+        --json      Emit a machine-readable validation summary
 
 DESCRIPTION:
     Validates bundled and library extension manifests against the schema
@@ -50,6 +52,7 @@ EXAMPLES:
     $(basename "$0")              # Validate all manifests
     $(basename "$0") --strict     # Fail on warnings
     $(basename "$0") --verbose    # Show all checks
+    $(basename "$0") --json       # Emit a validation receipt
 EOF
 }
 
@@ -64,11 +67,11 @@ warn() {
 }
 
 info() {
-    [[ "$VERBOSE" == "true" ]] && echo -e "${BLUE}ℹ${NC} $*"
+    [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" == "false" ]] && echo -e "${BLUE}ℹ${NC} $*"
 }
 
 success() {
-    [[ "$VERBOSE" == "true" ]] && echo -e "${GREEN}✓${NC} $*"
+    [[ "$VERBOSE" == "true" && "$JSON_OUTPUT" == "false" ]] && echo -e "${GREEN}✓${NC} $*"
 }
 
 check_python_deps() {
@@ -208,6 +211,7 @@ while [[ $# -gt 0 ]]; do
         -h|--help) usage; exit 0 ;;
         -s|--strict) STRICT_MODE=true; shift ;;
         -v|--verbose) VERBOSE=true; shift ;;
+        --json) JSON_OUTPUT=true; shift ;;
         *) echo "Unknown: $1" >&2; usage; exit 2 ;;
     esac
 done
@@ -216,9 +220,11 @@ check_python_deps
 SCHEMA_PATH="$(resolve_schema_path)"
 
 # Main
-echo "Validating manifests in: $MANIFEST_DIRS"
-echo "Schema: ${SCHEMA_PATH#"$ROOT_DIR/"}"
-echo ""
+if [[ "$JSON_OUTPUT" == "false" ]]; then
+    echo "Validating manifests in: $MANIFEST_DIRS"
+    echo "Schema: ${SCHEMA_PATH#"$ROOT_DIR/"}"
+    echo ""
+fi
 
 TOTAL=0 VALID=0
 IFS=':' read -r -a MANIFEST_DIR_ARRAY <<< "$MANIFEST_DIRS"
@@ -242,17 +248,43 @@ for extensions_dir in "${MANIFEST_DIR_ARRAY[@]}"; do
 done
 
 # Summary
-echo ""
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
-echo "Summary: $TOTAL total, $VALID valid, $ERRORS errors, $WARNINGS warnings"
-echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+if [[ "$JSON_OUTPUT" == "false" ]]; then
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "Summary: $TOTAL total, $VALID valid, $ERRORS errors, $WARNINGS warnings"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+fi
 
 if [[ $ERRORS -gt 0 ]]; then
-    echo -e "${RED}✗ FAILED${NC} ($ERRORS errors)"; exit 1
+    if $JSON_OUTPUT; then
+        printf '{"ok":false,"strict":%s,"total":%d,"valid":%d,"errors":%d,"warnings":%d}\n' \
+            "$STRICT_MODE" "$TOTAL" "$VALID" "$ERRORS" "$WARNINGS"
+    else
+        echo -e "${RED}✗ FAILED${NC} ($ERRORS errors)"
+    fi
+    exit 1
 elif [[ $WARNINGS -gt 0 && "$STRICT_MODE" == "true" ]]; then
-    echo -e "${YELLOW}✗ FAILED${NC} ($WARNINGS warnings in strict mode)"; exit 1
+    if $JSON_OUTPUT; then
+        printf '{"ok":false,"strict":true,"total":%d,"valid":%d,"errors":%d,"warnings":%d}\n' \
+            "$TOTAL" "$VALID" "$ERRORS" "$WARNINGS"
+    else
+        echo -e "${YELLOW}✗ FAILED${NC} ($WARNINGS warnings in strict mode)"
+    fi
+    exit 1
 elif [[ $WARNINGS -gt 0 ]]; then
-    echo -e "${YELLOW}⚠ Passed with warnings${NC}"; exit 0
+    if $JSON_OUTPUT; then
+        printf '{"ok":true,"strict":false,"total":%d,"valid":%d,"errors":%d,"warnings":%d}\n' \
+            "$TOTAL" "$VALID" "$ERRORS" "$WARNINGS"
+    else
+        echo -e "${YELLOW}⚠ Passed with warnings${NC}"
+    fi
+    exit 0
 else
-    echo -e "${GREEN}✓ All valid${NC}"; exit 0
+    if $JSON_OUTPUT; then
+        printf '{"ok":true,"strict":%s,"total":%d,"valid":%d,"errors":0,"warnings":0}\n' \
+            "$STRICT_MODE" "$TOTAL" "$VALID"
+    else
+        echo -e "${GREEN}✓ All valid${NC}"
+    fi
+    exit 0
 fi

--- a/ods/tests/test-validate-manifest-schema.sh
+++ b/ods/tests/test-validate-manifest-schema.sh
@@ -35,6 +35,21 @@ assert_success "generated library schema mirror is current" \
     python3 "$ROOT_DIR/scripts/sync-manifest-schema.py" --check
 assert_success "bundled and library manifests validate together" \
     bash "$VALIDATOR"
+
+json_output="$(bash "$VALIDATOR" --json)"
+MANIFEST_JSON="$json_output" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["MANIFEST_JSON"])
+assert payload["ok"] is True
+assert payload["strict"] is False
+assert payload["total"] == payload["valid"]
+assert payload["total"] > 0
+assert payload["errors"] == 0
+assert payload["warnings"] >= 0
+PY
+pass "schema validator emits a standalone JSON summary"
 assert_success "standalone library validator accepts all library manifests" \
     python3 "$ROOT_DIR/extensions/library/validate-manifests.py"
 


### PR DESCRIPTION
## Summary
- add `validate-manifest-schema.sh --json` with strict mode, totals, valid count, errors, and warnings
- keep diagnostics on stderr so stdout remains one parseable JSON document
- preserve warning and strict-mode exit semantics
- retain the existing human/verbose interface as the default

## Why this matters
Extension authors and release tooling run this public validator before publishing manifests. A stable receipt lets dashboards and CI aggregate validation state without scraping box-drawing output, including the distinction between accepted warnings and strict failures.

## Overlap check
Searched open and closed PRs for `manifest schema validator json` and PRs referencing `ods/scripts/validate-manifest-schema.sh`. Open PR #2600 adds custom schema mirrors, #2328 changes validation performance, and #2669/#2574 harden schema paths; none adds a JSON summary contract. The schema rules are unchanged.

## Test plan
- [x] `bash ods/tests/test-validate-manifest-schema.sh`
- [x] `bash -n ods/scripts/validate-manifest-schema.sh`
- [x] `git diff --check -- ods/scripts/validate-manifest-schema.sh ods/tests/test-validate-manifest-schema.sh`

## Tradeoffs and rollback
Per-manifest diagnostic text remains on stderr rather than being duplicated in the summary; counts provide the stable automation contract. The current catalog reports three accepted compose-file warnings, accurately represented without failing non-strict mode. Removing `--json` restores the prior surface.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.