### PR TITLE
fix(dashboard-api): add string boolean parsing for first_run status

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -46,7 +46,13 @@ def get_active_persona_prompt() -> str:
 async def setup_status(api_key: str = Depends(verify_api_key)):
     """Check if this is a first-run scenario."""
     state = await asyncio.to_thread(_call_agent, "/v1/setup/state", "GET", None, 10)
-    first_run = state.get("first_run") is not False
+    first_run_raw = state.get("first_run")
+    if isinstance(first_run_raw, str):
+        first_run = first_run_raw.strip().lower() not in {"false", "0", "no"}
+    elif first_run_raw is False:
+        first_run = False
+    else:
+        first_run = True
     step = state.get("step", 0)
     if not isinstance(step, int) or isinstance(step, bool) or step < 0:
         step = 0

--- a/ods/extensions/services/dashboard-api/tests/test_setup.py
+++ b/ods/extensions/services/dashboard-api/tests/test_setup.py
@@ -87,6 +87,15 @@ def test_setup_status_already_complete(test_client, setup_config_dir):
     assert resp.json()["first_run"] is False
 
 
+def test_setup_status_string_first_run(test_client, monkeypatch):
+    """String representations like 'false' evaluate to first_run=False."""
+    import routers.setup as setup_router
+    monkeypatch.setattr(setup_router, "_call_agent", lambda *a, **kw: {"first_run": "false", "step": 1})
+    resp = test_client.get("/api/setup/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["first_run"] is False
+
+
 def test_setup_status_with_progress_step(test_client, setup_config_dir):
     """Progress step is read from setup-progress.json."""
     (setup_config_dir / "setup-progress.json").write_text(


### PR DESCRIPTION
Ensure setup status router handles string boolean values (such as 'false' or '0') correctly when checking host agent state.