### PR TITLE
fix(token-spy): prevent ssh command injection during remote session cleanup

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-session-manager-ssh-injection.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/extensions/services/token-spy/session-manager.sh
+++ b/ods/extensions/services/token-spy/session-manager.sh
@@ -286,11 +286,11 @@ REMOTESCRIPT
   log "  Sessions: $session_count total, ${#to_remove[@]} to remove"
 
   if [ "${#to_remove[@]}" -gt 0 ]; then
-    local rm_args=""
+    local paths_to_remove=()
     for sid in "${to_remove[@]}"; do
-      rm_args="${rm_args} ${remote_dir}/${sid}.jsonl"
+      paths_to_remove+=("${remote_dir}/${sid}.jsonl")
     done
-    ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "rm -f ${rm_args}" 2>/dev/null || true
+    printf '%s\0' "${paths_to_remove[@]}" | ssh -o ConnectTimeout=5 -o BatchMode=yes "${host}" "xargs -0 rm -f" 2>/dev/null || true
     log "  [DONE] Removed ${#to_remove[@]} sessions on $host"
   else
     log "  [OK] No cleanup needed"

--- a/ods/tests/test-session-manager-ssh-injection.sh
+++ b/ods/tests/test-session-manager-ssh-injection.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Tests that extensions/services/token-spy/session-manager.sh securely handles
+# malicious session file names over SSH without command injection.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MANAGER_SCRIPT="$REPO_ROOT/extensions/services/token-spy/session-manager.sh"
+
+echo "Running token-spy SSH command injection test..."
+
+if [[ ! -f "$MANAGER_SCRIPT" ]]; then
+    echo "FAIL: Could not find $MANAGER_SCRIPT"
+    exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+# 1. Create a fake SSH binary to intercept the calls
+mkdir -p "$TMP_DIR/bin"
+cat << 'EOF' > "$TMP_DIR/bin/ssh"
+#!/bin/bash
+# Extract the last argument (the remote command)
+command="${*: -1}"
+
+if [[ "$command" == "bash" ]]; then
+    # Phase 1: Info gathering. We return a fake oversized session with a malicious name
+    echo "SESSION_LIST_START"
+    echo 'evil_session; echo pwned|9999999|0'
+    echo "SESSION_LIST_END"
+    echo "TOTAL_SIZE=9999999"
+elif [[ "$command" == "xargs -0 rm -f" ]]; then
+    # Phase 2 (Fixed): Deletion. Capture the null-delimited stream from stdin
+    cat > "$TMP_DIR_ENV/ssh_rm_input.bin"
+else
+    # Phase 2 (Vulnerable): The old script passed a flat string directly to rm
+    echo "$command" > "$TMP_DIR_ENV/ssh_vuln_input.txt"
+fi
+EOF
+chmod +x "$TMP_DIR/bin/ssh"
+
+# 2. Inject our mock agents into a copy of the script
+TEST_SCRIPT="$TMP_DIR/session-manager.sh"
+# Insert mock variables right after the set -euo pipefail line
+awk '/^set -euo pipefail/ {
+    print
+    print "AGENTS=()"
+    print "REMOTE_AGENTS=(\"mock-agent|mock-host|/mock/dir\")"
+    next
+} 1' "$MANAGER_SCRIPT" > "$TEST_SCRIPT"
+
+# 3. Execute the script with our fake SSH in the PATH
+export PATH="$TMP_DIR/bin:$PATH"
+export TMP_DIR_ENV="$TMP_DIR"
+
+bash "$TEST_SCRIPT" >/dev/null 2>&1 || true
+
+# 4. Assertions
+if [[ -f "$TMP_DIR/ssh_vuln_input.txt" ]]; then
+    echo "FAIL: Script executed vulnerable flat string SSH command:"
+    cat "$TMP_DIR/ssh_vuln_input.txt"
+    exit 1
+fi
+
+if [[ ! -f "$TMP_DIR/ssh_rm_input.bin" ]]; then
+    echo "FAIL: Did not capture xargs -0 rm input. Is the fix applied?"
+    exit 1
+fi
+
+# Convert null bytes to newlines to read the captured payload safely
+CAPTURED=$(tr '\0' '\n' < "$TMP_DIR/ssh_rm_input.bin")
+
+# Verify the exact malicious path was passed as a single literal string
+EXPECTED="/mock/dir/evil_session; echo pwned.jsonl"
+if [[ "$CAPTURED" != *"$EXPECTED"* ]]; then
+    echo "FAIL: Captured input does not match expected payload."
+    echo "Got: $CAPTURED"
+    exit 1
+fi
+
+echo "PASS: SSH command injection mitigated successfully."


### PR DESCRIPTION
FIX : https://github.com/Osmantic/ODS/issues/2929
## Summary

The token-spy `session-manager.sh` performs cost-aware session pruning for local and remote agents. During remote cleanup, the script previously constructed a deletion command by interpolating paths into a flat string (`ssh ... "rm -f ${rm_args}"`). Because the session IDs (derived from remote directory listings) can theoretically contain shell metacharacters, this exposed the remote host to arbitrary command injection during evaluation. 

This PR applies a defense-in-depth fix. Instead of evaluating the paths as shell arguments, the script now pipes the exact file paths as a null-delimited stream (`printf '%s\0'`) directly into `xargs -0 rm -f` on the remote host. This completely bypasses the remote shell's command-line parser, ensuring paths are treated strictly as literals. 

A Bash mock test is included to prove the injection vector is neutralized.



## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text


```

## Changed Surface

* [ ] Docs only
* [x] Tests only (added new test)
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [ ] Installer / bootstrap / lifecycle
* [ ] Docker Compose / service manifests
* [x] Model routing / Hermes / capabilities (token-spy extension)
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

## Risk And Validation

* Risk level: Low
* Validation run:
* [ ] `git diff --check`
* [ ] Markdown/link sanity for docs
* [x] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`
* [ ] Not required because:



Commands/results:

```bash
# Run the mock SSH injection test
bash ods/tests/test-session-manager-ssh-injection.sh

# Expected output:
# Running token-spy SSH command injection test...
# PASS: SSH command injection mitigated successfully.

```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

* [x] This is not an operational change. (Background extension task only).
* [ ] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

None

```

```