### PR TITLE
fix(dashboard-api): handle None inputs gracefully in strip_matching_quotes

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -1,14 +1,16 @@
 """Small, dependency-free helpers for values read from ODS ``.env`` files."""
 
 
-def strip_matching_quotes(value: str) -> str:
+def strip_matching_quotes(value: str | None) -> str:
     """Trim whitespace and remove exactly one matching outer quote pair.
 
     ODS writes shell-compatible values that may be wrapped in single or
     double quotes. Unmatched or mixed quotes are data, not delimiters, and
     must survive reads unchanged.
     """
-    value = value.strip()
+    if value is None:
+        return ""
+    value = str(value).strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -20,6 +20,7 @@ from env_values import strip_matching_quotes
         ('"value\'', '"value\''),
         ("''value''", "'value'"),
         ('""value""', '"value"'),
+        (None, ""),
     ],
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):


### PR DESCRIPTION
Check if value is None in strip_matching_quotes and return empty string instead of raising AttributeError.