### PR TITLE
Add security_opt: no-new-privileges to Tailscale service

### DIFF
--- a/ods/extensions/services/tailscale/compose.yaml
+++ b/ods/extensions/services/tailscale/compose.yaml
@@ -24,6 +24,8 @@ services:
       # NET_RAW: send raw packets (NAT traversal probes)
       - NET_ADMIN
       - NET_RAW
+    security_opt:
+      - no-new-privileges:true
     devices:
       # The TUN device is how Tailscale's userspace daemon hands packets
       # back to the kernel. Without this, tailscale up exits with


### PR DESCRIPTION
Tailscale is configured with elevated capabilities (NET_ADMIN, NET_RAW) for mesh networking and NAT traversal, but was missing the no-new-privileges security option that all other services in ODS enforce. This security hardening prevents privilege escalation even if the container process is compromised.