### PR TITLE
feat(api): add conditional model-state reads

### DIFF
--- a/ods/docs/MODEL-SWITCHBOARD.md
+++ b/ods/docs/MODEL-SWITCHBOARD.md
@@ -182,7 +182,7 @@ Rules:
 
 Product API:
 
-- `GET /api/models/state`: sanitized desired/active/history summary and capability impact
+- `GET /api/models/state`: sanitized desired/active/history summary and capability impact; accepts `history_limit=0..10` and returns an `ETag` for authenticated `If-None-Match` polling
 - `GET /api/models/events`: SSE stream keyed by `seq` and operation ID; retains at most 1,024 events for 15 minutes, emits a heartbeat every 15 seconds, supports `Last-Event-ID`, and sends a `model.state.snapshot` event before live events when the requested ID is absent or expired
 - Existing `POST /api/models/{id}/load`: unchanged user contract; backed by the reconciler
 - `POST /api/models/rollback`: activate a requested verified history entry, defaulting to the newest, through the same reconciler

--- a/ods/extensions/services/dashboard-api/routers/model_state.py
+++ b/ods/extensions/services/dashboard-api/routers/model_state.py
@@ -11,10 +11,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+from hashlib import sha256
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Header, Query, Response
 from jsonschema import Draft202012Validator
 from jsonschema.exceptions import SchemaError
 
@@ -53,6 +54,7 @@ def _invalid_response(errors: list[str], *, exists: bool = True) -> dict[str, An
         "active": None,
         "history": [],
         "historyCount": 0,
+        "historyTotal": 0,
         "availability": None,
         "capabilityImpact": {"agentViable": None},
     }
@@ -76,7 +78,7 @@ def _validate_document(doc: Any) -> list[str]:
     return errors
 
 
-def _summarize(doc: dict[str, Any]) -> dict[str, Any]:
+def _summarize(doc: dict[str, Any], history_limit: int) -> dict[str, Any]:
     active = doc.get("active") if isinstance(doc.get("active"), dict) else None
     capabilities = None
     if active and isinstance(active.get("capabilities"), dict):
@@ -92,8 +94,9 @@ def _summarize(doc: dict[str, Any]) -> dict[str, Any]:
         "operation": doc.get("operation"),
         "desired": doc.get("desired"),
         "active": active,
