### PR TITLE
test(bats): isolate macOS host state in three suites

### DIFF
--- a/ods/tests/bats-tests/amd-topo.bats
+++ b/ods/tests/bats-tests/amd-topo.bats
@@ -228,7 +228,16 @@ setup() {
     rm -rf "$tmpdir"
 }
 
+# amd_gpu_name pipes readlink -f through grep -oP. BSD grep (macOS) has no
+# PCRE support, so on such hosts the usage error lands in the captured output
+# and the exact-output assertions below cannot hold. The library only runs on
+# Linux sysfs; skip these cases where the host grep lacks -P.
+require_pcre_grep() {
+    printf 'x\n' | grep -P 'x' >/dev/null 2>&1 || skip "host grep lacks -P (PCRE); amd_gpu_name uses grep -oP on Linux sysfs paths"
+}
+
 @test "amd_gpu_name: skips empty product_name" {
+    require_pcre_grep
     local tmpdir
     tmpdir=$(mktemp -d)
     echo "" > "$tmpdir/product_name"
@@ -242,6 +251,7 @@ setup() {
 }
 
 @test "amd_gpu_name: skips (null) product_name" {
+    require_pcre_grep
     local tmpdir
     tmpdir=$(mktemp -d)
     echo "(null)" > "$tmpdir/product_name"
@@ -254,6 +264,7 @@ setup() {
 }
 
 @test "amd_gpu_name: falls back to device ID format" {
+    require_pcre_grep
     local tmpdir
     tmpdir=$(mktemp -d)
     # No product_name file

--- a/ods/tests/bats-tests/phase-06-perms.bats
+++ b/ods/tests/bats-tests/phase-06-perms.bats
@@ -36,7 +36,9 @@ teardown() {
 TEST_KEY=test-value
 ENV_EOF
         )
-        stat -c "%a" "'"$INSTALL_DIR"'/.env"
+        # GNU stat -c on Linux; BSD stat -f on macOS.
+        mode_of() { stat -c "%a" "$1" 2>/dev/null || stat -f "%Lp" "$1"; }
+        mode_of "'"$INSTALL_DIR"'/.env"
     '
     assert_success
     assert_output "600"
@@ -51,6 +53,8 @@ ENV_EOF
     # ComfyUI root) could not enter them.
     run bash -c '
         umask 022   # Ambient umask the installer normally inherits
+        # GNU stat -c on Linux; BSD stat -f on macOS.
+        mode_of() { stat -c "%a" "$1" 2>/dev/null || stat -f "%Lp" "$1"; }
         (
             umask 077
             cat > "'"$INSTALL_DIR"'/.env" << ENV_EOF
@@ -67,7 +71,7 @@ ENV_EOF
             "'"$INSTALL_DIR"'/config/searxng" \
             "'"$INSTALL_DIR"'/config/llama-server" \
             "'"$INSTALL_DIR"'/data/comfyui/output"; do
-            mode=$(stat -c "%a" "$d")
+            mode=$(mode_of "$d")
             # Octal world-traverse bit is the 1s digit & 1.
             world_x=$(( 8#$mode & 1 ))
             if [[ $world_x -ne 1 ]]; then

--- a/ods/tests/bats-tests/requirements-phase.bats
+++ b/ods/tests/bats-tests/requirements-phase.bats
@@ -94,6 +94,10 @@ STUB
 }
 
 @test "check_port_conflict: detects conflict when port is occupied" {
+    # This case replays the ss(8) branch of check_port_conflict. ss is
+    # iproute2 and does not exist on macOS, so there the replay can only
+    # ever report CLEAR. Skip before starting the background listener.
+    command -v ss >/dev/null 2>&1 || skip "ss(8) not available on this host; the ss-based conflict check is Linux-only"
     # Start a background listener on a test port
     local test_port=59877
     python3 -c "


### PR DESCRIPTION
## Summary

`make bats` reports 11 failures on a macOS checkout. Six are host-tooling gaps inside the tests (same class as #1539 and #3161); this PR isolates them, test-only:

- **`amd-topo.bats`** (3 cases): `amd_gpu_name` pipes `readlink -f` through `grep -oP`; BSD `grep` has no PCRE, so its usage error lands in the captured output and the exact-output assertions fail. The library only runs on Linux sysfs. Skip where the host `grep` lacks `-P` — the neighbouring `detect_gpu` cases in this suite already skip on macOS for exactly this reason.
- **`phase-06-perms.bats`** (2 cases): the test's replay script used GNU `stat -c "%a"`; BSD `stat` spells it `-f "%Lp"`. A two-line helper tries GNU first, so Linux behavior is unchanged.
- **`requirements-phase.bats`** (1 case): the occupied-port case replays the `ss(8)` branch only; `ss` is iproute2 and does not exist on macOS, so the replay can only report `CLEAR`. Skip before the background listener starts (so nothing leaks).

The other five macOS failures are already claimed: #2101 (`normalize_path`/`realpath`), #3668 (Docker-phase fixture), and the three `preflight-phase.bats` cases (`Unsupported OS. This installer requires Linux.`) live in the file #3161 is restructuring — a Darwin `uname` shim there can follow once it lands.

Fixes #3792

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low — tests only; every change is gated on the host lacking the Linux tool (`grep -P`, `ss`) or prefers the GNU form first (`stat`), so Linux CI behavior is unchanged.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: no runtime surface is touched.

Commands/results:

```text
# Host: macOS 15 (Darwin 24.6), Intel i7-9750H, Homebrew Bash 5.3.15, BSD grep/stat, no ss

# BEFORE (upstream/main 21f4b3a6)
$ make bats
1..418 — ok: 407, not ok: 11   (13,14,15 amd_gpu_name; 119 docker phase; 204 normalize_path; 216,217 phase-06 perms;
                               241,242,243 preflight; 258 check_port_conflict)

# AFTER (this branch)
$ make bats
1..418 — ok: 414, not ok: 4, skipped: 7
  not ok 204 normalize_path: removes trailing components via realpath        -> #2101
  not ok 241/242/243 preflight: ... "Unsupported OS. This installer requires Linux." -> preflight-phase.bats, being restructured in #3161
  ok 216 .env is mode 600 immediately after creation (subshell umask wrap)   (was failing)
  ok 217 container-bind-mount dirs are not 700-class after .env subshell     (was failing)
  ok 13/14/15 amd_gpu_name: ... # skip host grep lacks -P (PCRE)             (new skips, next to the 3 pre-existing detect_gpu skips)
  ok 258 check_port_conflict: ... # skip ss(8) not available on this host    (new skip)
$ git diff --check   # clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Possible follow-up outside this PR: `installers/lib/amd-topo.sh` uses `grep -oP` with patterns that are plain ERE (`[0-9a-f]{4}:…`, `^\d+`, `gfx\d+`); switching to `grep -oE` would also make it work on busybox grep. Left alone here because it is GPU detection code and this PR is tests-only.
- Overlap, stated plainly: the large #1934 (centralize extension health probes, July) already carries an equivalent BSD-first `stat` fallback for the **same two lines** of `phase-06-perms.bats`, and it also rewrites the body of the occupied-port case in `requirements-phase.bats` just below where this PR adds the `ss` skip. If #1934 lands first, the `phase-06-perms.bats` part of this PR becomes a no-op rebase and the port-case skip needs a one-line re-apply; if this lands first, #1934's `stat` hunk is the one to drop. The `amd-topo.bats` skips are not in #1934. None of #3161, #3668, #2101 or #1935 touch these three files. Searched open PRs/issues for the file names, "grep -P", "stat -c" and "make bats".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

