### PR TITLE
feat(bootstrap): list hosted verification endpoints

### DIFF
--- a/ods/scripts/verify-hosted-bootstrap.sh
+++ b/ods/scripts/verify-hosted-bootstrap.sh
@@ -45,12 +45,22 @@ header_value() {
     ' "$headers_file"
 }
 
+if [[ "${1:-}" == "--list-endpoints" ]]; then
+    if [[ $# -ne 1 ]]; then
+        echo "Usage: $0 --list-endpoints" >&2
+        exit 2
+    fi
+    printf '%s\n' "${DEFAULT_ENDPOINTS[@]}"
+    exit 0
+fi
+
 [[ -n "$REPO_ROOT" ]] || fail "Run this verifier from an ODS Git checkout."
 command -v curl >/dev/null 2>&1 || fail "curl is required."
 command -v cmp >/dev/null 2>&1 || fail "cmp is required."
 
 if [[ $# -lt 1 ]]; then
     echo "Usage: $0 EXPECTED_GIT_REF [ENDPOINT ...]" >&2
+    echo "       $0 --list-endpoints" >&2
     echo "Example: $0 \"\$(git rev-parse HEAD)\"" >&2
     exit 2
 fi

--- a/ods/tests/test-hosted-bootstrap-verifier.sh
+++ b/ods/tests/test-hosted-bootstrap-verifier.sh
@@ -116,6 +116,17 @@ https://osmantic.com/get/ods.sh
 https://osmantic.com/get/ods/main
 https://osmantic.com/get/ods/main.sh
 EOF
+
+bash "$VERIFIER" --list-endpoints > "$TMP_DIR/listed-default-endpoints"
+cmp -s "$TMP_DIR/expected-default-endpoints" "$TMP_DIR/listed-default-endpoints" \
+    || fail "--list-endpoints drifted from the verifier's active default aliases."
+
+if bash "$VERIFIER" --list-endpoints unexpected >"$TMP_DIR/list-extra.log" 2>&1; then
+    fail "--list-endpoints accepted an unrelated argument."
+fi
+grep -qF "Usage:" "$TMP_DIR/list-extra.log" \
+    || fail "invalid list invocation did not return usage guidance."
+
 cmp -s "$TMP_DIR/expected-default-endpoints" "$TMP_DIR/default-trace" \
     || fail "Verifier defaults do not cover all twelve active Worker aliases."
 


### PR DESCRIPTION
## Summary
- add `verify-hosted-bootstrap.sh --list-endpoints`
- print the exact twelve default aliases consumed by the live hosted-bootstrap verifier
- avoid curl, compare, and Git-ref verification in discovery mode
- reject extra list arguments and keep the verification path unchanged

## Why this matters
Release automation must verify every public installer alias, but the canonical alias list previously existed only inside the executable verifier. Maintainers can now discover that external contract directly and feed it into deployment checks without duplicating URLs or making network requests.

## Overlap check
Searched open and closed PRs for `hosted bootstrap endpoints list` and PRs referencing `ods/scripts/verify-hosted-bootstrap.sh`. Open PRs #3391/#2765 trim response media types; closed #1776 updates branding. None exposes the verifier's endpoint inventory. This PR does not change transport, metadata, body, syntax, or cache checks.

## Test plan
- [x] `bash ods/tests/test-hosted-bootstrap-verifier.sh`
- [x] `bash -n ods/scripts/verify-hosted-bootstrap.sh`
- [x] `bash -n ods/tests/test-hosted-bootstrap-verifier.sh`
- [x] `git diff --check -- ods/scripts/verify-hosted-bootstrap.sh ods/tests/test-hosted-bootstrap-verifier.sh`

## Tradeoffs and rollback
The list is newline-delimited for direct shell composition and remains sourced from the verifier's active defaults. Removing the optional discovery mode restores the old CLI; hosted endpoint behavior is unaffected.

Generated with Codex
## Batch compatibility
- Independently mergeable; tested combined in order #3657 → #3666.
- Base: `upstream/main@6ff9b4fc`; synthetic integration head: `e45e2647`.
- All focused public-boundary suites, the canonical generated-config JSON scan (12 surfaces), `make lint`, and `git diff --check upstream/main...HEAD` passed.
- `tests/test-installer-context-parity.sh` still fails at `Hermes template bounds each model turn`; the identical failure was reproduced on the exact upstream base, so it is not introduced by this batch.
- No live Docker mutation, model activation, migration, hosted deployment, or hardware validation is claimed.