### PR TITLE
Add resource limits to Tailscale service

### DIFF
--- a/ods/extensions/services/tailscale/compose.yaml
+++ b/ods/extensions/services/tailscale/compose.yaml
@@ -52,6 +52,14 @@ services:
       - TS_USERSPACE=false
     volumes:
       - ./data/tailscale:/var/lib/tailscale:z
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.1'
+          memory: 64M
     healthcheck:
       # `tailscale status` returns 0 if the daemon is up and authenticated,
       # 1 if not. Useful for "is this device on the tailnet right now."


### PR DESCRIPTION
Tailscale service was missing deploy resource limits that all other ODS services define. Added reasonable limits (0.5 CPU, 256MB memory) and reservations (0.1 CPU, 64MB memory) consistent with lightweight services like hermes-proxy and brave-search.

PR Description:
## Summary
Adds missing resource limits and reservations to the Tailscale service to match resource management patterns of other ODS services.

## Details
- Tailscale service had no `deploy.resources` section defined
- All other ODS services (hermes-proxy, brave-search, ape, etc.) explicitly define CPU and memory limits
- Added limits (0.5 CPU, 256MB memory) and reservations (0.1 CPU, 64MB memory) appropriate for a lightweight daemon
- These values align with similar lightweight services in the stack

## Testing
No functional impact — Tailscale will continue to function identically. The change only adds resource constraints to prevent runaway resource consumption.