### PR TITLE
fix(dashboard): ignore superseded first-run status responses

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useFirstRun.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useFirstRun.test.js
@@ -1,0 +1,48 @@
+import { act, renderHook } from '@testing-library/react'
+import { useFirstRun } from '../useFirstRun'
+
+const deferred = () => {
+  let resolve
+  let reject
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no })
+  return { promise, resolve, reject }
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+test.each(['success', 'failure'])('ignores stale setup %s after the completion refresh', async (outcome) => {
+  const older = deferred()
+  const newer = deferred()
+  vi.stubGlobal('fetch', vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise))
+  const { result } = renderHook(() => useFirstRun())
+  let refresh
+  act(() => { refresh = result.current.refresh() })
+  await act(async () => {
+    newer.resolve({ ok: true, json: async () => ({ first_run: false }) })
+    await refresh
+  })
+  expect(result.current.firstRun).toBe(false)
+  await act(async () => {
+    if (outcome === 'success') older.resolve({ ok: true, json: async () => ({ first_run: true }) })
+    else older.reject(new Error('old request failed'))
+  })
+  expect(result.current.firstRun).toBe(false)
+  expect(result.current.error).toBeNull()
+  expect(result.current.loading).toBe(false)
+})
+
+test('an older completion cannot clear loading while the latest refresh is pending', async () => {
+  const older = deferred()
+  const newer = deferred()
+  vi.stubGlobal('fetch', vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise))
+  const { result } = renderHook(() => useFirstRun())
+  let refresh
+  act(() => { refresh = result.current.refresh() })
+  await act(async () => { older.resolve({ ok: true, json: async () => ({ first_run: true }) }) })
+  expect(result.current.loading).toBe(true)
+  await act(async () => {
+    newer.resolve({ ok: true, json: async () => ({ first_run: false }) })
+    await refresh
+  })
+  expect(result.current.loading).toBe(false)
+})

--- a/ods/extensions/services/dashboard/src/hooks/useFirstRun.js
+++ b/ods/extensions/services/dashboard/src/hooks/useFirstRun.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 
 // Auth: nginx injects the Authorization header for /api/ requests
 // (see nginx.conf). The fetch below is a plain relative URL.
@@ -23,26 +23,33 @@ export function useFirstRun() {
   const [firstRun, setFirstRun] = useState(false)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const requestGeneration = useRef(0)
 
   const refresh = useCallback(async () => {
+    const generation = ++requestGeneration.current
     setLoading(true)
     try {
       const resp = await fetch('/api/setup/status')
       if (!resp.ok) throw new Error(`setup-status returned ${resp.status}`)
       const data = await resp.json()
+      if (generation !== requestGeneration.current) return
       setFirstRun(!!data.first_run)
       setError(null)
     } catch (err) {
+      if (generation !== requestGeneration.current) return
       // See the failure-mode comment above. We mark loading=false so the
       // UI proceeds normally; the wizard is hidden until the next refresh.
       setFirstRun(false)
       setError(err.message)
     } finally {
-      setLoading(false)
+      if (generation === requestGeneration.current) setLoading(false)
     }
   }, [])
 
-  useEffect(() => { refresh() }, [refresh])
+  useEffect(() => {
+    refresh()
+    return () => { requestGeneration.current += 1 }
+  }, [refresh])
 
   return { firstRun, loading, error, refresh }
 }


### PR DESCRIPTION
## Why this matters

A slow initial setup-status request can finish after the completion refresh and restore first_run=true, reopening onboarding after setup completed. A stale failure could likewise overwrite the newer successful state.

## Fix and overlap check

Only the latest request generation may publish firstRun/error/loading; unmount invalidates pending generations. Updated this original PR onto beta. Searched all-state first-run/stale setup PRs and useFirstRun.js; this is the canonical status-ordering fix, separate from wizard-save or install lifecycle changes.

## Validation

`npm test -- --maxWorkers=2 src/hooks/__tests__/useFirstRun.test.js`: 3 passed. Deferred status responses exercise stale success, stale rejection and an older completion while the latest refresh remains pending. The production hook used by App is exercised; no synthetic business function without a caller. Focused ESLint/pre-commit/diff check passed.

Baseline full dashboard1,232 tests/build and smoke/simulation passed; full make gate/BATS have existing environment/fixture failures. Real setup was not run.

## Tradeoffs and rollback

This prevents stale writes, not request cancellation or a network deadline. Latest-request failure retains existing fallback behavior. No stored state or API changes; revert restores the race. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `8d91bb2815439f5153956a4538d2b83997808bbc`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
