### PR TITLE
fix(installer): stop reporting "Single GPU detected" on CPU-only hosts

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -35,6 +35,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-external-services.sh
 	@bash tests/test-resolve-compose-resilient.sh
 	@bash tests/test-phase03-multigpu-tty.sh
+	@bash tests/test-phase03-no-gpu-assignment-message.sh
 	@bash tests/contracts/test-preflight-fixtures.sh
 	@bash tests/test-preflight-resolver-bug.sh
 	@bash tests/test-linux-cloud-mode.sh

--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -239,6 +239,13 @@ fi
 
 log "All services enabled (core install)"
 
+# No GPU (CPU-only) — nothing to assign. Say so plainly instead of falling
+# into the single-GPU branch below and logging "Single GPU detected".
+if [[ "${GPU_COUNT:-0}" -eq 0 ]]; then
+    log "No GPU detected — skipping GPU assignment (CPU-only mode)."
+    return
+fi
+
 # Single GPU — generate a trivial assignment so the dashboard API can map
 # the GPU UUID to services (without this, /api/gpu/detailed shows empty
 # assigned_services).  Multi-GPU systems fall through to the full TUI below.

--- a/ods/tests/test-phase03-no-gpu-assignment-message.sh
+++ b/ods/tests/test-phase03-no-gpu-assignment-message.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# Phase 03 must not report "Single GPU detected" on a host with no GPU.
+#
+# The single-GPU assignment branch was guarded with `GPU_COUNT -le 1`, which
+# also matches 0, so every CPU-only install logged
+# "Single GPU detected — non-NVIDIA backend, skipping GPU assignment." right
+# after "No GPU detected". Source the real phase with the same stub set the
+# multi-GPU harness uses and check the zero-GPU and single-GPU messages.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FEATURES_PHASE="$ROOT_DIR/installers/phases/03-features.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$FEATURES_PHASE" ]] || fail "missing phase 03: $FEATURES_PHASE"
+
+# Static guard: the zero-GPU branch must sit before the single-GPU branch.
+zero_line="$(grep -n 'GPU_COUNT:-0}" -eq 0' "$FEATURES_PHASE" | head -1 | cut -d: -f1)"
+single_line="$(grep -n '"$GPU_COUNT" -le 1' "$FEATURES_PHASE" | head -1 | cut -d: -f1)"
+[[ -n "$zero_line" && -n "$single_line" && "$zero_line" -lt "$single_line" ]] \
+    || fail "phase 03 must handle GPU_COUNT=0 before the single-GPU (-le 1) branch"
+pass "zero-GPU branch precedes the single-GPU branch"
+
+# Phase 03 needs Bash 4+ (associative arrays); the installer guarantees it.
+if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+    echo "[SKIP] phase 03 requires Bash 4+; this host only has Bash ${BASH_VERSION} (brew install bash)"
+    exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+run_phase() {
+    # $1 = GPU_COUNT, $2 = GPU_BACKEND. Prints the phase's log lines.
+    local gpu_count="$1" gpu_backend="$2"
+    mkdir -p "$tmp_dir/install" "$tmp_dir/scripts"
+    HARNESS_TMP="$tmp_dir" HARNESS_GPU_COUNT="$gpu_count" HARNESS_GPU_BACKEND="$gpu_backend" \
+        bash -c '
+set -euo pipefail
+INTERACTIVE=false
+DRY_RUN=true
+INSTALL_CHOICE=1
+TIER=1
+ODS_MODE=local
+ENABLE_VOICE=false
+ENABLE_WORKFLOWS=false
+ENABLE_RAG=false
+ENABLE_RECOMMENDED=false
+ENABLE_HERMES=false
+ENABLE_OPENCLAW=false
+ENABLE_COMFYUI=false
+ENABLE_APE=false
+ENABLE_PERPLEXICA=false
+ENABLE_PRIVACY_SHIELD=false
+ENABLE_LANGFUSE=false
+ENABLE_BRAVE_SEARCH=false
+GPU_COUNT="$HARNESS_GPU_COUNT"
+GPU_BACKEND="$HARNESS_GPU_BACKEND"
+HOST_ARCH=amd64
+HOST_PAGE_SIZE=4096
+INSTALL_DIR="$HARNESS_TMP/install"
+SCRIPT_DIR="$HARNESS_TMP"
+LLM_MODEL_SIZE_MB=6000
+MAX_CONTEXT=8192
+VERBOSE=false
+DEBUG=false
+AMB=
+BGRN=
+DIM=
+GRN=
+NC=
+RED=
+WHT=
+GPU_TOPOLOGY_JSON=""
+
+ods_progress() { :; }
+show_phase() { :; }
+show_install_menu() { :; }
+ai_warn() { :; }
+log() { printf "LOG: %s\n" "$*"; }
+warn() { printf "WARN: %s\n" "$*"; }
+success() { :; }
+chapter() { :; }
+bootline() { :; }
+signal() { :; }
+get_rank() { printf "10\n"; }
+error() { printf "ERROR: %s\n" "$*" >&2; return 1; }
+
+# shellcheck source=/dev/null
+source "$1"
+echo PHASE03_COMPLETED
+' _ "$FEATURES_PHASE"
+}
+
+# Case 1: no GPU (CPU-only install).
+out="$(run_phase 0 cpu)" || fail "phase 03 failed with GPU_COUNT=0 (CPU-only)"
+grep -q 'PHASE03_COMPLETED' <<<"$out" || fail "phase 03 did not complete with GPU_COUNT=0"
+grep -q 'No GPU detected — skipping GPU assignment' <<<"$out" \
+    || fail "GPU_COUNT=0 must log the no-GPU skip message; got: $(grep 'GPU' <<<"$out" | tr '\n' '|')"
+grep -q 'Single GPU detected' <<<"$out" \
+    && fail "GPU_COUNT=0 must not log 'Single GPU detected'"
+pass "CPU-only install logs the no-GPU skip, not 'Single GPU detected'"
+
+# Case 2: one non-NVIDIA GPU keeps its existing message.
+out="$(run_phase 1 amd)" || fail "phase 03 failed with GPU_COUNT=1 (amd)"
+grep -q 'PHASE03_COMPLETED' <<<"$out" || fail "phase 03 did not complete with GPU_COUNT=1"
+grep -q 'Single GPU detected — non-NVIDIA backend, skipping GPU assignment' <<<"$out" \
+    || fail "GPU_COUNT=1 with a non-NVIDIA backend must keep the single-GPU message"
+grep -q 'No GPU detected — skipping' <<<"$out" \
+    && fail "GPU_COUNT=1 must not log the no-GPU skip message"
+pass "single non-NVIDIA GPU keeps the single-GPU skip message"


