### PR TITLE
feat(release): emit golden-path validation JSON

### DIFF
--- a/ods/scripts/validate-golden-paths.py
+++ b/ods/scripts/validate-golden-paths.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -17,21 +18,29 @@ VALID_PLATFORMS = {"linux", "windows-wsl2", "macos"}
 
 class Issues:
     def __init__(self) -> None:
-        self.items: list[str] = []
+        self.items: list[dict[str, str]] = []
 
     def add(self, path: str, message: str) -> None:
-        self.items.append(f"{path}: {message}")
+        self.items.append({"path": path, "message": message})
 
     def require(self, condition: bool, path: str, message: str) -> None:
         if not condition:
             self.add(path, message)
 
-    def exit_if_any(self) -> None:
+    def exit_if_any(self, *, json_output: bool, source: Path, scenario_count: int) -> None:
         if not self.items:
             return
-        print("[FAIL] golden path validation")
-        for item in self.items:
-            print(f"  - {item}")
+        if json_output:
+            print(json.dumps({
+                "ok": False,
+                "source": str(source),
+                "scenario_count": scenario_count,
+                "issues": self.items,
+            }, separators=(",", ":")))
+        else:
+            print("[FAIL] golden path validation")
+            for item in self.items:
+                print(f"  - {item['path']}: {item['message']}")
         raise SystemExit(1)
 
 
@@ -179,21 +188,41 @@ def validate_scenario(issues: Issues, scenario: Any, path: str) -> str | None:
 
 
 def main(argv: list[str]) -> int:
-    path = Path(argv[0]) if argv else DEFAULT_PATH
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=DEFAULT_PATH)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable validation receipt")
+    args = parser.parse_args(argv)
+    path = args.path
     if not path.exists():
-        print(f"[FAIL] golden path file not found: {path}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "source": str(path),
+                "scenario_count": 0,
+                "issues": [{"path": "$file", "message": "golden path file not found"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] golden path file not found: {path}")
         return 1
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        print(f"[FAIL] invalid JSON in {path}: {exc}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "source": str(path),
+                "scenario_count": 0,
+                "issues": [{"path": "$", "message": f"invalid JSON: {exc}"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] invalid JSON in {path}: {exc}")
         return 1
 
     issues = Issues()
     root = as_dict(data)
     if root is None:
         issues.add("$", "must be an object")
-        issues.exit_if_any()
+        issues.exit_if_any(json_output=args.json, source=path, scenario_count=0)
         return 1
 
     issues.require(root.get("version") == 1, "$.version", "must be 1")
@@ -211,8 +240,21 @@ def main(argv: list[str]) -> int:
         expected_ids = {"linux-nvidia", "windows-wsl2-nvidia", "windows-wsl2-amd-lemonade", "apple-silicon"}
         issues.require(set(seen) == expected_ids, "$.scenarios", f"must define exactly {sorted(expected_ids)}")
 
-    issues.exit_if_any()
-    print("[PASS] golden path contracts")
+    scenario_count = len(scenarios) if isinstance(scenarios, list) else 0
+    issues.exit_if_any(
+        json_output=args.json,
+        source=path,
+        scenario_count=scenario_count,
+    )
+    if args.json:
+        print(json.dumps({
+            "ok": True,
+            "source": str(path),
+            "scenario_count": scenario_count,
+            "issues": [],
+        }, separators=(",", ":")))
+    else:
+        print("[PASS] golden path contracts")
     return 0
 
 

--- a/ods/tests/test-golden-paths.sh
+++ b/ods/tests/test-golden-paths.sh
@@ -6,4 +6,30 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 python3 -m py_compile "$ROOT_DIR/scripts/validate-golden-paths.py"
 python3 "$ROOT_DIR/scripts/validate-golden-paths.py" "$ROOT_DIR/config/golden-paths.json"
 
+json_output="$(python3 "$ROOT_DIR/scripts/validate-golden-paths.py" --json "$ROOT_DIR/config/golden-paths.json")"
+GOLDEN_JSON="$json_output" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["GOLDEN_JSON"])
+assert payload["ok"] is True
+assert payload["scenario_count"] == 4
+assert payload["issues"] == []
+PY
+
+missing_output=""
+missing_rc=0
+missing_output=$(python3 "$ROOT_DIR/scripts/validate-golden-paths.py" --json "$ROOT_DIR/config/missing-golden-paths.json") \
+    || missing_rc=$?
+[[ "$missing_rc" -eq 1 ]]
+GOLDEN_JSON="$missing_output" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["GOLDEN_JSON"])
+assert payload["ok"] is False
+assert payload["scenario_count"] == 0
+assert payload["issues"] == [{"path": "$file", "message": "golden path file not found"}]
+PY
+
 echo "[PASS] golden path validator test"


### PR DESCRIPTION
## Summary
- add `validate-golden-paths.py --json` with source, scenario count, and structured issues
- return valid JSON for success, missing files, invalid JSON, and aggregated contract failures
- preserve the existing human output and exit code 1 on invalid contracts
- keep the default canonical contract path optional

## Why this matters
Golden-path validation protects the four documented installation routes before release. CI and release dashboards can now attach exact JSON paths and messages to a candidate artifact instead of parsing prose, including early file/JSON failures.

## Overlap check
Searched open and closed PRs for `golden path validation json` and PRs referencing `ods/scripts/validate-golden-paths.py`. Open PRs #3409/#2742 harden file decoding and #2536 confines contract paths; none adds structured output. The four-scenario validation rules remain unchanged.

## Test plan
- [x] `bash ods/tests/test-golden-paths.sh`
- [x] `python -m py_compile ods/scripts/validate-golden-paths.py`
- [x] `git diff --check -- ods/scripts/validate-golden-paths.py ods/tests/test-golden-paths.sh`

## Tradeoffs and rollback
Issue objects expose JSON path and message without adding a schema dependency. The human format remains default, and removing `--json` requires no data migration or caller rollback.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.