### PR TITLE
fix(test): validate functional responses as JSON

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-functional-json-contract.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/scripts/ods-test-functional.sh
+++ b/ods/scripts/ods-test-functional.sh
@@ -21,6 +21,11 @@ fi
 
 set -euo pipefail
 
+command -v jq >/dev/null 2>&1 || {
+    echo "ERROR: jq is required for functional API response validation" >&2
+    exit 1
+}
+
 # Colors
 RED='\e[0;31m'
 GREEN='\e[0;32m'
@@ -73,16 +78,9 @@ test_llm_functional() {
     echo ""
     echo "> Testing LLM Functional Generation"
 
-    # The grep-based extraction pipelines in this script may legitimately
-    # produce zero matches (LLM/TTS/embeddings/whisper offline or returning
-    # unexpected payload). Under `set -euo pipefail` such a no-match would
-    # abort the script before the `[[ -z ... ]]` guard below can treat it
-    # as a test failure. Using `if ! VAR=$(...)` keeps the set -e safety
-    # net engaged everywhere else; `set -e` is disabled only for the
-    # evaluation of the condition (per bash spec), so a failed pipeline
-    # leaves VAR empty and the explicit `fail` path below runs.
     local model_id=""
-    if ! model_id=$(curl -s --max-time 10 "$LLM_URL/v1/models" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4); then
+    if ! model_id=$(curl -s --max-time 10 "$LLM_URL/v1/models" 2>/dev/null \
+        | jq -er '.data[0].id | select(type == "string" and length > 0)'); then
         model_id=""
     fi
     model_id="${model_id:-local}"
@@ -102,7 +100,9 @@ test_llm_functional() {
     fi
 
     local content=""
-    if ! content=$(echo "$response" | grep -oE '"content":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4); then
+    if ! content=$(jq -er \
+        '.choices[0].message.content | select(type == "string" and length > 0)' \
+        <<< "$response"); then
         content=""
     fi
 
@@ -197,12 +197,11 @@ test_embeddings_functional() {
         return 1
     fi
     
-    # Check if response contains array of numbers
-    if echo "$response" | grep -qE '\[\s*-?[0-9]+\.[0-9]+'; then
-        local vector_len=0
-        if ! vector_len=$(echo "$response" | grep -oE '-?[0-9]+\.[0-9]+' | wc -l); then
-            vector_len=0
-        fi
+    # TEI returns an array (usually nested) of numeric vector components.
+    local vector_len=0
+    if vector_len=$(jq -er \
+        'if type == "array" then ([.. | numbers] | length) else 0 end | select(. > 0)' \
+        <<< "$response"); then
         pass "Embeddings generates vectors ($vector_len dimensions)"
     else
         fail "Embeddings did not return valid vectors"
@@ -252,7 +251,7 @@ test_whisper_functional() {
     fi
     
     local transcription=""
-    if ! transcription=$(echo "$response" | grep -oE '"text":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4); then
+    if ! transcription=$(jq -er '.text | select(type == "string" and length > 0)' <<< "$response"); then
         transcription=""
     fi
     

--- a/ods/tests/test-functional-json-contract.sh
+++ b/ods/tests/test-functional-json-contract.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# End-to-end JSON contract coverage for the functional service probes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-functional-json.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/bin"
+cat > "$FIXTURE/bin/curl" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+url=""
+output=""
+write_code=false
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    case "${args[$i]}" in
+        http://*) url="${args[$i]}" ;;
+        -o) output="${args[$((i + 1))]}" ;;
+        -w) write_code=true ;;
+    esac
+done
+
+case "$url" in
+    http://llm.test/v1/models)
+        printf '{\n  "data": [\n    {"id": "pretty/model"}\n  ]\n}\n'
+        ;;
+    http://llm.test/v1/chat/completions)
+        printf '{\n  "choices": [\n    {"message": {"content": "4"}}\n  ]\n}\n'
+        ;;
+    http://tts.test/v1/audio/speech)
+        dd if=/dev/zero of="$output" bs=2048 count=1 2>/dev/null
+        if $write_code; then
+            printf '200'
+        fi
+        ;;
+    http://embeddings.test/embed)
+        printf '[\n  [1, 0, -1, 2]\n]\n'
+        ;;
+    http://whisper.test/v1/audio/transcriptions)
+        printf '{\n  "text": "hello world"\n}\n'
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+STUB
+chmod +x "$FIXTURE/bin/curl"
+
+output=$(PATH="$FIXTURE/bin:$PATH" \
+    LLM_URL=http://llm.test \
+    TTS_URL=http://tts.test \
+    EMBEDDING_URL=http://embeddings.test \
+    WHISPER_URL=http://whisper.test \
+    bash "$ROOT_DIR/scripts/ods-test-functional.sh" 2>&1)
+
+grep -F 'Results: 4 passed, 0 failed' <<< "$output" >/dev/null
+grep -F 'Embeddings generates vectors (4 dimensions)' <<< "$output" >/dev/null
+grep -F "LLM generates correct answer: '4'" <<< "$output" >/dev/null
+grep -F "Whisper transcribes correctly: 'hello world'" <<< "$output" >/dev/null
+
+echo "Functional probes accept semantic JSON response contracts"


### PR DESCRIPTION
## Why this matters

The setup API invokes `ods-test-functional.sh` to prove LLM, embeddings, and voice behavior. The script parsed JSON with grep/cut patterns, so legal formatting, integer vector components, and escaped JSON strings could be rejected or misread. That creates false setup failures even when services satisfy their API contracts.

Root cause: syntax-dependent text matching was used for semantic JSON. The invariant is: equivalent valid JSON representations produce the same functional-test result, while malformed/wrong-shaped payloads fail explicitly.

## Overlap check

Searched open and closed PRs for functional-test JSON parsing/responses and reviewed all fetched history for `scripts/ods-test-functional.sh`. `fix/functional-test-temp-isolation` only isolates audio paths; resilience PRs only preserve summary execution. No branch validates response shapes.

## Change

- Parse model IDs, chat content, TEI vectors, and transcription text with jq.
- Accept numeric vectors containing integers or floats while requiring an array with at least one number.
- Add a full-script regression using pretty-printed service responses and an integer vector.
- Register it in `make test`.

## Validation

- `bash tests/test-functional-json-contract.sh`
- `bash -n scripts/ods-test-functional.sh tests/test-functional-json-contract.sh`
- `git diff --check`

All passed. The vendored BATS checkout on this Windows worktree has CRLF shebangs (`bash\r`) and could not launch locally; the new public-boundary shell test covers the changed behavior, and CI will run the existing resilience BATS suite on Linux.

## Tradeoffs and rollback

jq becomes explicit here; it is already a hard ODS installer dependency. Endpoint URLs, timeouts, and pass/fail policy are unchanged. Reverting restores format-sensitive parsing.