### PR TITLE
feat(api): batch model route evidence queries

### DIFF
--- a/ods/docs/MODEL-SWITCHBOARD.md
+++ b/ods/docs/MODEL-SWITCHBOARD.md
@@ -187,6 +187,7 @@ Product API:
 - Existing `POST /api/models/{id}/load`: unchanged user contract; backed by the reconciler
 - `POST /api/models/rollback`: activate a requested verified history entry, defaulting to the newest, through the same reconciler
 - `GET /api/models/routes/{probeId}`: authenticated dashboard-api proxy to bounded in-memory route evidence for fleet validation
+- `POST /api/models/routes/query`: authenticated batch lookup for 1-50 unique probe IDs, with ordered per-item status and bounded router concurrency
 
 Host-agent API:
 

--- a/ods/extensions/services/dashboard-api/routers/model_routes.py
+++ b/ods/extensions/services/dashboard-api/routers/model_routes.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
 
 from security import verify_api_key
 
@@ -21,6 +22,7 @@ MODEL_ROUTER_URL = os.environ.get("MODEL_ROUTER_URL", "http://model-router:4010"
 _EVIDENCE_TIMEOUT_SECONDS = 5.0
 _EVIDENCE_ATTEMPTS = 3
 _EVIDENCE_RETRY_DELAY_SECONDS = 0.5
+_BATCH_CONCURRENCY = 8
 
 _STRING_FIELDS = {
     "probeId",
@@ -34,6 +36,26 @@ _STRING_FIELDS = {
     "instanceId",
 }
 _INT_FIELDS = {"routeSeq", "status"}
+
+
+class RouteEvidenceBatchRequest(BaseModel):
+    probe_ids: list[str] = Field(alias="probeIds", min_length=1, max_length=50)
+
+    @field_validator("probe_ids")
+    @classmethod
+    def canonical_unique_probe_ids(cls, values: list[str]) -> list[str]:
+        normalized: list[str] = []
+        for value in values:
+            try:
+                parsed = str(uuid.UUID(value))
+            except (TypeError, ValueError) as exc:
+                raise ValueError("probe ids must be canonical UUIDs") from exc
+            if value != parsed:
+                raise ValueError("probe ids must be canonical UUIDs")
+            if value in normalized:
+                raise ValueError("probe ids must be unique")
+            normalized.append(value)
+        return normalized
 
 
 def _normal_probe_id(value: str) -> str:
@@ -71,24 +93,18 @@ def _sanitize_evidence(payload: Any, probe_id: str) -> dict[str, Any]:
     return clean
 
 
-@router.get("/api/models/routes/{probe_id}", dependencies=[Depends(verify_api_key)])
-async def get_model_route_evidence(probe_id: str) -> dict[str, Any]:
-    """Fetch sanitized route evidence recorded by the internal model-router."""
-    probe_id = _normal_probe_id(probe_id)
-    internal_key = _router_internal_key()
-    if not internal_key:
-        raise HTTPException(status_code=503, detail="Model router evidence key is not configured.")
-
+async def _fetch_route_evidence(
+    client: httpx.AsyncClient, probe_id: str, internal_key: str
+) -> dict[str, Any]:
     url = f"{MODEL_ROUTER_URL.rstrip('/')}/internal/route-evidence/{probe_id}"
     attempts = max(1, _EVIDENCE_ATTEMPTS)
     response: httpx.Response | None = None
     for attempt in range(attempts):
         try:
-            async with httpx.AsyncClient(timeout=_EVIDENCE_TIMEOUT_SECONDS) as client:
-                response = await client.get(
-                    url,
-                    headers={"Authorization": f"Bearer {internal_key}"},
-                )
+            response = await client.get(
+                url,
+                headers={"Authorization": f"Bearer {internal_key}"},
+            )
         except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as exc:
             if attempt + 1 < attempts:
                 await asyncio.sleep(_EVIDENCE_RETRY_DELAY_SECONDS)
@@ -121,3 +137,54 @@ async def get_model_route_evidence(probe_id: str) -> dict[str, Any]:
     except ValueError as exc:
         raise HTTPException(status_code=502, detail="Model router returned invalid evidence.") from exc
     return _sanitize_evidence(payload, probe_id)
+
+
+@router.post("/api/models/routes/query", dependencies=[Depends(verify_api_key)])
+async def query_model_route_evidence(request: RouteEvidenceBatchRequest) -> dict[str, Any]:
+    """Fetch several route receipts with bounded concurrency and per-item status."""
+    internal_key = _router_internal_key()
+    if not internal_key:
+        raise HTTPException(status_code=503, detail="Model router evidence key is not configured.")
+
+    semaphore = asyncio.Semaphore(_BATCH_CONCURRENCY)
+    async with httpx.AsyncClient(timeout=_EVIDENCE_TIMEOUT_SECONDS) as client:
+
+        async def fetch_one(probe_id: str) -> dict[str, Any]:
+            async with semaphore:
+                try:
+                    evidence = await _fetch_route_evidence(client, probe_id, internal_key)
+                except HTTPException as exc:
+                    status = "not_found" if exc.status_code == 404 else "error"
+                    return {
+                        "probeId": probe_id,
+                        "status": status,
+                        "statusCode": exc.status_code,
+                        "detail": exc.detail,
+                    }
+                return {"probeId": probe_id, "status": "found", "evidence": evidence}
+
+        results = await asyncio.gather(
+            *(fetch_one(probe_id) for probe_id in request.probe_ids)
+        )
+
+    return {
+        "results": results,
+        "summary": {
+            "requested": len(results),
+            "found": sum(item["status"] == "found" for item in results),
+            "notFound": sum(item["status"] == "not_found" for item in results),
+            "errors": sum(item["status"] == "error" for item in results),
+        },
+    }
+
+
+@router.get("/api/models/routes/{probe_id}", dependencies=[Depends(verify_api_key)])
+async def get_model_route_evidence(probe_id: str) -> dict[str, Any]:
+    """Fetch sanitized route evidence recorded by the internal model-router."""
+    probe_id = _normal_probe_id(probe_id)
+    internal_key = _router_internal_key()
+    if not internal_key:
+        raise HTTPException(status_code=503, detail="Model router evidence key is not configured.")
+
+    async with httpx.AsyncClient(timeout=_EVIDENCE_TIMEOUT_SECONDS) as client:
+        return await _fetch_route_evidence(client, probe_id, internal_key)

--- a/ods/extensions/services/dashboard-api/tests/test_model_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_routes.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from typing import Any
 
@@ -46,6 +47,13 @@ def _patch_router_client(monkeypatch, response: httpx.Response | None = None,
 def test_route_evidence_requires_dashboard_auth(test_client):
     probe_id = str(uuid.uuid4())
     resp = test_client.get(f"/api/models/routes/{probe_id}")
+    assert resp.status_code == 401
+
+
+def test_route_evidence_batch_requires_dashboard_auth(test_client):
+    resp = test_client.post(
+        "/api/models/routes/query", json={"probeIds": [str(uuid.uuid4())]}
+    )
     assert resp.status_code == 401
 
 
@@ -244,3 +252,138 @@ def test_route_evidence_passes_through_instance_id(test_client, monkeypatch):
     )
     assert resp.status_code == 200
     assert resp.json()["instanceId"] == "0b7f9d2c-8a41-4f0e-9d5b-1c2e3f4a5b6c"
+
+
+def test_route_evidence_batch_preserves_order_and_partial_results(
+    test_client, monkeypatch
+):
+    from routers import model_routes as mr
+
+    found_id = str(uuid.uuid4())
+    missing_id = str(uuid.uuid4())
+    error_id = str(uuid.uuid4())
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "internal-secret")
+    monkeypatch.setattr(mr, "_EVIDENCE_ATTEMPTS", 1)
+    calls = _patch_router_client(
+        monkeypatch,
+        outcomes=[
+            httpx.Response(
+                200,
+                json={
+                    "probeId": found_id,
+                    "requestedModel": "ods/current",
+                    "routedModel": "Qwen.gguf",
+                    "routeSeq": 9,
+                    "prompt": "never return batch payload secrets",
+                },
+            ),
+            httpx.Response(404, json={"error": "not_found"}),
+            httpx.ConnectError("router unavailable"),
+        ],
+    )
+
+    resp = test_client.post(
+        "/api/models/routes/query",
+        headers=test_client.auth_headers,
+        json={"probeIds": [found_id, missing_id, error_id]},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["summary"] == {
+        "requested": 3,
+        "found": 1,
+        "notFound": 1,
+        "errors": 1,
+    }
+    assert body["results"] == [
+        {
+            "probeId": found_id,
+            "status": "found",
+            "evidence": {
+                "probeId": found_id,
+                "requestedModel": "ods/current",
+                "routedModel": "Qwen.gguf",
+                "routeSeq": 9,
+            },
+        },
+        {
+            "probeId": missing_id,
+            "status": "not_found",
+            "statusCode": 404,
+            "detail": "Route evidence not found.",
+        },
+        {
+            "probeId": error_id,
+            "status": "error",
+            "statusCode": 503,
+            "detail": "Model router is not reachable.",
+        },
+    ]
+    assert len([call for call in calls if call[0] == "timeout"]) == 1
+    assert len([call for call in calls if call[0] == "get"]) == 3
+
+
+def test_route_evidence_batch_rejects_duplicates_and_oversized_requests(
+    test_client, monkeypatch
+):
+    probe_id = str(uuid.uuid4())
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "internal-secret")
+    calls = _patch_router_client(monkeypatch)
+
+    duplicate = test_client.post(
+        "/api/models/routes/query",
+        headers=test_client.auth_headers,
+        json={"probeIds": [probe_id, probe_id]},
+    )
+    oversized = test_client.post(
+        "/api/models/routes/query",
+        headers=test_client.auth_headers,
+        json={"probeIds": [str(uuid.uuid4()) for _ in range(51)]},
+    )
+
+    assert duplicate.status_code == 422
+    assert oversized.status_code == 422
+    assert calls == []
+
+
+def test_route_evidence_batch_bounds_router_concurrency(test_client, monkeypatch):
+    from routers import model_routes as mr
+
+    probe_ids = [str(uuid.uuid4()) for _ in range(5)]
+    activity = {"current": 0, "peak": 0}
+
+    class ConcurrentClient:
+        def __init__(self, timeout: float):
+            assert timeout == mr._EVIDENCE_TIMEOUT_SECONDS
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url: str, headers: dict[str, str]):
+            probe_id = url.rsplit("/", 1)[-1]
+            activity["current"] += 1
+            activity["peak"] = max(activity["peak"], activity["current"])
+            try:
+                await asyncio.sleep(0.01)
+                return httpx.Response(200, json={"probeId": probe_id, "status": 200})
+            finally:
+                activity["current"] -= 1
+
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "internal-secret")
+    monkeypatch.setattr(mr, "_BATCH_CONCURRENCY", 2)
+    monkeypatch.setattr(mr, "_EVIDENCE_ATTEMPTS", 1)
+    monkeypatch.setattr(mr.httpx, "AsyncClient", ConcurrentClient)
+
+    resp = test_client.post(
+        "/api/models/routes/query",
+        headers=test_client.auth_headers,
+        json={"probeIds": probe_ids},
+    )
+
+    assert resp.status_code == 200
+    assert [item["probeId"] for item in resp.json()["results"]] == probe_ids
+    assert activity["peak"] == 2


