### PR TITLE
fix(doctor): isolate concurrent report generation

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -46,6 +46,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh
+	@bash tests/test-doctor-concurrency.sh
 	@echo "=== Docker rootless bind-mount ownership ==="
 	@bash tests/test-rootless-docker-ownership.sh
 	@echo ""

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -24,8 +24,13 @@ esac
 
 REPORT_FILE="${1:-/tmp/ods-doctor-report.json}"
 
-CAP_FILE="/tmp/ods-doctor-capabilities.json"
-PREFLIGHT_FILE="/tmp/ods-doctor-preflight.json"
+DOCTOR_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ods-doctor.XXXXXX")"
+cleanup_doctor_tmp() {
+    rm -rf "$DOCTOR_TMP_DIR"
+}
+trap cleanup_doctor_tmp EXIT
+CAP_FILE="$DOCTOR_TMP_DIR/capabilities.json"
+PREFLIGHT_FILE="$DOCTOR_TMP_DIR/preflight.json"
 DOCTOR_BASH_CMD="${BASH:-}"
 if [[ -z "$DOCTOR_BASH_CMD" || ! -x "$DOCTOR_BASH_CMD" ]]; then
     DOCTOR_BASH_CMD="$(command -v bash 2>/dev/null || printf '%s\n' bash)"
@@ -559,6 +564,7 @@ import pathlib
 import re
 import shlex
 import sys
+import tempfile
 from datetime import datetime, timezone
 from urllib import error, parse, request
 
@@ -1663,7 +1669,23 @@ report["autofix_hints"] = uniq_hints  # overwrite initial empty list
 
 path = pathlib.Path(report_file)
 path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+if path.is_symlink():
+    path = path.resolve(strict=False)
+fd, temporary_name = tempfile.mkstemp(
+    dir=path.parent,
+    prefix=f".{path.name}.",
+    suffix=".tmp",
+)
+temporary = pathlib.Path(temporary_name)
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    os.replace(temporary, path)
+finally:
+    temporary.unlink(missing_ok=True)
 PY
 
 echo "ODS Doctor report: $REPORT_FILE"

--- a/ods/tests/test-doctor-concurrency.sh
+++ b/ods/tests/test-doctor-concurrency.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Concurrent public-command coverage for isolated doctor artifacts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-doctor-concurrency.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/sync" "$FIXTURE/work" "$FIXTURE/bin"
+
+for command_name in curl docker nvidia-smi; do
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$FIXTURE/bin/$command_name"
+    chmod +x "$FIXTURE/bin/$command_name"
+done
+
+for marker in A B; do
+    install_root="$FIXTURE/$marker"
+    mkdir -p "$install_root/ods/scripts" "$install_root/ods/lib" "$install_root/ods/extensions/services"
+    cp "$ROOT_DIR/scripts/ods-doctor.sh" "$install_root/ods/scripts/ods-doctor.sh"
+    cp "$ROOT_DIR/lib/service-registry.sh" "$ROOT_DIR/lib/safe-env.sh" "$install_root/ods/lib/"
+
+    cat > "$install_root/ods/scripts/build-capability-profile.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+output=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --output) output="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '{"marker":"%s"}\n' "$MARKER" > "$output"
+touch "$SYNC_DIR/cap-$MARKER"
+for _ in {1..500}; do
+    [[ -f "$SYNC_DIR/cap-A" && -f "$SYNC_DIR/cap-B" ]] && break
+    sleep 0.01
+done
+[[ -f "$SYNC_DIR/cap-A" && -f "$SYNC_DIR/cap-B" ]]
+printf '%s\n' \
+    'CAP_RECOMMENDED_TIER=T1' \
+    'CAP_LLM_BACKEND=cpu' \
+    'CAP_GPU_VRAM_MB=0' \
+    'CAP_GPU_NAME=None' \
+    'CAP_PLATFORM_ID=test' \
+    'CAP_COMPOSE_OVERLAYS='
+STUB
+
+    cat > "$install_root/ods/scripts/preflight-engine.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+report=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report) report="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '{"marker":"%s"}\n' "$MARKER" > "$report"
+printf '%s\n' 'PREFLIGHT_BLOCKERS=0' 'PREFLIGHT_WARNINGS=0'
+STUB
+    chmod +x "$install_root/ods/scripts/"*.sh
+done
+
+run_doctor() {
+    local marker="$1"
+    MARKER="$marker" \
+    SYNC_DIR="$FIXTURE/sync" \
+    TMPDIR="$FIXTURE/work" \
+    PATH="$FIXTURE/bin:$PATH" \
+        bash "$FIXTURE/$marker/ods/scripts/ods-doctor.sh" \
+        "$FIXTURE/report-$marker.json" > "$FIXTURE/output-$marker.log"
+}
+
+run_doctor A &
+pid_a=$!
+run_doctor B &
+pid_b=$!
+wait "$pid_a"
+wait "$pid_b"
+
+python3 - "$FIXTURE/report-A.json" "$FIXTURE/report-B.json" <<'PY'
+import json
+import sys
+
+for marker, path in zip(("A", "B"), sys.argv[1:]):
+    report = json.load(open(path, encoding="utf-8"))
+    assert report["capability_profile"]["marker"] == marker
+PY
+
+if find "$FIXTURE/work" -mindepth 1 -print -quit | grep . >/dev/null; then
+    echo "doctor left private intermediate files behind" >&2
+    exit 1
+fi
+
+echo "Concurrent doctor reports remain isolated"


### PR DESCRIPTION
## Why this matters

`ods doctor` used two global `/tmp/ods-doctor-*.json` intermediates. Concurrent runs (for example an operator command plus support automation) could read each other's capability/preflight snapshot and publish a valid-looking report for the wrong run. The final JSON was also truncated in place, exposing partial data to readers if generation was interrupted.

Root cause: run-scoped evidence and publication shared process-global paths. The invariant is: every report is assembled from its own evidence and readers see either the old complete report or the new complete report.

## Overlap check

Searched open and closed PRs for doctor temp files, concurrent reports, and atomic doctor output; reviewed all fetched history for `scripts/ods-doctor.sh`. Preflight-engine atomic-report PRs affect a different standalone report writer. Existing doctor branches cover env loading, rootless IDs, and external LLM diagnostics, not report isolation.

## Change

- Allocate a private doctor workspace through portable `mktemp -d` and clean it on exit.
- Publish final JSON via same-directory fsync + atomic replace while preserving symlink targets.
- Add a concurrent public-command fixture whose two runs emit distinct capability markers and must retain them.
- Register the regression in `make test`.

## Validation

- `bash tests/test-doctor-concurrency.sh`
- `bash tests/test-ods-doctor.sh`
- `bash -n scripts/ods-doctor.sh tests/test-doctor-concurrency.sh`
- `git diff --check`

All passed locally.

## Tradeoffs and rollback

Each run creates one short-lived private directory and one same-directory report temp. Report permissions inherit secure `mkstemp` defaults. Reverting restores cross-run contamination and partial-publication risk.