### PR TITLE
fix(dashboard): prevent stale invite refreshes from restoring revoked cards

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import {
   UserPlus, Copy, Check, Trash2, RefreshCw, QrCode, Share2, X,
   Loader2, AlertCircle, Clock, Users, KeyRound, ShieldCheck, Mic2,
@@ -79,8 +79,10 @@ export default function Invites() {
   const [generated, setGenerated] = useState(null)
   const [refreshing, setRefreshing] = useState(false)
   const [ownerCardStatus, setOwnerCardStatus] = useState(null)
+  const refreshGeneration = useRef(0)
 
   const refresh = useCallback(async () => {
+    const generation = ++refreshGeneration.current
     setRefreshing(true)
     try {
       const [resp, ownerStatusResp] = await Promise.all([
@@ -89,8 +91,10 @@ export default function Invites() {
       ])
       if (!resp.ok) throw new Error(`list failed: ${resp.status}`)
       const data = await resp.json()
+      const ownerStatus = ownerStatusResp.ok ? await ownerStatusResp.json() : null
+      if (generation !== refreshGeneration.current) return
       if (ownerStatusResp.ok) {
-        setOwnerCardStatus(await ownerStatusResp.json())
+        setOwnerCardStatus(ownerStatus)
       } else {
         setOwnerCardStatus({
           ready: false,
@@ -100,18 +104,24 @@ export default function Invites() {
       setTokens(data.tokens || [])
       setError(null)
     } catch (err) {
+      if (generation !== refreshGeneration.current) return
       setOwnerCardStatus(current => current || {
         ready: false,
         reason: 'Owner-card status unavailable.',
       })
       setError(err.message)
     } finally {
-      setLoading(false)
-      setRefreshing(false)
+      if (generation === refreshGeneration.current) {
+        setLoading(false)
+        setRefreshing(false)
+      }
     }
   }, [])
 
-  useEffect(() => { refresh() }, [refresh])
+  useEffect(() => {
+    refresh()
+    return () => { refreshGeneration.current += 1 }
+  }, [refresh])
 
   const handleRevoke = async (prefix) => {
     try {

--- a/ods/extensions/services/dashboard/src/pages/Invites.refresh.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.refresh.test.jsx
@@ -1,0 +1,36 @@
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import Invites from './Invites' // eslint-disable-line no-unused-vars
+
+const response = body => ({ ok: true, status: 200, json: async () => body })
+
+test('an older refresh cannot restore a card after successful revocation', async () => {
+  const card = {
+    token_hash_prefix: 'abc12345', target_username: 'owner', token_type: 'owner',
+    scope: 'hermes', reusable: true, expires_at: null, redemption_count: 0,
+    revoked_at: null, created_at: '2026-09-01T00:00:00Z',
+  }
+  let finishOld
+  const oldRequest = new Promise(resolve => { finishOld = resolve })
+  let lists = 0
+  vi.stubGlobal('fetch', vi.fn(async (url, options = {}) => {
+    if (url === '/api/auth/magic-link/list') {
+      lists += 1
+      if (lists === 2) return oldRequest
+      return response({ tokens: lists === 1 ? [card] : [] })
+    }
+    if (url === '/api/auth/magic-link/owner-card/status') return response({ ready: true })
+    if (options.method === 'DELETE') return response({ revoked: true })
+    if (url === '/api/talk/status') return response({})
+    throw new Error(`Unexpected request: ${url}`)
+  }))
+  render(<Invites />)
+  await screen.findByRole('button', { name: /revoke owner card for owner/i })
+  fireEvent.click(screen.getByRole('button', { name: 'Refresh setup owner links' }))
+  await waitFor(() => expect(lists).toBe(2))
+  fireEvent.click(screen.getByRole('button', { name: /revoke owner card for owner/i }))
+  await screen.findByText('No owner cards yet')
+  await act(async () => { finishOld(response({ tokens: [card] })) })
+  expect(screen.getByText('No owner cards yet')).toBeInTheDocument()
+  expect(screen.queryByRole('button', { name: /revoke owner card for owner/i })).not.toBeInTheDocument()
+})


### PR DESCRIPTION
## Why this matters
The Invites page can finish an old manual refresh after a revoke-triggered refresh, restoring the revoked card on screen. A request generation guard applies the newest complete inventory and owner-status response only, including error/loading state and unmount cleanup.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files before implementation, using the full PR inventory and inspecting related descriptions; refreshed latest PRs through #3832 before publication.

Files: `ods/extensions/services/dashboard/src/pages/Invites.jsx`.

#3038 isolates owner-status failures; #3289/#3207/#3290 cover helpers; #2327 handles clipboard failures. None orders overlapping refresh completion.

## Regression and focused validation
Invites.refresh.test.jsx reproduces refresh → revoke → newer empty inventory → older populated response through rendered controls. Focused invite suites: 7 passed.

## Tradeoffs, rollback and remaining validation
UI consistency only; backend revocation semantics are unchanged. Reverting restores the display race.

## Combined validation and merge order
Validated the ten independent branches on synthetic integration commit `8d5e17801b6789985f74496f709e482bf571f278` (branch `integration/quality-next-ten-20260908` on tang-vu/DreamServer). Dashboard: 262 tests passed, lint and production build passed. Related dashboard API suites: 70 passed; interpreter timeout suite: 3 passed; four new standalone release/CLI tests and existing provider egress contracts passed. CI-equivalent Ruff selection passed across ods; shell/Python syntax passed. Smoke and installer simulation passed.

`make gate` is NOT green: it stops at the Hermes max_tokens template contract, reproduced unchanged on base `21f4b3a6`. Full BATS: 408 passed and 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer/path tests. All ten failures reproduce on the untouched base in the affected suites. Pre-commit gitleaks, size and shell hooks pass, while detect-private-key flags the two existing dummy-key fixtures in `test_host_agent.py` and `test-remote-provider-egress-policy.py`. These results do not establish hardware or live-service behavior. API tests also emit an existing unclosed aiohttp-session warning.

Suggested batch merge order: invites, interpreter timeout, n8n pagination, Milvus (only after its live gate), healthcheck, provider redirects (after human review), Usage CSV, branch exclusions, PWA storage, Lemonade paths. Production changes are independent; draft reviews need not block unrelated changes. Four branches add adjacent Makefile test registrations: preserve all four lines when resolving that textual conflict, as on the integration head. Each PR starts directly from upstream main; no stacked branch dependency.

GitHub checks completed for candidate `a5a550e232d121b04130797cf477df9724241abf`: 28 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed; the local baseline failures and live-validation limitations above still apply.

