### PR TITLE
fix(restore): consume complete archive scans

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-restore-large-archive-scan.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -154,8 +154,8 @@ list_backups() {
             # Compressed backup
             size=$(du -sh "$backup" 2>/dev/null | cut -f1)
             # Try to read manifest from tar
-            if tar -tzf "$backup" 2>/dev/null | grep -q "manifest.json"; then
-                manifest=$(tar -xzf "$backup" -O */manifest.json 2>/dev/null || echo "")
+            if tar -tzf "$backup" 2>/dev/null | grep "manifest.json" >/dev/null; then
+                manifest=$(tar -xzf "$backup" -O "$id/manifest.json" 2>/dev/null || echo "")
                 if [[ -n "$manifest" ]]; then
                     backup_type=$(echo "$manifest" | grep -o '"backup_type": "[^"]*"' | cut -d'"' -f4 || echo "unknown")
                     description=$(echo "$manifest" | grep -o '"description": "[^"]*"' | cut -d'"' -f4 || echo "")
@@ -220,7 +220,7 @@ extract_backup() {
 
     if [[ -f "$compressed" ]]; then
         # Validate: reject archives with absolute paths or path traversal
-        if tar -tzf "$compressed" 2>/dev/null | grep -qE '(^/|\.\./)'; then
+        if tar -tzf "$compressed" 2>/dev/null | grep -E '(^/|\.\./)' >/dev/null; then
             log_error "Backup archive contains unsafe paths (absolute or ../) — refusing to extract" >&2
             return 1
         fi

--- a/ods/tests/test-restore-large-archive-scan.sh
+++ b/ods/tests/test-restore-large-archive-scan.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Boundary coverage for complete archive scans under strict pipefail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-restore-archive.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+ODS_FIXTURE="$FIXTURE/ods"
+mkdir -p "$ODS_FIXTURE/.backups" "$ODS_FIXTURE/data" "$ODS_FIXTURE/lib"
+cp "$ROOT_DIR/lib/rsync.sh" "$ODS_FIXTURE/lib/rsync.sh"
+
+python3 - "$ODS_FIXTURE/.backups" <<'PY'
+import io
+import json
+import sys
+import tarfile
+from pathlib import Path
+
+root = Path(sys.argv[1])
+
+manifest = json.dumps({
+    "manifest_version": "1.0",
+    "backup_id": "20260902-120000",
+    "backup_type": "user-data",
+    "description": "large archive",
+    "contents": {"user_data": True, "config": False, "cache": False},
+}).encode()
+
+with tarfile.open(root / "20260902-120000.tar.gz", "w:gz") as bundle:
+    info = tarfile.TarInfo("20260902-120000/manifest.json")
+    info.size = len(manifest)
+    bundle.addfile(info, io.BytesIO(manifest))
+    for index in range(30000):
+        bundle.addfile(tarfile.TarInfo(f"20260902-120000/data/entry-{index:05d}"))
+
+with tarfile.open(root / "20260902-130000.tar.gz", "w:gz") as bundle:
+    bundle.addfile(tarfile.TarInfo("../escape"))
+    for index in range(30000):
+        bundle.addfile(tarfile.TarInfo(f"20260902-130000/data/entry-{index:05d}"))
+PY
+
+list_output=$(ODS_DIR="$ODS_FIXTURE" bash "$ROOT_DIR/ods-restore.sh" --list)
+grep -E '20260902-120000[[:space:]]+user-data' <<< "$list_output" >/dev/null || {
+    echo "large compressed backup lost its manifest metadata" >&2
+    exit 1
+}
+
+set +e
+restore_output=$(ODS_DIR="$ODS_FIXTURE" bash "$ROOT_DIR/ods-restore.sh" --force 20260902-130000 2>&1)
+restore_status=$?
+set -e
+[[ "$restore_status" -ne 0 ]] || {
+    echo "unsafe archive was accepted" >&2
+    exit 1
+}
+grep -F 'contains unsafe paths' <<< "$restore_output" >/dev/null || {
+    echo "unsafe member was not rejected by the pre-extraction scan" >&2
+    exit 1
+}
+[[ ! -e "$FIXTURE/escape" ]] || {
+    echo "unsafe archive wrote outside the backup root" >&2
+    exit 1
+}
+
+echo "Large restore archives retain metadata and safety matches"


### PR DESCRIPTION
## Why this matters

Compressed restore archives are inspected while `ods-restore.sh` runs with `pipefail`. Both manifest discovery and unsafe-path detection ended in `grep -q`; an early match in a large archive can SIGPIPE `tar`, invert the pipeline result, hide backup metadata, and bypass ODS's explicit pre-extraction refusal. In addition, listing tried to extract a shell wildcard member that GNU tar did not resolve, so valid compressed backups appeared as `unknown`.

Root cause: early-closing consumers made scan success depend on archive length, and manifest extraction did not use the archive's known root. The invariant is: every archive member is consumed for scan status, and an own-format compressed backup exposes its manifest metadata.

## Overlap check

Searched open and closed PRs for restore archive scans, compressed manifest metadata, tar/pipefail, and reviewed fetched history for `ods-restore.sh`. PR #3609 changes compose-stack resolution in `stop_containers`; restore cleanup/config/confinement branches change later validation. None changes these listing/pre-extraction pipelines or manifest lookup.

## Change

- Make manifest and unsafe-path matchers consume complete tar listings.
- Extract the manifest by the backup ID/root contract instead of an unresolved wildcard.
- Add a public CLI regression with 30,000-member safe and unsafe compressed archives.
- Register it in `make test`.

## Validation

- `bash tests/test-restore-large-archive-scan.sh`
- `bash tests/test-backup-restore-roundtrip.sh`
- `bash -n ods-restore.sh tests/test-restore-large-archive-scan.sh`
- `git diff --check`

All passed locally. `tests/test-restore-safety-ux.sh` remains independently broken on main because its fixture does not provide the now-required `lib/rsync.sh`; this PR does not touch that fixture or code path.

## Tradeoffs and rollback

Scans now read finite archive listings to completion before acting. Large archives already require a full tar listing for size estimation, so this favors deterministic correctness over an early exit. Reverting restores size-dependent metadata and safety behavior.