### PR TITLE
fix(uninstall): prevent --force from deleting source code checkouts

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
+	@bash tests/test-uninstall-source-checkout-guard.sh
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh

--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -130,6 +130,14 @@ if [[ ! -d "$INSTALL_DIR" ]]; then
     exit 1
 fi
 
+if command -v git >/dev/null 2>&1 && git -C "$INSTALL_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if [[ ! -f "$INSTALL_DIR/.env" ]]; then
+        log_error "Safety abort: $INSTALL_DIR appears to be a source code checkout, not a deployed installation (it is a git working tree lacking a .env file)."
+        log_error "Refusing to rm -rf your source tree."
+        exit 1
+    fi
+fi
+
 log_info "Install directory: $INSTALL_DIR"
 $KEEP_MODELS && log_info "Keeping models (--keep-models)"
 $KEEP_DATA && log_info "Keeping user data (--keep-data)"

--- a/ods/tests/test-uninstall-source-checkout-guard.sh
+++ b/ods/tests/test-uninstall-source-checkout-guard.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Tests that ods-uninstall.sh safely aborts when run from a source checkout
+# instead of deleting the developer's working tree.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UNINSTALLER="$REPO_ROOT/ods-uninstall.sh"
+
+echo "Running uninstall source-checkout guard test..."
+
+if [[ ! -f "$UNINSTALLER" ]]; then
+    echo "FAIL: Could not find $UNINSTALLER"
+    exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cd "$TMP_DIR"
+
+# 1. Simulate a git checkout containing the uninstaller and ods-cli marker
+git init -q
+mkdir ods
+cp "$UNINSTALLER" ods/
+touch ods/ods-cli
+
+# 2. Execute the uninstaller with --force
+set +e
+OUTPUT=$(./ods/ods-uninstall.sh --force 2>&1)
+EXIT_CODE=$?
+set -e
+
+# 3. Assertions
+if [[ $EXIT_CODE -ne 1 ]]; then
+    echo "FAIL: Expected uninstaller to exit with code 1, got $EXIT_CODE"
+    echo "Output was:"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+if ! echo "$OUTPUT" | grep -q "Safety abort"; then
+    echo "FAIL: Safety abort message not found in output."
+    echo "Output was:"
+    echo "$OUTPUT"
+    exit 1
+fi
+
+if [[ ! -d "ods" ]]; then
+    echo "FAIL: The uninstaller deleted the source directory anyway!"
+    exit 1
+fi
+
+echo "PASS: Uninstaller refused to delete the source checkout."


### PR DESCRIPTION
FIX : https://github.com/Osmantic/ODS/issues/2929

## Summary

`ods/ods-uninstall.sh` resolves its installation directory based on its own path when it sits next to `ods-cli`. If a developer or contributor runs `ods-uninstall.sh --force` directly from a cloned Git repository, the script identifies the repo as the install directory and runs `rm -rf` against it. Because `--force` bypasses the interactive confirmation, the working tree (including any uncommitted work) is silently and instantly deleted.

This PR introduces a safety guard that checks if the resolved installation directory is a Git working tree without an installer-generated `.env` file. Because real deployments strip `.git` and always include a `.env`, this accurately differentiates a deployed stack from a cloned repository and safely aborts. 

A Bash test is included to ensure the uninstaller correctly bails out when executed in a mock repository.

## Changed Surface

* [ ] Docs only
* [x] Tests only (added new test)
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [x] Installer / bootstrap / lifecycle (ods-uninstall.sh)
* [ ] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [ ] Dependencies / runtime wiring

## Risk And Validation

* Risk level: Low
* Validation run:
* [ ] `git diff --check`
* [ ] Markdown/link sanity for docs
* [x] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.6.x`
* [ ] Not required because:



Commands/results:

```bash
# Run the mock source-checkout test
bash ods/tests/test-uninstall-source-checkout-guard.sh

# Expected output:
# Running uninstall source-checkout guard test...
# PASS: Uninstaller refused to delete the source checkout.

```

## Operational Change Check

* [x] This is not an operational change.
* [ ] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

None

```

```