### PR TITLE
fix(dashboard): export usage rows with CSV escaping

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -839,11 +839,14 @@ function UsageByModelTable({ rows }) {
 
   const exportCsv = () => {
     const header = ['model', 'provider', 'service', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'requests', 'cost_usd', 'cost_source']
+    const csvCell = value => typeof value === 'number'
+      ? String(value)
+      : `"${String(value ?? '').replaceAll('"', '""')}"`
     const lines = [
       header.join(','),
-      ...filtered.map(row => header.map(key => JSON.stringify(row[key] ?? '')).join(',')),
+      ...filtered.map(row => header.map(key => csvCell(row[key])).join(',')),
     ]
-    const blob = new Blob([lines.join('\n')], { type: 'text/csv;charset=utf-8' })
+    const blob = new Blob([lines.join('\r\n')], { type: 'text/csv;charset=utf-8' })
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url

--- a/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
@@ -120,6 +120,24 @@ const currentReport = {
   ],
 }
 
+test('CSV export preserves quotes, commas, newlines and literal backslashes', async () => {
+  const row = { ...currentReport.models[0], model: 'research "a",\nβ\\path' }
+  installFetchMock({ current: { ...currentReport, models: [row] } })
+  vi.stubGlobal('URL', { createObjectURL: vi.fn(() => 'blob:usage'), revokeObjectURL: vi.fn() })
+  vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  render(<Usage />)
+  await screen.findByRole('button', { name: /Export CSV/i })
+  fireEvent.click(screen.getByRole('button', { name: /Export CSV/i }))
+  const blob = URL.createObjectURL.mock.calls[0][0]
+  const text = await new Promise((resolve, reject) => {
+    const reader = new window.FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(blob)
+  })
+  expect(text).toContain('"research ""a"",\nβ\\path","openai","Open WebUI",8200,2100,600,20,3.75,"priced_from_tokens"')
+})
+
 const previousReport = {
   ...currentReport,
   period: { start: '2026-04-01', end: '2026-04-30' },


### PR DESCRIPTION
## Why this matters
Usage export currently uses JSON string quoting for CSV cells, corrupting model names containing quotes, backslashes or newlines. Quote text cells with doubled CSV quotes and emit CRLF row separators while preserving numeric cells.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files before implementation, using the full PR inventory and inspecting related descriptions; refreshed latest PRs through #3832 before publication.

Files: `ods/extensions/services/dashboard/src/pages/Usage.jsx`.

#3043 handles auxiliary report failures; #3051 readiness; existing helper-test PRs cover selectors. #3711 exports GPU history in another file. None fixes Usage CSV serialization.

## Regression and focused validation
Rendered Usage export regression captures the downloaded Blob and checks a model containing quotes, comma, newline, Unicode and backslash. Usage + history suites: 12 passed.

## Tradeoffs, rollback and remaining validation
Format correctness only: no spreadsheet-formula sanitization claim. No external spreadsheet application was tested. Revert restores JSON escaping in CSV downloads.

## Combined validation and merge order
Validated the ten independent branches on synthetic integration commit `8d5e17801b6789985f74496f709e482bf571f278` (branch `integration/quality-next-ten-20260908` on tang-vu/DreamServer). Dashboard: 262 tests passed, lint and production build passed. Related dashboard API suites: 70 passed; interpreter timeout suite: 3 passed; four new standalone release/CLI tests and existing provider egress contracts passed. CI-equivalent Ruff selection passed across ods; shell/Python syntax passed. Smoke and installer simulation passed.

`make gate` is NOT green: it stops at the Hermes max_tokens template contract, reproduced unchanged on base `21f4b3a6`. Full BATS: 408 passed and 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer/path tests. All ten failures reproduce on the untouched base in the affected suites. Pre-commit gitleaks, size and shell hooks pass, while detect-private-key flags the two existing dummy-key fixtures in `test_host_agent.py` and `test-remote-provider-egress-policy.py`. These results do not establish hardware or live-service behavior. API tests also emit an existing unclosed aiohttp-session warning.

Suggested batch merge order: invites, interpreter timeout, n8n pagination, Milvus (only after its live gate), healthcheck, provider redirects (after human review), Usage CSV, branch exclusions, PWA storage, Lemonade paths. Production changes are independent; draft reviews need not block unrelated changes. Four branches add adjacent Makefile test registrations: preserve all four lines when resolving that textual conflict, as on the integration head. Each PR starts directly from upstream main; no stacked branch dependency.

GitHub checks completed for candidate `cac11e23be316940e26ec0aebdb0caf18cb406c7`: 28 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed; the local baseline failures and live-validation limitations above still apply.

