### PR TITLE
feat(healthcheck): enforce operator latency budgets

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -124,6 +124,7 @@ test: ## Run unit and contract tests
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
 	@bash tests/test-backup-data-coverage.sh
+	@python3 tests/test-healthcheck-latency.py
 	@echo ""
 	@echo "=== backup integrity and restore round-trip ==="
 	@bash tests/test-backup-integrity.sh

--- a/ods/docs/HEALTHCHECK_LATENCY.md
+++ b/ods/docs/HEALTHCHECK_LATENCY.md
@@ -1,0 +1,12 @@
+# Healthcheck latency budgets
+
+Use a latency budget when a listening service can still be too slow for callers:
+
+```bash
+python3 scripts/healthcheck.py http://127.0.0.1:8080/health --max-latency-ms 500 --json
+python3 scripts/healthcheck.py tcp://127.0.0.1:6333 --max-latency-ms 200 --retries 0
+```
+
+The positive integer budget covers the complete probe, including retries and their waits. An otherwise successful probe exceeding the budget exits 1 and reports `ok: false`, measured `elapsed_ms`, and a `latency budget exceeded` detail. HTTP status is preserved. Existing connection/status/body failures retain their own diagnostic; a fast failure never becomes healthy.
+
+This is an acceptance threshold, not cancellation: `--timeout` still controls request/connection waiting. Without the new flag, behavior is unchanged. It measures this probe's duration rather than application inference throughput or a percentile over multiple requests. The dependency-free script uses the same behavior on Linux, macOS and Windows with Python.

--- a/ods/scripts/healthcheck.py
+++ b/ods/scripts/healthcheck.py
@@ -22,6 +22,7 @@ Options
 -------
   --timeout SECONDS              Overall timeout for the request/connection
   --retries N                    Retry count (with small backoff)
+  --max-latency-ms N              Fail successful checks exceeding N milliseconds
   --method {HEAD,GET}            HTTP method (default: HEAD, with GET fallback)
   --expect-status 200,204,3xx    Allowed HTTP status codes/ranges
   --expect-body-regex REGEX      Regex to match in response body (GET only)
@@ -53,7 +54,7 @@ import sys
 import time
 import urllib.error
 import urllib.request
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import List, Optional, Sequence, Set, Tuple
 
 
@@ -265,11 +266,19 @@ def with_retries(fn, *, retries: int, base_sleep: float = 0.15):
 # -----------------------------
 
 
+def _latency_budget(value: str) -> int:
+    budget = int(value)
+    if budget <= 0:
+        raise argparse.ArgumentTypeError("latency budget must be a positive integer in milliseconds")
+    return budget
+
+
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     p = argparse.ArgumentParser(prog="healthcheck.py", add_help=True)
     p.add_argument("target", help="http(s) URL, tcp://host:port, or host:port")
     p.add_argument("--timeout", type=float, default=5.0, help="Timeout seconds (default: 5)")
     p.add_argument("--retries", type=int, default=1, help="Retry count (default: 1)")
+    p.add_argument("--max-latency-ms", type=_latency_budget, help="Maximum total check duration in milliseconds, including retries; does not cancel requests")
     p.add_argument("--method", default="HEAD", choices=["HEAD", "GET"], help="HTTP method")
     p.add_argument(
         "--expect-status",
@@ -391,6 +400,9 @@ def main(argv: Sequence[str]) -> int:
             status=int(status) if status is not None else None,
             elapsed_ms=elapsed_ms,
         )
+
+    if res.ok and args.max_latency_ms is not None and res.elapsed_ms > args.max_latency_ms:
+        res = replace(res, ok=False, detail=f"latency budget exceeded: {res.elapsed_ms}ms > {args.max_latency_ms}ms")
 
     if args.json:
         print(res.to_json())

--- a/ods/tests/test-healthcheck-latency.py
+++ b/ods/tests/test-healthcheck-latency.py
@@ -1,0 +1,53 @@
+"""Real CLI probes distinguish slow success from an operator latency budget."""
+import json
+import subprocess
+import sys
+import threading
+import time
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / 'scripts/healthcheck.py'
+
+
+class LatencyBudgetTest(unittest.TestCase):
+    def test_slow_success_and_existing_failure(self):
+        class Handler(BaseHTTPRequestHandler):
+            def do_HEAD(self):
+                time.sleep(0.05)
+                self.send_response(int(self.path[1:]))
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+        thread = threading.Thread(target=server.serve_forever)
+        thread.start()
+        try:
+            for status, budget, expected in [(200, None, 0), (200, '10000', 0), (200, '1', 1), (503, '1', 1)]:
+                with self.subTest(status=status, budget=budget):
+                    args = [sys.executable, str(SCRIPT), f'http://127.0.0.1:{server.server_port}/{status}', '--retries', '0', '--json']
+                    if budget:
+                        args += ['--max-latency-ms', budget]
+                    result = subprocess.run(args, capture_output=True, text=True, timeout=10)
+                    self.assertEqual(result.returncode, expected, result.stderr)
+                    payload = json.loads(result.stdout)
+                    self.assertEqual(payload['status'], status)
+                    self.assertEqual(payload['ok'], expected == 0)
+                    self.assertEqual('latency budget exceeded' in payload['detail'], status == 200 and budget == '1')
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join()
+
+    def test_invalid_budgets_fail_before_connecting(self):
+        for budget in ('0', '-1', 'nan', 'inf', '1.5'):
+            with self.subTest(budget=budget):
+                result = subprocess.run([sys.executable, str(SCRIPT), 'http://127.0.0.1:1', '--max-latency-ms', budget], capture_output=True, timeout=5)
+                self.assertEqual(result.returncode, 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Why this matters

A health endpoint can answer correctly but too slowly for an operator's readiness threshold. Status/body success alone cannot express that acceptance criterion.

## Feature and overlap check

Add --max-latency-ms as a positive integer threshold on the completed probe, including existing retries. Preserve status and the original diagnostic for already-failed checks. Updated the original PR onto beta and reconciled first-hop redirect support. Searched all-state health latency and healthcheck.py: #3837 status/body conjunction, #4883 redirect selection and #5272 overall retry deadline are different contracts. This threshold evaluates completion; it is not cancellation.

## Validation

Linux Python3.11: `pytest -q tests/test-healthcheck-latency.py tests/test_healthcheck_redirect_policy.py`: 13 passed. Real local HTTP/CLI tests cover delayed success with absent/generous/tight thresholds, preserved HTTP failure and invalid inputs before connecting. Focused pre-commit/diff check passed; wired into make test. Baseline smoke/simulation passed; full gate/BATS retain known failures. No production service latency claim.

## Rollback

Omit the flag for prior behavior; --timeout still controls waiting. It measures one probe, not percentiles or inference throughput. Revert removes the optional flag; no state migration. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `f141a2ac78315eb082db217b0b6aa05e500ceb4a`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
