### PR TITLE
fix(preflight): match the managed LLM container exactly

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-preflight-llm-container-identity.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -224,7 +224,7 @@ done
 
 if [ "$LLM_FOUND" = false ]; then
     # Check if container is running but model still loading
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qi "${LLM_CONTAINER_MATCH}"; then
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -Fxi "${LLM_CONTAINER_MATCH}" >/dev/null; then
         warn "$LLM_SERVICE_NAME container running but not responding yet (model may still be loading)"
     else
         fail "No LLM endpoint found — checked: ${LLM_ENDPOINTS[*]}"

--- a/ods/tests/test-preflight-llm-container-identity.sh
+++ b/ods/tests/test-preflight-llm-container-identity.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Public preflight regression for exact LLM container identity.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-preflight-container.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/lib" "$FIXTURE/bin"
+cp "$ROOT_DIR/ods-preflight.sh" "$FIXTURE/ods-preflight.sh"
+cp "$ROOT_DIR/lib/safe-env.sh" "$FIXTURE/lib/safe-env.sh"
+
+cat > "$FIXTURE/bin/docker" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-} ${2:-}" in
+    '--version ')
+        echo 'Docker version 27.0.0, build test'
+        ;;
+    'info ')
+        echo 'Server: test'
+        ;;
+    'compose version')
+        echo 'Docker Compose version v2.27.0'
+        ;;
+    'port ods-llama-server')
+        exit 1
+        ;;
+    'ps --format')
+        echo 'ods-llama-server-debug'
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+STUB
+
+cat > "$FIXTURE/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+
+cat > "$FIXTURE/bin/nvidia-smi" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+chmod +x "$FIXTURE/bin/"*
+
+set +e
+output=$(PATH="$FIXTURE/bin:$PATH" GPU_BACKEND=cpu bash "$FIXTURE/ods-preflight.sh" 2>&1)
+status=$?
+set -e
+
+[[ "$status" -eq 1 ]] || {
+    echo "expected failing preflight with offline services, got $status" >&2
+    exit 1
+}
+grep -F 'No LLM endpoint found' <<< "$output" >/dev/null || {
+    echo "preflight treated a similarly named container as the LLM" >&2
+    exit 1
+}
+if grep -F 'container running but not responding yet' <<< "$output" >/dev/null; then
+    echo "preflight reported the debug container as the managed LLM" >&2
+    exit 1
+fi
+
+echo "Preflight requires the exact managed LLM container name"


### PR DESCRIPTION
## Why this matters

When the LLM endpoint is offline, `ods-preflight.sh` distinguishes a managed container that is still loading from a service that is not running. Its substring/regex match treated names such as `ods-llama-server-debug` or `ods-llama-server-old` as the production container, hiding the actionable “start the service” failure behind a misleading loading warning.

Root cause: container identity was tested as an unanchored regular expression. The invariant is: only the exact configured managed-container name can prove that service is running.

## Overlap check

Searched open and closed PRs for preflight container identity/exact matching and reviewed fetched history for `ods-preflight.sh`. Runtime readiness JSON, dashboard-port, and curl-timeout changes do not alter LLM container identity.

## Change

- Match the complete literal container name and consume Docker output safely under `pipefail`.
- Add a hermetic public `ods-preflight.sh` regression with only `ods-llama-server-debug` running.
- Register the boundary test in `make test`.

## Validation

- `bash tests/test-preflight-llm-container-identity.sh`
- `bash tests/test-preflight.sh` — 22 passed.
- `bash -n ods-preflight.sh tests/test-preflight-llm-container-identity.sh`
- `git diff --check`

## Tradeoffs and rollback

ODS-managed container names are already exact registry contracts; similarly named debug/old containers remain visible through Docker but no longer satisfy readiness. Reverting restores false loading reports.