### PR TITLE
feat(cli): add native Fish completions and preset discovery

### DIFF
--- a/.github/workflows/fish-completions.yml
+++ b/.github/workflows/fish-completions.yml
@@ -1,0 +1,17 @@
+name: Fish completions
+on:
+  pull_request:
+    paths: ['ods/completions/**', 'ods/tests/test-fish-completions.py', '.github/workflows/fish-completions.yml']
+  push:
+    branches: [main]
+    paths: ['ods/completions/**', 'ods/tests/test-fish-completions.py', '.github/workflows/fish-completions.yml']
+permissions:
+  contents: read
+jobs:
+  fish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - run: sudo apt-get update && sudo apt-get install -y fish
+      - run: fish --no-execute ods/completions/ods.fish ods/completions/ods-cli.fish
+      - run: python3 ods/tests/test-fish-completions.py

--- a/ods/completions/README.md
+++ b/ods/completions/README.md
@@ -1,0 +1,18 @@
+# Shell completion
+
+## Fish 3.6 and newer
+
+From the `ods/` directory, install both autoload files:
+
+```fish
+mkdir -p ~/.config/fish/completions
+cp completions/ods.fish completions/ods-cli.fish ~/.config/fish/completions/
+```
+
+Open a new Fish session, then try `ods gpu <TAB>`, `ods logs <TAB>`, `ods preset load <TAB>` or `ods update --<TAB>`. Both `ods` and `ods-cli` are supported. Main commands, nested subcommands, common built-in services and selected flags are suggested only at the matching argument position. Custom service IDs can still be typed manually.
+
+Saved preset suggestions read directories with `meta.txt` and `extensions.list` under `INSTALL_DIR/presets`, then `ODS_HOME/presets`, then `ODS_INSTALL_DIR/presets`, or `~/ods/presets` when no override is set. For a custom installation resolved through a script hint or symlink, explicitly set `INSTALL_DIR` in Fish. No `.env` or preset values are sourced, and completion never starts ODS, Docker or a network call.
+
+Validation: `python3 tests/test-fish-completions.py` with Fish installed. Remove the two copied files to uninstall completion. Existing Bash completion remains available in `ods-cli.bash`.
+
+The implementation uses Fish's native [completion API](https://fishshell.com/docs/3.6/cmds/complete.html), not Bash compatibility mode.

--- a/ods/completions/ods-cli.fish
+++ b/ods/completions/ods-cli.fish
@@ -1,0 +1,2 @@
+# Fish autoload entry point for users invoking the script by its full name.
+source (path dirname (status filename))/ods.fish

--- a/ods/completions/ods.fish
+++ b/ods/completions/ods.fish
@@ -3,7 +3,8 @@ function __ods_at
     set -l words (commandline -opc)
     test (count $words) -eq (math (count $argv) + 1); or return 1
     for index in (seq (count $argv))
-        test "$words[(math $index + 1)]" = "$argv[$index]"; or return 1
+        set -l word_index (math $index + 1)
+        test "$words[$word_index]" = "$argv[$index]"; or return 1
     end
 end
 

