### PR TITLE
fix(registry): fail closed when PyYAML is missing

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -103,6 +103,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
+	@bash tests/test-service-registry-pyyaml-fail-closed.sh
 	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh

--- a/ods/lib/service-registry.sh
+++ b/ods/lib/service-registry.sh
@@ -77,9 +77,8 @@ sr_load() {
         if ! "$PYTHON_CMD" -c "import yaml" 2>/dev/null; then
             declare -f warn &>/dev/null && warn "PyYAML not available. Service registry will be incomplete and lifecycle commands ('ods enable', 'ods start') will fail."
             declare -f warn &>/dev/null && warn "Install manually: pip3 install pyyaml"
-            _SR_LOADED=true  # Prevent repeated retries
             _SR_FAILED=true
-            return 0
+            return 1
         fi
     fi
 
@@ -221,9 +220,8 @@ PYEOF
     then
         rm -f "$_SR_CACHE"
         declare -f warn &>/dev/null && warn "Service registry: manifest parser failed"
-        _SR_LOADED=true  # Prevent repeated retries
         _SR_FAILED=true
-        return 0
+        return 1
     fi
 
     # Source the generated registry (one subprocess for all manifests)

--- a/ods/tests/test-service-registry-pyyaml-fail-closed.sh
+++ b/ods/tests/test-service-registry-pyyaml-fail-closed.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# sr_load must fail closed when PyYAML is missing (not return 0 with an empty registry).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== service registry PyYAML fail-closed ==="
+echo ""
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+cat > "$TMP/python3" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == *import\ yaml* ]] || [[ "$*" == *'import yaml'* ]]; then
+  echo "No module named yaml" >&2
+  exit 1
+fi
+exit 1
+EOF
+chmod +x "$TMP/python3"
+# Also shadow `python` so sr_load cannot fall through to a YAML-capable interpreter.
+cp "$TMP/python3" "$TMP/python"
+chmod +x "$TMP/python"
+
+export PATH="$TMP:$PATH"
+export SCRIPT_DIR="$TMP"
+# Empty SCRIPT_DIR lib so python-cmd.sh is not sourced.
+mkdir -p "$TMP/lib"
+
+# shellcheck source=../lib/service-registry.sh
+. "$PROJECT_DIR/lib/service-registry.sh"
+
+_SR_LOADED=false
+_SR_FAILED=false
+set +e
+sr_load
+rc=$?
+set -e
+
+if [[ "$rc" -ne 0 ]]; then
+    pass "sr_load exits nonzero without PyYAML"
+else
+    fail "sr_load returned 0 without PyYAML"
+fi
+if [[ "$_SR_FAILED" == "true" ]]; then
+    pass "_SR_FAILED is set"
+else
+    fail "_SR_FAILED was not set"
+fi
+if [[ "$_SR_LOADED" != "true" ]]; then
+    pass "_SR_LOADED stays false so a later pip install can retry"
+else
+    fail "_SR_LOADED was set true (would skip retry)"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
Without PyYAML, `sr_load` returned success after setting `_SR_LOADED=true` with an empty registry. `ods enable` / `ods start` looked fine and did nothing.

Missing YAML now fails the load (`return 1`), `_SR_FAILED` is set, and `_SR_LOADED` stays false so a later `pip install pyyaml` can retry. The Linux installer still installs PyYAML before the first load.

## Test plan
- [x] `bash ods/tests/test-service-registry-pyyaml-fail-closed.sh` (3 passed)
