### PR TITLE
feat(workflows): make chat endpoint runnable

### DIFF
--- a/ods/config/n8n/01-chat-endpoint.json
+++ b/ods/config/n8n/01-chat-endpoint.json
@@ -2,27 +2,186 @@
   "name": "Chat API Endpoint",
   "nodes": [
     {
-      "parameters": {},
-      "id": "start",
-      "name": "Start",
-      "type": "n8n-nodes-base.manualTrigger",
+      "parameters": {
+        "content": "## Chat API Endpoint\n\nExpose a bounded OpenAI-compatible chat facade backed by the local llama-server:\n```bash\ncurl -X POST http://localhost:5678/webhook/ods-chat-completions \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"messages\":[{\"role\":\"user\",\"content\":\"Explain local-first AI in one sentence.\"}]}'\n```\n\nAccepted roles are `system`, `user`, and `assistant`. Requests are limited to 50 messages, 16,000 characters per message, 32,000 characters total, and 4,096 output tokens. Streaming and tool calls are intentionally outside this response-node workflow; use the direct ODS API for those features.",
+        "height": 540,
+        "width": 580
+      },
+      "id": "note-overview",
+      "name": "How to use this",
+      "type": "n8n-nodes-base.stickyNote",
       "typeVersion": 1,
-      "position": [240, 300]
+      "position": [-220, 20]
     },
     {
       "parameters": {
-        "content": "## Chat API Endpoint\n\nThis is a template workflow for REST API chat completions.\n\nCustomize the nodes below to match your setup.",
-        "height": 200,
-        "width": 400
+        "httpMethod": "POST",
+        "path": "ods-chat-completions",
+        "responseMode": "responseNode",
+        "options": {}
       },
-      "id": "note",
-      "name": "Setup Instructions",
-      "type": "n8n-nodes-base.stickyNote",
-      "typeVersion": 1,
-      "position": [440, 140]
+      "id": "webhook-chat",
+      "name": "Receive Chat Request",
+      "type": "n8n-nodes-base.webhook",
+      "typeVersion": 2,
+      "position": [420, 260],
+      "webhookId": "89f37ee0-d7bd-48ac-a099-c7b6618ee353"
+    },
+    {
+      "parameters": {
+        "jsCode": "const body = $input.first().json.body || {};\nconst messages = body.messages;\nconst allowedRoles = new Set(['system', 'user', 'assistant']);\n\nfunction invalid(error) {\n  return [{ json: { ok: false, statusCode: 400, error } }];\n}\n\nif (!Array.isArray(messages) || messages.length < 1 || messages.length > 50) {\n  return invalid('messages must contain between 1 and 50 entries.');\n}\nif (body.stream === true) {\n  return invalid('streaming is not supported by this workflow endpoint.');\n}\n\nlet totalCharacters = 0;\nconst cleanMessages = [];\nfor (const message of messages) {\n  if (!message || typeof message !== 'object' || Array.isArray(message)) {\n    return invalid('every message must be an object.');\n  }\n  if (!allowedRoles.has(message.role)) {\n    return invalid(`unsupported message role: ${String(message.role)}`);\n  }\n  if (typeof message.content !== 'string' || !message.content.trim()) {\n    return invalid('every message must contain non-empty text content.');\n  }\n  if (message.content.length > 16000) {\n    return invalid('a message exceeds the 16000-character limit.');\n  }\n  totalCharacters += message.content.length;\n  if (totalCharacters > 32000) {\n    return invalid('message content exceeds the 32000-character request limit.');\n  }\n  cleanMessages.push({ role: message.role, content: message.content });\n}\n\nconst model = String(body.model || 'local-model').trim();\nif (!model || model.length > 200) {\n  return invalid('model must contain between 1 and 200 characters.');\n}\nconst temperature = body.temperature ?? 0.7;\nif (typeof temperature !== 'number' || !Number.isFinite(temperature) || temperature < 0 || temperature > 2) {\n  return invalid('temperature must be a number between 0 and 2.');\n}\nconst maxTokens = body.max_tokens ?? 512;\nif (!Number.isInteger(maxTokens) || maxTokens < 1 || maxTokens > 4096) {\n  return invalid('max_tokens must be an integer between 1 and 4096.');\n}\n\nreturn [{ json: {\n  ok: true,\n  statusCode: 200,\n  model,\n  messages: cleanMessages,\n  temperature,\n  max_tokens: maxTokens,\n} }];"
+      },
+      "id": "code-validate",
+      "name": "Validate Chat Request",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [660, 260]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "request-valid",
+              "leftValue": "={{ $json.ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-request-valid",
+      "name": "Request Valid?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [900, 260]
+    },
+    {
+      "parameters": {
+        "method": "POST",
+        "url": "http://llama-server:8080/v1/chat/completions",
+        "sendBody": true,
+        "specifyBody": "json",
+        "jsonBody": "={{ JSON.stringify({ model: $json.model, messages: $json.messages, temperature: $json.temperature, max_tokens: $json.max_tokens, stream: false }) }}",
+        "options": {
+          "timeout": 180000
+        }
+      },
+      "id": "http-completion",
+      "name": "Complete With llama-server",
+      "type": "n8n-nodes-base.httpRequest",
+      "typeVersion": 4.2,
+      "position": [1140, 180],
+      "onError": "continueRegularOutput"
+    },
+    {
+      "parameters": {
+        "jsCode": "const response = $input.first().json || {};\nconst request = $('Validate Chat Request').first().json;\nconst choice = Array.isArray(response.choices) ? response.choices[0] : null;\nconst content = choice?.message?.content;\n\nif (typeof content !== 'string' || !content.trim()) {\n  return [{ json: {\n    ok: false,\n    statusCode: 502,\n    error: 'llama-server returned no assistant message.',\n  } }];\n}\n\nconst tokenCount = (value) => Number.isInteger(value) && value >= 0 ? value : null;\nconst usage = response.usage && typeof response.usage === 'object'\n  ? {\n      prompt_tokens: tokenCount(response.usage.prompt_tokens),\n      completion_tokens: tokenCount(response.usage.completion_tokens),\n      total_tokens: tokenCount(response.usage.total_tokens),\n    }\n  : null;\n\nreturn [{ json: {\n  ok: true,\n  statusCode: 200,\n  completion: {\n    id: typeof response.id === 'string' ? response.id : `chatcmpl-${Date.now()}`,\n    object: 'chat.completion',\n    created: Number.isInteger(response.created) ? response.created : Math.floor(Date.now() / 1000),\n    model: typeof response.model === 'string' ? response.model : request.model,\n    choices: [{\n      index: Number.isInteger(choice.index) ? choice.index : 0,\n      message: { role: 'assistant', content },\n      finish_reason: typeof choice.finish_reason === 'string' ? choice.finish_reason : null,\n    }],\n    usage,\n  },\n} }];"
+      },
+      "id": "code-normalize",
+      "name": "Normalize Chat Completion",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [1380, 180]
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": true,
+            "leftValue": "",
+            "typeValidation": "strict",
+            "version": 2
+          },
+          "conditions": [
+            {
+              "id": "completion-ready",
+              "leftValue": "={{ $json.ok }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "true",
+                "singleValue": true
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "if-completion-ready",
+      "name": "Completion Ready?",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2.2,
+      "position": [1620, 180]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify($json.completion) }}",
+        "options": {
+          "responseCode": 200
+        }
+      },
+      "id": "respond-success",
+      "name": "Return Chat Completion",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1860, 100]
+    },
+    {
+      "parameters": {
+        "respondWith": "json",
+        "responseBody": "={{ JSON.stringify({ error: { message: $json.error, type: $json.statusCode === 400 ? 'invalid_request_error' : 'upstream_error' } }) }}",
+        "options": {
+          "responseCode": "={{ $json.statusCode || 500 }}"
+        }
+      },
+      "id": "respond-error",
+      "name": "Return Chat Error",
+      "type": "n8n-nodes-base.respondToWebhook",
+      "typeVersion": 1.1,
+      "position": [1620, 420]
     }
   ],
