### PR TITLE
fix(dashboard-api): add list deduplicate preserving order bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,28 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def deduplicate_list_preserve_order(items: object) -> list:
+    """Deduplicate list elements while strictly preserving original insertion order.
+
+    Filters non-hashable values cleanly or handles None and non-sequence inputs safely.
+    """
+    if not isinstance(items, (list, tuple)):
+        return []
+    seen = set()
+    res = []
+    for item in items:
+        if item is None:
+            continue
+        try:
+            if item not in seen:
+                seen.add(item)
+                res.append(item)
+        except TypeError:
+            key = str(item)
+            if key not in seen:
+                seen.add(key)
+                res.append(item)
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDeduplicateListPreserveOrder:
+
+    def test_deduplicates_preserving_order(self):
+        from helpers import deduplicate_list_preserve_order
+        raw = ["a", "b", "a", "c", "b"]
+        assert deduplicate_list_preserve_order(raw) == ["a", "b", "c"]
+
+    def test_handles_none_and_non_hashables(self):
+        from helpers import deduplicate_list_preserve_order
+        assert deduplicate_list_preserve_order(None) == []
+        assert deduplicate_list_preserve_order([1, [2], 1, [2]]) == [1, [2]]
+


### PR DESCRIPTION
Add deduplicate_list_preserve_order utility function in helpers.py to safely deduplicate sequence elements while strictly preserving insertion order, handling unhashable items and None values without exception. Includes unit test suite.