### PR TITLE
feat(release): emit platform claim receipts as JSON

### DIFF
--- a/ods/scripts/check-release-claims.sh
+++ b/ods/scripts/check-release-claims.sh
@@ -5,9 +5,43 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MANIFEST="${ROOT_DIR}/manifest.json"
 MATRIX="${ROOT_DIR}/docs/SUPPORT-MATRIX.md"
 TRUTH="${ROOT_DIR}/docs/PLATFORM-TRUTH-TABLE.md"
+JSON_OUTPUT=false
+[[ "${1:-}" == "--json" ]] && JSON_OUTPUT=true
+CHECKS_JSON='[]'
+linux_supported=null
+wsl_supported=null
+macos_supported=null
+windows_native_supported=null
 
-fail() { echo "[FAIL] $1"; exit 1; }
-pass() { echo "[PASS] $1"; }
+record_check() {
+    local status="$1" name="$2"
+    command -v jq >/dev/null 2>&1 || return 0
+    CHECKS_JSON=$(jq -c --arg status "$status" --arg name "$name" \
+        '. + [{name: $name, status: $status}]' <<< "$CHECKS_JSON")
+}
+
+emit_json() {
+    local ok="$1"
+    jq -cn \
+        --argjson ok "$ok" \
+        --argjson checks "$CHECKS_JSON" \
+        --argjson linux "$linux_supported" \
+        --argjson windows_wsl2 "$wsl_supported" \
+        --argjson macos "$macos_supported" \
+        --argjson windows_native "$windows_native_supported" \
+        '{ok: $ok, support: {linux: $linux, windows_wsl2: $windows_wsl2, macos: $macos, windows_native: $windows_native}, checks: $checks}'
+}
+
+fail() {
+    record_check "fail" "$1"
+    if $JSON_OUTPUT && command -v jq >/dev/null 2>&1; then emit_json false; else echo "[FAIL] $1"; fi
+    exit 1
+}
+pass() {
+    record_check "pass" "$1"
+    $JSON_OUTPUT || echo "[PASS] $1"
+}
+checked() { record_check "pass" "$1"; }
 
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 test -f "$MANIFEST" || fail "manifest.json missing"
@@ -21,18 +55,29 @@ macos_supported="$(jq -r '.compatibility.os.macos.supported' "$MANIFEST")"
 windows_native_supported="$(jq -r '.compatibility.os.windows_native.supported' "$MANIFEST")"
 
 [[ "$linux_supported" == "true" ]] || fail "manifest must mark linux supported"
+checked "manifest marks Linux supported"
 [[ "$wsl_supported" == "true" ]] || fail "manifest must mark windows_wsl2 supported"
+checked "manifest marks Windows WSL2 supported"
 [[ "$macos_supported" == "true" ]] || fail "manifest must mark macos supported (Tier B)"
+checked "manifest marks macOS supported"
 [[ "$windows_native_supported" == "false" ]] || fail "manifest must mark windows_native unsupported"
+checked "manifest marks Windows native unsupported"
 
 # Support matrix wording expectations
 grep -q "Windows (Docker Desktop + WSL2).*Supported\|Windows (Docker Desktop + WSL2).*Tier B" "$MATRIX" || fail "support matrix missing Windows Tier B claim"
+checked "support matrix includes Windows Tier B"
 grep -q "macOS (Apple Silicon).*Supported\|macOS (Apple Silicon).*Tier B" "$MATRIX" || fail "support matrix missing macOS Tier B claim"
+checked "support matrix includes macOS Tier B"
 grep -q "install\.ps1" "$MATRIX" || fail "support matrix missing Windows installer reference"
+checked "support matrix includes Windows installer"
 
 # Truth table consistency
 grep -q "Windows (Docker Desktop + WSL2).*Tier B" "$TRUTH" || fail "truth table missing Windows Tier B"
+checked "truth table includes Windows Tier B"
 grep -q "macOS Apple Silicon.*Tier B" "$TRUTH" || fail "truth table missing macOS Tier B"
+checked "truth table includes macOS Tier B"
 grep -q "Not safe to claim now" "$TRUTH" || fail "truth table missing launch guardrails section"
+checked "truth table includes launch guardrails"
 
 pass "release claim gates"
+$JSON_OUTPUT && emit_json true

--- a/ods/scripts/check-release-claims.sh
+++ b/ods/scripts/check-release-claims.sh
@@ -80,4 +80,6 @@ grep -q "Not safe to claim now" "$TRUTH" || fail "truth table missing launch gua
 checked "truth table includes launch guardrails"
 
 pass "release claim gates"
-$JSON_OUTPUT && emit_json true
+if $JSON_OUTPUT; then
+    emit_json true
+fi

--- a/ods/tests/test-release-claims-json.sh
+++ b/ods/tests/test-release-claims-json.sh
@@ -22,7 +22,9 @@ assert all(check["status"] == "pass" for check in payload["checks"])
 assert payload["checks"][-1]["name"] == "release claim gates"
 PY
 
-human="$(bash "$SCRIPT")"
+human_rc=0
+human="$(bash "$SCRIPT")" || human_rc=$?
+[[ "$human_rc" -eq 0 ]]
 grep -qF "[PASS] release claim gates" <<< "$human"
 
 echo "[PASS] release claim gate emits a standalone JSON receipt"

--- a/ods/tests/test-release-claims-json.sh
+++ b/ods/tests/test-release-claims-json.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/check-release-claims.sh"
+
+output="$(bash "$SCRIPT" --json)"
+RELEASE_CLAIMS_JSON="$output" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["RELEASE_CLAIMS_JSON"])
+assert payload["ok"] is True
+assert payload["support"] == {
+    "linux": True,
+    "windows_wsl2": True,
+    "macos": True,
+    "windows_native": False,
+}
+assert len(payload["checks"]) == 11
+assert all(check["status"] == "pass" for check in payload["checks"])
+assert payload["checks"][-1]["name"] == "release claim gates"
+PY
+
+human="$(bash "$SCRIPT")"
+grep -qF "[PASS] release claim gates" <<< "$human"
+
+echo "[PASS] release claim gate emits a standalone JSON receipt"


### PR DESCRIPTION
## Summary
- add `check-release-claims.sh --json` with canonical platform support values
- expose every manifest, support-matrix, truth-table, installer, and guardrail assertion as an ordered check
- emit a partial structured receipt on fail-fast errors
- preserve the existing one-line human success output and exit codes

## Why this matters
The release gate prevents ODS from publishing platform claims beyond validated support. Release dashboards can now show which evidence source drifted and the exact declared support matrix without parsing shell output.

## Overlap check
Searched open and closed PRs for `release claims json` and PRs referencing `ods/scripts/check-release-claims.sh`. Open PR #3187 adds tests, #3153 adds assertions, and #2678/#3412 adjust missing-doc behavior; none adds a machine-readable receipt. This PR changes reporting only, not the accepted claims.

## Test plan
- [x] `bash ods/tests/test-release-claims-json.sh`
- [x] `bash -n ods/scripts/check-release-claims.sh`
- [x] `bash -n ods/tests/test-release-claims-json.sh`
- [x] `git diff --check -- ods/scripts/check-release-claims.sh ods/tests/test-release-claims-json.sh`

## Tradeoffs and rollback
The receipt records boolean support exactly as declared in `manifest.json`; documentation checks remain named pass/fail entries. Removing `--json` restores the previous surface without changing release data.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.
- Integration follow-up `58a47f2a` preserves exit 0 in human mode and adds a regression assertion; focused tests were rerun.