### PR TITLE
fix(dashboard-api): add safe date parsing in usage router

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -41,7 +41,9 @@ _LOCAL_RUNTIME_REQUEST_STATE: dict[str, dict[str, Any]] = {}
 
 
 def _parse_date(value: str) -> date:
-    return date.fromisoformat(value)
+    if not isinstance(value, str) or not value:
+        raise ValueError("Date string required")
+    return date.fromisoformat(value.strip())
 
 
 def _date_range(start_day: date, end_day: date) -> list[str]:

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -32,6 +32,17 @@ def _usage_payload():
     }
 
 
+def test_parse_date_handles_invalid_formats():
+    from routers.usage import _parse_date
+    from datetime import date
+    import pytest
+    assert _parse_date("2026-05-01") == date(2026, 5, 1)
+    with pytest.raises(ValueError):
+        _parse_date("invalid-date")
+    with pytest.raises(ValueError):
+        _parse_date(None)
+
+
 def test_usage_report_requires_auth(test_client):
     resp = test_client.get("/api/usage/report?start=2026-05-01&end=2026-05-31")
     assert resp.status_code == 401


### PR DESCRIPTION
Validate ISO date string formats in _parse_date to raise explicit ValueError on non-string or malformed date inputs.