### PR TITLE
fix(tests): make 'make test' pass on macOS hosts again

### DIFF
--- a/ods/tests/test-bootstrap-upgrade-compose-flags-recovery.sh
+++ b/ods/tests/test-bootstrap-upgrade-compose-flags-recovery.sh
@@ -55,6 +55,17 @@ printf 'Linux\n'
 EOF
 chmod +x "$fakebin/uname"
 
+# With uname faked to Linux, the model lifecycle lock library requires
+# flock(1). That is util-linux and does not exist on macOS, so provide a no-op
+# shim there; hosts that have flock keep using the real one.
+if ! command -v flock >/dev/null 2>&1; then
+    cat > "$fakebin/flock" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$fakebin/flock"
+fi
+
 # Docker is "up" with a running llama-server so the restart branch is taken.
 # inspect reports a restarting container so the health wait aborts quickly.
 cat > "$fakebin/docker" <<'EOF'

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -80,7 +80,15 @@ docker() {
     hermes_docker_args=("$@")
     local arg_count=${#hermes_docker_args[@]}
     local sed_arg_count=$((arg_count - 4))
-    command sed "${hermes_docker_args[@]:3:$sed_arg_count}" "$hermes_config"
+    local replay_args=("${hermes_docker_args[@]:3:$sed_arg_count}")
+    # The helper targets GNU/busybox sed inside the container, where -i takes
+    # no argument. BSD sed (macOS) treats the next word as the -i suffix, so a
+    # host replay of "-i -e ... -e ..." would eat the first -e and then read
+    # the second one as a filename. Give BSD sed the explicit empty suffix.
+    if ! sed --version 2>/dev/null | grep -q GNU && [[ "${replay_args[0]:-}" == "-i" ]]; then
+        replay_args=(-i '' "${replay_args[@]:1}")
+    fi
+    command sed "${replay_args[@]}" "$hermes_config"
 }
 DOCKER_CMD=docker
 hermes_malicious_model="model&branch|tag\\path\"quoted' ; touch ${hermes_patch_marker} ; #"


### PR DESCRIPTION
## Summary

`make test` cannot pass on a macOS checkout: two suites fail for host-environment reasons and report what look like product failures (same class of problem as #1539).

- **`tests/test-bootstrap-upgrade-hotswap-contract.sh`** replays the arguments `patch_hermes_yaml_in_container` hands to `docker exec ods-hermes sed -i -e … -e …` through the *host* `sed`. Inside the container that is GNU/busybox `sed`, where `-i` takes no argument; BSD `sed` consumes the first `-e` as the `-i` suffix and then reads the second `-e` as a filename (`sed: -e: No such file or directory`). Because `tests/contracts/test-installer-contracts.sh` runs this suite at line 57, the whole composite stops there and the 16 sub-suites after it never run on a Mac.
- **`tests/test-bootstrap-upgrade-compose-flags-recovery.sh`** fakes `uname` to `Linux`, which routes `bootstrap-upgrade.sh` through the model lifecycle lock, and that requires `flock(1)`. `flock` is util-linux and does not exist on macOS, so the script bails (`flock is unavailable`) before the recovery path under test.

Changes (tests only):

- Hot-swap stub: replay through a copy of the recorded args, and give BSD `sed` the explicit empty `-i` suffix when the host `sed` is not GNU. The recorded `hermes_docker_args` are untouched, so the existing argv-boundary assertions still check the real helper output.
- Recovery test: add a no-op `flock` shim to the fake bin **only when the host has no `flock`**. Hosts with `flock` keep using the real one.

Production code is untouched: the container `sed` call is correct, and `ods_model_lifecycle_lock_acquire` is Linux-only by design.

Fixes #3788

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low — test-only; both changes are gated on the host lacking GNU `sed` / `flock`, so Linux CI behavior is unchanged.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: no runtime surface is touched.

Commands/results:

```text
# Host: macOS 15 (Darwin 24.6), Intel i7-9750H, Homebrew Bash 5.3.15, BSD sed, no flock

# BEFORE (upstream/main 21f4b3a6) — identical output on a clean worktree
$ bash tests/test-bootstrap-upgrade-hotswap-contract.sh
sed: -e: No such file or directory
[FAIL] Hermes live patch helper rejected metacharacters that should remain data
$ bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
[bootstrap] ... Cannot safely run background full-model activation: flock is unavailable.
[FAIL] recovery path never invoked resolve-compose-stack.sh

# AFTER (this branch)
$ bash tests/test-bootstrap-upgrade-hotswap-contract.sh          # all [PASS]
$ bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh    # [PASS] compose-flags recovery forwards GPU_COUNT and ODS_MODE to the resolver
$ bash tests/contracts/test-installer-contracts.sh               # exit 0, "[PASS] installer contracts" — whole composite now completes on macOS

$ /bin/bash -n <both files>                                       # OK under Bash 3.2
$ shellcheck --exclude=SC1091,SC2034 --severity=error <both files>   # clean (CI gate); warning count 0 -> 0 on both
$ git diff --check                                                # clean
$ make -n test | run each command   # 68 of 69 pass on this Mac (Homebrew Bash 5.3)
# Only failure: bash tests/test-cli-update-verification.sh — pre-existing and platform-independent (it also fails on a clean Ubuntu 24.04 run of upstream/main); out of scope, fixed by #3159.
#   PASS  bash tests/contracts/test-installer-contracts.sh   (previously stopped at the hot-swap replay)
#   PASS  bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- The third failure in `make test`, `tests/test-cli-update-verification.sh` (the host-agent refresh aborts `ods update` when `bin/ods-host-agent.py` is absent), is not macOS-specific — it reproduces on a clean Ubuntu 24.04 run of `upstream/main` — and is already addressed by #3159.
- No overlap with #3137, which also edits the hot-swap suite but at line 619 (this change is the `docker()` stub at line 78).
- Overlap check: searched open PRs/issues for `BSD sed`, `flock`, both test file names, and "make test macOS" — only #1539 (merged) is related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

