### PR TITLE
fix(dashboard-api): add host agent client request timeout bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -327,3 +327,26 @@ async def shutdown_clients() -> None:
         await asyncio.to_thread(sync_client.close)
     if async_client is not None and not async_client.is_closed:
         await async_client.aclose()
+
+
+def validate_host_agent_timeout(
+    timeout_sec: object, min_timeout: float = 1.0, max_timeout: float = 300.0, default_timeout: float = 10.0
+) -> float:
+    """Validate and constrain HTTP timeout seconds within bounds [min_timeout, max_timeout].
+
+    Returns default_timeout if input is None or non-numeric. Clamps values below min_timeout
+    or above max_timeout safely.
+    """
+    if timeout_sec is None:
+        return default_timeout
+    try:
+        val = float(timeout_sec)
+    except (ValueError, TypeError):
+        return default_timeout
+
+    if val < min_timeout:
+        return min_timeout
+    if val > max_timeout:
+        return max_timeout
+    return round(val, 2)
+

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -245,3 +245,19 @@ async def test_async_request_and_shutdown_close_both_pools(monkeypatch):
     assert sync_client.is_closed
     assert agent_client._async_client is None
     assert agent_client._sync_client is None
+
+
+class TestValidateHostAgentTimeout:
+
+    def test_valid_float_timeout(self):
+        from host_agent_client import validate_host_agent_timeout
+        assert validate_host_agent_timeout(15.5) == 15.5
+        assert validate_host_agent_timeout("30") == 30.0
+
+    def test_clamping_and_default_fallbacks(self):
+        from host_agent_client import validate_host_agent_timeout
+        assert validate_host_agent_timeout(None) == 10.0
+        assert validate_host_agent_timeout("invalid") == 10.0
+        assert validate_host_agent_timeout(0.5, min_timeout=2.0) == 2.0
+        assert validate_host_agent_timeout(999.0, max_timeout=120.0) == 120.0
+


### PR DESCRIPTION
Add validate_host_agent_timeout utility function in host_agent_client.py to validate and constrain HTTP timeout seconds within min/max boundaries, handling None and non-numeric types safely. Includes unit test suite.