### PR TITLE
fix(dashboard-api): add array length safety bound in GGUF inspector

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -134,6 +134,8 @@ def _skip_value(reader: _Reader, value_type: int, depth: int = 0) -> None:
             raise ValueError("GGUF array nesting too deep")
         item_type = reader.unpack("<I")
         length = reader.unpack("<Q")
+        if length > 1_000_000:
+            raise ValueError(f"GGUF array length {length} exceeds safety limit")
         for _ in range(length):
             _skip_value(reader, item_type, depth + 1)
         return
@@ -145,6 +147,8 @@ def _read_array(reader: _Reader, depth: int = 0) -> Any:
         raise ValueError("GGUF array nesting too deep")
     item_type = reader.unpack("<I")
     length = reader.unpack("<Q")
+    if length > 1_000_000:
+        raise ValueError(f"GGUF array length {length} exceeds safety limit")
     if item_type not in _STRUCTS and item_type not in (8, 9):
         raise ValueError(f"unsupported GGUF array type: {item_type}")
 

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -210,6 +210,22 @@ def test_shallow_nested_array_still_parses(tmp_path):
     assert result["metadata"]["nested.arr"] == [[[[0]]]]
 
 
+def test_excessive_array_length_degrades_gracefully(tmp_path):
+    path = _write(tmp_path, "huge_arr.gguf", build_gguf([
+        ("general.architecture", STR, "llama"),
+        ("huge.arr", ARR, (U32, [])),
+    ]))
+    # Patch array length byte in file payload to simulate corrupted 10_000_000 elements length
+    data = bytearray(path.read_bytes())
+    # Modify last QWORD (array length) to 10_000_000
+    struct.pack_into("<Q", data, len(data) - 8, 10_000_000)
+    path.write_bytes(bytes(data))
+
+    result = inspect_gguf(path)
+    assert result["readable"] is False
+    assert "exceeds safety limit" in result.get("error", "")
+
+
 def test_deeply_nested_array_degrades_without_recursion_error(tmp_path):
     # A pathologically nested array must not crash the parser (RecursionError
     # escaping the failure contract) — it degrades to a bounded-depth error.


### PR DESCRIPTION
Add explicit length safety checks when parsing GGUF array metadata to prevent high memory allocation or CPU loops from malformed array length values.