### PR TITLE
fix(token-spy): bound recent usage queries

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -18,10 +18,11 @@ import shlex
 import tempfile
 import time
 from pathlib import Path
+from typing import Annotated
 from urllib.parse import urlparse
 
 import httpx
-from fastapi import Depends, FastAPI, HTTPException, Request, Response, Security
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, Security
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from filters import apply_filters
@@ -1685,8 +1686,16 @@ def _update_timer_interval(minutes: int):
     except Exception as e:
         log.warning(f"[SETTINGS] Could not update timer: {e} (may need sudo)")
 
+UsageHours = Annotated[int, Query(ge=1, le=24 * 366)]
+UsageLimit = Annotated[int, Query(ge=1, le=1000)]
+
+
 @app.get("/api/usage", dependencies=[Depends(verify_api_key)])
-def api_usage(agent: str | None = None, hours: int = 24, limit: int = 200):
+def api_usage(
+    agent: str | None = None,
+    hours: UsageHours = 24,
+    limit: UsageLimit = 200,
+):
     return query_usage(agent=agent, hours=hours, limit=limit)
 
 
@@ -1700,7 +1709,11 @@ def api_report(start: str, end: str):
 
 
 @app.get("/token-usage", dependencies=[Depends(verify_api_key)])
-def token_usage_alias(agent: str | None = None, hours: int = 24, limit: int = 200):
+def token_usage_alias(
+    agent: str | None = None,
+    hours: UsageHours = 24,
+    limit: UsageLimit = 200,
+):
     """Alias for /api/usage — returns recent token usage events."""
     return query_usage(agent=agent, hours=hours, limit=limit)
 

--- a/ods/extensions/services/token-spy/tests/test_usage_query_bounds.py
+++ b/ods/extensions/services/token-spy/tests/test_usage_query_bounds.py
@@ -1,0 +1,59 @@
+"""HTTP bounds for Token Spy's recent-usage queries."""
+
+from __future__ import annotations
+
+import importlib
+import os
+
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("TOKEN_SPY_API_KEY", "token-spy-test-key")
+
+main = importlib.import_module("main")
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {main.TOKEN_SPY_API_KEY}"}
+
+
+def test_usage_routes_reject_unbounded_query_ranges(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "query_usage",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("invalid query reached the database")
+        ),
+    )
+    client = TestClient(main.app)
+
+    for path in ("/api/usage", "/token-usage"):
+        for query in (
+            "limit=-1",
+            "limit=0",
+            "limit=1001",
+            "hours=-1",
+            "hours=0",
+            "hours=8785",
+        ):
+            response = client.get(f"{path}?{query}", headers=_headers())
+            assert response.status_code == 422, (path, query, response.text)
+
+
+def test_usage_routes_accept_documented_defaults_and_bounds(monkeypatch):
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        main,
+        "query_usage",
+        lambda **kwargs: calls.append(kwargs) or [],
+    )
+    client = TestClient(main.app)
+
+    assert client.get("/api/usage", headers=_headers()).status_code == 200
+    assert client.get(
+        "/token-usage?agent=hermes&hours=8784&limit=1000",
+        headers=_headers(),
+    ).status_code == 200
+    assert calls == [
+        {"agent": None, "hours": 24, "limit": 200},
+        {"agent": "hermes", "hours": 8784, "limit": 1000},
+    ]


### PR DESCRIPTION
﻿## Summary

Bounds the authenticated Token Spy recent-usage endpoints before they reach either database backend. Both `/api/usage` and its `/token-usage` alias now accept 1?8,784 hours and 1?1,000 rows, while preserving their existing defaults.

## Why this matters

SQLite interprets `LIMIT -1` as ?no limit.? A caller with a valid Token Spy key could therefore bypass the intended 200-row default and materialize the entire usage history with one request. Very large positive limits had the same resource-exhaustion shape. The alias exposed the identical query path, so both boundaries need the same validation.

## Changes

- Add shared FastAPI query constraints for the history window and row count.
- Apply the constraints consistently to both recent-usage routes.
- Add HTTP-level tests proving invalid values return 422 before `query_usage` runs.
- Preserve and verify default values and accepted upper bounds.

## Testing

- [x] RED: an invalid `limit=-1` reached the database callable
- [x] GREEN: Token Spy suite ? 22 passed, 5 skipped (live PostgreSQL unavailable)
- [x] Focused Ruff syntax/import checks pass
- [x] Pre-commit hooks pass
- [x] `git diff --check`
- [ ] `bash -n` (not applicable; no shell files changed)
- [ ] Dashboard build (not applicable; no frontend change)

## Overlap check

Searched open and closed PRs for ?token spy usage limit validation?, ?token-usage negative limit?, ?api_usage hours limit bounds?, and ?Token Spy unbounded usage query?. No overlapping PR was found.

## Related Issues

No linked issue.

## AI assistance

AI-assisted investigation and regression-test drafting; the endpoint contract, diff, and test results were reviewed before submission.

