### PR TITLE
fix(macos): point Podman installs at machine start

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -134,6 +134,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS CLI .env quote handling ==="
 	@bash tests/test-macos-env-quote-strip.sh
 	@echo ""
+	@echo "=== macOS Podman docker-CLI preflight ==="
+	@bash tests/test-macos-podman-docker-preflight.sh
+	@echo ""
 	@echo "=== macOS uninstall LaunchAgent cleanup ==="
 	@bash tests/test-macos-uninstall-launchagents.sh
 	@echo ""

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1165,13 +1165,7 @@ ai_ok "Docker CLI found"
 
 if ! $DOCKER_RUNNING; then
     ai_err "Docker daemon is not responding."
-    case "${DOCKER_BACKEND:-unknown}" in
-        desktop)  ai "Start Docker Desktop from /Applications or the menu bar, then re-run this installer." ;;
-        colima)   ai "Run \`colima start\` (e.g. \`colima start --cpu 6 --memory 12 --disk 60\`) then re-run this installer." ;;
-        rancher)  ai "Open Rancher Desktop and wait for the daemon to come up, then re-run this installer." ;;
-        orbstack) ai "Open OrbStack and wait for the daemon to come up, then re-run this installer." ;;
-        *)        ai "Start your docker daemon (Docker Desktop, Colima, Rancher Desktop, OrbStack, ...) and re-run this installer." ;;
-    esac
+    ai "$(macos_docker_daemon_startup_hint)"
     exit 1
 fi
 ai_ok "Docker daemon ready (v${DOCKER_VERSION}, backend=${DOCKER_BACKEND:-unknown})"

--- a/ods/installers/macos/lib/detection.sh
+++ b/ods/installers/macos/lib/detection.sh
@@ -98,7 +98,7 @@ test_docker_desktop() {
     DOCKER_INSTALLED=false
     DOCKER_RUNNING=false
     DOCKER_VERSION=""
-    DOCKER_BACKEND="unknown"  # "desktop" | "colima" | "rancher" | "orbstack" | "other"
+    DOCKER_BACKEND="unknown"  # "desktop" | "colima" | "rancher" | "orbstack" | "podman" | "other"
 
     # Check if docker CLI is available
     if ! command -v docker >/dev/null 2>&1; then
@@ -124,11 +124,67 @@ test_docker_desktop() {
         *)                                                    DOCKER_BACKEND="other" ;;
     esac
 
-    # Check if Docker daemon is responsive
-    if docker version >/dev/null 2>&1; then
-        DOCKER_RUNNING=true
-        DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "unknown")
+    # Podman Desktop / podman-docker expose a `docker` CLI whose --version
+    # string is "podman …". Context inspect often yields an empty/unknown
+    # endpoint, so classify before the daemon probe (issue #2933).
+    if docker --version 2>/dev/null | grep -qi podman \
+       || docker version 2>&1 | grep -qi podman; then
+        DOCKER_BACKEND="podman"
     fi
