### PR TITLE
fix(macos): keep compose platform pins in the image preflight

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2409,17 +2409,34 @@ else
         return 1
     }
 
+    # Emits one "<image>\t<platform>" line per external Compose service.
+    #
+    # The platform column carries the per-service `platform:` pin that Compose
+    # already merged across every compose file (e.g. the embeddings extension
+    # pins linux/amd64 because text-embeddings-inference publishes no arm64
+    # manifest). `config --format json` is the only Compose output that exposes
+    # it, so it is the single authoritative source here.
+    #
+    # There is deliberately no `config --images` fallback: that command prints
+    # bare image refs with no platform column, so falling back to it silently
+    # downgrades every pinned image to a host-arch pull. On Apple Silicon that
+    # turns into an unfixable `no matching manifest for linux/arm64/v8` that
+    # burns the whole retry budget. A resolver that cannot report platforms is
+    # worse than no resolver -- fail loudly instead.
     _macos_compose_external_images() {
-        local config_json
-        if config_json="$(docker compose "${COMPOSE_FLAGS[@]}" config --format json 2>>"$ODS_LOG_FILE")"; then
-            if printf '%s' "$config_json" | python3 -c '
+        local config_json python_cmd
+        # Same interpreter the compose resolver proved out in _ensure_macos_pyyaml;
+        # a bare `python3` can be a different (or absent) PATH entry.
+        python_cmd="${ODS_PYTHON_CMD:-python3}"
+
+        config_json="$(docker compose "${COMPOSE_FLAGS[@]}" config --format json 2>>"$ODS_LOG_FILE")" || return 1
+        [[ -n "$config_json" ]] || return 1
+
+        printf '%s' "$config_json" | "$python_cmd" -c '
 import json
 import sys
 
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    sys.exit(1)
+data = json.load(sys.stdin)
 
 for service in (data.get("services") or {}).values():
     if service.get("build") is not None:
@@ -2430,16 +2447,8 @@ for service in (data.get("services") or {}).values():
     platform = str(service.get("platform") or "").strip()
     print(image + "\t" + platform)
 ' | while IFS=$'\t' read -r _image _platform; do
-                _macos_is_local_image "$_image" && continue
-                printf '%s\t%s\n' "$_image" "$_platform"
-            done | awk '!seen[$0]++'; then
-                return 0
-            fi
-        fi
-
-        docker compose "${COMPOSE_FLAGS[@]}" config --images 2>>"$ODS_LOG_FILE" | while IFS= read -r _image; do
             _macos_is_local_image "$_image" && continue
-            printf '%s\n' "$_image"
+            printf '%s\t%s\n' "$_image" "$_platform"
         done | awk '!seen[$0]++'
     }
 
@@ -2497,12 +2506,22 @@ for service in (data.get("services") or {}).values():
         _macos_normalize_image_platform "$inspected"
     }
 
+    # True when the registry error is a property of the published image rather
+    # than of the network. No amount of backoff makes a missing manifest appear,
+    # so retrying one only delays the abort by 5s+15s+30s.
+    _macos_pull_error_is_permanent() {
+        grep -Eqi \
+            'no matching manifest for|no match for platform in manifest|manifest unknown|manifest for .* not found' \
+            "$1"
+    }
+
     _macos_pull_image_with_retry() {
         # $2 is the compose service's platform pin (may be empty). Without it,
         # docker pull resolves the host platform (linux/arm64 on Apple
         # Silicon), which hard-fails for amd64-only images like TEI even
         # though compose would run them pinned under emulation.
         local image="$1" platform="${2:-}" attempt max_attempts delay cached_platform requested_platform
+        local attempt_log
         local -a delays=(5 15 30)
         local -a pull_cmd=(docker pull "$image")
         [[ -n "$platform" ]] && pull_cmd=(docker pull --platform "$platform" "$image")
@@ -2525,18 +2544,37 @@ for service in (data.get("services") or {}).values():
         fi
 
         max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-4}"
