### PR TITLE
feat(workflows): export portable installed n8n definitions

### DIFF
--- a/ods/docs/WORKFLOW_EXPORT.md
+++ b/ods/docs/WORKFLOW_EXPORT.md
@@ -1,0 +1,15 @@
+# Export an installed workflow
+
+Save a portable copy before editing an installed n8n workflow or moving it to another ODS box. Read `/api/workflows` and use the selected item's `n8nId` (not its catalog ID):
+
+```bash
+curl --fail --header "Authorization: Bearer $DASHBOARD_API_KEY" \
+  "http://127.0.0.1:3002/api/workflows/n8n/WORKFLOW_ID/export" \
+  --output workflow.json
+```
+
+The authenticated endpoint downloads `name`, `nodes`, `connections` and `settings` from the installed definition. It excludes execution state, sharing metadata, activation state and the source instance's workflow ID. It does not read the bundled template and never changes or disables the source workflow. Import the JSON through n8n's workflow import interface, then review credentials and activate explicitly when ready.
+
+Node parameters and credential references are part of the definition: review them before sharing. This is not a credential backup or a secret-redaction tool; values manually embedded in node parameters are included. Credential-store secrets and execution history are not fetched. Responses use `Cache-Control: no-store`.
+
+Missing workflows return 404, malformed or failed upstream responses return 502, and the ten-second upstream deadline returns 504. The exporter refuses upstream redirects. The contract uses the public GET workflow API of the shipped [n8n 2.6.4](https://github.com/n8n-io/n8n/blob/n8n%402.6.4/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml). Automated tests mock this transport; a live export/import round trip remains unverified.

--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -7,6 +7,7 @@ import re
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
 
 from config import (
     SERVICES, WORKFLOW_DIR, WORKFLOW_CATALOG_FILE,
@@ -98,6 +99,32 @@ async def check_n8n_available() -> bool:
 
 
 # --- Endpoints ---
+
+@router.get("/api/workflows/n8n/{n8n_id}/export")
+async def export_installed_workflow(n8n_id: str, api_key: str = Depends(verify_api_key)):
+    """Export an installed n8n workflow's portable definition without modifying it."""
+    _validate_workflow_id(n8n_id)
+    headers = {"X-N8N-API-KEY": N8N_API_KEY} if N8N_API_KEY else {}
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+            async with session.get(f"{N8N_URL}/api/v1/workflows/{n8n_id}", headers=headers, params={"excludePinnedData": "true"}, allow_redirects=False) as response:
+                if response.status == 404:
+                    raise HTTPException(status_code=404, detail="Installed workflow not found")
+                if response.status != 200:
+                    raise HTTPException(status_code=502, detail="n8n could not export the workflow")
+                workflow = await response.json()
+    except asyncio.TimeoutError as exc:
+        raise HTTPException(status_code=504, detail="n8n workflow export timed out") from exc
+    except (aiohttp.ClientError, OSError, json.JSONDecodeError) as exc:
+        raise HTTPException(status_code=502, detail="n8n workflow export unavailable") from exc
+    if not isinstance(workflow, dict) or not isinstance(workflow.get("name"), str) or not isinstance(workflow.get("nodes"), list) or not isinstance(workflow.get("connections"), dict) or not isinstance(workflow.get("settings", {}), dict):
+        raise HTTPException(status_code=502, detail="n8n returned an invalid workflow definition")
+    portable = {key: workflow[key] for key in ("name", "nodes", "connections")}
+    portable["settings"] = workflow.get("settings", {})
+    return JSONResponse(portable, headers={
+        "Content-Disposition": f'attachment; filename="ods-workflow-{n8n_id}.json"',
+        "Cache-Control": "no-store",
+    })
 
 @router.get("/api/workflows/categories")
 async def api_workflow_categories(api_key: str = Depends(verify_api_key)):

--- a/ods/extensions/services/dashboard-api/tests/test_workflow_export.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflow_export.py
@@ -1,0 +1,38 @@
+"""Authenticated portable exports use exact n8n identity and never mutate it."""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+@pytest.mark.parametrize('mode,expected', [('ok', 200), ('missing', 404), ('denied', 502), ('malformed', 502), ('timeout', 504)])
+def test_export_boundary(test_client, monkeypatch, mode, expected):
+    from routers import workflows
+    source = {'id': 'wf-42', 'name': 'Saved workflow', 'nodes': [{'id': 'a', 'parameters': {'text': 'Hello'}}], 'connections': {}, 'settings': {'executionOrder': 'v1'}, 'active': True, 'staticData': {'cursor': 'private-runtime-state'}, 'shared': [{'userId': 'owner'}]}
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.__aexit__ = AsyncMock(return_value=False)
+    response = MagicMock(status={'missing': 404, 'denied': 401}.get(mode, 200))
+    response.json = AsyncMock(return_value=[] if mode == 'malformed' else source)
+    session.get.return_value.__aenter__ = AsyncMock(return_value=response)
+    session.get.return_value.__aexit__ = AsyncMock(return_value=False)
+    if mode == 'timeout':
+        session.get.return_value.__aenter__.side_effect = asyncio.TimeoutError
+    monkeypatch.setattr(workflows.aiohttp, 'ClientSession', lambda **kwargs: session)
+    monkeypatch.setattr(workflows, 'N8N_API_KEY', 'server-only-key')
+    result = test_client.get('/api/workflows/n8n/wf-42/export', headers=test_client.auth_headers)
+    assert result.status_code == expected
+    session.get.assert_called_once_with(f'{workflows.N8N_URL}/api/v1/workflows/wf-42', headers={'X-N8N-API-KEY': 'server-only-key'}, params={'excludePinnedData': 'true'}, allow_redirects=False)
+    session.post.assert_not_called()
+    session.patch.assert_not_called()
+    assert 'server-only-key' not in result.text
+    if expected == 200:
+        assert result.json() == {key: source[key] for key in ('name', 'nodes', 'connections', 'settings')}
+        assert source['active'] is True
+        assert result.headers['cache-control'] == 'no-store'
+        assert result.headers['content-disposition'] == 'attachment; filename="ods-workflow-wf-42.json"'
+
+
+def test_export_rejects_unauthenticated_and_invalid_identity(test_client):
+    assert test_client.get('/api/workflows/n8n/wf-42/export').status_code == 401
+    assert test_client.get('/api/workflows/n8n/bad%20id/export', headers=test_client.auth_headers).status_code == 400


### PR DESCRIPTION
## Why this matters
Authenticated clients can export a selected installed workflow by its exact n8nId, rather than downloading a possibly stale bundled template. The JSON attachment contains name/nodes/connections/settings, omits instance identity, activation/sharing/static state, excludes pinned data upstream and never changes the source workflow.

## Overlap check
Searched open and closed upstream PRs by semantic keywords and changed production files, inspected related scopes, and refreshed latest PRs through #3842 before publication.

Changed surface: dashboard-api/routers/workflows.py and docs/WORKFLOW_EXPORT.md.

#3681/#2469 validate list/read receipts; #2114 resolves catalog identity; #2964/#3586 handle activation; #3835 paginates inventory. None implements a portable installed-definition export. The new route uses the exact n8n ID and avoids ambiguous name matching.

## Regression and focused validation
test_workflow_export.py + test_workflows.py: 51 passed; export-only follow-up: 6 passed after adding excludePinnedData. Authenticated HTTP boundary covers portable content/headers, missing/upstream-denied/malformed/timeout responses, invalid IDs and unauthenticated requests; no POST/PATCH is issued.

## Tradeoffs, rollback and remaining validation
Uses shipped [n8n 2.6.4 GET workflow contract](https://github.com/n8n-io/n8n/blob/n8n%402.6.4/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml). Node parameters and credential references are intentionally included; this is not a secret-redaction or credential-backup tool. No credential-store secrets are fetched. A live export/import round trip remains unverified. Reverting removes only the read endpoint.

## Batch integration and validation limits
All ten feature branches start independently from upstream main `21f4b3a6`. Feature integration: `9b4005885390603b9473992fd41c12621214f746` on `integration/feat-ten-20260908`. No merge-order dependency within this batch. Suggested review order follows the numbered feature list, but each PR is useful independently.

Also validated these features together with preceding fixes #3833–#3842 on combined integration `155e728a045e20a40eedba2893308199663faa85` (`integration/feat-and-fixes-20260908` on tang-vu/DreamServer): **270 UI tests and 103 related API tests passed**, plus real Fish and healthcheck boundary tests. Production files merged cleanly; the Makefile conflict was resolved by retaining all five standalone test registrations. This includes the invite refresh, CSV escaping, workflow pagination and healthcheck error-body fixes where files overlap.

Feature-only dashboard testing initially passed 265 tests; the subsequent storage-quota test passed in the 12-test Extensions suite and final 270-test combined run. Dashboard lint/build, CI-equivalent Ruff, shell/Python syntax, platform smoke and installer simulation passed. Local `make gate` is NOT green: the existing Hermes max_tokens contract fails on unchanged main too. BATS: 408 passed, 10 failed in AMD text fixtures, WSL dispatch and root-sensitive installer tests, reproducing the preceding baseline. Pre-commit gitleaks/size/shell hooks passed; private-key detection still flags the two unchanged dummy-key test fixtures. No fixture exclusions were added. Linux/WSL tests and mocked transports do not establish live hardware, migration or provider behavior.

Final review follow-up: `dfd62230` also treats missing/unrecognized Usage cost provenance as unknown. Latest feature integration is `333b4adfc3ca4fed08b50b17ff4fb2b2efddc781`; latest combined integration is `f74ddbc317bb72e2d41bade6fb22d73c962f16bd`. The affected 13-test Usage/history/CSV suite and dashboard lint passed on that combined head; the 270-test full UI receipt above is bound to its stated predecessor.

GitHub checks completed for candidate `25fc4143d81bd1d48a42e38202e5de9cb83794a4`: 29 successful checks, 4 conditionally skipped review checks, zero failed or pending checks. All scheduled technical CI checks passed. Local baseline and live-validation limits above still apply.

