### PR TITLE
fix(healthcheck): enforce body predicates on allowed error statuses

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -124,6 +124,7 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@bash tests/test-backup-data-coverage.sh
+	@python3 tests/test-healthcheck-error-body.py
 	@echo ""
 	@echo "=== backup integrity and restore round-trip ==="
 	@bash tests/test-backup-integrity.sh

--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -224,7 +224,13 @@ def check_http(
             # HTTPError is a valid response with status code; treat via status checks.
             status = getattr(exc, "code", None)
             if allowed_status is not None and status in allowed_status:
-                return (True, f"http {m}: ok (error status allowed)", int(status) if status is not None else None)
+                with exc:
+                    if body_regex is not None:
+                        body = exc.read(1024 * 1024)
+                        if not body_regex.search(body.decode("utf-8", errors="replace")):
+                            return (False, f"http {m}: body regex did not match", status)
+                    return (True, f"http {m}: ok (error status allowed)", int(status) if status is not None else None)
+            exc.close()
             last_err = f"http {m}: HTTPError {status}"
 
             # If HEAD is rejected, allow retry with GET.

--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -226,7 +226,10 @@ def check_http(
             if allowed_status is not None and status in allowed_status:
                 with exc:
                     if body_regex is not None:
-                        body = exc.read(1024 * 1024)
+                        try:
+                            body = exc.read(1024 * 1024)
+                        except socket.timeout:
+                            return (False, f"http {m}: timeout", status)
                         if not body_regex.search(body.decode("utf-8", errors="replace")):
                             return (False, f"http {m}: body regex did not match", status)
                     return (True, f"http {m}: ok (error status allowed)", int(status) if status is not None else None)

--- a/ods/tests/test-healthcheck-error-body.py
+++ b/ods/tests/test-healthcheck-error-body.py
@@ -1,0 +1,46 @@
+"""Allowed HTTP error statuses must still satisfy the CLI body predicate."""
+import json
+import subprocess
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class HealthcheckBodyTest(unittest.TestCase):
+    def test_allowed_error_status_does_not_skip_body_regex(self):
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                self.send_response(int(self.path[1:]))
+                self.end_headers()
+                self.wfile.write(b'expected maintenance state')
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        try:
+            script = Path(__file__).resolve().parents[1] / 'scripts/healthcheck.py'
+            for status in (401, 503):
+                for pattern, expected in [('maintenance', 0), ('ready', 1)]:
+                    with self.subTest(status=status, pattern=pattern):
+                        result = subprocess.run([
+                            sys.executable, str(script), f'http://127.0.0.1:{server.server_port}/{status}',
+                            '--expect-status', str(status), '--expect-body-regex', pattern,
+                            '--retries', '0', '--json',
+                        ], capture_output=True, text=True, timeout=10)
+                        self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
+                        payload = json.loads(result.stdout)
+                        self.assertEqual(payload['ok'], expected == 0)
+                        self.assertEqual(payload['status'], status)
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ods/tests/test-healthcheck-error-body.py
+++ b/ods/tests/test-healthcheck-error-body.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import sys
 import threading
+import time
 import unittest
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -14,6 +15,9 @@ class HealthcheckBodyTest(unittest.TestCase):
             def do_GET(self):
                 self.send_response(int(self.path[1:]))
                 self.end_headers()
+                if self.path == '/504':
+                    time.sleep(0.2)
+                    return
                 self.wfile.write(b'expected maintenance state')
 
             def log_message(self, *args):
@@ -24,13 +28,15 @@ class HealthcheckBodyTest(unittest.TestCase):
         thread.start()
         try:
             script = Path(__file__).resolve().parents[1] / 'scripts/healthcheck.py'
-            for status in (401, 503):
+            for status in (401, 503, 504):
                 for pattern, expected in [('maintenance', 0), ('ready', 1)]:
                     with self.subTest(status=status, pattern=pattern):
+                        if status == 504:
+                            expected = 1
                         result = subprocess.run([
                             sys.executable, str(script), f'http://127.0.0.1:{server.server_port}/{status}',
                             '--expect-status', str(status), '--expect-body-regex', pattern,
-                            '--retries', '0', '--json',
+                            '--retries', '0', '--json', '--timeout', '0.1',
                         ], capture_output=True, text=True, timeout=10)
                         self.assertEqual(result.returncode, expected, result.stdout + result.stderr)
                         payload = json.loads(result.stdout)


### PR DESCRIPTION
## Why this matters

An operator can explicitly allow an HTTP error status while requiring a body predicate (for example a maintenance response). The CLI previously accepted the status and skipped the body check, reporting healthy for the wrong service state.

## Root cause and invariant

urllib represents these responses as HTTPError. Apply the same bounded body predicate to that response path, report a body-read timeout as failure and close error responses. Status-only checks remain supported. Updated the original PR onto current public-beta while retaining its redirect controls.

## Overlap check

Searched open/closed healthcheck body/status PRs and scripts/healthcheck.py. This is the original body-predicate fix. #4883 first-hop redirect controls and #5272 overall retry deadline are separate scopes, not replacements for the status/body conjunction. No duplicate PR was created.

## Validation

- Linux Python 3.11: `python -m pytest -q tests/test-healthcheck-error-body.py tests/test_healthcheck_redirect_policy.py`: 12 passed. CLI subprocess tests assert JSON status and exit code for matching/mismatching 401/503 bodies and a stalled 504 body; existing redirect tests pass.
- Focused pre-commit and diff check passed; regression wired into `make test`.
- Baseline smoke/simulation passed; full make gate/BATS retain pre-existing environment/fixture failures. No live deployment health claim is made.

## Tradeoffs and rollback

Body reads retain the 1 MiB cap and configured socket timeout, not a new total retry policy. A previously false-positive health check may now fail correctly. Revert only if the operator accepts that false-positive behavior. No persisted state changes. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `c81489225836efdfdd7f989c0d17171636bc541d`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
