### PR TITLE
fix(detect-hardware): witness NVIDIA GPUs on WSL2 via nvidia-smi

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -21,6 +21,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-install-docs.sh
 	@bash tests/test-hosted-bootstrap-verifier.sh
 	@echo ""
+	@echo "=== Hardware detection ==="
+	@bash tests/test-wsl2-gpu-detection.sh
+	@echo ""
 	@echo "=== Tier map tests ==="
 	@bash tests/test-tier-map.sh
 	@bash tests/test-installer-context-parity.sh

--- a/ods/scripts/detect-hardware.sh
+++ b/ods/scripts/detect-hardware.sh
@@ -76,7 +76,9 @@ in_container() {
 
 # Detect if inside WSL2
 is_wsl() {
-    [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>/dev/null
+    # ODS_PROC_VERSION can be overridden in tests to point at a fixture.
+    local _proc_version="${ODS_PROC_VERSION:-/proc/version}"
+    [[ -f "$_proc_version" ]] && grep -qi microsoft "$_proc_version" 2>/dev/null
 }
 
 # Colors
@@ -135,10 +137,18 @@ detect_nvidia() {
     # Validate NVIDIA hardware present in sysfs before trusting nvidia-smi,
     # which may be installed without NVIDIA hardware (e.g. nvidia-container-toolkit
     # on AMD-only systems).
+    # ODS_DRM_SYS can be overridden in tests to point at a mock sysfs tree.
+    local _drm_sys="${ODS_DRM_SYS:-/sys/class/drm}"
     local _has_nvidia=false
-    for _v in /sys/class/drm/card*/device/vendor; do
+    for _v in "$_drm_sys"/card*/device/vendor; do
         [[ "$(cat "$_v" 2>/dev/null)" == "0x10de" ]] && _has_nvidia=true && break
     done
+    # WSL2 exposes no /sys/class/drm/card* entries, so sysfs cannot witness the GPU there even
+    # though CUDA works and nvidia-smi reports it. Fall back to nvidia-smi as the sole hardware
+    # witness on WSL2 -- the same fallback installers/lib/detection.sh already applies.
+    if ! $_has_nvidia && is_wsl; then
+        command -v nvidia-smi &>/dev/null && _has_nvidia=true
+    fi
     $_has_nvidia || return 1
 
     # Works on bare metal Linux; on WSL2 it may be present via Docker Desktop GPU integration.

--- a/ods/tests/test-wsl2-gpu-detection.sh
+++ b/ods/tests/test-wsl2-gpu-detection.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# ============================================================================
+# WSL2 NVIDIA GPU detection contract
+#
+# Regression guard for scripts/detect-hardware.sh::detect_nvidia().
+#
+# The sysfs vendor scan (/sys/class/drm/card*/device/vendor == 0x10de) exists so
+# a stray nvidia-smi -- e.g. nvidia-container-toolkit installed on an AMD-only
+# box -- cannot be mistaken for NVIDIA hardware. WSL2 exposes no
+# /sys/class/drm/card* entries at all, so on WSL2 that scan finds nothing even
+# though CUDA works and nvidia-smi reports the GPU.
+#
+# installers/lib/detection.sh already falls back to nvidia-smi as the sole
+# hardware witness under WSL2; scripts/detect-hardware.sh carried a copy of the
+# same guard without that fallback, and so reported "no GPU" on every WSL2 host.
+#
+# These cases pin both halves: the WSL2 fallback must fire, and it must not
+# weaken the AMD-only guard on non-WSL hosts.
+#
+# Run: bash tests/test-wsl2-gpu-detection.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+# Source the script under test (detect_nvidia, is_wsl, first_line). The script
+# guards its own main() with [[ "${BASH_SOURCE[0]}" == "$0" ]], so this is inert.
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/scripts/detect-hardware.sh"
+set +e
+
+assert_detects() {
+    local label="$1" status="$2" output="$3"
+    if [[ "$status" -eq 0 && -n "$output" ]]; then
+        echo "  PASS: $label (detected '$output')"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected detection, got status=$status output='$output')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_rejects() {
+    local label="$1" status="$2" output="$3"
+    if [[ "$status" -ne 0 ]]; then
+        echo "  PASS: $label (correctly rejected)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected rejection, got status=0 output='$output')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+FIXTURE_DIR="$(mktemp -d -t ods-wsl2-fixture-XXXXXX)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# WSL2 kernels carry "microsoft" in /proc/version; native kernels do not.
+echo "Linux version 6.6.87.2-microsoft-standard-WSL2 (root@builder) #1 SMP" \
+    > "$FIXTURE_DIR/proc-version-wsl"
+echo "Linux version 6.8.0-51-generic (buildd@lcy02) #52-Ubuntu SMP" \
+    > "$FIXTURE_DIR/proc-version-native"
+
+# An empty DRM tree: what WSL2 actually presents (no card* entries at all).
+mkdir -p "$FIXTURE_DIR/drm-empty"
+
+# A bare-metal NVIDIA DRM tree.
+mkdir -p "$FIXTURE_DIR/drm-nvidia/card0/device"
+echo "0x10de" > "$FIXTURE_DIR/drm-nvidia/card0/device/vendor"
+
+# An AMD-only DRM tree -- the case the sysfs guard was added to defend.
+mkdir -p "$FIXTURE_DIR/drm-amd/card0/device"
+echo "0x1002" > "$FIXTURE_DIR/drm-amd/card0/device/vendor"
+
+# nvidia-smi stub answering only the query detect_nvidia() makes.
+mkdir -p "$FIXTURE_DIR/bin"
+cat > "$FIXTURE_DIR/bin/nvidia-smi" <<'STUB'
+#!/usr/bin/env bash
+echo "NVIDIA GeForce RTX 3060, 12288"
+STUB
+chmod +x "$FIXTURE_DIR/bin/nvidia-smi"
+
+WITH_SMI="$FIXTURE_DIR/bin:$PATH"
+
+# A PATH with every nvidia-smi-bearing directory removed, so "not installed"
+# is simulated without assuming where the real binary lives.
+path_without_nvidia_smi() {
+    local out="" d
+    local -a dirs
+    IFS=':' read -ra dirs <<< "$PATH"
+    for d in "${dirs[@]}"; do
+        [[ -n "$d" && -x "$d/nvidia-smi" ]] && continue
+        out="${out:+$out:}$d"
+    done
+    printf '%s' "$out"
+}
+WITHOUT_SMI="$(path_without_nvidia_smi)"
+
+run_case() {
+    # run_case <proc-version> <drm-tree> <path>
+    local out
+    out="$(ODS_PROC_VERSION="$1" ODS_DRM_SYS="$2" PATH="$3" detect_nvidia 2>/dev/null)"
+    LAST_STATUS=$?
+    LAST_OUTPUT="$out"
+}
+
+echo "=== detect_nvidia() on WSL2 (no sysfs DRM entries) ==="
+echo ""
+
+run_case "$FIXTURE_DIR/proc-version-wsl" "$FIXTURE_DIR/drm-empty" "$WITH_SMI"
+assert_detects "WSL2 + nvidia-smi present -> GPU detected" "$LAST_STATUS" "$LAST_OUTPUT"
+
+run_case "$FIXTURE_DIR/proc-version-wsl" "$FIXTURE_DIR/drm-empty" "$WITHOUT_SMI"
+assert_rejects "WSL2 + no nvidia-smi -> no witness, no GPU" "$LAST_STATUS" "$LAST_OUTPUT"
+
+echo ""
+echo "=== the sysfs guard still holds on non-WSL hosts ==="
+echo ""
+
+run_case "$FIXTURE_DIR/proc-version-native" "$FIXTURE_DIR/drm-empty" "$WITH_SMI"
+assert_rejects "native + nvidia-smi but no NVIDIA in sysfs -> rejected" "$LAST_STATUS" "$LAST_OUTPUT"
+
+run_case "$FIXTURE_DIR/proc-version-native" "$FIXTURE_DIR/drm-amd" "$WITH_SMI"
+assert_rejects "native AMD-only box with nvidia-container-toolkit -> rejected" "$LAST_STATUS" "$LAST_OUTPUT"
+
+echo ""
+echo "=== bare-metal NVIDIA detection is unchanged ==="
+echo ""
+
+run_case "$FIXTURE_DIR/proc-version-native" "$FIXTURE_DIR/drm-nvidia" "$WITH_SMI"
+assert_detects "native + NVIDIA vendor 0x10de in sysfs -> GPU detected" "$LAST_STATUS" "$LAST_OUTPUT"
+
+echo ""
+echo "============================================================"
+echo "  Passed: $PASS   Failed: $FAIL"
+echo "============================================================"
+
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`scripts/detect-hardware.sh` reported **no GPU on every WSL2 host**, even with working CUDA and a healthy `nvidia-smi`.

`detect_nvidia()` gates `nvidia-smi` behind a sysfs vendor scan (`/sys/class/drm/card*/device/vendor == 0x10de`) so a stray `nvidia-smi` — e.g. `nvidia-container-toolkit` installed on an AMD-only box — cannot be mistaken for NVIDIA hardware. That guard is right on bare metal. But **WSL2 exposes no `/sys/class/drm/card*` entries at all**, so the scan finds nothing there regardless of what hardware is present.

`installers/lib/detection.sh` already handles exactly this — it falls back to `nvidia-smi` as the sole hardware witness under WSL2 ([`detection.sh#L345-L348`](https://github.com/Osmantic/ODS/blob/main/ods/installers/lib/detection.sh#L345-L348)). `scripts/detect-hardware.sh` carries a copy of the same sysfs guard **without** that fallback. This PR restores parity — it is not a new policy, it is the sibling module's existing one applied where it was dropped.

Measured on a WSL2 host with 2× NVIDIA GPUs:

| | `gpu.type` | `count` | `vram_mb` | recommendation |
|---|---|---|---|---|
| before | `none` | 0 | 0 | `phi-4-mini`, TIER 1 |
| after | `nvidia` | 2 | 12288 | `qwen3.5-9b`, TIER 2 |

The installer's summary card moves from `GPU: None / VRAM: 0GB / TIER 1` to `VRAM: 12GB / CLASSIFICATION: TIER 2`.

Also adds `tests/test-wsl2-gpu-detection.sh` (wired into `make test`). The two `ODS_*` overrides introduced here (`ODS_PROC_VERSION`, `ODS_DRM_SYS`) mirror the fixture hooks `installers/lib/detection.sh` already exposes, and are what let the test run against fixtures instead of real hardware.

## AI Assistance

Claude (Claude Code) did the investigation, wrote the patch and the test, and drafted this description. I ran it on my own WSL2 box and reviewed the diff. Two earlier hypotheses it raised were checked and **discarded as wrong** before this PR: that `installers/lib/detection.sh` mishandled WSL2 (it does not), and that `nvidia-smi` was missing (it was a `PATH` gap for a service user — `/usr/lib/wsl/lib`). Only the defect that reproduced is included here.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: **Low**. The new branch is reachable only when the sysfs scan already found nothing **and** `is_wsl` is true, so no non-WSL code path changes behaviour. On WSL2 the prior result was unconditionally "no GPU", so there is no working case to regress.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation — see Operational Change Check

Commands/results:

```text
$ bash tests/test-wsl2-gpu-detection.sh
=== detect_nvidia() on WSL2 (no sysfs DRM entries) ===
  PASS: WSL2 + nvidia-smi present -> GPU detected (detected 'NVIDIA GeForce RTX 3060, 12288')
  PASS: WSL2 + no nvidia-smi -> no witness, no GPU (correctly rejected)
=== the sysfs guard still holds on non-WSL hosts ===
  PASS: native + nvidia-smi but no NVIDIA in sysfs -> rejected (correctly rejected)
  PASS: native AMD-only box with nvidia-container-toolkit -> rejected (correctly rejected)
=== bare-metal NVIDIA detection is unchanged ===
  PASS: native + NVIDIA vendor 0x10de in sysfs -> GPU detected
  Passed: 5   Failed: 0

# Negative control -- the fix hunk removed, test hooks retained:
  FAIL: WSL2 + nvidia-smi present -> GPU detected (expected detection, got status=1 output='')
  Passed: 4   Failed: 1
# Exactly one case flips. The other four hold, so the fix is pinned and scoped.

$ scripts/detect-hardware.sh --json      # real WSL2 host, 2x NVIDIA
  before: gpu.type=none    count=0  vram_mb=0      recommended=phi-4-mini  tier=1
  after:  gpu.type=nvidia  count=2  vram_mb=12288  recommended=qwen3.5-9b  tier=2

$ make test
  === Hardware detection ===  Passed: 5  Failed: 0
```

`make test` on my box also shows 2 failures in `tests/contracts/test-installer-contracts.sh`
(`no-sudo run promoted Docker to sudo`, `no-sudo run invoked raw sudo`). These are **pre-existing and
unrelated** — they reproduce identically at `6ff9b4f` with this branch's changes stashed, and are an
artifact of my running the suite as `uid=0`, where no-sudo mode cannot be exercised.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

This touches GPU/runtime detection, so per the template it would normally want release-grade fleet
validation. I am offering a **narrower equivalent**: the affected platform is WSL2 only, the change was
verified end-to-end on a real WSL2 host with 2× NVIDIA GPUs (before/after above), and both halves of the
behaviour are pinned by fixture tests including the AMD-only case the original guard exists to defend.
Non-WSL platforms are unreachable from the new branch. Happy to run anything further you'd like.

## Notes For Reviewers

- **Scope is detection only.** This fixes what `detect-hardware.sh` reports. It is the first blocker on
  WSL2, not the last: on the same host I then hit `ERROR: no GPUs found in topology` from
  `assign_gpus.py`, because `nvidia-smi topo -m` has no topology matrix under WSL2. I have **not**
  root-caused that one and deliberately left it out rather than ship a guess. Happy to open a separate
  issue with the trace if useful.
- The WSL2 predicate differs slightly between the two modules: `detection.sh` greps
  `/proc/sys/kernel/osrelease`, while `detect-hardware.sh` has its own `is_wsl()` helper reading
  `/proc/version` (already used at two other call sites in that file). I used the file's own helper to
  stay local-idiomatic. Say the word if you'd rather they be unified.
- `is_wsl()` gains an `ODS_PROC_VERSION` override. It is used elsewhere in the file; the override is
  inert in production and only lets tests point at a fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
