### PR TITLE
fix(dashboard-api): add safe dict key value inverter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_invert_dict_unique(data: object) -> dict:
+    """Invert dictionary keys and values safely into unique value -> key mapping.
+
+    Handles non-hashable values, None, or non-dict inputs without raising TypeError.
+    Converts keys/values to strings when necessary.
+    """
+    if not isinstance(data, dict):
+        return {}
+    res = {}
+    for k, v in data.items():
+        if k is None or v is None:
+            continue
+        try:
+            res[v] = k
+        except TypeError:
+            res[str(v)] = str(k)
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafeInvertDictUnique:
+
+    def test_inverts_simple_dict(self):
+        from helpers import safe_invert_dict_unique
+        assert safe_invert_dict_unique({"a": 1, "b": 2}) == {1: "a", 2: "b"}
+
+    def test_handles_non_hashable_and_none_values(self):
+        from helpers import safe_invert_dict_unique
+        assert safe_invert_dict_unique(None) == {}
+        assert safe_invert_dict_unique("not_dict") == {}
+        assert safe_invert_dict_unique({"a": [1, 2], "b": None}) == {"[1, 2]": "a"}
+


### PR DESCRIPTION
Add safe_invert_dict_unique utility function in helpers.py to safely handle dictionary key-value inversion, non-hashable values, None values, and non-dict inputs without TypeError. Includes unit test suite.