### PR TITLE
fix(hermes): publish patched config atomically

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -24,6 +24,7 @@ test: ## Run unit and contract tests
 	@echo "=== Tier map tests ==="
 	@bash tests/test-tier-map.sh
 	@bash tests/test-installer-context-parity.sh
+	@bash tests/test-patch-hermes-config-atomic.sh
 	@bash tests/test-hermes-context-floor.sh
 	@echo ""
 	@echo "=== Hermes slash worker prune ==="

--- a/ods/scripts/patch-hermes-config.py
+++ b/ods/scripts/patch-hermes-config.py
@@ -10,8 +10,33 @@ the rest of the user's config.
 from __future__ import annotations
 
 import argparse
+import os
 import re
+import stat
+import tempfile
 from pathlib import Path
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Replace a live Hermes config without exposing partial contents."""
+    target = path.resolve(strict=False) if path.is_symlink() else path
+    previous_mode = stat.S_IMODE(target.stat().st_mode) if target.exists() else None
+    fd, temporary_name = tempfile.mkstemp(
+        dir=target.parent,
+        prefix=f".{target.name}.",
+        suffix=".tmp",
+    )
+    temporary = Path(temporary_name)
+    try:
+        if previous_mode is not None:
+            os.fchmod(fd, previous_mode)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _top_level_block(lines: list[str], name: str) -> tuple[int, int] | None:
@@ -290,7 +315,7 @@ def patch_config(
         updated += "\n"
     if updated == original:
         return False
-    path.write_text(updated, encoding="utf-8")
+    _atomic_write_text(path, updated)
     return True
 
 

--- a/ods/tests/test-patch-hermes-config-atomic.sh
+++ b/ods/tests/test-patch-hermes-config-atomic.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Production-function and CLI coverage for atomic Hermes config updates.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PATCHER="$ROOT_DIR/scripts/patch-hermes-config.py"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-hermes-config.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+cat > "$FIXTURE/config.yaml" <<'YAML'
+model:
+  default: "old-model"
+  provider: "custom"
+  base_url: "http://old.example/v1"
+  context_length: 8192
+providers:
+  custom:
+    request_timeout_seconds: 180
+YAML
+cp "$FIXTURE/config.yaml" "$FIXTURE/known-good.yaml"
+
+python3 - "$PATCHER" "$FIXTURE/config.yaml" <<'PY'
+import importlib.util
+import sys
+from pathlib import Path
+
+script = Path(sys.argv[1])
+config = Path(sys.argv[2])
+spec = importlib.util.spec_from_file_location("patch_hermes_config", script)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+def fail_replace(_source, _target):
+    raise OSError("injected publication failure")
+
+module.os.replace = fail_replace
+try:
+    module.patch_config(config, "new-model", "http://new.example/v1", 16384)
+except OSError as exc:
+    assert "injected publication failure" in str(exc)
+else:
+    raise AssertionError("patch unexpectedly succeeded")
+
+assert config.read_text(encoding="utf-8") == (config.parent / "known-good.yaml").read_text(encoding="utf-8")
+assert list(config.parent.glob(".config.yaml.*.tmp")) == []
+PY
+
+ln -s "$FIXTURE/config.yaml" "$FIXTURE/live-config.yaml"
+python3 "$PATCHER" "$FIXTURE/live-config.yaml" \
+    --model new-model \
+    --base-url http://new.example/v1 \
+    --context-length 16384 >/dev/null
+
+[[ -L "$FIXTURE/live-config.yaml" ]] || {
+    echo "atomic patch replaced the configured symlink" >&2
+    exit 1
+}
+grep -F 'default: "new-model"' "$FIXTURE/config.yaml" >/dev/null
+grep -F 'base_url: "http://new.example/v1"' "$FIXTURE/config.yaml" >/dev/null
+grep -F 'context_length: 16384' "$FIXTURE/config.yaml" >/dev/null
+
+echo "Hermes config publication preserves old bytes on failure and symlink targets"


### PR DESCRIPTION
## Why this matters

Installer and migration paths patch the live Hermes YAML before restart. `Path.write_text` truncates that config in place, so a write failure or interruption can leave Hermes with empty/partial YAML and turn a recoverable update into a startup outage.

Root cause: mutation and publication were the same filesystem operation. The invariant is: the active config changes only after a complete durable replacement; failures preserve its prior bytes, permissions, and symlink contract.

## Overlap check

Searched open and closed PRs for Hermes config atomic writes/patch publication and reviewed all fetched history for `scripts/patch-hermes-config.py`. Existing changes validate runtime limits, escape YAML scalars, and bound response length; none changes file publication.

## Change

- Stage patched YAML in a private same-directory temp, preserve the prior mode, fsync, and atomically replace.
- Resolve a configured symlink to preserve installer/operator layout.
- Add failure injection proving byte-for-byte rollback and temp cleanup, plus a CLI symlink-path regression.
- Register the test in `make test`.

## Validation

- `bash tests/test-patch-hermes-config-atomic.sh`
- `python -m compileall -q scripts/patch-hermes-config.py`
- `bash -n tests/test-patch-hermes-config-atomic.sh`
- `git diff --check`

The focused tests passed. `tests/test-installer-context-parity.sh` stops on an existing main-branch template assertion (`Hermes template bounds each model turn`) before reaching its patcher behavior section; this PR does not change that template.

## Tradeoffs and rollback

Atomic replacement changes the inode but deliberately preserves file mode and symlink target. The writer runs as the existing config owner in installer flows. Reverting restores in-place truncation risk.