### PR TITLE
test(installer): make Docker phase BATS fixture hermetic

### DIFF
--- a/ods/tests/bats-tests/docker-phase.bats
+++ b/ods/tests/bats-tests/docker-phase.bats
@@ -25,6 +25,8 @@ setup() {
     pkg_install() { :; }; export -f pkg_install
     pkg_update() { :; }; export -f pkg_update
     pkg_resolve() { echo "$1"; }; export -f pkg_resolve
+    ods_sudo_available() { return 1; }; export -f ods_sudo_available
+    ods_sudo() { return 1; }; export -f ods_sudo
 
     export SCRIPT_DIR="$BATS_TEST_TMPDIR/ods"
     export LOG_FILE="$BATS_TEST_TMPDIR/docker.log"
@@ -37,7 +39,9 @@ setup() {
     export DOCKER_COMPOSE_CMD=""
     export DOCKER_NEEDS_SUDO=false
 
-    mkdir -p "$SCRIPT_DIR"
+    mkdir -p "$SCRIPT_DIR/installers/lib"
+    cp "$BATS_TEST_DIRNAME/../../installers/lib/podman-registries.sh" \
+        "$SCRIPT_DIR/installers/lib/podman-registries.sh"
     touch "$LOG_FILE"
 }
 
@@ -76,12 +80,26 @@ teardown() {
         pkg_update() { :; }
         pkg_resolve() { echo "$1"; }
 
+        # --skip-docker means the operator supplied a usable runtime. Keep the
+        # test independent of whether the BATS host happens to provide one.
+        docker() {
+            case "$*" in
+                "version --format "*) echo "27.0.0" ;;
+                "--version"|"version") echo "Docker version 27.0.0" ;;
+                "compose version") echo "Docker Compose version v2.27.0" ;;
+                "info") return 0 ;;
+                *) return 0 ;;
+            esac
+        }
+
         source "'"$BATS_TEST_DIRNAME/../../installers/phases/05-docker.sh"'"
         echo "PHASE_COMPLETE"
     '
     assert_success
     assert_output --partial "PHASE_COMPLETE"
     assert_output --partial "Skipping Docker"
+    refute_output --partial "No such file or directory"
+    refute_output --partial "command not found"
 }
 
 # ── _docker_cmd_arr ─────────────────────────────────────────────────────────


### PR DESCRIPTION
﻿## Summary

- mirror the Docker phase's required Podman registry helper inside its isolated BATS fixture
- stub the shared no-sudo contract used by the phase
- give the `--skip-docker` path a deterministic usable Docker/Compose runtime instead of inheriting the host
- fail the test if missing-file or missing-command diagnostics leak through

## Why this matters

`05-docker.sh` now sources `podman-registries.sh` and calls the shared sudo contract, but its BATS fixture still created an empty installer tree. On a minimal host the test fails before reaching its assertion. On a GitHub runner with Docker available, the same missing dependency can be printed and then masked by later successful commands, producing a false green. The fixture should exercise the phase contract, not the tools that happen to be installed on the test host.

## Overlap check

Searched open and closed PRs for `docker-phase.bats`, `podman-registries BATS`, and `SKIP_DOCKER docker phase test`. No open PR covers this fixture regression. Historical PRs #958 and #1063 created and repaired earlier Docker-phase BATS coverage but predate the Podman helper dependency.

## AI Assistance

AI-assisted investigation and test drafting. The diff, failure mode, overlap search, and validation results were reviewed before submission.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not a stable-lane change; this repairs mainline test isolation.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because: tests-only fixture change

Commands/results:

```text
# RED on main
bats tests/bats-tests/docker-phase.bats
# 5 passed, 1 failed: missing podman-registries.sh / ods_sudo_available

# GREEN
bats tests/bats-tests/docker-phase.bats
# 6 passed, 0 failed

# All BATS files except the host-dispatch suite, whose Linux expectation
# intentionally identifies this validation host as WSL
find tests/bats-tests -type f -name '*.bats' ! -name 'dispatch.bats' ...
# 409 passed, 0 failed

make lint       # passed
make smoke      # 4 platform smoke paths passed
make simulate   # passed
pre-commit run --files ods/tests/bats-tests/docker-phase.bats
# secret/private-key/large-file checks passed
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

Only the BATS fixture changes. Production installer behavior is untouched. The runtime mock models the documented `--skip-docker` precondition: the operator has already supplied a usable Docker/Compose installation.
