### PR TITLE
docs: sync module/phase counts and add phase 02b external services

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -167,7 +167,7 @@ The LLM inference engine (`llama-server`) is the foundation. GPU overlays select
 
 ## Installer Architecture
 
-The installer is a 13-phase pipeline orchestrated by `install-core.sh`.
+The installer is a 14-phase pipeline orchestrated by `install-core.sh`.
 Installer libraries in `installers/lib/` are pure functions (no side effects);
 `lib/service-registry.sh` loads service manifests and port metadata; phases in
 `installers/phases/` execute sequentially.
@@ -189,7 +189,8 @@ graph LR
 
     subgraph Phases["installers/phases/ (sequential)"]
         P01["01 Preflight"] --> P02["02 Detection"]
-        P02 --> P03["03 Features"]
+        P02 --> P02B["02b External Services"]
+        P02B --> P03["03 Features"]
         P03 --> P04["04 Requirements"]
         P04 --> P05["05 Docker"]
         P05 --> P06["06 Directories"]
@@ -209,6 +210,7 @@ graph LR
 |-------|---------|
 | 01 Preflight | Root/OS/tools checks, existing install detection |
 | 02 Detection | GPU hardware detection, tier assignment, compose config selection |
+| 02b External Services | Load service manifests, resolve extensions, configure service registry |
 | 03 Features | Interactive feature selection (voice, workflows, RAG, images, etc.) |
 | 04 Requirements | RAM, disk, GPU, port availability checks |
 | 05 Docker | Install Docker, Compose, NVIDIA Container Toolkit |

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ ods disable my-service    # Disable it
 ods list                  # See everything
 ```
 
-The installer itself is modular — 19 library modules, a shared service registry, and 13 ordered phases. Want to add a hardware tier, swap a default model, or skip a phase? Start with the installer architecture map so you update the Linux, macOS, Windows, upgrade, and host-agent writers together.
+The installer itself is modular — 24 library modules, a shared service registry, and 14 ordered phases. Want to add a hardware tier, swap a default model, or skip a phase? Start with the installer architecture map so you update the Linux, macOS, Windows, upgrade, and host-agent writers together.
 
 [Full extension guide](ods/docs/EXTENSIONS.md) | [Installer architecture](ods/docs/INSTALLER-ARCHITECTURE.md)
 

--- a/ods/README.md
+++ b/ods/README.md
@@ -315,8 +315,8 @@ Full guide: [docs/EXTENSIONS.md](docs/EXTENSIONS.md)
 
 ### Installer Architecture
 
-The installer is modular — 19 library modules, a shared service registry, and
-13 ordered phases. The architecture doc also maps the generated config writers
+The installer is modular — 24 library modules, a shared service registry, and
+14 ordered phases. The architecture doc also maps the generated config writers
 that have to stay in sync across Linux, macOS, Windows, bootstrap upgrades, and
 host-agent model activation.
 Want to add a hardware tier, swap the theme, or skip a phase? Start with the


### PR DESCRIPTION
Fix : https://github.com/Osmantic/ODS/issues/3230

### Summary

Fix documentation accuracy: installer module and phase counts were undercounted in `README.md`, `ods/README.md`, and `ARCHITECTURE.md`. Updated counts from 19→24 library modules and 13→14 ordered phases to match actual codebase. Added the previously-omitted `02b-external-services.sh` phase to the `ARCHITECTURE.md` mermaid diagram and phase purpose table to resolve internal consistency issues.

### AI Assistance

Claude Code drafted all documentation updates based on verification of actual file counts in `installers/lib/` (24 modules) and `installers/phases/` (14 phases including 02b).

### Release Lane

* [x] Mainline change targeting `main`
* [ ] Stable hotfix targeting `release/2.6.x`
* [ ] Next-minor work targeting the next feature/minor release
* [ ] Not sure; reviewer should help classify

### Changed Surface

* [x] Docs only
* [ ] Tests only
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [ ] Installer / bootstrap / lifecycle
* [ ] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

### Risk And Validation

* Risk level: Low
* Validation run:
* [x] `git diff --check`
* [x] Markdown/link sanity for docs
* [ ] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`
* [x] Not required because: Documentation-only changes with no code impact; counts verified against actual file system



Commands/results:

```bash
$ find ods/installers/lib -maxdepth 1 -name "*.sh" | wc -l
24

$ find ods/installers/phases -maxdepth 1 -name "*.sh" | sort
ods/installers/phases/01-preflight.sh
ods/installers/phases/02-detection.sh
ods/installers/phases/02b-external-services.sh
ods/installers/phases/03-features.sh
... (14 total)

$ grep -n "library modules\|ordered phases" README.md ods/README.md
✓ All instances updated to "24 library modules" and "14 ordered phases"

$ grep "02b External Services" ARCHITECTURE.md
✓ Added to mermaid diagram and phase table with purpose description

```

### Operational Change Check

* [x] This is not an operational change.
* [ ] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

### Notes For Reviewers

Documentation-only fix with zero code impact. All counts verified against filesystem state. The `02b-external-services.sh` phase was already in place but omitted from architecture docs—this brings docs into sync with reality.