### PR TITLE
feat(simulation): emit validation receipts as JSON

### DIFF
--- a/ods/scripts/validate-sim-summary.py
+++ b/ods/scripts/validate-sim-summary.py
@@ -59,12 +59,24 @@ class Validator:
     def add(self, path: str, message: str) -> None:
         self.issues.append(ValidationIssue(path=path, message=message))
 
-    def fail_if_any(self) -> None:
+    def fail_if_any(self, *, json_output: bool, source: Path) -> None:
         if not self.issues:
             return
-        print("[FAIL] simulation summary validation")
-        for issue in self.issues:
-            print(issue.format())
+        if json_output:
+            print(json.dumps({
+                "ok": False,
+                "strict": self.strict,
+                "source": str(source),
+                "issue_count": len(self.issues),
+                "issues": [
+                    {"path": issue.path, "message": issue.message}
+                    for issue in self.issues
+                ],
+            }, separators=(",", ":")))
+        else:
+            print("[FAIL] simulation summary validation")
+            for issue in self.issues:
+                print(issue.format())
         raise SystemExit(2)
 
 
@@ -343,6 +355,7 @@ def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
     )
     p.add_argument("summary_json", help="Path to summary.json")
     p.add_argument("--strict", action="store_true", help="Fail on unknown keys and require generated_at")
+    p.add_argument("--json", action="store_true", help="Emit a machine-readable validation receipt")
     return p.parse_args(argv)
 
 
@@ -351,30 +364,76 @@ def main(argv: Sequence[str]) -> int:
 
     path = Path(args.summary_json)
     if not path.exists():
-        print(f"[FAIL] summary file not found: {path}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "strict": bool(args.strict),
+                "source": str(path),
+                "issue_count": 1,
+                "issues": [{"path": "$file", "message": "summary file not found"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] summary file not found: {path}")
         return 2
 
     try:
         raw = path.read_text(encoding="utf-8")
     except Exception as exc:
-        print(f"[FAIL] cannot read summary file: {exc}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "strict": bool(args.strict),
+                "source": str(path),
+                "issue_count": 1,
+                "issues": [{"path": "$file", "message": f"cannot read summary file: {exc}"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] cannot read summary file: {exc}")
         return 3
 
     try:
         data = json.loads(raw)
     except Exception as exc:
-        print(f"[FAIL] invalid JSON: {exc}")
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "strict": bool(args.strict),
+                "source": str(path),
+                "issue_count": 1,
+                "issues": [{"path": "$", "message": f"invalid JSON: {exc}"}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] invalid JSON: {exc}")
         return 3
 
     if not isinstance(data, Mapping):
-        print(f"[FAIL] root must be an object, got {_type_name(data)}")
+        message = f"root must be an object, got {_type_name(data)}"
+        if args.json:
+            print(json.dumps({
+                "ok": False,
+                "strict": bool(args.strict),
+                "source": str(path),
+                "issue_count": 1,
+                "issues": [{"path": "$", "message": message}],
+            }, separators=(",", ":")))
+        else:
+            print(f"[FAIL] {message}")
         return 2
 
     v = Validator(strict=bool(args.strict))
     validate_summary(v, data)
-    v.fail_if_any()
+    v.fail_if_any(json_output=bool(args.json), source=path)
 
-    print("[PASS] simulation summary structure")
+    if args.json:
+        print(json.dumps({
+            "ok": True,
+            "strict": bool(args.strict),
+            "source": str(path),
+            "issue_count": 0,
+            "issues": [],
+        }, separators=(",", ":")))
+    else:
+        print("[PASS] simulation summary structure")
     return 0
 
 

--- a/ods/tests/test-validate-sim-summary.sh
+++ b/ods/tests/test-validate-sim-summary.sh
@@ -137,6 +137,19 @@ else
     fail "valid summary should print PASS marker"
 fi
 
+json_out=$(python3 "$ROOT_DIR/scripts/validate-sim-summary.py" --json "$TMP_DIR/valid.json")
+SIM_JSON="$json_out" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["SIM_JSON"])
+assert payload["ok"] is True
+assert payload["strict"] is False
+assert payload["issue_count"] == 0
+assert payload["issues"] == []
+PY
+pass "valid summary emits a JSON receipt"
+
 python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR/bad-golden-count.json"
 import json
 import sys
@@ -162,6 +175,26 @@ if echo "$out" | grep -q "pass_count"; then
 else
     fail "golden path validation error should mention pass_count"
 fi
+
+set +e
+json_out=$(python3 "$ROOT_DIR/scripts/validate-sim-summary.py" --json "$TMP_DIR/bad-golden-count.json")
+r=$?
+set -e
+if [[ $r -eq 2 ]]; then
+    pass "invalid JSON receipt preserves validation exit 2"
+else
+    fail "invalid JSON receipt should exit 2, got $r"
+fi
+SIM_JSON="$json_out" python3 - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["SIM_JSON"])
+assert payload["ok"] is False
+assert payload["issue_count"] == len(payload["issues"])
+assert any(issue["path"] == "$.golden_paths.pass_count" for issue in payload["issues"])
+PY
+pass "invalid summary emits structured JSON issues"
 
 python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR/missing-signal.json"
 import json


### PR DESCRIPTION
## Summary
- add `validate-sim-summary.py --json` with strict state, source, issue count, and structured JSON paths/messages
- produce receipts for success, missing/unreadable files, invalid JSON, invalid roots, and aggregated semantic failures
- preserve exit codes 0, 2, and 3 for existing automation
- keep human output as the default

## Why this matters
Installer simulations are the hardware-independent release receipt for Linux, macOS, Windows, doctor, and golden-path contracts. CI can now publish exact validation findings without parsing console markers while retaining the existing error taxonomy.

## Overlap check
Searched open and closed PRs for `simulation summary validation json` and PRs referencing `ods/scripts/validate-sim-summary.py`. Open PR #3563 fixes simulation failure propagation, #3012 captures installer exit codes, and #2484 validates timestamps; none adds structured validator output. Validation rules and exit codes are unchanged.

## Test plan
- [x] `bash ods/tests/test-validate-sim-summary.sh` (15 passed)
- [x] `python -m py_compile ods/scripts/validate-sim-summary.py`
- [x] `git diff --check -- ods/scripts/validate-sim-summary.py ods/tests/test-validate-sim-summary.sh`

## Tradeoffs and rollback
Receipts expose all aggregated issues, matching the validator's existing diagnostic behavior. Removing `--json` restores the old surface without changing simulation artifacts or their schema.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.