### PR TITLE
feat(invites): search and filter the access-link inventory

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -72,6 +72,8 @@ function tokenCanRevoke(token) {
 
 export default function Invites() {
   const [tokens, setTokens] = useState([])
+  const [query, setQuery] = useState('')
+  const [inventoryStatus, setInventoryStatus] = useState('all')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
   const [showOwnerCreate, setShowOwnerCreate] = useState(false)
@@ -140,8 +142,15 @@ export default function Invites() {
     )
   }
 
-  const ownerTokens = tokens.filter(isOwnerToken)
-  const guestTokens = tokens.filter(t => !isOwnerToken(t))
+  const filteredTokens = tokens.filter(token => {
+    const state = tokenStatus(token).label
+    if (inventoryStatus !== 'all' && !(inventoryStatus === 'used' ? state.startsWith('used') : state === inventoryStatus)) return false
+    const needle = query.trim().toLowerCase()
+    return !needle || [token.target_username, token.note, token.token_hash_prefix].some(value => String(value || '').toLowerCase().includes(needle))
+  })
+  const ownerTokens = filteredTokens.filter(isOwnerToken)
+  const guestTokens = filteredTokens.filter(t => !isOwnerToken(t))
+  const filtering = query.trim() || inventoryStatus !== 'all'
   const ownerCardUnavailable = ownerCardStatus?.ready === false
 
   return (
@@ -173,6 +182,15 @@ export default function Invites() {
 
       <VoiceReadiness />
 
+      <div className="mb-5 flex flex-wrap items-center gap-3 text-sm text-theme-text">
+        <input aria-label="Search access links" placeholder="Search username, note or ID" value={query} onChange={event => setQuery(event.target.value)} className="rounded-lg border border-theme-border bg-theme-card p-2" />
+        <select aria-label="Access link status" value={inventoryStatus} onChange={event => setInventoryStatus(event.target.value)} className="rounded-lg border border-theme-border bg-theme-card p-2">
+          <option value="all">All statuses</option><option value="active">Unused active</option><option value="used">Used / redeemed</option><option value="expired">Expired</option><option value="revoked">Revoked</option>
+        </select>
+        <span role="status">Showing {filteredTokens.length} of {tokens.length} access links</span>
+        {filtering && <button type="button" onClick={() => { setQuery(''); setInventoryStatus('all') }} className="text-theme-accent">Clear filters</button>}
+      </div>
+
       <section className="mb-8 bg-theme-card border border-theme-border rounded-xl p-5">
         <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
           <div>
@@ -202,7 +220,7 @@ export default function Invites() {
           </div>
         )}
 
-        {ownerTokens.length === 0 ? (
+        {filtering && ownerTokens.length === 0 ? <p className="mt-5 text-sm text-theme-text-muted">No owner cards match these filters.</p> : ownerTokens.length === 0 ? (
           <EmptyOwnerState
             onCreate={() => setShowOwnerCreate(true)}
             disabled={ownerCardUnavailable}
@@ -236,7 +254,7 @@ export default function Invites() {
           </button>
         </div>
 
-        {guestTokens.length === 0 ? (
+        {filtering && guestTokens.length === 0 ? <p className="mt-5 text-sm text-theme-text-muted">No guest invites match these filters.</p> : guestTokens.length === 0 ? (
           <EmptyGuestState onCreate={() => setShowGuestCreate(true)} />
         ) : (
           <div className="mt-5 space-y-3">

--- a/ods/extensions/services/dashboard/src/pages/Invites.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.test.jsx
@@ -251,3 +251,26 @@ describe('Invites', () => {
     expect(screen.getByRole('button', { name: 'Create owner card' })).toBeDisabled()
   })
 })
+
+test('searches access inventory and combines lifecycle filters without mutating credentials', async () => {
+  const tokens = [
+    { token_hash_prefix: 'owner-id', target_username: 'Alice', token_type: 'owner', note: 'Factory North', expires_at: null, redemption_count: 2, reusable: true },
+    { token_hash_prefix: 'guest-id', target_username: 'Bob', note: 'Workshop', expires_at: '2000-01-01T00:00:00Z', redemption_count: 0 },
+    { token_hash_prefix: 'revoked-id', target_username: 'Carol', revoked_at: future, redemption_count: 0 },
+  ]
+  const fetchMock = vi.fn(async url => response(url === '/api/auth/magic-link/list' ? { tokens } : ownerCardReady))
+  vi.stubGlobal('fetch', fetchMock)
+  render(<Invites />)
+  await screen.findByText('Alice')
+  fireEvent.change(screen.getByLabelText('Search access links'), { target: { value: 'factory north' } })
+  expect(screen.getByText('Alice')).toBeInTheDocument()
+  expect(screen.queryByText('Bob')).not.toBeInTheDocument()
+  fireEvent.change(screen.getByLabelText('Access link status'), { target: { value: 'expired' } })
+  expect(screen.getByText('Showing 0 of 3 access links')).toBeInTheDocument()
+  expect(screen.queryByText('No owner cards yet')).not.toBeInTheDocument()
+  fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }))
+  fireEvent.change(screen.getByLabelText('Access link status'), { target: { value: 'used' } })
+  expect(screen.getByText('Alice')).toBeInTheDocument()
+  expect(screen.queryByText('Carol')).not.toBeInTheDocument()
+  expect(fetchMock.mock.calls.every(([, init]) => !init?.method || init.method === 'GET')).toBe(true)
+})


### PR DESCRIPTION
## Why this matters

Owners with many access cards and guest links need to locate credentials by username, note or visible ID and distinguish unused, used, expired and revoked records without mutating credentials.

## Current public-beta integration

Updated the original inventory-filter PR and retained beta's owner-access layout, authenticated creation/revocation boundaries and expiry clock. Search and status filters intersect. Whole-inventory access summaries do not shrink when filters hide rows. Guest records enter/leave the active/expired view at their expiry boundary without additional requests. A filtered empty result does not pretend no cards exist.

## Overlap check

Searched all-state invite inventory/search/filter PRs and Invites.jsx changes. This original PR is the canonical filter scope. #5295 handles expiry timing, #5291 creation pending state, #4955 dialog focus, #4353 deadlines and #4210 layout; their current beta behavior is preserved. No replacement PR was created.

## Validation

- `npm test -- --maxWorkers=2 src/pages/Invites`: 4 suites, 24 passed, including creation, deadlines, focus, filtering and expiry.
- Regression at the rendered page verifies combined search/status, non-mutating requests, global summary under a zero-match filter, and automatic filtered-view expiry. Follow-up `d3acf90bb7d93a49903bc235da8171c576384cf7` additionally verifies username, note and visible-ID search at the page boundary.
- Focused ESLint: zero errors (existing JSX warnings). Focused pre-commit and diff check passed.
- Batch baseline dashboard tests/build and Linux smoke/simulation passed; full make gate/BATS retain pre-existing environment/fixture failures. No live credential or browser mutation was performed.

## Tradeoffs and rollback

Filtering uses the already-authorized inventory response; no new API, polling or credential persistence. It is a view filter, not authorization. Reverting removes controls without changing any credential. Ready for independent review; no merge is requested by this automation.

## Final beta-batch receipt — 2026-09-16

Candidate: `d3acf90bb7d93a49903bc235da8171c576384cf7`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
