### PR TITLE
fix(egress): enforce body limit while streaming

### DIFF
--- a/ods/extensions/services/remote-provider-egress/app/main.py
+++ b/ods/extensions/services/remote-provider-egress/app/main.py
@@ -128,6 +128,25 @@ def _error_response(exc: EgressError) -> JSONResponse:
     )
 
 
+async def _read_bounded_body(request: Request) -> bytes:
+    content_length = request.headers.get("content-length")
+    if content_length:
+        try:
+            if int(content_length) > MAX_BODY_BYTES:
+                raise EgressError(413, "payload_too_large", "request body exceeds limit")
+        except ValueError:
+            pass
+
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in request.stream():
+        size += len(chunk)
+        if size > MAX_BODY_BYTES:
+            raise EgressError(413, "payload_too_large", "request body exceeds limit")
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
 def _probe_error_response(exc: ProbeError) -> JSONResponse:
     return JSONResponse(
         {
@@ -347,7 +366,7 @@ async def forward(full_path: str, request: Request) -> Response:
             method=request.method,
             path=path,
             headers=dict(request.headers),
-            body=await request.body(),
+            body=await _read_bounded_body(request),
             route=route,
             provider_secret=secret,
             max_body_bytes=MAX_BODY_BYTES,

--- a/ods/extensions/services/remote-provider-egress/tests/test_body_limit.py
+++ b/ods/extensions/services/remote-provider-egress/tests/test_body_limit.py
@@ -1,0 +1,75 @@
+"""ASGI-boundary tests for remote-provider egress request limits."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from starlette.requests import Request
+
+
+SERVICE_DIR = Path(__file__).resolve().parents[1]
+ODS_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(SERVICE_DIR))
+sys.path.insert(0, str(ODS_ROOT / "bin"))
+
+from app import main as app_main  # noqa: E402
+
+
+def _request(chunks: list[bytes], content_length: int | None = None):
+    calls = 0
+
+    async def receive():
+        nonlocal calls
+        calls += 1
+        if chunks:
+            body = chunks.pop(0)
+            return {"type": "http.request", "body": body, "more_body": bool(chunks)}
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    headers = []
+    if content_length is not None:
+        headers.append((b"content-length", str(content_length).encode("ascii")))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/chat/completions",
+        "headers": headers,
+    }
+    return Request(scope, receive), lambda: calls
+
+
+def _patch_route_boundary(monkeypatch) -> None:
+    monkeypatch.setattr(app_main, "_load_route", lambda: {"transport": "direct"})
+    monkeypatch.setattr(
+        app_main,
+        "validate_direct_provider_resolution",
+        lambda route: ["203.0.113.10"],
+    )
+    monkeypatch.setattr(app_main, "read_provider_secret", lambda path: "provider-key")
+
+
+def test_content_length_rejected_before_body_read(monkeypatch):
+    _patch_route_boundary(monkeypatch)
+    monkeypatch.setattr(app_main, "MAX_BODY_BYTES", 4)
+    request, receive_calls = _request([b"12345"], content_length=5)
+
+    response = asyncio.run(app_main.forward("v1/chat/completions", request))
+
+    assert response.status_code == 413
+    assert json.loads(response.body)["error"]["type"] == "payload_too_large"
+    assert receive_calls() == 0
+
+
+def test_chunked_body_stops_when_limit_is_crossed(monkeypatch):
+    _patch_route_boundary(monkeypatch)
+    monkeypatch.setattr(app_main, "MAX_BODY_BYTES", 4)
+    request, receive_calls = _request([b"123", b"45", b"unread"])
+
+    response = asyncio.run(app_main.forward("v1/chat/completions", request))
+
+    assert response.status_code == 413
+    assert json.loads(response.body)["error"]["type"] == "payload_too_large"
+    assert receive_calls() == 2


### PR DESCRIPTION
## Summary

- reject declared oversized requests before reading any ASGI body bytes
- enforce the same limit incrementally for chunked/unknown-length requests
- add public forward-handler tests proving reads stop as soon as the limit is crossed

## Why this matters

The egress policy already defines a maximum request body, but `forward()` called `await request.body()` before checking it. An internal client could therefore make the proxy buffer an arbitrarily large body and only receive 413 after memory had been consumed. The invariant is that the proxy buffers at most the configured limit plus the boundary-crossing chunk and never contacts the provider for an oversized request.

## Overlap check

Searched open and closed PR titles/bodies for `remote provider egress body limit` and compared open PRs #3498, #3497, #3350, and #3322. Those address blocking probes and HTTP-client lifecycle/pool bounds; none changes request-body ingestion or 413 behavior.

## Validation

- `pytest ods/extensions/services/remote-provider-egress/tests/test_body_limit.py -q` — 2 passed at the ASGI forward boundary
- `python ods/tests/contracts/test-remote-provider-egress-service.py` — 15 contracts passed
- `python -m py_compile ods/extensions/services/remote-provider-egress/app/main.py ods/extensions/services/remote-provider-egress/tests/test_body_limit.py`
- `git diff --check`

## Tradeoffs and rollback

Chunked bodies may exceed the limit by at most one received ASGI chunk before rejection; that is the streaming boundary available to the app. Invalid Content-Length still falls through to measured streaming, preserving compatibility. Reverting restores post-buffer validation; no persisted or provider-side state is changed.