### PR TITLE
fix(token-spy): remove forced choices for filtered-out tools

### DIFF
--- a/ods/extensions/services/token-spy/filters.py
+++ b/ods/extensions/services/token-spy/filters.py
@@ -121,6 +121,10 @@ def _filter_tools(body: dict, cfg: dict, result: FilterResult,
 
     if removed_names:
         body["tools"] = kept
+        choice = body.get("tool_choice")
+        if isinstance(choice, dict) and choice.get("function", {}).get("name") in removed_names:
+            # A forced choice cannot refer to a tool the filter removed.
+            body.pop("tool_choice")
         # If all tools removed, also drop tool_choice to avoid API errors
         if not kept:
             body.pop("tools", None)

--- a/ods/extensions/services/token-spy/tests/test_filter_tool_choice.py
+++ b/ods/extensions/services/token-spy/tests/test_filter_tool_choice.py
@@ -1,0 +1,48 @@
+"""Tool filtering must forward a choice that still names an available tool."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.parametrize("mode", ["blocklist", "allowlist"])
+@pytest.mark.parametrize("choice", ["blocked", "kept", "auto", "required", "none"])
+def test_filtered_proxy_keeps_tool_choice_consistent(monkeypatch, tmp_path, mode, choice):
+    service_dir = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service_dir))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "filter-test-key")
+    monkeypatch.setenv("SETTINGS_PATH", str(tmp_path / "settings.json"))
+    spec = importlib.util.spec_from_file_location("token_spy_filter_choice", service_dir / "main.py")
+    proxy = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(proxy)
+    monkeypatch.setattr(proxy, "get_filter_settings", lambda agent: {
+        "enabled": True,
+        "tools": {"enabled": True, "mode": mode, "blocklist": ["blocked"], "allowlist": ["kept"]},
+    })
+    monkeypatch.setattr(proxy, "_log_entry", lambda *args, **kwargs: None)
+    forwarded = []
+
+    def upstream(request):
+        forwarded.append(json.loads(request.content))
+        return httpx.Response(200, json={"choices": [], "usage": {}})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(upstream), base_url="http://model")
+    monkeypatch.setattr(proxy, "get_moonshot_client", lambda: client)
+    tool_choice = {"type": "function", "function": {"name": choice}} if choice in {"blocked", "kept"} else choice
+    response = TestClient(proxy.app).post(
+        "/v1/chat/completions",
+        headers={"Authorization": "Bearer filter-test-key"},
+        json={"model": "local", "messages": [{"role": "user", "content": "Hello"}],
+              "tools": [{"type": "function", "function": {"name": name}} for name in ["blocked", "kept"]],
+              "tool_choice": tool_choice},
+    )
+    assert response.status_code == 200
+    assert [tool["function"]["name"] for tool in forwarded[0]["tools"]] == ["kept"]
+    if choice == "blocked":
+        assert "tool_choice" not in forwarded[0]
+    else:
+        assert forwarded[0]["tool_choice"] == tool_choice


### PR DESCRIPTION
## Why this matters

Token Spy could remove a blocked tool while forwarding a forced tool_choice naming that removed function, causing the upstream model API to reject an otherwise valid filtered request.

## Fix and overlap check

Remove only forced choices naming removed functions; retain allowed choices and auto/required/none. Nullable/malformed function payloads remain for upstream validation rather than crashing the proxy. Updated this original PR onto beta. Searched all-state tool-choice/filter PRs and filters.py; #4082 guards non-dict tool items, #4558 removes retired tool-call messages and #4550 protects fenced text. These are independent contracts.

## Validation

Linux Python3.11: `pytest -q tests/test_filter_tool_choice.py tests/test_filters.py`: 16 passed, including 14 authenticated proxy cases across allow/block lists and valid/null choices. Assertions inspect the actual forwarded request. Focused pre-commit/diff check passed. No live/billable provider call; baseline smoke/simulation passed, full gate/BATS retain known failures.

## Rollback

Filtering remains operator-configured. This does not broaden tool permissions or synthesize a replacement forced choice. Revert restores contradictory payloads. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `f7098be30a3322a486df4e7f6bbd8149e9c5597a`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
