### PR TITLE
fix(doctor): re-exec ods-doctor.sh under Bash 4+ on stock macOS

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -102,6 +102,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Bash 3.2 guard contracts ==="
 	@bash tests/test-bash32-guards.sh
+	@bash tests/test-ods-doctor-bash32-guard.sh
 	@echo ""
 	@echo "=== CLI update post-verification ==="
 	@bash tests/test-cli-update-verification.sh

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -22,6 +22,35 @@ case "${1:-}" in
     -h|--help) usage; exit 0 ;;
 esac
 
+# ods-doctor sources lib/service-registry.sh, which uses Bash 4 associative
+# arrays. macOS ships Bash 3.2, and every caller launches this script by its
+# shebang (ods-cli's `ods doctor`, installers/macos.sh, the dashboard host
+# agent, and the documented `scripts/ods-doctor.sh` invocation), so it runs
+# under whatever `bash` is first on PATH — often /bin/bash 3.2. Without a
+# guard the report failed to generate with "service-registry.sh requires
+# Bash 4.0+". Re-exec under a modern Bash, mirroring install-macos.sh.
+_ods_doctor_bash_is_modern() {
+    [ -x "$1" ] || return 1
+    # The test string must evaluate in the candidate shell, not this one.
+    # shellcheck disable=SC2016
+    "$1" -c '[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]' >/dev/null 2>&1
+}
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    _ods_doctor_bash_candidates=("${BASH:-}" /opt/homebrew/bin/bash /usr/local/bin/bash)
+    if command -v brew >/dev/null 2>&1; then
+        _ods_doctor_brew_prefix="$(brew --prefix 2>/dev/null)"
+        [ -n "$_ods_doctor_brew_prefix" ]             && _ods_doctor_bash_candidates=("$_ods_doctor_brew_prefix/bin/bash" "${_ods_doctor_bash_candidates[@]}")
+    fi
+    for _ods_doctor_candidate in "${_ods_doctor_bash_candidates[@]}"; do
+        if _ods_doctor_bash_is_modern "$_ods_doctor_candidate"; then
+            exec "$_ods_doctor_candidate" "$0" "$@"
+        fi
+    done
+    echo "ods-doctor.sh requires Bash 4+ (you have ${BASH_VERSION})." >&2
+    echo "macOS ships only Bash 3.2; install a modern one with: brew install bash" >&2
+    exit 1
+fi
+
 REPORT_FILE="${1:-/tmp/ods-doctor-report.json}"
 
 CAP_FILE="/tmp/ods-doctor-capabilities.json"

--- a/ods/tests/test-ods-doctor-bash32-guard.sh
+++ b/ods/tests/test-ods-doctor-bash32-guard.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Regression coverage for scripts/ods-doctor.sh under stock macOS Bash 3.2.
+#
+# ods-doctor.sh sources lib/service-registry.sh (Bash 4 associative arrays).
+# Callers launch it by its shebang (ods-cli `ods doctor`, installers/macos.sh,
+# the host agent, the documented direct invocation), so on macOS it can run
+# under /bin/bash 3.2 and used to die with "service-registry.sh requires
+# Bash 4.0+" before generating a report. It must now re-exec under a modern
+# Bash instead.
+#
+# Run from repo root:  bash ods/tests/test-ods-doctor-bash32-guard.sh
+# Or from ods:         bash tests/test-ods-doctor-bash32-guard.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCTOR="$ROOT_DIR/scripts/ods-doctor.sh"
+SR_ERR="service-registry.sh requires Bash 4.0+"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+[[ -f "$DOCTOR" ]] || { echo "ods-doctor.sh not found at $DOCTOR" >&2; exit 1; }
+
+# 1. Static: the Bash-4 re-exec guard must appear before lib/service-registry.sh
+# is sourced, or the source runs under the wrong shell first.
+guard_line="$(grep -nE 'BASH_VERSINFO\[0\]:-0\}" -lt 4' "$DOCTOR" | head -n1 | cut -d: -f1)"
+source_line="$(grep -nE '\. "\$ROOT_DIR/lib/service-registry.sh"' "$DOCTOR" | head -n1 | cut -d: -f1)"
+if [[ -n "$guard_line" && -n "$source_line" && "$guard_line" -lt "$source_line" ]]; then
+    pass "re-exec guard precedes the service-registry.sh source"
+else
+    fail "re-exec guard must precede the service-registry.sh source (guard=$guard_line source=$source_line)"
+fi
+
+# 2. --help must work under any Bash (it precedes the guard and needs no Bash 4).
+if /bin/bash "$DOCTOR" --help >/dev/null 2>&1; then
+    pass "--help works under stock /bin/bash"
+else
+    fail "--help failed under stock /bin/bash"
+fi
+
+tmp_report="$(mktemp)"
+trap 'rm -f "$tmp_report"' EXIT
+
+# 3. Launched under stock /bin/bash, a real run must never leak the raw
+# service-registry.sh Bash-version error: on macOS the guard re-execs into a
+# modern Bash (Homebrew paths are hard-coded candidates), and on Linux
+# /bin/bash is already 4+. The report itself may still fail later on this
+# host (no Docker), which is fine — we only assert the version gate is gone.
+out="$(/bin/bash "$DOCTOR" "$tmp_report" 2>&1 || true)"
+if [[ "$out" == *"$SR_ERR"* ]]; then
+    fail "stock /bin/bash run leaked the service-registry Bash-version error"
+else
+    pass "stock /bin/bash run clears the service-registry version gate"
+fi
+
+# 4. Same when a caller passes an explicit modern Bash via \$BASH (how ods-cli
+# invokes its Bash-4 helpers): the re-exec still clears the version gate.
+modern_bash="$(command -v bash 2>/dev/null || true)"
+if [[ -n "$modern_bash" ]] && "$modern_bash" -c '[ "${BASH_VERSINFO[0]:-0}" -ge 4 ]' 2>/dev/null; then
+    out="$(BASH="$modern_bash" /bin/bash "$DOCTOR" "$tmp_report" 2>&1 || true)"
+    if [[ "$out" == *"$SR_ERR"* ]]; then
+        fail "re-exec via \$BASH did not happen; service-registry version error leaked"
+    else
+        pass "re-exec via \$BASH clears the service-registry version gate"
+    fi
+else
+    pass "no modern Bash on PATH here; \$BASH re-exec case skipped"
+fi
+
+# 5. Static: the guard keeps an actionable fallback message for hosts with no
+# modern Bash at all (cannot be exercised where Homebrew Bash exists).
+if grep -q "requires Bash 4+" "$DOCTOR"; then
+    pass "guard retains an actionable no-modern-Bash message"
+else
+    fail "guard should print an actionable message when no modern Bash is found"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`scripts/ods-doctor.sh` sources `lib/service-registry.sh` (Bash 4 associative arrays) with no version guard of its own, and every caller launches it by its `#!/usr/bin/env bash` shebang — `ods-cli`'s `ods doctor` (`ods-cli:2433`), `installers/macos.sh` (line 116), the dashboard host agent, and the invocation documented in `docs/ODS-DOCTOR.md` / `docs/TROUBLESHOOTING.md`. On stock macOS that shebang resolves to `/bin/bash` 3.2, so the script died with `service-registry.sh requires Bash 4.0+` before writing the report, surfacing to the user as `✗ Doctor report not generated`. Root cause behind the caller-side #3786/#3787. Details and repro in #3825.