+        attempt_log="$(mktemp "${TMPDIR:-/tmp}/ods-compose-pull.XXXXXX")"
         for ((attempt=1; attempt<=max_attempts; attempt++)); do
             ai "Pulling Compose image ($attempt/$max_attempts): $image${platform:+ [$platform]}"
-            if "${pull_cmd[@]}" >>"$ODS_LOG_FILE" 2>&1; then
+            if "${pull_cmd[@]}" >"$attempt_log" 2>&1; then
+                cat "$attempt_log" >>"$ODS_LOG_FILE"
+                rm -f "$attempt_log"
                 ai_ok "Pulled $image"
                 return 0
             fi
+            cat "$attempt_log" >>"$ODS_LOG_FILE"
+
+            if _macos_pull_error_is_permanent "$attempt_log"; then
+                rm -f "$attempt_log"
+                ai_err "No ${platform:-host-architecture} manifest published for $image"
+                if [[ -n "$platform" ]]; then
+                    ai "Compose pins this service to $platform but the registry has no such manifest."
+                    ai "Check the image tag in the owning extension's compose.yaml."
+                else
+                    ai "This image is not published for the host architecture and Compose has no platform pin for it."
+                    ai "Add a 'platform:' key to the owning service (e.g. platform: linux/amd64) to run it under Rosetta 2."
+                fi
+                return 1
+            fi
+
             if (( attempt < max_attempts )); then
                 delay="${delays[$((attempt - 1))]:-30}"
                 ai_warn "Pull failed for $image; retrying in ${delay}s"
                 sleep "$delay"
             fi
         done
+        rm -f "$attempt_log"
 
         ai_err "Failed to pull Compose image after retries: $image"
         return 1
