### PR TITLE
fix(amd): consume GFX probe output under pipefail

### DIFF
--- a/ods/installers/lib/amd-topo.sh
+++ b/ods/installers/lib/amd-topo.sh
@@ -108,7 +108,7 @@ amd_gfx_version() {
             | sed 's/\x1b\[[0-9;]*m//g' \
             | grep "GPU\[$gpu_idx\].*GFX Version" \
             | sed 's/.*GFX Version:[[:space:]]*//' \
-            | head -1)
+            | sed -n '1p')
         [[ -n "$gfx" && "$gfx" != "N/A" ]] && echo "$gfx" && return 0
     fi
 
@@ -139,7 +139,7 @@ amd_gfx_version() {
         pci_bdf=$(readlink -f "$card_dir" | grep -oP '[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9]') || pci_bdf=""
         if [[ -n "$pci_bdf" ]]; then
             local gfx
-            gfx=$(rocminfo 2>/dev/null | grep -A10 "$pci_bdf" | grep -oP 'gfx\d+' | head -1)
+            gfx=$(rocminfo 2>/dev/null | grep -A10 "$pci_bdf" | grep -oP 'gfx\d+' | sed -n '1p')
             [[ -n "$gfx" ]] && echo "$gfx" && return 0
         fi
     fi

--- a/ods/tests/test-amd-topo.sh
+++ b/ods/tests/test-amd-topo.sh
@@ -283,6 +283,26 @@ test_gfx_version_mixed() {
     assert_eq "GPU[1] gfx1101" "gfx1101" "$gfx1"
 }
 
+# ── Test: GFX parsing consumes large producer output under pipefail ─────────
+
+test_gfx_version_large_output_pipefail() {
+    echo -e "${BLU}Testing: amd_gfx_version handles large rocm-smi output under pipefail${NC}"
+
+    rocm-smi() {
+        local i
+        for ((i = 0; i < 20000; i++)); do
+            printf 'GPU[0] : GFX Version: gfx942\n'
+        done
+    }
+    amd-smi() { return 1; }
+
+    source "$TOPO_SCRIPT"
+
+    local gfx
+    gfx=$(set -o pipefail; amd_gfx_version "/fake" 0)
+    assert_eq "large output keeps first GFX match" "gfx942" "$gfx"
+}
+
 # ── Main test runner ───────────────────────────────────────────────────────
 
 echo -e "${MAG}=== AMD Topology Detection Tests ===${NC}\n"
@@ -302,6 +322,8 @@ echo
 test_gfx_version_parsing
 echo
 test_gfx_version_mixed
+echo
+test_gfx_version_large_output_pipefail
 
 echo -e "\n${MAG}=== Test Summary ===${NC}"
 echo -e "Tests run:    $TESTS_RUN"


### PR DESCRIPTION
## Why this matters

AMD topology discovery runs inside strict-mode installer paths. Both `rocm-smi` and `rocminfo` GFX parsers selected the first match with `head`, which can close a large producer stream early. Under `pipefail`, the resulting SIGPIPE makes a valid GFX probe look unsuccessful and can fall through to `unknown`, degrading backend/model selection.

Root cause: first-result selection did not consume the producer stream. The invariant is: GFX selection returns the first matching architecture without changing success based on output size.

## Overlap check

Searched open and closed PRs for `amd topology`, `gfx version`, `rocm-smi`, `rocminfo`, and `pipefail`, and reviewed all fetched history for `installers/lib/amd-topo.sh`. The only other branch changes PCIe link schema parity; it does not touch GFX parsing.

## Change

- Use consuming first-line selectors for both ROCm GFX fallback pipelines.
- Add a 20,000-line `rocm-smi` regression executed with `pipefail` enabled.

## Validation

- New `large output keeps first GFX match` boundary: passed.
- `bash -n installers/lib/amd-topo.sh tests/test-amd-topo.sh`: passed.
- `git diff --check`: passed.
- `bash tests/test-amd-topo.sh`: the new regression passed; the Windows checkout also reported 7 pre-existing CRLF-sensitive fixture mismatches (`PCIE\r`/`gfx942\r`). No changed assertion is among those failures; Linux CI remains the authoritative full-suite run.

## Tradeoffs and rollback

The selected value remains the first match. The parsers now read finite command output to completion, avoiding output-size-dependent status. Reverting restores the prior SIGPIPE false-negative behavior.