### PR TITLE
fix(cli): show Docker's own error when the daemon is unreachable

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -48,6 +48,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-ods-doctor-rootless-subid.sh
 	@echo "=== Docker rootless bind-mount ownership ==="
 	@bash tests/test-rootless-docker-ownership.sh
+	@bash tests/test-cli-status-docker-error.sh
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh

--- a/ods/lib/rootless-ownership.sh
+++ b/ods/lib/rootless-ownership.sh
@@ -30,15 +30,21 @@ ods_docker_rootless_state() {
     fi
 
     # Podman (invoked through the docker CLI shim) reports rootless via
-    # .Host.Security.Rootless — a plain "true"/"false" boolean.
-    local podman_rootless
-    if podman_rootless=$(_ods_rootless_docker_info --format '{{.Host.Security.Rootless}}' 2>/dev/null) \
-       && [[ -n "$podman_rootless" ]]; then
+    # .Host.Security.Rootless — a plain "true"/"false" boolean. Keep this
+    # probe's stderr: when both probes fail it carries the actual reason
+    # (typically "Cannot connect to the Docker daemon ...").
+    local podman_rootless probe_rc=0
+    podman_rootless=$(_ods_rootless_docker_info --format '{{.Host.Security.Rootless}}' 2>&1) || probe_rc=$?
+    if [[ "$probe_rc" -eq 0 && -n "$podman_rootless" ]]; then
         [[ "$podman_rootless" == "true" ]]
         return
     fi
 
     echo "[error] Could not determine whether Docker is running in rootless mode." >&2
+    # First non-empty line: the CLI prints an empty template result before
+    # its connection error.
+    podman_rootless="${podman_rootless#"${podman_rootless%%[![:space:]]*}"}"
+    [[ -n "$podman_rootless" ]] && echo "[error] docker info: ${podman_rootless%%$'\n'*}" >&2
     return 2
 }
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1329,8 +1329,11 @@ cmd_status() {
     echo -e "${BLUE}━━━ ODS Status ━━━${NC}"
     echo ""
 
-    # Container status
-    docker compose "${flags[@]}" ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || docker-compose ps
+    # Container status. Let compose's own stderr through: when the daemon is
+    # unreachable the user needs "Cannot connect to the Docker daemon", not a
+    # flag-less fallback complaining about a missing configuration file.
+    docker compose "${flags[@]}" ps --format "table {{.Name}}\t{{.Status}}\t{{.Ports}}" \
+        || warn "Could not list containers (see the docker error above); continuing with health checks."
 
     echo ""
 

--- a/ods/tests/test-cli-status-docker-error.sh
+++ b/ods/tests/test-cli-status-docker-error.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Contract: `ods status` must show docker compose's own error when listing
+# containers fails. It used to silence compose (2>/dev/null) and fall back to a
+# flag-less `docker-compose ps`, so a stopped daemon surfaced as
+# "no configuration file provided: not found" (or "command not found").
+#
+# Run from repo root:  bash ods/tests/test-cli-status-docker-error.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLI="$ROOT_DIR/ods-cli"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$CLI" ]] || fail "ods-cli not found"
+
+status_src="$(sed -n '/^cmd_status()/,/^}/p' "$CLI")"
+[[ -n "$status_src" ]] || fail "could not extract cmd_status from ods-cli"
+
+echo "Test 1: cmd_status does not fall back to a flag-less docker-compose"
+if grep -qE '\|\| *docker-compose ps' <<<"$status_src"; then
+    fail "cmd_status still falls back to 'docker-compose ps' without compose flags"
+fi
+pass "no flag-less docker-compose fallback"
+
+echo "Test 2: cmd_status lets the compose ps error through"
+ps_line="$(grep -E 'docker compose "\$\{flags\[@\]\}" ps --format "table' <<<"$status_src" || true)"
+[[ -n "$ps_line" ]] || fail "cmd_status no longer lists containers with 'docker compose \"\${flags[@]}\" ps --format \"table ...'"
+if grep -qE '2> */dev/null' <<<"$ps_line"; then
+    fail "cmd_status still discards the stderr of 'docker compose ps'"
+fi
+pass "docker compose ps stderr is not discarded"
+
+echo "All ods status docker-error checks passed."

--- a/ods/tests/test-rootless-docker-ownership.sh
+++ b/ods/tests/test-rootless-docker-ownership.sh
@@ -87,6 +87,25 @@ pass "fresh-install Docker detection uses the verified installer command"
 ) || fail "selected-command rootless detection"
 pass "selected-command rootless detection preserves ownership mode"
 
+(
+    source "$LIB"
+    unset ODS_ASSUME_ROOTLESS
+    docker() {
+        # Mirrors the real CLI: an empty template result on stdout, then the
+        # connection error (and a template error) on stderr.
+        echo ""
+        echo "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?" >&2
+        echo "template: :1:7: executing \"\" at <.Host.Security.Rootless>: can't evaluate field Host in type system.dockerInfo" >&2
+        return 1
+    }
+    state_rc=0
+    probe_err="$(ods_docker_rootless_state 2>&1)" || state_rc=$?
+    [[ "$state_rc" -eq 2 ]] || exit 1
+    [[ "$probe_err" == *"Could not determine whether Docker is running in rootless mode"* ]] || exit 1
+    [[ "$probe_err" == *"docker info: Cannot connect to the Docker daemon"* ]] || exit 1
+) || fail "daemon-unreachable probe did not surface docker's own error"
+pass "indeterminate rootless state reports why docker info failed"
+
 INSTALL_DIR="$TMP_DIR/ods"
 mkdir -p "$INSTALL_DIR/data"/{ape,privacy-shield,token-spy,n8n,whisper,hermes,comfyui}
 mkdir -p "$INSTALL_DIR/data/langfuse"/{postgres,clickhouse}


