### PR TITLE
fix(dashboard-api): add dict safety checks for feature requirements in features router

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -31,7 +31,9 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
             pass
         gpu_vram_free_gb = gpu_vram_gb  # assumes zero current usage; Docker can't measure host memory pressure
 
-    req = feature["requirements"]
+    req = feature.get("requirements") if isinstance(feature, dict) else {}
+    if not isinstance(req, dict):
+        req = {}
     vram_ok = gpu_vram_gb >= req.get("vram_gb", 0)
     vram_fits = gpu_vram_free_gb >= req.get("vram_gb", 0)
 

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -26,6 +26,12 @@ class TestCalculateFeatureStatusDefaults:
         assert result["setupTime"] == "Unknown"
         assert result["priority"] == 99
 
+    def test_missing_requirements_dict_uses_default(self):
+        """A feature missing requirements dictionary should handle gracefully."""
+        feature_without_req = {"id": "noreq", "name": "No Req"}
+        result = calculate_feature_status(feature_without_req, [], None)
+        assert result["id"] == "noreq"
+
 
 class TestCalculateFeatureStatusAppleFallback:
 


### PR DESCRIPTION
Safe-get requirements dictionary in calculate_feature_status to prevent KeyError or TypeError when parsing incomplete feature definitions.