### PR TITLE
fix(dashboard-api): add dict safety checks in voice router status calculation

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/voice.py
+++ b/ods/extensions/services/dashboard-api/routers/voice.py
@@ -56,13 +56,14 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
     # An uninstalled optional service is not a failure, so it sits out the
     # verdict. Everything that IS installed still has to be healthy.
     required_healthy = all(
-        services_status.get(name, {}).get("status") == "healthy"
+        isinstance(services_status.get(name), dict)
+        and services_status.get(name, {}).get("status") == "healthy"
         for name in REQUIRED_VOICE_SERVICES
     )
     installed_healthy = all(
-        entry["status"] == "healthy"
+        entry.get("status") == "healthy"
         for entry in services_status.values()
-        if entry["status"] != NOT_CONFIGURED
+        if isinstance(entry, dict) and entry.get("status") != NOT_CONFIGURED
     )
     all_healthy = required_healthy and installed_healthy
 

--- a/ods/extensions/services/dashboard-api/tests/test_voice.py
+++ b/ods/extensions/services/dashboard-api/tests/test_voice.py
@@ -95,3 +95,16 @@ class TestVoiceStatus:
         result = await voice_status(api_key="test")
 
         assert result["available"] is True
+
+    @pytest.mark.asyncio
+    async def test_handles_health_check_exception_resilience(self, monkeypatch):
+        async def mock_fail(*args, **kwargs):
+            raise RuntimeError("Check failed")
+
+        monkeypatch.setattr("config.SERVICES", _services("whisper", "tts"))
+        monkeypatch.setattr("helpers.check_service_health", mock_fail)
+
+        result = await voice_status(api_key="test")
+        assert result["available"] is False
+        assert result["services"]["stt"]["status"] == "unavailable"
+


### PR DESCRIPTION
Safely check dictionary types and status keys when evaluating voice services health verdict.