### PR DESCRIPTION
## Summary

With the Docker daemon stopped, `ods status` reported `no configuration file provided: not found` and `ods restart` / `ods start` cancelled with "Rootless bind-mount ownership is not ready" — neither mentioned the daemon. `cmd_status` discarded compose's stderr and fell back to a flag-less `docker-compose ps` (whose own failure also ended the command before the health checks), and `ods_docker_rootless_state` swallowed the stderr of both `docker info` probes before returning "undeterminable". Details and repro in #3823.

Change (one concern: when Docker is unreachable, lifecycle commands must say so):

- **`ods-cli` `cmd_status`**: run `docker compose "${flags[@]}" ps …` with its stderr intact, drop the `|| docker-compose ps` fallback (nothing else in `ods-cli` supports Compose v1), and continue to the HTTP health checks after a `warn` instead of exiting.
- **`lib/rootless-ownership.sh` `ods_docker_rootless_state`**: capture the stderr of the second probe (the Podman-shim field) and, when both probes fail, print its first non-empty line under the existing "Could not determine…" message. Return codes and the Docker/Podman detection are unchanged; the first probe keeps its `2>/dev/null` because its template error on Podman is expected.
- **Tests**: `tests/test-rootless-docker-ownership.sh` gains a case with a fake `docker` that mimics the real CLI (empty template result on stdout, connection + template error on stderr) and asserts rc 2 plus the surfaced `docker info: Cannot connect to the Docker daemon…` line; new `tests/test-cli-status-docker-error.sh` (in `make test` next to the rootless test) asserts `cmd_status` has no flag-less `docker-compose` fallback and does not discard the `ps` stderr. Both fail on current `main`.

Fixes #3823.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low — output/diagnostic paths only. On a healthy host `docker compose ps` succeeds and nothing changes; `ods_docker_rootless_state` still returns 0/1/2 exactly as before (all 29 existing rootless cases pass), it only prints one more line in the failure case.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11, Docker CLI 29.6.1 with the daemon stopped,
# install dir seeded from the checkout

# BEFORE (upstream/main 21f4b3a6)
$ ods status
━━━ ODS Status ━━━
no configuration file provided: not found            # health checks never run (exit 1)
$ ods restart
[error] Could not determine whether Docker is running in rootless mode.
✗ Rootless bind-mount ownership is not ready; service restart was cancelled.

# AFTER (this branch)
$ ods status
━━━ ODS Status ━━━
Cannot connect to the Docker daemon at unix:///…/docker.sock. Is the docker daemon running?
⚠ Could not list containers (see the docker error above); continuing with health checks.
━━━ Health Checks ━━━
⚠ Dashboard (Control Center): not responding
…
$ ods restart
[error] Could not determine whether Docker is running in rootless mode.
[error] docker info: Cannot connect to the Docker daemon at unix:///…/docker.sock. Is the docker daemon running?
✗ Rootless bind-mount ownership is not ready; service restart was cancelled.

$ bash tests/test-rootless-docker-ownership.sh   → All 29 rootless ownership tests passed.
$ bash tests/test-cli-status-docker-error.sh     → All ods status docker-error checks passed. (also under /bin/bash 3.2)
# same two tests against main's ods-cli / lib:  [FAIL] cmd_status still falls back to 'docker-compose ps' …
#                                                FAIL: daemon-unreachable probe did not surface docker's own error
$ bash tests/test-ods-cli-pipefail-tolerance.sh  → 16 passed; test-unix-restart-recreate-env.sh, test-cli-install-dir-resolution.sh,
  test-session-cleanup.sh → pass (test-cli-user-extension-deps.sh fails 5/10 identically on clean main: macOS host)
$ shellcheck --exclude=SC1091,SC2034 --severity=error ods-cli lib/rootless-ownership.sh tests/test-rootless-docker-ownership.sh tests/test-cli-status-docker-error.sh → clean
$ shellcheck --exclude=SC1091,SC2034 lib/rootless-ownership.sh tests/test-cli-status-docker-error.sh → clean at default severity
$ awk -f scripts/check-heredoc-backticks.awk <changed files> → clean; /bin/bash -n → ok; git diff --check → clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Dropping the Compose v1 fallback: `ods-cli` uses `docker compose` (v2) in every other lifecycle path, so a host with only `docker-compose` v1 could not run `start`/`stop`/`restart` anyway; the fallback only ever ran after the real call had already failed.
- Searched open issues/PRs for "no configuration file provided", "rootless ownership is not ready", "docker-compose ps" — nothing overlapping. #3158 touches `_docker_try_with_optional_sudo` in phase 05, a different file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

