### PR TITLE
fix(macos): report Intel Macs as a preflight blocker

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -137,6 +137,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== macOS ods-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
+	@bash tests/test-macos-intel-preflight-blocker.sh
 	@echo ""
 	@echo "=== desktop host-agent environment contract ==="
 	@bash tests/test-desktop-agent-host-env.sh

--- a/ods/docs/PREFLIGHT-ENGINE.md
+++ b/ods/docs/PREFLIGHT-ENGINE.md
@@ -46,6 +46,11 @@ scripts/preflight-engine.sh \
   --report /tmp/ods-preflight-report.json
 ```
 
+`--host-arch <uname -m>` is optional. With `--platform-id macos`, `arm64`/`aarch64`
+passes and anything else is a blocker, because the macOS installer requires Apple
+Silicon. Leave it empty or omit it when the caller cannot know the real host
+architecture, for example the Linux CI simulation of `installers/macos.sh`.
+
 For shell integration:
 
 ```bash

--- a/ods/installers/macos.sh
+++ b/ods/installers/macos.sh
@@ -41,11 +41,18 @@ echo ""
 [[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
 
 ARCH="$(uname -m 2>/dev/null || echo unknown)"
+HOST_OS="$(uname -s 2>/dev/null || echo unknown)"
+# Only a real Darwin host knows its Mac architecture. The Linux CI simulation
+# of this script passes an empty value, which the engine treats as unknown.
+PREFLIGHT_HOST_ARCH=""
 if [[ "$ARCH" == "arm64" ]]; then
     echo "[OK] Apple Silicon detected: $ARCH"
+elif [[ "$HOST_OS" == "Darwin" ]]; then
+    echo "[WARN] Intel Mac detected ($ARCH): the macOS installer requires Apple Silicon (arm64)."
 else
     echo "[WARN] Non-Apple-Silicon architecture detected: $ARCH"
 fi
+[[ "$HOST_OS" == "Darwin" ]] && PREFLIGHT_HOST_ARCH="$ARCH"
 
 if command -v docker >/dev/null 2>&1; then
     if docker version >/dev/null 2>&1; then
@@ -77,6 +84,7 @@ if [[ -x "$SCRIPT_DIR/scripts/preflight-engine.sh" ]]; then
         --gpu-vram-mb 0 \
         --gpu-name "Apple Silicon" \
         --platform-id "macos" \
+        --host-arch "$PREFLIGHT_HOST_ARCH" \
         --compose-overlays "docker-compose.base.yml,docker-compose.amd.yml" \
         --script-dir "$SCRIPT_DIR" \
         --env)"

--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -56,6 +56,10 @@ while [[ $# -gt 0 ]]; do
             SCRIPT_DIR="${2:-$SCRIPT_DIR}"
             shift 2
             ;;
+        --host-arch)
+            HOST_ARCH="${2:-}"
+            shift 2
+            ;;
         --strict)
             STRICT="true"
             shift
@@ -80,7 +84,8 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$REPORT_FILE" "$TIER" "$RAM_GB" "$DISK_GB" "$GPU_BACKEND" "$GPU_VRAM_MB" "$GPU_NAME" "$PLATFORM_ID" "$COMPOSE_OVERLAYS" "$SCRIPT_DIR" "$ENV_MODE" "$STRICT" <<'PY'
+HOST_ARCH="${HOST_ARCH:-}"
+"$PYTHON_CMD" - "$REPORT_FILE" "$TIER" "$RAM_GB" "$DISK_GB" "$GPU_BACKEND" "$GPU_VRAM_MB" "$GPU_NAME" "$PLATFORM_ID" "$COMPOSE_OVERLAYS" "$SCRIPT_DIR" "$ENV_MODE" "$STRICT" "$HOST_ARCH" <<'PY'
 import json
 import pathlib
 import sys
@@ -99,6 +104,7 @@ from datetime import datetime, timezone
     script_dir,
     env_mode,
     strict_mode,
+    host_arch,
 ) = sys.argv[1:]
 
 env_mode = env_mode == "true"
@@ -197,6 +203,26 @@ else:
         f"Platform '{platform_id}' is not yet supported by install-core.sh.",
         "Use Linux/WSL path for now or run platform-specific installer once implemented.",
     )
