### PR TITLE
fix(dashboard-api): add tuple pair validator type safety and index bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,16 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def validate_tuple_pair_types(pair: object, expected_types: tuple = (str, str)) -> bool:
+    """Validate 2-element tuple or list pair for strict length and item types.
+
+    Returns True if pair is a sequence of exactly 2 elements matching expected_types,
+    otherwise returns False safely without raising TypeError or IndexError.
+    """
+    if not isinstance(pair, (tuple, list)) or len(pair) != 2:
+        return False
+    t1, t2 = expected_types
+    return isinstance(pair[0], t1) and isinstance(pair[1], t2)
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,19 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestValidateTuplePairTypes:
+
+    def test_valid_pair_types(self):
+        from helpers import validate_tuple_pair_types
+        assert validate_tuple_pair_types(("key", "val")) is True
+        assert validate_tuple_pair_types(["host", 8080], expected_types=(str, int)) is True
+
+    def test_invalid_pair_types_or_lengths(self):
+        from helpers import validate_tuple_pair_types
+        assert validate_tuple_pair_types(None) is False
+        assert validate_tuple_pair_types(("single",)) is False
+        assert validate_tuple_pair_types(("a", "b", "c")) is False
+        assert validate_tuple_pair_types(("host", "not_int"), expected_types=(str, int)) is False
+


### PR DESCRIPTION
Add validate_tuple_pair_types helper utility in helpers.py to validate 2-element tuple/list sequences against length and item type constraints without IndexError or TypeError. Includes unit test suite.