--- a/ods/completions/ods.fish
+++ b/ods/completions/ods.fish
@@ -1,0 +1,51 @@
+# Native Fish completions. Sourcing this file never invokes ODS or Docker.
+function __ods_at
+    set -l words (commandline -opc)
+    test (count $words) -eq (math (count $argv) + 1); or return 1
+    for index in (seq (count $argv))
+        test "$words[(math $index + 1)]" = "$argv[$index]"; or return 1
+    end
+end
+
+function __ods_presets
+    set -l root "$HOME/ods"
+    if set -q INSTALL_DIR; and test -n "$INSTALL_DIR"
+        set root "$INSTALL_DIR"
+    else if set -q ODS_HOME; and test -n "$ODS_HOME"
+        set root "$ODS_HOME"
+    else if set -q ODS_INSTALL_DIR; and test -n "$ODS_INSTALL_DIR"
+        set root "$ODS_INSTALL_DIR"
+    end
+    for directory in "$root"/presets/*/
+        if test -f "$directory/meta.txt"; and test -f "$directory/extensions.list"
+            string escape -- (path basename "$directory")
+        end
+    end
+end
+
+set -l commands gpu status status-json list enable disable purge preset mode model remote-provider stt backup restore rollback logs restart repair start stop update shell config chat benchmark doctor audit template agent help version
+set -l services ape embeddings llama-server n8n open-webui opencode qdrant searxng tts whisper llm webui vector search kokoro voice stt
+for executable in ods ods-cli
+    complete -c $executable -f
+    complete -c $executable -n '__ods_at' -a "$commands"
+    complete -c $executable -n '__ods_at gpu' -a 'status topology assignment validate reassign help'
+    complete -c $executable -n '__ods_at preset' -a 'save load list delete export import diff'
+    complete -c $executable -n '__ods_at mode' -a 'local cloud hybrid'
+    complete -c $executable -n '__ods_at model' -a 'current list swap'
+    complete -c $executable -n '__ods_at config' -a 'show edit validate'
+    complete -c $executable -n '__ods_at template' -a 'list preview apply'
+    complete -c $executable -n '__ods_at agent' -a 'status start stop restart logs'
+    complete -c $executable -n '__ods_at remote-provider' -a 'status plan configure test disable remove peer-models'
+    complete -c $executable -n '__ods_at remote-provider peer-models' -a 'list'
+    for operation in enable disable purge logs restart start stop shell
+        complete -c $executable -n "__ods_at $operation" -a "$services"
+    end
+    for operation in load delete export diff
+        complete -c $executable -n "__ods_at preset $operation" -a '(__ods_presets)'
+    end
+    complete -c $executable -n '__ods_at preset import' -F
+    complete -c $executable -n '__ods_at restore' -F
+    complete -c $executable -n '__ods_at doctor' -l json -d 'Print a JSON diagnostic report'
+    complete -c $executable -n '__ods_at gpu reassign' -l dry-run -d 'Preview GPU reassignment'
+    complete -c $executable -n '__ods_at update' -l dry-run -d 'Preview update changes'
+end

--- a/ods/tests/test-fish-completions.py
+++ b/ods/tests/test-fish-completions.py
@@ -1,0 +1,33 @@
+"""Ask real Fish for interactive completion candidates without running ODS."""
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+COMPLETION = Path(__file__).resolve().parents[1] / 'completions/ods.fish'
+
+
+class FishCompletionTest(unittest.TestCase):
+    def complete(self, line, root):
+        result = subprocess.run(['fish', '--no-config', '-c', 'source "$argv[1]"; complete -C "$argv[2]"', str(COMPLETION), line], env={**os.environ, 'INSTALL_DIR': str(root)}, capture_output=True, text=True, check=True)
+        return result.stdout
+
+    def test_command_context_alias_and_saved_presets(self):
+        with tempfile.TemporaryDirectory(prefix='ods fish ') as root:
+            preset = Path(root) / 'presets' / 'office setup'
+            preset.mkdir(parents=True)
+            (preset / 'meta.txt').touch()
+            (preset / 'extensions.list').touch()
+            (Path(root) / 'presets' / 'incomplete').mkdir()
+            self.assertIn('remote-provider', self.complete('ods remote', root))
+            self.assertIn('llama-server', self.complete('ods-cli logs llama', root))
+            self.assertIn('office', self.complete('ods preset load ', root))
+            self.assertNotIn('incomplete', self.complete('ods preset load ', root))
+            self.assertNotIn('office', self.complete('ods model ', root))
+            self.assertIn('--dry-run', self.complete('ods gpu reassign --dry', root))
+            self.assertNotIn('--dry-run', self.complete('ods gpu status --dry', root))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/ods/tests/test-fish-completions.py
+++ b/ods/tests/test-fish-completions.py
@@ -11,6 +11,7 @@ COMPLETION = Path(__file__).resolve().parents[1] / 'completions/ods.fish'
 class FishCompletionTest(unittest.TestCase):
     def complete(self, line, root):
         result = subprocess.run(['fish', '--no-config', '-c', 'source "$argv[1]"; complete -C "$argv[2]"', str(COMPLETION), line], env={**os.environ, 'INSTALL_DIR': str(root)}, capture_output=True, text=True, check=True)
+        self.assertEqual(result.stderr, '', result.stderr)
         return result.stdout
 
     def test_command_context_alias_and_saved_presets(self):
@@ -22,7 +23,7 @@ class FishCompletionTest(unittest.TestCase):
             (Path(root) / 'presets' / 'incomplete').mkdir()
             self.assertIn('remote-provider', self.complete('ods remote', root))
             self.assertIn('llama-server', self.complete('ods-cli logs llama', root))
-            self.assertIn('office', self.complete('ods preset load ', root))
+            self.assertIn('office setup', self.complete('ods preset load ', root).replace('\\ ', ' '))
             self.assertNotIn('incomplete', self.complete('ods preset load ', root))
             self.assertNotIn('office', self.complete('ods model ', root))
             self.assertIn('--dry-run', self.complete('ods gpu reassign --dry', root))


### PR DESCRIPTION
## Why this matters
Fish users gain context-sensitive completion for ods and ods-cli, including nested GPU/provider commands, common services, flags and actual saved preset directories. The completion code does not invoke ODS/Docker/network operations or source configuration values. Preset discovery handles paths and names with spaces.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files, inspected related scopes, and refreshed latest PRs through #3842 before publication.

Changed surface: ods/completions/ods.fish, ods-cli.fish, README.md and .github/workflows/fish-completions.yml.

#3615 adds native Zsh; #3685 fixes Bash preset-directory discovery. Those affect other shells; open/closed Fish/completion searches found no equivalent implementation.

## Regression and focused validation
python3 tests/test-fish-completions.py: passed against real Fish 4.2.1. Checks actual complete -C candidates for both executable names, nested flag scope, valid preset metadata and a space-containing preset name. Added dedicated CI with Fish installation and syntax/runtime tests.

## Tradeoffs, rollback and remaining validation
Supports the documented main command names, common built-in services and explicit preset directory overrides; custom IDs remain typable. Read docs for installation resolution limits. No macOS/WSL interactive terminal UX qualification is claimed beyond Linux Fish execution. Remove the two installed completion files to roll back.

## Batch integration and validation limits
All ten feature branches start independently from upstream main `21f4b3a6`. Feature integration: `9b4005885390603b9473992fd41c12621214f746` on `integration/feat-ten-20260908`. No merge-order dependency within this batch. Suggested review order follows the numbered feature list, but each PR is useful independently.

Also validated these features together with preceding fixes #3833–#3842 on combined integration `155e728a045e20a40eedba2893308199663faa85` (`integration/feat-and-fixes-20260908` on tang-vu/DreamServer): **270 UI tests and 103 related API tests passed**, plus real Fish and healthcheck boundary tests. Production files merged cleanly; the Makefile conflict was resolved by retaining all five standalone test registrations. This includes the invite refresh, CSV escaping, workflow pagination and healthcheck error-body fixes where files overlap.

Feature-only dashboard testing initially passed 265 tests; the subsequent storage-quota test passed in the 12-test Extensions suite and final 270-test combined run. Dashboard lint/build, CI-equivalent Ruff, shell/Python syntax, platform smoke and installer simulation passed. Local `make gate` is NOT green: the existing Hermes max_tokens contract fails on unchanged main too. BATS: 408 passed, 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer tests, reproducing the preceding baseline. Pre-commit gitleaks/size/shell hooks passed; private-key detection still flags the two unchanged dummy-key test fixtures. No fixture exclusions were added. Linux/WSL tests and mocked transports do not establish live hardware, migration or provider behavior.

Final review follow-up: `dfd62230` also treats missing/unrecognized Usage cost provenance as unknown. Latest feature integration is `333b4adfc3ca4fed08b50b17ff4fb2b2efddc781`; latest combined integration is `f74ddbc317bb72e2d41bade6fb22d73c962f16bd`. The affected 13-test Usage/history/CSV suite and dashboard lint passed on that combined head; the 270-test full UI receipt above is bound to its stated predecessor.

GitHub checks completed for candidate `43b240654ee642330682774c003621b53ce85288`: 30 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed. Local baseline and live-validation limits above still apply.

