### PR TITLE
Add auto-discovery of GGUF models and update configs on refresh

### DIFF
--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -4342,6 +4342,30 @@ _remote_provider_probe_configured() {
     rm -f "$response_file"; trap - INT TERM HUP
 }
 
+cmd_refresh_models() {
+    check_install; cd "$INSTALL_DIR"
+    local subcommand="${1:-discover}"
+
+    case "$subcommand" in
+        discover|refresh)
+            echo "Scanning $INSTALL_DIR/data/models for new GGUF models..."
+            if python3 "$SCRIPT_DIR/scripts/auto-discover-models.py"; then
+                echo -e "${GREEN}✓${NC} Model configuration updated"
+                echo ""
+                echo "Available models in:"
+                echo "  • llama-server: ods/config/llama-server/models.ini"
+                echo "  • litellm: ods/config/litellm/local.yaml, hybrid.yaml"
+                return 0
+            else
+                error "Failed to discover models. Check that Python 3 is installed."
+            fi
+            ;;
+        *)
+            error "Unknown subcommand: $subcommand. Use 'ods refresh-models discover' to scan for new models."
+            ;;
+    esac
+}
+
 cmd_remote_provider_peer_models() {
     local subcmd="${1:-list}"
     shift || true
@@ -6570,6 +6594,7 @@ case "${1:-help}" in
     preset|p)    shift; cmd_preset "$@" ;;
     mode|m)      shift; cmd_mode "$@" ;;
     model)       shift; cmd_model "$@" ;;
+    refresh-models) shift; cmd_refresh_models "$@" ;;
     remote-provider) shift; cmd_remote_provider "$@" ;;
     stt)         shift; cmd_stt "$@" ;;
     backup)      shift; cmd_backup "$@" ;;

