### PR TITLE
fix(installer): put podman-only hosts on the Podman path instead of installing Docker CE

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -41,6 +41,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Linux install preflight ==="
 	@bash tests/test-linux-install-preflight.sh
+	@bash tests/test-phase05-podman-shim.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@bash tests/test-preflight-dashboard-port.sh
 	@echo ""

--- a/ods/installers/lib/packaging.sh
+++ b/ods/installers/lib/packaging.sh
@@ -249,6 +249,7 @@ pkg_resolve() {
         apt)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose-plugin" ;;
+                podman-compose)        echo "podman-compose" ;;
                 python3-pyyaml)        echo "python3-yaml" ;;
                 python3-pip)           echo "python3-pip" ;;
                 *) echo "$canonical" ;;
@@ -264,6 +265,7 @@ pkg_resolve() {
                     fi
                     ;;
                 docker-compose-plugin) echo "docker-compose-plugin" ;;
+                podman-compose)        echo "podman-compose" ;;
                 python3-pyyaml)        echo "python3-pyyaml" ;;
                 python3-pip)           echo "python3-pip" ;;
                 build-essential)       echo "gcc gcc-c++ make" ;;
@@ -273,6 +275,7 @@ pkg_resolve() {
         pacman)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose" ;;
+                podman-compose)        echo "podman-compose" ;;
                 python3-pyyaml)        echo "python-yaml" ;;
                 python3-pip)           echo "python-pip" ;;
                 build-essential)       echo "base-devel" ;;
@@ -282,6 +285,7 @@ pkg_resolve() {
         zypper)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose" ;;
+                podman-compose)        echo "docker-compose" ;;
                 python3-pyyaml)        echo "python3-PyYAML" ;;
                 python3-pip)           echo "python3-pip" ;;
                 build-essential)       echo "devel_basis" ;;
@@ -291,6 +295,7 @@ pkg_resolve() {
         xbps)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose" ;;
+                podman-compose)        echo "podman-compose" ;;
                 python3-pyyaml)        echo "python3-yaml" ;;
                 python3-pip)           echo "python3-pip" ;;
                 build-essential)       echo "base-devel" ;;
@@ -300,6 +305,7 @@ pkg_resolve() {
         apk)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-cli-compose" ;;
+                podman-compose)        echo "podman-compose" ;;
                 python3-pyyaml)        echo "py3-yaml" ;;
                 python3-pip)           echo "py3-pip" ;;
                 build-essential)       echo "build-base" ;;

--- a/ods/installers/phases/05-docker.sh
+++ b/ods/installers/phases/05-docker.sh
@@ -132,6 +132,28 @@ if [[ "$SKIP_DOCKER" == "true" ]]; then
     log "Skipping Docker installation (--skip-docker)"
 elif command -v docker &> /dev/null; then
     ai_ok "Docker already installed: $(docker --version)"
+elif command -v podman &> /dev/null; then
+    # Podman is installed but its docker-compatible CLI is not (Fedora ships
+    # them as separate packages). ODS drives Podman through that shim, so
+    # install the shim rather than putting Docker CE next to an existing Podman.
+    ods_progress 31 "docker" "Enabling Podman docker-compatible CLI"
+    ai "Podman found without a docker-compatible CLI; installing the podman-docker shim..."
+    if $DRY_RUN; then
+        log "[DRY RUN] Would install podman-docker (Podman present, docker CLI missing)"
+    else
+        if ! ods_sudo_available; then
+            error "Podman is installed but its docker-compatible CLI is missing, and privileged package installation is unavailable. Install the podman-docker package, then re-run ODS."
+        fi
+        pkg_update
+        # shellcheck disable=SC2046
+        pkg_install $(pkg_resolve podman-docker) || true
+        hash -r
+        if command -v docker &> /dev/null; then
+            ai_ok "Podman docker-compatible CLI installed: $(docker --version 2>/dev/null | head -1)"
+        else
+            error "Could not install the podman-docker shim. Install the podman-docker package manually, then re-run ODS."
+        fi
+    fi
 else
     ods_progress 31 "docker" "Installing Docker engine"
     ai "Installing Docker..."
