### PR TITLE
fix(preflight): graceful exit when install dir is not writable

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-preflight-log-writable.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -97,6 +97,13 @@ pass() { log "${GREEN}✓${NC} $1"; PASS=$((PASS+1)); }
 fail() { log "${RED}✗${NC} $1"; FAIL=$((FAIL+1)); }
 warn() { log "${YELLOW}⚠${NC} $1"; WARN=$((WARN+1)); }
 
+if ! : > "$LOG_FILE" 2>/dev/null; then
+    echo -e "${RED}✗ ERROR: Cannot write to log file.${NC}" >&2
+    echo -e "  Path: ${LOG_FILE}" >&2
+    echo -e "  Fix: Check permissions on directory: ${ODS_DIR}" >&2
+    exit 1
+fi
+
 echo "" > "$LOG_FILE"
 log "========================================"
 log "ODS Pre-flight Check"

--- a/ods/tests/test-preflight-log-writable.sh
+++ b/ods/tests/test-preflight-log-writable.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Tests that ods-preflight.sh fails gracefully with an actionable error
+# when the installation directory is not writable.
+
+set -euo pipefail
+
+# Locate the root of the repo
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREFLIGHT_SCRIPT="$REPO_ROOT/ods-preflight.sh"
+
+echo "Running preflight unwritable log test..."
+
+if [[ ! -f "$PREFLIGHT_SCRIPT" ]]; then
+    echo "FAIL: Could not find $PREFLIGHT_SCRIPT"
+    exit 1
+fi
+
+# Create a secure temp directory
+TMP_DIR=$(mktemp -d)
+# Ensure we can delete the folder on exit even if we made it read-only
+trap 'chmod -R 777 "$TMP_DIR" 2>/dev/null; rm -rf "$TMP_DIR"' EXIT
+
+# Copy the script and stub required dependencies
+cp "$PREFLIGHT_SCRIPT" "$TMP_DIR/"
+mkdir -p "$TMP_DIR/lib"
+touch "$TMP_DIR/lib/safe-env.sh"
+touch "$TMP_DIR/.env"
+
+# Remove write permissions from the directory
+chmod 555 "$TMP_DIR"
+
+# Run the copied preflight script and capture stderr/stdout
+set +e
+OUTPUT=$("$TMP_DIR/ods-preflight.sh" 2>&1)
+EXIT_CODE=$?
+set -e
+
+# Assertions
+if [[ $EXIT_CODE -ne 1 ]]; then
+    echo "FAIL: Expected preflight to exit with code 1, got $EXIT_CODE"
+    echo "Output was:"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+if ! echo "$OUTPUT" | grep -q "Cannot write to log file"; then
+    echo "FAIL: Actionable error message not found in output."
+    echo "Output was:"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+echo "PASS: Preflight gracefully caught the unwritable directory."


### PR DESCRIPTION
FIX : https://github.com/Osmantic/ODS/issues/2930

This adds a writability probe to `ods-preflight.sh` before it attempts to initialize its log file. Previously, running the script in a read-only or root-owned installation directory under `set -euo pipefail` caused a silent crash, leaving users without actionable feedback. The script now safely catches the permission error and prints a diagnostic message indicating the exact path to fix. Also includes a new test script to validate this behavior.