### PR TITLE
fix(token-spy): tolerate null optional provider usage metadata

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -738,13 +738,13 @@ async def _handle_streaming(client, raw_body, headers, model, sys_analysis,
                             continue
 
                         if current_event == "message_start":
-                            msg_usage = (data.get("message", {}).get("usage", {}))
+                            msg_usage = data.get("message", {}).get("usage") or {}
                             usage["input_tokens"] = msg_usage.get("input_tokens", 0)
                             usage["cache_read_tokens"] = msg_usage.get("cache_read_input_tokens", 0)
                             usage["cache_write_tokens"] = msg_usage.get("cache_creation_input_tokens", 0)
 
                         elif current_event == "message_delta":
-                            delta_usage = data.get("usage", {})
+                            delta_usage = data.get("usage") or {}
                             if delta_usage.get("output_tokens") is not None:
                                 usage["output_tokens"] = delta_usage["output_tokens"]
                             stop = data.get("delta", {}).get("stop_reason")
@@ -807,7 +807,7 @@ async def _handle_non_streaming(client, raw_body, headers, model, sys_analysis,
         log.warning("Failed to parse Anthropic response JSON — token usage will be recorded as zero")
         data = {}
 
-    resp_usage = data.get("usage", {})
+    resp_usage = data.get("usage") or {}
     usage = {
         "input_tokens": resp_usage.get("input_tokens", 0),
         "output_tokens": resp_usage.get("output_tokens", 0),
@@ -979,7 +979,7 @@ async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysi
                     if chunk_usage:
                         usage["input_tokens"] = chunk_usage.get("prompt_tokens", 0)
                         usage["output_tokens"] = chunk_usage.get("completion_tokens", 0)
-                        usage["cache_read_tokens"] = chunk_usage.get("prompt_tokens_details", {}).get("cached_tokens", 0)
+                        usage["cache_read_tokens"] = (chunk_usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0)
 
                     choices = data.get("choices", [])
                     if choices:
@@ -1030,11 +1030,11 @@ async def _handle_openai_non_streaming(client, raw_body, headers, model, sys_ana
         log.warning("Failed to parse OpenAI response JSON — token usage will be recorded as zero")
         data = {}
 
-    resp_usage = data.get("usage", {})
+    resp_usage = data.get("usage") or {}
     usage = {
         "input_tokens": resp_usage.get("prompt_tokens", 0),
         "output_tokens": resp_usage.get("completion_tokens", 0),
-        "cache_read_tokens": resp_usage.get("prompt_tokens_details", {}).get("cached_tokens", 0),
+        "cache_read_tokens": (resp_usage.get("prompt_tokens_details") or {}).get("cached_tokens", 0),
         "cache_write_tokens": 0,
         "stop_reason": (data.get("choices", [{}])[0].get("finish_reason") if data.get("choices") else None),
     }

--- a/ods/extensions/services/token-spy/tests/test_nullable_proxy_usage.py
+++ b/ods/extensions/services/token-spy/tests/test_nullable_proxy_usage.py
@@ -1,0 +1,46 @@
+"""Optional upstream telemetry must not interrupt response passthrough."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.parametrize("protocol", ["openai", "anthropic"])
+@pytest.mark.parametrize("stream", [False, True])
+def test_null_usage_does_not_interrupt_proxy(monkeypatch, protocol, stream):
+    service_dir = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service_dir))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "nullable-usage-test")
+    monkeypatch.setenv("UPSTREAM_API_KEY", "upstream-test-key")
+    spec = importlib.util.spec_from_file_location("token_spy_nullable_usage", service_dir / "main.py")
+    proxy = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(proxy)
+    monkeypatch.setattr(proxy, "get_filter_settings", lambda agent: {})
+    entries = []
+    monkeypatch.setattr(proxy, "_log_entry", lambda *args, **kwargs: entries.append(dict(args[5])))
+    path = "/v1/chat/completions" if protocol == "openai" else "/v1/messages"
+    if stream and protocol == "openai":
+        payload = 'data: {"choices":[],"usage":{"prompt_tokens":7,"completion_tokens":3,"prompt_tokens_details":null}}\n\ndata: [DONE]\n\n'
+    elif stream:
+        payload = 'event: message_start\ndata: {"message":{"usage":null}}\n\nevent: message_delta\ndata: {"usage":null,"delta":{"stop_reason":"end_turn"}}\n\nevent: message_stop\ndata: {}\n\n'
+    else:
+        payload = json.dumps({"choices": [], "usage": None})
+    client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=payload)),
+        base_url="http://upstream",
+    )
+    monkeypatch.setattr(proxy, "get_moonshot_client", lambda: client)
+    monkeypatch.setattr(proxy, "get_http_client", lambda: client)
+    response = TestClient(proxy.app).post(
+        path, headers={"Authorization": "Bearer nullable-usage-test"},
+        json={"model": "test", "messages": [], "stream": stream},
+    )
+    assert response.status_code == 200
+    assert response.text == payload
+    assert len(entries) == 1
+    assert entries[0]["input_tokens"] == (7 if stream and protocol == "openai" else 0)
+    assert entries[0]["cache_read_tokens"] == 0


### PR DESCRIPTION
## Why this matters

Optional provider usage objects and token-detail fields can be JSON null. Token Spy dereferenced them and could interrupt an otherwise valid OpenAI/Anthropic response instead of passing it through.

## Fix and overlap check

Normalize nullable optional telemetry to an empty object at the proxy boundary. Updated the original PR onto beta and explicitly reconciled Anthropic cumulative usage from #4561/#5175: omitted/null metadata does not erase counters already observed. Searched all-state Token Spy null/usage and main.py PRs; persistence scheduling #4913 and pricing #5174 are separate. No duplicate was opened.

## Validation

Linux Python3.11/FastAPI0.119: `pytest -q tests/test_nullable_proxy_usage.py tests/test_anthropic_cumulative_usage.py tests/test_interrupted_usage_receipts.py tests/test_proxy_persistence_io.py`: 38 passed. Authenticated proxy tests cover both protocols with streaming/nonstreaming null metadata, unchanged response bytes and one usage receipt; cumulative/interrupted/persistence suites remain green. Deprecation warnings remain. Focused pre-commit/diff check passed.

Baseline smoke/simulation passed; full make gate/BATS retain existing environment/fixture failures. No live billable provider calls.

## Tradeoffs and rollback

Absent telemetry is unknown/zero according to the existing accounting contract, not estimated billing. No response rewriting or schema migration. Revert reintroduces nullable-metadata failures. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `f26301b03fe1aec3fae4d83638969e2a583749c2`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
