### PR TITLE
fix(privacy): bound buffered request bodies

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -491,6 +491,7 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # PII_CACHE_ENABLED=true
 # PII_CACHE_SIZE=1000
 # PII_CACHE_TTL=300
+# SHIELD_REQUEST_MAX_BYTES=8388608  # 8 MiB request-buffer cap before PII scrubbing
 # LOG_LEVEL=info
 
 # OpenClaw bootstrap model (small model for instant startup)

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -920,6 +920,12 @@
       "description": "Privacy Shield PII cache TTL (seconds)",
       "default": 300
     },
+    "SHIELD_REQUEST_MAX_BYTES": {
+      "type": "integer",
+      "description": "Maximum Privacy Shield request body buffered for PII scrubbing",
+      "minimum": 1,
+      "default": 8388608
+    },
     "LOG_LEVEL": {
       "type": "string",
       "description": "Logging level",

--- a/ods/extensions/services/privacy-shield/README.md
+++ b/ods/extensions/services/privacy-shield/README.md
@@ -60,6 +60,7 @@ Environment variables (set in `.env`):
 | `PII_CACHE_ENABLED` | true | Enable session PII caching |
 | `PII_CACHE_SIZE` | 1000 | Max cached sessions |
 | `PII_CACHE_TTL` | 300 | Session TTL in seconds |
+| `SHIELD_REQUEST_MAX_BYTES` | 8388608 | Maximum buffered request body before a 413 response |
 
 ### API Usage
 

--- a/ods/extensions/services/privacy-shield/compose.yaml
+++ b/ods/extensions/services/privacy-shield/compose.yaml
@@ -19,6 +19,7 @@ services:
       - PII_CACHE_ENABLED=${PII_CACHE_ENABLED:-true}
       - PII_CACHE_SIZE=${PII_CACHE_SIZE:-1000}
       - PII_CACHE_TTL=${PII_CACHE_TTL:-300}
+      - SHIELD_REQUEST_MAX_BYTES=${SHIELD_REQUEST_MAX_BYTES:-8388608}
       - LOG_LEVEL=${LOG_LEVEL:-info}
     volumes:
       - ./data/privacy-shield:/data:z

--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -45,6 +45,9 @@ _TEXTUAL_RE = re.compile(
 # Bodies larger than this are passed through untouched even if textual, so a
 # pathological response cannot pin the box buffering a hold-back window.
 RESTORE_MAX_BYTES = int(os.getenv("SHIELD_RESTORE_MAX_BYTES", str(8 * 1024 * 1024)))
+# Requests must be fully buffered before PII scrubbing. Bound that buffer even
+# when Content-Length is absent or untrusted (for example, chunked uploads).
+REQUEST_MAX_BYTES = int(os.getenv("SHIELD_REQUEST_MAX_BYTES", str(8 * 1024 * 1024)))
 
 
 def _parse_content_type(content_type: str) -> tuple[str, str]:
@@ -70,6 +73,32 @@ def _sanitize_error(exc: Exception) -> str:
         r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b", "[EMAIL]", error_str
     )
     return error_str
+
+
+async def _read_request_body_bounded(request: Request) -> bytes:
+    """Read at most REQUEST_MAX_BYTES, rejecting before PII processing."""
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > REQUEST_MAX_BYTES:
+                raise HTTPException(
+                    status_code=413,
+                    detail="Request body exceeds privacy shield limit",
+                )
+        except ValueError:
+            # An invalid or combined header is not trusted for enforcement;
+            # the streaming byte count below remains authoritative.
+            pass
+
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > REQUEST_MAX_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail="Request body exceeds privacy shield limit",
+            )
+        body.extend(chunk)
+    return bytes(body)
 
 # Security: API Key Authentication
 DEFAULT_KEY_PATH = os.environ.get("SHIELD_API_KEY_PATH", "/data/shield_api_key")
@@ -281,7 +310,7 @@ async def proxy(request: Request, path: str):
     start_time = time.time()
     shield = get_session(request)
 
-    raw_body = await request.body()
+    raw_body = await _read_request_body_bounded(request)
     if raw_body:
         try:
             body_str = raw_body.decode("utf-8")

