### PR TITLE
fix(brave-search): enforce timeout while reading upstream response bodies

### DIFF
--- a/ods/extensions/services/brave-search/proxy.mjs
+++ b/ods/extensions/services/brave-search/proxy.mjs
@@ -94,7 +94,7 @@ function send(res, status, body) {
   res.end(JSON.stringify(body));
 }
 
-async function callBrave(query, count, offset) {
+async function callBrave(query, count, offset, signal) {
   const url = new URL(parsedBraveUrl);
   url.searchParams.set("q", query);
   url.searchParams.set("count", String(count));
@@ -103,10 +103,7 @@ async function callBrave(query, count, offset) {
   } else {
     url.searchParams.delete("offset");
   }
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
-  try {
-    return await fetch(url, {
+  return await fetch(url, {
       headers: {
         Accept: "application/json",
         "Accept-Encoding": "gzip",
@@ -116,20 +113,23 @@ async function callBrave(query, count, offset) {
       // redirecting upstream could receive the subscription token. The Brave
       // API never redirects; refuse rather than follow.
       redirect: "error",
-      signal: ctrl.signal,
+      signal,
     });
-  } finally {
-    clearTimeout(timer);
-  }
 }
 
 // Shared upstream call. Maps transport failures to a tagged shape so each
 // route can render them in its own error contract (/v1 as 5xx, searxng
 // compat as unresponsive_engines).
 async function fetchBraveWeb(query, count, offset) {
-  let upstream;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), REQUEST_TIMEOUT_MS);
   try {
-    upstream = await callBrave(query, count, offset);
+    const upstream = await callBrave(query, count, offset, ctrl.signal);
+    if (!upstream.ok) {
+      await upstream.body?.cancel();
+      return { error: "http_error", status: upstream.status };
+    }
+    return { data: await upstream.json() };
   } catch (err) {
     if (err && err.name === "AbortError") {
       return { error: "timeout" };
@@ -137,18 +137,12 @@ async function fetchBraveWeb(query, count, offset) {
     if (err instanceof TypeError) {
       return { error: "unavailable" };
     }
-    throw err;
-  }
-  if (!upstream.ok) {
-    return { error: "http_error", status: upstream.status };
-  }
-  try {
-    return { data: await upstream.json() };
-  } catch (err) {
     if (err instanceof SyntaxError) {
       return { error: "invalid_json" };
     }
     throw err;
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/ods/tests/test-brave-search-searxng-compat.mjs
+++ b/ods/tests/test-brave-search-searxng-compat.mjs
@@ -78,6 +78,10 @@ function stubHandler(req, res) {
     respond(200, JSON.stringify({ web: { results: "not-an-array" } }));
   } else if (q === "slow") {
     setTimeout(() => respond(200, braveBody()), SLOW_UPSTREAM_DELAY_MS);
+  } else if (q === "slow-body") {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.flushHeaders();
+    setTimeout(() => res.end(braveBody()), SLOW_UPSTREAM_DELAY_MS);
   } else if (q === "redirect") {
     res.writeHead(302, { location: redirectTarget });
     res.end();
@@ -172,6 +176,8 @@ async function testV1Route(base) {
   console.log("v1 route (must stay stable):");
 
   const ok = await getJson(base, "/v1/search?q=ok&count=5");
+  const slowBody = await getJson(base, "/v1/search?q=slow-body");
+  check("504 when headers arrive but the body stalls", slowBody.status === 504 && slowBody.body.error === "upstream_timeout");
   check("200 on success", ok.status === 200, `got ${ok.status}`);
   check("query echoed", ok.body.query === "ok");
   check("empty-url result dropped", ok.body.results.length === 2, `got ${ok.body.results.length}`);
@@ -345,6 +351,7 @@ async function testCompatEnabled(base) {
     ["err500", "HTTP error 500"],
     ["badjson", "invalid JSON"],
     ["slow", "timeout"],
+    ["slow-body", "timeout"],
     ["redirect", "unavailable"],
   ];
   for (const [q, reason] of cases) {


### PR DESCRIPTION
## Why this matters
An upstream sending headers promptly but stalling its JSON body escaped BRAVE_SEARCH_TIMEOUT_MS because the timer was cleared when fetch returned headers. Keep one deadline through body decoding, cancel unused error bodies and preserve each public route's error shape.

## Overlap check
ods/extensions/services/brave-search/proxy.mjs; searched timeout, stalled body, AbortController and upstream JSON in open/closed PRs. #3052 blank queries, #2998 malformed results, #2734 caller key and #1736 searxng compatibility address different behaviors. Inventory searched across 3,447 open/closed upstream PRs, with latest PRs rechecked before publication.

## Regression validation
bash tests/test-brave-search-searxng-compat.sh: passed. A real loopback HTTP upstream flushes headers then delays its body beyond the 1-second configured timeout. The v1 and searxng cases failed before the fix; existing error/redirect/auth cases remain covered.

## Contract, tradeoffs and rollback
Caller -> proxy -> upstream fetch/body -> route-specific timeout receipt. Shared Node implementation applies on all hosts running the extension. No config migration. Revert restores headers-only timeout. Tested Node 22 on Linux/WSL; no live Brave API call.

Candidate commit: 5b59d076.


## Batch compatibility and validation limits
Independent branch from upstream main 21f4b3a6. All ten branches merged without conflicts into [synthetic integration head c48f4061](https://github.com/tang-vu/DreamServer/commit/c48f40619b269355a3cb8e379f6b68c988fdabcb), in order: tool-choice filtering, Talk cleanup, inactive apply status, terminal dismissal, first-run ordering, Brave deadline, null telemetry, auth backup, Bark validation, interpreter JSON. No hard merge dependencies; this order was tested. Token Spy filtering and telemetry touch distinct production files and their tests run together.

On that exact tracked tree in Linux/WSL: 264 UI tests and 179 focused Python tests passed (one additional Postgres test skipped); UI lint/build, repository Ruff, Brave compatibility, backup roundtrip/data coverage, smoke and installer simulation passed. Tests demonstrate these boundaries, not live GPU/fleet/provider behavior. Native macOS/Windows runtime was not exercised.

Full pre-commit: gitleaks, large-file and shell hooks passed; private-key detection flags existing dummy-key fixtures in unchanged test_host_agent.py and test-remote-provider-egress-policy.py. Full make gate stopped at the unchanged Windows backend contract: WSL-launched powershell.exe lacked ROOT_DIR (64 AMD contracts passed, 1 failed). Standalone BATS completed with 416 passed and 2 failed: dispatch expects Linux but detects this WSL host; Docker skip-install fixture lacks existing podman/sudo helpers. Neither failing implementation/fixture is changed by this batch. Smoke and simulation were run separately and passed. GitHub checks are tracked on this PR; do not interpret focused tests as a full release gate.



## Final GitHub validation
At candidate head 5b59d0762d0b596e129afec42688cf8b9ab9abb2: 26 technical checks passed, 0 skipped, none failed or pending (2026-09-07). This count excludes the separate Claude Code Review workflow. Hosted integration-smoke, dashboard API/UI, lint/type, schema, secret scan and platform smoke results are linked in this PR's Checks tab. These results do not remove the local gate limitations or deferred live probes described above.
