### PR TITLE
fix(dashboard-api): add body type validation in _requested_activation_context

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -522,7 +522,7 @@ def _already_active_model(model_id: str, model: dict) -> tuple[bool, str | None]
 def _requested_activation_context(
     body: dict[str, Any] | None,
 ) -> int | None:
-    if body is None or "context_length" not in body:
+    if not isinstance(body, dict) or "context_length" not in body:
         return None
     value = body.get("context_length")
     if isinstance(value, bool) or not isinstance(value, int):

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -37,6 +37,14 @@ def test_active_model_reader_preserves_unmatched_quote(monkeypatch, tmp_path):
     assert models_router._read_active_model() == "model-v2.gguf'"
 
 
+def test_requested_activation_context_handles_non_dict_body():
+    import routers.models as models_router
+
+    assert models_router._requested_activation_context(None) is None
+    assert models_router._requested_activation_context("not-a-dict") is None
+    assert models_router._requested_activation_context([1, 2, 3]) is None
+
+
 def test_huggingface_artifacts_group_complete_shards_and_require_integrity():
     import routers.models as models_router
 


### PR DESCRIPTION
Check isinstance(body, dict) in _requested_activation_context to handle non-dict JSON body payloads safely.