### PR TITLE
fix(dashboard-api): add null and range port bounds guard in model router helper

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,21 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def sanitize_model_router_port(port_val: object, default_port: int = 8000) -> int:
+    """Sanitize model router port configuration inputs safely.
+
+    Ensures non-integer, out-of-range (1-65535), or None values fallback
+    gracefully to standard default port without crashing network sockets.
+    """
+    if port_val is None:
+        return default_port
+    try:
+        port_num = int(port_val)
+        if 1 <= port_num <= 65535:
+            return port_num
+    except (ValueError, TypeError):
+        pass
+    return default_port
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,20 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSanitizeModelRouterPort:
+
+    def test_valid_integer_port(self):
+        from helpers import sanitize_model_router_port
+        assert sanitize_model_router_port(8080) == 8080
+        assert sanitize_model_router_port("9000") == 9000
+
+    def test_invalid_or_out_of_bounds_port(self):
+        from helpers import sanitize_model_router_port
+        assert sanitize_model_router_port(None) == 8000
+        assert sanitize_model_router_port("invalid") == 8000
+        assert sanitize_model_router_port(0) == 8000
+        assert sanitize_model_router_port(70000) == 8000
+        assert sanitize_model_router_port(-1, default_port=8080) == 8080
+


### PR DESCRIPTION
Add sanitize_model_router_port utility to validate and sanitize port configuration values against integer boundaries (1-65535) and handle None or non-integer inputs gracefully. Includes unit test suite.