### PR TITLE
feat(models): compare catalog models before downloading

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/ModelComparison.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/ModelComparison.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+
+const value = (number, unit) => Number.isFinite(number) && number > 0 ? `${number.toLocaleString()} ${unit}` : 'Not reported'
+
+export default function ModelComparison({ models }) {
+  const [open, setOpen] = useState(false)
+  const [selected, setSelected] = useState(['', '', ''])
+  const compared = selected.map(id => models.find(model => model.id === id)).filter(Boolean)
+  const rows = [
+    ['Download size', model => model.size || value(model.sizeGb, 'GB')],
+    ['Estimated VRAM', model => value(model.estimatedRequired ?? model.vramRequired, 'GB')],
+    ['Catalog context', model => value(model.contextLength, 'tokens')],
+    ['Reported speed', model => value(model.tokensPerSec, 'tokens/s')],
+    ['Quantization', model => model.quantization || 'Not reported'],
+    ['VRAM fit', model => model.fitsVram === true ? 'Fits' : model.fitsVram === false ? 'Does not fit' : 'Not reported'],
+  ]
+  return (
+    <section className="mb-4 rounded-xl border border-theme-border bg-theme-card p-4">
+      <button type="button" aria-expanded={open} onClick={() => setOpen(!open)} className="font-semibold text-theme-text">Compare models</button>
+      {open && <>
+      <p className="my-3 text-sm text-theme-text-muted">Compare up to three catalog models before downloading. Estimates do not guarantee runtime compatibility.</p>
+      <div className="mb-4 flex flex-wrap gap-3">
+        {selected.map((id, index) => (
+          <label key={index} className="text-sm text-theme-text">
+            Model {index + 1}
+            <select aria-label={`Comparison model ${index + 1}`} value={models.some(model => model.id === id) ? id : ''}
+              onChange={event => setSelected(previous => previous.map((item, slot) => slot === index ? event.target.value : item))}
+              className="ml-2 rounded border border-theme-border bg-theme-card p-2">
+              <option value="">Choose a model</option>
+              {models.map(model => <option key={model.id} value={model.id} disabled={selected.includes(model.id) && id !== model.id}>{model.name}</option>)}
+            </select>
+          </label>
+        ))}
+        <button type="button" onClick={() => setSelected(['', '', ''])} className="text-sm text-theme-accent">Clear comparison</button>
+      </div>
+      {compared.length < 2 ? <p className="text-sm text-theme-text-muted">Select at least two models to compare.</p> : (
+        <div className="overflow-x-auto">
+          <table aria-label="Model comparison" className="w-full text-left text-sm text-theme-text">
+            <thead><tr><th scope="col" className="p-2">Attribute</th>{compared.map(model => <th scope="col" className="p-2" key={model.id}>{model.name}</th>)}</tr></thead>
+            <tbody>{rows.map(([label, read]) => <tr key={label}><th scope="row" className="p-2">{label}</th>{compared.map(model => <td className="p-2" key={model.id}>{read(model)}</td>)}</tr>)}</tbody>
+          </table>
+        </div>
+      )}
+      </>}
+    </section>
+  )
+}

--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom'
 import { useModels } from '../hooks/useModels'
 import { useDownloadProgress } from '../hooks/useDownloadProgress'
 import HuggingFaceModelBrowser from '../components/model-library/HuggingFaceModelBrowser'
+import ModelComparison from '../components/model-library/ModelComparison'
 
 const PAGE_SIZE = 10
 const DOWNLOAD_STATUS_TIMEOUT_MS = 15000
@@ -355,6 +356,7 @@ export default function Models() {
         recommendedCount={odsCatalogModels.length}
       />
 
+      <ModelComparison models={models} />
       {libraryScope === 'huggingface' ? (
         <section
           ref={libraryRef}

--- a/ods/extensions/services/dashboard/src/pages/Models.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.test.jsx
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Models from './Models'
 
@@ -1092,4 +1092,21 @@ test('filters models by search and category without changing catalog data', () =
 
   fireEvent.click(screen.getByRole('button', { name: /reset/i }))
   expect(screen.getByText('Qwen 3.5 9B')).toBeInTheDocument()
+})
+
+test('compares catalog models without starting a download or activation', () => {
+  const state = baseState({ models: [model(), model({ id: 'tiny', name: 'Tiny', vramRequired: 2, contextLength: null, tokensPerSec: null })] })
+  useModelsMock.mockReturnValue(state)
+  renderModels()
+  fireEvent.click(screen.getByText('Compare models'))
+  fireEvent.change(screen.getByLabelText('Comparison model 1'), { target: { value: 'qwen3.5-9b-q4' } })
+  fireEvent.change(screen.getByLabelText('Comparison model 2'), { target: { value: 'tiny' } })
+  const table = within(screen.getByRole('table', { name: 'Model comparison' }))
+  expect(table.getByText('7 GB')).toBeInTheDocument()
+  expect(table.getByText('2 GB')).toBeInTheDocument()
+  expect(table.getAllByText('Not reported')).toHaveLength(2)
+  expect(state.downloadModel).not.toHaveBeenCalled()
+  expect(state.loadModel).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: 'Clear comparison' }))
+  expect(screen.queryByRole('table', { name: 'Model comparison' })).not.toBeInTheDocument()
 })


### PR DESCRIPTION
## Why this matters

Model selection requires comparing download size, estimated memory, catalog context, reported speed and quantization before spending time or disk space on a download.

## Behavior and beta integration

Updated the original comparison PR onto current public-beta. Compare up to three catalog models side by side, prevent duplicate selection and clear the comparison. Unknown values are explicitly "Not reported" and fit/throughput estimates are not runtime guarantees. Both compact portal and full library are covered; no download, activation or provider route is changed.

## Overlap check

Searched all-state compare-model PRs and Models.jsx/ModelComparison production paths. This is the original canonical model-comparison PR. Catalog/model benchmark work such as #4885 measures throughput; it does not provide side-by-side selection, and its beta behavior is retained. No duplicate was created.

## Validation

- `npm test -- --maxWorkers=2 src/pages/Models src/hooks/__tests__/useModels`: 5 suites, 94 passed.
- Rendered-page regressions in compact and full views verify table values, unknown fields, clearing, and no download/activation calls. Follow-up `c1266e9f99a7f02d617b3bbaae2e38109638e27c` explicitly exercises duplicate selection against the current catalog.
- Focused ESLint: zero errors, existing JSX warnings. Focused pre-commit and diff check passed.
- Baseline dashboard tests/build and Linux smoke/simulation passed; full make gate/BATS retain existing environment/fixture failures. No model download or hardware throughput validation is claimed.

## Tradeoffs and rollback

Comparison is local view state and uses current catalog metadata, not new benchmarks. Removing the component has no persisted state, service restart or rollback migration. Ready for independent review, not approval to merge.

## Final beta-batch receipt — 2026-09-16

Candidate: `c1266e9f99a7f02d617b3bbaae2e38109638e27c`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