@@ -278,10 +300,33 @@ elif command -v docker-compose &> /dev/null; then
     fi
     ai_ok "Docker Compose v1 available (using docker-compose)"
 else
+    # Podman's `docker compose` delegates to an external provider, and the
+    # docker-compose-plugin package only exists in Docker's repositories, so a
+    # Podman host gets podman-compose instead. In a dry run the shim may not be
+    # installed yet, so a podman-only host counts as Podman too.
+    _compose_provider_is_podman() {
+        # No pipeline here: under pipefail, `docker --version | grep -q` can
+        # report the SIGPIPE'd left side even when it matched.
+        local cli_version=""
+        cli_version="$(docker --version 2>/dev/null || true)"
+        case "$cli_version" in
+            *[Pp]odman*) return 0 ;;
+        esac
+        ! command -v docker &> /dev/null && command -v podman &> /dev/null
+    }
     if [[ "$SKIP_DOCKER" == "true" ]]; then
         warn "Docker Compose not found (docker compose / docker-compose). Install manually or re-run without --skip-docker."
     elif $DRY_RUN; then
-        log "[DRY RUN] Would install Docker Compose plugin"
+        if _compose_provider_is_podman; then
+            log "[DRY RUN] Would install podman-compose (compose provider for Podman's docker-compatible CLI)"
+        else
+            log "[DRY RUN] Would install Docker Compose plugin"
+        fi
+    elif _compose_provider_is_podman; then
+        ai "Installing podman-compose (compose provider for Podman)..."
+        pkg_update
+        # shellcheck disable=SC2046
+        pkg_install $(pkg_resolve podman-compose)
     else
         ai "Installing Docker Compose plugin..."
         pkg_update

--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -130,9 +130,17 @@ fi
 # --- Docker CLI ---
 DOCKER_IS_PODMAN=false
 if ! command -v docker >/dev/null 2>&1; then
-    append_check "DOCKER_INSTALLED" "fail" \
-        "Docker CLI not found in PATH" \
-        "Install Docker Engine and ensure your user can run docker (see LINUX-TROUBLESHOOTING-GUIDE.md#docker_installed)."
+    if command -v podman >/dev/null 2>&1; then
+        # Podman without its docker-compatible CLI (Fedora ships them as
+        # separate packages). ODS drives Podman through that shim.
+        append_check "DOCKER_INSTALLED" "fail" \
+            "Podman is installed but no docker-compatible CLI is in PATH" \
+            "Install the podman-docker package (the installer does this for you), plus a compose provider, then re-run (see LINUX-TROUBLESHOOTING-GUIDE.md#docker_installed)."
+    else
+        append_check "DOCKER_INSTALLED" "fail" \
+            "Docker CLI not found in PATH" \
+            "Install Docker Engine and ensure your user can run docker (see LINUX-TROUBLESHOOTING-GUIDE.md#docker_installed)."
+    fi
 else
     DV="$(docker --version 2>/dev/null | head -1 || true)"
     append_check "DOCKER_INSTALLED" "pass" "Docker CLI: ${DV:-present}" ""

