### PR TITLE
fix(settings): report staged changes for inactive services

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -508,7 +508,7 @@ def _compute_env_apply_plan(
     services_list = sorted(services)
     inactive_list = sorted(inactive_services)
     manual_list = sorted(set(manual_keys))
-    if not changed_keys or (not services_list and not manual_list):
+    if not changed_keys or (not services_list and not manual_list and not inactive_list):
         status = "none"
     elif services_list and (manual_list or inactive_list):
         status = "partial"

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -570,6 +570,28 @@ def test_api_settings_env_rejects_null_byte_in_value(test_client, settings_env_f
     assert "invalid characters" in response.json()["detail"]
 
 
+@pytest.mark.parametrize("active", [False, True])
+@pytest.mark.parametrize("port", ["5678", "5679"])
+def test_settings_save_reports_disabled_service_changes(
+    test_client, settings_env_fixture, monkeypatch, active, port,
+):
+    env_path = settings_env_fixture["env_path"]
+    env_path.write_text(env_path.read_text(encoding="utf-8") + "N8N_PORT=5678\n", encoding="utf-8")
+    monkeypatch.setattr("main._active_settings_apply_services", lambda: {"n8n"} if active else set())
+    response = test_client.put(
+        "/api/settings/env", headers=test_client.auth_headers,
+        json={"mode": "form", "values": {"N8N_PORT": port}},
+    )
+    assert response.status_code == 200
+    plan = response.json()["applyPlan"]
+    changed = port != "5678"
+    expected_status = ("ready" if active else "staged") if changed else "none"
+    assert plan["status"] == expected_status
+    assert plan["inactiveServices"] == (["n8n"] if changed and not active else [])
+    assert plan["services"] == (["n8n"] if changed and active else [])
+    assert f"N8N_PORT={port}" in env_path.read_text(encoding="utf-8")
+
+
 def test_api_settings_env_save_returns_llama_apply_plan(test_client, settings_env_fixture):
     env_path = settings_env_fixture["env_path"]
     env_path.write_text(


### PR DESCRIPTION
## Why this matters

Saving settings used only by an inactive service returned applyPlan.status=none despite persisting a real change. Operators could mistake a staged change for a no-op.

## Fix and overlap check

Include inactiveServices when deciding whether the apply plan is empty. Updated this original PR onto public-beta. Searched all-state inactive/settings PRs and settings.py; #5118 validates declared scalar constraints, while this fixes the saved plan's lifecycle status. It does not start inactive services or bypass the existing authenticated save/apply boundary.

## Validation

Linux Python3.11: `pytest -q tests/test_settings_env.py`: 130 passed. Four authenticated PUT regressions cover changed/unchanged ports and active/inactive services, persisted values and ready/staged/none plans. Focused pre-commit/diff check passed. Baseline smoke/simulation passed; full-gate/BATS environment/fixture failures remain. No live restart was performed.

## Rollback

No storage schema or execution change; it corrects the status consumers receive. Revert restores misleading no-op reporting for inactive services. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `81303a88a7a8017c6e8dbd577f3b67a3a8234997`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
