### PR TITLE
feat(dashboard): focus GPU topology links

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TopologyView.jsx
+++ b/ods/extensions/services/dashboard/src/components/TopologyView.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react'
+import { memo, useState } from 'react'
 import { Network } from 'lucide-react'
 
 // Rank → visual style mapping
@@ -21,11 +21,19 @@ function buildMatrix(gpuCount, links) {
 }
 
 export const TopologyView = memo(function TopologyView({ topology }) {
+  const [focusedGpu, setFocusedGpu] = useState(null)
   if (!topology) return null
 
   const { gpus = [], links = [], gpu_count, vendor, driver_version, mig_enabled } = topology
   const n = gpu_count || gpus.length
   const matrix = buildMatrix(n, links)
+  const focus = Number.isInteger(focusedGpu) && focusedGpu >= 0 && focusedGpu < n
+    ? focusedGpu
+    : null
+
+  const toggleFocus = gpuIndex => {
+    setFocusedGpu(current => current === gpuIndex ? null : gpuIndex)
+  }
 
   return (
     <div className="p-5 bg-zinc-900/50 border border-zinc-800 rounded-xl">
@@ -47,13 +55,30 @@ export const TopologyView = memo(function TopologyView({ topology }) {
       {/* GPU reference chips */}
       <div className="flex flex-wrap gap-2 mb-4">
         {gpus.map(g => (
-          <div key={g.index} className="flex items-center gap-1.5 px-2 py-1 bg-zinc-800 rounded-lg text-xs">
+          <button
+            key={g.index}
+            type="button"
+            aria-label={`Focus GPU ${g.index}`}
+            aria-pressed={focus === g.index}
+            onClick={() => toggleFocus(g.index)}
+            className={`flex items-center gap-1.5 px-2 py-1 rounded-lg border text-xs transition-colors ${
+              focus === g.index
+                ? 'border-indigo-400 bg-indigo-500/20'
+                : 'border-transparent bg-zinc-800 hover:border-zinc-600'
+            }`}
+          >
             <span className="text-indigo-300 font-mono">GPU{g.index}</span>
             <span className="text-zinc-400">{g.name.replace('NVIDIA ', '').replace('AMD Radeon ', '')}</span>
             <span className="text-zinc-600 font-mono">{g.memory_gb}GB</span>
-          </div>
+          </button>
         ))}
       </div>
+
+      {focus != null && (
+        <p role="status" className="mb-3 text-[11px] text-indigo-300">
+          Focused on GPU{focus}; select it again to restore the full matrix.
+        </p>
+      )}
 
       {/* Topology matrix table */}
       {n > 1 && links.length > 0 ? (
@@ -63,7 +88,12 @@ export const TopologyView = memo(function TopologyView({ topology }) {
               <tr>
                 <th className="px-2 py-1.5 text-zinc-500 text-left" />
                 {Array.from({ length: n }, (_, i) => (
-                  <th key={i} className="px-3 py-1.5 text-indigo-300 text-center font-medium">
+                  <th
+                    key={i}
+                    className={`px-3 py-1.5 text-indigo-300 text-center font-medium transition-opacity ${
+                      focus != null && focus !== i ? 'opacity-30' : ''
+                    }`}
+                  >
                     GPU{i}
                   </th>
                 ))}
@@ -72,13 +102,16 @@ export const TopologyView = memo(function TopologyView({ topology }) {
             <tbody>
               {Array.from({ length: n }, (_, row) => (
                 <tr key={row}>
-                  <td className="px-2 py-1.5 text-indigo-300 font-medium whitespace-nowrap">
+                  <td className={`px-2 py-1.5 text-indigo-300 font-medium whitespace-nowrap transition-opacity ${
+                    focus != null && focus !== row ? 'opacity-30' : ''
+                  }`}>
                     GPU{row}
                   </td>
                   {Array.from({ length: n }, (_, col) => {
+                    const isFocusedLink = focus == null || row === focus || col === focus
                     if (row === col) {
                       return (
-                        <td key={col} className="px-3 py-1.5 text-center">
+                        <td key={col} className={`px-3 py-1.5 text-center transition-opacity ${isFocusedLink ? '' : 'opacity-20'}`}>
                           <span className="text-zinc-600">—</span>
                         </td>
                       )
@@ -86,12 +119,12 @@ export const TopologyView = memo(function TopologyView({ topology }) {
                     const link = matrix[row][col]
                     if (!link) {
                       return (
-                        <td key={col} className="px-3 py-1.5 text-center text-zinc-600">?</td>
+                        <td key={col} className={`px-3 py-1.5 text-center text-zinc-600 transition-opacity ${isFocusedLink ? '' : 'opacity-20'}`}>?</td>
                       )
                     }
                     const style = linkStyle(link.rank || 0)
                     return (
-                      <td key={col} className="px-1 py-1">
+                      <td key={col} className={`px-1 py-1 transition-opacity ${isFocusedLink ? '' : 'opacity-20'}`}>
                         <span
                           className={`block px-2 py-1 rounded text-center text-[10px] ${style.bg} ${style.text}`}
                           title={`GPU${link.gpu_a} ↔ GPU${link.gpu_b}: ${link.link_type}`}

--- a/ods/extensions/services/dashboard/src/components/TopologyView.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/TopologyView.test.jsx
@@ -1,0 +1,56 @@
+import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { render } from '../test/test-utils'
+import { TopologyView } from './TopologyView' // eslint-disable-line no-unused-vars
+
+const topology = {
+  gpu_count: 3,
+  vendor: 'nvidia',
+  driver_version: '600.1',
+  mig_enabled: false,
+  gpus: [
+    { index: 0, name: 'NVIDIA Alpha', memory_gb: 24 },
+    { index: 1, name: 'NVIDIA Beta', memory_gb: 24 },
+    { index: 2, name: 'NVIDIA Gamma', memory_gb: 48 },
+  ],
+  links: [
+    { gpu_a: 0, gpu_b: 1, link_type: 'NVLink', rank: 100 },
+    { gpu_a: 0, gpu_b: 2, link_type: 'PHB', rank: 20 },
+    { gpu_a: 1, gpu_b: 2, link_type: 'SYS', rank: 5 },
+  ],
+}
+
+describe('TopologyView GPU focus', () => {
+  it('focuses direct links from a GPU chip and toggles back to the full matrix', () => {
+    render(<TopologyView topology={topology} />)
+    const focusButton = screen.getByRole('button', { name: 'Focus GPU 1' })
+    const directCell = screen.getAllByTitle(/GPU0.*GPU1/)[0].closest('td')
+    const unrelatedCell = screen.getAllByTitle(/GPU0.*GPU2/)[0].closest('td')
+
+    fireEvent.click(focusButton)
+
+    expect(focusButton).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('status')).toHaveTextContent('Focused on GPU1')
+    expect(directCell).not.toHaveClass('opacity-20')
+    expect(unrelatedCell).toHaveClass('opacity-20')
+
+    fireEvent.click(focusButton)
+
+    expect(focusButton).toHaveAttribute('aria-pressed', 'false')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(unrelatedCell).not.toHaveClass('opacity-20')
+  })
+
+  it('supports keyboard focus controls through native buttons', async () => {
+    const user = userEvent.setup()
+    render(<TopologyView topology={topology} />)
+    const focusButton = screen.getByRole('button', { name: 'Focus GPU 2' })
+
+    focusButton.focus()
+    await user.keyboard('{Enter}')
+
+    expect(focusButton).toHaveFocus()
+    expect(focusButton).toHaveAttribute('aria-pressed', 'true')
+  })
+})


### PR DESCRIPTION
## Why this matters

In a multi-GPU topology matrix, operators need to trace one device's links without losing the surrounding matrix or changing assignments.

## Feature and overlap check

Native GPU chip buttons highlight the selected row/column links, dim unrelated cells and toggle back to the full view. Focus state is local and validates against the current device count. Updated the original PR onto beta. Searched all-state topology-focus and TopologyView/GPUMonitor paths. #4947 improves narrow layouts; this adds selection, not another layout variant. GPUMonitor's production Topology tab renders this component.

## Validation

`npm test -- --maxWorkers=2 src/components/TopologyView.test.jsx`: 2 passed, covering link emphasis/reset and keyboard Enter with focus retention. Focused ESLint/pre-commit/diff check passed. Synthetic GPU topology only, not a live NVLink/MIG test. Baseline dashboard tests/build and smoke/simulation passed; full gate/BATS have known failures.

## Rollback

No host call, reassignment or persistence. Unknown links stay unknown; emphasis is not a performance claim. Revert removes the focus controls. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `16f2b5909597c0b8e0b5e8af9a34bf6e4fc5849c`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
