### PR TITLE
feat(resources): query scoped snapshots without disk scans

### DIFF
--- a/ods/docs/RESOURCE_SNAPSHOTS.md
+++ b/ods/docs/RESOURCE_SNAPSHOTS.md
@@ -1,0 +1,16 @@
+# Scoped service resource snapshots
+
+Use the authenticated resource API to monitor a selected subsystem:
+
+```bash
+curl --fail --header "Authorization: Bearer $DASHBOARD_API_KEY" \
+  'http://127.0.0.1:3002/api/services/resources?service=llama-server&service=open-webui&include_disk=false'
+```
+
+Repeat `service` for up to 50 IDs. Duplicates are collapsed and totals cover only returned services. Omit the filter for the existing full snapshot. Invalid IDs return 400, unknown IDs return 404, and invalid query types/oversized lists return 422. Use IDs from the unfiltered response, not container names or display labels.
+
+`include_disk=false` skips directory traversal, including on a cold cache, for lightweight CPU/RAM polling. Each `disk` value and `totals.disk_data_gb` are null, not zero; `scope.disk_included` is false. Orphaned data-only entries are available only with disk collection enabled. The default still includes disk usage.
+
+The host-agent container cache remains a full snapshot (20-second TTL), and the full disk cache retains its 60-second TTL. Filtering never replaces either cache with a subset. This option reduces disk collection work, not the host agent's container-stat query. Resource availability and Docker Desktop caveats remain those of the original endpoint; missing metrics are not proof that a service is stopped. No lifecycle actions are issued.
+
+Tests exercise authenticated HTTP responses, deduplicated totals, full-snapshot reads after filtered requests, cold-cache disk omission and auth/validation failures. Live Docker CPU/RAM collection is not exercised by those transport-mocked tests.

--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -5,7 +5,7 @@ import logging
 import re
 from pathlib import Path
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from config import DATA_DIR, GPU_BACKEND, SERVICES
 from helpers import dir_size_gb
@@ -90,12 +90,16 @@ def _post_agent_json(path: str, body: dict, timeout: int = 65) -> dict:
 
 
 @router.get("/api/services/resources")
-async def service_resources(api_key: str = Depends(verify_api_key)):
+async def service_resources(service: list[str] | None = Query(default=None, max_length=50), include_disk: bool = True, api_key: str = Depends(verify_api_key)):
     """Get per-service resource metrics (CPU, RAM, disk)."""
     from main import _cache  # noqa: PLC0415 — deferred import to avoid circular dependency
 
+    selected = set(service or [])
+    if any(not _SERVICE_ID_RE.fullmatch(sid) for sid in selected):
+        raise HTTPException(status_code=400, detail="Invalid service filter")
+
     container_stats = _cache.get("service_resources_containers")
-    disk_usage = _cache.get("service_resources_disk")
+    disk_usage = _cache.get("service_resources_disk") if include_disk else {}
 
     need_containers = container_stats is None
     need_disk = disk_usage is None
@@ -168,13 +172,23 @@ async def service_resources(api_key: str = Depends(verify_api_key)):
     total_mem = sum(s.get("memory_used_mb", 0) for s in container_stats)
     total_disk = sum(d.get("data_gb", 0) for d in disk_usage.values())
 
