### PR TITLE
fix(windows): keep compose config out of report.json

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -56,6 +56,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@bash tests/contracts/test-windows-hermes-config-patching.sh
+	@bash tests/test-windows-report-command.sh
 	@bash tests/contracts/test-llama-metrics-flag.sh
 	@bash tests/contracts/test-llama-reasoning-format.sh
 	@echo ""

--- a/ods/installers/windows/lib/install-report.ps1
+++ b/ods/installers/windows/lib/install-report.ps1
@@ -87,7 +87,6 @@ function New-ODSInstallReport {
     $dashboardPort = Get-WindowsODSEnvPort -EnvMap $envMap -Name "DASHBOARD_PORT" -DefaultPort 3001
     $dashboardApiPort = Get-WindowsODSEnvPort -EnvMap $envMap -Name "DASHBOARD_API_PORT" -DefaultPort 3002
 
-    $composeConfigArgs = @("compose") + $ComposeFlags + @("config")
     $composePsArgs = @("compose") + $ComposeFlags + @("ps", "-a")
 
     $whisperPort = if ($envMap.ContainsKey("WHISPER_PORT") -and $envMap["WHISPER_PORT"]) { $envMap["WHISPER_PORT"] } else { "9000" }
@@ -118,7 +117,12 @@ function New-ODSInstallReport {
             flags = @($ComposeFlags)
             docker_version = Invoke-OptionalCommand -Command "docker" -CommandArgs @("version") -MaxLines 40
             docker_info = Invoke-OptionalCommand -Command "docker" -CommandArgs @("info") -MaxLines 80
-            compose_config = Invoke-OptionalCommand -Command "docker" -CommandArgs $composeConfigArgs
+            # `docker compose config` interpolates .env (API keys, tokens).
+            # Never persist it in report.json — operators attach this file to GitHub.
+            compose_config = [ordered]@{
+                omitted = $true
+                reason  = "omitted: compose config interpolates .env secrets"
+            }
             compose_ps = Invoke-OptionalCommand -Command "docker" -CommandArgs $composePsArgs -MaxLines 80
         }
         health = [ordered]@{
@@ -163,7 +167,7 @@ function Write-ODSInstallReport {
     $lines += "Generated: $($report.generated_at)"
     $lines += ""
     $lines += "Privacy"
-    $lines += "- docker compose config output (inside report.json) can include interpolated env values from .env -- API keys, tokens, or other secrets. Review and redact before sharing publicly."
+    $lines += "- report.json does not store `docker compose config` output (it interpolates .env secrets)."
     $lines += ""
     $lines += "Platform"
     $lines += "- OS: $($report.platform.os_caption) ($($report.platform.os_version), build $($report.platform.os_build))"

--- a/ods/tests/test-windows-report-command.sh
+++ b/ods/tests/test-windows-report-command.sh
@@ -44,6 +44,16 @@ if grep -q 'http://localhost:8080/health' "$REPORT_LIB"; then
 else
     pass "report lib does not hardcode localhost:8080/health"
 fi
+if grep -qE 'compose_config = Invoke-OptionalCommand.*composeConfigArgs' "$REPORT_LIB"; then
+    fail "report.json still dumps docker compose config (interpolated .env secrets)"
+else
+    pass "report.json does not dump docker compose config"
+fi
+if grep -q 'omitted: compose config interpolates .env secrets' "$REPORT_LIB"; then
+    pass "compose_config omission is explicit in the JSON payload"
+else
+    fail "compose_config omission reason missing"
+fi
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary
Windows `ods report` stored full `docker compose config` in `report.json`. That output interpolates `.env`, so API keys follow the file onto GitHub issues.

The JSON now records an explicit omission instead of the config blob. `compose ps` and docker version/info stay for diagnostics.

## Test plan
- [x] `bash ods/tests/test-windows-report-command.sh` (14 passed)