+
+    # Check if the engine is responsive. `docker version` talks to the
+    # server; a Podman machine that is stopped fails here while `docker
+    # --version` (client-only) still succeeds — that is the #2933 split.
+    if docker info >/dev/null 2>&1 || docker version >/dev/null 2>&1; then
+        DOCKER_RUNNING=true
+        DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' 2>/dev/null \
+            || docker info --format '{{.ServerVersion}}' 2>/dev/null \
+            || echo "unknown")
+    elif [[ "$DOCKER_BACKEND" == "podman" ]] && macos_try_podman_docker_host; then
+        DOCKER_RUNNING=true
+        DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' 2>/dev/null \
+            || echo "unknown")
+    fi
+}
+
+# When the docker CLI is Podman's shim but DOCKER_HOST still points at a
+# missing Docker Desktop socket, bind the live Podman remote socket so
+# later compose/info calls use the same engine the operator already started.
+macos_try_podman_docker_host() {
+    command -v podman >/dev/null 2>&1 || return 1
+    podman info >/dev/null 2>&1 || return 1
+    local sock
+    sock=$(podman info --format '{{.Host.RemoteSocket.Path}}' 2>/dev/null || true)
+    sock="${sock#unix://}"
+    [[ -n "$sock" && -S "$sock" ]] || return 1
+    export DOCKER_HOST="unix://${sock}"
+    docker info >/dev/null 2>&1
+}
+
+# Operator-facing next step when the engine CLI is present but the daemon
+# (or Podman machine) is down. Keep this next to detection so tests can
+# assert the Podman hint without sourcing the full installer.
+macos_docker_daemon_startup_hint() {
+    case "${DOCKER_BACKEND:-unknown}" in
+        desktop)
+            echo "Start Docker Desktop from /Applications or the menu bar, then re-run this installer."
+            ;;
+        colima)
+            echo "Run \`colima start\` (e.g. \`colima start --cpu 6 --memory 12 --disk 60\`) then re-run this installer."
+            ;;
+        rancher)
+            echo "Open Rancher Desktop and wait for the daemon to come up, then re-run this installer."
+            ;;
+        orbstack)
+            echo "Open OrbStack and wait for the daemon to come up, then re-run this installer."
+            ;;
+        podman)
+            echo "Start the Podman machine (\`podman machine start\`) or open Podman Desktop, then re-run this installer."
+            ;;
+        *)
+            echo "Start your container engine (Docker Desktop, Colima, Rancher Desktop, OrbStack, or Podman) and re-run this installer."
+            ;;
+    esac
 }
 
 # Detect a stale `credsStore: desktop` config (left by `brew install docker`

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -86,9 +86,10 @@ INSTALL_DIR="${ODS_INSTALL_DIR}"
 # ============================================================================
 
 test_docker_running() {
-    if ! docker info >/dev/null 2>&1; then
-        ai_err "Docker Desktop is not running."
-        ai "Start it from the Applications folder or menu bar, then try again."
+    test_docker_desktop
+    if ! $DOCKER_RUNNING; then
+        ai_err "Docker daemon is not responding."
+        ai "$(macos_docker_daemon_startup_hint)"
         return 1
     fi
     return 0

--- a/ods/tests/test-macos-podman-docker-preflight.sh
+++ b/ods/tests/test-macos-podman-docker-preflight.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Contract: macOS docker detection classifies a Podman docker-CLI shim and
+# tells the operator to start the Podman machine (#2933), instead of a
+# generic "start Docker Desktop / Colima / …" miss.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DET="$ROOT_DIR/installers/macos/lib/detection.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n" "$1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== macOS Podman docker-CLI preflight (#2933) ==="
+echo ""
+
+if bash -n "$DET"; then
+    pass "detection.sh passes bash -n"
+else
+    fail "detection.sh bash -n failed"
+fi
+
+# shellcheck source=../installers/macos/lib/detection.sh
+source "$DET"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+write_stub() {
+    local dest="$1"
+    cat > "$dest"
+    chmod +x "$dest"
+}
+
+assert_eq() {
+    local label="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label (got <$actual>, expected <$expected>)"
+    fi
+}
+
+# --- Stub: Podman docker CLI, machine stopped (client --version works, engine does not)
+write_stub "$TMP_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    --version)
+        echo "podman version 5.8.1"
+        exit 0
+        ;;
+    context)
+        exit 1
+        ;;
+    version|info)
+        echo "Cannot connect to Podman" >&2
+        exit 1
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+
+PATH="$TMP_DIR:$PATH"
+hash -r 2>/dev/null || true
+unset DOCKER_HOST
+test_docker_desktop
+assert_eq "Podman shim is installed" "$DOCKER_INSTALLED" "true"
+assert_eq "stopped Podman machine is not running" "$DOCKER_RUNNING" "false"
+assert_eq "backend is podman" "$DOCKER_BACKEND" "podman"
+
+hint="$(macos_docker_daemon_startup_hint)"
+if [[ "$hint" == *"podman machine start"* ]] && [[ "$hint" == *"Podman Desktop"* ]]; then
+    pass "daemon-down hint names podman machine start"
+else
+    fail "daemon-down hint missing Podman guidance: <$hint>"
+fi
+if [[ "$hint" == *"Docker Desktop from /Applications"* ]]; then
+    fail "Podman backend still used Docker Desktop-only hint"
+else
+    pass "Podman backend does not use Docker Desktop-only hint"
+fi
+
+# --- Stub: Docker Desktop engine up
+write_stub "$TMP_DIR/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    --version)
+        echo "Docker version 28.0.4, build b8034c0"
+        exit 0
+        ;;
+    context)
+        if [[ "${2:-}" == "show" ]]; then
+            echo "desktop-linux"
+            exit 0
+        fi
+        if [[ "${2:-}" == "inspect" ]]; then
+            echo "unix:///Users/me/.docker/run/docker.sock"
+            exit 0
+        fi
+        exit 1
+        ;;
+    version)
+        if [[ "${2:-}" == "--format" ]]; then
+            echo "28.0.4"
+            exit 0
+        fi
+        echo "Client: Docker Engine"
+        echo "Server: Docker Engine"
+        exit 0
+        ;;
+    info)
+        if [[ "${2:-}" == "--format" ]]; then
+            echo "28.0.4"
+            exit 0
+        fi
+        exit 0
+        ;;
+    *)
+        exit 1
+        ;;
+esac
+EOF
+
+hash -r 2>/dev/null || true
+unset DOCKER_HOST
+test_docker_desktop
+assert_eq "Docker Desktop is installed" "$DOCKER_INSTALLED" "true"
+assert_eq "Docker Desktop daemon is running" "$DOCKER_RUNNING" "true"
+assert_eq "backend is desktop" "$DOCKER_BACKEND" "desktop"
+
+DOCKER_BACKEND=desktop
+hint="$(macos_docker_daemon_startup_hint)"
+if [[ "$hint" == *"Docker Desktop"* ]]; then
+    pass "desktop hint still names Docker Desktop"
+else
+    fail "desktop hint lost Docker Desktop: <$hint>"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ "$FAILED" -eq 0 ]]


### PR DESCRIPTION
## Summary
macOS install/CLI treated a Podman `docker` shim as a dead Docker daemon (issue #2933). Operators saw "Docker CLI found" then "start Docker Desktop", even though the real next step is `podman machine start`.

Detection now classifies Podman from `docker --version`, stays fail-closed when the machine is down, and sets `DOCKER_HOST` from the live Podman socket when the engine is already up. The same hint is used by `install-macos.sh` and `ods-macos.sh`.

## Test plan
- [x] `bash ods/tests/test-macos-podman-docker-preflight.sh` (10 passed, 0 failed)
- [ ] On a Mac with Podman Desktop stopped: installer names `podman machine start`
- [ ] After `podman machine start`, preflight reaches "Docker daemon ready"
