### PR TITLE
fix(lemonade): normalize trailing API path slashes in runtime probes

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -124,7 +124,7 @@ class LemonadeClient:
             self._client = None
 
     def api_url(self, path: str) -> str:
-        return f"{self.settings.api_root}/{path.lstrip('/')}"
+        return f"{self.settings.api_root.rstrip('/')}/{path.lstrip('/')}"
 
     def auth_headers(self) -> dict[str, str]:
         if not self.settings.api_key:

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_path_status.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_path_status.py
@@ -1,0 +1,35 @@
+"""Configured trailing API slashes must not mark a reachable provider unhealthy."""
+import httpx
+import pytest
+
+
+@pytest.mark.parametrize('api_path', ['/api/v1', '/api/v1/', '/api/v1///'])
+def test_external_lemonade_status_normalizes_api_path(test_client, monkeypatch, api_path):
+    import lemonade_client
+
+    for key, value in {
+        'GPU_BACKEND': 'amd', 'AMD_INFERENCE_RUNTIME': 'lemonade',
+        'AMD_INFERENCE_BACKEND': 'vulkan', 'AMD_INFERENCE_LOCATION': 'host',
+        'AMD_INFERENCE_RUNTIME_MODE': 'external-lemonade', 'AMD_INFERENCE_MANAGED': 'false',
+        'AMD_INFERENCE_SUPPORTED_BACKENDS': 'vulkan', 'LLM_API_BASE_PATH': api_path,
+        'LEMONADE_CONTAINER_BASE_URL': 'http://provider:13305',
+    }.items():
+        monkeypatch.setenv(key, value)
+    seen = []
+
+    def handler(request):
+        seen.append(request.url.path)
+        if request.url.path == '/api/v1/health':
+            return httpx.Response(200, json={'version': 'test', 'model_loaded': 'model-a'})
+        if request.url.path == '/api/v1/models':
+            return httpx.Response(200, json={'data': [{'id': 'model-a'}]})
+        return httpx.Response(404, json={'error': 'wrong path'})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(lemonade_client.httpx, 'AsyncClient', lambda **kwargs: client)
+    response = test_client.get('/api/gpu/amd-runtime', headers=test_client.auth_headers)
+    assert response.status_code == 200
+    assert response.json()['health'] == 'reachable'
+    assert response.json()['modelCount'] == 1
+    assert seen == ['/api/v1/health', '/api/v1/models']
+    assert client.is_closed


### PR DESCRIPTION
## Why this matters
Configured LLM_API_BASE_PATH values with trailing slashes produce double-slash health/model URLs through the external Lemonade adapter, making a reachable runtime appear unhealthy. Strip trailing separators at the adapter's URL join boundary.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files before implementation, using the full PR inventory and inspecting related descriptions; refreshed latest PRs through #3832 before publication.

Files: `ods/extensions/services/dashboard-api/lemonade_client.py`.

#2027 strips base URL quotes; #2507 timeout settings; #3410/#2825 model ID encoding; #2332 audio errors; #1677 timeout contracts. None fixes API-root separator joining.

## Regression and focused validation
Authenticated GET /api/gpu/amd-runtime tests run the actual adapter with HTTPX MockTransport for /api/v1, /api/v1/ and /api/v1///, asserting canonical request paths, reachable health, model count and client cleanup. New + Lemonade + AMD runtime suites: 23 passed.

## Tradeoffs, rollback and remaining validation
Transport is mocked; no AMD host or live Lemonade service was exercised. Model IDs and other URL components are unchanged. Revert restores false-unhealthy reports for trailing-slash configuration.

## Combined validation and merge order
Validated the ten independent branches on synthetic integration commit `8d5e17801b6789985f74496f709e482bf571f278` (branch `integration/quality-next-ten-20260908` on tang-vu/DreamServer). Dashboard: 262 tests passed, lint and production build passed. Related dashboard API suites: 70 passed; interpreter timeout suite: 3 passed; four new standalone release/CLI tests and existing provider egress contracts passed. CI-equivalent Ruff selection passed across ods; shell/Python syntax passed. Smoke and installer simulation passed.

`make gate` is NOT green: it stops at the Hermes max_tokens template contract, reproduced unchanged on base `21f4b3a6`. Full BATS: 408 passed and 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer/path tests. All ten failures reproduce on the untouched base in the affected suites. Pre-commit gitleaks, size and shell hooks pass, while detect-private-key flags the two existing dummy-key fixtures in `test_host_agent.py` and `test-remote-provider-egress-policy.py`. These results do not establish hardware or live-service behavior. API tests also emit an existing unclosed aiohttp-session warning.

Suggested batch merge order: invites, interpreter timeout, n8n pagination, Milvus (only after its live gate), healthcheck, provider redirects (after human review), Usage CSV, branch exclusions, PWA storage, Lemonade paths. Production changes are independent; draft reviews need not block unrelated changes. Four branches add adjacent Makefile test registrations: preserve all four lines when resolving that textual conflict, as on the integration head. Each PR starts directly from upstream main; no stacked branch dependency.

GitHub checks completed for candidate `2b75e5141817f432cedd2703384e24a964c25af2`: 29 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed; the local baseline failures and live-validation limitations above still apply.

