### PR TITLE
fix(model-router): retain valid endpoint allowlist

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -330,7 +330,14 @@ def _load_endpoints() -> dict[str, dict[str, Any]]:
     endpoints: dict[str, dict[str, Any]] = {}
     try:
         raw = json.loads(ENDPOINTS_PATH.read_text(encoding="utf-8"))
-        for entry in raw.get("endpoints", []):
+        if not isinstance(raw, dict):
+            raise ValueError("endpoint allowlist root must be an object")
+        entries = raw.get("endpoints", [])
+        if not isinstance(entries, list):
+            raise ValueError("endpoint allowlist entries must be an array")
+        if not all(isinstance(entry, dict) for entry in entries):
+            raise ValueError("endpoint allowlist entries must be objects")
+        for entry in entries:
             endpoint_id = str(entry.get("id") or "")
             base_url = str(entry.get("baseUrl") or "")
             if not endpoint_id or not base_url.startswith(("http://", "https://")):

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -122,6 +122,30 @@ def test_internal_key_falls_back_to_dashboard_api_key(monkeypatch):
     assert mod.INTERNAL_KEY == "dashboard-secret"
 
 
+@pytest.mark.parametrize(
+    "invalid_document",
+    [
+        [],
+        {"endpoints": None},
+        {"endpoints": ["not-an-object"]},
+    ],
+)
+def test_invalid_endpoint_allowlist_retains_last_good_config(
+    router,
+    invalid_document,
+):
+    mod, _client, _write_state, _calls = router
+    previous = mod._load_endpoints().copy()
+    assert previous
+
+    mod.ENDPOINTS_PATH.write_text(
+        json.dumps(invalid_document),
+        encoding="utf-8",
+    )
+
+    assert mod._load_endpoints() == previous
+
+
 class _ChunkedStream(httpx.AsyncByteStream):
     def __init__(self, chunks, error=None, started=None, release=None):
         self.chunks = chunks


### PR DESCRIPTION
﻿## Summary

Makes the model-router endpoint allowlist honor its last-known-good contract for structurally invalid JSON. Non-object roots, non-array `endpoints`, and non-object entries are now treated as invalid updates and leave the cached allowlist intact.

## Why this matters

The allowlist is re-read while model activation rewrites routing configuration. The loader already promises to retain the last good routes when the file is missing or invalid, but valid JSON with the wrong shape escaped its error boundary as `AttributeError` or `TypeError`. A partial or externally damaged write could therefore turn routing requests into 500s instead of continuing on the proven configuration.

## Changes

- Validate the JSON root and endpoint collection types before iteration.
- Reject malformed entry types as one invalid allowlist update.
- Preserve existing behavior for valid empty lists and individually unusable object entries.
- Add regression cases for all three previously escaping shapes.

## Testing

- [x] RED: three malformed shapes raised uncaught exceptions
- [x] Model-router suite: 51 passed
- [x] Focused Ruff syntax/import checks pass
- [x] Pre-commit hooks pass
- [x] `git diff --check`
- [ ] Dashboard build (not applicable; no frontend change)

## Overlap check

Searched open and closed PRs for ?model router endpoint allowlist non-object JSON?, ?_load_endpoints list AttributeError?, ?model-router malformed endpoints retain previous?, and ?endpoints allowlist invalid json object?. No overlapping PR was found.

## Related Issues

No linked issue.

## AI assistance

AI-assisted failure-shape analysis and regression-test drafting; the fail-safe behavior, diff, and complete service test run were reviewed before submission.

