### PR TITLE
fix(dashboard): keep dismissed download errors dismissed across polling

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -120,6 +120,28 @@ describe('useDownloadProgress', () => {
     })
   })
 
+  test.each(['failed', 'error', 'cancelled'])('keeps a dismissed %s receipt hidden until a new transfer', async (status) => {
+    let snapshot = { status, model: 'model.gguf', error: 'transfer stopped', updatedAt: 'first' }
+    fetch.mockImplementation(async () => ({ ok: true, json: async () => snapshot }))
+    const { result } = renderHook(() => useDownloadProgress())
+    await waitFor(() => expect(result.current.progress?.status).toBe(status))
+    act(() => result.current.clearTerminal())
+    await act(async () => { await result.current.refresh() })
+    expect(result.current.progress).toBeNull()
+
+    snapshot = { ...snapshot, updatedAt: 'second' }
+    await act(async () => { await result.current.refresh() })
+    expect(result.current.progress?.status).toBe(status)
+    act(() => result.current.clearTerminal())
+    const nextFailure = snapshot
+    snapshot = { status: 'downloading', model: 'model.gguf', bytesDownloaded: 1, bytesTotal: 10 }
+    await act(async () => { await result.current.refresh() })
+    expect(result.current.isDownloading).toBe(true)
+    snapshot = nextFailure
+    await act(async () => { await result.current.refresh() })
+    expect(result.current.progress?.status).toBe(status)
+  })
+
   test('does not let an older idle response overwrite newer download progress', async () => {
     const olderRequest = deferred()
     const newerRequest = deferred()

--- a/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -33,6 +33,8 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
   const progressRequestRef = useRef(0)
   const latestAppliedProgressRequestRef = useRef(0)
   const cancelInFlightRef = useRef(false)
+  const lastTerminalKeyRef = useRef(null)
+  const dismissedTerminalKeyRef = useRef(null)
 
   const fetchProgress = useCallback(async () => {
     const requestId = ++progressRequestRef.current
@@ -45,6 +47,7 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
       latestAppliedProgressRequestRef.current = requestId
       
       if (data.status === 'downloading' || data.status === 'verifying') {
+        dismissedTerminalKeyRef.current = null
         const downloaded = data.bytesDownloaded || 0
         const total = data.bytesTotal || 0
         const rawPercent = total > 0 ? (downloaded / total) * 100 : 0
@@ -83,6 +86,9 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
       } else if (TERMINAL_DOWNLOAD_STATUSES.has(data.status)) {
         setIsDownloading(false)
         setCancelError(null)
+        const terminalKey = JSON.stringify([data.status, data.model, data.updatedAt, data.error, data.message])
+        lastTerminalKeyRef.current = terminalKey
+        if (terminalKey === dismissedTerminalKeyRef.current) return data
         setProgress({
           status: data.status,
           error: data.error || data.message || (data.status === 'cancelled' ? 'Download cancelled' : 'Download failed'),
@@ -163,6 +169,7 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
   }, [fetchProgress])
 
   const clearTerminal = useCallback(() => {
+    dismissedTerminalKeyRef.current = lastTerminalKeyRef.current
     setProgress(current => isTerminalProgress(current) ? null : current)
     setCancelError(null)
   }, [])


### PR DESCRIPTION
## Why this matters

Dismissing a failed/cancelled model-download receipt only cleared React state. The next normal progress poll returned the same terminal receipt and immediately restored the dismissed error.

## Fix and overlap check

Remember the dismissed receipt identity for this mounted hook. The same receipt stays hidden; changed terminal metadata or a newly observed active transfer makes a later result visible. Updated this original PR onto public-beta, retaining cancellation deadline behavior from #4873. Searched all-state download-dismiss and useDownloadProgress.js PRs; this is the canonical dismissal scope.

## Validation

`npm test -- --maxWorkers=2 src/hooks/__tests__/useDownloadProgress.test.js src/pages/Models.test.jsx`: 58 passed, including failed/error/cancelled dismissal across refreshes, a changed receipt, and a new transfer. Focused ESLint/pre-commit/diff check passed.

Baseline full dashboard tests/build and smoke/simulation passed; full make gate/BATS retain existing environment/fixture failures. No real model download was started.

## Tradeoffs and rollback

Dismissal is session/view-local, not deletion of backend evidence. Identity uses existing status/model/timestamp/error/message fields, not a new server job ID. Revert restores reappearing receipts. No service mutation or migration. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `76dc671c9868695374201c25caa762c38bf796d0`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
