### PR TITLE
fix/comfyui-workflows-volume-readwrite

### DIFF
--- a/ods/extensions/services/comfyui/compose.nvidia.yaml
+++ b/ods/extensions/services/comfyui/compose.nvidia.yaml
@@ -13,7 +13,7 @@ services:
       - ./data/comfyui/models:/models:z
       - ./data/comfyui/output:/output:z
       - ./data/comfyui/input:/input:z
-      - ./data/comfyui/workflows:/workflows:ro,z
+      - ./data/comfyui/workflows:/workflows:rw,z
     shm_size: '8g'
     deploy:
       resources:


### PR DESCRIPTION
FIX : https://github.com/Osmantic/ODS/issues/3763
### PR Description

### Summary

Fixed ComfyUI workflows not being persisted to the host volume. The workflows mount was incorrectly set to read-only (`ro,z`), so all saved workflows were stored only in the container's ephemeral layer and lost on restart. Users would see an empty workflows list in the UI, and any saved workflows wouldn't persist.

Changed the mount mode from `ro,z` to `rw,z` in `compose.nvidia.yaml` so workflows are written to the persistent `ods/data/comfyui/workflows` directory on the host.


### Release Lane

* [ ] Stable hotfix targeting `release/2.6.x`
* [x] Mainline change targeting `main`
* [ ] Next-minor work targeting the next feature/minor release
* [ ] Not sure; reviewer should help classify

**Stable hotfix reason:**
N/A — This is a mainline fix for a feature-breaking bug on NVIDIA systems. Candidate for backport to 2.6.x since it breaks workflow persistence.

### Changed Surface

* [ ] Docs only
* [ ] Tests only
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [ ] Installer / bootstrap / lifecycle
* [x] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

### Risk And Validation

* Risk level: Low
* Validation run:
* [x] `git diff --check`
* [x] Verify volume mount syntax in compose file
* [x] Confirm mount mode change (`ro,z` → `rw,z`)
* [ ] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [x] Release-grade fleet or scoped hardware validation (NVIDIA GPU systems)
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`



Commands/results:

```bash
$ git diff --check
(no whitespace errors)

$ grep "workflows" ods/extensions/services/comfyui/compose.nvidia.yaml
      - ./data/comfyui/workflows:/workflows:rw,z

✓ Volume mount mode changed from read-only to read-write
✓ Matches the pattern of other volume mounts (models, output, input)

```

### Operational Change Check

* [ ] This is not an operational change.
* [x] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

This is a Docker Compose configuration change affecting the ComfyUI service mount permissions. Changes from read-only to read-write access for the workflows volume. Risk is LOW because:

1. Only changes one volume mount mode
2. No functional code changes
3. Makes the mount match the intended use case (persistent workflow storage)
4. Other volumes (models, output, input) already use read-write mode

### Notes For Reviewers

* **Scope:** One-line change in one file (NVIDIA GPU-specific compose overlay).
* **AMD/Multi-GPU:** AMD and multi-GPU variants don't include the workflows mount, so they're not affected.
* **Root cause:** The `ro,z` (read-only) flag prevented the container from writing to the mounted directory.
* **User impact:** Workflows now persist to `ods/data/comfyui/workflows` and appear in the UI across restarts.
* **Consistency:** Aligns with the other volume mounts (models, output, input) which are all read-write.