### PR TITLE
fix(remote-provider): reject redirects during authenticated probes

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -124,6 +124,7 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@bash tests/test-backup-data-coverage.sh
+	@python3 tests/test-provider-probe-redirects.py
 	@echo ""
 	@echo "=== backup integrity and restore round-trip ==="
 	@bash tests/test-backup-integrity.sh

--- a/ods/bin/remote_provider/probe.py
+++ b/ods/bin/remote_provider/probe.py
@@ -26,6 +26,17 @@ PROBE_RECEIPT_SCHEMA = "ods.remote-provider-probe-receipt.v1"
 UrlOpener = Callable[..., Any]
 
 
+class _RejectProbeRedirects(urllib_request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        # A redirect target has not passed route/address policy and must not
+        # receive the configured provider credential, even on the same host.
+        return None
+
+
+def _open_probe_request(request, *, timeout: float):
+    return urllib_request.build_opener(_RejectProbeRedirects()).open(request, timeout=timeout)
+
+
 class ProbeError(Exception):
     """HTTP-friendly remote-provider probe failure."""
 
@@ -149,6 +160,9 @@ def _probe_models_endpoint(
             body = _read_probe_body(response)
             content_type = str(response.headers.get("content-type", ""))
     except urllib_error.HTTPError as exc:
+        if 300 <= exc.code < 400:
+            exc.close()
+            raise ProbeError(502, "provider_redirect_rejected", "remote provider probe redirects are not allowed") from exc
         raise ProbeError(
             int(exc.code),
             "provider_http_error",
@@ -183,7 +197,7 @@ def probe_provider_route(
     *,
     provider_secret: str,
     resolver: Callable[..., list[tuple[Any, ...]]] = socket.getaddrinfo,
-    opener: UrlOpener = urllib_request.urlopen,
+    opener: UrlOpener = _open_probe_request,
     timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     """Probe an OpenAI-compatible provider through the route's transport boundary."""
@@ -224,7 +238,7 @@ def probe_direct_provider(
     *,
     provider_secret: str,
     resolver: Callable[..., list[tuple[Any, ...]]] = socket.getaddrinfo,
-    opener: UrlOpener = urllib_request.urlopen,
+    opener: UrlOpener = _open_probe_request,
     timeout: float = DEFAULT_PROBE_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     """Probe an OpenAI-compatible direct provider without leaking credentials."""

--- a/ods/tests/test-provider-probe-redirects.py
+++ b/ods/tests/test-provider-probe-redirects.py
@@ -1,0 +1,55 @@
+"""Real HTTP redirect responses must not move a credential-bearing probe."""
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / 'bin'))
+from remote_provider.probe import ProbeError, probe_provider_route
+
+
+class ProbeRedirectTest(unittest.TestCase):
+    def test_default_transport_refuses_redirects(self):
+        captures = []
+        redirect_status = 302
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                if self.path == '/capture':
+                    captures.append(self.headers.get('Authorization'))
+                    self.send_response(200)
+                    self.end_headers()
+                    self.wfile.write(b'{"data": []}')
+                    return
+                self.send_response(redirect_status)
+                self.send_header('Location', f'http://localhost:{self.server.server_port}/capture')
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        route = {'enabled': True, 'transport': 'direct', 'provider': {'baseUrl': f'http://127.0.0.1:{server.server_port}'}}
+        try:
+            # Only allow the local fixture past address policy. The production
+            # opener, HTTP parsing and redirect handling are exercised unchanged.
+            with patch('remote_provider.probe.validate_direct_provider_resolution', return_value=['127.0.0.1']):
+                for redirect_status in (301, 302, 303, 307, 308):
+                    with self.subTest(status=redirect_status):
+                        with self.assertRaises(ProbeError) as caught:
+                            probe_provider_route(route, provider_secret='redirect-test-key')
+                        self.assertEqual(caught.exception.status, 502)
+                        self.assertEqual(caught.exception.code, 'provider_redirect_rejected')
+                        self.assertEqual(captures, [])
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Why this matters

Authenticated remote-provider probes must not forward their credential to a redirect destination that has not passed route/address policy. Python's default URL opener followed redirects after only the original route was validated.

## Contract

The default transport refuses 301/302/303/307/308 redirects, including same-host redirects, closes the rejected response and reports a sanitized 502 `provider_redirect_rejected`. Direct host-agent probes and egress route probes both use this default. Dependency-injected openers remain available for tests. Configure the canonical provider base URL rather than relying on a redirect.

## Overlap check

Searched all-state provider probe/redirect PRs and remote_provider/probe.py. Updated this original canonical PR onto public-beta, not a duplicate. Healthcheck first-hop selection (#4883) is a separate unauthenticated CLI contract; unrelated beta egress and provider changes are preserved.

## Validation

- Linux Python 3.11: `python -m pytest -q tests/test-provider-probe-redirects.py`: passed, with five redirect subcases against a real local HTTP fixture. The destination receives zero requests/credentials; only local-fixture address policy is substituted, not the production opener.
- Focused pre-commit and diff check passed; test remains wired into `make test`.
- Baseline dashboard tests/build and Linux smoke/simulation passed. Full make gate/BATS have existing environment/fixture failures. No real external provider credential or live hosted service was used.

## Risk and rollback

Providers that relied on redirects must use their final configured endpoint. Redirect targets are not automatically revalidated or retried. Reverting restores credential-forwarding risk; there is no state migration. Security-sensitive transport change: independent human review is required before merge. Review readiness is not merge approval.

## Final beta-batch receipt — 2026-09-16

Candidate: `6c5bcbc4a337f551b06455f6c629ec6f5240802f`. GitHub check audit at 11:07:47 UTC: **38 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
