### PR TITLE
fix(update): stop word-splitting compose service names in health

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -81,6 +81,9 @@ test: ## Run unit and contract tests
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh
 	@echo ""
+	@echo "=== ods-update runtime compose + health ==="
+	@bash tests/test-ods-update-runtime-compose.sh
+	@echo ""
 	@echo "=== restore refuses empty backup config ==="
 	@bash tests/test-restore-empty-config.sh
 	@echo ""

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -956,10 +956,25 @@ cmd_health() {
         compose_args=("${COMPOSE_PARSED_ARGS[@]}")
     fi
     
-    local services
-    services=$("${compose_cmd[@]}" "${compose_args[@]}" ps --services 2>/dev/null || echo "")
-    
-    if [[ -z "$services" ]]; then
+    # `ps --services` prints one service name per line, and Compose allows
+    # spaces in a service name. Collecting that into a scalar and iterating it
+    # unquoted word-splits such a name into fragments, so the per-service `ps`
+    # below queries a fragment, matches nothing, and reports "unknown" -- which
+    # fails the health check for a stack that is actually running. Read whole
+    # lines into an array and iterate them quoted.
+    #
+    # A while-read loop rather than mapfile: this script is still bash 3.2
+    # clean, and macOS ships /bin/bash 3.2, where mapfile does not exist.
+    local -a services=()
+    local service
+    while IFS= read -r service; do
+        [[ -n "$service" ]] || continue
+        services+=("$service")
+    done < <("${compose_cmd[@]}" "${compose_args[@]}" ps --services 2>/dev/null)
+
+    # Covers both a failed `ps` and a stack that resolved to no services, so a
+    # failure can never fall through and iterate one empty service name.
+    if [[ ${#services[@]} -eq 0 ]]; then
         if [[ -n "$compose_flags" ]]; then
             log_warn "No services found for resolved compose stack: ${compose_flags}"
         else
@@ -967,8 +982,8 @@ cmd_health() {
         fi
         return 1
     fi
-    
-    for service in $services; do
+
+    for service in "${services[@]}"; do
         local status
         status=$("${compose_cmd[@]}" "${compose_args[@]}" ps --format json "$service" 2>/dev/null \
             | jq -r 'if type == "array" then (.[0].State // "unknown") else (.State // "unknown") end' 2>/dev/null \

--- a/ods/tests/test-ods-update-runtime-compose.sh
+++ b/ods/tests/test-ods-update-runtime-compose.sh
@@ -181,3 +181,99 @@ if find "$INSTALL_DIR/data/backups" -mindepth 1 -maxdepth 1 -type d -name 'pre-u
 fi
 [[ ! -s "$DOCKER_LOG" ]] || { cat "$DOCKER_LOG"; fail "non-git update invoked Docker"; }
 pass "ods-update fails cleanly before mutating non-git runtime installs"
+
+#------------------------------------------------------------------------------
+# Regression: `ps --services` emits one service name per line and Compose allows
+# spaces in a service name. cmd_health used to collect that into a scalar and
+# iterate it unquoted, word-splitting "custom worker" into "custom" + "worker".
+# Each fragment then matched no container, reported "unknown", and failed the
+# health check for a stack that was actually running.
+#------------------------------------------------------------------------------
+SPACE_BIN_DIR="$TMP_DIR/space-bin"
+mkdir -p "$SPACE_BIN_DIR"
+SERVICE_QUERY_LOG="$TMP_DIR/service-queries.log"
+PS_SERVICES_EXIT="$TMP_DIR/ps-services-exit"
+export SERVICE_QUERY_LOG PS_SERVICES_EXIT
+printf '0\n' > "$PS_SERVICES_EXIT"
+: > "$SERVICE_QUERY_LOG"
+
+cat > "$SPACE_BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+[[ "${1:-}" == "info" ]] && exit 0
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then exit 0; fi
+[[ "${1:-}" == "compose" ]] && shift
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "ps" ]]; then
+        next="${args[$((i + 1))]:-}"
+        if [[ "$next" == "--services" ]]; then
+            # Simulate a failing `ps` when the fixture asks for it.
+            if [[ "$(cat "${PS_SERVICES_EXIT:?}")" != "0" ]]; then
+                echo "compose: no configuration file provided" >&2
+                exit 1
+            fi
+            printf '%s\n' 'dashboard-api' 'custom worker' 'litellm'
+            exit 0
+        fi
+        if [[ "$next" == "--format" ]]; then
+            # docker compose ps --format json <service>
+            requested="${args[$((i + 3))]:-}"
+            printf '%s\n' "$requested" >> "${SERVICE_QUERY_LOG:?}"
+            case "$requested" in
+                dashboard-api|"custom worker"|litellm)
+                    printf '%s\n' '{"State":"running"}' ;;
+                *)
+                    printf '%s\n' '[]' ;;
+            esac
+            exit 0
+        fi
+    fi
+done
+exit 0
+SH
+chmod +x "$SPACE_BIN_DIR/docker"
+
+printf '%s\n' '-f docker-compose.base.yml -f docker-compose.cpu.yml' > "$INSTALL_DIR/.compose-flags"
+
+PATH="$SPACE_BIN_DIR:$BIN_DIR:$PATH" bash "$INSTALL_DIR/ods-update.sh" health \
+    > "$TMP_DIR/spaced-service.out" 2>&1 \
+    || { cat "$TMP_DIR/spaced-service.out"; fail "health should pass when a service name contains a space"; }
+
+grep -qF "Service custom worker: running" "$TMP_DIR/spaced-service.out" \
+    || { cat "$TMP_DIR/spaced-service.out"; fail "spaced service name was not reported as a single running service"; }
+if grep -Eq "Service (custom|worker): " "$TMP_DIR/spaced-service.out"; then
+    cat "$TMP_DIR/spaced-service.out"
+    fail "spaced service name was word-split into separate services"
+fi
+grep -qF "All health checks passed" "$TMP_DIR/spaced-service.out" \
+    || { cat "$TMP_DIR/spaced-service.out"; fail "a healthy stack was flagged unhealthy by the spaced service name"; }
+grep -qxF "custom worker" "$SERVICE_QUERY_LOG" \
+    || { cat "$SERVICE_QUERY_LOG"; fail "per-service ps was not queried with the whole service name"; }
+if grep -qxE "custom|worker" "$SERVICE_QUERY_LOG"; then
+    cat "$SERVICE_QUERY_LOG"
+    fail "per-service ps was queried with a word-split fragment"
+fi
+pass "ods-update health treats a spaced service name as one service"
+
+# A failing `ps --services` must warn and return 1, never fall through and
+# iterate a single empty service name.
+printf '1\n' > "$PS_SERVICES_EXIT"
+: > "$SERVICE_QUERY_LOG"
+set +e
+PATH="$SPACE_BIN_DIR:$BIN_DIR:$PATH" bash "$INSTALL_DIR/ods-update.sh" health \
+    > "$TMP_DIR/no-services.out" 2>&1
+no_services_exit=$?
+set -e
+
+[[ "$no_services_exit" -ne 0 ]] \
+    || { cat "$TMP_DIR/no-services.out"; fail "health should fail when the service list cannot be resolved"; }
+grep -q "No services found for resolved compose stack" "$TMP_DIR/no-services.out" \
+    || { cat "$TMP_DIR/no-services.out"; fail "health did not warn about the unresolvable service list"; }
+if grep -q "Service : " "$TMP_DIR/no-services.out"; then
+    cat "$TMP_DIR/no-services.out"
+    fail "health iterated an empty service name after a failed ps"
+fi
+[[ ! -s "$SERVICE_QUERY_LOG" ]] \
+    || { cat "$SERVICE_QUERY_LOG"; fail "health queried a service after ps --services failed"; }
+pass "ods-update health fails cleanly when the service list cannot be resolved"


### PR DESCRIPTION
Fixes https://github.com/Osmantic/ODS/issues/3339

cmd_health captured `docker compose ps --services` into a scalar and
  iterated it unquoted. Compose emits one service name per line and allows
  spaces in a name, so "custom worker" split into two tokens. The
  per-service `ps --format json` then queried each fragment, matched no
  container, and reported "unknown" -- flagging a running stack as
  unhealthy and failing the whole health check.

  Read the list line by line into an array and iterate it quoted. Guard on
  array length rather than an empty string so a failed `ps` cannot fall
  through and inspect one empty service name.

  Use a while-read loop rather than mapfile: this script is bash 3.2 clean
  and macOS ships /bin/bash 3.2, where mapfile does not exist. Under
  `set -euo pipefail` a missing mapfile leaves services unset and the
  quoted expansion then aborts on an unbound variable, which would turn a
  misreported status into a hard crash of `ods-update.sh health`.

  Add regression coverage for a spaced service name and for an
  unresolvable service list, and wire tests/test-ods-update-runtime-
  compose.sh into `make test` -- nothing referenced it, so its existing
  cases had never run in CI either.