### PR TITLE
fix(hermes): keep overage pruning pipefail-safe

### DIFF
--- a/ods/scripts/prune-hermes-slash-workers.sh
+++ b/ods/scripts/prune-hermes-slash-workers.sh
@@ -159,7 +159,7 @@ if [[ "$WORKER_COUNT" -gt "$MAX_COUNT" ]]; then
     # is -1, so break the tie on the lowest pid — the longest-lived worker —
     # instead of leaving the pick to sort order.
     sort -t "$(printf '\t')" -k2,2nr -k1,1n "$WORKERS_FILE" \
-        | head -n "$OVERAGE" > "$OVERAGE_FILE"
+        | awk -v limit="$OVERAGE" 'NR <= limit' > "$OVERAGE_FILE"
     cat "$OVERAGE_FILE" >> "$CANDIDATES_FILE"
 fi
 

--- a/ods/tests/test-hermes-slash-worker-prune.sh
+++ b/ods/tests/test-hermes-slash-worker-prune.sh
@@ -229,6 +229,22 @@ fi
 
 # ── Summary ───────────────────────────────────────────────────────────────
 
+# A large process table used to make `sort | head -n 1` fail under pipefail:
+# head closed the pipe early and sort surfaced SIGPIPE instead of a candidate.
+LARGE_FIXTURE="$WORKDIR/large.txt"
+awk 'BEGIN {
+    for (i = 1; i <= 20000; i++) {
+        printf "%d %d python -m hermes.tui_gateway.slash_worker --id %d\n", \
+            10000 + i, 100000 - i, i
+    }
+}' > "$LARGE_FIXTURE"
+OUT="$WORKDIR/out8.txt"
+ODS_HERMES_SLASH_WORKER_PS_FIXTURE="$LARGE_FIXTURE" \
+    bash "$PRUNE" --max-age-seconds 999999 --max-count 19999 > "$OUT" 2>&1
+rc=$?
+check_eq "large fixture: count selection exits 0 under pipefail" "0" "$rc"
+check_eq "large fixture: selects the single oldest overage" "10001" "$(selected_pids "$OUT")"
+
 echo ""
 echo "Passed: $PASS  Failed: $FAIL"
 [[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- replace the early-closing `head` stage in overage selection with a consuming awk selector
- exercise the repair command with a 20,000-worker process-table fixture

## Why this matters

`prune-hermes-slash-workers.sh` runs with `set -o pipefail`. For a large process table and a small overage, `head` closed its input after the first row, allowing `sort` to receive SIGPIPE and abort the repair command exactly when workers needed pruning. The invariant is that selecting the oldest N workers must complete successfully for any process-table size.

## Overlap check

Searched open and closed PR titles/bodies for `prune hermes workers` and scanned open PR changes touching `ods/scripts/prune-hermes-slash-workers.sh`; no overlapping PR was found.

## Validation

- `bash ods/tests/test-hermes-slash-worker-prune.sh` — 17 behavioral checks pass, including the large-table regression
- `python ods/tests/contracts/test-hermes-worker-guardrails.py`
- `bash -n ods/scripts/prune-hermes-slash-workers.sh ods/tests/test-hermes-slash-worker-prune.sh`
- `git diff --check`

## Tradeoffs and rollback

The selector still emits only the first N sorted rows but consumes the complete stream to preserve pipe status. Runtime remains O(worker count), as sorting already dominates. Reverting restores the former pipeline with no data migration required.