+
+# Host architecture check (macOS). The macOS installer requires Apple Silicon.
+# Callers that cannot know the real host architecture (e.g. the Linux CI
+# simulation of installers/macos.sh) pass an empty value and skip this check.
+host_arch = (host_arch or "").strip().lower()
+if platform_id == "macos" and host_arch:
+    if host_arch in {"arm64", "aarch64"}:
+        add_check(
+            "host-arch",
+            "pass",
+            f"Apple Silicon host detected ({host_arch}).",
+            "",
+        )
+    else:
+        add_check(
+            "host-arch",
+            "blocker",
+            f"Intel Mac ({host_arch}) is not supported by the macOS installer; Apple Silicon (arm64) is required.",
+            "Intel Macs have no Metal acceleration for local inference. See docs/COMPATIBILITY-MATRIX.md; use the Linux or Windows+WSL2 path on this hardware.",
+        )
 
 # Compose overlay existence check
 overlays = [o.strip() for o in compose_overlays.split(",") if o.strip()]
@@ -330,6 +356,7 @@ report = {
         "gpu_vram_mb": gpu_vram_mb,
         "gpu_name": gpu_name,
         "platform_id": platform_id,
+        "host_arch": host_arch,
         "compose_overlays": overlays,
         "script_dir": script_dir,
     },

--- a/ods/tests/contracts/test-preflight-fixtures.sh
+++ b/ods/tests/contracts/test-preflight-fixtures.sh
@@ -59,6 +59,28 @@ scripts/preflight-engine.sh \
 blockers="$(json_summary_blockers "$tmpdir/windows-mvp-good.json")"
 assert_eq "$blockers" "0" "windows-mvp-good blockers"
 
+# macOS: the installer requires Apple Silicon. An empty --host-arch (what the
+# Linux CI simulation of installers/macos.sh passes) must not add a blocker.
+for macos_case in "macos-arm64-good:arm64:0" "macos-intel-blocked:x86_64:1" "macos-arch-unknown::0"; do
+  IFS=: read -r case_name host_arch expected <<<"$macos_case"
+  echo "[contract] preflight fixture: $case_name"
+  scripts/preflight-engine.sh \
+    --report "$tmpdir/$case_name.json" \
+    --tier T1 \
+    --ram-gb 16 \
+    --disk-gb 120 \
+    --gpu-backend apple \
+    --gpu-vram-mb 0 \
+    --gpu-name "Apple Silicon" \
+    --platform-id macos \
+    --host-arch "$host_arch" \
+    --compose-overlays docker-compose.base.yml,docker-compose.amd.yml \
+    --script-dir "$ROOT_DIR" \
+    --env >/dev/null
+  blockers="$(json_summary_blockers "$tmpdir/$case_name.json")"
+  assert_eq "$blockers" "$expected" "$case_name blockers"
+done
+
 echo "[contract] preflight fixture: macos-mvp-good"
 scripts/preflight-engine.sh \
   --report "$tmpdir/macos-mvp-good.json" \

