### PR TITLE
fix(dashboard-api): add dictionary value mask sensitive keys bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,26 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def mask_sensitive_dict_values(data: object, mask_keys: tuple = ("key", "secret", "token", "password")) -> dict:
+    """Mask sensitive value strings in dictionaries matching mask_keys substrings safely.
+
+    Replaces string values for matching keys with '[REDACTED]'. Handles nested dicts,
+    None, or non-dict inputs without raising AttributeError.
+    """
+    if not isinstance(data, dict):
+        return {}
+    res = {}
+    for k, v in data.items():
+        if k is None:
+            continue
+        key_str = str(k)
+        if isinstance(v, dict):
+            res[key_str] = mask_sensitive_dict_values(v, mask_keys)
+        elif any(mk.lower() in key_str.lower() for mk in mask_keys):
+            res[key_str] = "[REDACTED]"
+        else:
+            res[key_str] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,21 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestMaskSensitiveDictValues:
+
+    def test_masks_sensitive_keys(self):
+        from helpers import mask_sensitive_dict_values
+        raw = {"user": "alice", "api_key": "secret123", "nested": {"token": "xyz"}}
+        assert mask_sensitive_dict_values(raw) == {
+            "user": "alice",
+            "api_key": "[REDACTED]",
+            "nested": {"token": "[REDACTED]"},
+        }
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import mask_sensitive_dict_values
+        assert mask_sensitive_dict_values(None) == {}
+        assert mask_sensitive_dict_values("not_dict") == {}
+


### PR DESCRIPTION
Add mask_sensitive_dict_values utility function in helpers.py to safely mask sensitive values in nested dictionaries matching keyword targets without raising AttributeError. Includes unit test suite.