### PR TITLE
fix(env): drop inline comments from live .env.example assignments

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -253,8 +253,10 @@ SYSTEM_RAM_GB=32
 # Ports — all overridable, defaults shown
 # ═══════════════════════════════════════════════════════════════════
 
-OLLAMA_PORT=11434          # llama-server API (external → internal 8080)
-WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
+# llama-server API (external → internal 8080)
+OLLAMA_PORT=11434
+# Open WebUI (external → internal 8080)
+WEBUI_PORT=3000
 # SEARXNG_PORT=8888          # SearXNG metasearch (external → internal 8080)
 # PERPLEXICA_PORT=3004       # Perplexica deep research (external → internal 3000)
 # WHISPER_PORT=9000          # Whisper STT (external → internal 8000)
@@ -344,19 +346,20 @@ WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
 
 LANGFUSE_PORT=3006
 LANGFUSE_ENABLED=false
-LANGFUSE_NEXTAUTH_SECRET=  # auto-generated during install
-LANGFUSE_SALT=            # auto-generated during install
-LANGFUSE_ENCRYPTION_KEY=  # auto-generated during install
-LANGFUSE_DB_PASSWORD=     # auto-generated during install
-LANGFUSE_CLICKHOUSE_PASSWORD=  # auto-generated during install
-LANGFUSE_REDIS_PASSWORD=       # auto-generated during install
-LANGFUSE_MINIO_ACCESS_KEY=     # auto-generated during install
-LANGFUSE_MINIO_SECRET_KEY=     # auto-generated during install
-LANGFUSE_PROJECT_PUBLIC_KEY=   # auto-generated during install
-LANGFUSE_PROJECT_SECRET_KEY=   # auto-generated during install
-LANGFUSE_INIT_PROJECT_ID=      # auto-generated during install
+# Secrets below are auto-generated during install; leave them empty.
+LANGFUSE_NEXTAUTH_SECRET=
+LANGFUSE_SALT=
+LANGFUSE_ENCRYPTION_KEY=
+LANGFUSE_DB_PASSWORD=
+LANGFUSE_CLICKHOUSE_PASSWORD=
+LANGFUSE_REDIS_PASSWORD=
+LANGFUSE_MINIO_ACCESS_KEY=
+LANGFUSE_MINIO_SECRET_KEY=
+LANGFUSE_PROJECT_PUBLIC_KEY=
+LANGFUSE_PROJECT_SECRET_KEY=
+LANGFUSE_INIT_PROJECT_ID=
 LANGFUSE_INIT_USER_EMAIL=admin@ods.local
-LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
+LANGFUSE_INIT_USER_PASSWORD=
 
 # ═══════════════════════════════════════════════════════════════════
 # Multi-GPU Settings (auto-populated by installer for multi-GPU)

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -66,6 +66,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
+	@bash tests/test-env-example-inline-comments.sh
 	@bash tests/test-phase06-secret-generation.sh
 	@echo ""
 	@echo "=== QR code helper LAN detection ==="

--- a/ods/tests/test-env-example-inline-comments.sh
+++ b/ods/tests/test-env-example-inline-comments.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Contract: every live assignment in .env.example must read back as the same
+# value for Docker Compose and for ODS's own .env readers.
+#
+# Compose (and a plain `source .env`) treat " # ..." after an unquoted value as
+# a comment. lib/safe-env.sh, the dashboard settings reader and the macOS CLI
+# keep the rest of the line as the value instead. A trailing inline comment on
+# a live line therefore hands containers one value and ODS tooling another,
+# e.g. OLLAMA_PORT="11434          # llama-server API ..." inside `ods chat`.
+#
+# Run from repo root:  bash ods/tests/test-env-example-inline-comments.sh
+# Or from ods:         bash tests/test-env-example-inline-comments.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_EXAMPLE="$ROOT_DIR/.env.example"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$ENV_EXAMPLE" ]] || fail ".env.example not found at $ENV_EXAMPLE"
+[[ -f "$ROOT_DIR/lib/safe-env.sh" ]] || fail "lib/safe-env.sh not found"
+
+echo "Test 1: no live .env.example assignment carries an inline comment"
+# Live (uncommented) KEY=value lines with whitespace + '#' after the value.
+# Commented-out reference lines are free to keep their trailing notes.
+offenders="$(grep -nE '^[A-Za-z_][A-Za-z0-9_]*=.*[[:space:]]#' "$ENV_EXAMPLE" || true)"
+if [[ -n "$offenders" ]]; then
+    echo "$offenders"
+    fail "inline comment on a live .env.example assignment; put the note on its own line"
+fi
+pass "no live assignment has an inline comment"
+
+echo "Test 2: safe-env.sh reads the shipped port defaults as plain numbers"
+ports="$(
+    # shellcheck source=../lib/safe-env.sh
+    . "$ROOT_DIR/lib/safe-env.sh"
+    load_env_file "$ENV_EXAMPLE"
+    printf '%s\n%s\n' "${OLLAMA_PORT:-}" "${WEBUI_PORT:-}"
+)"
+ollama_port="${ports%%$'\n'*}"
+webui_port="${ports#*$'\n'}"
+[[ "$ollama_port" =~ ^[0-9]+$ ]] || fail "OLLAMA_PORT read as <$ollama_port>"
+[[ "$webui_port" =~ ^[0-9]+$ ]] || fail "WEBUI_PORT read as <$webui_port>"
+pass "OLLAMA_PORT=$ollama_port WEBUI_PORT=$webui_port"
+
+echo "All .env.example inline-comment checks passed."


