### PR TITLE
fix(workflows): validate n8n read receipts

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -26,6 +26,15 @@ def _validate_workflow_id(workflow_id: str) -> None:
         raise HTTPException(status_code=400, detail="Invalid workflow ID format")
 
 
+def _n8n_data_items(data: object) -> list[dict]:
+    if not isinstance(data, dict):
+        raise ValueError("n8n response must be a JSON object")
+    items = data.get("data", [])
+    if not isinstance(items, list) or any(not isinstance(item, dict) for item in items):
+        raise ValueError("n8n response data must be an array of objects")
+    return items
+
+
 def load_workflow_catalog() -> dict:
     """Load workflow catalog from JSON file."""
     if not WORKFLOW_CATALOG_FILE.exists():
@@ -58,8 +67,14 @@ async def get_n8n_workflows() -> list[dict]:
             async with session.get(f"{N8N_URL}/api/v1/workflows", headers=headers) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    return data.get("data", [])
-    except (aiohttp.ClientError, OSError, json.JSONDecodeError) as e:
+                    return _n8n_data_items(data)
+    except (
+        asyncio.TimeoutError,
+        aiohttp.ClientError,
+        OSError,
+        json.JSONDecodeError,
+        ValueError,
+    ) as e:
         logger.warning(f"Failed to fetch workflows from n8n: {e}")
     return []
 
@@ -299,9 +314,19 @@ async def workflow_executions(workflow_id: str, limit: int = 20, api_key: str = 
             async with session.get(f"{N8N_URL}/api/v1/executions", headers=headers, params={"workflowId": n8n_wf["id"], "limit": limit}) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    return {"workflowId": workflow_id, "n8nId": n8n_wf["id"], "executions": data.get("data", [])}
+                    return {
+                        "workflowId": workflow_id,
+                        "n8nId": n8n_wf["id"],
+                        "executions": _n8n_data_items(data),
+                    }
                 else:
                     return {"executions": [], "error": "Failed to fetch executions"}
-    except (aiohttp.ClientError, OSError, json.JSONDecodeError):
+    except (
+        asyncio.TimeoutError,
+        aiohttp.ClientError,
+        OSError,
+        json.JSONDecodeError,
+        ValueError,
+    ):
         logger.exception("Failed to fetch workflow executions")
         return {"executions": [], "error": "Failed to fetch executions"}

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -191,6 +191,27 @@ def test_get_n8n_workflows_failure(test_client, monkeypatch):
     assert result == []
 
 
+def test_get_n8n_workflows_rejects_malformed_items(test_client):
+    import asyncio
+    import routers.workflows as wf_mod
+
+    resp_mock = AsyncMock()
+    resp_mock.status = 200
+    resp_mock.json = AsyncMock(return_value={"data": ["not-an-object"]})
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=resp_mock)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    session_mock = AsyncMock()
+    session_mock.get = MagicMock(return_value=ctx)
+    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+    session_mock.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+        result = asyncio.run(wf_mod.get_n8n_workflows())
+
+    assert result == []
+
+
 # ---------------------------------------------------------------------------
 # check_workflow_dependencies() unit tests
 # ---------------------------------------------------------------------------
@@ -859,6 +880,37 @@ def test_workflow_executions_n8n_error(test_client, tmp_path, monkeypatch):
     data = resp.json()
     assert data["executions"] == []
     assert "error" in data
+
+
+def test_workflow_executions_timeout_returns_error(test_client, tmp_path, monkeypatch):
+    import asyncio
+    import routers.workflows as wf_mod
+
+    catalog = {
+        "workflows": [
+            {"id": "slow-wf", "name": "Slow Workflow", "description": "test",
+             "file": "slow.json", "dependencies": []}
+        ],
+        "categories": {},
+    }
+    catalog_file = tmp_path / "catalog.json"
+    catalog_file.write_text(json.dumps(catalog))
+    monkeypatch.setattr(wf_mod, "WORKFLOW_CATALOG_FILE", catalog_file)
+    n8n_workflows = [{"id": "99", "name": "Slow Workflow", "active": True}]
+    session_mock = AsyncMock()
+    session_mock.get = MagicMock(side_effect=asyncio.TimeoutError())
+    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
+    session_mock.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.get_n8n_workflows", new_callable=AsyncMock, return_value=n8n_workflows), \
+         patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+        resp = test_client.get(
+            "/api/workflows/slow-wf/executions",
+            headers=test_client.auth_headers,
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"executions": [], "error": "Failed to fetch executions"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- validate n8n list envelopes and require object entries before downstream matching
- treat n8n read timeouts like the existing unavailable/error fallback
- share the same receipt contract for workflows and execution history

## Why this matters

Read-only n8n calls sit on a remote JSON boundary. A timeout escaped both fallback paths, and a 200 response with a non-object root or item later crashed `/api/workflows` through `.get()` calls. The invariant is that n8n read data reaches workflow matching only as a list of objects; transport or receipt failures return the endpoint's established unavailable response.

## Overlap check

Searched open and closed PR titles/bodies for `workflows n8n timeout malformed` and compared the two open PRs touching this router. PR #3667 changes activation messaging and PR #3591 gates non-runnable import templates. Neither touches workflow/execution reads, timeout handling, or response validation.

## Validation

- `pytest ods/extensions/services/dashboard-api/tests/test_workflows.py -q` — 47 passed
- `python -m py_compile ods/extensions/services/dashboard-api/routers/workflows.py ods/extensions/services/dashboard-api/tests/test_workflows.py`
- `git diff --check`

## Tradeoffs and rollback

A malformed individual n8n item invalidates that complete receipt instead of partially presenting untrusted state. Existing success and fallback response shapes are unchanged. Reverting restores permissive parsing; no stored workflow data is modified.