### PR TITLE
test(models): isolate NVIDIA replanning from WSL host

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -2598,6 +2598,7 @@ def _write_nvidia_gpu_plan_fixture(tmp_path, monkeypatch):
         "GPU_ASSIGNMENT_JSON_B64": encoded,
     }
     monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+    monkeypatch.setattr(_mod, "_is_wsl_linux", lambda: False)
     return install_dir, target, env
 
 
@@ -3132,6 +3133,7 @@ def test_model_gpu_plan_rejects_malformed_or_duplicate_assignment(
     target = tmp_path / "model.gguf"
     target.write_bytes(b"model")
     monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+    monkeypatch.setattr(_mod, "_is_wsl_linux", lambda: False)
 
     with pytest.raises(RuntimeError, match="assignment is malformed"):
         _mod._plan_nvidia_model_gpu_assignment(
@@ -3350,7 +3352,7 @@ def test_model_gpu_plan_leaves_non_applicable_runtimes_unchanged(
 def test_model_gpu_plan_explicitly_skips_wsl_auto_replan(tmp_path, monkeypatch):
     _install_dir, target, env = _write_nvidia_gpu_plan_fixture(tmp_path, monkeypatch)
     monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
-    monkeypatch.setenv("WSL_DISTRO_NAME", "Ubuntu")
+    monkeypatch.setattr(_mod, "_is_wsl_linux", lambda: True)
     monkeypatch.setattr(
         _mod,
         "_run_nvidia_gpu_planner",
@@ -3624,6 +3626,7 @@ class TestModelActivateRollback:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(_mod, "_is_wsl_linux", lambda: False)
         monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
         monkeypatch.setattr(
             _mod,
@@ -3696,6 +3699,7 @@ class TestModelActivateRollback:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        monkeypatch.setattr(_mod, "_is_wsl_linux", lambda: False)
         monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
         monkeypatch.setattr(
             _mod,


### PR DESCRIPTION
﻿## Summary

Makes the NVIDIA model-replanning tests independent of the machine that runs them. The fixtures now control the WSL detector explicitly, so native-Linux scenarios exercise replanning even when pytest itself runs inside WSL, while the dedicated WSL test still proves the skip contract.

## Why this matters

Before this change, running the dashboard API suite in WSL silently skipped the production path under test. Fifteen model activation and rollback tests failed because the host's WSL identity leaked into fixtures that otherwise model native Linux. That makes a supported development environment unable to provide a trustworthy regression signal for transactional multi-GPU model activation.

## Changes

- Pin native-Linux NVIDIA fixtures to a non-WSL platform boundary.
- Pin the explicit WSL case to the WSL branch directly instead of relying on the host environment.
- Apply the same isolation to transactional activation/rollback scenarios.

## Testing

- [x] Focused model GPU/rollback set: 37 passed
- [x] Full dashboard API suite: 2117 passed, 1 skipped
- [x] Pre-commit hooks pass for the changed file
- [x] `git diff --check`
- [ ] `bash -n` passes on all changed `.sh` files (not applicable; no shell files changed)
- [ ] `bash tests/test-tier-map.sh` passes (not applicable; no tier/model metadata changed)
- [ ] `bash tests/integration-test.sh` passes (requires live services; no runtime code changed)
- [ ] Relevant smoke tests pass (not applicable; fixture-only change)
- [ ] Dashboard builds (not applicable; no frontend change)

## Overlap check

Searched open and closed PRs for ?model activation tests WSL NVIDIA GPU plan?, ?test_model_activate _is_wsl_linux?, ?nvidia gpu plan WSL tests?, and ?dashboard pytest WSL?. No overlapping PR was found.

## Related Issues

No linked issue.

## AI assistance

AI-assisted investigation and test isolation; the diff and full test results were reviewed before submission.

