### PR TITLE
fix(uninstall): preserve the complete model tree

### DIFF
--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -327,10 +327,15 @@ fi
 # 5. Remove install directory (with optional data/model preservation)
 log_info "Removing installation directory..."
 INSTALL_DIR_CLEANED=true
+MODELS_BACKUP="$HOME/.ods-models-backup"
 if $KEEP_MODELS && [[ -d "$INSTALL_DIR/data/models" ]]; then
-    MODELS_BACKUP="$HOME/.ods-models-backup"
-    mkdir -p "$MODELS_BACKUP"
-    mv "$INSTALL_DIR/data/models"/* "$MODELS_BACKUP/" 2>/dev/null || true
+    # Move the directory as one unit so dotfiles are included and an existing
+    # backup cannot silently merge with (or overwrite) this install's models.
+    # A failed move must abort before the install directory is deleted.
+    if [[ -e "$MODELS_BACKUP" ]]; then
+        MODELS_BACKUP="${MODELS_BACKUP}-$(date +%Y%m%d-%H%M%S)-$$"
+    fi
+    mv "$INSTALL_DIR/data/models" "$MODELS_BACKUP"
     log_info "Models preserved at: $MODELS_BACKUP"
 fi
 
@@ -390,7 +395,7 @@ echo -e "${GREEN}║     ODS has been uninstalled.           ║${NC}"
 echo -e "${GREEN}╚══════════════════════════════════════════════════╝${NC}"
 echo ""
 if $KEEP_MODELS; then
-    echo "Your models were saved to: $HOME/.ods-models-backup"
+    echo "Your models were saved to: $MODELS_BACKUP"
     echo "To reuse them on reinstall, move them back to ~/ods/data/models/"
 fi
 if $KEEP_DATA; then

--- a/ods/tests/test-uninstall-keep-models.sh
+++ b/ods/tests/test-uninstall-keep-models.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/ods-uninstall.sh"
+TEST_ROOT="$(mktemp -d -t ods-uninstall-models-XXXXXX)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+make_fixture() {
+    local name="$1"
+    local fixture="$TEST_ROOT/$name"
+    local install_dir="$fixture/install"
+    local mock_bin="$fixture/bin"
+
+    mkdir -p "$install_dir/data/models/nested" "$mock_bin" "$fixture/home"
+    cp "$TARGET" "$install_dir/ods-uninstall.sh"
+    touch "$install_dir/ods-cli"
+    printf 'weights\n' > "$install_dir/data/models/model.gguf"
+    printf 'metadata\n' > "$install_dir/data/models/.catalog"
+    printf 'nested\n' > "$install_dir/data/models/nested/tokenizer.json"
+
+    for command_name in docker systemctl pgrep timeout sudo; do
+        printf '#!/usr/bin/env bash\nexit 0\n' > "$mock_bin/$command_name"
+        chmod +x "$mock_bin/$command_name"
+    done
+
+    printf '%s\n' "$fixture"
+}
+
+test_preserves_complete_tree_without_merging() {
+    local fixture install_dir backup_dir output
+    fixture="$(make_fixture preserve)"
+    install_dir="$fixture/install"
+    mkdir -p "$fixture/home/.ods-models-backup"
+    printf 'older\n' > "$fixture/home/.ods-models-backup/existing.gguf"
+
+    output="$(HOME="$fixture/home" PATH="$fixture/bin:$PATH" \
+        bash "$install_dir/ods-uninstall.sh" --keep-models --force)"
+
+    backup_dir="$(find "$fixture/home" -mindepth 1 -maxdepth 1 \
+        -type d -name '.ods-models-backup-*' -print -quit)"
+    [[ -n "$backup_dir" ]]
+    [[ -f "$backup_dir/model.gguf" ]]
+    [[ -f "$backup_dir/.catalog" ]]
+    [[ -f "$backup_dir/nested/tokenizer.json" ]]
+    [[ -f "$fixture/home/.ods-models-backup/existing.gguf" ]]
+    [[ ! -e "$install_dir" ]]
+    [[ "$output" == *"Your models were saved to: $backup_dir"* ]]
+}
+
+test_move_failure_keeps_install_tree() {
+    local fixture install_dir
+    fixture="$(make_fixture failure)"
+    install_dir="$fixture/install"
+    printf '#!/usr/bin/env bash\nexit 73\n' > "$fixture/bin/mv"
+    chmod +x "$fixture/bin/mv"
+
+    if HOME="$fixture/home" PATH="$fixture/bin:$PATH" \
+        bash "$install_dir/ods-uninstall.sh" --keep-models --force \
+        > "$fixture/output" 2>&1; then
+        echo "expected model preservation failure" >&2
+        return 1
+    fi
+
+    [[ -f "$install_dir/data/models/model.gguf" ]]
+    [[ -f "$install_dir/data/models/.catalog" ]]
+}
+
+test_preserves_complete_tree_without_merging
+test_move_failure_keeps_install_tree
+echo "uninstall keep-models tests passed"


### PR DESCRIPTION
## Summary

- move the complete model directory, including dotfiles, before uninstall cleanup
- choose a collision-free backup path when an older backup already exists
- abort uninstall if preservation fails instead of deleting the source tree

## Why this matters

`ods-uninstall.sh --keep-models` previously expanded `models/*`, which omitted hidden metadata. It also swallowed `mv` failures and then deleted the installation directory, so an operator could explicitly request preservation and still lose model data. The preserved invariant is: installation cleanup starts only after the entire model tree has moved successfully to a non-conflicting destination.

## Overlap check

Searched open and closed PR titles/bodies for `uninstall preserve models` and reviewed open PR #3635 plus the production file `ods/ods-uninstall.sh`. No existing PR covers model-tree preservation; #3635 concerns Docker resource pruning.

## Validation

- `bash ods/tests/test-uninstall-keep-models.sh` — passes CLI-boundary cases for dotfiles, nested content, existing backups, and failed moves
- `bash -n ods/ods-uninstall.sh ods/tests/test-uninstall-keep-models.sh`
- `git diff --check`

## Tradeoffs and rollback

An existing backup now causes a timestamp/PID-suffixed destination instead of merging trees. This favors loss prevention and makes the selected path explicit in output. Reverting the commit restores the old merge behavior; no persisted format changes are introduced.