### PR TITLE
feat(api): add GPU history query controls

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -9,9 +9,9 @@ import urllib.error
 import urllib.request
 from collections import deque
 from datetime import datetime, timezone
-from typing import Optional
+from typing import Annotated, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from security import verify_api_key
 
@@ -35,7 +35,8 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["gpu"])
 
 # Rolling history buffer — 60 samples max (5 min at 5 s intervals)
-_GPU_HISTORY: deque = deque(maxlen=60)
+_HISTORY_MAX_SAMPLES = 60
+_GPU_HISTORY: deque = deque(maxlen=_HISTORY_MAX_SAMPLES)
 _HISTORY_POLL_INTERVAL = 5.0
 
 # Simple per-endpoint TTL caches
@@ -490,15 +491,21 @@ async def amd_runtime():
 
 
 @router.get("/api/gpu/history", dependencies=[Depends(verify_api_key)])
-async def gpu_history():
-    """Rolling 5-minute per-GPU metrics history sampled every 5 s."""
+async def gpu_history(
+    samples: Annotated[int, Query(ge=1, le=_HISTORY_MAX_SAMPLES)] = _HISTORY_MAX_SAMPLES,
+    step: Annotated[int, Query(ge=1, le=_HISTORY_MAX_SAMPLES)] = 1,
+):
+    """Return a recent, optionally downsampled GPU metrics window."""
     if not _GPU_HISTORY:
         return {"timestamps": [], "gpus": {}}
 
-    timestamps = [s["timestamp"] for s in _GPU_HISTORY]
+    window = list(_GPU_HISTORY)[-samples:]
+    latest_aligned_start = (len(window) - 1) % step
+    selected = window[latest_aligned_start::step]
+    timestamps = [sample["timestamp"] for sample in selected]
 
     gpu_keys: set[str] = set()
-    for sample in _GPU_HISTORY:
+    for sample in selected:
         gpu_keys.update(sample["gpus"].keys())
 
     gpus_data: dict[str, dict] = {}
@@ -509,7 +516,7 @@ async def gpu_history():
             "temperature": [],
             "power_w": [],
         }
-        for sample in _GPU_HISTORY:
+        for sample in selected:
             g = sample["gpus"].get(gpu_key, {})
             gpus_data[gpu_key]["utilization"].append(g.get("utilization"))
             gpus_data[gpu_key]["memory_percent"].append(g.get("memory_percent"))

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -411,6 +411,64 @@ class TestGpuHistoryBuffer:
             for item in saved:
                 gpu_mod._GPU_HISTORY.append(item)
 
+    def test_history_query_returns_recent_downsampled_window(
+        self, test_client
+    ):
+        import routers.gpu as gpu_mod
+        saved = list(gpu_mod._GPU_HISTORY)
+        gpu_mod._GPU_HISTORY.clear()
+        try:
+            for index in range(10):
+                gpu_mod._GPU_HISTORY.append({
+                    "timestamp": f"2026-09-04T00:00:{index:02d}Z",
+                    "gpus": {
+                        "0": {
+                            "utilization": index,
+                            "memory_percent": index + 10,
+                            "temperature": index + 20,
+                            "power_w": index + 30,
+                        },
+                        **({
+                            "1": {
+                                "utilization": index + 40,
+                                "memory_percent": index + 50,
+                                "temperature": index + 60,
+                                "power_w": None,
+                            }
+                        } if index == 9 else {}),
+                    },
+                })
+
+            response = test_client.get(
+                "/api/gpu/history?samples=5&step=2",
+                headers=test_client.auth_headers,
+            )
+
+            assert response.status_code == 200
+            body = response.json()
+            assert body["timestamps"] == [
+                "2026-09-04T00:00:05Z",
+                "2026-09-04T00:00:07Z",
+                "2026-09-04T00:00:09Z",
+            ]
+            assert body["gpus"]["0"]["utilization"] == [5, 7, 9]
+            assert body["gpus"]["1"]["utilization"] == [None, None, 49]
+        finally:
+            gpu_mod._GPU_HISTORY.clear()
+            for item in saved:
+                gpu_mod._GPU_HISTORY.append(item)
+
+    def test_history_query_rejects_unbounded_controls(self, test_client):
+        too_many = test_client.get(
+            "/api/gpu/history?samples=61", headers=test_client.auth_headers
+        )
+        zero_step = test_client.get(
+            "/api/gpu/history?step=0", headers=test_client.auth_headers
+        )
+
+        assert too_many.status_code == 422
+        assert zero_step.status_code == 422
+
 
 # ============================================================================
 # _get_raw_gpus — Apple Silicon dispatch (routers/gpu.py)


### PR DESCRIPTION
## Why this matters

GPU-history consumers may need a smaller recent window or fewer plotted samples without extra telemetry collection.

## Feature and overlap check

Add authenticated samples/step query controls bounded to the existing 60-sample buffer. Downsampling stays aligned to the latest sample and preserves timestamp/metric alignment and missing-device gaps. Default requests retain the existing full window. Updated the original PR onto beta. Searched all-state GPU history and routers/gpu.py: #4879 outage advancement and #4878 probe coalescing affect sampling, not read-time query selection; #3711 CSV export is an independent consumer.

## Validation

Linux Python3.11: `pytest -q tests/test_gpu_detailed.py tests/test_gpu_history_outages.py tests/test_gpu_probe_coalescing.py`: 42 passed. Authenticated HTTP assertions cover recent downsampling, newly appearing GPUs and invalid bounds. Focused pre-commit/diff check passed. No physical GPU; baseline smoke/simulation passed, known full-gate/BATS failures remain.

## Rollback

No buffer size, polling interval or default response change. Revert removes optional query controls; clients using defaults are unaffected. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `cb9cdf52fb54b0eee1c75fac8b106f7d07636248`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
