### PR TITLE
feat(test): support multi-service validation subsets

### DIFF
--- a/ods/scripts/ods-test.sh
+++ b/ods/scripts/ods-test.sh
@@ -14,6 +14,7 @@
 #   ./ods-test.sh --quick          # Fast mode (~30s, no inference)
 #   ./ods-test.sh --json           # JSON output for automation
 #   ./ods-test.sh --service llm     # Test specific service
+#   ./ods-test.sh -s llm,whisper -s tts  # Test an ordered service subset
 #
 # Exit codes:
 #   0 - All critical tests passed
@@ -74,7 +75,7 @@ START_TIME=0
 # Mode flags
 JSON_OUTPUT=false
 QUICK_MODE=false
-SPECIFIC_SERVICE=""
+SELECTED_SERVICES=()
 VERBOSE=false
 
 # Results storage
@@ -631,7 +632,7 @@ USAGE:
 OPTIONS:
     --quick, -q        Fast mode (~30s, no inference tests)
     --json, -j         Output results as JSON
-    --service, -s      Test specific service only
+    --service, -s LIST Test one or more services (repeatable or comma-separated)
     --verbose, -v      Show detailed output
     --help, -h         Show this help
 
@@ -644,6 +645,7 @@ EXAMPLES:
     ods-test.sh --quick            # Fast health check
     ods-test.sh --json > results.json
     ods-test.sh --service llm      # Test LLM only
+    ods-test.sh -s llm,whisper -s tts
 
 EXIT CODES:
     0 - All tests passed
@@ -670,9 +672,7 @@ run_all_tests() {
 
 run_specific_service() {
     local service="$1"
-    
-    print_header
-    
+
     case "$service" in
         docker)          test_docker ;;
         gpu)             test_gpu ;;
@@ -692,6 +692,55 @@ run_specific_service() {
     esac
 }
 
