### PR TITLE
feat(integrations): explore indirect service dependency impact

### DIFF
--- a/ods/extensions/services/dashboard/src/components/ServiceImpact.jsx
+++ b/ods/extensions/services/dashboard/src/components/ServiceImpact.jsx
@@ -1,0 +1,40 @@
+import { useState } from 'react'
+
+function affectedPaths(id, edges) {
+  const paths = new Map([[id, [id]]])
+  const pending = [id]
+  for (let index = 0; index < pending.length; index += 1) {
+    const dependency = pending[index]
+    for (const edge of edges) {
+      if (edge.target !== dependency || paths.has(edge.source)) continue
+      paths.set(edge.source, [edge.source, ...paths.get(dependency)])
+      pending.push(edge.source)
+    }
+  }
+  paths.delete(id)
+  return paths
+}
+
+export default function ServiceImpact({ nodes, edges }) {
+  const [selected, setSelected] = useState('')
+  const selectedNode = nodes.find(node => node.id === selected)
+  const paths = selectedNode ? affectedPaths(selected, edges) : new Map()
+  const names = new Map(nodes.map(node => [node.id, node.name]))
+  return (
+    <section className="mb-4 rounded-xl border border-theme-border bg-theme-card p-4 text-sm text-theme-text" aria-label="Service impact explorer">
+      <label className="font-semibold">Explore service impact
+        <select aria-label="Service to inspect" value={selectedNode ? selected : ''} onChange={event => setSelected(event.target.value)} className="ml-3 rounded border border-theme-border bg-theme-card p-2">
+          <option value="">Choose a service</option>
+          {[...nodes].sort((a, b) => a.name.localeCompare(b.name)).map(node => <option key={node.id} value={node.id}>{node.name}</option>)}
+        </select>
+      </label>
+      {selectedNode && <div className="mt-3">
+        <p>{paths.size} potentially affected services if {selectedNode.name} becomes unavailable.</p>
+        <p className="mt-1 text-theme-text-muted">Based on the connections shown in this map, including indirect dependencies. This is a planning aid, not a live failure diagnosis.</p>
+        {paths.size === 0 ? <p className="mt-2">No dependent services are shown in this map.</p> : <ul aria-label="Affected services" className="mt-2 space-y-2">
+          {[...paths].map(([id, path]) => <li key={id}><span className="font-semibold">{names.get(id)}</span><span className="ml-2 text-theme-text-muted">{path.map(part => names.get(part) || part).join(' → ')}</span></li>)}
+        </ul>}
+      </div>}
+    </section>
+  )
+}

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.impact.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.impact.test.jsx
@@ -1,0 +1,23 @@
+import { createElement } from 'react'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import ServiceMap from './ServiceMap'
+
+test('traces direct and indirect affected services from the live status map', async () => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({ services: [
+    { id: 'llama-server', name: 'Inference', status: 'healthy' },
+    { id: 'litellm', name: 'Gateway', status: 'healthy' },
+    { id: 'open-webui', name: 'Chat', status: 'healthy' },
+    { id: 'whisper', name: 'Voice', status: 'healthy' },
+  ] }) })))
+  render(createElement(ServiceMap))
+  const selector = await screen.findByLabelText('Service to inspect')
+  fireEvent.change(selector, { target: { value: 'llama-server' } })
+  const affected = within(screen.getByRole('list', { name: 'Affected services' }))
+  expect(affected.getByText('Gateway → Inference')).toBeInTheDocument()
+  expect(affected.getByText('Chat → Gateway → Inference')).toBeInTheDocument()
+  expect(affected.queryByText('Voice')).not.toBeInTheDocument()
+  fireEvent.change(selector, { target: { value: 'open-webui' } })
+  expect(screen.getByText('No dependent services are shown in this map.')).toBeInTheDocument()
+  fireEvent.change(selector, { target: { value: '' } })
+  expect(screen.queryByText(/potentially affected/)).not.toBeInTheDocument()
+})

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { ExternalLink, GitBranch, RefreshCw, X } from 'lucide-react'
 import { serviceUrl } from '../lib/serviceUrls'
+import ServiceImpact from '../components/ServiceImpact'
 
 const POLL_INTERVAL = 10000
 const NODE_W = 170
@@ -336,6 +337,7 @@ export default function ServiceMap() {
         <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-zinc-500" />Not deployed</span>
       </div>
 
+      <ServiceImpact nodes={nodes} edges={edges} />
       <div className="relative min-h-[70vh] overflow-auto rounded-xl border border-theme-border bg-theme-card">
         <svg width={svgWidth} height={svgHeight} viewBox={`0 0 ${svgWidth} ${svgHeight}`} className="mx-auto block">
           <defs>


### PR DESCRIPTION
## Why this matters

Operators need to see which displayed services depend directly or indirectly on a selected integration before planning downtime. The existing map only makes individual edges visible.

## Behavior and beta integration

The impact explorer follows the map's directed dependency edges, visits each service once (including cyclic graphs), and shows a dependency path for each potentially affected service. It uses the current status-map snapshot and does not change deployment or health state. Updated this original PR onto public-beta, preserved snapshot export and refreshed selection behavior, and made the explorer reachable in both compact portal and full map views.

## Overlap check

Searched open/closed dependency-impact PRs and ServiceMap/ServiceImpact production paths. This remains the canonical transitive-impact feature. #4462 handles selection freshness and #4891 snapshot downloads; their current beta code is preserved. No replacement or subset PR was opened.

## Validation

- `npm test -- --maxWorkers=2 src/pages/ServiceMap`: 4 suites, 18 passed. The public-page regression runs in compact and full modes and asserts direct/indirect paths, unrelated-service exclusion and clearing the selection. Follow-up `b1eb6e2149c0542e0d85ff2abd7b111d78013562` verifies selection is removed when the refreshed snapshot removes that service.
- Focused ESLint: zero errors, existing JSX warnings. Focused pre-commit and diff check passed.
- Baseline dashboard tests/build and Linux smoke/simulation passed; pre-existing full-gate/BATS environment/fixture failures remain. No live service outage or hardware qualification is claimed.

## Limitations and rollback

This is planning information from known map connections, not exhaustive dependency discovery or a live failure diagnosis. Refresh errors retain the existing snapshot/error behavior. No new API or mutation is introduced. Reverting removes the explorer without data migration. Ready for independent review, not approval to merge.

## Final beta-batch receipt — 2026-09-16

Candidate: `b1eb6e2149c0542e0d85ff2abd7b111d78013562`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
