### PR TITLE
fix(installer): preserve structured progress phases

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -206,7 +206,7 @@ pub fn get_install_progress() -> ProgressInfo {
     if let Ok(data) = std::fs::read_to_string(&state_path) {
         if let Ok(state) = serde_json::from_str::<InstallState>(&data) {
             return ProgressInfo {
-                phase: format!("{:?}", state.phase),
+                phase: state.progress_phase,
                 percent: state.progress_pct,
                 message: state.progress_message,
                 error: state.error,

--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -38,11 +38,11 @@ pub fn run_install(
     features: Vec<String>,
 ) -> Result<(), String> {
     // Phase 1: Clone the repo
-    update_progress(&state, "Downloading ODS", 5);
+    update_progress(&state, "download", "Downloading ODS", 5);
 
     ensure_checkout(&install_dir)?;
 
-    update_progress(&state, "Configuring installation", 15);
+    update_progress(&state, "configuration", "Configuring installation", 15);
 
     // Phase 2: Build installer arguments
     let ods_dir = install_dir.join("ods");
@@ -65,7 +65,7 @@ pub fn run_install(
     }
 
     // Phase 3: Run the installer with progress parsing
-    update_progress(&state, "Running installer", 20);
+    update_progress(&state, "installing", "Running installer", 20);
 
     let install_script = ods_dir.join("install.sh");
     let install_ps1 = install_dir.join("install.ps1");
@@ -136,7 +136,7 @@ pub fn run_install(
         for line in reader.lines() {
             if let Ok(line) = line {
                 if let Some(progress) = parse_progress_line(&line) {
-                    update_progress(&state, &progress.message, progress.percent);
+                    update_progress(&state, &progress.phase, &progress.message, progress.percent);
                 }
             }
         }
@@ -150,7 +150,7 @@ pub fn run_install(
         .unwrap_or_default();
 
     if output.success() {
-        update_progress(&state, "Installation complete!", 100);
+        update_progress(&state, "complete", "Installation complete!", 100);
         let mut s = state.lock().unwrap();
         s.phase = InstallPhase::Complete;
         let _ = s.save();
@@ -295,12 +295,15 @@ fn repo_urls_identify_same_repository(candidate: &str, expected: &str) -> bool {
 }
 
 /// Parse a progress line from the installer.
-/// Expected format: ODS_PROGRESS:<percent>:<message>
+/// Expected format: ODS_PROGRESS:<percent>:<phase_id>:<message>
 fn parse_progress_line(line: &str) -> Option<ProgressEvent> {
     if let Some(rest) = line.strip_prefix("ODS_PROGRESS:") {
         let parts: Vec<&str> = rest.splitn(3, ':').collect();
         if parts.len() >= 2 {
-            let percent = parts[0].parse().unwrap_or(0);
+            let percent: u8 = parts[0].parse().ok()?;
+            if percent > 100 {
+                return None;
+            }
             let phase = if parts.len() >= 3 { parts[1] } else { "" };
             let message = if parts.len() >= 3 { parts[2] } else { parts[1] };
             return Some(ProgressEvent {
@@ -338,10 +341,11 @@ fn parse_progress_line(line: &str) -> Option<ProgressEvent> {
     })
 }
 
-fn update_progress(state: &Arc<Mutex<InstallState>>, message: &str, percent: u8) {
+fn update_progress(state: &Arc<Mutex<InstallState>>, phase: &str, message: &str, percent: u8) {
     if let Ok(mut s) = state.lock() {
         s.progress_pct = percent;
         s.progress_message = message.to_string();
+        s.progress_phase = phase.to_string();
         s.phase = InstallPhase::Installing;
         let _ = s.save();
     }
@@ -428,5 +432,20 @@ mod tests {
             "https://github.com/example/ODS.git",
             DEFAULT_REPO_URL
         ));
+    }
+
+    #[test]
+    fn structured_progress_keeps_the_protocol_phase() {
+        let event =
+            parse_progress_line("ODS_PROGRESS:48:images:Downloading container images").unwrap();
+
+        assert_eq!(event.phase, "images");
+        assert_eq!(event.percent, 48);
+        assert_eq!(event.message, "Downloading container images");
+    }
+
+    #[test]
+    fn malformed_structured_progress_is_ignored() {
+        assert!(parse_progress_line("ODS_PROGRESS:not-a-number:images:Downloading").is_none());
     }
 }

--- a/installer/src-tauri/src/state.rs
+++ b/installer/src-tauri/src/state.rs
@@ -13,6 +13,8 @@ pub struct InstallState {
     pub error: Option<String>,
     pub progress_pct: u8,
     pub progress_message: String,
+    #[serde(default = "legacy_progress_phase")]
+    pub progress_phase: String,
     pub reboot_pending: bool,
 }
 
@@ -58,6 +60,7 @@ impl Default for InstallState {
             error: None,
             progress_pct: 0,
             progress_message: String::new(),
+            progress_phase: "starting".into(),
             reboot_pending: false,
         }
     }
@@ -118,5 +121,49 @@ fn dirs_next() -> PathBuf {
                 let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
                 PathBuf::from(home).join(".local/share")
             })
+    }
+}
+
+fn legacy_progress_phase() -> String {
+    "installing".into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_state_without_progress_phase_remains_readable() {
+        let json = r#"{
+            "phase": "installing",
+            "install_dir": "/tmp/ods",
+            "detected_gpu": null,
+            "selected_tier": 1,
+            "selected_features": [],
+            "error": null,
+            "progress_pct": 42,
+            "progress_message": "Working",
+            "reboot_pending": false
+        }"#;
+
+        let state: InstallState = serde_json::from_str(json).unwrap();
+
+        assert_eq!(state.progress_phase, "installing");
+        assert_eq!(state.progress_pct, 42);
+    }
+
+    #[test]
+    fn progress_phase_round_trips_in_new_state() {
+        let state = InstallState {
+            progress_phase: "images".into(),
+            progress_pct: 48,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&state).unwrap();
+        let restored: InstallState = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.progress_phase, "images");
+        assert_eq!(restored.progress_pct, 48);
     }
 }

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -79,6 +79,7 @@ export interface InstallState {
   error: string | null;
   progress_pct: number;
   progress_message: string;
+  progress_phase: string;
   reboot_pending: boolean;
 }
 

--- a/installer/src/pages/Installing.tsx
+++ b/installer/src/pages/Installing.tsx
@@ -10,12 +10,22 @@ interface Props {
 }
 
 const PHASE_LABELS: Record<string, string> = {
+  download: "Downloading ODS",
+  configuration: "Configuring installation",
+  installing: "Starting installer",
   preflight: "Running preflight checks",
   detection: "Detecting hardware",
+  features: "Selecting features",
+  requirements: "Installing system dependencies",
   docker: "Setting up Docker",
+  directories: "Preparing installation directory",
+  devtools: "Installing development tools",
   images: "Downloading container images",
+  offline: "Configuring offline mode",
+  "amd-tuning": "Tuning AMD GPU settings",
   services: "Starting services",
   health: "Checking service health",
+  summary: "Finishing up",
   complete: "Finishing up",
 };
 


### PR DESCRIPTION
## Summary

- persist the structured installer phase ID alongside percent and message
- return that phase through the Tauri progress command instead of the coarse `InstallPhase::Installing` enum
- cover every emitted installer phase in the React progress UI and keep legacy state files readable
- reject malformed structured percentages instead of silently turning them into 0%

## Why this matters

The backend parsed `ODS_PROGRESS:<percent>:<phase>:<message>` correctly, then discarded `phase` while saving state. Polling therefore returned `Installing` for every in-progress event, which does not match the frontend's lowercase phase IDs. Labels could fall back to text, but the phase indicator never advanced and malformed protocol events could look like a reset to 0%.

Persisting the protocol phase restores the intended progress contract without breaking state files written by older installer builds.

## Validation

- `cargo test --manifest-path installer/src-tauri/Cargo.toml` — 10 passed
- `cd installer && npm run build` — passed
- `git diff --check` — passed

## Overlap check

Searched open and closed PRs for Tauri/desktop installer progress phases, progress protocol handling, and `progress_phase`; no matching PR was found. A current-open-PR file audit also found no PR touching these desktop installer files.