### PR TITLE
fix(env-values): add quote stripping guard for non-string types and unit test suite

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -8,6 +8,10 @@ def strip_matching_quotes(value: str) -> str:
     double quotes. Unmatched or mixed quotes are data, not delimiters, and
     must survive reads unchanged.
     """
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        value = str(value)
     value = value.strip()
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -20,6 +20,8 @@ from env_values import strip_matching_quotes
         ('"value\'', '"value\''),
         ("''value''", "'value'"),
         ('""value""', '"value"'),
+        (None, ""),
+        (12345, "12345"),
     ],
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):


### PR DESCRIPTION
Add type validation and None handling to strip_matching_quotes in env_values.py to ensure non-string inputs are safely processed without raising AttributeError. Includes expanded unit test coverage.