--- a/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
+++ b/ods/extensions/services/privacy-shield/tests/test_streaming_proxy.py
@@ -282,6 +282,55 @@ class TestBinaryPassthrough:
         assert seen["body"] == bad, "non-utf8 request body not forwarded verbatim"
 
 
+# ── 3b. Request buffering is bounded before PII scrubbing ──────────────────
+
+class TestRequestBodyLimit:
+    @staticmethod
+    def _reject_upstream(_request):  # pragma: no cover - must not be reached
+        raise AssertionError("oversized request reached the upstream")
+
+    def test_declared_oversized_request_rejected_before_upstream(
+        self, client, install_upstream, monkeypatch
+    ):
+        monkeypatch.setattr(proxy, "REQUEST_MAX_BYTES", 16)
+        install_upstream(self._reject_upstream)
+
+        resp = client.post("/v1/chat/completions", headers=AUTH, content=b"x" * 17)
+
+        assert resp.status_code == 413
+        assert resp.json()["detail"] == "Request body exceeds privacy shield limit"
+
+    def test_chunked_oversized_request_rejected_while_streaming(
+        self, client, install_upstream, monkeypatch
+    ):
+        monkeypatch.setattr(proxy, "REQUEST_MAX_BYTES", 16)
+        install_upstream(self._reject_upstream)
+
+        resp = client.post(
+            "/v1/chat/completions",
+            headers=AUTH,
+            content=(chunk for chunk in (b"x" * 10, b"y" * 10)),
+        )
+
+        assert resp.status_code == 413
+
+    def test_request_at_limit_is_forwarded(
+        self, client, install_upstream, monkeypatch
+    ):
+        monkeypatch.setattr(proxy, "REQUEST_MAX_BYTES", 16)
+        seen = {}
+
+        def handler(request):
+            seen["body"] = request.content
+            return _resp(200, {"content-type": "application/json"}, [b'{"ok":true}'])
+
+        install_upstream(handler)
+        resp = client.post("/v1/chat/completions", headers=AUTH, content=b"x" * 16)
+
+        assert resp.status_code == 200
+        assert seen["body"] == b"x" * 16
+
+
 # ── 4. WebSocket upgrade lane ───────────────────────────────────────────────
 
 class TestWebSocketLane:


### PR DESCRIPTION
﻿## Summary

Adds an 8 MiB default cap to Privacy Shield request buffering before PII scrubbing. The proxy rejects oversized declared and chunked bodies with HTTP 413 before opening an upstream connection, while requests at the configured boundary continue to be scrubbed and forwarded.

## Why this matters

Privacy Shield must buffer a complete prompt before it can safely scrub PII. The previous `await request.body()` had no upper bound, so an authenticated client could make the 2 GiB container accumulate an arbitrarily large body before any validation or upstream I/O. Checking only `Content-Length` would not close the boundary because chunked uploads can omit it.

## Changes

- Read request streams with an authoritative byte counter.
- Fail early from a trusted oversized `Content-Length`, and fail during streaming when the header is absent or invalid.
- Expose `SHIELD_REQUEST_MAX_BYTES` through Compose, `.env.example`, the environment schema, and the service README.
- Cover declared oversize, chunked oversize, and exact-boundary forwarding.

## Testing

- [x] RED: all three boundary tests failed before the cap existed
- [x] Privacy Shield suite: 55 passed
- [x] Environment validation: 45 passed
- [x] Manifest validation: 7 passed
- [x] Extension audit: 15 passed
- [x] JSON schema parses successfully
- [x] Focused Ruff syntax/import checks pass
- [x] Pre-commit hooks and `git diff --check` pass
- [ ] Dashboard build (not applicable; no frontend change)

## Overlap check

Searched open and closed PRs for ?privacy shield request body limit?, ?SHIELD request max bytes?, ?proxy raw_body unbounded?, and ?privacy proxy payload size?. No overlapping PR was found.

## Related Issues

No linked issue.

## AI assistance

AI-assisted boundary analysis and regression-test drafting; the streaming behavior, configuration wiring, diff, and validation results were reviewed before submission.

