### PR TITLE
fix(open-interpreter): return 504 when synchronous execution times out

### DIFF
--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -147,6 +147,8 @@ def chat(req: ChatRequest, _auth=Depends(verify_api_key)):
 
         return {"output": result.stdout}
 
+    except subprocess.TimeoutExpired as exc:
+        raise HTTPException(status_code=504, detail="Interpreter execution timed out") from exc
     finally:
         os.unlink(script_path)
 

--- a/ods/extensions/library/services/open-interpreter/test_chat_timeout.py
+++ b/ods/extensions/library/services/open-interpreter/test_chat_timeout.py
@@ -1,0 +1,39 @@
+"""The public chat endpoint reports its worker deadline and removes its script."""
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.parametrize('outcome,status', [('timeout', 504), ('failure', 500), ('success', 200)])
+def test_chat_worker_outcomes_and_cleanup(monkeypatch, outcome, status):
+    monkeypatch.setenv('OPEN_INTERPRETER_API_KEY', 'timeout-test-key')
+    spec = importlib.util.spec_from_file_location('interpreter_timeout_server', Path(__file__).with_name('server.py'))
+    server = importlib.util.module_from_spec(spec)
+    mkdir = Path.mkdir
+    with monkeypatch.context() as context:
+        context.setattr(Path, 'mkdir', lambda p, *a, **k: None if p == Path('/app/data') else mkdir(p, *a, **k))
+        spec.loader.exec_module(server)
+    scripts = []
+
+    def run(command, **kwargs):
+        script = Path(command[1])
+        assert script.is_file()
+        assert kwargs['timeout'] == 300
+        scripts.append(script)
+        if outcome == 'timeout':
+            raise subprocess.TimeoutExpired(command, 300, output='private partial output')
+        return subprocess.CompletedProcess(command, 1 if outcome == 'failure' else 0, 'RESULT: done', 'private stderr')
+
+    monkeypatch.setattr(server.subprocess, 'run', run)
+    response = TestClient(server.app, raise_server_exceptions=False).post(
+        '/chat', json={'message': 'Run my analysis'},
+        headers={'Authorization': 'Bearer timeout-test-key'},
+    )
+    assert response.status_code == status
+    assert len(scripts) == 1 and not scripts[0].exists()
+    assert 'private' not in response.text
+    if outcome == 'timeout':
+        assert response.json() == {'detail': 'Interpreter execution timed out'}


### PR DESCRIPTION
## Why this matters

The synchronous Open Interpreter /chat endpoint already limits its worker to 300 seconds, but subprocess.TimeoutExpired escaped as an opaque 500. Clients could not distinguish a deadline from execution failure.

## Fix and overlap check

Map only TimeoutExpired to a sanitized HTTP504 and retain temporary-script cleanup in finally. Success and nonzero-exit behavior are unchanged. Updated the original PR onto public-beta. Searched all-state interpreter PRs and server.py: #4964/#5325 concern model connection/port, #2324/#2818/#3976 stream worker cleanup, and #3809 JSON framing. This synchronous timeout contract is independent; no duplicate was opened.

## Validation

`pytest -q test_chat_timeout.py`: 3 passed on Linux Python3.12.14, FastAPI0.111.0, Pydantic2.12.5 (matching declared runtime/API versions), also passed on Python3.11. Authenticated HTTP tests simulate timeout, worker failure and success, assert response status, no private stderr/partial output in the response and removal of the temporary script. Focused pre-commit/diff check passed. No real five-minute inference or subprocess kill was executed; subprocess.run's behavior is not reimplemented.

Baseline smoke/simulation passed; full make gate/BATS retain known environment/fixture failures.

## Rollback

No state migration or timeout-duration change. Revert changes the deadline response back to 500. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `bc5625c7cf229572c5ea8b3473069a88bae1b866`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
