### PR TITLE
fix(features): reject invalid Apple memory fallbacks

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -1,6 +1,7 @@
 """Feature discovery endpoints."""
 
 import logging
+import math
 import os
 from typing import Optional
 
@@ -16,6 +17,15 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["features"])
 
 
+def _apple_host_ram_gb() -> float:
+    """Return a finite, non-negative unified-memory fallback."""
+    try:
+        value = float(os.environ.get("HOST_RAM_GB", "0") or "0")
+    except (ValueError, TypeError):
+        return 0
+    return value if math.isfinite(value) and value >= 0 else 0
+
+
 def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
     """Calculate whether a feature can be enabled and its status."""
     gpu_vram_gb = (gpu_info.memory_total_mb / 1024) if gpu_info else 0
@@ -25,10 +35,7 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     # On Apple Silicon, when HOST_CHIP is missing (get_gpu_info_apple returned None),
     # fall back to HOST_RAM_GB. Unified memory = VRAM on Apple Silicon.
     if gpu_vram_gb == 0 and GPU_BACKEND == "apple":
-        try:
-            gpu_vram_gb = float(os.environ.get("HOST_RAM_GB", "0") or "0")
-        except (ValueError, TypeError):
-            pass
+        gpu_vram_gb = _apple_host_ram_gb()
         gpu_vram_free_gb = gpu_vram_gb  # assumes zero current usage; Docker can't measure host memory pressure
 
     req = feature["requirements"]
@@ -148,10 +155,7 @@ async def api_features(api_key: str = Depends(verify_api_key)):
 
     # Apply Apple Silicon fallback for endpoint-level GPU summary (mirrors calculate_feature_status)
     if gpu_vram_gb == 0 and GPU_BACKEND == "apple":
-        try:
-            gpu_vram_gb = float(os.environ.get("HOST_RAM_GB", "0") or "0")
-        except (ValueError, TypeError):
-            pass
+        gpu_vram_gb = _apple_host_ram_gb()
         if gpu_vram_gb == 0:
             logger.warning(
                 "Apple Silicon VRAM fallback: HOST_RAM_GB is 0 or unset; "

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -95,6 +95,21 @@ class TestApiFeaturesAppleFallback:
         data = response.json()
         assert data["gpu"]["vramGb"] == 16.0
 
+    def test_api_features_rejects_non_finite_or_negative_host_ram(self, test_client):
+        """Invalid env values must not escape as non-JSON numbers or fake capacity."""
+        for host_ram in ("nan", "inf", "-1"):
+            with patch.dict(os.environ, {"HOST_RAM_GB": host_ram}):
+                with patch("routers.features.GPU_BACKEND", "apple"):
+                    with patch("routers.features.get_gpu_info", return_value=None):
+                        with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
+                            response = test_client.get(
+                                "/api/features",
+                                headers=test_client.auth_headers,
+                            )
+
+            assert response.status_code == 200
+            assert response.json()["gpu"]["vramGb"] == 0
+
 
 # --- calculate_feature_status general cases ---
 


### PR DESCRIPTION
## Why this matters

On Apple Silicon, `/api/features` treats `HOST_RAM_GB` as unified VRAM when GPU probing is unavailable. Python accepts `nan` and `inf` as floats, but Starlette's JSON serializer rejects non-finite values; `HOST_RAM_GB=nan` therefore turned a read-only dashboard endpoint into HTTP 500. Negative values also produced impossible capacity decisions.

Root cause: conversion checked syntax but not the numeric domain. The invariant is: feature capacity and API payloads contain finite, non-negative memory values.

## Overlap check

Searched open and closed PRs for `HOST_RAM_GB`, Apple feature memory, finite/non-finite values, and reviewed every fetched change to `routers/features.py`. Existing branches preserve public service URLs and IPv6 launch hosts; neither changes memory parsing.

## Change

- Centralize Apple host-memory parsing with finite/non-negative validation.
- Reuse it for feature gating and the endpoint GPU summary.
- Exercise `nan`, `inf`, and negative values through authenticated `/api/features` requests.

## Validation

- `pytest tests/test_features.py -q` — 21 passed.
- `python -m compileall -q routers/features.py`
- `git diff --check`

## Tradeoffs and rollback

Invalid capacity now degrades to the existing zero-memory behavior and warning instead of crashing or overstating hardware. Valid numeric values are unchanged. Reverting restores the HTTP 500 risk for non-finite configuration.