### PR TITLE
fix(backup): preserve the magic-link registry in user-data snapshots

### DIFF
--- a/ods/lib/backup-paths.sh
+++ b/ods/lib/backup-paths.sh
@@ -28,6 +28,7 @@ ODS_USER_DATA_PATHS=(
     "data/hermes"           # agent state and configuration
     "data/persona"          # Hermes persona (SOUL.md)
     "data/hermes-proxy"     # proxy session state
+    "data/auth"             # dashboard owner cards, guest links and revocations
     "data/ape"              # governance decisions and approvals
     "data/token-spy"        # usage and cost history
     "data/privacy-shield"   # scrubber state and keys

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -27,6 +27,9 @@ trap 'rm -rf "$TMP"' EXIT
 SRC="$TMP/src"
 mkdir -p "$SRC/data/open-webui" "$SRC/data/hermes/sessions" "$SRC/data/persona"
 mkdir -p "$SRC/data/n8n"
+mkdir -p "$SRC/data/auth"
+printf '%s\n' '{"tokens":[{"token_hash":"owner-fixture","revoked_at":null},{"token_hash":"revoked-fixture","revoked_at":"2026-09-01T00:00:00Z"}]}' > "$SRC/data/auth/magic-links.json"
+chmod 600 "$SRC/data/auth/magic-links.json"
 mkdir -p "$SRC/config"
 mkdir -p "$SRC/models"
 echo "1.0.0" > "$SRC/.version"
@@ -64,6 +67,10 @@ pass "Backup created: $BACKUP_ID"
     || fail "Full backup lost its environment config"
 
 BACKUP_DIR="$SRC/.backups/$BACKUP_ID"
+cmp "$SRC/data/auth/magic-links.json" "$BACKUP_DIR/data/auth/magic-links.json" \
+    || fail "Backup omitted the magic-link registry"
+jq -e '.paths.data_auth == "data/auth"' "$BACKUP_DIR/manifest.json" >/dev/null \
+    || fail "Manifest omitted the authentication registry path"
 [[ -f "$BACKUP_DIR/data/hermes/sessions/session.jsonl" ]] \
     || fail "Backup omitted data/hermes"
 [[ -f "$BACKUP_DIR/data/persona/SOUL.md" ]] \
@@ -120,6 +127,16 @@ pass "All expected files/dirs present after restore"
     || fail "persona SOUL.md content mismatch"
 
 pass "All file contents match after restore"
+cmp "$SRC/data/auth/magic-links.json" "$DST/data/auth/magic-links.json" \
+    || fail "Restore lost owner cards or revocation records"
+python3 - "$DST/data/auth/magic-links.json" <<'PY'
+import os
+import stat
+import sys
+
+assert stat.S_IMODE(os.stat(sys.argv[1]).st_mode) == 0o600, "Registry permissions widened"
+PY
+pass "Owner cards and revocation records survive backup and restore"
 
 # Exercise the older macOS rsync branch, where `--info=progress2` is absent and
 # the helper falls back to `--progress`. The fallback must keep the same


### PR DESCRIPTION
## Why this matters

The shared user-data backup inventory omitted data/auth, which stores owner cards, guest links and their revocation records. A restore could retain application data while losing the dashboard access inventory.

## Fix and overlap check

Add the existing authentication directory to the same shared backup/restore path registry. Updated this original PR onto public-beta. Searched all-state backup magic-link PRs and backup-paths.sh/roundtrip changes. #3892 fixes full-backup cache tier coverage; this is independent durable authentication state. Its beta cache/restore behavior is retained.

## Validation

Linux `bash tests/test-backup-restore-roundtrip.sh`: passed. The real scripts create/restore a temporary backup and compare authentication bytes, manifest inclusion and mode0600, alongside existing full/cache/user-data/legacy/compressed/interactive contracts. Focused pre-commit/diff check passed. No real user backup or credential was accessed.

Baseline smoke/simulation passed; full make gate/BATS retain existing environment/fixture failures.

## Security and rollback

Backups now contain sensitive credential metadata and must be protected. They preserve the snapshot's revocations, not revocations made afterward: restoring an older snapshot can roll access state back and requires operator review/revocation. Existing backups lacking data/auth cannot recover it. Revert removes future coverage; existing backup contents remain. Independent human review required before merge; Ready is not rollout approval.

## Final beta-batch receipt — 2026-09-16

Candidate: `7329c471bfd949258605d439635542e95668f547`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
