### PR TITLE
fix(installer): stop blocking voice install on 8-CPU Macs

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -994,6 +994,23 @@ _install_opencode() {
     rm -f "$tmpfile"
 }
 
+# Pre-flight the docker daemon's CPU allocation.
+#
+# This is a viability floor, NOT a compose-validity guard. Two reasons it
+# cannot be the latter:
+#
+#   1. Docker enforces `deploy.resources.limits.cpus` per service, never as a
+#      sum across the stack. The `range of CPUs is from 0.01 to N` error fires
+#      only when a *single* service pins more CPUs than the daemon exposes, so
+#      the relevant comparison is `max_pin <= N` — not `max_pin + headroom`.
+#   2. Even that can't be violated: the env generator clamps every generated
+#      *_CPU_LIMIT to the daemon's CPU count (`cap_cpu_value` in
+#      lib/env-generator.sh), which is why .env.example documents them as
+#      "capped to CPUs actually exposed by Docker". An over-large pin never
+#      reaches compose.
+#
+# So: hard-fail only when the daemon is too small to run the stack at all, and
+# warn — don't exit — when the workload's largest single pin will be clamped.
 _require_docker_cpu_budget() {
     local min_cpus="${1:-6}"
     local max_pin="${2:-4}"
@@ -1006,7 +1023,7 @@ _require_docker_cpu_budget() {
 
     docker_ncpu=$(get_docker_available_cpus)
     if [[ "$docker_ncpu" =~ ^[0-9]+$ ]] && [[ "$docker_ncpu" -lt "$min_cpus" ]]; then
-        ai_err "Docker daemon only has ${docker_ncpu} CPU(s); ODS's ${workload} pins limits up to ${max_pin} CPUs per service and needs at least ${min_cpus} to avoid 'range of CPUs is from 0.01 to N' compose failures."
+        ai_err "Docker daemon only has ${docker_ncpu} CPU(s); ODS's ${workload} needs at least ${min_cpus} to run."
         case "${DOCKER_BACKEND:-unknown}" in
             colima)
                 ai "Stop and re-create the Colima VM with more CPUs:"
@@ -1028,6 +1045,11 @@ _require_docker_cpu_budget() {
         esac
         exit 1
     fi
+
+    if [[ "$docker_ncpu" =~ ^[0-9]+$ ]] && [[ "$docker_ncpu" -lt "$max_pin" ]]; then
+        ai_warn "Docker daemon has ${docker_ncpu} CPU(s) and ODS's ${workload} pins up to ${max_pin} CPUs for a single service; those limits are clamped to ${docker_ncpu}. Expect slower voice responses under load."
+    fi
+
     ai_ok "Docker CPU budget: ${docker_ncpu} (>=${min_cpus} required for ${workload})"
 }
 
@@ -1180,21 +1202,19 @@ if ! _ensure_colima_private_network; then
     exit 1
 fi
 
-# Pre-flight the docker daemon's CPU allocation. Trip early with a clear
-# message rather than letting compose fail after pulls/builds. If the user
-# already requested voice from CLI flags (for example --all), account for
-# Kokoro's 8-CPU pin now; interactive feature selection is checked again
-# after the user picks features.
+# Check the daemon's CPU allocation early so an unusably small VM is caught
+# before pulls and builds. Voice raises the largest single-service pin to 8
+# (Kokoro/TTS) but not the floor — that pin is clamped to whatever Docker
+# exposes, so 8 CPUs runs the voice stack fine. Interactive feature selection
+# is re-checked after the user picks features.
 _docker_cpu_override="${ODS_MIN_DOCKER_CPUS:-}"
 _docker_cpu_min="${_docker_cpu_override:-6}"
 _docker_cpu_max_pin=4
 _docker_cpu_workload="base compose stack"
-if $ENABLE_VOICE && [[ -z "$_docker_cpu_override" ]]; then
-    _docker_cpu_min=10
+if $ENABLE_VOICE; then
     _docker_cpu_max_pin=8
     _docker_cpu_workload="voice-enabled compose stack"
 fi
-_docker_cpu_preflight_min="$_docker_cpu_min"
 _require_docker_cpu_budget "$_docker_cpu_min" "$_docker_cpu_max_pin" "$_docker_cpu_workload"
 
 # Catch a common Colima-after-DockerDesktop config bomb: when a prior
@@ -1547,8 +1567,11 @@ info_box "  Langfuse:" "$(if $ENABLE_LANGFUSE; then echo enabled; else echo disa
 # why the dashboard shows no image-gen tile after install.
 info_box "  ComfyUI:" "not available on macOS (no MPS Docker image upstream)"
 
-if $ENABLE_VOICE && [[ -z "$_docker_cpu_override" ]] && [[ "${_docker_cpu_preflight_min:-0}" -lt 10 ]]; then
-    _require_docker_cpu_budget 10 8 "voice-enabled compose stack"
+# Voice may have been turned on during interactive feature selection, after
+# the preflight above already ran with base-stack pins. Re-check so the
+# operator still gets the clamp advisory for Kokoro's 8-CPU pin.
+if $ENABLE_VOICE && [[ "$_docker_cpu_max_pin" -lt 8 ]]; then
+    _require_docker_cpu_budget "$_docker_cpu_min" 8 "voice-enabled compose stack"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Summary

The macOS installer refused to install the voice stack on any Mac with 8 Docker CPUs (M1/M2 Air, base M1 Pro), failing with:

> Docker daemon only has 8 CPU(s); ODS's voice-enabled compose stack pins limits up to 8 CPUs per service and needs at least 10 to avoid 'range of CPUs is from 0.01 to N' compose failures.

The remedy it suggests — raise Docker Desktop to 10+ CPUs — is impossible on an 8-core machine. Affected users are installing without whisper and kokoro.

The gate required `max_pin + 2` CPUs. Neither half of that reasoning holds:

1. Docker enforces `deploy.resources.limits.cpus` per service, never as a sum across the stack. The `range of CPUs is from 0.01 to N` error fires only when a single service pins more than N, so the real constraint is `max_pin <= N`. An 8-CPU daemon running an 8.0 TTS pin is valid; the +2 headroom guards nothing Docker checks.
2. The error is unreachable regardless. `cap_cpu_value()` (`installers/macos/lib/env-generator.sh:85`, mirrored at `installers/phases/06-directories.sh:636`) already clamps every generated `*_CPU_LIMIT` to the daemon's CPU count before compose sees it — which is why `.env.example:240` documents them as "capped to CPUs actually exposed by Docker."

So the gate hard-failed working configurations to prevent a failure that cannot occur.

This reframes the check as a viability floor rather than a compose-validity guard: voice keeps the base 6-CPU floor instead of escalating to 10, and the 8-CPU pin now emits a clamp advisory rather than calling `exit 1`. Also drops the dead `_docker_cpu_preflight_min` bookkeeping, which existed only to avoid double-tripping the 10-CPU gate during interactive feature selection.

macOS-only — the Linux `installers/phases/` path has no equivalent guard.


## Release Lane

* [x] Stable hotfix targeting `release/2.6.x`
* [ ] Mainline change targeting `main`
* [ ] Next-minor work targeting the next feature/minor release
* [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
release/2.6.x carries the identical gate (lines 1009 and 1193 of installers/macos/install-macos.sh), so users on current stable hit this on any 8-CPU Apple Silicon Mac. This is a clean-install blocker on a supported default path with no workaround available to the user — the error's own remediation advice cannot be followed on 8-core hardware.

RELEASE_CHANNELS.md lists "installer, bootstrap, reinstall, restart, or doctor regressions" as a stable patch candidate. The change is narrow: it relaxes one preflight threshold and downgrades one fatal path to a warning. It adds no service, changes no default, and refactors nothing.

```

## Changed Surface

* [ ] Docs only
* [ ] Tests only
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [x] Installer / bootstrap / lifecycle
* [ ] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

## Risk And Validation

* Risk level: High — HIGH_RISK_CHANGE_MAP.md classifies the macOS installer as High. Note the change is risk-reducing in direction: it removes a fatal exit and adds no new failure path. The residual risk is that the 6-CPU floor is now the only gate for voice.
* Validation run:
* [x] `git diff --check`
* [ ] Markdown/link sanity for docs
* [x] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`
* [ ] Not required because: 



Commands/results:

```text
$ git diff --check
(clean — no whitespace errors)

$ make lint
=== Shell syntax ===
=== Python compile ===
All lint checks passed.

$ bash tests/smoke/macos-dispatch.sh
[smoke] macOS dispatch and support messaging
[smoke] PASS macos-dispatch

$ make test
Results: 76 passed
ERROR: 03-features.sh requires Bash 4.0+ (current: 3.2.57(1)-release)
   -> environment limit, not a regression. Dev box has only macOS system bash
      3.2 and no Homebrew bash. CI covers the remainder.

Gate behavior, _require_docker_cpu_budget exercised against stubbed CPU counts:
   ncpu=8  min=6 max_pin=8 (voice)  -> PROCEEDS   <- the reported failure case
   ncpu=6  min=6 max_pin=8 (voice)  -> PROCEEDS + clamp advisory
   ncpu=4  min=6 max_pin=8 (voice)  -> EXIT 1 on the floor
   ncpu=16 min=6 max_pin=8 (voice)  -> PROCEEDS
   ncpu=8  min=6 max_pin=4 (base)   -> PROCEEDS

Clamp confirmed to make an out-of-range pin unreachable (cap_cpu_value):
   ncpu=4  -> TTS_CPU_LIMIT=4.0   COMFYUI_CPU_LIMIT=4.0
   ncpu=6  -> TTS_CPU_LIMIT=6.0   COMFYUI_CPU_LIMIT=6.0
   ncpu=8  -> TTS_CPU_LIMIT=8.0   COMFYUI_CPU_LIMIT=8.0
   ncpu=16 -> TTS_CPU_LIMIT=8.0   COMFYUI_CPU_LIMIT=16.0
   Every result satisfies cpus <= ncpu, so compose never receives a pin that
   could raise "range of CPUs is from 0.01 to N".

```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation, service manifests, dashboard API control flows, Hermes, model routing, GPU or runtime detection, lifecycle commands, host mutation, or network exposure, it requires release-grade fleet validation before release unless the PR explains a narrower equivalent.

* [ ] This is not an operational change.
* [ ] This is an operational change and validation is recorded above.
* [x] This is an operational change and validation is intentionally deferred for:

```text
This touches clean install, so it is operational under the map. Deferred lanes and why the narrower validation is proposed as sufficient:

- No real 8-CPU Apple Silicon Docker install was run. I have no such host. The gate is pure Bash arithmetic over `docker info --format {{.NCPU}}`, and it was exercised directly across the relevant CPU counts above.
- No macOS lifecycle or model-swap lane. The change cannot reach either: it runs once in preflight, before any install work, and only decides whether to exit. It writes no config and mutates no host state.
- No compose validation lane. No compose file or manifest changed, and the generated *_CPU_LIMIT values are produced by the untouched clamp path verified above.

A reviewer with an 8-core Mac confirming that `./install.sh --all` gets past preflight would close the remaining gap. Requesting that before release.

```
