### PR TITLE
Add missing service dependency: remote-provider-egress depends on rem…

### DIFF
--- a/ods/extensions/services/remote-provider-egress/manifest.yaml
+++ b/ods/extensions/services/remote-provider-egress/manifest.yaml
@@ -17,7 +17,7 @@ service:
   type: docker
   gpu_backends: [all]
   category: core
-  depends_on: []
+  depends_on: [remote-provider-ssh-tunnel]
   startup_check: true
   description: >
     Internal-only OpenAI-compatible egress boundary for optional remote LLM


### PR DESCRIPTION
The remote-provider-egress service references the SSH tunnel health endpoint (http://remote-provider-ssh-tunnel:18090/health) in its ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL configuration but did not declare the dependency. Added the dependency to ensure proper startup ordering.

PR Description:
## Summary
Adds missing service dependency declaration in remote-provider-egress manifest to ensure correct startup ordering with remote-provider-ssh-tunnel.

## Details
- remote-provider-egress service reads the SSH tunnel health endpoint via `ODS_REMOTE_PROVIDER_SSH_TUNNEL_HEALTH_URL=http://remote-provider-ssh-tunnel:18090/health`
- The manifest had `depends_on: []` (empty) despite this hard dependency
- Without the declaration, Docker Compose may start egress before the SSH tunnel is ready, causing health checks to fail
- Updated manifest to declare the dependency: `depends_on: [remote-provider-ssh-tunnel]`

## Testing
No behavioral changes — ensures correct startup ordering so the SSH tunnel service is available before egress service attempts to check its health endpoint. Particularly important in scaled deployments where startup order matters.