### PR TITLE
fix(dashboard-api): add giga bytes storage unit converter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def convert_bytes_to_gb_bounds(bytes_val: object, precision: int = 2) -> float:
+    """Convert bytes count safely to gigabytes (GB) rounded to precision.
+
+    Returns 0.0 for negative values, None, or non-numeric inputs.
+    Handles float overflow/NaN/Inf without raising ValueError.
+    """
+    if bytes_val is None:
+        return 0.0
+    try:
+        val = float(bytes_val)
+        if math.isnan(val) or math.isinf(val) or val < 0:
+            return 0.0
+    except (ValueError, TypeError):
+        return 0.0
+
+    gb = val / (1024 ** 3)
+    return round(gb, max(0, precision))
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestConvertBytesToGbBounds:
+
+    def test_converts_bytes_to_gb(self):
+        from helpers import convert_bytes_to_gb_bounds
+        assert convert_bytes_to_gb_bounds(1073741824) == 1.0
+        assert convert_bytes_to_gb_bounds(2147483648, precision=1) == 2.0
+
+    def test_handles_none_negative_and_invalid_inputs(self):
+        from helpers import convert_bytes_to_gb_bounds
+        assert convert_bytes_to_gb_bounds(None) == 0.0
+        assert convert_bytes_to_gb_bounds(-100) == 0.0
+        assert convert_bytes_to_gb_bounds("invalid") == 0.0
+


### PR DESCRIPTION
Add convert_bytes_to_gb_bounds utility function in helpers.py to safely convert byte bytecounts into gigabytes (GB) with precision rounding, negative value rejection, and float overflow/NaN/Inf protection. Includes unit test suite.