### PR TITLE
fix(dashboard-api): sanitize timeout parameter in host agent client

### DIFF
--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -267,6 +267,11 @@ def request_json(
     params: dict[str, Any] | None = None,
     timeout: float = 5.0,
 ) -> dict[str, Any]:
+    try:
+        t_val = float(timeout)
+        timeout = t_val if t_val > 0 else 5.0
+    except (TypeError, ValueError):
+        timeout = 5.0
     response = _sync_request(method, path, payload=payload, params=params, timeout=timeout)
     _raise_for_status(response)
     return _decode_json(response)

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -21,6 +21,21 @@ def test_host_agent_url_usage_is_centralized():
     assert users == {"config.py", "host_agent_client.py", "main.py"}
 
 
+def test_request_json_sanitizes_invalid_timeout(monkeypatch):
+    captured = {}
+    def mock_sync_req(method, path, payload=None, params=None, timeout=5.0):
+        captured["timeout"] = timeout
+        resp = agent_client.httpx.Response(200, json={"ok": True})
+        return resp
+
+    monkeypatch.setattr(agent_client, "_sync_request", mock_sync_req)
+    agent_client.request_json("GET", "/v1/test", timeout=-1.0)
+    assert captured["timeout"] == 5.0
+
+    agent_client.request_json("GET", "/v1/test", timeout="invalid")
+    assert captured["timeout"] == 5.0
+
+
 def test_sync_client_is_singleton_with_bounded_limits(monkeypatch):
     created = []
 


### PR DESCRIPTION
Ensure timeout parameter in request_json is parsed as a positive float with a 5.0 fallback.