### PR TITLE
fix(completions): read saved preset directory

### DIFF
--- a/ods/completions/ods-cli.bash
+++ b/ods/completions/ods-cli.bash
@@ -83,7 +83,7 @@ _ods_completion() {
                     case $prev in
                         save|load|delete)
                             # Complete with existing preset names
-                            local preset_dir="${ODS_HOME:-$HOME/ods}/.presets"
+                            local preset_dir="${ODS_HOME:-$HOME/ods}/presets"
                             if [[ -d "$preset_dir" ]]; then
                                 local presets=$(ls -1 "$preset_dir" 2>/dev/null | sed 's/\.preset$//')
                                 COMPREPLY=($(compgen -W "$presets" -- "$cur"))
@@ -92,7 +92,7 @@ _ods_completion() {
                             ;;
                         export)
                             # Complete with existing preset names for export
-                            local preset_dir="${ODS_HOME:-$HOME/ods}/.presets"
+                            local preset_dir="${ODS_HOME:-$HOME/ods}/presets"
                             if [[ -d "$preset_dir" ]]; then
                                 local presets=$(ls -1 "$preset_dir" 2>/dev/null | sed 's/\.preset$//')
                                 COMPREPLY=($(compgen -W "$presets" -- "$cur"))

--- a/ods/tests/test-bash-completion-presets.sh
+++ b/ods/tests/test-bash-completion-presets.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_ROOT="$(mktemp -d -t ods-preset-completion-XXXXXX)"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+mkdir -p "$TEST_ROOT/presets/mysetup" "$TEST_ROOT/presets/another"
+mkdir -p "$TEST_ROOT/.presets/legacy-only"
+export ODS_HOME="$TEST_ROOT"
+
+_init_completion() {
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
+    words=("${COMP_WORDS[@]}")
+    cword="$COMP_CWORD"
+}
+
+# shellcheck source=completions/ods-cli.bash
+source "$ROOT_DIR/completions/ods-cli.bash"
+
+assert_preset_completion() {
+    local action="$1"
+    COMP_WORDS=(ods preset "$action" my)
+    COMP_CWORD=3
+    COMPREPLY=()
+    _ods_completion
+
+    [[ " ${COMPREPLY[*]} " == *" mysetup "* ]]
+    [[ " ${COMPREPLY[*]} " != *" legacy-only "* ]]
+}
+
+assert_preset_completion load
+assert_preset_completion delete
+assert_preset_completion export
+
+echo "bash preset completion tests passed"


### PR DESCRIPTION
## Summary

- read preset candidates from the same `presets/` directory used by `ods-cli`
- cover load, delete, and export through the shipped Bash completion function
- prove the obsolete `.presets/` tree is not offered

## Why this matters

`ods preset save` writes `${INSTALL_DIR}/presets/<name>`, while Bash completion looked in `${ODS_HOME}/.presets`. Saved presets were therefore never suggested for load/delete/export, forcing operators to remember exact names. The invariant is that the CLI producer and completion consumer use the same preset root.

Fixes #3144

## Overlap check

Reviewed the open and recent closed PR lists for preset-completion terms and changed files. No open or closed PR covers #3144. Open PR #3258 also touches `completions/ods-cli.bash`, but it changes `COMPREPLY` population to avoid word-splitting; it leaves both incorrect `.presets` paths unchanged, so the scopes are complementary.

## Validation

- `bash ods/tests/test-bash-completion-presets.sh` — passes load/delete/export completion at the public `_ods_completion` boundary
- `bash -n ods/completions/ods-cli.bash ods/tests/test-bash-completion-presets.sh`
- `git diff --check`

## Tradeoffs and rollback

This intentionally follows the current `PRESETS_DIR=${INSTALL_DIR}/presets` contract and does not provide legacy `.presets` fallback because the CLI never writes that tree. Reverting only restores the broken lookup; preset data is untouched.