@@ -2545,8 +2583,8 @@ for service in (data.get("services") or {}).values():
     _macos_pre_pull_compose_images() {
         local image_output image platform failed
         image_output="$(_macos_compose_external_images)" || {
-            ai_err "Could not resolve macOS Docker Compose images before service launch"
-            ai "Inspect compose config with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} config --images"
+            ai_err "Could not resolve macOS Docker Compose images and platform pins before service launch"
+            ai "Inspect compose config with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} config --format json"
             return 1
         }
         [[ -n "$image_output" ]] || return 0

--- a/ods/tests/test-macos-compose-image-cache.sh
+++ b/ods/tests/test-macos-compose-image-cache.sh
@@ -44,7 +44,9 @@ for function_name in \
     _macos_compose_external_images \
     _macos_normalize_image_platform \
     _macos_cached_image_platform \
-    _macos_pull_image_with_retry; do
+    _macos_pull_error_is_permanent \
+    _macos_pull_image_with_retry \
+    _macos_pre_pull_compose_images; do
     function_body="$(extract_installer_function "$function_name")"
     [[ -n "$function_body" ]] || fail "could not extract $function_name"
     eval "$function_body"
@@ -59,7 +61,9 @@ MOCK_DOCKER_CALLS="$TMP_DIR/docker-calls.log"
 MOCK_INSPECT_EXIT=1
 MOCK_INSPECT_OUTPUT=""
 MOCK_PULL_EXIT=0
+MOCK_PULL_STDERR=""
 MOCK_COMPOSE_JSON=""
+MOCK_COMPOSE_CONFIG_EXIT=0
 
 ai() { :; }
 ai_ok() { :; }
@@ -76,9 +80,11 @@ docker() {
         return 0
     fi
     if [[ "$1" == "pull" ]]; then
+        [[ -n "$MOCK_PULL_STDERR" ]] && printf '%s\n' "$MOCK_PULL_STDERR" >&2
         return "$MOCK_PULL_EXIT"
     fi
     if [[ "$1" == "compose" && "$*" == *"config --format json"* ]]; then
+        [[ "$MOCK_COMPOSE_CONFIG_EXIT" -eq 0 ]] || return "$MOCK_COMPOSE_CONFIG_EXIT"
         printf '%s\n' "$MOCK_COMPOSE_JSON"
         return 0
     fi
@@ -90,6 +96,8 @@ reset_docker_mock() {
     MOCK_INSPECT_EXIT=1
     MOCK_INSPECT_OUTPUT=""
     MOCK_PULL_EXIT=0
+    MOCK_PULL_STDERR=""
+    MOCK_COMPOSE_CONFIG_EXIT=0
 }
 
 assert_call_count() {
@@ -137,6 +145,41 @@ grep -Fqx "$expected_unpinned" <<< "$compose_images" \
     || fail "local or built image leaked into external pre-pull set"
 pass "Compose JSON parsing preserves platform pins and filters local builds"
 
+# Regression: the resolver used to fall back to `config --images`, which has no
+# platform column. That silently degraded every pinned image to a host-arch pull
+# and made text-embeddings-inference unpullable on Apple Silicon. Unresolvable
+# compose config must now be a hard failure, never a platform-blind image list.
+reset_docker_mock
+MOCK_COMPOSE_CONFIG_EXIT=1
+if compose_images="$(_macos_compose_external_images)"; then
+    fail "unresolvable compose config did not fail the image resolver"
+fi
+[[ -z "${compose_images:-}" ]] || fail "failed resolver still emitted images: $compose_images"
+assert_call_count "config --images" 0
+MOCK_COMPOSE_CONFIG_EXIT=0
+pass "unresolvable compose config fails loudly instead of dropping platform pins"
+
+manifest_error_log="$TMP_DIR/manifest-error.log"
+printf '%s\n' \
+    'no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found' \
+    > "$manifest_error_log"
+_macos_pull_error_is_permanent "$manifest_error_log" \
+    || fail "missing arm64 manifest was not classified as permanent"
+printf '%s\n' 'error pulling image: net/http: TLS handshake timeout' > "$manifest_error_log"
+if _macos_pull_error_is_permanent "$manifest_error_log"; then
+    fail "transient network error was misclassified as permanent"
+fi
+pass "permanent manifest errors are distinguished from transient pull failures"
+
+reset_docker_mock
+MOCK_PULL_EXIT=1
+MOCK_PULL_STDERR='no matching manifest for linux/arm64/v8 in the manifest list entries: no match for platform in manifest: not found'
+if _macos_pull_image_with_retry "ghcr.io/example/tei:latest" "linux/amd64"; then
+    fail "unpullable manifest unexpectedly reported success"
+fi
+assert_call_count "^pull --platform linux/amd64 ghcr.io/example/tei:latest$" 1
+pass "missing manifest aborts on the first attempt instead of burning the retry budget"
+
 reset_docker_mock
 _macos_pull_image_with_retry "ghcr.io/example/tei:latest" "linux/amd64" \
     || fail "absent cache did not pull the requested platform"
@@ -180,5 +223,30 @@ if _macos_pull_image_with_retry "ghcr.io/example/tei:latest" "linux/amd64"; then
 fi
 assert_call_count "^pull --platform linux/amd64 ghcr.io/example/tei:latest$" 2
 pass "pull failure remains fatal when the cached platform is wrong"
+
+# End-to-end wiring for the real Apple Silicon failure in #3257: the embeddings
+# extension pins text-embeddings-inference to linux/amd64 because the image has
+# no arm64 manifest. The preflight must carry that pin all the way from
+# `compose config` into the docker pull argv.
+reset_docker_mock
+# Used by the installer function loaded with eval below.
+# shellcheck disable=SC2034
+INSTALL_DIR="$TMP_DIR"
+MOCK_COMPOSE_JSON='{
+  "services": {
+    "embeddings": {
+      "image": "ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1",
+      "platform": "linux/amd64"
+    },
+    "open-webui": {"image": "ghcr.io/open-webui/open-webui:main"}
+  }
+}'
+_macos_pre_pull_compose_images \
+    || fail "preflight failed for a healthy platform-pinned stack"
+assert_call_count \
+    "^pull --platform linux/amd64 ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1$" 1
+assert_call_count "^pull ghcr.io/open-webui/open-webui:main$" 1
+assert_call_count "^pull ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1$" 0
+pass "preflight carries the compose platform pin into docker pull for TEI"
 
 echo "[OK] macOS Compose image cache preflight passed"


### PR DESCRIPTION
### Summary

  The macOS installer's image preflight permanently failed on ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1 with no matching manifest for linux/arm64/v8, burning all four retries on something
  no retry could fix.

  The reported root cause was one release out of date — install-macos.sh has read per-service platform: from docker compose config --format json since 43da9bb1. The actual bug is one layer down, in
  _macos_compose_external_images: a silent fallback chain.

  if config_json="$(docker compose ... config --format json)"; then
      if printf '%s' "$config_json" | python3 -c '...' | ... ; then
          return 0
      fi
  fi
  # ↓ reached whenever the JSON path fails — emits BARE image refs, no platform column
  docker compose ... config --images | ...

  When either config --format json or the python3 parse fails, the resolver silently degrades to config --images, which has no platform column. The caller splits on tab, gets platform="", and issues a
  bare docker pull that resolves the host arch. Two contributing factors: the resolver used bare python3 while the rest of this installer uses the vetted ${ODS_PYTHON_CMD:-python3} (set by
  _ensure_macos_pyyaml, which may point at an ODS-owned venv), and its Python had try/except Exception: sys.exit(1), turning any parse problem into the same silent downgrade.

###   Changes to ods/installers/macos/install-macos.sh:

  1. Removed the config --images fallback. Per CLAUDE.md ("No fallback chains", "Let It Crash"), a resolver that cannot report platform pins is worse than none — it now returns non-zero and the caller
     aborts with an actionable message. Safe because python3 is already a hard requirement (_ensure_macos_pyyaml does exit 1 at line 1059, long before this code at ~2400), and config --images is no more
     available than config --format json.
  2. Use ${ODS_PYTHON_CMD:-python3}, matching the rest of the file.
  3. Dropped the broad except Exception so a malformed config crashes visibly.
  4. Fast-fail on non-retryable errors via a new _macos_pull_error_is_permanent. A missing manifest is a property of the published image, not of the network, so the 5s/15s/30s backoff was pure waste.
     Aborts on attempt 1 and, when there is no pin, tells the user to add platform: linux/amd64.

  ods/tests/test-macos-compose-image-cache.sh gains four cases: the fallback regression, permanent-vs-transient classification, first-attempt abort, and an end-to-end _macos_pre_pull_compose_images test
  using the real TEI ref asserting --platform linux/amd64 reaches the pull argv.

###   Fixes #3257.

 

  **Release Lane**

  - [ ] Stable hotfix targeting release/2.6.x
  - [x] Mainline change targeting main
  - [ ] Next-minor work targeting the next feature/minor release
  - [ ] Not sure; reviewer should help classify

  **Stable hotfix reason:**

  N/A — targeting main. Worth noting for the reviewer: this is a hard install
  failure on Apple Silicon whenever the RAG/embeddings service is enabled, so it
  may warrant a backport to release/2.6.x if that branch carries the same
  `config --images` fallback. Deferring that call to the maintainers.

  **Changed Surface**

  - [ ] Docs only
  - [ ] Tests only
  - [ ] Dashboard UI
  - [ ] Dashboard API / host agent
  - [x] Installer / bootstrap / lifecycle
  - [ ] Docker Compose / service manifests
  - [ ] Model routing / Hermes / capabilities
  - [ ] Network exposure / auth / proxy
  - [ ] Dependencies / runtime wiring

  No compose file or manifest was edited — extensions/services/embeddings/compose.yaml already carried the correct pin. Only the installer's consumption of it changed.

###   Risk And Validation

  - Risk level: Medium — installer-phase change on the macOS launch path. Contained to the pre-launch pull preflight; no host mutation, network exposure, or compose generation is touched.
  - Validation run:
    - [x] git diff --check
    - [ ] Markdown/link sanity for docs
    - [x] Focused tests listed below
    - [ ] Dashboard lint/test/build
    - [ ] Extension audit / compose validation
    - [ ] Release-grade fleet or scoped hardware validation
    - [ ] Stable-lane patch validation, if targeting release/2.6.x
    - [x] Not required because: no docs, dashboard, or compose/manifest files changed.

###   Commands/results:

  $ git diff --check
  (clean, exit 0)

  $ make lint
  === Shell syntax ===
  === Python compile ===
  All lint checks passed.

  $ bash tests/test-macos-compose-image-cache.sh    # via bash-3.2 shim, see note
  [PASS] platform aliases and inspect output variants normalize safely
  [PASS] Compose JSON parsing preserves platform pins and filters local builds
  [PASS] unresolvable compose config fails loudly instead of dropping platform pins
  [PASS] permanent manifest errors are distinguished from transient pull failures
  [PASS] missing manifest aborts on the first attempt instead of burning the retry budget
  [PASS] absent cache pulls the pinned platform
  [PASS] matching cached image is reused without registry access
  [PASS] mismatched cached architecture is replaced by a pinned pull
  [PASS] offline rerun succeeds with a normalized matching cache
  [PASS] pull failure remains fatal when the cached platform is wrong
  [PASS] preflight carries the compose platform pin into docker pull for TEI
  [OK] macOS Compose image cache preflight passed

  11/11 pass: 7 pre-existing (no regressions) + 4 new.

  Negative control — the new regression test run against pre-fix HEAD, proving
  it actually catches the defect rather than just passing:

  [PASS] platform aliases and inspect output variants normalize safely
  [PASS] Compose JSON parsing preserves platform pins and filters local builds
  [FAIL] expected 0 calls matching 'config --images', got 1


###   Operational Change Check

  - [ ] This is not an operational change.
  - [ ] This is an operational change and validation is recorded above.
  - [x] This is an operational change and validation is intentionally deferred for: hardware access. This touches an installer phase, so it requires release-grade fleet validation per the policy. I have
    no Apple Silicon host or Docker daemon available, so the narrower equivalent I ran is mock-level argv assertion plus a negative control against pre-fix HEAD. That proves the platform pin now
    reaches docker pull and that the old path did not — it does not prove a clean end-to-end macOS install. Requesting one maintainer run of ./installers/macos/install-macos.sh with embeddings enabled
    on an M-series machine before release.

###  Notes For Reviewers

  Deliberate behavior change worth a close look. Removing the config --images fallback means a macOS install now aborts where it previously limped forward. That is intended and matches CLAUDE.md's "No
  fallback chains" / "Let It Crash" rules, and the previous limp produced exactly the unfixable failure in #3257 — but it is a real change in failure mode, so please confirm you want it rather than a
  platform-preserving fallback. I judged a second fallback to be strictly worse: any replacement still needs a JSON parser, so it would reintroduce the same class of silent degradation.

  Out of scope, flagging deliberately. ods/installers/phases/08-images.sh:64 puts the same bare TEI ref into the Linux PULL_LIST, and pull_with_progress (phase 11) is likewise platform-blind. Harmless
  on amd64 Linux, but it fails identically on an arm64 Linux host. I left it alone to keep this PR to the reported macOS defect — happy to open a follow-up issue or fold it in if you would rather have
  one change.

  Minor. _macos_pull_image_with_retry now writes each attempt's output to a mktemp file so the error can be classified, then appends it to $ODS_LOG_FILE — log content is unchanged. A hard interrupt
  mid-pull leaks one temp file in $TMPDIR; this matches existing practice in the file (see the untrapped mktemp at line 982), so I did not add a trap.

  Rollback is a clean revert of both files; no state, env keys, or on-disk artifacts are written by this change.