### PR TITLE
fix(token-spy): recover malformed settings safely

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -8,6 +8,7 @@ Supports Anthropic, Moonshot, OpenAI, and generic OpenAI-compatible APIs.
 """
 
 import asyncio
+import copy
 import ipaddress
 import json
 import logging
@@ -180,11 +181,24 @@ _DEFAULT_SETTINGS = {
 
 def _ensure_agent_in_settings(settings: dict, agent_name: str):
     """Ensure the current agent has an entry in settings."""
-    if "agents" not in settings:
+    if not isinstance(settings.get("agents"), dict):
         settings["agents"] = {}
-    if agent_name not in settings["agents"]:
+    if not isinstance(settings["agents"].get(agent_name), dict):
         settings["agents"][agent_name] = {"session_char_limit": None, "poll_interval_minutes": None}
     return settings
+
+
+def _fresh_default_settings() -> dict:
+    """Return defaults without sharing mutable nested state across loads."""
+    return copy.deepcopy(_DEFAULT_SETTINGS)
+
+
+def _valid_setting_int(value, minimum: int, maximum: int | None = None) -> bool:
+    return (
+        type(value) is int
+        and value >= minimum
+        and (maximum is None or value <= maximum)
+    )
 
 
 def load_settings() -> dict:
@@ -192,15 +206,60 @@ def load_settings() -> dict:
     try:
         with open(SETTINGS_PATH, "r") as f:
             data = json.load(f)
-        # Merge defaults for any missing top-level keys
-        for k, v in _DEFAULT_SETTINGS.items():
+        if not isinstance(data, dict):
+            raise ValueError("settings root must be an object")
+
+        defaults = _fresh_default_settings()
+        # Merge fresh defaults for any missing top-level keys.
+        for k, v in defaults.items():
             if k not in data:
                 data[k] = v
+        if not _valid_setting_int(data.get("session_char_limit"), 10_000):
+            data["session_char_limit"] = defaults["session_char_limit"]
+        if not _valid_setting_int(data.get("poll_interval_minutes"), 1, 60):
+            data["poll_interval_minutes"] = defaults["poll_interval_minutes"]
+        if not isinstance(data.get("agents"), dict):
+            data["agents"] = {}
+        else:
+            data["agents"] = {
+                name: config if isinstance(config, dict) else {}
+                for name, config in data["agents"].items()
+            }
+        if not isinstance(data.get("filters"), dict):
+            data["filters"] = defaults["filters"]
+        else:
+            for name, default in defaults["filters"].items():
+                value = data["filters"].get(name)
+                if name not in data["filters"] or (
+                    isinstance(default, dict) and not isinstance(value, dict)
+                ):
+                    data["filters"][name] = default
+        for config in data["agents"].values():
+            if (
+                config.get("session_char_limit") is not None
+                and not _valid_setting_int(config["session_char_limit"], 10_000)
+            ):
+                config["session_char_limit"] = None
+            if (
+                config.get("poll_interval_minutes") is not None
+                and not _valid_setting_int(config["poll_interval_minutes"], 1, 60)
+            ):
+                config["poll_interval_minutes"] = None
+            if "filters" in config and not isinstance(config["filters"], dict):
+                config["filters"] = {}
+            for name, default in defaults["filters"].items():
+                value = config.get("filters", {}).get(name)
+                if (
+                    isinstance(default, dict)
+                    and value is not None
+                    and not isinstance(value, dict)
+                ):
+                    config["filters"][name] = None
         # Ensure current agent exists in settings
         data = _ensure_agent_in_settings(data, AGENT_NAME)
         return data
-    except (FileNotFoundError, json.JSONDecodeError):
-        data = dict(_DEFAULT_SETTINGS)
+    except (FileNotFoundError, json.JSONDecodeError, ValueError):
+        data = _fresh_default_settings()
         data = _ensure_agent_in_settings(data, AGENT_NAME)
         return data
 

--- a/ods/extensions/services/token-spy/tests/test_settings_loading.py
+++ b/ods/extensions/services/token-spy/tests/test_settings_loading.py
@@ -1,0 +1,90 @@
+"""Recovery contracts for Token Spy's persisted dynamic settings."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+
+import pytest
+
+os.environ.setdefault("TOKEN_SPY_API_KEY", "token-spy-test-key")
+
+main = importlib.import_module("main")
+
+
+@pytest.fixture
+def settings_file(tmp_path, monkeypatch):
+    path = tmp_path / "settings.json"
+    monkeypatch.setattr(main, "SETTINGS_PATH", str(path))
+    monkeypatch.setattr(main, "AGENT_NAME", "test-agent")
+    return path
+
+
+@pytest.mark.parametrize("document", [None, [], "settings"])
+def test_non_object_settings_fall_back_to_fresh_defaults(settings_file, document):
+    settings_file.write_text(json.dumps(document), encoding="utf-8")
+
+    settings = main.load_settings()
+
+    assert settings["session_char_limit"] == 200_000
+    assert settings["poll_interval_minutes"] == 5
+    assert isinstance(settings["filters"], dict)
+    assert settings["agents"]["test-agent"]["session_char_limit"] is None
+
+
+@pytest.mark.parametrize(
+    "document",
+    [
+        {"agents": []},
+        {"agents": {"test-agent": "invalid"}},
+        {"filters": []},
+        {"filters": {"tools": []}},
+        {"agents": {"test-agent": {"filters": ["invalid"]}}},
+    ],
+)
+def test_invalid_settings_containers_are_repaired(settings_file, document):
+    settings_file.write_text(json.dumps(document), encoding="utf-8")
+
+    settings = main.load_settings()
+
+    assert isinstance(settings["agents"], dict)
+    assert isinstance(settings["agents"]["test-agent"], dict)
+    assert isinstance(settings["filters"], dict)
+    assert isinstance(main.get_filter_settings("test-agent"), dict)
+
+
+def test_invalid_numeric_settings_fall_back_safely(settings_file):
+    settings_file.write_text(
+        json.dumps({
+            "session_char_limit": "many",
+            "poll_interval_minutes": 0,
+            "agents": {
+                "test-agent": {
+                    "session_char_limit": 1,
+                    "poll_interval_minutes": 61,
+                }
+            },
+        }),
+        encoding="utf-8",
+    )
+
+    settings = main.load_settings()
+
+    assert settings["session_char_limit"] == 200_000
+    assert settings["poll_interval_minutes"] == 5
+    assert settings["agents"]["test-agent"]["session_char_limit"] is None
+    assert settings["agents"]["test-agent"]["poll_interval_minutes"] is None
+
+
+def test_fallback_settings_do_not_mutate_process_defaults(settings_file):
+    first = main.load_settings()
+    first["filters"]["tools"]["mode"] = "blocklist"
+    first["filters"]["tools"]["allowlist"].append("mutated")
+    first["agents"]["test-agent"]["session_char_limit"] = 10_000
+
+    second = main.load_settings()
+
+    assert second["filters"]["tools"]["mode"] == "allowlist"
+    assert "mutated" not in second["filters"]["tools"]["allowlist"]
+    assert second["agents"]["test-agent"]["session_char_limit"] is None


