### PR TITLE
fix(scripts): support symlinked session files in wipe cleanup loop

### DIFF
--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -236,7 +236,7 @@ finally:
 PY
 
     for f in "${WIPE_FILES[@]}"; do
-        if [[ -f "$f" ]]; then
+        if [[ -f "$f" || -L "$f" ]]; then
             rm -f "$f"
             REMOVED_BLOATED=$((REMOVED_BLOATED + 1))
         fi


### PR DESCRIPTION
Check for both regular files and symlinks when deleting unreferenced session files during index wipe operations.