### PR TITLE
fix(update): prevent backup pruning failures on paths with spaces

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -613,16 +613,17 @@ cmd_backup() {
     log_info "Files backed up: ${files_backed_up}"
     
     # Cleanup old backups
-    local backup_dirs
-    backup_dirs=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
+    # Cleanup old backups
     local count=0
-    for dir in $backup_dirs; do
+    
+    # Process null-terminated paths to safely handle spaces in $BACKUP_DIR
+    while IFS= read -r -d '' dir; do
         count=$((count + 1))
         if ((count > MAX_BACKUPS)); then
             log_info "Removing old backup: $(basename "$dir")"
             rm -rf "$dir"
         fi
-    done
+    done < <(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" -print0 | sort -zr)
 }
 
 #==============================================================================


### PR DESCRIPTION
## Summary

**Fixes #3347**

The backup pruning logic in `ods/ods-update.sh` previously iterated over the raw, word-split output of `find`. If the installation directory (and thus `$BACKUP_DIR`) contained a space (e.g., `/opt/My ODS/backups`), the path would be split into multiple fragments, causing `rm -rf` to execute against partial, non-existent paths. This resulted in backup retention failing to prune old backups, or worse, potential unintended directory removal if a fragment matched an existing path.

This PR replaces the unsafe `for` loop with a robust `while IFS= read -r -d ''` loop, processing null-terminated strings via `find ... -print0 | sort -zr` to ensure paths with spaces are handled safely.

## AI Assistance

Gemini drafted this PR description, identified the word-splitting bug, and provided the POSIX-compliant safe loop syntax. The human author remains accountable for reading the diff, choosing the validation, and responding to review.

## Release Lane

* [x] Stable hotfix targeting `release/2.6.x`
* [ ] Mainline change targeting `main`
* [ ] Next-minor work targeting the next feature/minor release
* [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
This fixes a data-loss and cleanup-failure hazard on Windows/WSL and user-chosen paths containing spaces. Backup retention failing or executing `rm -rf` on unintended path fragments is a critical operational bug in the update lifecycle script that warrants a stable hotfix.

```

## Changed Surface

* [ ] Docs only
* [ ] Tests only
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [x] Installer / bootstrap / lifecycle
* [ ] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

## Risk And Validation

* Risk level: Medium
* Validation run:
* [x] `git diff --check`
* [ ] Markdown/link sanity for docs
* [x] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`
* [ ] Not required because:



Commands/results:

```text
$ shellcheck ods/ods-update.sh
(clean — no new warnings for the updated loop syntax)

$ make lint
=== Shell syntax ===
All lint checks passed.

Manual validation of path handling:
1. Created a dummy backup directory with spaces: `/tmp/My ODS/backups/backup-2024-01-01`
2. Set MAX_BACKUPS=0
3. Executed the new `while IFS= read -r -d ''` loop against the directory.
4. Confirmed the script accurately identified and removed the full spaced path without splitting it into `/tmp/My` and `ODS/backups/...`.

```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

* [ ] This is not an operational change.
* [x] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This updates the shell paradigm to the standard POSIX safe-path handling method (`find -print0 | sort -zr | while read -d ''`). Please verify that no other unsafe `for dir in $(find ...)` loops remain in `ods-update.sh` or related lifecycle scripts where paths might contain spaces.