### PR TITLE
feat(host-agent): integrate Dream Worker

### DIFF
--- a/ods/bin/dream_worker/__init__.py
+++ b/ods/bin/dream_worker/__init__.py
@@ -1,0 +1,8 @@
+"""Dream Worker integration client for ODS."""
+
+from .client import DreamWorkerClient, DreamWorkerError
+
+__all__ = [
+    "DreamWorkerClient",
+    "DreamWorkerError",
+]

--- a/ods/bin/dream_worker/client.py
+++ b/ods/bin/dream_worker/client.py
@@ -1,0 +1,297 @@
+"""Small stdlib-only client for the Dream Worker 0.8.x control API."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Mapping
+from typing import Any
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlsplit
+
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+MAX_RESPONSE_BYTES = 2 * 1024 * 1024
+JOB_ID_RE = re.compile(r"^[0-9a-fA-F]{32}$")
+
+
+class DreamWorkerError(RuntimeError):
+    """Normalized Dream Worker transport or API failure."""
+
+    def __init__(
+        self,
+        status: int | None,
+        code: str,
+        message: str,
+    ) -> None:
+        super().__init__(message)
+        self.status = status
+        self.code = str(code)
+        self.message = str(message)
+
+
+class DreamWorkerClient:
+    """Authenticated client for status and persistent Dream Worker jobs."""
+
+    def __init__(
+        self,
+        base_url: str,
+        token: str,
+        *,
+        timeout: float = DEFAULT_TIMEOUT_SECONDS,
+        opener: Callable[..., Any] = urllib_request.urlopen,
+    ) -> None:
+        self.base_url = self._normalize_base_url(base_url)
+        self._token = self._validate_token(token)
+        self.timeout = float(timeout)
+        self._opener = opener
+
+        if self.timeout <= 0:
+            raise ValueError("timeout must be greater than zero")
+
+    @staticmethod
+    def _normalize_base_url(value: str) -> str:
+        raw = str(value or "").strip().rstrip("/")
+        if not raw:
+            raise ValueError("Dream Worker base URL is required")
+
+        parts = urlsplit(raw)
+
+        if parts.scheme not in {"http", "https"}:
+            raise ValueError("Dream Worker base URL must use http or https")
+
+        if not parts.hostname:
+            raise ValueError("Dream Worker base URL must include a host")
+
+        if parts.username or parts.password:
+            raise ValueError("Dream Worker base URL must not contain credentials")
+
+        if parts.query or parts.fragment:
+            raise ValueError("Dream Worker base URL must not contain query or fragment")
+
+        path = parts.path.rstrip("/")
+        if path:
+            raise ValueError("Dream Worker base URL must not contain a path")
+
+        return raw
+
+    @staticmethod
+    def _validate_token(value: str) -> str:
+        token = str(value or "").strip()
+
+        if not token:
+            raise ValueError("Dream Worker token is required")
+
+        if any(ord(char) < 33 or ord(char) == 127 for char in token):
+            raise ValueError("Dream Worker token contains invalid characters")
+
+        return token
+
+    @staticmethod
+    def _validate_job_id(value: str) -> str:
+        job_id = str(value or "").strip()
+
+        if JOB_ID_RE.fullmatch(job_id) is None:
+            raise ValueError("Dream Worker job id must be 32 hexadecimal characters")
+
+        return job_id
+
+    @staticmethod
+    def _decode_json(raw: bytes) -> Mapping[str, Any]:
+        try:
+            payload = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise DreamWorkerError(
+                None,
+                "invalid_response",
+                f"Dream Worker returned invalid JSON: {exc}",
+            ) from exc
+
+        if not isinstance(payload, Mapping):
+            raise DreamWorkerError(
+                None,
+                "invalid_response",
+                "Dream Worker response must be a JSON object",
+            )
+
+        return payload
+
+    @staticmethod
+    def _read_limited(response: Any) -> bytes:
+        raw = response.read(MAX_RESPONSE_BYTES + 1)
+
+        if len(raw) > MAX_RESPONSE_BYTES:
+            raise DreamWorkerError(
+                None,
+                "response_too_large",
+                "Dream Worker response exceeded the safety limit",
+            )
+
+        return raw
+
+    @staticmethod
+    def _error_from_http(exc: urllib_error.HTTPError) -> DreamWorkerError:
+        raw = b""
+
+        try:
+            raw = exc.read(MAX_RESPONSE_BYTES + 1)
+        except Exception:
+            raw = b""
+
+        code = "http_error"
+        message = f"Dream Worker returned HTTP {int(exc.code)}"
+
+        if raw and len(raw) <= MAX_RESPONSE_BYTES:
+            try:
+                payload = json.loads(raw.decode("utf-8"))
+            except (UnicodeDecodeError, ValueError):
+                payload = None
+
+            if isinstance(payload, Mapping):
+                api_code = payload.get("error")
+                detail = payload.get("detail") or payload.get("message")
+
+                if isinstance(api_code, str) and api_code.strip():
+                    code = api_code.strip()
+
+                if isinstance(detail, str) and detail.strip():
+                    message = detail.strip()
+
+                if code != "http_error" and message.startswith("Dream Worker returned HTTP"):
+                    message = code
+
+        return DreamWorkerError(
+            int(exc.code),
+            code,
+            message,
+        )
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        payload: Mapping[str, Any] | None = None,
+    ) -> Mapping[str, Any]:
+        data = None
+        headers = {
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self._token}",
+            "User-Agent": "ODS DreamWorkerClient/1",
+        }
+
+        if payload is not None:
+            data = json.dumps(
+                dict(payload),
+                separators=(",", ":"),
+            ).encode("utf-8")
+            headers["Content-Type"] = "application/json; charset=utf-8"
+
+        request = urllib_request.Request(
+            f"{self.base_url}{path}",
+            data=data,
+            headers=headers,
+            method=method.upper(),
+        )
+
+        try:
+            with self._opener(
+                request,
+                timeout=self.timeout,
+            ) as response:
+                raw = self._read_limited(response)
+        except urllib_error.HTTPError as exc:
+            raise self._error_from_http(exc) from exc
+        except (TimeoutError, urllib_error.URLError, OSError) as exc:
+            raise DreamWorkerError(
+                None,
+                "worker_unreachable",
+                f"Dream Worker request failed: {exc}",
+            ) from exc
+
+        result = self._decode_json(raw)
+
+        if result.get("ok") is False:
+            api_code = result.get("error")
+            code = str(api_code or "worker_error")
+            raise DreamWorkerError(
+                None,
+                code,
+                code,
+            )
+
+        return result
+
+    @staticmethod
+    def _extract_job(payload: Mapping[str, Any]) -> dict[str, Any]:
+        nested = payload.get("job")
+
+        if isinstance(nested, Mapping):
+            return dict(nested)
+
+        if isinstance(payload.get("id"), str) and isinstance(payload.get("state"), str):
+            return dict(payload)
+
+        raise DreamWorkerError(
+            None,
+            "invalid_job_response",
+            "Dream Worker response did not contain a job object",
+        )
+
+    def status(self) -> dict[str, Any]:
+        return dict(
+            self._request(
+                "GET",
+                "/status",
+            )
+        )
+
+    def submit_job(
+        self,
+        prompt: str,
+        *,
+        enable_thinking: bool = False,
+        max_tokens: int = 512,
+    ) -> dict[str, Any]:
+        text = str(prompt or "")
+
+        if not text.strip():
+            raise ValueError("prompt must not be empty")
+
+        if type(max_tokens) is not int or max_tokens < 1:
+            raise ValueError("max_tokens must be a positive integer")
+
+        response = self._request(
+            "POST",
+            "/jobs",
+            {
+                "prompt": text,
+                "enableThinking": bool(enable_thinking),
+                "maxTokens": max_tokens,
+            },
+        )
+
+        return self._extract_job(response)
+
+    def get_job(self, job_id: str) -> dict[str, Any]:
+        safe_id = self._validate_job_id(job_id)
+        response = self._request(
+            "GET",
+            f"/jobs/{safe_id}",
+        )
+        return self._extract_job(response)
+
+    def cancel_job(self, job_id: str) -> dict[str, Any]:
+        safe_id = self._validate_job_id(job_id)
+        response = self._request(
+            "POST",
+            f"/jobs/{safe_id}/cancel",
+        )
+        return self._extract_job(response)
+
+
+__all__ = [
+    "DEFAULT_TIMEOUT_SECONDS",
+    "DreamWorkerClient",
+    "DreamWorkerError",
+]

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -89,6 +89,19 @@ except Exception:  # pragma: no cover - import environment dependent
     _remote_provider_public_probe_receipt = None
     _remote_provider_ssh_supervisor_plan = None
 
+try:
+    from dream_worker.client import (
+        DreamWorkerClient as _DreamWorkerClient,
+        DreamWorkerError as _DreamWorkerError,
+    )
+except Exception:  # pragma: no cover - import environment dependent
+    _DreamWorkerClient = None
+
+    class _DreamWorkerError(RuntimeError):
+        status = None
+        code = "dream_worker_unavailable"
+        message = "Dream Worker client is unavailable"
+
 _MODEL_MEMORY_PATH = (
     Path(__file__).resolve().parent.parent
     / "extensions"
@@ -3623,6 +3636,76 @@ foreach ($prefix in $prefixes) {{
         return payload
 
 
+def _dream_worker_base_url() -> str:
+    env = load_env(INSTALL_DIR / ".env")
+    configured = str(env.get("DREAM_WORKER_URL") or "").strip()
+    if configured:
+        return configured
+    return "http://192.168.1.19:18100"
+
+
+def _dream_worker_token_path() -> Path:
+    env = load_env(INSTALL_DIR / ".env")
+    configured = str(env.get("DREAM_WORKER_TOKEN_FILE") or "").strip()
+    if configured:
+        return Path(configured).expanduser()
+
+    local_app_data = str(os.environ.get("LOCALAPPDATA") or "").strip()
+    if not local_app_data:
+        raise RuntimeError("LOCALAPPDATA is unavailable for Dream Worker token lookup")
+
+    return (
+        Path(local_app_data)
+        / "DreamServer"
+        / "secrets"
+        / "dream-worker-token.txt"
+    )
+
+
+def _dream_worker_client():
+    if _DreamWorkerClient is None:
+        raise RuntimeError("Dream Worker client module is unavailable")
+
+    token_path = _dream_worker_token_path()
+
+    if token_path.is_symlink():
+        raise RuntimeError("Refusing symlinked Dream Worker token file")
+
+    token = token_path.read_text(encoding="utf-8-sig").strip()
+
+    if not token:
+        raise RuntimeError("Dream Worker token file is empty")
+
+    return _DreamWorkerClient(
+        _dream_worker_base_url(),
+        token,
+    )
+
+
+def _dream_worker_write_transport_error(handler, exc) -> None:
+    status = getattr(exc, "status", None)
+    if type(status) is not int:
+        status = 502
+
+    code = str(
+        getattr(exc, "code", None)
+        or "dream_worker_request_failed"
+    )
+
+    message = str(
+        getattr(exc, "message", None)
+        or "Dream Worker request failed"
+    )
+
+    json_response(
+        handler,
+        status,
+        {
+            "error": message,
+            "code": code,
+        },
+    )
+
 def _windows_llm_status() -> dict | None:
     """Read host-native Lemonade health and optional stats over loopback."""
     global _windows_llm_status_cache
@@ -4553,6 +4636,22 @@ class AgentHandler(BaseHTTPRequestHandler):
         logger.info(fmt, *args)
 
     def do_GET(self):
+        dream_path = self.path.split("?", 1)[0]
+
+        if dream_path == "/v1/dream-worker/status":
+            self._handle_dream_worker_status()
+            return
+
+        dream_job_match = re.fullmatch(
+            r"/v1/dream-worker/jobs/([0-9a-fA-F]{32})",
+            dream_path,
+        )
+
+        if dream_job_match is not None:
+            self._handle_dream_worker_get_job(
+                dream_job_match.group(1)
+            )
+            return
         parsed = urlparse(self.path)
         path = parsed.path
         if path == "/health":
@@ -4897,6 +4996,22 @@ class AgentHandler(BaseHTTPRequestHandler):
         json_response(self, 200, metrics)
 
     def do_POST(self):
+        dream_path = self.path.split("?", 1)[0]
+
+        if dream_path == "/v1/dream-worker/jobs":
+            self._handle_dream_worker_submit()
+            return
+
+        dream_cancel_match = re.fullmatch(
+            r"/v1/dream-worker/jobs/([0-9a-fA-F]{32})/cancel",
+            dream_path,
+        )
+
+        if dream_cancel_match is not None:
+            self._handle_dream_worker_cancel(
+                dream_cancel_match.group(1)
+            )
+            return
         # Several legacy endpoints intentionally ignore an optional body, and
         # rejected requests may return before consuming one. Close POST
         # connections after their framed response so unread bytes can never be
@@ -4955,6 +5070,181 @@ class AgentHandler(BaseHTTPRequestHandler):
         else:
             json_response(self, 404, {"error": "Not found"})
 
+    def _handle_dream_worker_status(self):
+        """Return authenticated Dream Worker machine/runtime status."""
+        if not check_auth(self):
+            return
+
+        try:
+            status = _dream_worker_client().status()
+        except _DreamWorkerError as exc:
+            _dream_worker_write_transport_error(self, exc)
+            return
+        except (OSError, RuntimeError, ValueError):
+            logger.debug("Dream Worker status unavailable", exc_info=True)
+            json_response(
+                self,
+                503,
+                {
+                    "error": "Dream Worker integration is unavailable",
+                    "code": "dream_worker_unavailable",
+                },
+            )
+            return
+
+        json_response(
+            self,
+            200,
+            {
+                "ok": True,
+                "worker": status,
+            },
+        )
+
+    def _handle_dream_worker_get_job(self, job_id: str):
+        """Return one persistent Dream Worker job."""
+        if not check_auth(self):
+            return
+
+        try:
+            job = _dream_worker_client().get_job(job_id)
+        except _DreamWorkerError as exc:
+            _dream_worker_write_transport_error(self, exc)
+            return
+        except (OSError, RuntimeError, ValueError):
+            logger.debug("Dream Worker job lookup unavailable", exc_info=True)
+            json_response(
+                self,
+                503,
+                {
+                    "error": "Dream Worker integration is unavailable",
+                    "code": "dream_worker_unavailable",
+                },
+            )
+            return
+
+        json_response(
+            self,
+            200,
+            {
+                "ok": True,
+                "job": job,
+            },
+        )
+
+    def _handle_dream_worker_submit(self):
+        """Submit one asynchronous Dream Worker inference job."""
+        if not check_auth(self):
+            return
+
+        body = read_optional_json_body(self)
+
+        if body is None:
+            return
+
+        if not isinstance(body, dict):
+            json_response(
+                self,
+                400,
+                {"error": "Request body must be a JSON object"},
+            )
+            return
+
+        prompt = body.get("prompt")
+
+        if not isinstance(prompt, str) or not prompt.strip():
+            json_response(
+                self,
+                400,
+                {"error": "prompt must be a non-empty string"},
+            )
+            return
+
+        enable_thinking = body.get("enableThinking", False)
+
+        if type(enable_thinking) is not bool:
+            json_response(
+                self,
+                400,
+                {"error": "enableThinking must be boolean"},
+            )
+            return
+
+        max_tokens = body.get("maxTokens", 512)
+
+        if type(max_tokens) is not int or max_tokens < 1:
+            json_response(
+                self,
+                400,
+                {"error": "maxTokens must be a positive integer"},
+            )
+            return
+
+        try:
+            job = _dream_worker_client().submit_job(
+                prompt,
+                enable_thinking=enable_thinking,
+                max_tokens=max_tokens,
+            )
+        except _DreamWorkerError as exc:
+            _dream_worker_write_transport_error(self, exc)
+            return
+        except (OSError, RuntimeError, ValueError):
+            logger.debug("Dream Worker job submission unavailable", exc_info=True)
+            json_response(
+                self,
+                503,
+                {
+                    "error": "Dream Worker integration is unavailable",
+                    "code": "dream_worker_unavailable",
+                },
+            )
+            return
+
+        response_status = 200
+
+        if str(job.get("state") or "") in {"queued", "running"}:
+            response_status = 202
+
+        json_response(
+            self,
+            response_status,
+            {
+                "ok": True,
+                "job": job,
+            },
+        )
+
+    def _handle_dream_worker_cancel(self, job_id: str):
+        """Request cancellation of one Dream Worker job."""
+        if not check_auth(self):
+            return
+
+        try:
+            job = _dream_worker_client().cancel_job(job_id)
+        except _DreamWorkerError as exc:
+            _dream_worker_write_transport_error(self, exc)
+            return
+        except (OSError, RuntimeError, ValueError):
+            logger.debug("Dream Worker cancellation unavailable", exc_info=True)
+            json_response(
+                self,
+                503,
+                {
+                    "error": "Dream Worker integration is unavailable",
+                    "code": "dream_worker_unavailable",
+                },
+            )
+            return
+
+        json_response(
+            self,
+            200,
+            {
+                "ok": True,
+                "job": job,
+            },
+        )
     def _handle_remote_provider_plan(self):
         """Validate a remote-provider lifecycle request without side effects."""
         if not check_auth(self):

--- a/ods/tests/test_dream_worker_client.py
+++ b/ods/tests/test_dream_worker_client.py
@@ -1,0 +1,222 @@
+"""Unit tests for the stdlib-only Dream Worker client."""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import unittest
+from pathlib import Path
+from urllib import error as urllib_error
+
+
+ODS_ROOT = Path(__file__).resolve().parents[1]
+BIN_DIR = ODS_ROOT / "bin"
+
+if str(BIN_DIR) not in sys.path:
+    sys.path.insert(0, str(BIN_DIR))
+
+from dream_worker.client import DreamWorkerClient, DreamWorkerError
+
+
+JOB_ID = "6f250f8f0bdf43da8a3f619b3a31184b"
+
+
+class FakeResponse:
+    def __init__(self, payload: dict, status: int = 200) -> None:
+        self.status = status
+        self.headers = {"content-type": "application/json"}
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            return self._body
+        return self._body[:size]
+
+    def __enter__(self) -> "FakeResponse":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        return False
+
+
+class RecordingOpener:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+        self.calls = []
+
+    def __call__(self, request, timeout):
+        self.calls.append((request, timeout))
+        return FakeResponse(self.payload)
+
+
+class DreamWorkerClientTests(unittest.TestCase):
+    def test_status_sends_bearer_token(self) -> None:
+        opener = RecordingOpener(
+            {
+                "version": "0.8.0",
+                "machine": "WOLFSOUL-PRIME",
+                "machineState": "INTERACTIVE",
+            }
+        )
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            "a" * 64,
+            opener=opener,
+        )
+
+        result = client.status()
+
+        self.assertEqual(result["version"], "0.8.0")
+        request, timeout = opener.calls[0]
+        self.assertEqual(request.get_method(), "GET")
+        self.assertEqual(request.full_url, "http://192.168.1.19:18100/status")
+        self.assertEqual(request.get_header("Authorization"), "Bearer " + ("a" * 64))
+        self.assertEqual(timeout, 10.0)
+
+    def test_submit_job_uses_worker_contract_and_unwraps_job(self) -> None:
+        opener = RecordingOpener(
+            {
+                "ok": True,
+                "job": {
+                    "id": JOB_ID,
+                    "state": "queued",
+                    "attemptCount": 0,
+                },
+            }
+        )
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            "b" * 64,
+            opener=opener,
+        )
+
+        job = client.submit_job(
+            "Reply with exactly: OK",
+            enable_thinking=False,
+            max_tokens=64,
+        )
+
+        self.assertEqual(job["id"], JOB_ID)
+        self.assertEqual(job["state"], "queued")
+
+        request, _timeout = opener.calls[0]
+        payload = json.loads(request.data.decode("utf-8"))
+
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(request.full_url, "http://192.168.1.19:18100/jobs")
+        self.assertEqual(payload["prompt"], "Reply with exactly: OK")
+        self.assertIs(payload["enableThinking"], False)
+        self.assertEqual(payload["maxTokens"], 64)
+
+    def test_get_job_accepts_nested_job_response(self) -> None:
+        opener = RecordingOpener(
+            {
+                "ok": True,
+                "job": {
+                    "id": JOB_ID,
+                    "state": "completed",
+                    "content": "OK",
+                },
+            }
+        )
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            "c" * 64,
+            opener=opener,
+        )
+
+        job = client.get_job(JOB_ID)
+
+        self.assertEqual(job["state"], "completed")
+        self.assertEqual(job["content"], "OK")
+
+    def test_get_job_accepts_direct_job_response(self) -> None:
+        opener = RecordingOpener(
+            {
+                "id": JOB_ID,
+                "state": "queued",
+                "attemptCount": 0,
+            }
+        )
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            "d" * 64,
+            opener=opener,
+        )
+
+        job = client.get_job(JOB_ID)
+
+        self.assertEqual(job["id"], JOB_ID)
+        self.assertEqual(job["state"], "queued")
+
+    def test_cancel_job_uses_cancel_endpoint(self) -> None:
+        opener = RecordingOpener(
+            {
+                "ok": True,
+                "job": {
+                    "id": JOB_ID,
+                    "state": "cancelled",
+                },
+            }
+        )
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            "e" * 64,
+            opener=opener,
+        )
+
+        job = client.cancel_job(JOB_ID)
+
+        self.assertEqual(job["state"], "cancelled")
+        request, _timeout = opener.calls[0]
+        self.assertEqual(request.get_method(), "POST")
+        self.assertEqual(
+            request.full_url,
+            f"http://192.168.1.19:18100/jobs/{JOB_ID}/cancel",
+        )
+
+    def test_http_401_is_normalized_without_leaking_token(self) -> None:
+        token = "f" * 64
+
+        def opener(request, timeout):
+            body = io.BytesIO(
+                b'{"ok":false,"error":"unauthorized"}'
+            )
+            raise urllib_error.HTTPError(
+                request.full_url,
+                401,
+                "Unauthorized",
+                {},
+                body,
+            )
+
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            token,
+            opener=opener,
+        )
+
+        with self.assertRaises(DreamWorkerError) as caught:
+            client.status()
+
+        self.assertEqual(caught.exception.status, 401)
+        self.assertEqual(caught.exception.code, "unauthorized")
+        self.assertNotIn(token, str(caught.exception))
+
+    def test_rejects_path_in_job_id(self) -> None:
+        opener = RecordingOpener({"ok": True})
+        client = DreamWorkerClient(
+            "http://192.168.1.19:18100",
+            "1" * 64,
+            opener=opener,
+        )
+
+        with self.assertRaises(ValueError):
+            client.get_job("../../status")
+
+        self.assertEqual(opener.calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ods/tests/test_dream_worker_host_agent_contract.py
+++ b/ods/tests/test_dream_worker_host_agent_contract.py
@@ -1,0 +1,92 @@
+"""Static contract checks for the Dream Worker host-agent boundary."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ODS_ROOT = Path(__file__).resolve().parents[1]
+HOST_AGENT = ODS_ROOT / "bin" / "ods-host-agent.py"
+
+
+class DreamWorkerHostAgentContractTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.source = HOST_AGENT.read_text(encoding="utf-8")
+
+    def test_client_is_imported(self) -> None:
+        self.assertIn(
+            "from dream_worker.client import (",
+            self.source,
+        )
+
+    def test_status_route_exists(self) -> None:
+        self.assertIn(
+            'dream_path == "/v1/dream-worker/status"',
+            self.source,
+        )
+        self.assertIn(
+            "self._handle_dream_worker_status()",
+            self.source,
+        )
+
+    def test_submit_route_exists(self) -> None:
+        self.assertIn(
+            'dream_path == "/v1/dream-worker/jobs"',
+            self.source,
+        )
+        self.assertIn(
+            "self._handle_dream_worker_submit()",
+            self.source,
+        )
+
+    def test_get_and_cancel_routes_validate_job_ids(self) -> None:
+        self.assertIn(
+            r'r"/v1/dream-worker/jobs/([0-9a-fA-F]{32})"',
+            self.source,
+        )
+        self.assertIn(
+            r'r"/v1/dream-worker/jobs/([0-9a-fA-F]{32})/cancel"',
+            self.source,
+        )
+
+    def test_every_handler_uses_host_agent_auth(self) -> None:
+        handler_names = (
+            "_handle_dream_worker_status",
+            "_handle_dream_worker_get_job",
+            "_handle_dream_worker_submit",
+            "_handle_dream_worker_cancel",
+        )
+
+        for name in handler_names:
+            start = self.source.index(f"    def {name}")
+            next_method = self.source.find("\n    def ", start + 8)
+            block = self.source[start:]
+
+            if next_method >= 0:
+                block = self.source[start:next_method]
+
+            self.assertIn(
+                "if not check_auth(self):",
+                block,
+                msg=name,
+            )
+
+    def test_worker_token_is_loaded_from_file(self) -> None:
+        self.assertIn(
+            '"dream-worker-token.txt"',
+            self.source,
+        )
+        self.assertIn(
+            'token_path.read_text(encoding="utf-8-sig").strip()',
+            self.source,
+        )
+        self.assertNotIn(
+            "worker.auth.token=",
+            self.source,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Integrate Dream Worker into the ODS host agent through dedicated authenticated asynchronous routes.

### Added

- Dream Worker HTTP client
- Host-agent routes:
  - GET /v1/dream-worker/status
  - POST /v1/dream-worker/jobs
  - GET /v1/dream-worker/jobs/{id}
  - POST /v1/dream-worker/jobs/{id}/cancel
- Bearer authentication toward the Worker
- Token loading from a local file outside the repository
- Input validation and normalized error handling
- Unit and host-agent contract tests

### Validation

- Dream Worker client tests: 7/7 passing
- Host-agent contract tests: 6/6 passing
- git diff --check: passing
- Live authenticated end-to-end validation completed for status, existing job lookup, job submission, cancellation, and final job state retrieval