### PR TITLE
fix(preflight): publish Linux reports atomically

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -41,6 +41,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Linux install preflight ==="
 	@bash tests/test-linux-install-preflight.sh
+	@bash tests/test-linux-preflight-atomic-report.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
 	@echo ""

--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -72,6 +72,35 @@ print(json.dumps({
 ' >>"$CHECKS_JSONL"
 }
 
+write_json_report() {
+    local target="$1"
+    local content="$2"
+    local link target_dir temporary hops=0
+
+    # Preserve the existing behavior for operator-provided symlink paths.
+    while [[ -L "$target" ]]; do
+        hops=$((hops + 1))
+        [[ "$hops" -le 40 ]] || return 1
+        link="$(readlink "$target")" || return 1
+        case "$link" in
+            /*) target="$link" ;;
+            *) target="$(dirname "$target")/$link" ;;
+        esac
+    done
+
+    target_dir="$(cd -P "$(dirname "$target")" && pwd)" || return 1
+    target="$target_dir/$(basename "$target")"
+    temporary="$(mktemp "$target_dir/.$(basename "$target").XXXXXX")" || return 1
+    if ! printf '%s\n' "$content" > "$temporary"; then
+        rm -f "$temporary"
+        return 1
+    fi
+    if ! mv -f "$temporary" "$target"; then
+        rm -f "$temporary"
+        return 1
+    fi
+}
+
 docker_cli_looks_like_podman() {
     local docker_version=""
     docker_version="$(docker --version 2>/dev/null || true)"
@@ -405,7 +434,7 @@ fi
 if [[ "$OUTPUT_MODE" == "json" ]]; then
     echo "$REPORT_JSON"
     if [[ -n "$JSON_FILE" ]]; then
-        printf '%s\n' "$REPORT_JSON" >"$JSON_FILE"
+        write_json_report "$JSON_FILE" "$REPORT_JSON"
     fi
     exit "$EXIT_CODE"
 fi
@@ -454,7 +483,7 @@ else
 fi
 
 if [[ -n "$JSON_FILE" ]]; then
-    printf '%s\n' "$REPORT_JSON" >"$JSON_FILE"
+    write_json_report "$JSON_FILE" "$REPORT_JSON"
     echo "JSON written to: $JSON_FILE"
 fi
 

--- a/ods/tests/test-linux-preflight-atomic-report.sh
+++ b/ods/tests/test-linux-preflight-atomic-report.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Public CLI regression: failed publication preserves the previous report.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFLIGHT="$ROOT_DIR/scripts/linux-install-preflight.sh"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-linux-preflight-report.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p "$FIXTURE/bin"
+cat > "$FIXTURE/bin/mv" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$MV_CALLS"
+exit 42
+STUB
+chmod +x "$FIXTURE/bin/mv"
+
+report="$FIXTURE/report.json"
+printf '%s\n' '{"generation":"known-good"}' > "$report"
+
+set +e
+MV_CALLS="$FIXTURE/mv.log" PATH="$FIXTURE/bin:$PATH" \
+    bash "$PREFLIGHT" --json-file "$report" > "$FIXTURE/stdout.log" 2> "$FIXTURE/stderr.log"
+status=$?
+set -e
+
+[[ "$status" -ne 0 ]] || {
+    echo "preflight reported success after publication failed" >&2
+    exit 1
+}
+[[ -s "$FIXTURE/mv.log" ]] || {
+    echo "preflight did not use atomic replacement" >&2
+    exit 1
+}
+[[ "$(cat "$report")" == '{"generation":"known-good"}' ]] || {
+    echo "failed publication replaced the known-good report" >&2
+    exit 1
+}
+if find "$FIXTURE" -maxdepth 1 -name '.report.json.*' -print -quit | grep . >/dev/null; then
+    echo "failed publication left a temporary report behind" >&2
+    exit 1
+fi
+
+echo "Linux preflight preserves its previous report on publish failure"


### PR DESCRIPTION
## Why this matters

`linux-install-preflight.sh --json-file` is an installer/release evidence boundary. It truncated the destination before writing, so an interrupted or failed publication could destroy the last known-good report and leave automation reading partial JSON.

Root cause: report generation and publication were one in-place write. The invariant is: a new complete report replaces the previous complete report atomically; publication failure leaves the previous bytes intact and no temp debris.

## Overlap check

Searched open and closed PRs for Linux install-preflight JSON/atomic output and reviewed every fetched change to `scripts/linux-install-preflight.sh`. PRs #1954/#2225 target `preflight-engine.sh`, a different report producer. Rootless-subid branches change checks only.

## Change

- Stage JSON beside its destination and replace it only after a complete write.
- Preserve operator-provided symlink targets with a bounded resolver.
- Use the same publisher in JSON and human output modes.
- Add a public CLI failure-injection regression and register it in `make test`.

## Validation

- `bash tests/test-linux-preflight-atomic-report.sh`
- `bash tests/test-linux-install-preflight.sh` — 15 passed.
- `bash -n scripts/linux-install-preflight.sh tests/test-linux-preflight-atomic-report.sh`
- `git diff --check`

## Tradeoffs and rollback

New reports are staged with `mktemp` permissions and promoted with same-filesystem `mv`; parent directories must already exist, matching prior behavior. Reverting restores destructive in-place publication.