### PR TITLE
fix(windows): stop sizing llama RAM from the host when Docker MemTotal is 0

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -56,6 +56,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@bash tests/contracts/test-windows-hermes-config-patching.sh
+	@powershell -NoProfile -File tests/test-windows-llama-memory-budget.ps1
 	@bash tests/contracts/test-llama-metrics-flag.sh
 	@bash tests/contracts/test-llama-reasoning-format.sh
 	@echo ""

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -84,14 +84,17 @@ function Get-ODSEffectiveContainerMemoryGB {
     if ($DockerRamGB -gt 0) {
         return $DockerRamGB
     }
-    return [Math]::Max(0, $SystemRamGB)
+    # Unknown Docker VM size. Do not treat host RAM as container RAM — Docker
+    # Desktop / WSL2 VMs are often 4–8 GiB on a 32–64 GiB Windows box, and a
+    # 60G llama memory limit OOMs the engine.
+    return 0
 }
 
 function Get-ODSDefaultNvidiaLlamaMemoryLimit {
     param([int]$AvailableRamGB)
 
     if ($AvailableRamGB -le 0) {
-        return "64G"
+        return "8G"
     }
 
     $reserveGB = $(if ($AvailableRamGB -lt 16) { 3 } else { 4 })

--- a/ods/tests/test-windows-llama-memory-budget.ps1
+++ b/ods/tests/test-windows-llama-memory-budget.ps1
@@ -12,9 +12,9 @@ function Assert-Equal {
 
 Assert-Equal (Get-ODSEffectiveContainerMemoryGB -SystemRamGB 64 -DockerRamGB 8) 8 "Docker VM lower bound"
 Assert-Equal (Get-ODSEffectiveContainerMemoryGB -SystemRamGB 8 -DockerRamGB 64) 8 "Host lower bound"
-Assert-Equal (Get-ODSEffectiveContainerMemoryGB -SystemRamGB 32 -DockerRamGB 0) 32 "Host fallback"
+Assert-Equal (Get-ODSEffectiveContainerMemoryGB -SystemRamGB 32 -DockerRamGB 0) 0 "Unknown Docker RAM does not inherit host"
 
-Assert-Equal (Get-ODSDefaultNvidiaLlamaMemoryLimit -AvailableRamGB 0) "64G" "Unknown RAM"
+Assert-Equal (Get-ODSDefaultNvidiaLlamaMemoryLimit -AvailableRamGB 0) "8G" "Unknown RAM conservative"
 Assert-Equal (Get-ODSDefaultNvidiaLlamaMemoryLimit -AvailableRamGB 2) "1G" "Minimum"
 Assert-Equal (Get-ODSDefaultNvidiaLlamaMemoryLimit -AvailableRamGB 8) "5G" "8 GiB"
 Assert-Equal (Get-ODSDefaultNvidiaLlamaMemoryLimit -AvailableRamGB 16) "12G" "16 GiB"


### PR DESCRIPTION
## Summary
When `docker info` MemTotal was missing, Windows env generation treated the host's RAM as the container budget. NVIDIA installs then wrote a 60G llama memory limit on machines whose Docker VM is far smaller, and the engine OOM'd.

Unknown Docker RAM now yields an effective budget of 0, and the NVIDIA default limit is 8G instead of 64G. Explicit `LLAMA_SERVER_MEMORY_LIMIT` in `.env` is still preserved.

## Test plan
- [x] `powershell -NoProfile -File ods/tests/test-windows-llama-memory-budget.ps1`