--- a/ods/tests/test-phase05-podman-shim.sh
+++ b/ods/tests/test-phase05-podman-shim.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Phase 05 must put a podman-only host on the supported Podman path: install
+# Podman's docker-compatible CLI (podman-docker) instead of Docker CE, and a
+# compose provider Podman can delegate to (podman-compose) instead of
+# docker-compose-plugin, which only exists in Docker's repositories.
+#
+# ODS drives Podman through the podman-docker shim (see #2804 and
+# scripts/linux-install-preflight.sh). Fedora ships podman and podman-docker as
+# separate packages, so a podman-only host used to fall into the "Installing
+# Docker..." branch. Source the real phase with the stub set the Docker-phase
+# BATS suite uses, on a PATH that holds only base utilities plus the runtimes
+# each case declares (the host's own docker/podman must stay invisible), and
+# check which branches run and which packages get requested.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHASE="$ROOT_DIR/installers/phases/05-docker.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$PHASE" ]] || fail "missing phase 05: $PHASE"
+
+# Static guard: the podman arm must sit between the docker-found arm and the
+# Docker CE install branch.
+docker_line="$(grep -n 'elif command -v docker &> /dev/null; then' "$PHASE" | head -1 | cut -d: -f1)"
+podman_line="$(grep -n 'elif command -v podman &> /dev/null; then' "$PHASE" | head -1 | cut -d: -f1)"
+install_line="$(grep -n 'ods_progress 31 "docker" "Installing Docker engine"' "$PHASE" | head -1 | cut -d: -f1)"
+[[ -n "$docker_line" && -n "$podman_line" && -n "$install_line" \
+    && "$docker_line" -lt "$podman_line" && "$podman_line" -lt "$install_line" ]] \
+    || fail "phase 05 must check for podman after docker and before the Docker CE install branch"
+pass "podman arm sits between the docker-found arm and the Docker CE install branch"
+
+if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]]; then
+    echo "[SKIP] phase 05 requires Bash 4+; this host only has Bash ${BASH_VERSION} (brew install bash)"
+    exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+# Base utilities only: a symlink farm so the host's real docker/podman are
+# never on PATH unless a case adds a fake one.
+TOOLS="$tmp_dir/tools"; mkdir -p "$TOOLS"
+for t in bash sh grep egrep sed awk head tail cut tr cat sort uniq wc mktemp rm mkdir touch chmod ls \
+         dirname basename id uname sleep env date find xargs readlink realpath tee stat ps hostname python3; do
+    p="$(command -v "$t" 2>/dev/null || true)"
+    [[ -n "$p" ]] && ln -sf "$p" "$TOOLS/$t"
+done
+
+run_phase() {
+    # $1 = runtimes to provide on PATH (space separated: podman, docker, none)
+    # $2 = DRY_RUN value, $3 = package manager id. Prints the phase's log,
+    # then the recorded package/network calls.
+    local tools="$1" dry_run="$2" pkg="$3"
+    local bin="$tmp_dir/bin" log="$tmp_dir/phase.log" calls="$tmp_dir/calls.log"
+    rm -rf "$bin" "$log" "$calls"; mkdir -p "$bin"; : > "$log"; : > "$calls"
+    for t in $tools; do
+        case "$t" in
+            podman)
+                printf '#!/usr/bin/env bash\ncase "${1:-}" in --version) echo "podman version 5.6.2";; version) echo "Client: Podman Engine";; info) echo "{}";; esac\nexit 0\n' > "$bin/podman"
+                chmod +x "$bin/podman" ;;
+            docker)
+                # A real Docker CLI: compose is already available.
+                printf '#!/usr/bin/env bash\ncase "${1:-}" in --version) echo "Docker version 29.0.0";; esac\nexit 0\n' > "$bin/docker"
+                chmod +x "$bin/docker" ;;
+        esac
+    done
+    # Any attempt to fetch get.docker.com is a Docker CE install attempt.
+    printf '#!/usr/bin/env bash\necho "DOCKER_CE_INSTALL_ATTEMPTED" >> "%s"\nexit 1\n' "$calls" > "$bin/curl"; chmod +x "$bin/curl"
+    HARNESS_BIN="$bin" HARNESS_TOOLS="$TOOLS" HARNESS_LOG="$log" HARNESS_CALLS="$calls" HARNESS_DRY="$dry_run" HARNESS_PKG="$pkg" HARNESS_ROOT="$ROOT_DIR" \
+    bash -c '
+set -uo pipefail
+export PATH="$HARNESS_BIN:$HARNESS_TOOLS"
+export SCRIPT_DIR="$HARNESS_ROOT" LOG_FILE="$HARNESS_LOG"
+export DRY_RUN="$HARNESS_DRY" INTERACTIVE=false SKIP_DOCKER=false GPU_COUNT=0 GPU_BACKEND=cpu
+export DOCKER_CMD="" DOCKER_COMPOSE_CMD="" DOCKER_NEEDS_SUDO=false PKG_MANAGER="$HARNESS_PKG"
+log() { echo "LOG: $1" >> "$LOG_FILE"; }
+warn() { echo "WARN: $1" >> "$LOG_FILE"; }
+error() { echo "ERROR: $1" >> "$LOG_FILE"; exit 1; }
+ai() { echo "AI: $1" >> "$LOG_FILE"; }
+ai_ok() { echo "OK: $1" >> "$LOG_FILE"; }
+ai_bad() { :; }
+ai_warn() { echo "AI_WARN: $1" >> "$LOG_FILE"; }
+show_phase() { :; }
+ods_progress() { :; }
+detect_pkg_manager() { :; }
+ods_sudo_available() { return 0; }
+ods_sudo() { "$@"; }
+pkg_update() { :; }
+pkg_resolve() { echo "$1"; }
+pkg_install() {
+    echo "pkg_install $*" >> "$HARNESS_CALLS"
+    # Installing the shim makes a docker CLI appear (as podman-docker does);
+    # its compose subcommand only works once a provider is installed.
+    if [[ " $* " == *" podman-docker "* ]]; then
+        cat > "$HARNESS_BIN/docker" <<DOCKER
+#!/usr/bin/env bash
+case "\${1:-}" in
+    --version) echo "podman version 5.6.2" ;;
+    compose) [[ -f "$HARNESS_BIN/.compose-provider" ]] || exit 1 ;;
+esac
+exit 0
+DOCKER
+        chmod +x "$HARNESS_BIN/docker"
+    fi
+    if [[ " $* " == *" podman-compose "* ]]; then
+        : > "$HARNESS_BIN/.compose-provider"
+    fi
+}
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/installers/phases/05-docker.sh" >/dev/null 2>&1 || true
+'
+    cat "$log"; echo "--- calls ---"; cat "$calls"
+}
+
+# Sanity: with no runtimes declared, neither docker nor podman may be visible.
+out="$(run_phase "" true apt)"
+grep -q 'Docker already installed' <<<"$out" && fail "harness leaks the host docker onto PATH; got: $out"
+
+# Case 1: podman only, dry run -> announces the shim and podman-compose, not Docker CE.
+out="$(run_phase "podman" true dnf)"
+grep -q 'Would install podman-docker' <<<"$out" || fail "dry run on a podman-only host must announce the podman-docker shim; got: $out"
+grep -q 'Would install Docker via official script' <<<"$out" && fail "dry run on a podman-only host must not plan a Docker CE install"
+grep -q 'Would install podman-compose' <<<"$out" || fail "dry run on a podman-only host must plan podman-compose; got: $out"
+grep -q 'Would install Docker Compose plugin' <<<"$out" && fail "dry run on a podman-only host must not plan docker-compose-plugin"
+pass "dry run on a podman-only host plans podman-docker and podman-compose, not Docker CE"
+
+# Case 2: podman only, real run -> installs the shim and podman-compose, never fetches get.docker.com.
+out="$(run_phase "podman" false dnf)"
+grep -q 'pkg_install podman-docker' <<<"$out" || fail "real run on a podman-only host must install podman-docker; got: $out"
+grep -q 'DOCKER_CE_INSTALL_ATTEMPTED' <<<"$out" && fail "real run on a podman-only host must not attempt a Docker CE install"
+grep -q 'Podman docker-compatible CLI installed' <<<"$out" || fail "real run must confirm the shim once docker resolves; got: $out"
+grep -q 'pkg_install podman-compose' <<<"$out" || fail "real run on a podman-only host must install podman-compose; got: $out"
+grep -q 'pkg_install docker-compose-plugin' <<<"$out" && fail "real run on a podman-only host must not install docker-compose-plugin"
+pass "real run on a podman-only host installs podman-docker and podman-compose, skipping the Docker CE path"
+
+# Case 3 (unchanged): nothing installed, dry run -> Docker CE plan as before.
+out="$(run_phase "" true apt)"
+grep -q 'Would install Docker via official script' <<<"$out" || fail "hosts without podman must keep the Docker CE plan; got: $out"
+grep -q 'podman' <<<"$out" && fail "hosts without podman must not mention podman packages"
+pass "hosts with neither runtime keep the Docker CE install plan"
+
+# Case 4 (unchanged): docker present -> nothing installed, compose untouched.
+out="$(run_phase "docker" true apt)"
+grep -q 'Docker already installed' <<<"$out" || fail "hosts with docker must report it as already installed; got: $out"
+grep -q 'Would install' <<<"$out" && fail "hosts with a working docker CLI must not plan any install; got: $out"
+pass "hosts with a docker CLI keep the already-installed path"


