### PR TITLE
feat(usage): rank model activity and cost before pagination

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -816,26 +816,38 @@ function UsageByModelTable({ rows }) {
   const [provider, setProvider] = useState('all')
   const [service, setService] = useState('all')
   const [source, setSource] = useState('all')
+  const [sort, setSort] = useState('original')
   const [page, setPage] = useState(0)
   const providers = useMemo(() => ['all', ...new Set(rows.map(row => row.provider || 'unknown'))], [rows])
   const services = useMemo(() => ['all', ...new Set(rows.map(row => row.service || 'unknown'))], [rows])
   const sources = useMemo(() => ['all', ...new Set(rows.map(row => row.cost_source || 'untracked'))], [rows])
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase()
-    return rows.filter(row => {
+    const matches = rows.filter(row => {
       if (provider !== 'all' && (row.provider || 'unknown') !== provider) return false
       if (service !== 'all' && (row.service || 'unknown') !== service) return false
       if (source !== 'all' && (row.cost_source || 'untracked') !== source) return false
       if (!q) return true
       return [row.model, row.provider, row.service, row.cost_source].some(value => String(value || '').toLowerCase().includes(q))
     })
-  }, [provider, query, rows, service, source])
+    if (sort === 'original') return matches
+    const [field, direction] = sort.split(':')
+    return matches.sort((a, b) => {
+      const left = a[field]
+      const right = b[field]
+      if (field === 'model') return String(left || '').localeCompare(String(right || '')) * (direction === 'asc' ? 1 : -1)
+      const leftKnown = typeof left === 'number' && Number.isFinite(left) && (field !== 'cost_usd' || a.cost_source !== 'untracked')
+      const rightKnown = typeof right === 'number' && Number.isFinite(right) && (field !== 'cost_usd' || b.cost_source !== 'untracked')
+      if (leftKnown !== rightKnown) return leftKnown ? -1 : 1
+      return leftKnown ? (left - right) * (direction === 'asc' ? 1 : -1) : 0
+    })
+  }, [provider, query, rows, service, source, sort])
   const pageSize = 10
   const pageCount = Math.max(Math.ceil(filtered.length / pageSize), 1)
   const safePage = Math.min(page, pageCount - 1)
   const visible = filtered.slice(safePage * pageSize, safePage * pageSize + pageSize)
 
-  useEffect(() => { setPage(0) }, [provider, query, service, source])
+  useEffect(() => { setPage(0) }, [provider, query, service, source, sort])
 
   const exportCsv = () => {
     const header = ['model', 'provider', 'service', 'input_tokens', 'output_tokens', 'cache_read_tokens', 'requests', 'cost_usd', 'cost_source']
@@ -857,6 +869,12 @@ function UsageByModelTable({ rows }) {
       <div className="flex min-h-[330px] flex-col p-3.5">
         <div className="mb-3 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <h2 className="whitespace-nowrap text-lg font-semibold">Usage by Model</h2>
+          <select aria-label="Rank model usage" value={sort} onChange={event => setSort(event.target.value)} className="h-9 rounded-md border border-theme-border bg-theme-card px-2 text-xs">
+            <option value="original">Report order</option>
+            <option value="cost_usd:desc">Highest cost</option><option value="cost_usd:asc">Lowest cost</option>
+            <option value="requests:desc">Most requests</option><option value="input_tokens:desc">Most input tokens</option>
+            <option value="output_tokens:desc">Most output tokens</option><option value="model:asc">Model name A–Z</option>
+          </select>
           <div className="grid gap-2 lg:grid-cols-[minmax(160px,1fr)_136px_136px_136px_auto]">
             <SearchBox value={query} onChange={setQuery} />
             <Select value={provider} onChange={setProvider} options={providers} label="All Providers" />

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -836,8 +836,8 @@ function UsageByModelTable({ rows }) {
       const left = a[field]
       const right = b[field]
       if (field === 'model') return String(left || '').localeCompare(String(right || '')) * (direction === 'asc' ? 1 : -1)
-      const leftKnown = typeof left === 'number' && Number.isFinite(left) && (field !== 'cost_usd' || a.cost_source !== 'untracked')
-      const rightKnown = typeof right === 'number' && Number.isFinite(right) && (field !== 'cost_usd' || b.cost_source !== 'untracked')
+      const leftKnown = typeof left === 'number' && Number.isFinite(left) && (field !== 'cost_usd' || (Object.hasOwn(SOURCE_META, a.cost_source) && a.cost_source !== 'untracked'))
+      const rightKnown = typeof right === 'number' && Number.isFinite(right) && (field !== 'cost_usd' || (Object.hasOwn(SOURCE_META, b.cost_source) && b.cost_source !== 'untracked'))
       if (leftKnown !== rightKnown) return leftKnown ? -1 : 1
       return leftKnown ? (left - right) * (direction === 'asc' ? 1 : -1) : 0
     })

--- a/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
@@ -385,6 +385,7 @@ describe('Usage page', () => {
 test('ranks the complete filtered inventory before pagination and keeps unknown costs last', async () => {
   const models = Array.from({ length: 12 }, (_, index) => ({ ...currentReport.models[0], model: `ranked-${index}`, requests: index, cost_usd: index }))
   models[11] = { ...models[11], cost_source: 'untracked', cost_usd: 0 }
+  models[10] = { ...models[10], cost_source: undefined, cost_usd: 0 }
   const originalOrder = models.map(row => row.model)
   installFetchMock({ current: { ...currentReport, models } })
   render(<Usage status={{}} />)
@@ -397,4 +398,5 @@ test('ranks the complete filtered inventory before pagination and keeps unknown 
   expect(screen.getByText('ranked-0')).toBeInTheDocument()
   expect(screen.queryByText('ranked-11')).not.toBeInTheDocument()
   expect(models.map(row => row.model)).toEqual(originalOrder)
+  expect(screen.queryByText('ranked-10')).not.toBeInTheDocument()
 })

--- a/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.test.jsx
@@ -381,3 +381,20 @@ describe('Usage page', () => {
     })
   })
 })