--- a/ods/scripts/auto-discover-models.py
+++ b/ods/scripts/auto-discover-models.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""
+Auto-discover GGUF models in ods/data/models and update configuration files.
+Runs on ODS startup to make newly downloaded models available in UI.
+"""
+import os
+import json
+import sys
+import yaml
+from pathlib import Path
+
+def get_model_name(filename):
+    """Convert filename to model name."""
+    # Remove .gguf extension and use filename as is
+    return filename.replace('.gguf', '').replace('.GGUF', '')
+
+def discover_models(models_dir):
+    """Discover all GGUF models in the directory."""
+    models_dir = Path(models_dir)
+    if not models_dir.exists():
+        return {}
+
+    models = {}
+    for gguf_file in models_dir.glob("**/*.gguf"):
+        model_name = get_model_name(gguf_file.name)
+        models[model_name] = gguf_file.name
+
+    return models
+
+def update_models_ini(ini_path, discovered_models):
+    """Update llama-server models.ini with discovered models."""
+    if not discovered_models:
+        return
+
+    content = []
+    added_models = set()
+
+    # Read existing config and preserve order
+    if Path(ini_path).exists():
+        with open(ini_path, 'r') as f:
+            lines = f.readlines()
+
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if line.startswith('[') and line.endswith(']\n'):
+                section = line[1:-2]
+                added_models.add(section)
+                content.append(line)
+                # Copy section content
+                i += 1
+                while i < len(lines) and not lines[i].startswith('['):
+                    content.append(lines[i])
+                    i += 1
+            else:
+                i += 1
+
+    # Add new models
+    for model_name, filename in sorted(discovered_models.items()):
+        if model_name not in added_models:
+            content.append(f"\n[{model_name}]\n")
+            content.append(f"filename = {filename}\n")
+            content.append("load-on-startup = false\n")
+            content.append("n-ctx = 32768\n")
+
+    # Write updated config
+    os.makedirs(Path(ini_path).parent, exist_ok=True)
+    with open(ini_path, 'w') as f:
+        f.writelines(content)
+
+def update_litellm_config(config_path, discovered_models):
+    """Update litellm YAML config with discovered models."""
+    if not discovered_models or not Path(config_path).exists():
+        return
+
+    try:
+        with open(config_path, 'r') as f:
+            config = yaml.safe_load(f)
+    except Exception:
+        return
+
+    if 'model_list' not in config:
+        config['model_list'] = []
+
+    # Get existing model names
+    existing_models = {item.get('model_name') for item in config['model_list'] if item.get('model_name') != '*'}
+
+    # Add new models before the wildcard entry
+    added_count = 0
+    for model_name in sorted(discovered_models.keys()):
+        if model_name not in existing_models:
+            new_entry = {
+                'model_name': model_name,
+                'litellm_params': {
+                    'model': f'openai/{model_name}',
+                    'api_base': 'http://llama-server:8080/v1',
+                    'api_key': 'not-needed'
+                }
+            }
+            # Find wildcard entry and insert before it
+            wildcard_idx = next((i for i, item in enumerate(config['model_list']) if item.get('model_name') == '*'), len(config['model_list']))
+            config['model_list'].insert(wildcard_idx, new_entry)
+            added_count += 1
+
+    if added_count > 0:
+        try:
+            with open(config_path, 'w') as f:
+                yaml.dump(config, f, default_flow_style=False, sort_keys=False)
+        except Exception:
+            pass
+
+def main():
+    try:
+        models_dir = Path("ods/data/models")
+
+        # Discover models
+        discovered = discover_models(models_dir)
+        if not discovered:
+            return 0
+
+        # Update llama-server models.ini
+        models_ini = Path("ods/config/llama-server/models.ini")
+        if models_ini.exists():
+            update_models_ini(models_ini, discovered)
+
+        # Update litellm configs
+        for config_file in ["ods/config/litellm/local.yaml", "ods/config/litellm/hybrid.yaml"]:
+            update_litellm_config(config_file, discovered)
+
+        return 0
+    except Exception as e:
+        # Silently fail - this is a nice-to-have feature
+        return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ods/scripts/auto-discover-models.py
+++ b/ods/scripts/auto-discover-models.py
@@ -4,7 +4,6 @@ Auto-discover GGUF models in ods/data/models and update configuration files.
 Runs on ODS startup to make newly downloaded models available in UI.
 """
 import os
-import json
 import sys
 import yaml
 from pathlib import Path
@@ -128,7 +127,7 @@ def main():
             update_litellm_config(config_file, discovered)
 
         return 0
-    except Exception as e:
+    except Exception:
         # Silently fail - this is a nice-to-have feature
         return 0
 

--- a/ods/scripts/discover-and-update-models.sh
+++ b/ods/scripts/discover-and-update-models.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Auto-discover GGUF models and update ODS configuration files
+# Should be called before starting llama-server and other model-consuming services
+
+set -euo pipefail
+
+MODELS_DIR="${1:-.}/data/models"
+SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Call Python script for model discovery
+python3 "$SCRIPTS_DIR/auto-discover-models.py"


### PR DESCRIPTION
FIX :  https://github.com/Osmantic/ODS/issues/3785

## Summary
Auto-discover GGUF models in ods/data/models and update configuration files to make them available in Open WebUI, LiteLLM, and other services.

## Problem
Downloaded models don't appear in UI dropdowns without manual config edits.

## Solution
New `ods refresh-models discover` command that:
- Scans ods/data/models for .gguf files
- Updates ods/config/llama-server/models.ini
- Updates ods/config/litellm/local.yaml and hybrid.yaml

## Usage
```bash
# Download model
cp my-model.gguf ~/ods/data/models/

# Refresh configs
ods refresh-models discover

# Model appears in Open WebUI dropdown

**Files Added**

- ods/scripts/auto-discover-models.py — Discovery & config update logic
- ods/scripts/discover-and-update-models.sh — Wrapper script
- ods/ods-cli — New refresh-models command

**Testing**
Models added to ods/data/models appear in UIs after running the command.