### PR TITLE
feat(installer): add configuration-first TUI

### DIFF
--- a/ods/install.sh
+++ b/ods/install.sh
@@ -4,6 +4,8 @@
 # --dry-run --skip-docker --force --tier --voice --workflows --rag
 # --openclaw --all --non-interactive --no-bootstrap --bootstrap --offline
 # --use-existing-lemonade --lemonade-url --lemonade-api-key
+# This dispatcher also owns --tui, an opt-in configuration-first menu that
+# compiles the user's choices into the existing non-interactive CLI contract.
 
 set -euo pipefail
 
@@ -11,6 +13,150 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/installers/dispatch.sh"
 
 target="$(resolve_installer_target)"
+
+_tui_read() {
+    local variable="$1" prompt="$2" default="$3" _tui_input=""
+    printf '%s [%s]: ' "$prompt" "$default"
+    if ! IFS= read -r _tui_input; then
+        echo "[ERROR] Installer configuration input ended before completion." >&2
+        exit 2
+    fi
+    printf -v "$variable" '%s' "${_tui_input:-$default}"
+}
+
+_tui_choice() {
+    local variable="$1" prompt="$2" default="$3" allowed="$4" answer=""
+    while true; do
+        _tui_read answer "$prompt" "$default"
+        case " $allowed " in
+            *" $answer "*) printf -v "$variable" '%s' "$answer"; return 0 ;;
+            *) echo "  Choose one of: ${allowed// /, }." >&2 ;;
+        esac
+    done
+}
+
+_tui_bool() {
+    local variable="$1" prompt="$2" default="$3" answer=""
+    while true; do
+        _tui_read answer "$prompt (yes/no)" "$default"
+        case "$answer" in
+            y|Y|yes|Yes|YES) printf -v "$variable" '%s' "true"; return 0 ;;
+            n|N|no|No|NO) printf -v "$variable" '%s' "false"; return 0 ;;
+            *) echo "  Enter yes or no." >&2 ;;
+        esac
+    done
+}
+
+_run_configuration_tui() {
+    if [[ "$target" == *.ps1 ]]; then
+        echo "[ERROR] --tui is available from Linux, WSL2, and macOS shells." >&2
+        echo "        Use .\\install.ps1 for the native Windows installer." >&2
+        exit 2
+    fi
+
+    local mode tier profile install_dir lan offline bootstrap dry_run confirmed
+    local voice workflows rag recommended hermes comfyui langfuse
+    local -a install_args=(--non-interactive)
+
+    echo "ODS Installer - configuration menu"
+    echo "Review every installation default before any system change is made."
+    echo ""
+    echo "Runtime:  1) Local AI  2) Cloud APIs"
+    _tui_choice mode "Runtime" "1" "1 2"
+
+    tier="auto"
+    if [[ "$mode" == "1" ]]; then
+        echo "Tier:     auto, 1 (8GB), 2 (12GB), 3 (24GB), 4 (48GB+)"
+        _tui_choice tier "Hardware tier" "auto" "auto 1 2 3 4"
+    fi
+
+    _tui_read install_dir "Install directory" "${INSTALL_DIR:-${ODS_HOME:-$HOME/ods}}"
+    if [[ "$install_dir" != /* ]]; then
+        echo "[ERROR] Install directory must be an absolute path." >&2
+        exit 2
+    fi
+
+    echo "Profile:  1) Recommended  2) Minimal  3) Full  4) Custom"
+    _tui_choice profile "Service profile" "1" "1 2 3 4"
+    case "$profile" in
+        1)
+            voice=true; workflows=true; rag=true; recommended=true
+            hermes=true; comfyui=true; langfuse=false
+            ;;
+        2)
+            voice=false; workflows=false; rag=false; recommended=false
+            hermes=false; comfyui=false; langfuse=false
+            ;;
+        3)
+            voice=true; workflows=true; rag=true; recommended=true
+            hermes=true; comfyui=true; langfuse=true
+            ;;
+        4)
+            _tui_bool voice "Enable voice (Whisper + Kokoro)" "yes"
+            _tui_bool workflows "Enable n8n workflows" "yes"
+            _tui_bool rag "Enable RAG (Qdrant + embeddings)" "yes"
+            _tui_bool recommended "Enable recommended support services" "yes"
+            _tui_bool hermes "Enable Hermes Agent" "yes"
+            _tui_bool comfyui "Enable ComfyUI image generation" "yes"
+            _tui_bool langfuse "Enable Langfuse observability" "no"
+            ;;
+    esac
+
+    _tui_bool lan "Expose web services to the LAN" "no"
+    offline=false
+    if [[ "$mode" == "1" ]]; then
+        _tui_bool offline "Prepare for offline operation" "no"
+    fi
+    _tui_bool bootstrap "Use bootstrap fast-start" "yes"
+    _tui_bool dry_run "Preview only (dry run)" "no"
+
+    [[ "$mode" == "2" ]] && install_args+=(--cloud)
+    [[ "$tier" != "auto" ]] && install_args+=(--tier "$tier")
+    [[ "$profile" == "3" ]] && install_args+=(--all)
+    if [[ "$profile" != "3" ]]; then
+        [[ "$voice" == "true" ]] && install_args+=(--voice) || install_args+=(--no-voice)
+        [[ "$workflows" == "true" ]] && install_args+=(--workflows) || install_args+=(--no-workflows)
+        [[ "$rag" == "true" ]] && install_args+=(--rag) || install_args+=(--no-rag)
+        [[ "$recommended" == "true" ]] && install_args+=(--recommended) || install_args+=(--no-recommended)
+        [[ "$hermes" == "true" ]] && install_args+=(--hermes) || install_args+=(--no-hermes)
+        [[ "$comfyui" == "true" ]] && install_args+=(--comfyui) || install_args+=(--no-comfyui)
+        [[ "$langfuse" == "true" ]] && install_args+=(--langfuse) || install_args+=(--no-langfuse)
+    fi
+    [[ "$lan" == "true" ]] && install_args+=(--lan)
+    [[ "$offline" == "true" ]] && install_args+=(--offline)
+    [[ "$bootstrap" == "false" ]] && install_args+=(--no-bootstrap)
+    [[ "$dry_run" == "true" ]] && install_args+=(--dry-run)
+
+    echo ""
+    echo "Installation plan"
+    echo "  runtime:   $([[ "$mode" == "2" ]] && echo cloud || echo local)"
+    echo "  tier:      $tier"
+    echo "  directory: $install_dir"
+    echo "  profile:   $profile"
+    echo "  command:   install.sh ${install_args[*]}"
+    echo ""
+    _tui_bool confirmed "Start with this plan" "yes"
+    if [[ "$confirmed" != "true" ]]; then
+        echo "Installation cancelled; no changes were made."
+        exit 0
+    fi
+
+    export INSTALL_DIR="$install_dir"
+    set -- "${install_args[@]}"
+    exec bash "$target" "$@"
+}
+
+if [[ "${1:-}" == "--tui" ]]; then
+    if [[ $# -ne 1 ]]; then
+        echo "[ERROR] --tui cannot be combined with installer flags; select them in the menu." >&2
+        exit 2
+    fi
+    _run_configuration_tui
+fi
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "Dispatcher option: --tui  Review and confirm all Unix installer defaults up front."
+fi
 
 case "$target" in
     unsupported:unknown)

--- a/ods/install.sh
+++ b/ods/install.sh
@@ -154,8 +154,19 @@ if [[ "${1:-}" == "--tui" ]]; then
     _run_configuration_tui
 fi
 
-if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
-    echo "Dispatcher option: --tui  Review and confirm all Unix installer defaults up front."
+if [[ ( "${1:-}" == "--help" || "${1:-}" == "-h" ) && "$target" == *.sh ]]; then
+    # Buffer the delegated help before writing it. Consumers commonly probe this
+    # command with `install.sh --help | grep -q ...`; writing a prefix before the
+    # delegate can make grep close the pipe while install-core.sh is still
+    # rendering help, turning a successful help request into SIGPIPE under
+    # pipefail. Explicitly preserve the delegate's status even if that consumer
+    # stops reading early.
+    help_output=""
+    help_status=0
+    help_output="$(bash "$target" "$@" 2>&1)" || help_status=$?
+    printf '%s\n' "$help_output" || true
+    printf '%s\n' "Dispatcher option: --tui  Review and confirm all Unix installer defaults up front." || true
+    exit "$help_status"
 fi
 
 case "$target" in

--- a/ods/tests/bats-tests/installer-configuration-tui.bats
+++ b/ods/tests/bats-tests/installer-configuration-tui.bats
@@ -86,3 +86,15 @@ EOF
     assert_failure 2
     assert_output --partial "--tui cannot be combined"
 }
+
+@test "installer help remains successful when a short reader closes the pipe" {
+    run /bin/bash -o pipefail -c \
+        '"$1" --help 2>&1 | grep -qiE "usage|option|ods"' \
+        help-probe "$TEST_ROOT/install.sh"
+
+    assert_success
+
+    run env ODS_PLATFORM_OVERRIDE=linux /bin/bash "$TEST_ROOT/install.sh" --help
+    assert_success
+    assert_output --partial "Dispatcher option: --tui"
+}

--- a/ods/tests/bats-tests/installer-configuration-tui.bats
+++ b/ods/tests/bats-tests/installer-configuration-tui.bats
@@ -1,0 +1,88 @@
+#!/usr/bin/env bats
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+setup() {
+    export TEST_ROOT="${ODS_TEST_ROOT_OVERRIDE:-$(cd "$BATS_TEST_DIRNAME/../.." && pwd)}"
+    export TUI_TMP="$BATS_TEST_TMPDIR/tui"
+    export TUI_BIN="$TUI_TMP/bin"
+    export TUI_ARGS="$TUI_TMP/args"
+    export TUI_INSTALL_DIR="$TUI_TMP/install-dir"
+    mkdir -p "$TUI_BIN"
+
+cat > "$TUI_BIN/bash" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$@" > "$TUI_ARGS"
+printf '%s\n' "$INSTALL_DIR" > "$TUI_INSTALL_DIR"
+EOF
+    chmod +x "$TUI_BIN/bash"
+}
+
+@test "configuration TUI compiles a confirmed custom plan before dispatch" {
+    run env \
+        ODS_PLATFORM_OVERRIDE=linux \
+        TUI_ARGS="$TUI_ARGS" \
+        TUI_INSTALL_DIR="$TUI_INSTALL_DIR" \
+        PATH="$TUI_BIN:$PATH" \
+        /bin/bash "$TEST_ROOT/install.sh" --tui <<EOF
+1
+3
+$TUI_TMP/install target
+4
+no
+yes
+no
+yes
+yes
+no
+yes
+yes
+no
+no
+yes
+yes
+EOF
+
+    assert_success
+    run grep -Fx -- "$TEST_ROOT/install-core.sh" "$TUI_ARGS"
+    assert_success
+    for expected in --non-interactive --tier --no-voice --workflows --no-rag \
+        --recommended --hermes --no-comfyui --langfuse --lan --no-bootstrap; do
+        run grep -Fx -- "$expected" "$TUI_ARGS"
+        assert_success
+    done
+    run grep -Fx -- "3" "$TUI_ARGS"
+    assert_success
+    run grep -Fx -- "--dry-run" "$TUI_ARGS"
+    assert_success
+    run grep -Fx -- "$TUI_TMP/install target" "$TUI_INSTALL_DIR"
+    assert_success
+}
+
+@test "configuration TUI cancellation never dispatches the installer" {
+    run env \
+        ODS_PLATFORM_OVERRIDE=linux \
+        TUI_ARGS="$TUI_ARGS" \
+        PATH="$TUI_BIN:$PATH" \
+        /bin/bash "$TEST_ROOT/install.sh" --tui <<EOF
+2
+$TUI_TMP/cloud
+2
+no
+yes
+no
+no
+EOF
+
+    assert_success
+    assert_output --partial "Installation cancelled; no changes were made."
+    [ ! -e "$TUI_ARGS" ]
+}
+
+@test "configuration TUI rejects ambiguous mixed CLI input" {
+    run env ODS_PLATFORM_OVERRIDE=linux /bin/bash "$TEST_ROOT/install.sh" --tui --all
+
+    assert_failure 2
+    assert_output --partial "--tui cannot be combined"
+}


### PR DESCRIPTION
## Summary

- add an opt-in `install.sh --tui` configuration menu for Linux, WSL2, and macOS
- expose runtime, tier, install directory, service profile, LAN, offline, bootstrap, and dry-run decisions before installation starts
- compile the confirmed plan into the existing non-interactive installer flags, preserving one canonical execution path
- prevent accidental execution when the plan is cancelled or `--tui` is mixed with CLI flags

Closes #2309.

## Why this matters

Operators currently have to discover profiles and flags before they can review installer defaults. The new menu makes those choices visible up front, supports custom absolute install paths, and provides an explicit final receipt before any system-changing installer phase runs.

The behavioral invariant is: the menu may collect and translate configuration, but only the existing installer owns installation effects. Cancellation must never dispatch the installer.

## Overlap check

Searched open and closed upstream PR titles/bodies for `installer TUI configuration menu`, reviewed the latest 1,000 open PRs and their changed production files, and inspected history for `ods/install.sh`. No open or closed PR covers this scope, no currently open PR changes this entrypoint, and its upstream history only contains the repository rename. Issue #2309 is the direct product request.

## Test plan

- `bats installer-configuration-tui.bats` - 4/4 passing against the public `install.sh` boundary
  - confirmed custom plans preserve tier, service choices, dry-run behavior, and a spaced custom install path
  - cancellation never invokes the installer target
  - ambiguous mixed TUI/CLI input exits with status 2
- `bash -n ods/install.sh`
- `shellcheck --rcfile=/dev/null -e SC1090,SC1091,SC3003 ods/install.sh`
- `git diff --check`

## Design and operational notes

- Existing flag-based installs are unchanged; the TUI is strictly opt-in.
- The menu uses Bash 3-compatible constructs for the macOS path and the shared dispatcher covers Linux and WSL2. Native Windows continues to use `install.ps1`, with an explicit error if a PowerShell target reaches this mode.
- The full profile delegates to the existing `--all` contract. Other profiles emit explicit positive/negative service flags so the review receipt is deterministic.
- Rollback is a single-entrypoint revert; no persisted configuration or migration is introduced.

Generated with Codex.

## Batch compatibility

- Recommended merge/application order: #3706 -> #3707 -> #3708 -> #3709 -> #3710 -> #3711 -> #3712 -> #3713 -> #3714 -> #3715. The PRs have no runtime dependency; this order also covers the shared MODEL-SWITCHBOARD.md edits in #3708/#3709.
- Synthetic integration head: tang-vu/DreamServer commit 5e4e354e on integration/features-ten-20260904, built from upstream/main 6ff9b4fc plus all ten PR heads.
- Combined validation: 12 BATS tests passed; 132 focused API/workflow pytest tests passed; 6 dashboard Vitest tests passed; ESLint and the 1,771-module Vite production build passed; make lint, installer integration (69 passed, 3 skipped), the 6-test ods-test contract, mobile dispatch smoke, and exact n8n 2.6.4 imports for both workflow templates passed. git diff --check is clean.
- Full-suite limitation: make test reaches tests/test-installer-noninteractive-sudo.sh and reports 3 passed / 2 failed when WSL runs as root. The same two assertions fail unchanged on the clean upstream base 6ff9b4fc, so this is recorded as environment/baseline evidence rather than attributed to this batch. All required GitHub checks for the ten PR heads are green as of 2026-09-04.
## CI follow-up

CI integration-smoke exposed a SIGPIPE race in the first help implementation: the dispatcher wrote its TUI hint before install-core rendered the rest of help, so a short grep reader could close the pipe under pipefail. Follow-up commit 6650e11e buffers delegated help, preserves its status, and writes defensively. The added public-boundary regression reproduces the exact piped probe; 4/4 focused BATS tests, ShellCheck, and integration-test.sh (69 passed, 3 skipped) now pass, and the rerun of every required GitHub check is green.
