### PR TITLE
fix(dashboard-api): add non-string version input resilience in updates router

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -133,14 +133,18 @@ def _get_cached_release_payload(allow_stale: bool = False) -> Optional[dict]:
     return None
 
 
-def _normalize_version(value: Optional[str]) -> str:
+def _normalize_version(value: object) -> str:
     """Normalize a version string for comparison and display.
 
     GitHub release tags are ``vX.Y.Z`` while ``.env``/``.version`` may store
     either form, so strip a leading ``v`` (and surrounding whitespace) to keep
     ``current`` and ``latest`` on the same footing.
     """
-    return (value or "").strip().lstrip("v")
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        value = str(value)
+    return value.strip().lstrip("v")
 
 
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -18,6 +18,15 @@ def test_current_version_reader_preserves_unmatched_quote(monkeypatch, tmp_path)
     assert updates_mod._read_current_version() == "2.6.0'"
 
 
+def test_normalize_version_handles_non_string_types():
+    import routers.updates as updates_mod
+
+    assert updates_mod._normalize_version(None) == ""
+    assert updates_mod._normalize_version(123) == "123"
+    assert updates_mod._normalize_version("v2.5.0") == "2.5.0"
+
+
+
 def test_github_release_urls_use_canonical_repository():
     import routers.updates as updates_mod
 


### PR DESCRIPTION
Safely handle non-string and numeric values in _normalize_version to prevent AttributeError.