### PR TITLE
fix(bark): reject blank text and null output formats before synthesis

### DIFF
--- a/ods/extensions/library/services/bark/server.py
+++ b/ods/extensions/library/services/bark/server.py
@@ -94,7 +94,14 @@ def _load_models():
 class TTSRequest(BaseModel):
     text: str = Field(..., max_length=MAX_TEXT_LENGTH, description="Text to synthesize (max 10K chars)")
     voice_preset: Optional[str] = "v2/en_speaker_6"
-    output_format: Optional[str] = "wav"  # wav, mp3, ogg, flac
+    output_format: str = "wav"  # wav, mp3, ogg, flac
+
+    @field_validator("text")
+    @classmethod
+    def validate_text(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Text cannot be empty or whitespace")
+        return v
 
     @field_validator("output_format")
     @classmethod

--- a/ods/extensions/library/services/bark/test_request_validation.py
+++ b/ods/extensions/library/services/bark/test_request_validation.py
@@ -1,0 +1,41 @@
+"""Reject unusable TTS payloads before they enter the synthesis executor."""
+
+import pytest
+from fastapi.responses import Response
+from fastapi.testclient import TestClient
+
+import server
+
+
+@pytest.fixture
+def synthesis_calls(monkeypatch):
+    calls = []
+
+    def generate(text, voice, output_format="WAV"):
+        calls.append((text, voice, output_format))
+        return {"audio_base64": "YXVkaW8=", "sample_rate": 24000, "format": output_format.lower()}
+
+    def generate_stream(text, voice):
+        generate(text, voice)
+        return Response(b"audio", media_type="audio/wav")
+
+    monkeypatch.setattr(server, "_generate_audio_sync", generate)
+    monkeypatch.setattr(server, "_generate_audio_stream_sync", generate_stream)
+    return calls
+
+
+@pytest.mark.parametrize("path", ["/tts", "/tts/stream"])
+@pytest.mark.parametrize("payload", [{"text": ""}, {"text": " \t\n"}, {"text": "hello", "output_format": None}])
+def test_invalid_payload_never_schedules_audio(path, payload, synthesis_calls):
+    response = TestClient(server.app, raise_server_exceptions=False).post(path, json=payload)
+    assert response.status_code == 422
+    assert synthesis_calls == []
+
+
+@pytest.mark.parametrize("path", ["/tts", "/tts/stream"])
+def test_default_format_and_optional_voice_still_work(path, synthesis_calls):
+    response = TestClient(server.app).post(path, json={"text": " Hello ", "voice_preset": None})
+    assert response.status_code == 200
+    assert len(synthesis_calls) == 1
+    assert synthesis_calls[0][:2] == (" Hello ", None)
+    assert synthesis_calls[0][2].upper() == "WAV"


### PR DESCRIPTION
## Why this matters

Bark accepted empty/whitespace text and explicit null output_format, then failed or scheduled needless synthesis instead of rejecting the unusable HTTP request.

## Fix and overlap check

Require nonblank text and a nonnullable output format while preserving the default WAV format, meaningful text whitespace and optional voice. Updated the original canonical request-validation PR onto public-beta. Searched all-state Bark validation and bark/server.py PRs. #5204 bounds generation admission, a different lifecycle contract; this patch rejects invalid requests before synthesis. No duplicate was created.

## Validation

`pytest -q test_request_validation.py test_server.py::test_tts_text_empty`: 9 passed on Linux Python3.10.21/FastAPI0.111.0/soundfile0.12.1/numpy1.26.4, matching the declared version families. Both /tts and /tts/stream reject three invalid payloads with 422 and zero synthesis calls; defaults/null voice remain valid. The synthesis backend is replaced with a fixture: no Torch model, GPU or audio-quality validation is claimed. Focused pre-commit/diff check passed.

Baseline smoke/simulation passed; full make gate/BATS retain known environment/fixture failures.

## Compatibility and rollback

Clients sending null output_format must omit it for WAV or supply a supported string. No model format or persisted state changes. Revert restores invalid-input acceptance. Ready for independent review.

## Follow-up and shared-file compatibility

Follow-up `797cc0b5799ee61b19f5451b107589bd13e1661d` updates the legacy empty-text expectation from 200 to the intended 422 response and validates the error location. Production code merges cleanly with #5204 at `02d0dd5809819fbc2ed2fe0a463308e50b749cc2`. Pair branch [integration/beta-bark-pair-20260916](https://github.com/tang-vu/DreamServer/tree/a1ab19704f18286b05727e75ef38faeec8416931) passed **20 tests at that exact SHA**: request validation, the legacy empty case and generation-admission regressions.

The broader legacy `test_server.py` suite was also attempted, but is not green in the fixture-only environment: 11 setup errors require the unavailable Bark package; old validation assertions assume string-shaped Pydantic errors, and a model-boundary case also requires that package. The empty-text mismatch is fixed here; #3974's separate legacy assertion/timeout scope is not duplicated. No Bark weights, live synthesis or GPU qualification is claimed. Independent human review remains required.

## Final beta-batch receipt — 2026-09-16

Candidate: `797cc0b5799ee61b19f5451b107589bd13e1661d`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