--- a/ods/tests/test-macos-intel-preflight-blocker.sh
+++ b/ods/tests/test-macos-intel-preflight-blocker.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# installers/macos.sh must report an Intel Mac as a preflight blocker.
+#
+# The macOS installer requires Apple Silicon (install-macos.sh exits on
+# x86_64), but the preflight/doctor wrapper used to warn about the
+# architecture and then hand the engine a hard-coded Apple Silicon profile,
+# so an Intel Mac got a report with no blocker for the one thing that will
+# stop the install. The wrapper now passes the real host architecture to the
+# engine on Darwin only; the Linux CI simulation passes an empty value and
+# must keep getting no architecture blocker.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+has() { printf '%s\n' "$1" | grep -q -- "$2"; }
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Fake uname so the wrapper sees the host we choose.
+mkdir -p "$TMP_ROOT/bin"
+cat > "$TMP_ROOT/bin/uname" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+    -m) printf '%s\n' "${FAKE_UNAME_M:-x86_64}" ;;
+    *) printf '%s\n' "${FAKE_UNAME_S:-Linux}" ;;
+esac
+EOF
+chmod +x "$TMP_ROOT/bin/uname"
+
+make_tree() {
+    # $1 = tree dir, $2 = "stub" | "real" preflight engine
+    local tree="$1" engine="$2"
+    mkdir -p "$tree/installers" "$tree/scripts" "$tree/lib"
+    cp "$ROOT_DIR/installers/macos.sh" "$tree/installers/macos.sh"
+    cp "$ROOT_DIR/lib/safe-env.sh" "$tree/lib/safe-env.sh"
+    cp "$ROOT_DIR/lib/python-cmd.sh" "$tree/lib/python-cmd.sh"
+    # Quiet doctor stub so only the preflight step is under test.
+    printf '#!/usr/bin/env bash\nprintf "{}\\n" > "$1"\n' > "$tree/scripts/ods-doctor.sh"
+    chmod +x "$tree/scripts/ods-doctor.sh"
+    if [[ "$engine" == "real" ]]; then
+        cp "$ROOT_DIR/scripts/preflight-engine.sh" "$tree/scripts/preflight-engine.sh"
+        # The engine only checks that the overlays exist.
+        : > "$tree/docker-compose.base.yml"
+        : > "$tree/docker-compose.amd.yml"
+    else
+        cat > "$tree/scripts/preflight-engine.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+report=""
+printf '%s\n' "$@" > "${ENGINE_ARGV_LOG:?}"
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report) report="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '{"checks": []}\n' > "$report"
+printf 'PREFLIGHT_BLOCKERS=0\nPREFLIGHT_WARNINGS=0\n'
+EOF
+        chmod +x "$tree/scripts/preflight-engine.sh"
+    fi
+}
+
+WRAPPER_RC=0
+WRAPPER_OUT=""
+run_wrapper() {
+    # $1 = tree, $2 = uname -s, $3 = uname -m. Runs in this shell (no command
+    # substitution) so the exit code survives; output lands in WRAPPER_OUT.
+    local tree="$1"
+    WRAPPER_RC=0
+    PATH="$TMP_ROOT/bin:$PATH" FAKE_UNAME_S="$2" FAKE_UNAME_M="$3" \
+        ENGINE_ARGV_LOG="$tree/engine-argv.log" \
+        bash "$tree/installers/macos.sh" --no-delegate \
+            --report "$tree/preflight.json" --doctor-report "$tree/doctor.json" \
+            > "$tree/out.log" 2>&1 \
+        || WRAPPER_RC=$?
+    WRAPPER_OUT="$(cat "$tree/out.log")"
+}
+
+host_arch_passed() {
+    # Value following --host-arch in the recorded engine argv (empty if absent).
+    awk 'found { print; exit } $0 == "--host-arch" { found = 1 }' "$1/engine-argv.log"
+}
+
+# --- Wrapper gating: what does the engine receive? ---------------------------
+
+STUB="$TMP_ROOT/stub"; make_tree "$STUB" stub
+
+run_wrapper "$STUB" Darwin x86_64
+if [[ "$(host_arch_passed "$STUB")" == "x86_64" ]]; then
+    pass "Darwin/x86_64: wrapper passes --host-arch x86_64 to the engine"
+else
+    fail "Darwin/x86_64: wrapper must pass --host-arch x86_64 (got '$(host_arch_passed "$STUB")')"
+fi
+if has "$WRAPPER_OUT" 'Intel Mac detected'; then
+    pass "Darwin/x86_64: wrapper names the Intel Mac in its output"
+else
+    fail "Darwin/x86_64: wrapper should say an Intel Mac was detected"
+fi
+
+run_wrapper "$STUB" Darwin arm64
+if [[ "$(host_arch_passed "$STUB")" == "arm64" ]]; then
+    pass "Darwin/arm64: wrapper passes --host-arch arm64 to the engine"
+else
+    fail "Darwin/arm64: wrapper must pass --host-arch arm64 (got '$(host_arch_passed "$STUB")')"
+fi
+if has "$WRAPPER_OUT" 'Apple Silicon detected'; then
+    pass "Darwin/arm64: wrapper reports Apple Silicon"
+else
+    fail "Darwin/arm64: wrapper should report Apple Silicon"
+fi
+
+run_wrapper "$STUB" Linux x86_64
+if grep -q -- '--host-arch' "$STUB/engine-argv.log" && [[ -z "$(host_arch_passed "$STUB")" ]]; then
+    pass "Linux/x86_64 (CI simulation): wrapper passes an empty --host-arch"
+else
+    fail "Linux/x86_64 (CI simulation): wrapper must pass an empty --host-arch (got '$(host_arch_passed "$STUB")')"
+fi
+if has "$WRAPPER_OUT" 'Intel Mac detected'; then
+    fail "Linux/x86_64: wrapper must not call a Linux host an Intel Mac"
+else
+    pass "Linux/x86_64: wrapper does not call a Linux host an Intel Mac"
+fi
+
+# --- End to end with the real engine ----------------------------------------
+
+REAL="$TMP_ROOT/real"; make_tree "$REAL" real
+
+run_wrapper "$REAL" Darwin x86_64
+if has "$WRAPPER_OUT" 'BLOCKER: Intel Mac (x86_64) is not supported'; then
+    pass "real engine, Darwin/x86_64: report carries the Intel Mac blocker"
+else
+    fail "real engine, Darwin/x86_64: report must carry the Intel Mac blocker"
+fi
+if [[ "$WRAPPER_RC" -eq 2 ]]; then
+    pass "real engine, Darwin/x86_64: wrapper exits 2 on the blocker"
+else
+    fail "real engine, Darwin/x86_64: wrapper should exit 2 (got $WRAPPER_RC)"
+fi
+
+# Disk/RAM on the host running this test may add their own blockers, so only
+# assert the architecture outcome for the remaining cases.
+run_wrapper "$REAL" Darwin arm64
+if has "$WRAPPER_OUT" 'Intel Mac'; then
+    fail "real engine, Darwin/arm64: no Intel Mac blocker expected"
+else
+    pass "real engine, Darwin/arm64: no Intel Mac blocker"
+fi
+
+run_wrapper "$REAL" Linux x86_64
+if has "$WRAPPER_OUT" 'Intel Mac'; then
+    fail "real engine, Linux/x86_64 (CI simulation): no Intel Mac blocker expected"
+else
+    pass "real engine, Linux/x86_64 (CI simulation): no Intel Mac blocker"
+fi
+
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`installers/macos.sh` warned about a non-`arm64` architecture and then handed the preflight engine a hard-coded Apple Silicon profile, so an Intel Mac got a report with **no blocker for the one thing that stops the install** — `install-macos.sh` refuses Intel Macs (`Apple Silicon (arm64) is required`), and `docs/COMPATIBILITY-MATRIX.md` lists them as not supported. The doctor built from that preflight then reported `hardware_class: apple_base` on an Intel machine.

