### PR TITLE
fix(litellm): handle NaN duration values safely in token spy callback

### DIFF
--- a/ods/extensions/services/litellm/ods_token_spy_callback.py
+++ b/ods/extensions/services/litellm/ods_token_spy_callback.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import time
 from datetime import datetime
@@ -53,7 +54,9 @@ def _duration_ms(start_time: Any, end_time: Any) -> int:
         try:
             seconds = float(end_time) - float(start_time)
         except (TypeError, ValueError):
-            seconds = 0
+            seconds = 0.0
+    if not math.isfinite(seconds):
+        seconds = 0.0
     return min(max(int(seconds * 1000), 0), 86_400_000)
 
 

--- a/ods/extensions/services/litellm/tests/test_token_spy_callback.py
+++ b/ods/extensions/services/litellm/tests/test_token_spy_callback.py
@@ -121,6 +121,17 @@ def test_callback_bounds_provider_counters_to_ingest_contract(monkeypatch):
     assert event["output_tokens"] == 0
 
 
+def test_callback_handles_nan_duration_without_exception(monkeypatch):
+    callback = load_callback(monkeypatch)
+    event = callback.build_event(
+        {},
+        {"model": "model"},
+        float("nan"),
+        1.0,
+    )
+    assert event["duration_ms"] == 0
+
+
 def test_callback_enqueues_without_waiting_for_token_spy(monkeypatch):
     monkeypatch.setenv("TOKEN_SPY_URL", "http://token-spy:8080")
     monkeypatch.setenv("TOKEN_SPY_API_KEY", "shared-secret")


### PR DESCRIPTION
Validate float finite status before converting duration seconds to milliseconds to avoid ValueError on NaN or infinite timestamps.