### PR TITLE
fix(dashboard-api): add session signer expiry window bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -169,3 +169,26 @@ def verify(cookie_value: str) -> Tuple[bool, str]:
         return False, "expired"
 
     return True, "ok"
+
+
+def validate_session_ttl_bounds(
+    ttl_seconds: object, min_ttl: int = 1, max_ttl: int = 2592000, default_ttl: int = 43200
+) -> int:
+    """Validate and constrain TTL seconds to valid integer boundaries [min_ttl, max_ttl].
+
+    Returns default_ttl if input is None, non-integer, or invalid type. Clamps values
+    exceeding max_ttl or below min_ttl safely.
+    """
+    if ttl_seconds is None:
+        return default_ttl
+    try:
+        val = int(ttl_seconds)
+    except (ValueError, TypeError):
+        return default_ttl
+
+    if val < min_ttl:
+        return min_ttl
+    if val > max_ttl:
+        return max_ttl
+    return val
+

--- a/ods/extensions/services/dashboard-api/tests/test_session_signer.py
+++ b/ods/extensions/services/dashboard-api/tests/test_session_signer.py
@@ -184,3 +184,19 @@ class TestVerify:
         ok, reason = session_signer.verify(cookie)
         assert ok is False
         assert reason == "malformed"
+
+
+class TestValidateSessionTtlBounds:
+
+    def test_valid_integer_ttl(self):
+        from session_signer import validate_session_ttl_bounds
+        assert validate_session_ttl_bounds(3600) == 3600
+        assert validate_session_ttl_bounds("7200") == 7200
+
+    def test_clamping_and_fallback(self):
+        from session_signer import validate_session_ttl_bounds
+        assert validate_session_ttl_bounds(None) == 43200
+        assert validate_session_ttl_bounds("invalid") == 43200
+        assert validate_session_ttl_bounds(0, min_ttl=10) == 10
+        assert validate_session_ttl_bounds(9999999, max_ttl=86400) == 86400
+


### PR DESCRIPTION
Add validate_session_ttl_bounds utility function to validate and constrain session cookie TTL values within min/max boundaries and fallback safely on None or invalid non-integer types. Includes unit test suite.