### PR TITLE
fix(setup): classify chat upstream failures

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -28,6 +28,26 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["setup"])
 
 
+def _chat_response_content(data: object) -> str:
+    if not isinstance(data, dict):
+        raise ValueError("LLM response must be a JSON object")
+    choices = data.get("choices")
+    if choices is None or choices == []:
+        return ""
+    if not isinstance(choices, list):
+        raise ValueError("LLM response choices must be an array of objects")
+    choice = choices[0] or {}
+    if not isinstance(choice, dict):
+        raise ValueError("LLM response choices must be an array of objects")
+    message = choice.get("message") or {}
+    if not isinstance(message, dict):
+        raise ValueError("LLM response choice must contain a message object")
+    content = message.get("content", "")
+    if not isinstance(content, str):
+        raise ValueError("LLM response content must be a string")
+    return content
+
+
 def get_active_persona_prompt() -> str:
     """Get the system prompt for the active persona."""
     persona_file = SETUP_CONFIG_DIR / "persona.json"
@@ -219,17 +239,20 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
             async with session.post(f"{llm_url}{_api_path}/chat/completions", json=payload, headers={"Content-Type": "application/json"}) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    choices = data.get("choices") or [{}]
-                    response_text = (choices[0] or {}).get("message", {}).get("content", "")
+                    response_text = _chat_response_content(data)
                     # Strip thinking model tags — content may contain <think>...</think> blocks
                     response_text = re.sub(r'<think>[\s\S]*?</think>\s*', '', response_text).strip()
                     return {"response": response_text, "success": True}
                 else:
                     error_text = await resp.text()
                     raise HTTPException(status_code=resp.status, detail=f"LLM error: {error_text}")
-    except aiohttp.ClientError:
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="LLM backend timed out") from exc
+    except (aiohttp.ContentTypeError, json.JSONDecodeError, ValueError) as exc:
+        raise HTTPException(status_code=502, detail="LLM backend returned an invalid response") from exc
+    except aiohttp.ClientError as exc:
         logger.exception("Cannot reach LLM backend")
-        raise HTTPException(status_code=503, detail="Cannot reach LLM backend")
+        raise HTTPException(status_code=503, detail="Cannot reach LLM backend") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/ods/extensions/services/dashboard-api/tests/test_routers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_routers.py
@@ -796,6 +796,50 @@ def test_chat_connection_error(test_client, monkeypatch):
     assert resp.status_code == 503
 
 
+def test_chat_timeout_returns_gateway_timeout(test_client):
+    import asyncio
+
+    session_mock = MagicMock()
+    session_mock.post = MagicMock(side_effect=asyncio.TimeoutError())
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.setup.aiohttp.ClientSession", return_value=session_ctx):
+        resp = test_client.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 504
+    assert resp.json()["detail"] == "LLM backend timed out"
+
+
+def test_chat_malformed_success_returns_bad_gateway(test_client):
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value={"choices": ["not-an-object"]})
+    response_ctx = AsyncMock()
+    response_ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    response_ctx.__aexit__ = AsyncMock(return_value=False)
+    session_mock = MagicMock()
+    session_mock.post = MagicMock(return_value=response_ctx)
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.setup.aiohttp.ClientSession", return_value=session_ctx):
+        resp = test_client.post(
+            "/api/chat",
+            json={"message": "hi"},
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "LLM backend returned an invalid response"
+
+
 # ---------------------------------------------------------------------------
 # Models router — split-file download status (issue #316)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- map setup-chat backend timeouts to 504 and connection failures to 503
- validate successful LLM receipts before traversing choices/message/content
- return 502 for malformed JSON shapes instead of leaking an internal 500

## Why this matters

The setup wizard calls the LLM across a network boundary. `aiohttp` total timeouts were not caught and malformed 200 responses were traversed as dictionaries, so ordinary upstream failures surfaced as dashboard-api 500s. The invariant is that each upstream failure class has an explicit gateway response while valid and empty-choice replies preserve existing behavior.

## Overlap check

Searched open and closed PR titles/bodies for `setup chat timeout malformed` and reviewed open PRs #3157 and #3381, the only open changes to `routers/setup.py`. They move setup-state persistence to the host agent (and add unique environment backups); neither changes `/api/chat` receipt validation or error mapping.

## Validation

- `pytest ods/extensions/services/dashboard-api/tests/test_routers.py -q -k 'chat'` — 5 passed
- `pytest ods/extensions/services/dashboard-api/tests/test_setup.py -q -k 'chat'` — 1 passed
- `python -m py_compile ods/extensions/services/dashboard-api/routers/setup.py ods/extensions/services/dashboard-api/tests/test_routers.py`
- `git diff --check`

## Tradeoffs and rollback

The endpoint continues forwarding non-200 LLM status codes unchanged. Only local transport timeout and malformed-success cases gain explicit 504/502 semantics. Reverting restores previous error behavior; there is no persisted state or API request-schema change.