### PR TITLE
fix(installer): align desktop requests with CLI contract

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -3,7 +3,14 @@ use crate::{docker, gpu, installer, platform};
 use serde::Serialize;
 use std::sync::Mutex;
 
-const ALLOWED_FEATURES: &[&str] = &["voice", "workflows", "rag", "image_gen", "all"];
+const ALLOWED_FEATURES: &[&str] = &[
+    "voice",
+    "workflows",
+    "rag",
+    "recommended",
+    "image_gen",
+    "all",
+];
 
 // ---- System Check ----
 
@@ -297,5 +304,39 @@ fn state_file_path() -> std::path::PathBuf {
         std::path::PathBuf::from(base)
             .join("ods")
             .join("installer-state.json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_request_accepts_every_feature_exposed_by_the_gui() {
+        let features = vec![
+            "voice".to_string(),
+            "workflows".to_string(),
+            "rag".to_string(),
+            "recommended".to_string(),
+            "image_gen".to_string(),
+        ];
+
+        assert_eq!(validate_install_request(0, &features), Ok(()));
+        assert_eq!(validate_install_request(4, &features), Ok(()));
+    }
+
+    #[test]
+    fn install_request_rejects_presentation_only_and_unknown_features() {
+        let chat = vec!["chat".to_string()];
+        let unknown = vec!["unknown".to_string()];
+
+        assert_eq!(
+            validate_install_request(1, &chat),
+            Err("Unsupported feature: chat".to_string())
+        );
+        assert_eq!(
+            validate_install_request(1, &unknown),
+            Err("Unsupported feature: unknown".to_string())
+        );
     }
 }

--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -46,23 +46,7 @@ pub fn run_install(
 
     // Phase 2: Build installer arguments
     let ods_dir = install_dir.join("ods");
-    let mut args = vec!["--tier".to_string(), tier.to_string()];
-
-    if features.contains(&"voice".to_string()) {
-        args.push("--voice".into());
-    }
-    if features.contains(&"workflows".to_string()) {
-        args.push("--workflows".into());
-    }
-    if features.contains(&"rag".to_string()) {
-        args.push("--rag".into());
-    }
-    if features.contains(&"image_gen".to_string()) {
-        args.push("--image-gen".into());
-    }
-    if features.contains(&"all".to_string()) {
-        args.push("--all".into());
-    }
+    let args = unix_installer_args(tier, &features);
 
     // Phase 3: Run the installer with progress parsing
     update_progress(&state, "Running installer", 20);
@@ -79,27 +63,7 @@ pub fn run_install(
     }
 
     let mut child = if cfg!(target_os = "windows") {
-        let mut ps_args = vec![
-            "-NoProfile".to_string(),
-            "-ExecutionPolicy".to_string(),
-            "Bypass".to_string(),
-            "-File".to_string(),
-            install_ps1.to_string_lossy().to_string(),
-            "-NonInteractive".to_string(),
-            "-Tier".to_string(),
-            tier.to_string(),
-        ];
-
-        for feature in &features {
-            match feature.as_str() {
-                "voice" => ps_args.push("-Voice".into()),
-                "workflows" => ps_args.push("-Workflows".into()),
-                "rag" => ps_args.push("-Rag".into()),
-                "image_gen" => ps_args.push("-Comfyui".into()),
-                "all" => ps_args.push("-All".into()),
-                _ => {}
-            }
-        }
+        let ps_args = windows_installer_args(tier, &features, &install_ps1);
 
         Command::new("powershell.exe")
             .args(&ps_args)
@@ -172,6 +136,69 @@ pub fn run_install(
             Err(format!("Installation failed:\n{}", detail))
         }
     }
+}
+
+fn unix_installer_args(tier: u8, features: &[String]) -> Vec<String> {
+    let mut args = if tier == 0 {
+        vec!["--cloud".to_string(), "--non-interactive".to_string()]
+    } else {
+        vec![
+            "--tier".to_string(),
+            tier.to_string(),
+            "--non-interactive".to_string(),
+        ]
+    };
+
+    for feature in features {
+        let flag = match feature.as_str() {
+            "voice" => Some("--voice"),
+            "workflows" => Some("--workflows"),
+            "rag" => Some("--rag"),
+            "recommended" => Some("--recommended"),
+            "image_gen" => Some("--comfyui"),
+            "all" => Some("--all"),
+            _ => None,
+        };
+        if let Some(flag) = flag {
+            args.push(flag.to_string());
+        }
+    }
+
+    args
+}
+
+fn windows_installer_args(tier: u8, features: &[String], script: &Path) -> Vec<String> {
+    let mut args = vec![
+        "-NoProfile".to_string(),
+        "-ExecutionPolicy".to_string(),
+        "Bypass".to_string(),
+        "-File".to_string(),
+        script.to_string_lossy().to_string(),
+        "-NonInteractive".to_string(),
+    ];
+    if tier == 0 {
+        args.push("-Cloud".to_string());
+    } else {
+        args.push("-Tier".to_string());
+        args.push(tier.to_string());
+    }
+
+    for feature in features {
+        let flag = match feature.as_str() {
+            "voice" => Some("-Voice"),
+            "workflows" => Some("-Workflows"),
+            "rag" => Some("-Rag"),
+            "recommended" => Some("-Recommended"),
+            "image_gen" => Some("-Comfyui"),
+            "all" => Some("-All"),
+            _ => None,
+        };
+        if let Some(flag) = flag {
+            args.push(flag.to_string());
+        }
+    }
+
+    args
 }
 
 fn ensure_checkout(install_dir: &Path) -> Result<(), String> {
@@ -428,5 +455,75 @@ mod tests {
             "https://github.com/example/ODS.git",
             DEFAULT_REPO_URL
         ));