+    if selected:
+        unknown = selected - {entry["id"] for entry in services}
+        if unknown:
+            raise HTTPException(status_code=404, detail=f"Unknown services: {', '.join(sorted(unknown))}")
+        services = [entry for entry in services if entry["id"] in selected]
+        total_cpu = sum(entry["container"].get("cpu_percent", 0) for entry in services if entry["container"])
+        total_mem = sum(entry["container"].get("memory_used_mb", 0) for entry in services if entry["container"])
+        total_disk = sum(entry["disk"].get("data_gb", 0) for entry in services if entry["disk"])
+
     return {
         "services": services,
         "totals": {
             "cpu_percent": round(total_cpu, 1),
             "memory_used_mb": round(total_mem),
-            "disk_data_gb": round(total_disk, 2),
+            "disk_data_gb": round(total_disk, 2) if include_disk else None,
         },
+        "scope": {"services": sorted(selected) if selected else None, "disk_included": include_disk},
         "caveats": {
             "docker_desktop_memory": GPU_BACKEND == "apple",
         },

--- a/ods/extensions/services/dashboard-api/tests/test_resource_scopes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_resource_scopes.py
@@ -1,0 +1,52 @@
+"""Filtered resource responses must not narrow shared cached snapshots."""
+from unittest.mock import Mock
+
+import pytest
+
+
+@pytest.fixture
+def resource_sources(monkeypatch):
+    from main import _cache
+    from routers import resources
+    _cache.invalidate('service_resources_containers')
+    _cache.invalidate('service_resources_disk')
+    monkeypatch.setattr(resources, 'SERVICES', {sid: {'name': sid, 'container_name': f'ods-{sid}'} for sid in ('alpha', 'beta')})
+    stats = Mock(return_value=[{'container_name': 'ods-alpha', 'cpu_percent': 10, 'memory_used_mb': 100}, {'container_name': 'ods-beta', 'cpu_percent': 20, 'memory_used_mb': 200}])
+    disk = Mock(return_value={'alpha': {'data_gb': 1}, 'beta': {'data_gb': 2}, 'orphan': {'data_gb': 4}})
+    monkeypatch.setattr(resources, '_fetch_container_stats', stats)
+    monkeypatch.setattr(resources, '_scan_service_disk', disk)
+    yield stats, disk
+    _cache.invalidate('service_resources_containers')
+    _cache.invalidate('service_resources_disk')
+
+
+def test_scoped_totals_and_cache_isolation(test_client, resource_sources):
+    response = test_client.get('/api/services/resources?service=alpha&service=alpha', headers=test_client.auth_headers)
+    assert response.status_code == 200
+    assert [row['id'] for row in response.json()['services']] == ['alpha']
+    assert response.json()['totals'] == {'cpu_percent': 10, 'memory_used_mb': 100, 'disk_data_gb': 1}
+    full = test_client.get('/api/services/resources', headers=test_client.auth_headers).json()
+    assert [row['id'] for row in full['services']] == ['alpha', 'beta', 'orphan']
+    assert full['totals'] == {'cpu_percent': 30, 'memory_used_mb': 300, 'disk_data_gb': 7}
+    for source in resource_sources:
+        source.assert_called_once()
+
+
+def test_cpu_memory_only_skips_disk_without_poisoning_cache(test_client, resource_sources):
+    result = test_client.get('/api/services/resources?service=beta&include_disk=false', headers=test_client.auth_headers).json()
+    assert result['totals']['disk_data_gb'] is None
+    assert result['services'][0]['disk'] is None
+    assert result['scope'] == {'services': ['beta'], 'disk_included': False}
+    resource_sources[1].assert_not_called()
+    full = test_client.get('/api/services/resources', headers=test_client.auth_headers).json()
+    assert full['totals']['disk_data_gb'] == 7
+    resource_sources[1].assert_called_once()
+
+
+@pytest.mark.parametrize('query,status', [('service=missing', 404), ('service=bad%0Aid', 400), ('service=', 400), ('include_disk=maybe', 422)])
+def test_invalid_filters_are_visible(test_client, resource_sources, query, status):
+    assert test_client.get(f'/api/services/resources?{query}', headers=test_client.auth_headers).status_code == status
+
+
+def test_filtered_metrics_still_require_auth(test_client):
+    assert test_client.get('/api/services/resources?service=alpha&include_disk=false').status_code == 401


### PR DESCRIPTION
## Why this matters

Resource consumers focused on a few services should not need disk scans or receive unrelated totals for a lightweight CPU/RAM snapshot.

## Feature and overlap check

Add authenticated repeated service filters (max50) and include_disk=false. Filter a complete shared snapshot without narrowing the cached data; report scoped totals and explicit null disk totals when disk is omitted. Validate malformed/unknown IDs. Updated the original PR onto beta. Searched all-state resource scope and resources.py PRs: #4966 shares concurrent collection, #5069 adds auxiliary containers, #5180 handles permission errors and #5469 nullable metrics. None supplies scoped/optional-disk reads.

## Validation

Linux Python3.11: `pytest -q tests/test_resource_scopes.py tests/test_resources.py tests/test_auxiliary_container_resources.py`: 29 passed. Authenticated HTTP tests cover scope, cache isolation, no disk collector for CPU/RAM-only calls, later full reads, bad filters and authentication. Focused pre-commit/diff check passed. No live Docker/disk scan claim. Baseline smoke/simulation passed; known full-gate/BATS failures remain.

## Rollback

Defaults preserve full snapshots and totals; filters do not mutate caches. No persisted state. Revert removes query features; default clients continue to work. Ready for independent review.

## Final beta-batch receipt — 2026-09-16

Candidate: `f24f8eea01c951b82fab58bef02fd270d8ef6725`. GitHub check audit at 11:07:47 UTC: **37 successful, 4 skipped, 0 failed, 0 pending**, matching this exact head; OPEN, public-beta base, Ready (not Draft). Skipped checks are not counted as passed tests.

The [combined integration head](https://github.com/tang-vu/DreamServer/tree/5b9877184ceab0751c6c9fe3564c73303e78f0a3), `5b9877184ceab0751c6c9fe3564c73303e78f0a3`, contains all 30 exact candidate heads on public-beta `3c186f3f12ba21dad7b7266ec5449393529abb00`. At this exact final SHA: full dashboard **171 files / 1,274 tests passed**; full dashboard API **3,124 passed, 2 skipped**; advice boundary suite **23 passed**; Bark request/legacy-empty cases **9 passed**; changed-file secret/key/size hooks and diff check passed. Shell-only hooks had no matching changed files.

Additional combined checks ran at predecessor `28adf1aa5c0710d3c0de13df7870629e24977fec`: Token Spy **130 passed, 1 skipped**; CLI contracts **16 passed**; real backup/restore round trip passed; Open Interpreter HTTP/runner cases **4 passed**; `make lint smoke simulate`, frontend lint (zero errors, 624 warnings) and production build passed. The only final-head differences are two test files (advice dialog fixtures and Bark's empty-text expectation); production files are identical. These results are not live GPU/model or service rollout qualification.

Qualified merge order: #5490 → #5494 → #5495 → #3848 → #3846 → #3845 → #3844 → #3843 → #3841 → #3838 → #3837 → #3836 → #3835 → #3834 → #3809 → #3808 → #3807 → #3806 → #3804 → #3803 → #3802 → #3801 → #3800 → #3712 → #3711 → #3710 → #3709 → #3708 → #3852 → #3849. Branches are independently useful. Shared-file merging required only preserving the union of four adjacent Makefile registrations: provider-probe redirects, healthcheck error-body, Milvus persistence and healthcheck latency. Production code in these 30 merged without manual conflict resolution. External advice/Bark overlaps have separate pairwise receipts in #5494/#3808. Recheck the combined tree if other shared-file PRs land first; do not drop test registrations.

Full release qualification remains **not green**: baseline `make gate` fails a no-sudo Docker fallback fixture; 5 of 428 BATS cases fail in this environment; all-files private-key scanning flags two pre-existing dummy-key fixtures. No checks were disabled. CI success and Ready status do not replace independent human review, especially for auth backups and Milvus data migration. No upstream merge or deployment was performed.