### PR DESCRIPTION
## Summary

`.env.example` is the documented configuration reference (`docs/README.md`, `extensions/CATALOG.md`, `install-core.sh`), and 14 of its live assignments carried a trailing inline comment: `OLLAMA_PORT=11434          # llama-server API (…)`, `WEBUI_PORT=3000            # Open WebUI (…)` and twelve `LANGFUSE_*=   # auto-generated during install`. Docker Compose treats ` # …` after an unquoted value as a comment; every ODS reader — `lib/safe-env.sh` (`ods-cli`), phase 06 `_env_get`, the macOS CLI's `read_env_value`/`read_ods_env`, the dashboard's `_parse_env_text` — keeps it as part of the value. A `.env` seeded from the reference file therefore hands containers one value and ODS tooling another: `ods chat` probes `http://127.0.0.1:11434          # llama-server API (…)/v1/models`, and a Linux reinstall on top of such a `.env` preserves the comment text as the Langfuse "secret" (repro in #3798).

Change (one concern: live lines in `.env.example` must read the same everywhere):

- **`.env.example`**: the two port notes move onto their own comment line above the assignment; the twelve Langfuse notes collapse into one comment line above the block. Values are unchanged (`11434`, `3000`, empty secrets). The commented-out reference lines (`# SEARXNG_PORT=8888   # …`) are untouched.
- **`tests/test-env-example-inline-comments.sh`** (new, wired into `make test` next to `test-safe-env.sh`): fails on any live `KEY=value … #` line in `.env.example`, and checks that `lib/safe-env.sh` reads `OLLAMA_PORT`/`WEBUI_PORT` from it as plain numbers. It fails on current `main` (lists the 14 lines) and passes here.

Fixes #3798.

Teaching ODS's readers Compose's inline-comment rule (so uncommenting `# LLAMA_THREADS=4   # …` becomes safe as well) is a follow-up that touches several parsers; it is deliberately kept out of this PR.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only (`.env.example` reference file — comment placement, values unchanged)
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low — no runtime code changes. The dashboard reads `.env.example` for Settings section titles and as the template when re-rendering `.env` (`_build_env_sections`, `_render_env_from_values`); both key off `KEY=` / `# KEY=` lines, which are unchanged, and the dashboard env/settings tests pass. `.env.schema.json` is untouched.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build (API tests touching env/settings; no UI change)
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3, shellcheck 0.11, Python 3.13 venv

# BEFORE (upstream/main 21f4b3a6)
$ ( . lib/safe-env.sh; load_env_file .env.example; printf '%q\n' "$OLLAMA_PORT" "$LANGFUSE_SALT" )
11434\ \ \ \ \ \ \ \ \ \ \#\ llama-server\ API\ \(external\ →\ internal\ 8080\)
\ \ \ \ \ \ \ \ \ \ \ \ \#\ auto-generated\ during\ install
$ bash tests/test-env-example-inline-comments.sh          # new test against main's .env.example
256:OLLAMA_PORT=11434          # llama-server API (external → internal 8080)
257:WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
347:LANGFUSE_NEXTAUTH_SECRET=  # auto-generated during install
... (12 LANGFUSE_* lines)
[FAIL] inline comment on a live .env.example assignment; put the note on its own line

# AFTER (this branch)
$ bash tests/test-env-example-inline-comments.sh
[PASS] no live assignment has an inline comment
[PASS] OLLAMA_PORT=11434 WEBUI_PORT=3000
$ ( . lib/safe-env.sh; load_env_file .env.example; printf 'LANGFUSE_SALT=<%s>\n' "${LANGFUSE_SALT-unset}" )
LANGFUSE_SALT=<>
$ /bin/bash tests/test-env-example-inline-comments.sh     # stock Bash 3.2 → same PASS

$ bash tests/test-safe-env.sh                             → All safe-env tests passed.
$ bash tests/test-validate-env.sh                         → Result: 45 passed, 0 failed
$ bash tests/test-secret-security.sh                      → 26 passed, 0 failed, 2 skipped
$ python3 tests/contracts/test-port-contracts.py          → [PASS] canonical port contract parity
$ python3 tests/contracts/test-remote-provider-egress-policy.py → 6/6 PASS
$ bash scripts/validate-env.sh .env.example               → unchanged: rc=2 with the same 6 pre-existing minLength errors (CHANGEME placeholders)
$ tests/integration-test.sh greps (^#?\s*WEBUI_PORT=, ^#?\s*(LLAMA_SERVER_PORT|OLLAMA_PORT)=) → still match
$ cd extensions/services/dashboard-api && pytest -k "env or settings or example or langfuse" → 183 passed
$ make lint                                               → All lint checks passed.
$ shellcheck --exclude=SC1091,SC2034 tests/test-env-example-inline-comments.sh → clean (error and default severity)
$ awk -f scripts/check-heredoc-backticks.awk tests/test-env-example-inline-comments.sh → clean
$ git diff --check upstream/main...HEAD                   → clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Searched open issues/PRs for `OLLAMA_PORT`, `env.example`, "inline comment": #2319 (port knob documentation test) parses only commented `# KEY=digits` lines and does not touch these lines; nothing else overlaps.
- Follow-up (not in this PR): `lib/safe-env.sh`, the macOS `read_ods_env` and the dashboard reader could strip unquoted ` # …` the way Compose does, so the 64 commented-out reference lines stay safe to uncomment. I'll raise that separately once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