Changes:

- **`installers/macos.sh`**: pass the real host architecture to the engine as `--host-arch`, but **only on Darwin**. The same wrapper runs on Linux x86_64 in CI (`simulate-installers.sh` requires zero blockers for `macos_installer_mvp`), so on non-Darwin hosts it passes an empty value. The Intel case gets a clearer `[WARN]` line; the blocker itself comes from the engine like every other check. Plain string, not an array: this script runs under stock Bash 3.2 with `set -u`, where an empty-array expansion is fatal.
- **`scripts/preflight-engine.sh`**: new optional `--host-arch` (appended as the *last* positional to the Python block, so existing positions do not move). With `--platform-id macos`, `arm64`/`aarch64` adds a `host-arch` pass check; anything else adds a blocker with the installer's wording; an empty/omitted value skips the check. The value is recorded in `inputs.host_arch`. Defaults preserve today's behavior for every existing caller (Linux, Windows simulation, macOS without the flag).
- **Tests**: three new fixture cases in `tests/contracts/test-preflight-fixtures.sh` (`arm64` → 0 blockers, `x86_64` → 1, empty → 0), and `tests/test-macos-intel-preflight-blocker.sh` (wired into `make test`), a hermetic run of the wrapper with a fake `uname` covering Darwin/x86_64, Darwin/arm64 and Linux/x86_64 against both a recording stub engine and the real engine.
- **Docs**: `docs/PREFLIGHT-ENGINE.md` documents the flag.

Fixes #3789

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Docs and tests boxes are ticked because the PR touches them; the substantive change is the preflight wrapper and engine.)

