### PR TITLE
feat(mobile): bootstrap remote ODS Talk portal

### DIFF
--- a/ods/docs/MOBILE-REMOTE-PORTAL.md
+++ b/ods/docs/MOBILE-REMOTE-PORTAL.md
@@ -1,0 +1,27 @@
+# Mobile remote portal
+
+ODS runs inference on the server. Android Termux and iOS a-Shell act as
+client-only entry points to the existing ODS Talk portal.
+
+```bash
+bash install.sh --server https://ods.example.test
+```
+
+The mobile dispatcher normalizes that origin to
+`https://ods.example.test/talk`, stores it in
+`~/.config/ods/mobile-portal-url`, and installs `~/.local/bin/ods-mobile` on
+Termux or `~/bin/ods-mobile` on a-Shell. The launcher uses
+`termux-open-url` on Termux or `open` on a-Shell. If neither command is
+available, it prints the portal URL for manual use.
+
+Use an existing `/talk` URL when the server is already exposed at that path.
+Embedded credentials, query parameters, and fragments are rejected so bearer
+tokens, passwords, and magic links are not persisted in launcher
+configuration.
+
+For automation, use `--no-open`. Use `--dry-run` to inspect the normalized URL
+and paths without writing state. `ODS_MOBILE_CONFIG_DIR` and
+`ODS_MOBILE_BIN_DIR` override the default destinations.
+
+This bootstrap does not install Docker, inference runtimes, or server services
+on the phone. The target ODS server must already be reachable from the device.

--- a/ods/installers/mobile/install-mobile.sh
+++ b/ods/installers/mobile/install-mobile.sh
@@ -1,23 +1,166 @@
 #!/bin/bash
-# Minimal mobile dispatch target. The Android and iOS preview installers land in
-# follow-up PRs so this infrastructure change stays reviewable on its own.
+# Configure a client-only launcher for the ODS Talk portal on Android Termux
+# and iOS a-Shell. Mobile devices connect to an existing ODS server; they do
+# not attempt to run the Docker stack locally.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$SCRIPT_DIR/installers/common.sh"
 
-platform="$(detect_platform)"
+server_url=""
+open_portal=true
+dry_run=false
 
+show_help() {
+    cat <<'EOF'
+ODS mobile remote-portal bootstrap
+
+USAGE:
+    install-mobile.sh [--server URL] [--no-open] [--dry-run]
+
+OPTIONS:
+    --server URL   Existing ODS server origin or /talk URL (http/https)
+    --no-open      Install the launcher without opening the portal
+    --dry-run      Print the resolved plan without writing files
+    --help, -h     Show this help
+
+The portal URL is stored in ~/.config/ods/mobile-portal-url. The launcher is
+installed to ~/.local/bin/ods-mobile on Termux or ~/bin/ods-mobile on a-Shell.
+Override those roots with ODS_MOBILE_BIN_DIR and ODS_MOBILE_CONFIG_DIR.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --server)
+            if [[ $# -lt 2 || "$2" == -* ]]; then
+                echo "[ERROR] --server requires an http:// or https:// URL." >&2
+                exit 2
+            fi
+            server_url="$2"
+            shift 2
+            ;;
+        --no-open)
+            open_portal=false
+            shift
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        --help|-h)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "[ERROR] Unknown mobile installer option: $1" >&2
+            show_help >&2
+            exit 2
+            ;;
+    esac
+done
+
+platform="$(detect_platform)"
 case "$platform" in
-    android-termux|ios-ashell)
-        echo "[INFO] ODS detected mobile platform: $platform" >&2
-        echo "[ERROR] Mobile preview installer is split into a follow-up PR." >&2
-        echo "        This PR only adds the dispatcher and platform detection contract." >&2
-        exit 1
-        ;;
+    android-termux|ios-ashell) ;;
     *)
         echo "[ERROR] install-mobile.sh only handles Android Termux or iOS a-Shell." >&2
         exit 1
         ;;
 esac
