### PR TITLE
fix(memory): isolate remote reset tempfiles

### DIFF
--- a/ods/memory-shepherd/memory-shepherd.sh
+++ b/ods/memory-shepherd/memory-shepherd.sh
@@ -180,7 +180,7 @@ reset_agent() {
     log "Reset $agent MEMORY.md to baseline (${baseline_size} bytes)"
 }
 
-reset_remote_agent() {
+reset_remote_agent() (
     local agent="$1"
     local remote_host="$2"
     local remote_user="$3"
@@ -201,7 +201,9 @@ reset_remote_agent() {
     fi
 
     # Fetch current memory from remote
-    local tmpfile="/tmp/memory-shepherd-${agent}-current.md"
+    local tmpfile
+    tmpfile=$(mktemp "${TMPDIR:-/tmp}/memory-shepherd-${agent}.XXXXXX")
+    trap 'rm -f "$tmpfile"' EXIT
     if ! scp -q "${remote_user}@${remote_host}:${remote_memory}" "$tmpfile" 2>/dev/null; then
         log "WARN: No memory file for $agent on $remote_host — pushing baseline"
         scp -q "$baseline" "${remote_user}@${remote_host}:${remote_memory}"
@@ -244,8 +246,7 @@ reset_remote_agent() {
     # Push baseline to remote
     scp -q "$baseline" "${remote_user}@${remote_host}:${remote_memory}"
     log "Reset $agent MEMORY.md on $remote_host to baseline (${baseline_size} bytes)"
-    rm -f "$tmpfile"
-}
+)
 
 # ── Dispatch ───────────────────────────────────────────────────────────
 

--- a/ods/tests/test-memory-shepherd-remote-tempfile.sh
+++ b/ods/tests/test-memory-shepherd-remote-tempfile.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SHEPHERD="$ROOT_DIR/memory-shepherd/memory-shepherd.sh"
+TEST_ROOT="$(mktemp -d -t memory-shepherd-remote-XXXXXX)"
+agent="remote-test-$$"
+legacy_tmp="/tmp/memory-shepherd-${agent}-current.md"
+trap 'rm -f "$legacy_tmp"; rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/bin" "$TEST_ROOT/tmp" "$TEST_ROOT/baselines"
+{
+    printf '# Baseline\n'
+    for _ in {1..80}; do
+        printf 'Durable baseline content.\n'
+    done
+} > "$TEST_ROOT/baselines/agent.md"
+printf '# Remote memory\n---\nprivate remote scratch\n' > "$TEST_ROOT/remote-memory.md"
+printf 'must not be overwritten\n' > "$TEST_ROOT/victim"
+ln -s "$TEST_ROOT/victim" "$legacy_tmp"
+
+config="$TEST_ROOT/memory-shepherd.conf"
+printf '%s\n' \
+    '[general]' \
+    "baseline_dir=$TEST_ROOT/baselines" \
+    "archive_dir=$TEST_ROOT/archives" \
+    'min_baseline_size=500' \
+    "[$agent]" \
+    'remote_host=example.invalid' \
+    'remote_user=tester' \
+    'remote_memory=/srv/MEMORY.md' \
+    'baseline=agent.md' \
+    > "$config"
+
+printf '%s\n' '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    '[[ "${1:-}" == "-q" ]] && shift' \
+    'if [[ "$1" == *:* ]]; then' \
+    '    cp "$ODS_TEST_REMOTE_MEMORY" "$2"' \
+    '    printf "%s\n" "$2" > "$ODS_TEST_FETCH_PATH"' \
+    '    exit 0' \
+    'fi' \
+    'exit 73' \
+    > "$TEST_ROOT/bin/scp"
+chmod +x "$TEST_ROOT/bin/scp"
+
+if HOME="$TEST_ROOT/home" \
+    TMPDIR="$TEST_ROOT/tmp" \
+    PATH="$TEST_ROOT/bin:$PATH" \
+    MEMORY_SHEPHERD_CONF="$config" \
+    ODS_TEST_REMOTE_MEMORY="$TEST_ROOT/remote-memory.md" \
+    ODS_TEST_FETCH_PATH="$TEST_ROOT/fetch-path" \
+    bash "$SHEPHERD" "$agent" > "$TEST_ROOT/output" 2>&1; then
+    echo "expected the mocked remote upload to fail" >&2
+    exit 1
+fi
+
+fetch_path="$(cat "$TEST_ROOT/fetch-path")"
+[[ "$fetch_path" == "$TEST_ROOT/tmp/memory-shepherd-${agent}."* ]]
+[[ ! -e "$fetch_path" ]]
+[[ "$(cat "$TEST_ROOT/victim")" == "must not be overwritten" ]]
+[[ -L "$legacy_tmp" ]]
+
+echo "memory shepherd remote tempfile tests passed"


### PR DESCRIPTION
## Summary

- allocate remote-memory downloads with `mktemp` under the configured temporary directory
- scope each remote reset to a subshell with unconditional EXIT cleanup
- cover predictable-path symlink isolation and cleanup after a failed upload

## Why this matters

Remote resets downloaded private memory into `/tmp/memory-shepherd-${agent}-current.md`. Concurrent invocations shared that path, a pre-created symlink could redirect the download, and an upload failure exited before cleanup, leaving memory contents behind. The invariant is that every remote reset owns a unique temporary file and removes it on every return or failure path.

## Overlap check

Searched open and closed PR titles/bodies for `memory shepherd remote temp` and reviewed open PRs #2070 and #2366 because they also change `memory-shepherd.sh`. Those PRs repair run-lock ownership/acquisition; they mention the fixed scratch path as an impact but do not change or test remote temporary-file handling. This scope is independent.

## Validation

- `bash ods/tests/test-memory-shepherd-remote-tempfile.sh` — passes the remote fetch/public script flow, symlink sentinel, upload failure, and EXIT cleanup assertions
- `bash -n ods/memory-shepherd/memory-shepherd.sh ods/tests/test-memory-shepherd-remote-tempfile.sh`
- `git diff --check`

## Tradeoffs and rollback

The remote reset function now executes in a subshell solely to give its tempfile an isolated EXIT trap; it does not publish shell variables to callers today. `TMPDIR` is honored when set and defaults to `/tmp`. Reverting restores the shared path; no remote or archive format changes are introduced.