### PR DESCRIPTION
﻿## Summary

Makes Token Spy recover safely from syntactically valid but structurally malformed `settings.json` files. Settings loads now normalize the root, agent/filter containers, and bounded numeric fields, while every fallback starts from a deep copy of defaults.

## Why this matters

The loader only handled missing files and malformed JSON. Values such as `null`, `[]`, `{"agents":[]}`, or an invalid agent record escaped as `TypeError`/attribute errors across health, dashboard, and polling paths. Separately, fallback used a shallow `dict(_DEFAULT_SETTINGS)`; changing a nested filter or agent entry could mutate process-wide defaults, so later ?fresh? loads inherited state that was never persisted.

## Changes

- Create fresh deep-copied defaults for every load.
- Recover non-object roots and invalid agent/filter containers.
- Normalize global and per-agent session/poll values to their existing safe domains.
- Repair invalid nested filter section containers while preserving valid custom settings.
- Add regression coverage for malformed shapes, numeric fields, and cross-load isolation.

## Testing

- [x] RED: 7 original recovery cases failed (six shape failures plus shared-default mutation)
- [x] Focused recovery suite: 10 passed
- [x] Full Token Spy suite: 30 passed, 5 skipped (live PostgreSQL unavailable)
- [x] Focused Ruff syntax/import checks pass
- [x] Pre-commit hooks pass
- [x] `git diff --check`
- [ ] Dashboard build (not applicable; no frontend change)

## Overlap check

Searched open and closed PRs for ?token spy invalid settings json shape?, ?load_settings non-object JSON?, ?Token Spy settings file list?, and ?settings.json wrong type token-spy?. No overlapping PR was found.

## Related Issues

No linked issue.

## AI assistance

AI-assisted state-shape analysis and regression-test drafting; normalization behavior, mutable-default isolation, diff, and complete service test run were reviewed before submission.

