### PR TITLE
fix(dashboard-api): add config type validation in _service_restartability

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -36,6 +36,8 @@ _DATA_DIR_MAP = {
 
 def _service_restartability(config: dict) -> tuple[bool, str | None]:
     """Return whether a service can be restarted with docker restart."""
+    if not isinstance(config, dict):
+        return False, "Invalid service configuration"
     service_type = config.get("type", "docker") or "docker"
     if service_type == "host-systemd":
         return False, "Host-level service; restart outside Docker"

--- a/ods/extensions/services/dashboard-api/tests/test_resources.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resources.py
@@ -20,6 +20,12 @@ class TestScanServiceDisk:
         result = _scan_service_disk()
         assert result == {}
 
+    def test_service_restartability_handles_non_dict(self):
+        from routers.resources import _service_restartability
+        ok, msg = _service_restartability(None)
+        assert ok is False
+        assert "Invalid" in msg
+
     def test_empty_data_dir(self, tmp_path, monkeypatch):
         """Empty DATA_DIR returns empty dict."""
         monkeypatch.setattr("routers.resources.DATA_DIR", str(tmp_path))


### PR DESCRIPTION
Check isinstance(config, dict) in _service_restartability to handle non-dict service configurations safely.