### PR TITLE
fix(safe-env): read .env values with Compose's inline-comment rule

### DIFF
--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -201,6 +201,22 @@ read_ods_env() {
         if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
             local key="${BASH_REMATCH[1]}"
             local val="${BASH_REMATCH[2]}"
+            # Apply Docker Compose's value grammar, mirrored from
+            # lib/safe-env.sh, before stripping quotes: trim surrounding
+            # whitespace (Compose trims leading space, so "KEY=  # x" becomes
+            # the literal "# x"), then for an unquoted value cut at the first
+            # " #", and for a quoted value drop a " #..." after the closing
+            # quote. "#" without a leading space and "#" inside quotes stay.
+            val="${val#"${val%%[![:space:]]*}"}"
+            val="${val%"${val##*[![:space:]]}"}"
+            case "$val" in
+                \"*) [[ "$val" =~ ^(\"(\\.|[^\"\\])*\")[[:space:]]+# ]] && val="${BASH_REMATCH[1]}" ;;
+                \'*) [[ "$val" =~ ^(\'[^\']*\')[[:space:]]+# ]] && val="${BASH_REMATCH[1]}" ;;
+                *)
+                    val="${val%% #*}"
+                    val="${val%"${val##*[![:space:]]}"}"
+                    ;;
+            esac
             # Strip exactly one matching pair of surrounding quotes. The old
             # sed removed a leading and a trailing quote independently (either
             # type), so KEY=abc" lost its trailing quote and "abc' was cut on

--- a/ods/lib/safe-env.sh
+++ b/ods/lib/safe-env.sh
@@ -11,6 +11,10 @@
 
 # Load a .env file safely: comments and empty lines skipped; key names must be
 # valid identifiers; values may be unquoted or quoted; no eval or word-splitting.
+# A quoted value followed by whitespace and '#': group 1 is the quoted part.
+_SAFE_ENV_DQ_COMMENT_RE='^("(\\.|[^"\\])*")[[:space:]]+#'
+_SAFE_ENV_SQ_COMMENT_RE="^('[^']*')[[:space:]]+#"
+
 load_env_file() {
     local path="$1"
     [[ -f "$path" ]] || return 0
@@ -38,13 +42,32 @@ load_env_file() {
         # UID=1000 is valid for Docker Compose, but exporting it here aborts
         # lifecycle commands under set -e before they can reach compose.
         [[ "$key" == "UID" ]] && continue
-        # Strip one leading space, then a single matching pair of surrounding
-        # quotes. Only strip when both ends carry the SAME quote character —
-        # stripping each quote type independently corrupts values whose content
-        # legitimately begins or ends with the other quote (e.g. a double-quoted
-        # "'literal'" would otherwise lose its inner single quotes, and KEY="'"
-        # would collapse to empty).
-        value="${value# }"
+        # Apply Docker Compose's value grammar before looking at quotes: these
+        # values are exported into the environment Compose interpolates, and
+        # Compose gives the environment precedence over .env. Surrounding
+        # whitespace is trimmed; an unquoted value ends at the first " #"; a
+        # quoted value may carry a comment after its closing quote.
+        # KEY=VAL#x and KEY="a # b" keep their '#'.
+        value="${value#"${value%%[![:space:]]*}"}"
+        value="${value%"${value##*[![:space:]]}"}"
+        case "$value" in
+            \"*) [[ "$value" =~ $_SAFE_ENV_DQ_COMMENT_RE ]] && value="${BASH_REMATCH[1]}" ;;
+            \'*) [[ "$value" =~ $_SAFE_ENV_SQ_COMMENT_RE ]] && value="${BASH_REMATCH[1]}" ;;
+            *)
+                # Cut at the first " #" of the already-trimmed value, then trim
+                # the exposed trailing whitespace. Compose trims leading
+                # whitespace before this cut, so "KEY=  # x" becomes "# x"
+                # (the "#" is no longer preceded by a space) and stays literal.
+                value="${value%% #*}"
+                value="${value%"${value##*[![:space:]]}"}"
+                ;;
+        esac
+        # Then strip a single matching pair of surrounding quotes. Only strip
+        # when both ends carry the SAME quote character — stripping each quote
+        # type independently corrupts values whose content legitimately begins
+        # or ends with the other quote (e.g. a double-quoted "'literal'" would
+        # otherwise lose its inner single quotes, and KEY="'" would collapse
+        # to empty).
         if [[ "$value" == '"'*'"' ]]; then
             value="${value#\"}"
             value="${value%\"}"

--- a/ods/tests/test-macos-env-quote-strip.sh
+++ b/ods/tests/test-macos-env-quote-strip.sh
@@ -48,6 +48,13 @@ MISMATCH=trailing-quote"
 CROSS="abc'
 LONE_DQ="
 EMPTY_DQ=""
+IC_PORT=11434          # llama-server API (external → internal 8080)
+IC_HASH_NO_SPACE=abc#not-a-comment
+IC_DQ="quoted value" # trailing note
+IC_SQ='single value'   # trailing note
+IC_DQ_INNER="keep # this"
+IC_EMPTY_COMMENT=  # auto-generated during install
+IC_LEADING_HASH= #x
 EOF
 
 INSTALL_DIR="$TMP_DIR"
@@ -71,6 +78,17 @@ assert_env "MISMATCH" 'trailing-quote"'
 assert_env "CROSS" '"abc'\'''
 assert_env "LONE_DQ" '"'
 assert_env "EMPTY_DQ" ''
+# Compose's inline-comment rule, mirrored from lib/safe-env.sh
+assert_env "IC_PORT" '11434'
+assert_env "IC_HASH_NO_SPACE" 'abc#not-a-comment'
+assert_env "IC_DQ" 'quoted value'
+assert_env "IC_SQ" 'single value'
+assert_env "IC_DQ_INNER" 'keep # this'
+# Compose trims leading whitespace before the inline-comment cut, so a value
+# that is only a comment keeps the literal "#..." (checked with docker compose
+# config); read_ods_env matches so ods exports what Compose would read.
+assert_env "IC_EMPTY_COMMENT" '# auto-generated during install'
+assert_env "IC_LEADING_HASH" '#x'
 
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"

--- a/ods/tests/test-safe-env.sh
+++ b/ods/tests/test-safe-env.sh
@@ -151,5 +151,39 @@ load_env_file "$tmpdir/.env-escaped"
     || fail "FILE_ESCAPED not decoded safely (got: ${FILE_ESCAPED:-})"
 pass "load_env_file decodes supported escapes without evaluation"
 
+echo "Test 14: load_env_file applies Compose's inline-comment and whitespace rules"
+# ods-cli exports these values before calling docker compose, and Compose gives
+# the environment precedence over .env — so a value Compose would read as
+# "11434" must not reach it as "11434 # comment" (invalid hostPort).
+unset IC_PORT IC_HASH_NO_SPACE IC_DQ IC_SQ IC_DQ_INNER IC_SQ_INNER IC_PAD IC_EMPTY_COMMENT IC_LEADING_HASH IC_DQ_PAD 2>/dev/null || true
+cat > "$tmpdir/.env-comments" << 'EOF'
+IC_PORT=11434          # llama-server API (external → internal 8080)
+IC_HASH_NO_SPACE=abc#not-a-comment
+IC_DQ="quoted value" # trailing note
+IC_SQ='single value'   # trailing note
+IC_DQ_INNER="keep # this"
+IC_SQ_INNER='keep # this too'
+IC_EMPTY_COMMENT=  # auto-generated during install
+IC_LEADING_HASH= #x
+EOF
+# Trailing whitespace on purpose; written with printf so the source stays clean.
+printf '%s\n' 'IC_PAD=   padded value   ' 'IC_DQ_PAD=  "spaced quotes"  ' >> "$tmpdir/.env-comments"
+load_env_file "$tmpdir/.env-comments"
+[[ "${IC_PORT:-}" == "11434" ]] || fail "IC_PORT kept its inline comment (got: '${IC_PORT:-}')"
+[[ "${IC_HASH_NO_SPACE:-}" == "abc#not-a-comment" ]] || fail "IC_HASH_NO_SPACE lost a '#' that is not a comment (got: '${IC_HASH_NO_SPACE:-}')"
+[[ "${IC_DQ:-}" == "quoted value" ]] || fail "IC_DQ kept the comment after its closing quote (got: '${IC_DQ:-}')"
+[[ "${IC_SQ:-}" == "single value" ]] || fail "IC_SQ kept the comment after its closing quote (got: '${IC_SQ:-}')"
+[[ "${IC_DQ_INNER:-}" == "keep # this" ]] || fail "IC_DQ_INNER lost quoted content (got: '${IC_DQ_INNER:-}')"
+[[ "${IC_SQ_INNER:-}" == "keep # this too" ]] || fail "IC_SQ_INNER lost quoted content (got: '${IC_SQ_INNER:-}')"
+[[ "${IC_PAD:-}" == "padded value" ]] || fail "IC_PAD kept surrounding whitespace (got: '${IC_PAD:-}')"
+# Compose trims leading whitespace BEFORE the inline-comment cut, so
+# "KEY=  # x" becomes "# x" — the '#' is no longer preceded by a space and is
+# kept as a literal value (verified with `docker compose config`). safe-env
+# must match, or ods-cli would export a value Compose never produced.
+[[ "${IC_EMPTY_COMMENT-unset}" == "# auto-generated during install" ]] || fail "IC_EMPTY_COMMENT should be the literal comment like Compose (got: '${IC_EMPTY_COMMENT-unset}')"
+[[ "${IC_LEADING_HASH-unset}" == "#x" ]] || fail "IC_LEADING_HASH should stay '#x' like Compose (got: '${IC_LEADING_HASH-unset}')"
+[[ "${IC_DQ_PAD:-}" == "spaced quotes" ]] || fail "IC_DQ_PAD not unquoted after trimming (got: '${IC_DQ_PAD:-}')"
+pass "load_env_file matches Compose for inline comments and surrounding whitespace"
+
 echo ""
 echo "All safe-env tests passed."


### PR DESCRIPTION
## Summary

`ods-cli` exports every `.env` key through `lib/safe-env.sh` `load_env_file` before it calls `docker compose`, and Compose gives the environment precedence over the `.env` file during interpolation. `load_env_file` kept the whole rest of the line as the value, while Compose ends an unquoted value at the first `` #``, allows a comment after a closing quote, and trims surrounding whitespace. So a line that is valid for Compose -- `OLLAMA_PORT=11434   # llama-server API` -- broke every `ods` lifecycle command:

```text
$ ods logs whisper
invalid hostPort: 11434   # llama-server API
```

while `docker compose $(cat .compose-flags) ...` in the same directory worked. Repro and the sources of such lines (the pre-#3799 `.env.example`, its commented reference lines meant to be uncommented, hand edits) in #3821.

Change (one concern: the values `ods-cli` hands Compose must be the values Compose would read itself):

- **`lib/safe-env.sh`** `load_env_file`: trim surrounding whitespace first, then cut an unquoted value at the first `` #`` on the trimmed value, and drop a `` #...`` that follows a quoted value's closing quote (two small ERE constants, one per quote type). Because leading whitespace is trimmed before the cut, a comment-only value like `KEY=  # note` keeps the literal `# note` exactly as Compose does (the `#` is then no longer preceded by a space). `KEY=VAL#x`, `#` inside quotes, the matching-quote-pair rule and the double-quoted escape decoding are unchanged. `load_env_from_output*` (which parses script output, not `.env`) is untouched.
- **`installers/macos/ods-macos.sh`** `read_ods_env`: the same rule, since that reader is documented to mirror `safe-env.sh` and feeds `ODS_MODE` / `BIND_ADDRESS` reads.
- **Tests**: `tests/test-safe-env.sh` Test 14 (inline comment on a port; `#` without a space kept; comment after `"..."` and `'...'`; `#` inside quotes kept; padded unquoted value trimmed; comment-only `KEY=  # note` kept as the literal `# note` and ` #x` as `#x`, matching Compose; padded quoted value); `tests/test-macos-env-quote-strip.sh` gains the same fixture lines. Both fail on current `main` and pass here, under Homebrew Bash 5.3 and stock Bash 3.2.

Fixes #3821.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium -- `load_env_file` backs every `ods-cli` lifecycle command. Values without `` #`` or surrounding whitespace parse exactly as before (Tests 1-13 unchanged and passing); values that do change are ones Compose was already reading differently, so the change only removes a disagreement. Nothing in the repo `source`s `.env` with Bash or relies on the old behaviour.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11, Docker CLI 29.6.1

# BEFORE (upstream/main 21f4b3a6) -- install dir seeded from the checkout, one Compose-valid line appended
$ ods logs whisper
invalid hostPort: 11434   # llama-server API
$ bash tests/test-safe-env.sh          # with Test 14 added
[FAIL] IC_PORT kept its inline comment (got: '11434          # llama-server API (external -> internal 8080)')

# AFTER (this branch)
$ ods logs whisper                     # value now reaches Compose intact; the host simply has no daemon
Cannot connect to the Docker daemon at unix:///.../docker.sock. Is the docker daemon running?
$ bash tests/test-safe-env.sh          -> All safe-env tests passed. (Tests 1-14)
$ /bin/bash tests/test-safe-env.sh     -> All safe-env tests passed. (Bash 3.2)
$ bash tests/test-macos-env-quote-strip.sh      -> Result: 16 passed, 0 failed
$ /bin/bash tests/test-macos-env-quote-strip.sh -> Result: 16 passed, 0 failed

# Consumers of load_env_file / read_ods_env (same results as on clean upstream/main)
test-dotenv-serializer.sh 27/27, test-health-check.sh 22/22, test-tier-map.sh 129/129,
test-ods-config-secret-mask.sh 9/9, test-macos-config-show-secret-mask.sh 15/15 -> pass

$ shellcheck --exclude=SC1091,SC2034 --severity=error lib/safe-env.sh installers/macos/ods-macos.sh tests/test-safe-env.sh tests/test-macos-env-quote-strip.sh -> clean
$ git diff --check -> clean
```

## Validation against real Docker Compose

The Compose value grammar here was not asserted from docs alone -- it was checked against `docker compose config`, which parses and interpolates `.env` without contacting the daemon. Over a 27-case battery, the patched `load_env_file` and `read_ods_env` each reproduce Compose's canonical value on every case, including:

```text
raw (.env, after '=')            docker compose config    both readers
11434          # llama API   ->  11434                    11434
a  # x                       ->  a                        a
a# b                         ->  a# b                     a# b
"quoted value" # trailing    ->  quoted value             quoted value
"keep # this"                ->  keep # this              keep # this
  # only comment             ->  # only comment           # only comment
 #x                          ->  #x                       #x
   padded value              ->  padded value             padded value
```

The `  # only comment -> # only comment` row is the surprising one: Compose trims leading whitespace first, so the `#` is no longer an inline-comment delimiter and the text survives. Matching it (rather than treating the line as empty) is what keeps `ods-cli` and a bare `docker compose` in agreement.

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Companion to #3799 (`.env.example` lines) and the reverse direction of #3820 (dashboard writer). Searched open issues/PRs for "inline comment", "safe-env", "load_env_file" -- nothing touches this parsing.
- Not covered on purpose: the dashboard's Python `_parse_env_text` (not exported to Compose; #3030 is active in that helper) and the per-key `read_env_value` helpers in `bootstrap-upgrade.sh` / `ods-support-bundle.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

