### PR TITLE
fix(remote-provider): reject invalid probe payloads

### DIFF
--- a/ods/bin/remote_provider/probe.py
+++ b/ods/bin/remote_provider/probe.py
@@ -167,13 +167,20 @@ def _probe_models_endpoint(
             "provider_http_error",
             f"remote provider probe returned HTTP {status}",
         )
+    model_count = _model_count(body)
+    if model_count is None:
+        raise ProbeError(
+            502,
+            "provider_probe_invalid_response",
+            "remote provider probe did not return an OpenAI-compatible model list",
+        )
     return {
         "ok": True,
         "status": status,
         "endpoint": "/v1/models",
         "transport": transport,
         "contentType": content_type,
-        "modelCount": _model_count(body),
+        "modelCount": model_count,
         "resolution": dict(resolution),
     }
 

--- a/ods/tests/contracts/test-remote-provider-egress-policy.py
+++ b/ods/tests/contracts/test-remote-provider-egress-policy.py
@@ -790,6 +790,32 @@ def test_direct_provider_probe_is_bounded_and_redacted() -> None:
     )
 
 
+def test_provider_probe_rejects_non_model_success_payloads() -> None:
+    route = plan_route(cloud_direct_env())
+
+    for body in (
+        b"<html><body>proxy login</body></html>",
+        b'{"object":"list","data":"not-a-list"}',
+    ):
+        error = assert_raises_probe_error(
+            lambda body=body: probe_direct_provider(
+                route,
+                provider_secret="unit-test-provider-token",
+                resolver=_public_resolver,
+                opener=lambda *_args, **_kwargs: _ProbeResponse(body),
+            ),
+            "a successful non-model response must not prove the provider route",
+        )
+        assert_true(
+            error.status == 502,
+            "invalid provider payload should report a bad gateway",
+        )
+        assert_true(
+            error.code == "provider_probe_invalid_response",
+            "invalid provider payload error code drifted",
+        )
+
+
 def test_public_probe_receipt_is_redacted_and_typed() -> None:
     receipt = public_probe_receipt(
         {
@@ -907,6 +933,7 @@ def main() -> int:
         test_lifecycle_ssh_operation_tracks_secret_custody_without_leaks,
         test_lifecycle_rejects_unsafe_or_secret_public_inputs,
         test_direct_provider_probe_is_bounded_and_redacted,
+        test_provider_probe_rejects_non_model_success_payloads,
         test_public_probe_receipt_is_redacted_and_typed,
         test_direct_provider_probe_fails_closed_before_unsafe_dns_request,
         test_generic_ssh_provider_probe_uses_tunnel_boundary,


### PR DESCRIPTION
﻿## Why this matters

The configured-provider handshake currently treats any HTTP 2xx response from `/v1/models` as proof that a route is OpenAI-compatible. A captive portal, reverse-proxy error page, or malformed JSON can therefore mark a broken provider as ready and defer the failure to the first user request.

This change requires the successful response to contain the OpenAI model-list `data` array. Invalid success payloads fail closed with a stable `provider_probe_invalid_response` / 502 error; an empty model list remains valid.

## What changed

- validate the bounded probe body before returning a successful receipt
- reuse the parsed model count instead of silently returning `null`
- cover both non-JSON and wrong-schema HTTP 200 responses

## Overlap check

Searched open and closed upstream PRs for remote-provider probe validation, invalid model-list responses, and `modelCount`; no semantic overlap found. No open upstream PR currently changes `ods/bin/remote_provider/probe.py` or its policy contract test.

## Validation

- `python3 tests/contracts/test-remote-provider-egress-policy.py`
- `python3 tests/contracts/test-remote-provider-egress-service.py`