### PR DESCRIPTION
## Summary

ODS drives Podman through its docker-compatible CLI — #2804 detects "rootless Podman through the Docker-compatible CLI", and `scripts/linux-install-preflight.sh` says the same. Fedora ships `podman` and that shim (`podman-docker`) as **separate packages**, so a host with only `podman` has no `docker` command. Phase 05 then takes the "Installing Docker..." branch: it adds Docker's repository and installs `docker-ce`, `docker-ce-cli`, `containerd.io` and the compose/buildx/model plugins (~420 MB) next to the existing Podman, and either fails there (a new Fedora release without Docker packages yet — the #2932 report is Fedora 44) or leaves the host with two container engines and Docker's daemon expected to run.

Change (one concern: a podman-only host must end up on the supported Podman path):

- **`installers/phases/05-docker.sh`**: a new arm between "docker already installed" and the Docker CE install — when `podman` exists and `docker` does not, install the `podman-docker` package via the existing `pkg_update`/`pkg_install`/`pkg_resolve` helpers (its name is the same on apt, dnf, pacman and zypper, so no resolver mapping is needed), re-check for `docker`, and continue into the existing runtime checks, which already know how to handle the shim. Dry run announces `[DRY RUN] Would install podman-docker …`; hosts without usable sudo get told exactly which package to install, mirroring the neighbouring branch. Hosts with neither runtime keep the Docker CE path byte-for-byte.
- **`installers/phases/05-docker.sh`, compose step**: with the shim in place the phase used to install `docker-compose-plugin`, which only exists in Docker's repositories — so a podman-only Fedora still stopped one step later (seen in the reproduction below). When the `docker` CLI is Podman (or the host is podman-only during a dry run), install `podman-compose` instead; Podman's `docker compose` delegates to it. New `podman-compose` entry in `pkg_resolve`: `podman-compose` on apt/dnf/pacman, the standalone `docker-compose` on zypper (openSUSE ships it and Podman delegates to it too; its `podman-compose` is only a python-versioned package).
- **`scripts/linux-install-preflight.sh`**: on such hosts `DOCKER_INSTALLED` still fails, but the message and remediation now name the missing shim instead of the generic "Docker CLI not found / install Docker Engine".
- **Tests**: `tests/test-phase05-podman-shim.sh` (wired into `make test` next to the Linux preflight test) sources the real phase with a controlled `PATH` and the Docker-phase stub set, and checks: podman-only + dry run → announces `podman-docker` and `podman-compose`, never Docker CE or `docker-compose-plugin`; podman-only + real run → `pkg_install podman-docker`, confirms the CLI once it resolves, then `pkg_install podman-compose`, and never fetches get.docker.com; no runtime → unchanged Docker CE plan; docker present → unchanged "already installed", nothing planned. Kept out of `docker-phase.bats`, which #3668 is restructuring.

