### PR TITLE
fix(dashboard-api): add key value pair list filter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,25 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def filter_valid_kv_pairs(pairs: object) -> list:
+    """Filter list of key-value pairs safely, dropping None, empty keys, or invalid formats.
+
+    Returns list of clean (str_key, str_val) tuples. Handles non-sequence inputs safely.
+    """
+    if not isinstance(pairs, (list, tuple)):
+        return []
+    res = []
+    for item in pairs:
+        if not isinstance(item, (list, tuple)) or len(item) != 2:
+            continue
+        k, v = item
+        if k is None or v is None:
+            continue
+        str_k = str(k).strip()
+        if not str_k:
+            continue
+        res.append((str_k, str(v)))
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFilterValidKvPairs:
+
+    def test_filters_valid_pairs(self):
+        from helpers import filter_valid_kv_pairs
+        raw = [("k1", "v1"), ("k2", 123), ("  ", "v3"), ("k4", None), "invalid"]
+        assert filter_valid_kv_pairs(raw) == [("k1", "v1"), ("k2", "123")]
+
+    def test_handles_none_and_non_sequence_inputs(self):
+        from helpers import filter_valid_kv_pairs
+        assert filter_valid_kv_pairs(None) == []
+        assert filter_valid_kv_pairs("not_pairs") == []
+


### PR DESCRIPTION
Add filter_valid_kv_pairs utility function in helpers.py to safely filter sequence pairs, drop None values or empty keys, and validate structure without raising TypeError. Includes unit test suite.