### PR DESCRIPTION
## Why this matters

Clients collecting several model-route receipts currently need separate authenticated HTTP requests. A bounded batch supports one read operation with explicit per-receipt outcomes.

## Feature and overlap check

Add POST /api/models/routes/query with 1–50 unique canonical UUIDs, up to eight concurrent internal reads, preserved input order, per-item found/not_found/error and summary counts. Reuse existing internal-key lookup, evidence sanitization and transport behavior; the POST is read-only and authenticated. Updated the original PR onto beta. Searched all-state model evidence/batch and model_routes.py; #5369 isolates internal credentials, not batch reads. No duplicate was opened.

## Validation

Linux Python3.11: `pytest -q tests/test_model_routes.py`: 13 passed, covering authentication, request bounds/UUIDs, existing GET behavior, sanitized mixed outcomes and batch concurrency. Focused pre-commit/diff check passed. Internal transport is mocked, not a live router qualification. Baseline smoke/simulation passed; known full-gate/BATS failures remain.

## Tradeoffs and rollback

Retains existing per-receipt retries/timeouts; no new global batch deadline is claimed. Failed receipts do not discard successful ones. No persisted state. Revert removes the new endpoint and restores the original GET implementation. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `a8b05c7e9bb0054ce17cfab46e08cfc7170e277d`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