-  "connections": {},
+  "connections": {
+    "Receive Chat Request": {
+      "main": [[{"node": "Validate Chat Request", "type": "main", "index": 0}]]
+    },
+    "Validate Chat Request": {
+      "main": [[{"node": "Request Valid?", "type": "main", "index": 0}]]
+    },
+    "Request Valid?": {
+      "main": [
+        [{"node": "Complete With llama-server", "type": "main", "index": 0}],
+        [{"node": "Return Chat Error", "type": "main", "index": 0}]
+      ]
+    },
+    "Complete With llama-server": {
+      "main": [[{"node": "Normalize Chat Completion", "type": "main", "index": 0}]]
+    },
+    "Normalize Chat Completion": {
+      "main": [[{"node": "Completion Ready?", "type": "main", "index": 0}]]
+    },
+    "Completion Ready?": {
+      "main": [
+        [{"node": "Return Chat Completion", "type": "main", "index": 0}],
+        [{"node": "Return Chat Error", "type": "main", "index": 0}]
+      ]
+    }
+  },
   "settings": {
     "executionOrder": "v1"
   },

--- a/ods/extensions/services/dashboard-api/tests/test_n8n_chat_endpoint_template.py
+++ b/ods/extensions/services/dashboard-api/tests/test_n8n_chat_endpoint_template.py
@@ -1,0 +1,111 @@
+"""Import-boundary contract for the shipped Chat API Endpoint workflow."""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+ROOT = Path(__file__).resolve().parents[4]
+WORKFLOW_FILE = ROOT / "config" / "n8n" / "01-chat-endpoint.json"
+
+
+def _response_context(response):
+    context = AsyncMock()
+    context.__aenter__ = AsyncMock(return_value=response)
+    context.__aexit__ = AsyncMock(return_value=False)
+    return context
+
+
+def test_chat_endpoint_public_enable_imports_and_activates_runnable_graph(
+    test_client, monkeypatch,
+):
+    import routers.workflows as workflows
+
+    workflow = json.loads(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    monkeypatch.setattr(workflows, "WORKFLOW_CATALOG_FILE", WORKFLOW_FILE.parent / "catalog.json")
+    monkeypatch.setattr(workflows, "WORKFLOW_DIR", WORKFLOW_FILE.parent)
+    monkeypatch.setattr(
+        workflows,
+        "check_workflow_dependencies",
+        AsyncMock(return_value={"llama-server": True}),
+    )
+
+    create_response = AsyncMock()
+    create_response.status = 201
+    create_response.json = AsyncMock(return_value={"data": {"id": "chat-endpoint-1"}})
+    activate_response = AsyncMock()
+    activate_response.status = 200
+
+    session = AsyncMock()
+    session.post = MagicMock(return_value=_response_context(create_response))
+    session.patch = MagicMock(return_value=_response_context(activate_response))
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.workflows.aiohttp.ClientSession", return_value=session):
+        response = test_client.post(
+            "/api/workflows/chat-endpoint/enable",
+            headers=test_client.auth_headers,
+        )
+
+    assert response.status_code == 200
+    assert response.json()["activated"] is True
+    assert response.json()["n8nId"] == "chat-endpoint-1"
+    assert session.post.call_args.kwargs["json"] == workflow
+    session.patch.assert_called_once()
+
+
+def test_chat_endpoint_graph_exposes_bounded_non_streaming_llama_request():
+    workflow = json.loads(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    by_name = {node["name"]: node for node in workflow["nodes"]}
+
+    assert "Start" not in by_name
+    assert by_name["Receive Chat Request"]["parameters"] == {
+        "httpMethod": "POST",
+        "path": "ods-chat-completions",
+        "responseMode": "responseNode",
+        "options": {},
+    }
+
+    completion = by_name["Complete With llama-server"]
+    assert completion["parameters"]["url"] == (
+        "http://llama-server:8080/v1/chat/completions"
+    )
+    assert completion["parameters"]["options"]["timeout"] == 180000
+    assert completion["onError"] == "continueRegularOutput"
+    request_body = completion["parameters"]["jsonBody"]
+    assert "messages: $json.messages" in request_body
+    assert "max_tokens: $json.max_tokens" in request_body
+    assert "stream: false" in request_body
+
+    connections = workflow["connections"]
+    assert connections["Request Valid?"]["main"][1][0]["node"] == (
+        "Return Chat Error"
+    )
+    assert connections["Completion Ready?"]["main"][1][0]["node"] == (
+        "Return Chat Error"
+    )
+
+
+def test_chat_endpoint_validates_input_and_sanitizes_upstream_output():
+    workflow = json.loads(WORKFLOW_FILE.read_text(encoding="utf-8"))
+    by_name = {node["name"]: node for node in workflow["nodes"]}
+    validation_code = by_name["Validate Chat Request"]["parameters"]["jsCode"]
+    normalize_code = by_name["Normalize Chat Completion"]["parameters"]["jsCode"]
+
+    for contract in (
+        "messages.length > 50",
+        "allowedRoles.has(message.role)",
+        "message.content.length > 16000",
+        "totalCharacters > 32000",
+        "body.stream === true",
+        "maxTokens > 4096",
+        "temperature > 2",
+    ):
+        assert contract in validation_code
+
+    assert "response.choices" in normalize_code
+    assert "message: { role: 'assistant', content }" in normalize_code
+    assert "prompt_tokens: tokenCount" in normalize_code
+    assert "statusCode: 502" in normalize_code
+    assert "...response" not in normalize_code


### PR DESCRIPTION
## Summary

- replace the Chat API Endpoint placeholder with an activatable `POST /webhook/ods-chat-completions` workflow
- validate and bound messages, roles, model ID, temperature, output tokens, total input size, and non-streaming mode
- forward a normalized request to the local llama-server with a three-minute inference timeout
- emit an allowlisted OpenAI-compatible completion shape or explicit 400/502 error JSON

## Why this matters

The dashboard catalog promises a one-minute REST chat endpoint, but enabling the template previously imported only a manual trigger and setup note. This PR turns that reachable catalog action into a usable local API facade with safer limits and predictable responses.

The invariant is: unvalidated fields never reach llama-server, streaming cannot enter a response-node workflow, upstream payloads are not reflected wholesale, and every accepted request has one terminal JSON response.

## Overlap check

Searched open and closed upstream PR titles/bodies for `n8n chat API endpoint workflow`, reviewed the latest 1,000 open PRs and changed production files, and inspected `01-chat-endpoint.json` history. No open or closed PR implements this workflow or changes its production file; upstream history only contains the repository rename. Other runnable n8n PRs operate on distinct catalog entries.

The HTTP Request node shape was checked against n8n's official implementation: https://github.com/n8n-io/n8n/blob/master/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts

## Test plan

- `python -m pytest test_n8n_chat_endpoint_template.py test_workflows.py -q` ? 48 passed
  - authenticated public enable imports the exact shipped graph and activates its n8n ID
  - webhook path, llama request, timeout, non-streaming body, validation ceilings, error branches, and allowlisted output
  - all existing workflow-management tests remain green
- `docker run --rm ... n8nio/n8n:2.6.4 import:workflow --input=/workflows/01-chat-endpoint.json` ? successfully imported 1 workflow using the exact image ODS ships
- `python -m json.tool ods/config/n8n/01-chat-endpoint.json`
- `python -m compileall -q .../test_n8n_chat_endpoint_template.py`
- `git diff --check`

## Design and operational notes

- This workflow intentionally supports text messages and non-streaming completion only; direct ODS APIs remain the path for streaming, tools, and multimodal payloads.
- The existing n8n/llama-server network boundary and dependency gate are reused; no external credential or service is introduced.
- HTTP failures continue into a controlled 502 response. Successful output retains only completion identity, one assistant choice, finish reason, and sanitized token counters.
- Exact-version CLI import proves n8n 2.6.4 accepts the graph. A live inference call was not claimed because no running model endpoint was part of this validation.
- Rollback restores the catalog placeholder with no persisted-data migration.

Generated with Codex.

## Batch compatibility

- Recommended merge/application order: #3706 -> #3707 -> #3708 -> #3709 -> #3710 -> #3711 -> #3712 -> #3713 -> #3714 -> #3715. The PRs have no runtime dependency; this order also covers the shared MODEL-SWITCHBOARD.md edits in #3708/#3709.
- Synthetic integration head: tang-vu/DreamServer commit 5e4e354e on integration/features-ten-20260904, built from upstream/main 6ff9b4fc plus all ten PR heads.
- Combined validation: 12 BATS tests passed; 132 focused API/workflow pytest tests passed; 6 dashboard Vitest tests passed; ESLint and the 1,771-module Vite production build passed; make lint, installer integration (69 passed, 3 skipped), the 6-test ods-test contract, mobile dispatch smoke, and exact n8n 2.6.4 imports for both workflow templates passed. git diff --check is clean.
- Full-suite limitation: make test reaches tests/test-installer-noninteractive-sudo.sh and reports 3 passed / 2 failed when WSL runs as root. The same two assertions fail unchanged on the clean upstream base 6ff9b4fc, so this is recorded as environment/baseline evidence rather than attributed to this batch. All required GitHub checks for the ten PR heads are green as of 2026-09-04.
