### PR TITLE
feat(release): emit generated-config validation JSON

### DIFF
--- a/ods/scripts/validate-generated-configs.py
+++ b/ods/scripts/validate-generated-configs.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -17,21 +18,29 @@ WRITER_SOURCE_SUFFIXES = {".py", ".ps1", ".sh", ".yaml"}
 
 class Issues:
     def __init__(self) -> None:
-        self.items: list[str] = []
+        self.items: list[dict[str, str]] = []
 
     def add(self, path: str, message: str) -> None:
-        self.items.append(f"{path}: {message}")
+        self.items.append({"path": path, "message": message})
 
     def require(self, condition: bool, path: str, message: str) -> None:
         if not condition:
             self.add(path, message)
 
-    def exit_if_any(self) -> None:
+    def exit_if_any(self, *, json_output: bool, source: Path, surface_count: int) -> None:
         if not self.items:
             return
-        print("[FAIL] generated config contract validation")
-        for item in self.items:
-            print(f"  - {item}")
+        if json_output:
+            print(json.dumps({
+                "ok": False,
+                "source": str(source),
+                "surface_count": surface_count,
+                "issues": self.items,
+            }, separators=(",", ":")))
+        else:
+            print("[FAIL] generated config contract validation")
+            for item in self.items:
+                print(f"  - {item['path']}: {item['message']}")
         raise SystemExit(1)
 
 
@@ -183,20 +192,40 @@ def validate_surface(issues: Issues, surface: Any, path: str) -> str | None:
 
 
 def main(argv: list[str]) -> int:
-    path = Path(argv[0]) if argv else DEFAULT_PATH
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", nargs="?", type=Path, default=DEFAULT_PATH)
+    parser.add_argument("--json", action="store_true", help="emit a machine-readable validation receipt")
+    args = parser.parse_args(argv)
+    path = args.path
     if not path.exists():
-        print(f"[FAIL] generated config contract file not found: {path}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "source": str(path),
+                "surface_count": 0,
+                "issues": [{"path": "$file", "message": "generated config contract file not found"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] generated config contract file not found: {path}")
         return 1
     try:
         data = load_json(path)
     except json.JSONDecodeError as exc:
-        print(f"[FAIL] invalid JSON in {path}: {exc}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "source": str(path),
+                "surface_count": 0,
+                "issues": [{"path": "$", "message": f"invalid JSON: {exc}"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] invalid JSON in {path}: {exc}")
         return 1
 
     issues = Issues()
     if not isinstance(data, dict):
         issues.add("$", "must be an object")
-        issues.exit_if_any()
+        issues.exit_if_any(json_output=args.json, source=path, surface_count=0)
         return 1
     issues.require(data.get("version") == 1, "$.version", "must be 1")
     surfaces = data.get("surfaces")
@@ -224,8 +253,21 @@ def main(argv: list[str]) -> int:
         }
         issues.require(set(surface_ids) == required, "$.surfaces", f"must define exactly {sorted(required)}")
 
-    issues.exit_if_any()
-    print("[PASS] generated config contracts")
+    surface_count = len(surfaces) if isinstance(surfaces, list) else 0
+    issues.exit_if_any(
+        json_output=args.json,
+        source=path,
+        surface_count=surface_count,
+    )
+    if args.json:
+        print(json.dumps({
+            "ok": True,
+            "source": str(path),
+            "surface_count": surface_count,
+            "issues": [],
+        }, separators=(",", ":")))
+    else:
+        print("[PASS] generated config contracts")
     return 0
 
 

--- a/ods/tests/test-generated-config-contracts.sh
+++ b/ods/tests/test-generated-config-contracts.sh
@@ -6,6 +6,20 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 python3 -m py_compile "$ROOT_DIR/scripts/validate-generated-configs.py"
 python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$ROOT_DIR/config/generated-config-contracts.json"
 
+json_output="$(python3 "$ROOT_DIR/scripts/validate-generated-configs.py" --json "$ROOT_DIR/config/generated-config-contracts.json")"
+GENERATED_JSON="$json_output" python3 - "$ROOT_DIR/config/generated-config-contracts.json" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+payload = json.loads(os.environ["GENERATED_JSON"])
+contract = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload["ok"] is True
+assert payload["surface_count"] == len(contract["surfaces"])
+assert payload["issues"] == []
+PY
+
 missing_writer_contract="$(mktemp)"
 missing_lemonade_writer_contract="$(mktemp)"
 trap 'rm -f "$missing_writer_contract" "$missing_lemonade_writer_contract"' EXIT
@@ -29,6 +43,23 @@ if python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$missing_writer_co
     echo "[FAIL] writer marker validation accepted an incomplete ownership inventory" >&2
     exit 1
 fi
+
+missing_output=""
+missing_rc=0
+missing_output=$(python3 "$ROOT_DIR/scripts/validate-generated-configs.py" --json "$ROOT_DIR/config/missing-generated-contract.json") \
+    || missing_rc=$?
+[[ "$missing_rc" -eq 1 ]]
+GENERATED_JSON="$missing_output" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["GENERATED_JSON"])
+assert payload["ok"] is False
+assert payload["surface_count"] == 0
+assert payload["issues"] == [
+    {"path": "$file", "message": "generated config contract file not found"}
+]
+PY
 
 python3 - "$ROOT_DIR/config/generated-config-contracts.json" "$missing_lemonade_writer_contract" <<'PY'
 import json


### PR DESCRIPTION
## Summary
- add `validate-generated-configs.py --json` with source, surface count, and structured issues
- return a valid receipt for success, missing files, invalid JSON, and aggregated ownership/invariant failures
- preserve the existing human output and exit behavior
- extend the public contract test with success and early-failure JSON assertions

## Why this matters
This validator traces every generated configuration surface from its declared writers to runtime invariants. Release automation can now surface precise ownership drift without scraping prose while keeping the same producer/consumer contract gate.

## Overlap check
Searched open and closed PRs for `generated config validation json` and PRs referencing `ods/scripts/validate-generated-configs.py`. Open PR #2676 changes decoding, #2535 confines paths, and #2483/#2590 adjust runtime validation/rendering; none adds machine-readable validation results. No writer or invariant rule changes here.

## Test plan
- [x] canonical human validation passed
- [x] canonical `--json` validation parsed successfully with the declared surface count
- [x] missing-contract JSON failure returns exit 1 with a structured issue
- [x] `python -m py_compile ods/scripts/validate-generated-configs.py`
- [x] `git diff --check -- ods/scripts/validate-generated-configs.py ods/tests/test-generated-config-contracts.sh`
- [ ] Full `test-generated-config-contracts.sh` completion deferred to Linux CI; on the local Windows-mounted workspace each existing whole-tree writer scan takes several minutes. The canonical human and JSON boundaries both completed successfully before the remaining repeated negative fixtures were stopped.

## Tradeoffs and rollback
The receipt intentionally reports contract issues, not discovered file contents. The default human interface is unchanged, and removing the optional flag requires no migration.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.