### PR TITLE
feat(talk): export conversations as Markdown or JSON

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TalkExport.jsx
+++ b/ods/extensions/services/dashboard/src/components/TalkExport.jsx
@@ -1,0 +1,34 @@
+import { useState } from 'react'
+
+export default function TalkExport({ messages, busy }) {
+  const [format, setFormat] = useState('md')
+  const transcript = messages.filter(message => message.id !== 'welcome').map(message => ({
+    role: message.role,
+    text: message.text || '',
+    status: message.status || 'done',
+  }))
+  function download() {
+    if (busy || transcript.length === 0) return
+    const exportedAt = new Date().toISOString()
+    const content = format === 'json'
+      ? JSON.stringify({ schema: 'ods.talk-transcript.v1', exportedAt, messages: transcript }, null, 2)
+      : `# ODS Talk\n\nExported: ${exportedAt}\n\n${transcript.map(message => `## ${message.role === 'user' ? 'You' : 'ODS'} (${message.status})\n\n${message.text}`).join('\n\n---\n\n')}\n`
+    const url = URL.createObjectURL(new Blob([content], { type: format === 'json' ? 'application/json;charset=utf-8' : 'text/markdown;charset=utf-8' }))
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = `ods-talk-${exportedAt.slice(0, 10)}.${format}`
+    document.body.appendChild(anchor)
+    anchor.click()
+    anchor.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-zinc-600">
+      <select aria-label="Transcript format" value={format} onChange={event => setFormat(event.target.value)} className="rounded border border-zinc-200 bg-white p-2">
+        <option value="md">Markdown</option><option value="json">JSON</option>
+      </select>
+      <button type="button" disabled={busy || transcript.length === 0} onClick={download} className="rounded border border-zinc-200 bg-white p-2 disabled:opacity-50">Export conversation</button>
+      <span>Text from this tab only; attachment files are not included.</span>
+    </div>
+  )
+}

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import TalkExport from '../components/TalkExport'
 import {
   AlertCircle, CheckCircle2, Loader2, Mic, Paperclip, RefreshCw,
   Send, Volume2, VolumeX,
@@ -681,6 +682,7 @@ export default function ODSTalk() {
               </button>
             </div>
           </div>
+          <TalkExport messages={messages} busy={sending || recording} />
         </header>
 
         <main className="flex-1 overflow-y-auto px-4 py-4">

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
@@ -562,3 +562,34 @@ describe('ODSTalk', () => {
     ))
   })
 })
+
+test.each(['md', 'json'])('exports the displayed conversation as %s without another network request', async (format) => {
+  const fetchMock = vi.fn(async url => url === '/api/talk/status'
+    ? response({ capabilities: { text_chat: true } })
+    : sseResponse([{ type: 'complete', text: 'Answer with Unicode ß', status: 'ok' }, { type: 'done' }]))
+  vi.stubGlobal('fetch', fetchMock)
+  const create = vi.fn(() => 'blob:transcript')
+  vi.stubGlobal('URL', Object.assign(URL, { createObjectURL: create, revokeObjectURL: vi.fn() }))
+  vi.spyOn(window.HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  render(<ODSTalk />)
+  expect(screen.getByRole('button', { name: 'Export conversation' })).toBeDisabled()
+  await screen.findByText('Ready')
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'), { target: { value: 'Keep this note' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+  await screen.findByText('Answer with Unicode ß')
+  await waitFor(() => expect(screen.getByRole('button', { name: 'Export conversation' })).toBeEnabled())
+  fireEvent.change(screen.getByLabelText('Transcript format'), { target: { value: format } })
+  const requests = fetchMock.mock.calls.length
+  fireEvent.click(screen.getByRole('button', { name: 'Export conversation' }))
+  const blob = create.mock.calls[0][0]
+  const text = await new Promise(resolve => {
+    const reader = new window.FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.readAsText(blob)
+  })
+  expect(text).toContain('Keep this note')
+  expect(text).toContain('Answer with Unicode ß')
+  expect(text).not.toContain("Hey, I'm ODS")
+  if (format === 'json') expect(JSON.parse(text).messages).toHaveLength(2)
+  expect(fetchMock).toHaveBeenCalledTimes(requests)
+})


### PR DESCRIPTION
## Why this matters

ODS Talk users can save the conversation displayed in their current tab as Markdown or structured JSON, without making a new inference request or uploading the transcript elsewhere.

## Current public-beta integration

Updated this original export PR onto current public-beta. The exporter reads visible message text/role/status, omits the welcome message, attachment file payloads and retry metadata, disables while sending/recording, and releases its temporary object URL after download. Error text retains its error status rather than being presented as a successful answer.

## Overlap check

Searched open/closed Talk export PRs and ODSTalk/TalkExport paths. This is the existing canonical transcript-export PR, not a new variant. Beta's streaming, attachment and cancellation changes remain intact; exporting does not alter their transport or lifecycle.

## Validation

- `npm test -- --maxWorkers=2 src/components/TalkExport.test.jsx src/pages/ODSTalk.test.jsx`: 18 passed. The object-URL lifecycle assertion was then added and its focused test passed again.
- Rendered ODSTalk tests download both formats without another request. Export component regression verifies busy gating, JSON field allowlist, Unicode, error status, attachment exclusion, filename and URL revocation.
- Focused ESLint has zero errors; focused pre-commit and diff check passed.
- Batch baseline dashboard 1,232 tests/build and Linux smoke/simulation passed. Existing full make gate/BATS environment/fixture failures remain disclosed. Real browser download and mobile recording behavior were not exercised live.

## Tradeoffs and rollback

This exports text from the current tab, not server history or attachment files. Downloaded text can contain sensitive conversation content and is owned by the user. Markdown preserves authored text rather than sanitizing its meaning. Revert removes export UI with no server migration or restart. Ready for independent review, not approval to merge.

## Follow-up regression receipt

Head `61e79d893acc1c8fe766bbd576f7dc9fc39f1e13` keeps export disabled while generation is busy. Focused export/page suites: **18 passed**. Three invalid Latin-1 fixture bytes in the pre-existing ODSTalk test were converted to the equivalent UTF-8 character; the rest of the file and line endings were preserved. This is a fixture encoding repair, not a production transcript rewrite.

## Final beta-batch receipt — 2026-09-16

Candidate: `61e79d893acc1c8fe766bbd576f7dc9fc39f1e13`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