+
+if [[ -z "$server_url" ]]; then
+    if [[ ! -t 0 ]]; then
+        echo "[ERROR] --server is required when input is non-interactive." >&2
+        exit 2
+    fi
+    printf 'Existing ODS server URL: '
+    IFS= read -r server_url
+fi
+
+if [[ ! "$server_url" =~ ^https?://[^[:space:]?#]+/?$ ]]; then
+    echo "[ERROR] Server URL must use http/https and cannot contain query parameters or fragments." >&2
+    exit 2
+fi
+
+server_authority="${server_url#*://}"
+server_authority="${server_authority%%/*}"
+if [[ -z "$server_authority" || "$server_authority" == *"@"* ]]; then
+    echo "[ERROR] Server URL must contain a host and cannot embed credentials." >&2
+    exit 2
+fi
+
+server_url="${server_url%/}"
+if [[ "$server_url" == */talk ]]; then
+    portal_url="$server_url"
+else
+    portal_url="$server_url/talk"
+fi
+
+config_dir="${ODS_MOBILE_CONFIG_DIR:-$HOME/.config/ods}"
+default_bin_dir="$HOME/.local/bin"
+[[ "$platform" == "ios-ashell" ]] && default_bin_dir="$HOME/bin"
+bin_dir="${ODS_MOBILE_BIN_DIR:-$default_bin_dir}"
+config_file="$config_dir/mobile-portal-url"
+launcher="$bin_dir/ods-mobile"
+
+echo "[INFO] ODS mobile platform: $platform"
+echo "[INFO] Remote portal: $portal_url"
+echo "[INFO] Launcher: $launcher"
+
+if [[ "$dry_run" == "true" ]]; then
+    echo "[INFO] Dry run complete; no files were written."
+    exit 0
+fi
+
+mkdir -p "$config_dir" "$bin_dir"
+chmod 700 "$config_dir"
+
+work_dir="$config_dir/.mobile-install.$$"
+if ! (umask 077 && mkdir "$work_dir"); then
+    echo "[ERROR] Cannot create mobile installer transaction directory: $work_dir" >&2
+    exit 1
+fi
+config_tmp="$work_dir/mobile-portal-url"
+launcher_tmp="$work_dir/ods-mobile"
+cleanup() {
+    rm -f "$config_tmp" "$launcher_tmp"
+    rmdir "$work_dir"
+}
+trap cleanup EXIT
+
+printf '%s\n' "$portal_url" > "$config_tmp"
+chmod 600 "$config_tmp"
+
+{
+    echo '#!/bin/bash'
+    echo 'set -euo pipefail'
+    printf 'CONFIG_FILE=%q\n' "$config_file"
+    cat <<'EOF'
+if [[ ! -r "$CONFIG_FILE" ]]; then
+    echo "[ERROR] ODS mobile portal configuration is missing: $CONFIG_FILE" >&2
+    exit 1
+fi
+IFS= read -r portal_url < "$CONFIG_FILE"
+if command -v termux-open-url >/dev/null 2>&1; then
+    exec termux-open-url "$portal_url"
+fi
+if command -v open >/dev/null 2>&1; then
+    exec open "$portal_url"
+fi
+echo "$portal_url"
+echo "[INFO] No URL opener was found; open the URL above in your browser." >&2
+EOF
+} > "$launcher_tmp"
+chmod 755 "$launcher_tmp"
+
+mv -f "$config_tmp" "$config_file"
+mv -f "$launcher_tmp" "$launcher"
+rmdir "$work_dir"
+trap - EXIT
+
+echo "[INFO] Mobile launcher installed. Run: $launcher"
+if [[ "$open_portal" == "true" ]]; then
+    "$launcher"
+fi

--- a/ods/tests/bats-tests/mobile-remote-portal.bats
+++ b/ods/tests/bats-tests/mobile-remote-portal.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+setup() {
+    export TEST_ROOT="${ODS_TEST_ROOT_OVERRIDE:-$(cd "$BATS_TEST_DIRNAME/../.." && pwd)}"
+    export MOBILE_HOME="$BATS_TEST_TMPDIR/mobile-home"
+    export MOBILE_BIN="$MOBILE_HOME/bin"
+    export MOBILE_CONFIG="$MOBILE_HOME/config"
+    export OPENER_BIN="$MOBILE_HOME/opener-bin"
+    export OPENED_URL="$MOBILE_HOME/opened-url"
+    mkdir -p "$OPENER_BIN"
+}
+
+_install_opener() {
+    local name="$1"
+    cat > "$OPENER_BIN/$name" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$1" > "$OPENED_URL"
+EOF
+    chmod +x "$OPENER_BIN/$name"
+}
+
+@test "Termux bootstrap persists a normalized portal and installs a working launcher" {
+    _install_opener termux-open-url
+
+    run env \
+        HOME="$MOBILE_HOME" \
+        ODS_PLATFORM_OVERRIDE=android-termux \
+        ODS_MOBILE_BIN_DIR="$MOBILE_BIN" \
+        ODS_MOBILE_CONFIG_DIR="$MOBILE_CONFIG" \
+        bash "$TEST_ROOT/install.sh" \
+            --server https://ods.example.test --no-open
+
+    assert_success
+    run grep -Fx 'https://ods.example.test/talk' "$MOBILE_CONFIG/mobile-portal-url"
+    assert_success
+    [ -x "$MOBILE_BIN/ods-mobile" ]
+
+    run env PATH="$OPENER_BIN:$PATH" OPENED_URL="$OPENED_URL" "$MOBILE_BIN/ods-mobile"
+    assert_success
+    run grep -Fx 'https://ods.example.test/talk' "$OPENED_URL"
+    assert_success
+}
+
+@test "a-Shell bootstrap uses its native URL opener without duplicating /talk" {
+    _install_opener open
+
+    run env \
+        HOME="$MOBILE_HOME" \
+        PATH="$OPENER_BIN:$PATH" \
+        OPENED_URL="$OPENED_URL" \
+        ODS_PLATFORM_OVERRIDE=ios-ashell \
+        ODS_MOBILE_BIN_DIR="$MOBILE_BIN" \
+        ODS_MOBILE_CONFIG_DIR="$MOBILE_CONFIG" \
+        bash "$TEST_ROOT/install.sh" \
+            --server http://talk.ods.local/talk
+
+    assert_success
+    run grep -Fx 'http://talk.ods.local/talk' "$OPENED_URL"
+    assert_success
+}
+
+@test "dry run resolves the plan without creating mobile state" {
+    run env \
+        HOME="$MOBILE_HOME" \
+        ODS_PLATFORM_OVERRIDE=android-termux \
+        ODS_MOBILE_BIN_DIR="$MOBILE_BIN" \
+        ODS_MOBILE_CONFIG_DIR="$MOBILE_CONFIG" \
+        bash "$TEST_ROOT/install.sh" \
+            --server https://ods.example.test --dry-run
+
+    assert_success
+    assert_output --partial 'Dry run complete; no files were written.'
+    [ ! -e "$MOBILE_BIN" ]
+    [ ! -e "$MOBILE_CONFIG" ]
+}
+
+@test "non-interactive bootstrap rejects missing or credential-like URLs" {
+    run env HOME="$MOBILE_HOME" ODS_PLATFORM_OVERRIDE=android-termux \
+        bash "$TEST_ROOT/install.sh" --no-open
+    assert_failure 2
+    assert_output --partial '--server is required'
+
+    run env HOME="$MOBILE_HOME" ODS_PLATFORM_OVERRIDE=android-termux \
+        bash "$TEST_ROOT/install.sh" \
+            --server 'https://ods.example.test?token=secret' --no-open
+    assert_failure 2
+    assert_output --partial 'cannot contain query parameters or fragments'
+
+    run env HOME="$MOBILE_HOME" ODS_PLATFORM_OVERRIDE=android-termux \
+        bash "$TEST_ROOT/install.sh" \
+            --server 'https://user:password@ods.example.test' --no-open
+    assert_failure 2
+    assert_output --partial 'cannot embed credentials'
+}


### PR DESCRIPTION
## Summary

- replace the mobile placeholder failure with a client-only ODS Talk bootstrap for Android Termux and iOS a-Shell
- normalize an existing ODS origin to `/talk`, persist it privately, and install an `ods-mobile` launcher
- use `termux-open-url` on Android and a-Shell's native `open` command on iOS, with a printable fallback
- add non-interactive, no-open, dry-run, custom-path, validation, and transactional-write behavior

## Why this matters

The dispatcher already routes real Termux and a-Shell users into `install-mobile.sh`, but that reachable path intentionally terminated with an error. This change turns it into a useful mobile onboarding flow without pretending phones can host the Docker/inference stack: they become clients of an existing ODS Talk server.

The invariant is: mobile bootstrap never installs server services, never persists credential-bearing URLs, and does not write anything in dry-run mode.

## Overlap check

Searched open and closed upstream PR titles/bodies for `mobile remote portal Termux a-Shell launcher`, reviewed the latest 1,000 open PRs and changed production files, and inspected `install-mobile.sh` history. No open PR changes this file or implements the preview; upstream history only contains the repository rename. The prior placeholder explicitly said the real mobile installer belonged in a follow-up, which is the independent scope completed here.

The iOS opener and filesystem command assumptions were checked against a-Shell's official command registry: https://github.com/holzschu/a-Shell/blob/master/Resources_mini/commandDictionary.plist

## Test plan

- `bats mobile-remote-portal.bats` ? 4/4 passing through the public `install.sh` dispatcher
  - Termux URL normalization, private persisted configuration, executable launcher, and native opener handoff
  - a-Shell opener parity and idempotent `/talk` handling
  - dry-run proves no destination state is created
  - missing, query-bearing, and embedded-credential URLs fail with status 2
- `bash tests/smoke/mobile-dispatch.sh` ? PASS
- `bash -n installers/mobile/install-mobile.sh`
- `shellcheck --rcfile=/dev/null -e SC1090,SC1091,SC3003 installers/mobile/install-mobile.sh`
- `git diff --check`

## Design and operational notes

- Termux defaults to `~/.local/bin`; a-Shell defaults to `~/bin`, matching its user-command convention. Both roots remain injectable for managed setups.
- Configuration is mode 0600 under a mode 0700 directory. Temporary artifacts live in a private transaction directory and are renamed into place.
- No live reachability check is claimed: the target server may be intentionally available only after VPN/LAN changes. The launcher surfaces the exact resolved URL instead.
- Rollback removes the generated launcher and `mobile-portal-url`; server state is untouched.

Generated with Codex.

## Batch compatibility

- Recommended merge/application order: #3706 -> #3707 -> #3708 -> #3709 -> #3710 -> #3711 -> #3712 -> #3713 -> #3714 -> #3715. The PRs have no runtime dependency; this order also covers the shared MODEL-SWITCHBOARD.md edits in #3708/#3709.
- Synthetic integration head: tang-vu/DreamServer commit 5e4e354e on integration/features-ten-20260904, built from upstream/main 6ff9b4fc plus all ten PR heads.
- Combined validation: 12 BATS tests passed; 132 focused API/workflow pytest tests passed; 6 dashboard Vitest tests passed; ESLint and the 1,771-module Vite production build passed; make lint, installer integration (69 passed, 3 skipped), the 6-test ods-test contract, mobile dispatch smoke, and exact n8n 2.6.4 imports for both workflow templates passed. git diff --check is clean.
- Full-suite limitation: make test reaches tests/test-installer-noninteractive-sudo.sh and reports 3 passed / 2 failed when WSL runs as root. The same two assertions fail unchanged on the clean upstream base 6ff9b4fc, so this is recorded as environment/baseline evidence rather than attributed to this batch. All required GitHub checks for the ten PR heads are green as of 2026-09-04.
