### PR TITLE
fix(installer): require Docker Compose in wizard

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -34,9 +34,26 @@ pub struct PrerequisiteStatus {
     pub git_installed: bool,
     pub docker_installed: bool,
     pub docker_running: bool,
+    pub compose_installed: bool,
+    pub compose_version: Option<String>,
     pub wsl2_needed: bool,
     pub wsl2_installed: bool,
     pub all_met: bool,
+}
+
+fn prerequisites_met(
+    git_installed: bool,
+    docker_installed: bool,
+    docker_running: bool,
+    compose_installed: bool,
+    wsl2_needed: bool,
+    wsl2_installed: bool,
+) -> bool {
+    git_installed
+        && docker_installed
+        && docker_running
+        && compose_installed
+        && (!wsl2_needed || wsl2_installed)
 }
 
 #[tauri::command]
@@ -54,16 +71,21 @@ pub fn check_prerequisites() -> PrerequisiteStatus {
         true
     };
 
-    let all_met = git
-        && docker_status.installed
-        && docker_status.running
-        && docker_status.compose_installed
-        && (!wsl2_needed || wsl2_installed);
+    let all_met = prerequisites_met(
+        git,
+        docker_status.installed,
+        docker_status.running,
+        docker_status.compose_installed,
+        wsl2_needed,
+        wsl2_installed,
+    );
 
     PrerequisiteStatus {
         git_installed: git,
         docker_installed: docker_status.installed,
         docker_running: docker_status.running,
+        compose_installed: docker_status.compose_installed,
+        compose_version: docker_status.compose_version,
         wsl2_needed,
         wsl2_installed,
         all_met,
@@ -297,5 +319,34 @@ fn state_file_path() -> std::path::PathBuf {
         std::path::PathBuf::from(base)
             .join("ods")
             .join("installer-state.json")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compose_is_required_before_installation_can_continue() {
+        assert!(!prerequisites_met(true, true, true, false, false, true));
+        assert!(prerequisites_met(true, true, true, true, false, true));
+    }
+
+    #[test]
+    fn prerequisite_payload_exposes_compose_status() {
+        let payload = serde_json::to_value(PrerequisiteStatus {
+            git_installed: true,
+            docker_installed: true,
+            docker_running: true,
+            compose_installed: false,
+            compose_version: None,
+            wsl2_needed: false,
+            wsl2_installed: true,
+            all_met: false,
+        })
+        .unwrap();
+
+        assert_eq!(payload["compose_installed"], false);
+        assert!(payload["compose_version"].is_null());
     }
 }

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -39,6 +39,8 @@ export interface PrerequisiteStatus {
   git_installed: boolean;
   docker_installed: boolean;
   docker_running: boolean;
+  compose_installed: boolean;
+  compose_version: string | null;
   wsl2_needed: boolean;
   wsl2_installed: boolean;
   all_met: boolean;

--- a/installer/src/pages/Prerequisites.tsx
+++ b/installer/src/pages/Prerequisites.tsx
@@ -50,6 +50,13 @@ export default function Prerequisites({ onNext, onError }: Props) {
             <StatusIcon status="pass" />
             <span className="text-gray-300">Docker</span>
           </div>
+          <div className="flex items-center gap-3">
+            <StatusIcon status="pass" />
+            <span className="text-gray-300">
+              Docker Compose
+              {prereqs.compose_version ? ` (${prereqs.compose_version})` : ""}
+            </span>
+          </div>
           {prereqs.wsl2_needed && (
             <div className="flex items-center gap-3">
               <StatusIcon status="pass" />
@@ -155,7 +162,9 @@ export default function Prerequisites({ onNext, onError }: Props) {
           <div className="flex items-center gap-3">
             <StatusIcon
               status={
-                prereqs.docker_installed && prereqs.docker_running
+                prereqs.docker_installed &&
+                prereqs.docker_running &&
+                prereqs.compose_installed
                   ? "pass"
                   : dockerStatus === "installing"
                     ? "loading"
@@ -169,6 +178,13 @@ export default function Prerequisites({ onNext, onError }: Props) {
                   Docker is installed but not running. Please start it.
                 </p>
               )}
+              {prereqs.docker_installed &&
+                prereqs.docker_running &&
+                !prereqs.compose_installed && (
+                  <p className="text-xs text-yellow-500">
+                    Docker Compose is not available. Install it, then re-check.
+                  </p>
+                )}
             </div>
           </div>
           {!prereqs.docker_installed && dockerStatus === "idle" && (
@@ -200,14 +216,7 @@ export default function Prerequisites({ onNext, onError }: Props) {
           <Button variant="ghost" onClick={handleRecheck}>
             Re-check
           </Button>
-          <Button
-            onClick={onNext}
-            disabled={
-              !prereqs.git_installed ||
-              !prereqs.docker_installed ||
-              !prereqs.docker_running
-            }
-          >
+          <Button onClick={onNext} disabled={!prereqs.all_met}>
             Continue
           </Button>
         </div>


### PR DESCRIPTION
﻿## Why this matters

The Rust prerequisite check already considers Docker Compose mandatory, but the desktop IPC payload omits Compose status and the React Continue button reimplements a weaker condition. A machine with Docker Engine running but no Compose can therefore advance and only fail after installation starts.

This change makes Compose part of the public prerequisite contract, shows an actionable missing-Compose state, and gates Continue on the backend's canonical `all_met` result.

## What changed

- expose Compose availability/version through `check_prerequisites`
- render Compose in both success and remediation states
- use the backend's complete prerequisite decision for the Continue button
- add Rust regression tests for the gate and serialized IPC payload

## Overlap check

Searched open and closed upstream PRs for desktop prerequisite handling, Docker Compose gating, and `PrerequisiteStatus`; no semantic overlap found. No open upstream PR changes the prerequisite page. Existing open installer PRs touch separate command sections; this patch remains logically independent.

## Validation

- `npm run build`
- `git diff --check`

The Rust unit tests are included for CI; this runner does not have a Rust toolchain installed.
