### PR TITLE
fix(memory): resolve configured home paths

### DIFF
--- a/ods/memory-shepherd/install.sh
+++ b/ods/memory-shepherd/install.sh
@@ -117,10 +117,18 @@ echo ""
 
 # ── Create Directories ─────────────────────────────────────────────────
 
-BASELINE_DIR="${CONFIG[general.baseline_dir]:-./baselines}"
-ARCHIVE_DIR="${CONFIG[general.archive_dir]:-./archives}"
-[[ "$BASELINE_DIR" != /* ]] && BASELINE_DIR="$SCRIPT_DIR/$BASELINE_DIR"
-[[ "$ARCHIVE_DIR" != /* ]] && ARCHIVE_DIR="$SCRIPT_DIR/$ARCHIVE_DIR"
+resolve_local_path() {
+    local path="$1"
+    case "$path" in
+        "~") printf '%s\n' "$HOME" ;;
+        "~/"*) printf '%s/%s\n' "$HOME" "${path#\~/}" ;;
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$SCRIPT_DIR" "$path" ;;
+    esac
+}
+
+BASELINE_DIR=$(resolve_local_path "${CONFIG[general.baseline_dir]:-./baselines}")
+ARCHIVE_DIR=$(resolve_local_path "${CONFIG[general.archive_dir]:-./archives}")
 
 if ! $DRY_RUN; then
     mkdir -p "$PREFIX" "$BASELINE_DIR" "$ARCHIVE_DIR"

--- a/ods/memory-shepherd/memory-shepherd.sh
+++ b/ods/memory-shepherd/memory-shepherd.sh
@@ -92,6 +92,16 @@ cfg() {
     echo "${CONFIG[$key]:-$default}"
 }
 
+resolve_local_path() {
+    local path="$1"
+    case "$path" in
+        "~") printf '%s\n' "$HOME" ;;
+        "~/"*) printf '%s/%s\n' "$HOME" "${path#\~/}" ;;
+        /*) printf '%s\n' "$path" ;;
+        *) printf '%s/%s\n' "$SCRIPT_DIR" "$path" ;;
+    esac
+}
+
 # ── Load Config ────────────────────────────────────────────────────────
 
 CONF_FILE=$(find_config) || {
@@ -105,16 +115,12 @@ log "Loaded config from $CONF_FILE (${#AGENTS[@]} agents)"
 
 # ── Global Settings ────────────────────────────────────────────────────
 
-BASELINE_DIR=$(cfg general baseline_dir "$SCRIPT_DIR/baselines")
-ARCHIVE_DIR=$(cfg general archive_dir "$SCRIPT_DIR/archives")
+BASELINE_DIR=$(resolve_local_path "$(cfg general baseline_dir "$SCRIPT_DIR/baselines")")
+ARCHIVE_DIR=$(resolve_local_path "$(cfg general archive_dir "$SCRIPT_DIR/archives")")
 MAX_MEMORY_SIZE=$(cfg general max_memory_size 16384)
 ARCHIVE_RETENTION_DAYS=$(cfg general archive_retention_days 30)
 SEPARATOR=$(cfg general separator "---")
 MIN_BASELINE_SIZE=$(cfg general min_baseline_size 500)
-
-# Resolve relative paths against script directory
-[[ "$BASELINE_DIR" != /* ]] && BASELINE_DIR="$SCRIPT_DIR/$BASELINE_DIR"
-[[ "$ARCHIVE_DIR" != /* ]] && ARCHIVE_DIR="$SCRIPT_DIR/$ARCHIVE_DIR"
 
 # ── Reset Functions ────────────────────────────────────────────────────
 
@@ -254,6 +260,9 @@ process_agent() {
 
     local memory_file
     memory_file=$(cfg "$agent" memory_file "")
+    if [ -n "$memory_file" ]; then
+        memory_file=$(resolve_local_path "$memory_file")
+    fi
     local baseline_name
     baseline_name=$(cfg "$agent" baseline "")
     local archive_subdir

--- a/ods/tests/test-memory-shepherd-paths.sh
+++ b/ods/tests/test-memory-shepherd-paths.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SHEPHERD="$ROOT_DIR/memory-shepherd/memory-shepherd.sh"
+TEST_ROOT="$(mktemp -d -t memory-shepherd-paths-XXXXXX)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+home_dir="$TEST_ROOT/home"
+baseline_dir="$home_dir/ods/memory-shepherd/baselines"
+archive_dir="$home_dir/ods/data/memory-archives/demo"
+memory_dir="$home_dir/ods/config/openclaw/workspace"
+mkdir -p "$baseline_dir" "$memory_dir"
+
+{
+    printf '# Baseline\n\n'
+    for _ in {1..80}; do
+        printf 'Operator-controlled baseline content.\n'
+    done
+} > "$baseline_dir/demo.md"
+printf '# Current memory\n\n---\n\n## Scratch Notes\nkeep this note\n' \
+    > "$memory_dir/MEMORY.md"
+
+config="$TEST_ROOT/memory-shepherd.conf"
+printf '%s\n' \
+    '[general]' \
+    'baseline_dir=~/ods/memory-shepherd/baselines' \
+    'archive_dir=~/ods/data/memory-archives' \
+    'min_baseline_size=500' \
+    '[demo]' \
+    'memory_file=~/ods/config/openclaw/workspace/MEMORY.md' \
+    'baseline=demo.md' \
+    'archive_subdir=demo' \
+    > "$config"
+
+HOME="$home_dir" MEMORY_SHEPHERD_CONF="$config" bash "$SHEPHERD" demo \
+    > "$TEST_ROOT/output"
+
+cmp "$baseline_dir/demo.md" "$memory_dir/MEMORY.md"
+archive_file="$(find "$archive_dir" -type f -name '*.md' -print -quit)"
+[[ -n "$archive_file" ]]
+grep -Fq 'keep this note' "$archive_file"
+if find "$ROOT_DIR/memory-shepherd" -maxdepth 1 -name '~' -print -quit | grep -q .; then
+    echo "tilde path was resolved beneath the script directory" >&2
+    exit 1
+fi
+
+echo "memory shepherd path tests passed"

--- a/ods/tests/test-memory-shepherd-paths.sh
+++ b/ods/tests/test-memory-shepherd-paths.sh
@@ -40,6 +40,14 @@ cmp "$baseline_dir/demo.md" "$memory_dir/MEMORY.md"
 archive_file="$(find "$archive_dir" -type f -name '*.md' -print -quit)"
 [[ -n "$archive_file" ]]
 grep -Fq 'keep this note' "$archive_file"
+
+install_output="$(HOME="$home_dir" MEMORY_SHEPHERD_CONF="$config" \
+    bash "$ROOT_DIR/memory-shepherd/install.sh" \
+    --dry-run --prefix "$TEST_ROOT/units")"
+[[ "$install_output" == *"Baselines:     $baseline_dir"* ]]
+[[ "$install_output" == *"Archives:      ${archive_dir%/demo}"* ]]
+[[ "$install_output" != *"memory-shepherd/~/ods"* ]]
+
 if find "$ROOT_DIR/memory-shepherd" -maxdepth 1 -name '~' -print -quit | grep -q .; then
     echo "tilde path was resolved beneath the script directory" >&2
     exit 1


### PR DESCRIPTION
## Summary

- resolve `~`, `~/...`, absolute, and relative local Memory Shepherd paths explicitly
- apply the same contract in the installer producer and runtime consumer
- run the real reset/archive workflow and installer dry-run against the checked-in tilde-style configuration shape

## Why this matters

The shipped `memory-shepherd.conf` documents paths such as `~/ods/...`, but tilde expansion does not occur after Bash variable expansion. Both installer and timer therefore interpreted them beneath `memory-shepherd/~/ods/...`; setup created the wrong directories and runtime skipped missing baselines. The invariant is that documented home-relative paths resolve against `$HOME`, while ordinary relative paths remain anchored to the script directory at both handoff points.

## Overlap check

Searched open and closed PR titles/bodies for `memory shepherd tilde path`, scanned all open PR changed files, and found no PR covering this path contract. Open lock PRs #2070/#2366 touch the runtime file but not configuration-path resolution.

## Validation

- `bash ods/tests/test-memory-shepherd-paths.sh` — passes installer path reporting plus full baseline reset and scratch-archive flow using `~/...` paths
- `bash -n ods/memory-shepherd/memory-shepherd.sh ods/memory-shepherd/install.sh ods/tests/test-memory-shepherd-paths.sh`
- `git diff --check`
- `bats ods/tests/bats-tests/macos-bsd-compat.bats` — not run locally because BATS is not installed; CI retains macOS helper coverage

Follow-up commit `b698aff7` reconciles the installer producer with the runtime consumer and reruns the focused suite.

## Tradeoffs and rollback

Relative `memory_file` values are now deterministic from the script directory rather than the service process working directory, matching baseline/archive behavior. Remote paths are intentionally untouched so remote-shell `~` semantics remain intact. Reverting restores literal tilde handling; no files are migrated.