### PR TITLE
feat(workflows): make voice memo runnable

### DIFF
--- a/ods/config/n8n/voice-memo.json
+++ b/ods/config/n8n/voice-memo.json
@@ -2,27 +2,287 @@
   "name": "Voice Memo",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Voice Memo\n\nUpload an audio memo to the production webhook:\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-voice-memo \\\n  -F 'data=@memo.webm' \\\n  -F 'title=Release notes'\n```\n\nThe multipart field must be named `data`. The workflow validates the upload, discovers the model already exposed by the bundled Whisper service, transcribes the audio, and returns bounded JSON. Optionally send a `model` field to select one of the IDs returned by Whisper. No audio or transcript is persisted by this workflow.",
+        "height": 520,
+        "width": 560
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-220, 20]
     },
     {
       "parameters": {
-        "content": "## Voice Memo\n\nThis is a template workflow for recording and transcribing voice memos.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-voice-memo",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-upload",
+      "name": "Upload Voice Memo",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [420, 260],
+      "webhookId": "1c35a68b-0b4f-4b9a-bf5e-35302e714db9"
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first();\nconst body = input.json.body || {};\nconst audio = input.binary?.data;\nconst title = String(body.title || audio?.fileName || 'Voice memo').trim().slice(0, 120) || 'Voice memo';\n\nif (!audio) {\n  return [{ json: {\n    ok: false,\n    statusCode: 400,\n    error: \"Multipart form field 'data' must contain an audio file.\",\n  } }];\n}\n\nconst mimeType = String(audio.mimeType || '');\nif (mimeType && !mimeType.startsWith('audio/') && mimeType !== 'application/octet-stream') {\n  return [{ json: {\n    ok: false,\n    statusCode: 415,\n    error: `Unsupported audio content type: ${mimeType}`,\n  } }];\n}\n\nconst requestedModel = String(body.model || '').trim();\nif (requestedModel.length > 200) {\n  return [{ json: {\n    ok: false,\n    statusCode: 400,\n    error: 'The requested model ID exceeds 200 characters.',\n  } }];\n}\n\nreturn [{\n  json: { ok: true, statusCode: 200, title, requestedModel },\n  binary: input.binary,\n}];"
+      },
+      "id": "code-validate",
+      "name": "Validate Audio Upload",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 260]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "upload-valid",
+              "leftValue": "={{ $json.ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-upload-valid",
+      "name": "Upload Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [900, 260]
+    },
+    {
+      "parameters": {
+        "url": "http://whisper:8000/v1/models",
+        "options": {
+          "timeout": 30000
+        }
+      },
+      "id": "http-models",
+      "name": "List Whisper Models",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 140],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "mode": "combine",
+        "combineBy": "combineByPosition",
+        "options": {}
+      },
+      "id": "merge-upload-models",
+      "name": "Merge Upload and Models",
+      "type": "n8n-nodes-base.merge",
+      "typeVersion": 3.2,
+      "position": [1380, 260]
+    },
+    {
+      "parameters": {
+        "jsCode": "const input = $input.first();\nconst upload = $('Validate Audio Upload').first();\nconst models = Array.isArray(input.json.data)\n  ? input.json.data.map((entry) => entry?.id).filter((id) => typeof id === 'string' && id)\n  : [];\nconst requested = upload.json.requestedModel;\n\nif (models.length === 0) {\n  return [{\n    json: { ok: false, statusCode: 503, error: 'Whisper reports no available transcription model.' },\n    binary: upload.binary,\n  }];\n}\nif (requested && !models.includes(requested)) {\n  return [{\n    json: { ok: false, statusCode: 400, error: `Requested model is not available: ${requested}` },\n    binary: upload.binary,\n  }];\n}\n\nreturn [{\n  json: {\n    ok: true,\n    statusCode: 200,\n    title: upload.json.title,\n    model: requested || models[0],\n  },\n  binary: upload.binary,\n}];"
+      },
+      "id": "code-select-model",
+      "name": "Select Available Model",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1620, 260]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "model-available",
+              "leftValue": "={{ $json.ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-model-available",
+      "name": "Model Available?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1860, 260]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://whisper:8000/v1/audio/transcriptions",
+        "sendBody": true,
+        "contentType": "multipart-form-data",
+        "bodyParameters": {
+          "parameters": [
+            {
+              "parameterType": "formBinaryData",
+              "name": "file",
+              "inputDataFieldName": "data"
+            },
+            {
+              "name": "model",
+              "value": "={{ $json.model }}"
+            },
+            {
+              "name": "response_format",
+              "value": "json"
+            }
+          ]
+        },
+        "options": {
+          "timeout": 180000
+        }
+      },
+      "id": "http-transcribe",
+      "name": "Transcribe With Whisper",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [2100, 180],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json || {};\nconst selected = $('Select Available Model').first().json;\nconst text = typeof response.text === 'string' ? response.text.trim() : '';\nif (!text) {\n  return [{ json: {\n    ok: false,\n    statusCode: 502,\n    error: 'Whisper returned an empty transcription.',\n  } }];\n}\n\nreturn [{ json: {\n  ok: true,\n  statusCode: 200,\n  title: selected.title,\n  model: selected.model,\n  text,\n  language: typeof response.language === 'string' ? response.language : null,\n  duration: Number.isFinite(response.duration) ? response.duration : null,\n} }];"
+      },
+      "id": "code-normalize",
+      "name": "Normalize Transcript",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [2340, 180]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "transcript-ready",
+              "leftValue": "={{ $json.ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-transcript-ready",
+      "name": "Transcript Ready?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [2580, 180]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "respond-success",
+      "name": "Return Transcript",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2820, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json) }}",
+        "options": {
+          "responseCode": "={{ $json.statusCode || 500 }}"
+        }
+      },
+      "id": "respond-error",
+      "name": "Return Voice Memo Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [2340, 420]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Upload Voice Memo": {
+      "main": [[{"node": "Validate Audio Upload", "type": "main", "index": 0}]]
+    },
+    "Validate Audio Upload": {
+      "main": [[{"node": "Upload Valid?", "type": "main", "index": 0}]]
+    },
+    "Upload Valid?": {
+      "main": [
+        [
+          {"node": "List Whisper Models", "type": "main", "index": 0},
+          {"node": "Merge Upload and Models", "type": "main", "index": 0}
+        ],
+        [{"node": "Return Voice Memo Error", "type": "main", "index": 0}]
+      ]
+    },
+    "List Whisper Models": {
+      "main": [[{"node": "Merge Upload and Models", "type": "main", "index": 1}]]
+    },
+    "Merge Upload and Models": {
+      "main": [[{"node": "Select Available Model", "type": "main", "index": 0}]]
+    },
+    "Select Available Model": {
+      "main": [[{"node": "Model Available?", "type": "main", "index": 0}]]
+    },
+    "Model Available?": {
+      "main": [
+        [{"node": "Transcribe With Whisper", "type": "main", "index": 0}],
+        [{"node": "Return Voice Memo Error", "type": "main", "index": 0}]
+      ]
+    },
+    "Transcribe With Whisper": {
+      "main": [[{"node": "Normalize Transcript", "type": "main", "index": 0}]]
+    },
+    "Normalize Transcript": {
+      "main": [[{"node": "Transcript Ready?", "type": "main", "index": 0}]]
+    },
+    "Transcript Ready?": {
+      "main": [
+        [{"node": "Return Transcript", "type": "main", "index": 0}],
+        [{"node": "Return Voice Memo Error", "type": "main", "index": 0}]
+      ]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },

--- a/ods/extensions/services/dashboard-api/tests/test_n8n_voice_memo_template.py
+++ b/ods/extensions/services/dashboard-api/tests/test_n8n_voice_memo_template.py
@@ -1,0 +1,121 @@
+"""Import-boundary contract for the shipped Voice Memo workflow."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[4]
+WORKFLOW_FILE = ROOT / "config" / "n8n" / "voice-memo.json"
+
+
+def _response_context(response):
+    context = AsyncMock()
+    context.__aenter__ = AsyncMock(return_value=response)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return context
+
+
+def test_voice_memo_public_enable_imports_and_activates_runnable_graph(
+    test_client, monkeypatch,
+):
+    import routers.workflows as workflows
+
+    workflow = json.loads(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    monkeypatch.setattr(workflows, "WORKFLOW_CATALOG_FILE", WORKFLOW_FILE.parent / "catalog.json")
+    monkeypatch.setattr(workflows, "WORKFLOW_DIR", WORKFLOW_FILE.parent)
+    monkeypatch.setattr(
+        workflows,
+        "check_workflow_dependencies",
+        AsyncMock(return_value={"whisper": True}),
+    )
+
+    create_response = AsyncMock()
+    create_response.status = 201
+    create_response.json = AsyncMock(return_value={"data": {"id": "voice-memo-1"}})
+    activate_response = AsyncMock()
+    activate_response.status = 200
+
+    session = AsyncMock()
+    session.post = MagicMock(return_value=_response_context(create_response))
+    session.patch = MagicMock(return_value=_response_context(activate_response))
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.aiohttp.ClientSession", return_value=session):
+        response = test_client.post(
+            "/api/workflows/voice-memo/enable",
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["activated"] is True
+    assert response.json()["n8nId"] == "voice-memo-1"
+    assert session.post.call_args.kwargs["json"] == workflow
+    session.patch.assert_called_once()
+
+
+def test_voice_memo_graph_preserves_binary_until_bounded_whisper_request():
+    workflow = json.loads(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    by_name = {node["name"]: node for node in workflow["nodes"]}
+
+    assert "Start" not in by_name
+    assert by_name["Upload Voice Memo"]["type"] == "n8n-nodes-base.webhook"
+    assert by_name["Upload Voice Memo"]["parameters"] == {
+        "httpMethod": "POST",
+        "path": "ods-voice-memo",
+        "responseMode": "responseNode",
+        "options": {},
+    }
+    assert by_name["List Whisper Models"]["parameters"]["url"] == (
+        "http://whisper:8000/v1/models"
+    )
+    assert by_name["List Whisper Models"]["onError"] == "continueRegularOutput"
+
+    transcribe = by_name["Transcribe With Whisper"]["parameters"]
+    assert transcribe["url"] == "http://whisper:8000/v1/audio/transcriptions"
+    assert transcribe["contentType"] == "multipart-form-data"
+    assert transcribe["options"]["timeout"] == 180000
+    assert by_name["Transcribe With Whisper"]["onError"] == (
+        "continueRegularOutput"
+    )
+    body_parameters = transcribe["bodyParameters"]["parameters"]
+    assert {
+        "parameterType": "formBinaryData",
+        "name": "file",
+        "inputDataFieldName": "data",
+    } in body_parameters
+    assert {"name": "model", "value": "={{ $json.model }}"} in body_parameters
+
+    connections = workflow["connections"]
+    upload_branches = connections["Upload Valid?"]["main"][0]
+    assert {"node": "Merge Upload and Models", "type": "main", "index": 0} in upload_branches
+    assert connections["List Whisper Models"]["main"][0][0] == {
+        "node": "Merge Upload and Models",
+        "type": "main",
+        "index": 1,
+    }
+    assert connections["Model Available?"]["main"][1][0]["node"] == (
+        "Return Voice Memo Error"
+    )
+    assert connections["Transcript Ready?"]["main"][1][0]["node"] == (
+        "Return Voice Memo Error"
+    )
+
+
+def test_voice_memo_validation_rejects_non_audio_and_unavailable_models():
+    workflow = json.loads(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    by_name = {node["name"]: node for node in workflow["nodes"]}
+    validation_code = by_name["Validate Audio Upload"]["parameters"]["jsCode"]
+    model_code = by_name["Select Available Model"]["parameters"]["jsCode"]
+    normalize_code = by_name["Normalize Transcript"]["parameters"]["jsCode"]
+
+    assert "input.binary?.data" in validation_code
+    assert "statusCode: 415" in validation_code
+    assert "requestedModel.length > 200" in validation_code
+    assert "!models.includes(requested)" in model_code
+    assert "$('Validate Audio Upload').first()" in model_code
+    assert "binary: upload.binary" in model_code
+    assert "statusCode: 503" in model_code
+    assert "statusCode: 502" in normalize_code
+    assert "response.text" in normalize_code


### PR DESCRIPTION
## Summary

- replace the Voice Memo placeholder with an activatable `POST /webhook/ods-voice-memo` workflow
- validate multipart audio, content type, title, and optional model selection before inference
- discover the model IDs actually served by bundled Whisper instead of hard-coding a backend-specific default
- preserve binary data across model discovery, send a bounded multipart transcription request, and normalize success/error JSON

## Why this matters

Voice Memo is already advertised in the workflow catalog with a one-minute setup time, but enabling it previously imported only a manual trigger and sticky note. Users got no webhook and no transcription path. This PR makes the catalog action deliver the runnable local feature it promises.

The invariant is: only multipart field `data` reaches Whisper, its model must exist in Whisper's live model catalog, binary data survives the discovery branch, and audio/transcript content is not persisted by the workflow.

## Overlap check

Searched open and closed upstream PR titles/bodies for `n8n voice memo Whisper workflow`, reviewed the latest 1,000 open PRs and changed production files, and inspected `voice-memo.json` history. No PR changes this workflow or implements this scope; its upstream history only contains the repository rename. The earlier runnable Daily Digest, Image Generation, and Email-to-Task PRs operate on different catalog entries and files.

Multipart field configuration was checked against n8n's official HTTP Request node implementation: https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts

## Test plan

- `python -m pytest test_n8n_voice_memo_template.py test_workflows.py -q` ? 48 passed
  - authenticated public enable imports the exact shipped graph and activates its returned n8n ID
  - webhook, branch, merge-input, binary-field, model-discovery, timeout, sanitizer, and terminal error contracts
  - all existing workflow management tests remain green
- `docker run --rm ... n8nio/n8n:2.6.4 import:workflow --input=/workflows/voice-memo.json` ? successfully imported 1 workflow using the exact image ODS ships
- `python -m json.tool ods/config/n8n/voice-memo.json`
- `python -m compileall -q .../test_n8n_voice_memo_template.py`
- `git diff --check`

## Design and operational notes

- The webhook relies on ODS's existing n8n exposure policy and Whisper service dependency; no external credential is added.
- Model discovery makes CPU, NVIDIA, AMD, and Apple-selected Whisper deployments use the model they actually expose.
- HTTP failures continue to controlled branches so callers receive explicit 503/502 JSON rather than an empty successful transcript.
- Exact-version CLI import proves n8n 2.6.4 accepts the graph. A live audio transcription was not claimed because no running Whisper model/audio fixture was available for this validation.
- Rollback restores the catalog placeholder; no database migration or stored memo cleanup is required.

Generated with Codex.

## Batch compatibility

- Recommended merge/application order: #3706 -> #3707 -> #3708 -> #3709 -> #3710 -> #3711 -> #3712 -> #3713 -> #3714 -> #3715. The PRs have no runtime dependency; this order also covers the shared MODEL-SWITCHBOARD.md edits in #3708/#3709.
- Synthetic integration head: tang-vu/DreamServer commit 5e4e354e on integration/features-ten-20260904, built from upstream/main 6ff9b4fc plus all ten PR heads.
- Combined validation: 12 BATS tests passed; 132 focused API/workflow pytest tests passed; 6 dashboard Vitest tests passed; ESLint and the 1,771-module Vite production build passed; make lint, installer integration (69 passed, 3 skipped), the 6-test ods-test contract, mobile dispatch smoke, and exact n8n 2.6.4 imports for both workflow templates passed. git diff --check is clean.
- Full-suite limitation: make test reaches tests/test-installer-noninteractive-sudo.sh and reports 3 passed / 2 failed when WSL runs as root. The same two assertions fail unchanged on the clean upstream base 6ff9b4fc, so this is recorded as environment/baseline evidence rather than attributed to this batch. All required GitHub checks for the ten PR heads are green as of 2026-09-04.
