### PR TITLE
fix(oauth): isolate concurrent callback writes

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -71,6 +71,8 @@ import logging
 import os
 import re
 import secrets
+import tempfile
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -84,6 +86,7 @@ from security import verify_api_key
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["oauth"])
+_ATOMIC_WRITE_LOCK = threading.Lock()
 
 # base64url alphabet (RFC 4648 §5). token_urlsafe(32) yields 43 chars; we
 # accept 22..128 to allow for future entropy tweaks without a breaking
@@ -263,16 +266,29 @@ def _prune_expired_nonces(nonce_dir: Path) -> None:
 def _atomic_write_0600(target: Path, data: str) -> None:
     """Write ``data`` to ``target`` atomically with mode 0600 on POSIX.
     The chmod is best-effort on filesystems that don't honour it
-    (Windows dev boxes, some overlayfs setups). Uses ``with_name`` rather
-    than ``with_suffix`` because Path.with_suffix rejects suffixes that
-    contain embedded dots on some Python versions."""
-    tmp = target.with_name(target.name + ".tmp")
-    tmp.write_text(data, encoding="utf-8")
+    (Windows dev boxes, some overlayfs setups). Each writer gets a private
+    same-directory temporary file so concurrent callbacks cannot collide."""
+    fd, tmp_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    tmp = Path(tmp_name)
     try:
-        tmp.chmod(0o600)
-    except OSError:
-        logger.debug("could not chmod %s to 0600", tmp, exc_info=True)
-    tmp.replace(target)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            logger.debug("could not chmod %s to 0600", tmp, exc_info=True)
+        # Concurrent destination replacement can fail on Windows. Serialize
+        # only the publication instant; preparation remains independent.
+        with _ATOMIC_WRITE_LOCK:
+            tmp.replace(target)
+    finally:
+        tmp.unlink(missing_ok=True)
 
 
 def _success_page(skill: str, return_url: Optional[str] = None) -> str:

--- a/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
@@ -21,12 +21,14 @@ import os
 import stat
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 
 import main as main_module
+from routers import oauth_passthrough
 
 
 @pytest.fixture
@@ -433,6 +435,27 @@ def test_callback_atomic_write(oauth_client):
     assert resp.status_code == 200
     assert not (oauth_client.tmp / "oauth_callback.json.tmp").exists()
     assert (oauth_client.tmp / "oauth_callback.json").exists()
+
+
+def test_atomic_writer_uses_independent_temps_for_concurrent_callbacks(tmp_path, monkeypatch):
+    """Two callback writers must not race over one shared temporary path."""
+    target = tmp_path / "oauth_callback.json"
+    real_replace = Path.replace
+    replacement_sources = []
+
+    def record_replace(source, destination):
+        replacement_sources.append(source.name)
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(Path, "replace", record_replace)
+    payloads = [json.dumps({"code": "a"}), json.dumps({"code": "b"})]
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(lambda payload: oauth_passthrough._atomic_write_0600(target, payload), payloads))
+
+    assert len(set(replacement_sources)) == 2
+    assert json.loads(target.read_text(encoding="utf-8"))["code"] in {"a", "b"}
+    assert list(tmp_path.glob(".oauth_callback.json.*.tmp")) == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why this matters

OAuth init and callback requests can arrive concurrently. The shared atomic helper used one predictable `<target>.tmp` path, so two legitimate writers could overwrite/remove each other's source file; on Windows even simultaneous destination replacements can fail. The callback then returns 500 after consuming a single-use nonce, forcing the user to restart authorization.

Root cause: atomicity for readers did not include writer/writer coordination. The invariant is: concurrent writes either publish one complete payload or the other, and neither request fails because of temporary-file collision.

## Overlap check

Searched open and closed PRs for OAuth callback files, concurrent/atomic writes, nonce state, and reviewed all fetched history for `routers/oauth_passthrough.py`. `fix/oauth-prune-malformed-nonces` changes nonce cleanup only; prior state-validation and credential-root fixes do not change the writer.

## Change

- Allocate private same-directory temporary files with mode 0600 semantics.
- Flush and fsync payloads before replacement.
- Serialize only the final replacement for Windows compatibility.
- Add concurrent-writer coverage proving distinct temp sources, complete JSON, and cleanup.

## Validation

- `pytest tests/test_oauth_passthrough.py -q` — 47 passed, 2 skipped.
- `python -m compileall -q routers/oauth_passthrough.py`
- `git diff --check`

## Tradeoffs and rollback

Publication is serialized for a few filesystem operations; OAuth writes are tiny and infrequent. Last-writer-wins behavior of the fixed callback file is intentionally preserved. Reverting restores shared-temp races.