### PR TITLE
fix(deps): bump fastapi to patch transitive starlette advisories in ape

### DIFF
--- a/ods/extensions/services/ape/requirements.txt
+++ b/ods/extensions/services/ape/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.6
+fastapi==0.141.1
 uvicorn[standard]==0.32.1
 pydantic==2.10.3
 pyyaml==6.0.2


### PR DESCRIPTION
Automated dependency bump to address several disclosed CVEs in a transitive dependency.

- **Package:** `ape/requirements.txt` — `fastapi` `0.115.6` → `0.141.1`
- **Why:** `fastapi==0.115.6` does not pin `starlette`, so a fresh install resolves it to `0.41.3`, which carries multiple open advisories:
  - **GHSA-86qp-5c8j-p5mr** / PYSEC-2026-161 — missing Host header validation poisons `request.url.path`, bypassing path-based security checks
  - **GHSA-jp82-jpqv-5vv3** — unvalidated request path concatenated into authority poisons `request.url.hostname`
  - **GHSA-2c2j-9gv5-cj73** / **GHSA-7f5h-v6xp-fcq8** — DoS parsing large multipart files / Range-header merging in `FileResponse`
  - **GHSA-82w8-qh3p-5jfq** — `request.form()` size limits silently ignored
  - **GHSA-wqp7-x3pw-xc5r** — SSRF + NTLM credential theft via UNC paths in `StaticFiles` on Windows
  - **GHSA-x746-7m8f-x49c** — arbitrary HTTP method dispatched to `HTTPEndpoint` via `getattr`
- **Fix:** `fastapi==0.141.1` relaxes its own constraint to `starlette>=0.46.0` (no upper bound), which resolves to the current `1.6.0` release. Verified against the OSV API: `starlette==1.6.0`, `fastapi==0.141.1`, `pydantic==2.10.3` (unchanged), and `uvicorn==0.32.1` (unchanged) all currently show **zero** open advisories. `fastapi 0.141.1` only requires `pydantic>=2.9.0`, so the existing `pydantic==2.10.3` pin is untouched and compatible.

`ape` (Agent Policy Engine) is a network-facing FastAPI service, so the Host-header/path-poisoning advisories are directly relevant to its own security-enforcement role, not just incidental exposure.

No code changes outside the requirements pin.

Detected by [osv-scanner](https://google.github.io/osv-scanner/).

---
Filed by [Aeon](https://github.com/aeonfun/aeon).