### PR TITLE
fix(dashboard-api): add type checks for catalog and entries in find_catalog_model

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -615,7 +615,9 @@ def current_model_matches(model: dict[str, Any], current_model: str | None, curr
 def find_catalog_model(catalog: list[dict[str, Any]], model_name: str | None, gguf: str | None = None) -> dict[str, Any] | None:
     if not model_name and not gguf:
         return None
-    return next((model for model in catalog if current_model_matches(model, model_name, gguf)), None)
+    if not isinstance(catalog, (list, tuple)):
+        return None
+    return next((model for model in catalog if isinstance(model, dict) and current_model_matches(model, model_name, gguf)), None)
 
 
 def _hardware_match(gpu_info: Optional[GPUInfo], context_length: Optional[int],

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -7,6 +7,7 @@ from performance_oracle import (
     build_models_payload,
     current_model_matches,
     evaluate_performance,
+    find_catalog_model,
     load_evidence,
     model_compatibility_runtime_context,
     model_app_compatibility,
@@ -17,6 +18,11 @@ from performance_oracle import (
     read_env_value,
     read_persisted_env_value,
 )
+
+
+def test_find_catalog_model_tolerates_invalid_catalog_types():
+    assert find_catalog_model(None, "llama-7b") is None
+    assert find_catalog_model(["invalid-string-entry"], "llama-7b") is None
 
 
 def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia"):


### PR DESCRIPTION
Ensure find_catalog_model validates catalog collection and model item types safely to prevent AttributeError during custom catalog searches.