### PR TITLE
fix(maintainers): require verified PR exclusions before listing stale branches

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -124,6 +124,7 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@bash tests/test-backup-data-coverage.sh
+	@python3 tests/test-stale-branch-exclusions.py
 	@echo ""
 	@echo "=== backup integrity and restore round-trip ==="
 	@bash tests/test-backup-integrity.sh

--- a/ods/scripts/maintainers/list-stale-branches.py
+++ b/ods/scripts/maintainers/list-stale-branches.py
@@ -2,8 +2,9 @@
 """List remote branches that may be safe to clean up.
 
 This helper is intentionally dry-run only. It never deletes branches. It uses
-local git remote refs, and when the GitHub CLI is available it excludes branches
-that currently back open pull requests.
+local git remote refs and excludes branches that currently back open pull requests.
+If that inventory cannot be verified, it stops before listing candidates.
+Use --include-open-prs explicitly to inspect branches without that protection.
 """
 
 from __future__ import annotations
@@ -41,26 +42,23 @@ def repo_root() -> Path:
 
 
 def open_pr_heads() -> set[str]:
-    result = run(
-        [
-            "gh",
-            "pr",
-            "list",
-            "--state",
-            "open",
-            "--limit",
-            "500",
-            "--json",
-            "headRefName",
-        ]
-    )
+    error = "error: cannot verify open PR exclusions; restore gh access or explicitly use --include-open-prs"
+    limit = 10000
+    try:
+        result = run(["gh", "pr", "list", "--state", "open", "--limit", str(limit), "--json", "headRefName"])
+    except FileNotFoundError as exc:
+        raise SystemExit(error) from exc
     if result.returncode != 0:
-        return set()
+        raise SystemExit(error)
     try:
         rows = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        return set()
-    return {row.get("headRefName", "") for row in rows if row.get("headRefName")}
+    except json.JSONDecodeError as exc:
+        raise SystemExit(error) from exc
+    if not isinstance(rows, list) or len(rows) >= limit:
+        raise SystemExit(error)
+    if any(not isinstance(row, dict) or not isinstance(row.get("headRefName"), str) or not row["headRefName"] for row in rows):
+        raise SystemExit(error)
+    return {row["headRefName"] for row in rows}
 
 
 def remote_branches() -> list[tuple[datetime, str, str]]:
@@ -99,7 +97,7 @@ def main() -> int:
     if heads:
         print(f"Excluding {len(heads)} open PR branch(es)")
     elif not args.include_open_prs:
-        print("Open PR branch exclusion unavailable or empty")
+        print("Verified: no open PR branches")
     print()
 
     candidates: list[tuple[int, str, str, str]] = []

--- a/ods/tests/test-stale-branch-exclusions.py
+++ b/ods/tests/test-stale-branch-exclusions.py
@@ -1,0 +1,43 @@
+"""The maintainer CLI must not list candidates with unverified PR exclusions."""
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+class StaleBranchExclusionTest(unittest.TestCase):
+    def test_cli_requires_complete_pr_inventory_or_explicit_override(self):
+        path = Path(__file__).resolve().parents[1] / 'scripts/maintainers/list-stale-branches.py'
+        spec = importlib.util.spec_from_file_location('stale_branches', path)
+        script = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(script)
+        for mode in ('unavailable', 'invalid-json', 'invalid-shape', 'truncated', 'empty', 'override'):
+            with self.subTest(mode=mode):
+                def run(command):
+                    if command[0] == 'gh':
+                        self.assertNotEqual(mode, 'override')
+                        rows = [{'headRefName': f'feature-{i}'} for i in range(int(command[command.index('--limit') + 1]))]
+                        payload = {'invalid-json': 'oops', 'invalid-shape': '{}', 'truncated': json.dumps(rows)}.get(mode, '[]')
+                        return subprocess.CompletedProcess(command, 1 if mode == 'unavailable' else 0, payload, '')
+                    if command[1] == 'rev-parse':
+                        return subprocess.CompletedProcess(command, 0, '/repo\n', '')
+                    return subprocess.CompletedProcess(command, 0, '2000-01-01T00:00:00+00:00\torigin/active-change\tabc123\n', '')
+
+                output = io.StringIO()
+                argv = ['list-stale-branches'] + (['--include-open-prs'] if mode == 'override' else [])
+                with patch.object(script, 'run', side_effect=run), patch.object(sys, 'argv', argv), redirect_stdout(output):
+                    if mode in ('empty', 'override'):
+                        self.assertEqual(script.main(), 0)
+                    else:
+                        with self.assertRaises(SystemExit):
+                            script.main()
+                self.assertEqual('origin/active-change' in output.getvalue(), mode in ('empty', 'override'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Why this matters
The branch-maintenance CLI can list active PR branches as stale when gh is missing, fails or returns an incomplete inventory. Stop before candidate output unless open-PR exclusions are verified; retain the existing explicit --include-open-prs override and reject truncated inventories.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files before implementation, using the full PR inventory and inspecting related descriptions; refreshed latest PRs through #3832 before publication.

Files: `ods/scripts/maintainers/list-stale-branches.py`.

#2481 adds JSON output and candidate validation; its scope does not validate retrieval of PR exclusions. Open/closed filename and semantic searches found no equivalent fix.

## Regression and focused validation
python3 tests/test-stale-branch-exclusions.py: passed, six CLI-boundary cases for gh failure, invalid JSON, invalid shape, capped inventory, verified empty inventory and explicit override.

## Tradeoffs, rollback and remaining validation
The helper only prints candidates; it never deletes branches. The 10,000-row cap fails visibly rather than assuming complete exclusions. Revert restores unverified output on retrieval failure.

## Combined validation and merge order
Validated the ten independent branches on synthetic integration commit `8d5e17801b6789985f74496f709e482bf571f278` (branch `integration/quality-next-ten-20260908` on tang-vu/DreamServer). Dashboard: 262 tests passed, lint and production build passed. Related dashboard API suites: 70 passed; interpreter timeout suite: 3 passed; four new standalone release/CLI tests and existing provider egress contracts passed. CI-equivalent Ruff selection passed across ods; shell/Python syntax passed. Smoke and installer simulation passed.

`make gate` is NOT green: it stops at the Hermes max_tokens template contract, reproduced unchanged on base `21f4b3a6`. Full BATS: 408 passed and 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer/path tests. All ten failures reproduce on the untouched base in the affected suites. Pre-commit gitleaks, size and shell hooks pass, while detect-private-key flags the two existing dummy-key fixtures in `test_host_agent.py` and `test-remote-provider-egress-policy.py`. These results do not establish hardware or live-service behavior. API tests also emit an existing unclosed aiohttp-session warning.

Suggested batch merge order: invites, interpreter timeout, n8n pagination, Milvus (only after its live gate), healthcheck, provider redirects (after human review), Usage CSV, branch exclusions, PWA storage, Lemonade paths. Production changes are independent; draft reviews need not block unrelated changes. Four branches add adjacent Makefile test registrations: preserve all four lines when resolving that textual conflict, as on the integration head. Each PR starts directly from upstream main; no stacked branch dependency.

GitHub checks completed for candidate `68e67aa32f821b16cdbe6683302145bb34dcc3a4`: 29 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed; the local baseline failures and live-validation limitations above still apply.