+    }
+
+    #[test]
+    fn unix_gui_install_is_non_interactive_and_maps_features_to_cli_flags() {
+        let args = unix_installer_args(
+            2,
+            &[
+                "voice".to_string(),
+                "recommended".to_string(),
+                "image_gen".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            args,
+            [
+                "--tier",
+                "2",
+                "--non-interactive",
+                "--voice",
+                "--recommended",
+                "--comfyui",
+            ]
+        );
+    }
+
+    #[test]
+    fn unix_tier_zero_selects_cloud_mode() {
+        assert_eq!(
+            unix_installer_args(0, &[]),
+            ["--cloud", "--non-interactive"]
+        );
+    }
+
+    #[test]
+    fn windows_gui_install_maps_features_to_powershell_switches() {
+        let args = windows_installer_args(
+            3,
+            &[
+                "workflows".to_string(),
+                "rag".to_string(),
+                "all".to_string(),
+            ],
+            Path::new("C:\\ODS\\install.ps1"),
+        );
+
+        assert_eq!(
+            args,
+            [
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-File",
+                "C:\\ODS\\install.ps1",
+                "-NonInteractive",
+                "-Tier",
+                "3",
+                "-Workflows",
+                "-Rag",
+                "-All",
+            ]
+        );
+    }
+
+    #[test]
+    fn windows_tier_zero_selects_cloud_mode() {
+        let args = windows_installer_args(0, &[], Path::new("install.ps1"));
+
+        assert!(args.contains(&"-Cloud".to_string()));
+        assert!(!args.contains(&"-Tier".to_string()));
     }
 }

--- a/installer/src/pages/Features.tsx
+++ b/installer/src/pages/Features.tsx
@@ -50,10 +50,9 @@ const FEATURES: FeatureOption[] = [
     vramNote: "Requires 8GB+ VRAM",
   },
   {
-    id: "search",
-    name: "Private Search",
-    description:
-      "Self-hosted search engine (SearXNG) with no tracking or ads.",
+    id: "recommended",
+    name: "Web & API Support",
+    description: "LiteLLM routing, private SearXNG search, and usage insights.",
     default: false,
   },
 ];
@@ -137,7 +136,13 @@ export default function Features({ onNext }: Props) {
         <Button variant="ghost" onClick={selectAll}>
           Select All
         </Button>
-        <Button onClick={() => onNext(Array.from(selected))}>
+        <Button
+          onClick={() =>
+            onNext(
+              Array.from(selected).filter((feature) => feature !== "chat"),
+            )
+          }
+        >
           Install
         </Button>
       </div>


### PR DESCRIPTION
## Summary

- translate the desktop feature picker into the flags supported by both installer entrypoints
- run Unix GUI installs non-interactively and route tier 0 through the real cloud-mode switch
- keep presentation-only `chat` out of the backend payload while exposing the CLI's recommended web/API bundle

## Why this matters

The feature picker always submitted `chat`, but the Rust command rejects that value before installation starts. The search option was also rejected, image generation used a nonexistent Unix flag, Unix installs could pause for terminal input, and tier 0 was passed as a local tier despite the UI describing cloud mode. Together these mismatches make the one-click path fail or behave differently from the user's selections.

This change puts the GUI-to-CLI boundary behind tested argument builders for both shell and PowerShell entrypoints.

## Validation

- `cargo test --manifest-path installer/src-tauri/Cargo.toml` — 12 passed
- `cd installer && npm run build` — passed
- `git diff --check` — passed
- baseline `cd ods && make test` was run before this change; 1 unrelated existing failure remains in `test-ods-cli-update-verification.sh` (missing host-agent fixture), while the preceding suites passed

## Overlap check

Searched open and closed PRs for desktop/Tauri installer feature selection, unsupported chat features, GUI non-interactive execution, and cloud-tier routing; no matching PR was found. I also compared the files of all currently open PRs: none touches `installer/src/pages/Features.tsx`, `installer/src-tauri/src/commands.rs`, or `installer/src-tauri/src/installer.rs`.