### PR DESCRIPTION
## Summary

On a host with no GPU, the Linux installer logs `No GPU detected. Falling back to CPU-only mode` and then, in phase 03, `Single GPU detected — non-NVIDIA backend, skipping GPU assignment.` — because the single-GPU assignment branch in `installers/phases/03-features.sh` is guarded with `GPU_COUNT -le 1`, which also matches the `0` that `02-detection.sh` sets when nothing is found.

Change: handle `GPU_COUNT=0` explicitly before that branch and log `No GPU detected — skipping GPU assignment (CPU-only mode).`, keeping the same early `return` so phase flow is unchanged. The single-GPU (NVIDIA and non-NVIDIA) and multi-GPU paths are byte-identical to before. Log message only — no assignment JSON was generated for 0 GPUs before either.

Adds `tests/test-phase03-no-gpu-assignment-message.sh` (wired into `make test` next to `test-phase03-multigpu-tty.sh`): a static ordering guard plus sourcing the real phase with the multi-GPU harness's stub set for `GPU_COUNT=0/cpu` (expects the new message, forbids "Single GPU detected") and `GPU_COUNT=1/amd` (expects the unchanged single-GPU message).

Fixes #3795

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low — a new zero-GPU branch that only emits a log line and returns exactly where the existing branch returned; every GPU_COUNT ≥ 1 path is unchanged.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [x] Not required because: log-message change on the CPU-only path only; validated with the installer dry-run on a CPU-only Linux host and the phase harness.

Commands/results:

```text
# BEFORE (upstream/main 21f4b3a6) — clean Ubuntu 24.04 x86_64 VM (2 vCPU / 4 GB, no GPU), Bash 5.2
$ ./install.sh --dry-run --non-interactive --skip-docker 2>&1 | grep -nE "No GPU|Single GPU"
50:[WARN] No GPU detected. Falling back to CPU-only mode (inference will be slow).
65:[INFO] Single GPU detected — non-NVIDIA backend, skipping GPU assignment.

# AFTER (this branch), same VM
50:[WARN] No GPU detected. Falling back to CPU-only mode (inference will be slow).
65:[INFO] No GPU detected — skipping GPU assignment (CPU-only mode).
(dry run completes, exit 0)

# Linux (VM): every suite that sources phase 03
$ bash tests/test-phase03-no-gpu-assignment-message.sh   # 3 passed
$ bash tests/test-phase03-multigpu-tty.sh                # PASS incl. the util-linux PTY lane
$ bash tests/test-installer-context-parity.sh            # PASS (76)
$ bash tests/test-linux-cloud-mode.sh                    # PASS (15)
$ bash tests/test-hermes-context-floor.sh                # PASS
$ bash tests/test-bash32-guards.sh                       # PASS (10)

# macOS (Homebrew Bash 5.3): new test 3 passed; under stock /bin/bash 3.2 the static guard passes and the sourcing lane skips
$ /bin/bash -n installers/phases/03-features.sh tests/test-phase03-no-gpu-assignment-message.sh   # OK under Bash 3.2 (matches the macos-smoke CI check)
$ shellcheck --exclude=SC1091,SC2034 --severity=error installers/phases/03-features.sh   # clean (CI gate); warning count 0 -> 0
$ awk -f scripts/check-heredoc-backticks.awk installers/phases/03-features.sh            # OK (pre-commit)
$ make lint            # All lint checks passed.
$ git diff --check     # clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Touches an installer phase, so listed as operational; the change is a log line and an early `return` on the `GPU_COUNT=0` path that previously took the equivalent `return` via the `-le 1` branch.

## Notes For Reviewers

- Overlap check: searched open PRs/issues for "Single GPU detected", "GPU assignment", "03-features" — none address this. Closed #789 introduced the single-GPU assignment branch this refines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

