### PR TITLE
fix(dashboard-api): add safe environment boolean parser bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -12,3 +12,23 @@ def strip_matching_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def parse_env_boolean_safe(val: object, default: bool = False) -> bool:
+    """Parse environment string or boolean values safely.
+
+    Truth-y strings: '1', 'true', 'yes', 'on', 'enable', 'enabled' (case-insensitive).
+    Fals-y strings: '0', 'false', 'no', 'off', 'disable', 'disabled'.
+    Returns default on None or unrecognized values without raising ValueError.
+    """
+    if val is None:
+        return default
+    if isinstance(val, bool):
+        return val
+    val_str = str(val).strip().lower()
+    if val_str in {"1", "true", "yes", "on", "enable", "enabled"}:
+        return True
+    if val_str in {"0", "false", "no", "off", "disable", "disabled"}:
+        return False
+    return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -24,3 +24,21 @@ from env_values import strip_matching_quotes
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):
     assert strip_matching_quotes(raw) == expected
+
+
+class TestParseEnvBooleanSafe:
+
+    def test_parses_truthy_and_falsy_values(self):
+        from env_values import parse_env_boolean_safe
+        assert parse_env_boolean_safe("true") is True
+        assert parse_env_boolean_safe("YES") is True
+        assert parse_env_boolean_safe("1") is True
+        assert parse_env_boolean_safe("false") is False
+        assert parse_env_boolean_safe("0") is False
+
+    def test_handles_none_and_defaults(self):
+        from env_values import parse_env_boolean_safe
+        assert parse_env_boolean_safe(None) is False
+        assert parse_env_boolean_safe(None, default=True) is True
+        assert parse_env_boolean_safe("unknown", default=False) is False
+


### PR DESCRIPTION
Add parse_env_boolean_safe utility function in env_values.py to parse truthy and falsy boolean string representations safely with configurable defaults and None guards. Includes unit test suite.