Refs #2932 — that report has no logs, so I cannot claim it is exactly this path; it is the path a podman-only Fedora takes today, reproduced below. If the reporter had `podman-docker` installed, their failure is a different one.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium — installer phase 05 gains a branch that installs a package on podman-only hosts. Every host that has `docker` or has neither runtime is unaffected (the new arm is only reachable when `podman` is present and `docker` is not).
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [x] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# Reproduction: disposable fedora:41 container on an Ubuntu 24.04 x86_64 VM, podman installed, no docker CLI,
# real (non-dry-run) install as an unprivileged user with passwordless sudo, no daemon possible inside the container.

# BEFORE (upstream/main 21f4b3a6)
podman: podman version 5.6.2
docker: absent
  ▸ Installing Docker...
+ sudo -E sh -c 'dnf5 config-manager addrepo --overwrite --save-filename=docker-ce.repo --from-repofile='\''https://download.docker.com/linu
 https://download.docker.com/linux/fedo 100% |  11.2 KiB/s | 811.0   B |  00m00s
+ sudo -E sh -c 'dnf -y -q --best install docker-ce docker-ce-cli containerd.io docker-compose-plugin docker-ce-rootless-extras docker-build
 docker-ce-cli             x86_64 1:29.3.0-1.fc41            docker-ce-stable  34.4 MiB
 From       : https://download.docker.com/linux/fedora/gpg
