### PR TITLE
fix(talk): close Hermes streams without yielding during cancellation

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -553,8 +553,11 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
                 })
     finally:
         await cancel_pending()
-        if emit_done:
-            yield _sse_event("done", {})
+        await bridge_iter.aclose()
+    # Only a completed response can accept a terminal frame. Yielding from
+    # finally suppresses cancellation and makes aclose() raise GeneratorExit.
+    if emit_done:
+        yield _sse_event("done", {})
 
 
 @router.get("/api/talk/status")

--- a/ods/extensions/services/dashboard-api/tests/test_talk_stream_cleanup.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk_stream_cleanup.py
@@ -1,0 +1,40 @@
+"""Closing a Talk response must release the upstream bridge immediately."""
+
+import asyncio
+
+import pytest
+from starlette.requests import Request
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("close_mode", ["close", "cancel"])
+async def test_talk_response_closes_bridge_after_yield(monkeypatch, close_mode):
+    import session_signer
+    from routers import talk
+
+    session_signer._set_secret_for_tests("stream-cleanup-test")
+    cookie = session_signer.issue(ttl_seconds=3600)
+    request = Request({"type": "http", "headers": [(b"cookie", f"ods-session={cookie}".encode())]})
+    closed = asyncio.Event()
+
+    async def compatible():
+        return {}
+
+    async def bridge(session_key, text):
+        try:
+            yield {"type": "delta", "text": "first token"}
+            await asyncio.Event().wait()
+        finally:
+            closed.set()
+
+    monkeypatch.setattr(talk, "_require_hermes_talk_compatible", compatible)
+    monkeypatch.setattr(talk.hermes_bridge, "stream_prompt", bridge)
+    response = await talk.talk_message_stream({"text": "hello"}, request)
+    iterator = response.body_iterator
+    assert b"first token" in await anext(iterator)
+    if close_mode == "close":
+        await iterator.aclose()
+    else:
+        with pytest.raises(asyncio.CancelledError):
+            await iterator.athrow(asyncio.CancelledError())
+    assert closed.is_set()


### PR DESCRIPTION
## Why this matters

Closing or cancelling a Talk streaming response could leave the upstream Hermes generator open, and yielding a terminal frame from finally violates asynchronous generator close semantics.

## Fix and overlap check

Close the bridge iterator after cancelling pending work; emit done only on normal response completion, outside finally. Updated this original canonical PR onto public-beta. Searched all-state Talk stream/close PRs and routers/talk.py. #4980 distinguishes incomplete vision output and #4454 validates attachment text; neither handles Hermes generator close/cancellation.

## Validation

Linux Python3.11: `pytest -q tests/test_talk_stream_cleanup.py tests/test_talk.py`: 41 passed. The public route's StreamingResponse body iterator is closed/cancelled immediately after its first token, and the bridge's finally must run. This exercises the response boundary directly to avoid TestClient buffering away cancellation. Focused pre-commit/diff check passed. No live Hermes session. Baseline smoke/simulation passed; full gate/BATS retain known failures.

## Rollback

Normal done framing is preserved; closed transports receive no extra frame. No persisted state or model configuration changes. Revert restores leaked-generator/close errors. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `f1abed8725eeec614054a47bd430b18427b5d056`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