+select_services() {
+    local selection="$1" service existing duplicate
+    local -a requested=()
+
+    if [[ -z "$selection" || "$selection" == ,* || "$selection" == *, || "$selection" == *,,* ]]; then
+        echo "Service selection cannot contain an empty name." >&2
+        exit 2
+    fi
+
+    IFS=',' read -r -a requested <<< "$selection"
+    for service in "${requested[@]}"; do
+        if [[ -z "$service" ]]; then
+            echo "Service selection cannot contain an empty name." >&2
+            exit 2
+        fi
+
+        case "$service" in
+            docker|gpu|llm|tool-calling|whisper|tts|embeddings|voice-roundtrip|privacy-shield|livekit) ;;
+            *)
+                echo "Unknown service: $service" >&2
+                echo "Available: docker, gpu, llm, tool-calling, whisper, tts, embeddings, voice-roundtrip, privacy-shield, livekit" >&2
+                exit 2
+                ;;
+        esac
+
+        duplicate=false
+        for existing in "${SELECTED_SERVICES[@]}"; do
+            if [[ "$existing" == "$service" ]]; then
+                duplicate=true
+                break
+            fi
+        done
+        if [[ "$duplicate" == "false" ]]; then
+            SELECTED_SERVICES+=("$service")
+        fi
+    done
+}
+
+run_selected_services() {
+    local service
+
+    print_header
+    for service in "${SELECTED_SERVICES[@]}"; do
+        if ! run_specific_service "$service"; then
+            log "Service suite '$service' reported a failed check; continuing the selected set"
+        fi
+    done
+}
+
 main() {
     START_TIME=$(date +%s)
     
@@ -708,7 +757,11 @@ main() {
                 shift
                 ;;
             --service|-s)
-                SPECIFIC_SERVICE="$2"
+                if [[ $# -lt 2 || "$2" == -* ]]; then
+                    echo "Option $1 requires a service list." >&2
+                    exit 2
+                fi
+                select_services "$2"
                 shift 2
                 ;;
             --verbose|-v)
@@ -731,8 +784,8 @@ main() {
     load_env
     
     # Run tests
-    if [[ -n "$SPECIFIC_SERVICE" ]]; then
-        run_specific_service "$SPECIFIC_SERVICE"
+    if [[ ${#SELECTED_SERVICES[@]} -gt 0 ]]; then
+        run_selected_services
     else
         run_all_tests
     fi

--- a/ods/tests/bats-tests/ods-test-service-selection.bats
+++ b/ods/tests/bats-tests/ods-test-service-selection.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+setup() {
+    export TEST_ROOT="${ODS_TEST_ROOT_OVERRIDE:-$(cd "$BATS_TEST_DIRNAME/../.." && pwd)}"
+    export TEST_TMP="$BATS_TEST_TMPDIR/ods-test-selection"
+    export TEST_BIN="$TEST_TMP/bin"
+    export DOCKER_MARKER="$TEST_TMP/docker-called"
+    mkdir -p "$TEST_BIN"
+
+    cat > "$TEST_BIN/docker" <<'EOF'
+#!/bin/sh
+printf 'called\n' > "$DOCKER_MARKER"
+case "${1:-}" in
+    info) exit 0 ;;
+    ps) printf 'ods-dashboard\nods-llama-server\n' ;;
+esac
+EOF
+    cat > "$TEST_BIN/curl" <<'EOF'
+#!/bin/sh
+printf '200'
+EOF
+    cat > "$TEST_BIN/timeout" <<'EOF'
+#!/bin/sh
+shift
+exec "$@"
+EOF
+    chmod +x "$TEST_BIN/docker" "$TEST_BIN/curl" "$TEST_BIN/timeout"
+}
+
+@test "repeatable and comma-separated service selections run once in request order" {
+    run env \
+        DOCKER_MARKER="$DOCKER_MARKER" \
+        ENV_FILE="$TEST_TMP/missing.env" \
+        PATH="$TEST_BIN:$PATH" \
+        bash "$TEST_ROOT/scripts/ods-test.sh" --quick \
+            --service docker,privacy-shield --service docker
+
+    assert_success
+    assert_output --partial "> Docker Infrastructure"
+    assert_output --partial "> Privacy Shield M3"
+    refute_output --partial "> GPU Resources"
+    [ "$(printf '%s\n' "$output" | grep -c '> Docker Infrastructure')" -eq 1 ]
+
+    local docker_line privacy_line
+    docker_line=$(printf '%s\n' "$output" | grep -n '> Docker Infrastructure' | cut -d: -f1)
+    privacy_line=$(printf '%s\n' "$output" | grep -n '> Privacy Shield M3' | cut -d: -f1)
+    [ "$docker_line" -lt "$privacy_line" ]
+}
+
+@test "the complete selection is validated before any service test runs" {
+    run env \
+        DOCKER_MARKER="$DOCKER_MARKER" \
+        ENV_FILE="$TEST_TMP/missing.env" \
+        PATH="$TEST_BIN:$PATH" \
+        bash "$TEST_ROOT/scripts/ods-test.sh" --service docker,unknown
+
+    assert_failure 2
+    assert_output --partial "Unknown service: unknown"
+    [ ! -e "$DOCKER_MARKER" ]
+}
+
+@test "service option without a value reports a configuration error" {
+    run env ENV_FILE="$TEST_TMP/missing.env" bash "$TEST_ROOT/scripts/ods-test.sh" --service
+
+    assert_failure 2
+    assert_output --partial "requires a service list"
+}
+
+@test "empty entries cannot silently expand into the all-services suite" {
+    run env ENV_FILE="$TEST_TMP/missing.env" bash "$TEST_ROOT/scripts/ods-test.sh" --service docker,
+
+    assert_failure 2
+    assert_output --partial "cannot contain an empty name"
+}


### PR DESCRIPTION
## Summary

- let `ods-test.sh --service/-s` accept comma-separated service lists
- allow the option to be repeated while preserving first-request order and deduplicating suites
- validate the complete selection before running tests and report missing/empty entries as configuration errors
- continue through the selected subset so the final summary remains a useful validation receipt

## Why this matters

Operators and CI jobs often need a focused cross-service check (for example LLM + Whisper + TTS) without paying for the entire validation suite or launching three separate processes. The previous single-service contract made that workflow awkward and produced fragmented summaries.

The behavioral invariant is: a requested service suite runs at most once, in request order, and malformed input never falls through to the all-services path.

## Overlap check

Searched open and closed upstream PR titles/bodies for `ods-test multiple services service selection`, reviewed the latest 1,000 open PRs and their changed production files, and inspected history for `ods/scripts/ods-test.sh`. No matching PR or currently open production-file overlap was found; upstream history for this script only contains the repository rename. PR #2651 mentions functional-test JSON output but changes a different script and behavior.

## Test plan

- `bats ods-test-service-selection.bats` ? 4/4 passing at the public CLI boundary
  - comma-separated and repeated selections run once in order
  - unselected suites do not run
  - unknown, missing, and empty service entries exit 2 before service dispatch
- `bash ods/tests/test-ods-test.sh` ? 6/6 error-handling contract checks passing
- `bash -n ods/scripts/ods-test.sh`
- ShellCheck: no new findings (the file retains three pre-existing SC2034 unused-variable warnings)
- `git diff --check`

## Design and operational notes

- Existing no-argument and single-service invocations are unchanged.
- Deduplication uses an indexed array rather than associative arrays, retaining compatibility with older Bash environments.
- A failing selected suite is recorded and the remaining requested suites still execute; the aggregate failure counter continues to determine exit status.
- Rollback only restores the one-service parser and has no persisted-state impact.

Generated with Codex.

## Batch compatibility

- Recommended merge/application order: #3706 -> #3707 -> #3708 -> #3709 -> #3710 -> #3711 -> #3712 -> #3713 -> #3714 -> #3715. The PRs have no runtime dependency; this order also covers the shared MODEL-SWITCHBOARD.md edits in #3708/#3709.
- Synthetic integration head: tang-vu/DreamServer commit 5e4e354e on integration/features-ten-20260904, built from upstream/main 6ff9b4fc plus all ten PR heads.
- Combined validation: 12 BATS tests passed; 132 focused API/workflow pytest tests passed; 6 dashboard Vitest tests passed; ESLint and the 1,771-module Vite production build passed; make lint, installer integration (69 passed, 3 skipped), the 6-test ods-test contract, mobile dispatch smoke, and exact n8n 2.6.4 imports for both workflow templates passed. git diff --check is clean.
- Full-suite limitation: make test reaches tests/test-installer-noninteractive-sudo.sh and reports 3 passed / 2 failed when WSL runs as root. The same two assertions fail unchanged on the clean upstream base 6ff9b4fc, so this is recorded as environment/baseline evidence rather than attributed to this batch. All required GitHub checks for the ten PR heads are green as of 2026-09-04.
