### PR TITLE
fix(milvus): persist embedded etcd metadata with vector data

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -124,6 +124,7 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@bash tests/test-backup-data-coverage.sh
+	@python3 tests/test-milvus-persistence.py
 	@echo ""
 	@echo "=== backup integrity and restore round-trip ==="
 	@bash tests/test-backup-integrity.sh

--- a/ods/extensions/library/services/milvus/README.md
+++ b/ods/extensions/library/services/milvus/README.md
@@ -16,6 +16,29 @@ ods disable milvus
 
 Your data is preserved when disabling. To re-enable later: `ods enable milvus`
 
+## Metadata persistence and existing installations
+
+New installations store embedded etcd metadata in `/var/lib/milvus/etcd`,
+inside the same `./data/milvus` bind mount as vector data and the message queue.
+This follows the [Milvus v2.4.5 standalone launcher](https://github.com/milvus-io/milvus/blob/v2.4.5/scripts/standalone_embed.sh).
+The previous ODS configuration left etcd at `default.etcd`, outside that mount;
+recreating that container could lose collection metadata even with vector files intact.
+
+**Existing installations require migration before applying this compose change.**
+Stop writes and stop the existing container before copying its etcd directory.
+Locate its effective `etcd.data.dir` (the old default is relative to the container
+working directory), preserve a separate copy, and copy the complete directory
+into `./data/milvus/etcd` with its ownership and permissions intact. Do not merge
+it into an already populated etcd directory. Keep the old stopped container
+and a full copy of `./data/milvus` until recovery is verified.
+
+Before production rollout, verify collection names, row counts, and a query
+after starting the migrated instance and again after a container recreation.
+The repository persistence test checks configuration containment only; it does
+not prove this data migration. If validation fails, stop the new instance and
+restore the saved metadata/vector-data pair with the original configuration.
+Do not simply remove `ETCD_DATA_DIR` after the new instance has accepted writes.
+
 ## Access
 
 - **URL:** `localhost:19530` (gRPC)

--- a/ods/extensions/library/services/milvus/compose.yaml
+++ b/ods/extensions/library/services/milvus/compose.yaml
@@ -10,6 +10,7 @@ services:
     environment:
       - MODE=standalone
       - ETCD_USE_EMBED=true
+      - ETCD_DATA_DIR=/var/lib/milvus/etcd
       - COMMON_STORAGETYPE=local
     command: ["milvus", "run", "standalone"]
     restart: unless-stopped

--- a/ods/tests/test-milvus-persistence.py
+++ b/ods/tests/test-milvus-persistence.py
@@ -1,0 +1,34 @@
+"""Release contract: all Milvus standalone storage belongs to a persistent mount.
+
+Defaults are from milvus-io/milvus v2.4.5 configs/milvus.yaml. This checks
+the shipped deployment plan; it is not a live collection recovery test.
+"""
+from pathlib import Path, PurePosixPath
+import unittest
+
+import yaml
+
+
+class MilvusPersistenceTest(unittest.TestCase):
+    def test_embedded_metadata_and_data_are_persistent(self):
+        root = Path(__file__).resolve().parents[1]
+        service = yaml.safe_load((root / 'extensions/library/services/milvus/compose.yaml').read_text())['services']['milvus']
+        self.assertEqual(service['image'], 'milvusdb/milvus:v2.4.5')
+        env = dict(item.split('=', 1) for item in service['environment'])
+        self.assertEqual(env['ETCD_USE_EMBED'], 'true')
+        self.assertEqual(env['COMMON_STORAGETYPE'], 'local')
+        mounts = [PurePosixPath(volume.split(':')[1]) for volume in service['volumes']]
+        paths = {
+            'metadata': env.get('ETCD_DATA_DIR', 'default.etcd'),
+            'vectors': env.get('LOCALSTORAGE_PATH', '/var/lib/milvus/data'),
+            'message queue': env.get('ROCKSMQ_PATH', '/var/lib/milvus/rdb_data'),
+        }
+        for name, value in paths.items():
+            with self.subTest(storage=name):
+                path = PurePosixPath(value)
+                self.assertTrue(path.is_absolute(), f'{name} uses container-relative storage: {path}')
+                self.assertTrue(any(path.is_relative_to(mount) for mount in mounts), f'{name} is outside persistent mounts: {path}')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Why this matters

The shipped Milvus standalone extension enables embedded etcd, but its default metadata directory is outside the persisted vector-data mount. Recreating a container can therefore lose collection metadata despite retaining vector files. This is release/data-durability correctness, not an untrusted-input security claim.

## Fix and migration boundary

Set `ETCD_DATA_DIR=/var/lib/milvus/etcd` inside the existing bind mount. Verified against the [v2.4.5 configuration](https://github.com/milvus-io/milvus/blob/v2.4.5/configs/milvus.yaml) and [launcher at that tag](https://github.com/milvus-io/milvus/blob/v2.4.5/scripts/standalone_embed.sh). The launcher itself names a v2.4.0 image; ODS ships v2.4.5 and this PR does not change its image.

Existing installations must stop writes, preserve the old metadata/data pair and migrate the complete etcd directory before applying this change. The README documents validation and recovery; there is no automatic live-data migration.

## Overlap check

Searched all-state Milvus PRs and the compose path. This original #3836 is the canonical persistence change. Compared #5228 by Vishaaallll: it checks manifest/compose existence and shape, but neither changes nor verifies etcd persistence. Those fixtures are complementary, not a stronger replacement; no contributor PR was closed. Historical #647 enables embedded mode but does not persist its metadata.

## Validation

- Linux Python 3.11: `python -m pytest -q tests/test-milvus-persistence.py`: passed; exact shipped image plus metadata/vector/queue path containment asserted at the compose boundary.
- `docker compose -f extensions/library/services/milvus/compose.yaml config --quiet`: passed.
- Focused pre-commit and diff check passed; test is in `make test`.
- No live Milvus collection, recreation or existing-data migration was executed. These remain explicit operator rollout gates, not covered by a static test or CI. Baseline smoke/simulation passed; full make gate/BATS have existing environment/fixture failures.

## Rollback and review

Do not simply remove the variable after the new instance accepts writes. Stop the new instance and restore the saved matching metadata/vector-data pair with the original configuration. High-risk data-path change requires independent human review and deployment-specific migration validation before rollout. Ready for code review, not approval to merge or deploy.

## Final beta-batch receipt — 2026-09-16

Candidate: `557219d6ca09b88205f56ea5df85772d00fa5ebf`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