-        "history": history,
-        "historyCount": len(history),
+        "history": history[:history_limit],
+        "historyCount": min(len(history), history_limit),
+        "historyTotal": len(history),
         "availability": doc.get("availability"),
         "capabilityImpact": {
             "agentViable": bool(capabilities.get("agentViable")) if capabilities else None,
@@ -101,8 +104,30 @@ def _summarize(doc: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _state_etag(raw: str, history_limit: int) -> str:
+    representation = f"history_limit={history_limit}\0{raw}"
+    return f'"{sha256(representation.encode("utf-8")).hexdigest()}"'
+
+
+def _etag_matches(if_none_match: str | None, etag: str) -> bool:
+    if not if_none_match:
+        return False
+    for candidate in if_none_match.split(","):
+        candidate = candidate.strip()
+        if candidate == "*" or candidate == etag:
+            return True
+        if candidate.startswith("W/") and candidate[2:] == etag:
+            return True
+    return False
+
+
 @router.get("/api/models/state")
-async def get_model_state(api_key: str = Depends(verify_api_key)):
+async def get_model_state(
+    response: Response,
+    history_limit: Annotated[int, Query(ge=0, le=10)] = 10,
+    if_none_match: Annotated[str | None, Header()] = None,
+    api_key: str = Depends(verify_api_key),
+):
     """Sanitized switchboard state summary; read-only by contract."""
     path = _state_path()
     try:
@@ -113,6 +138,12 @@ async def get_model_state(api_key: str = Depends(verify_api_key)):
         logger.warning("model-state read failed: %s", exc)
         return _invalid_response([f"read failed: {exc}"])
 
+    etag = _state_etag(raw, history_limit)
+    cache_headers = {"ETag": etag, "Cache-Control": "private, no-cache"}
+    if _etag_matches(if_none_match, etag):
+        return Response(status_code=304, headers=cache_headers)
+    response.headers.update(cache_headers)
+
     try:
         doc = json.loads(raw)
     except ValueError as exc:
@@ -120,4 +151,4 @@ async def get_model_state(api_key: str = Depends(verify_api_key)):
     errors = _validate_document(doc)
     if errors:
         return _invalid_response(errors)
-    return _summarize(doc)
+    return _summarize(doc, history_limit)

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -297,7 +297,52 @@ class TestModelStateEndpoint:
         assert body["routeSeq"] == 2
         assert body["active"]["catalogId"] == "phi-4-mini"
         assert body["historyCount"] == 1
+        assert body["historyTotal"] == 1
         assert body["capabilityImpact"]["agentViable"] is True
+
+    def test_conditional_state_read_and_bounded_history(
+        self, test_client, monkeypatch, tmp_path
+    ):
+        path = self._point_at(monkeypatch, tmp_path)
+        _record(path)
+        _record(path, model="phi-4-mini", runtime="Phi-4-mini-Q4_K_M.gguf")
+
+        first = test_client.get(
+            "/api/models/state?history_limit=0", headers=test_client.auth_headers
+        )
+        assert first.status_code == 200
+        assert first.headers["cache-control"] == "private, no-cache"
+        etag = first.headers["etag"]
+        assert etag.startswith('"') and etag.endswith('"')
+        assert first.json()["history"] == []
+        assert first.json()["historyCount"] == 0
+        assert first.json()["historyTotal"] == 1
+
+        unchanged = test_client.get(
+            "/api/models/state?history_limit=0",
+            headers={**test_client.auth_headers, "If-None-Match": f'W/{etag}, "other"'},
+        )
+        assert unchanged.status_code == 304
+        assert unchanged.content == b""
+        assert unchanged.headers["etag"] == etag
+
+        _record(path, model="gemma-3", runtime="Gemma-3-Q4_K_M.gguf")
+        changed = test_client.get(
+            "/api/models/state?history_limit=0",
+            headers={**test_client.auth_headers, "If-None-Match": etag},
+        )
+        assert changed.status_code == 200
+        assert changed.headers["etag"] != etag
+        assert changed.json()["routeSeq"] == 3
+
+    def test_history_limit_is_schema_bounded(
+        self, test_client, monkeypatch, tmp_path
+    ):
+        self._point_at(monkeypatch, tmp_path)
+        resp = test_client.get(
+            "/api/models/state?history_limit=11", headers=test_client.auth_headers
+        )
+        assert resp.status_code == 422
 
     def test_malformed_state_is_diagnostic(self, test_client, monkeypatch, tmp_path):
         path = self._point_at(monkeypatch, tmp_path)


### PR DESCRIPTION
## Why this matters

Model-state polling can avoid resending unchanged snapshots and can omit unneeded recent history without changing the host's persisted state.

## Feature and overlap check

Add private revalidation with ETag/If-None-Match (including weak/list/wildcard matches) and history_limit=0–10. Tags include the representation's history limit; authentication remains required on conditional reads. Updated this original PR onto beta. Searched all-state conditional model-state and model_state.py PRs; #5054 validates unreadable/malformed state, which is retained, not replaced.

## Validation

Linux Python3.11: `pytest -q tests/test_model_state.py`: 40 passed. Public HTTP tests verify unchanged304, changed200, representation-specific tags, bounded history and existing missing/invalid state behavior. Focused pre-commit/diff check passed. No live model activation. Baseline smoke/simulation passed; known full-gate/BATS failures remain.

## Compatibility and rollback

Default history remains ten; historyCount describes returned entries and historyTotal describes available recent history. Cache-Control is private,no-cache, not public caching. No state-file write/schema migration. Revert removes optional conditional reads; full GET remains. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `2fe201e6781e59ff6cd23f0e4e52095f3c3f8e95`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