[12/19] Installing docker-ce-cli-1:29.3 100% | 199.0 MiB/s |  34.4 MiB |  00m00s
#   -> Docker CE + containerd + plugins (~420 MB) installed next to Podman, then the daemon check fails.

# AFTER (this branch)
podman: podman version 5.6.2
docker: absent
[INFO] Compose selection: -f docker-compose.base.yml -f docker-compose.cpu.yml -f extensions/services/ape/compose.yaml -f extensions/service
[INFO] Compose flags refreshed after feature selection
  ▸ Podman found without a docker-compatible CLI; installing the podman-docker shim...
[INFO] Installing packages (dnf): podman-docker
 podman-docker noarch 5:5.6.2-1.fc41 updates     11.7 KiB
  ✓ Podman docker-compatible CLI installed: podman version 5.6.2
  ▸ Installing podman-compose (compose provider for Podman)...
[INFO] Installing packages (dnf): podman-compose
#   -> the podman-docker shim and podman-compose are installed instead; no Docker repository is added. The daemon check
#      still fails in a container (no runtime can start there) — that is the environment, and it is the same check the
#      shim path already relies on for rootless Podman on a real host.

# Contract test (macOS Homebrew Bash 5.3 and Ubuntu Bash 5.2)
$ bash tests/test-phase05-podman-shim.sh
[PASS] podman arm sits between the docker-found arm and the Docker CE install branch
[PASS] dry run on a podman-only host plans podman-docker and podman-compose, not Docker CE
[PASS] real run on a podman-only host installs podman-docker and podman-compose, skipping the Docker CE path
[PASS] hosts with neither runtime keep the Docker CE install plan
[PASS] hosts with a docker CLI keep the already-installed path

$ bash tests/test-linux-install-preflight.sh          # PASS (15)
$ bash tests/test-podman-rootless-contracts.sh        # PASS (25)
$ bash tests/test-installer-noninteractive-sudo.sh    # PASS (5)
$ /bin/bash -n installers/phases/05-docker.sh scripts/linux-install-preflight.sh tests/test-phase05-podman-shim.sh   # OK under Bash 3.2
$ shellcheck --exclude=SC1091,SC2034 --severity=error <changed .sh>   # clean (CI gate); warning count 0 -> 0 on both changed scripts
$ shellcheck --include=SC2006 …  /  awk -f scripts/check-heredoc-backticks.awk …   # clean (pre-commit)
$ make lint / git diff --check   # clean

# Full Linux recipe / BATS / simulation gate on this branch vs upstream/main, and the 10-distro fleet: posted as a comment below.
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Compose provider: Podman's `docker compose` shim needs `podman-compose` or the docker-compose plugin; that is unchanged here and still handled (warned about) by the existing `_docker_compose_verify` path. Auto-installing a compose provider for Podman would be a separate change.
- Overlap: #3158 edits `_docker_try_with_optional_sudo` (lines ~309–315), a different region of the same file; #3668 rewrites the Docker-phase BATS fixture (this PR adds a separate plain-bash test instead of touching it). Searched open PRs/issues for `podman-docker`, "podman shim", "05-docker.sh podman" — nothing addresses the podman-only case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

