### PR TITLE
fix(cli): prevent word-splitting of compose flags to support spaces i…

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -497,7 +497,7 @@ else
     mkdir -p "$INSTALL_DIR/logs"
 
     # Persist compose flags so ods-cli can reuse them without re-resolving
-    echo "$COMPOSE_FLAGS" > "$INSTALL_DIR/.compose-flags" || warn "Could not cache compose flags (non-fatal)"
+    printf '%s\n' "${COMPOSE_ARGS[@]}" > "$INSTALL_DIR/.compose-flags" || warn "Could not cache compose flags (non-fatal)"
     log "Saved compose flags to $INSTALL_DIR/.compose-flags"
 
     _phase11_compose_command_text() {

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -854,15 +854,12 @@ get_compose_flags() {
 
     # Fast path: use saved flags from installer if available
     if [[ -f "$INSTALL_DIR/.compose-flags" ]]; then
-        local cached
-        cached=$(< "$INSTALL_DIR/.compose-flags")
-        if [[ "$cached" == -f\ * ]]; then
-            # Validate that every referenced compose file still exists.
-            # Protects against renames across upgrades (e.g. multigpu.yml →
-            # multigpu-nvidia.yml) where the cache would otherwise hand docker
-            # compose a path that no longer resolves.
+        local -a cached_toks
+        [[ -f "$INSTALL_DIR/.compose-flags" ]] && mapfile -t cached_toks < "$INSTALL_DIR/.compose-flags"
+    
+        if [[ "${cached_toks[0]}" == "-f" ]]; then
             local stale=0 prev="" tok
-            for tok in $cached; do
+            for tok in "${cached_toks[@]}"; do
                 if [[ "$prev" == "-f" ]]; then
                     if [[ "$tok" = /* ]]; then
                         [[ -f "$tok" ]] || { stale=1; break; }


### PR DESCRIPTION
fix(cli): prevent word-splitting of compose flags to support spaces in paths

Fixes #3340

## Summary

The `get_compose_flags` function in `ods-cli` previously read `.compose-flags` as a flat string and iterated over it using `for tok in $cached`. This caused Bash to word-split on spaces, breaking the `-f` file existence check for installations located in directories with spaces in their names.

This PR fixes the issue by migrating the compose flag logic to use proper Bash arrays end-to-end:

* `installers/lib/compose-select.sh` now builds an array (`COMPOSE_ARGS`).
* `installers/phases/11-services.sh` writes the array line-by-line using `printf '%s\n'`.
* `ods-cli` safely reads the file back into an array using `mapfile -t`, entirely bypassing word-splitting.

## AI Assistance

Code modifications for Bash array handling and `mapfile` logic were drafted by Gemini.

## Release Lane

* [ ] Stable hotfix targeting `release/2.6.x`
* [x] Mainline change targeting `main`
* [ ] Next-minor work targeting the next feature/minor release
* [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text


```

## Changed Surface

* [ ] Docs only
* [ ] Tests only
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [x] Installer / bootstrap / lifecycle
* [ ] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

## Risk And Validation

* Risk level: Low
* Validation run:
* [ ] `git diff --check`
* [ ] Markdown/link sanity for docs
* [x] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`
* [ ] Not required because:



Commands/results:

```bash
# Setup a test installation path with spaces
INSTALL_DIR="/opt/my test install/ods"

# Verify .compose-flags is generated line-by-line
cat "$INSTALL_DIR/.compose-flags"

# Execute CLI wrapper to ensure flags are parsed correctly without 'file not found' errors
ods status
ods restart

```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

* [ ] This is not an operational change.
* [x] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The string variable `COMPOSE_FLAGS` is still exported from `compose-select.sh` for backwards compatibility with any custom downstream scripts, but the core installer and CLI now exclusively rely on the safely tokenized `COMPOSE_ARGS` array and line-delimited cache file.