### PR TITLE
fix(dashboard-api): add weight size fallback estimate in model memory

### DIFF
--- a/ods/extensions/services/dashboard-api/model_memory.py
+++ b/ods/extensions/services/dashboard-api/model_memory.py
@@ -134,6 +134,11 @@ def required_model_memory_gb(
     size_mb = _positive_number(
         weight_size_mb if weight_size_mb is not None else model.get("size_mb")
     )
+    if not size_mb:
+        params_b = estimated_param_billions(model)
+        if params_b:
+            size_mb = params_b * 650.0
+
     size_and_kv_gb = (
         (size_mb / 1024.0) + estimated_context_kv_gb(model, context_length)
         if size_mb

--- a/ods/extensions/services/dashboard-api/tests/test_model_memory.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_memory.py
@@ -132,6 +132,11 @@ class TestArchitectureAwareKvCache:
         model = {"params_b": 4, "block_count": 36}
         assert estimated_context_kv_gb(model, 32768) == 0.48
 
+    def test_missing_size_mb_estimates_from_params(self):
+        model = {"params_b": 8.0}
+        gb = required_model_memory_gb(model)
+        assert gb > 4.0
+
 
 @pytest.mark.skipif(
     not CATALOG_PATH.exists() or not SELECT_MODEL_PATH.exists(),


### PR DESCRIPTION
Estimate model weight size from parameter count when size_mb is not explicitly declared in metadata, preventing zero-value memory estimates.