## Risk And Validation

- Risk level: Low — a new optional engine input whose absence preserves current behavior (proven by the existing fixture cases still passing unchanged), and a wrapper change that only affects Darwin hosts. No host mutation; the preflight/doctor wrapper installs nothing.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: no compose, service, auth, routing or install-phase surface is touched; validated on the affected hardware.

Commands/results:

```text
# Host: macOS 15 (Darwin 24.6), Intel i7-9750H; wrapper run under stock /bin/bash 3.2.57, tests under Homebrew Bash 5.3

# BEFORE (upstream/main 21f4b3a6), real wrapper on this Intel Mac
$ /bin/bash installers/macos.sh --no-delegate --report /tmp/pre.json --doctor-report /tmp/doc.json
[WARN] Non-Apple-Silicon architecture detected: x86_64
[INFO] Blockers: 1  Warnings: 2     # only the disk blocker; report inputs: gpu_backend=apple, gpu_name="Apple Silicon"

# AFTER (this branch)
$ /bin/bash installers/macos.sh --no-delegate --report /tmp/pre.json --doctor-report /tmp/doc.json
[WARN] Intel Mac detected (x86_64): the macOS installer requires Apple Silicon (arm64).
[INFO] Blockers: 2  Warnings: 2
  - BLOCKER: Intel Mac (x86_64) is not supported by the macOS installer; Apple Silicon (arm64) is required.
    Suggestion: Intel Macs have no Metal acceleration for local inference. See docs/COMPATIBILITY-MATRIX.md; use the Linux or Windows+WSL2 path on this hardware.
  - BLOCKER: Disk 7GB is below required minimum for tier T1 (50GB).
exit=2 ; report: inputs.host_arch="x86_64", checks[] has {"id":"host-arch","status":"blocker"}, summary.can_proceed=false

$ bash tests/test-macos-intel-preflight-blocker.sh
Result: 10 passed, 0 failed          # Darwin/x86_64, Darwin/arm64, Linux/x86_64 x {recording stub engine, real engine}
$ bash tests/contracts/test-preflight-fixtures.sh
[PASS] preflight fixture contracts   # existing linux/windows/macos/cloud cases unchanged + macos-arm64-good(0), macos-intel-blocked(1), macos-arch-unknown(0)

$ /bin/bash -n installers/macos.sh scripts/preflight-engine.sh tests/contracts/test-preflight-fixtures.sh tests/test-macos-intel-preflight-blocker.sh   # OK under Bash 3.2
$ shellcheck --exclude=SC1091,SC2034 --severity=error <changed .sh files>          # clean (CI gate); warning count 0 -> 0 on each
$ shellcheck --include=SC2006 installers/macos.sh scripts/preflight-engine.sh      # clean (pre-commit)
$ awk -f scripts/check-heredoc-backticks.awk installers/macos.sh scripts/preflight-engine.sh   # OK (pre-commit)
$ make lint                          # All lint checks passed.
$ git diff --check                   # clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

`installers/macos.sh` and `scripts/preflight-engine.sh` only produce diagnostics; the actual refusal of Intel Macs already lives in `install-macos.sh` and is unchanged.

## Notes For Reviewers

- CI safety: `scripts/simulate-installers.sh` runs this wrapper on Linux x86_64 and marks `macos_installer_mvp` ok only with zero blockers. The wrapper passes `--host-arch ""` there and the engine skips the check — covered by the `macos-arch-unknown` fixture and the Linux/x86_64 cases of the new test.
- Follow-up, not in this PR: the doctor's `capability_profile.hardware_class` still says `apple_base` on an Intel Mac (`scripts/build-capability-profile.sh` has no architecture input either).
- Overlap: #2758 adds `--help` to the engine and touches the argument loop; this PR adds one `case` arm before `--strict`. Several open PRs (#3392, #2439, #2665, #2225, #1954) make the report write atomic around `report = {`; this PR adds one key inside `inputs`. Both are textually adjacent but semantically independent; happy to rebase on whichever lands first.
- Overlap check: searched open PRs/issues for "Intel Mac", "x86_64 macos preflight", "host-arch", "preflight-engine" — none address this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

