### PR TITLE
fix(ap-mode): preserve AP capability matches under pipefail

### DIFF
--- a/ods/scripts/ap-mode.sh
+++ b/ods/scripts/ap-mode.sh
@@ -152,7 +152,10 @@ interface_supports_ap() {
     log "WARNING: 'iw' not available — skipping AP-capability check"
     return 0
   fi
-  if ! iw list 2>/dev/null | grep -A20 "Supported interface modes" | grep -q "\* AP"; then
+  # The final matcher must consume its input. With pipefail, grep -q can close
+  # the pipe as soon as it sees AP and turn a successful, large `iw list`
+  # response into SIGPIPE (141) upstream.
+  if ! iw list 2>/dev/null | grep -A20 "Supported interface modes" | grep "\* AP" >/dev/null; then
     err "interface does not advertise AP mode in 'iw list' output"
     err "this driver may not support hostapd"
     return 1

--- a/ods/tests/test-ap-mode.sh
+++ b/ods/tests/test-ap-mode.sh
@@ -41,4 +41,19 @@ assert_fails "short AP password" require_password
 ODS_AP_PASSWORD="unique-device-pass"
 require_password >/dev/null
 
+# A real `iw list` can include a large capability dump after the interface
+# modes. The AP match must remain successful under pipefail even when the
+# producer writes more than one pipe buffer after the match.
+iw() {
+  printf '%s\n' \
+    'Supported interface modes:' \
+    '         * managed' \
+    '         * AP'
+  local i
+  for ((i = 0; i < 20000; i++)); do
+    printf 'capability-%05d\n' "$i"
+  done
+}
+interface_supports_ap >/dev/null
+
 printf 'AP mode helper checks passed\n'


### PR DESCRIPTION
## Why this matters

`ap-mode.sh` runs with `set -o pipefail`. Its AP-capability probe ended in `grep -q`, so a valid large `iw list` response could make the producer receive SIGPIPE after the early AP match. ODS then refused first-boot AP activation even though the adapter advertised AP mode.

Root cause: the last pipeline stage exited before consuming the capability stream. The preserved invariant is: an advertised `* AP` mode is accepted regardless of capability-output size.

## Overlap check

Searched open and closed PRs for `ap mode capability`, `iw`, and `pipefail`, plus all fetched branch history for `ods/scripts/ap-mode.sh`. PR branch `fix/ap-mode-activation-rollback` changes failed-activation rollback, not capability parsing. No PR covers this failure mode.

## Change

- Make the final AP matcher consume the complete filtered stream.
- Add a public helper regression with a capability dump larger than a pipe buffer.

## Validation

- `bash tests/test-ap-mode.sh`
- `bash -n scripts/ap-mode.sh tests/test-ap-mode.sh`
- `git diff --check`

All passed locally.

## Tradeoffs and rollback

The accepted syntax and warning behavior are unchanged. The probe reads the full `iw list` response instead of stopping at the first AP match; this is bounded by the command's finite capability output. Reverting the commit restores the prior false-negative risk.