Change (one concern: `ods-doctor.sh` must run under Bash 4 regardless of which Bash a caller launches it with):

- **`scripts/ods-doctor.sh`**: add the re-exec guard `install-macos.sh` and `installers/macos/ods-macos.sh` already use — a `_ods_doctor_bash_is_modern` probe, candidate paths (`$BASH`, the `brew --prefix`, `/opt/homebrew/bin/bash`, `/usr/local/bin/bash`), `exec` into the first modern Bash, and an actionable exit otherwise. Placed after the `--help` case (which needs no Bash 4) and before `lib/service-registry.sh` is sourced. On Linux, `/bin/bash` is already 4+, so the guard is a no-op and behaviour is unchanged.
- **`tests/test-ods-doctor-bash32-guard.sh`** (new, wired into `make test` next to `test-bash32-guards.sh`): guard precedes the service-registry source; `--help` works under `/bin/bash`; a real run under `/bin/bash` and under an explicit `$BASH` never leaks the service-registry Bash-version error; the no-modern-Bash message is retained. Fails on current `main`, passes here under Homebrew Bash 5.3 and stock Bash 3.2.

Fixes #3825.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [x] Installer / bootstrap / lifecycle
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low — the guard only fires when the running Bash is < 4 (stock macOS); on Bash 4+ hosts (all Linux, and macOS after Homebrew Bash is installed) it is skipped and the script is byte-for-byte unchanged in behaviour. It mirrors a pattern already shipping in `install-macos.sh` and `ods-macos.sh`.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), stock /bin/bash 3.2.57 + Homebrew Bash 5.3, shellcheck 0.11

# BEFORE (upstream/main 21f4b3a6)
$ /bin/bash scripts/ods-doctor.sh /tmp/rep.json ; ls /tmp/rep.json
ERROR: service-registry.sh requires Bash 4.0+ (current: 3.2.57(1)-release)
ls: /tmp/rep.json: No such file or directory

# AFTER (this branch)
$ /bin/bash scripts/ods-doctor.sh /tmp/rep.json ; wc -c < /tmp/rep.json
8146                       # valid report JSON, re-execed into Homebrew Bash

$ bash tests/test-ods-doctor-bash32-guard.sh      → Result: 5 passed, 0 failed
$ /bin/bash tests/test-ods-doctor-bash32-guard.sh → Result: 5 passed, 0 failed
# same test against main's ods-doctor.sh:          → 3 failed (guard absent, version error leaks)
$ bash tests/test-bash32-guards.sh                → 10 passed, 0 failed (neighbouring guard suite unaffected)

$ shellcheck --exclude=SC1091,SC2034 --severity=error scripts/ods-doctor.sh tests/test-ods-doctor-bash32-guard.sh → clean
$ shellcheck --exclude=SC1091,SC2034 scripts/ods-doctor.sh → default-severity warning count unchanged (2 → 2; the one intentional single-quoted probe carries a scoped SC2016 disable)
$ awk -f scripts/check-heredoc-backticks.awk <changed files> → clean
$ /bin/bash -n scripts/ods-doctor.sh tests/test-ods-doctor-bash32-guard.sh → ok
$ git diff --check → clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Complements #3787 (my open PR for #3786): that one keeps `installers/macos.sh` from announcing a report it never wrote; this one lets the doctor actually run for that caller and for `ods doctor`, the host agent, and the documented direct invocation. The two do not touch the same files (#3787: `installers/macos.sh`, its test, Makefile).
- The guard is deliberately a copy of the established `install-macos.sh` / `ods-macos.sh` pattern rather than a new shared helper — those scripts must stand alone before any lib is sourced, and so must this one.
- Searched open issues/PRs for "ods-doctor", "doctor bash", "service-registry Bash 4" — the doctor PRs in flight (#3690 concurrency, #3123 dependency probes, #2438 atomic write) touch unrelated regions; none add a Bash guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