+
+test('ranks the complete filtered inventory before pagination and keeps unknown costs last', async () => {
+  const models = Array.from({ length: 12 }, (_, index) => ({ ...currentReport.models[0], model: `ranked-${index}`, requests: index, cost_usd: index }))
+  models[11] = { ...models[11], cost_source: 'untracked', cost_usd: 0 }
+  const originalOrder = models.map(row => row.model)
+  installFetchMock({ current: { ...currentReport, models } })
+  render(<Usage status={{}} />)
+  await screen.findByText('ranked-0')
+  expect(screen.queryByText('ranked-11')).not.toBeInTheDocument()
+  fireEvent.change(screen.getByLabelText('Rank model usage'), { target: { value: 'requests:desc' } })
+  expect(screen.getByText('ranked-11')).toBeInTheDocument()
+  expect(screen.queryByText('ranked-0')).not.toBeInTheDocument()
+  fireEvent.change(screen.getByLabelText('Rank model usage'), { target: { value: 'cost_usd:asc' } })
+  expect(screen.getByText('ranked-0')).toBeInTheDocument()
+  expect(screen.queryByText('ranked-11')).not.toBeInTheDocument()
+  expect(models.map(row => row.model)).toEqual(originalOrder)
+})


### PR DESCRIPTION
## Why this matters
The Usage table can rank the entire filtered inventory by cost, requests, input/output tokens or model name before selecting a page. CSV export inherits the same ordering. Unknown/untracked costs remain last in either cost direction; source report objects are never sorted in place.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files, inspected related scopes, and refreshed latest PRs through #3842 before publication.

Changed surface: Usage.jsx.

#3043 isolates report failures; #3051 deduplicates actions; #3185 labels pagination; existing helper PRs test calculations. #3839 fixes CSV escaping in the same table but does not rank rows. Combined validation preserves both changes.

## Regression and focused validation
Usage.test.jsx + Usage.history.test.jsx: 12 passed. A 12-model page fixture proves a formerly off-page high-usage row reaches page one, unknown costs stay last and the source array retains its order.

## Tradeoffs, rollback and remaining validation
The default retains report order. Ranking changes presentation, not billing totals or price estimation. No external spreadsheet or live billing account was used. Revert restores fixed report ordering.

## Batch integration and validation limits
All ten feature branches start independently from upstream main `21f4b3a6`. Feature integration: `9b4005885390603b9473992fd41c12621214f746` on `integration/feat-ten-20260908`. No merge-order dependency within this batch. Suggested review order follows the numbered feature list, but each PR is useful independently.

Also validated these features together with preceding fixes #3833–#3842 on combined integration `155e728a045e20a40eedba2893308199663faa85` (`integration/feat-and-fixes-20260908` on tang-vu/DreamServer): **270 UI tests and 103 related API tests passed**, plus real Fish and healthcheck boundary tests. Production files merged cleanly; the Makefile conflict was resolved by retaining all five standalone test registrations. This includes the invite refresh, CSV escaping, workflow pagination and healthcheck error-body fixes where files overlap.

Feature-only dashboard testing initially passed 265 tests; the subsequent storage-quota test passed in the 12-test Extensions suite and final 270-test combined run. Dashboard lint/build, CI-equivalent Ruff, shell/Python syntax, platform smoke and installer simulation passed. Local `make gate` is NOT green: the existing Hermes max_tokens contract fails on unchanged main too. BATS: 408 passed, 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer tests, reproducing the preceding baseline. Pre-commit gitleaks/size/shell hooks passed; private-key detection still flags the two unchanged dummy-key test fixtures. No fixture exclusions were added. Linux/WSL tests and mocked transports do not establish live hardware, migration or provider behavior.

Final review follow-up: `dfd62230` also treats missing/unrecognized Usage cost provenance as unknown. Latest feature integration is `333b4adfc3ca4fed08b50b17ff4fb2b2efddc781`; latest combined integration is `f74ddbc317bb72e2d41bade6fb22d73c962f16bd`. The affected 13-test Usage/history/CSV suite and dashboard lint passed on that combined head; the 270-test full UI receipt above is bound to its stated predecessor.

GitHub checks completed for candidate `dfd62230a3cd9b38630aa627ebf65b7781b22a85`: 28 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed. Local baseline and live-validation limits above still apply.

