### PR TITLE
fix(open-interpreter): serialize streamed chunks as JSON

### DIFF
--- a/ods/extensions/library/services/open-interpreter/README.md
+++ b/ods/extensions/library/services/open-interpreter/README.md
@@ -37,9 +37,20 @@ curl http://localhost:7805/health
 
 # Chat (non-streaming)
 curl -X POST http://localhost:7805/chat \
+  -H "Authorization: Bearer $OPEN_INTERPRETER_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"message": "What OS are we running?", "stream": false}'
+
+# Chat as Server-Sent Events
+curl -N http://localhost:7805/chat/stream \
+  -H "Authorization: Bearer $OPEN_INTERPRETER_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Describe the current directory"}'
 ```
+
+Each `data:` frame contains one JSON-encoded Interpreter chunk. Clients can
+decode the frame with `JSON.parse(event.data)`; newlines within a chunk are
+escaped, and boolean and null values retain their JSON types.
 
 ### CLI Usage
 

--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -104,7 +104,7 @@ interpreter.auto_run = config["auto_run"]
 interpreter.offline = True
 
 for chunk in interpreter.chat(config["message"], stream=True):
-    print(f"SSE: {chunk}", flush=True)
+    print("SSE: " + json.dumps(chunk), flush=True)
 """
 
 

--- a/ods/extensions/library/services/open-interpreter/test_stream_json.py
+++ b/ods/extensions/library/services/open-interpreter/test_stream_json.py
@@ -1,0 +1,45 @@
+"""Exercise the authenticated stream and its real runner subprocess."""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+
+def test_stream_emits_json_chunks_without_splitting_message_lines(tmp_path, monkeypatch):
+    (tmp_path / "interpreter.py").write_text(
+        "from types import SimpleNamespace\n"
+        "class FakeInterpreter:\n"
+        "    llm = SimpleNamespace()\n"
+        "    def chat(self, message, stream=False):\n"
+        "        assert stream is True\n"
+        "        yield {'type': 'message', 'content': message, 'done': False, 'metadata': None}\n"
+        "        yield {'type': 'message', 'content': 'finished', 'done': True}\n"
+        "interpreter = FakeInterpreter()\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("PYTHONPATH", str(tmp_path))
+    monkeypatch.setenv("PATH", str(Path(sys.executable).parent) + os.pathsep + os.environ["PATH"])
+    monkeypatch.setenv("OPEN_INTERPRETER_API_KEY", "stream-json-test")
+    spec = importlib.util.spec_from_file_location("interpreter_stream_server", Path(__file__).with_name("server.py"))
+    server = importlib.util.module_from_spec(spec)
+    # The deployment's fixed data mount is unused by chat; isolate its mkdir
+    # so this HTTP test also runs as an unprivileged CI user.
+    mkdir = Path.mkdir
+    with monkeypatch.context() as context:
+        context.setattr(Path, "mkdir", lambda path, *args, **kwargs: None if path == Path("/app/data") else mkdir(path, *args, **kwargs))
+        spec.loader.exec_module(server)
+    message = 'first line\nsecond "quoted" line — café'
+    response = TestClient(server.app).post(
+        "/chat/stream", headers={"Authorization": "Bearer stream-json-test"},
+        json={"message": message},
+    )
+    assert response.status_code == 200
+    frames = [json.loads(line[6:]) for line in response.text.splitlines() if line.startswith("data: ")]
+    assert frames == [
+        {"type": "message", "content": message, "done": False, "metadata": None},
+        {"type": "message", "content": "finished", "done": True},
+    ]


### PR DESCRIPTION
## Why this matters

The Open Interpreter stream runner printed Python dict representations into SSE. JSON clients could not parse single quotes, Python booleans or None; embedded text must remain one framed JSON value.

## Fix and overlap check

Serialize each runner chunk with json.dumps before the existing SSE relay. Updated this original canonical PR onto public-beta. Searched all-state interpreter/stream PRs and server.py; #3834 is synchronous timeout reporting, #2324/#2818/#3976 worker cleanup, and #4964/#5325 model connection configuration. None replaces JSON framing. Their respective existing beta code is retained.

## Validation

`pytest -q test_stream_json.py`: passed on Linux Python3.12.14/FastAPI0.111.0/Pydantic2.12.5. The authenticated streaming endpoint launches the real runner subprocess with a fixture interpreter; the consumer parses frames containing quotes, newlines, Unicode, booleans and null. This does not run the actual model package. Focused pre-commit/diff check passed.

Baseline smoke/simulation passed; full make gate/BATS retain known environment/fixture failures. Combined compatibility with the sibling synchronous-timeout PR will be checked on the batch integration head.

## Compatibility and rollback

Frame boundaries and content fields stay unchanged; consumers must treat data as JSON, not Python repr. No persisted state. Revert restores non-JSON payloads. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `564c55e7f795e3b64d1b4f622717165068a26647`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
