### PR TITLE
fix(windows): require a live engine server, not just docker.exe

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -56,6 +56,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@bash tests/contracts/test-windows-hermes-config-patching.sh
+	@bash tests/test-windows-docker-engine-preflight.sh
 	@bash tests/contracts/test-llama-metrics-flag.sh
 	@bash tests/contracts/test-llama-reasoning-format.sh
 	@echo ""

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -329,7 +329,7 @@ function Test-DockerDesktop {
     .SYNOPSIS
         Verify Docker Desktop is installed, running, and using the WSL2 backend.
     .OUTPUTS
-        @{ Installed; Running; Version; WSL2Backend; GpuSupport }
+        @{ Installed; Running; Version; WSL2Backend; GpuSupport; Engine }
     #>
     $result = @{
         Installed   = $false
@@ -337,6 +337,7 @@ function Test-DockerDesktop {
         Version     = ""
         WSL2Backend = $false
         GpuSupport  = $false
+        Engine      = "unknown"  # docker-desktop | podman | other
     }
 
     # Check if docker CLI is available
@@ -344,19 +345,29 @@ function Test-DockerDesktop {
     if (-not $dockerCmd) { return $result }
     $result.Installed = $true
 
-    # Check if Docker daemon is responsive
+    try {
+        $clientVersion = docker --version 2>$null
+        if ($clientVersion -match '(?i)podman') {
+            $result.Engine = "podman"
+        } else {
+            $result.Engine = "docker-desktop"
+        }
+    } catch {
+        $result.Engine = "other"
+    }
+
+    # Engine is up only when the *server* answers. Client-only JSON (Podman /
+    # a stopped machine) used to count as Running=true and then the installer
+    # told people to start Docker Desktop.
     try {
         $versionJson = docker version --format "{{json .}}" 2>$null | ConvertFrom-Json -ErrorAction SilentlyContinue
-        if ($LASTEXITCODE -eq 0 -and $versionJson) {
+        if ($LASTEXITCODE -eq 0 -and $versionJson -and $versionJson.Server) {
             $result.Running = $true
-            if ($versionJson.Server) {
+            if ($versionJson.Server.Version) {
                 $result.Version = $versionJson.Server.Version
-            } elseif ($versionJson.Client) {
-                $result.Version = $versionJson.Client.Version
             }
         }
     } catch {
-        # Docker not responding
         return $result
     }
 

--- a/ods/installers/windows/phases/01-preflight.ps1
+++ b/ods/installers/windows/phases/01-preflight.ps1
@@ -88,20 +88,29 @@ if ($_sourceDrive -and $_installDrive -and $_sourceDrive -ne $_installDrive) {
 $preflight_docker = Test-DockerDesktop
 
 if (-not $preflight_docker.Installed) {
-    Write-AIError "Docker Desktop is not installed."
-    Write-AI "  Download: https://docs.docker.com/desktop/install/windows-install/"
-    Write-AI "  After installing, enable WSL2: Docker Desktop > Settings > General > Use WSL 2 based engine"
+    Write-AIError "A container engine CLI (`docker`) was not found on PATH."
+    Write-AI "  Docker Desktop: https://docs.docker.com/desktop/install/windows-install/"
+    Write-AI "  Podman Desktop: https://podman-desktop.io/"
     throw "ODS_INSTALL_ABORTED"
 }
-Write-AISuccess "Docker CLI found"
+Write-AISuccess "Container engine CLI found ($($preflight_docker.Engine))"
 
 if (-not $preflight_docker.Running) {
+    if ($preflight_docker.Engine -eq "podman") {
+        Write-AIError "Podman is installed but the machine is not responding."
+        Write-AI "  Start Podman Desktop, or run: podman machine start"
+        throw "ODS_INSTALL_ABORTED"
+    }
     Write-AIError "Docker Desktop is not running."
     Write-AI "  Start it from the Start Menu, then re-run this installer."
     Write-Host "  & 'C:\Program Files\Docker\Docker\Docker Desktop.exe'" -ForegroundColor Cyan
     throw "ODS_INSTALL_ABORTED"
 }
-Write-AISuccess "Docker Desktop running (v$($preflight_docker.Version))"
+if ($preflight_docker.Engine -eq "podman") {
+    Write-AISuccess "Podman engine running (v$($preflight_docker.Version))"
+} else {
+    Write-AISuccess "Docker Desktop running (v$($preflight_docker.Version))"
+}
 
 if (-not $preflight_docker.WSL2Backend) {
     Write-AIWarn "WSL2 backend not detected. GPU passthrough requires WSL2."

--- a/ods/tests/test-windows-docker-engine-preflight.sh
+++ b/ods/tests/test-windows-docker-engine-preflight.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Contract: Windows preflight must not treat a Podman docker CLI as Docker Desktop,
+# and must not mark the engine running from client-only `docker version` JSON.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DET="$ROOT_DIR/installers/windows/lib/detection.ps1"
+PRE="$ROOT_DIR/installers/windows/phases/01-preflight.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== Windows container-engine preflight ==="
+echo ""
+
+[[ -f "$DET" ]] && pass "detection.ps1 exists" || fail "detection.ps1 missing"
+[[ -f "$PRE" ]] && pass "01-preflight.ps1 exists" || fail "01-preflight.ps1 missing"
+
+if grep -q 'elseif ($versionJson.Client)' "$DET"; then
+    fail "Test-DockerDesktop still treats Client-only version JSON as Running"
+else
+    pass "Running requires a Server object"
+fi
+if grep -q '\$versionJson.Server' "$DET" && grep -q '\$result.Running = \$true' "$DET"; then
+    pass "Server presence gates Running"
+else
+    fail "Server gate missing"
+fi
+if grep -q '(?i)podman' "$DET" || grep -q "podman" "$DET"; then
+    pass "detection classifies Podman from docker --version"
+else
+    fail "no Podman classification"
+fi
+if grep -q 'podman machine start' "$PRE"; then
+    pass "preflight names podman machine start"
+else
+    fail "preflight missing Podman start hint"
+fi
+if grep -q 'Docker Desktop is not running' "$PRE"; then
+    pass "Docker Desktop hint kept for non-Podman engines"
+else
+    fail "Docker Desktop down-hint missing"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
`Test-DockerDesktop` marked the engine running whenever `docker version` returned JSON, including Client-only payloads, then told every operator to start Docker Desktop.

Running now requires a Server object. A Podman `docker --version` string sets Engine=podman and the down-path names `podman machine start`.

## Test plan
- [x] `bash ods/tests/test-windows-docker-engine-preflight.sh` (7 passed)
