### PR TITLE
fix(dashboard-api): add dictionary value list flattener bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,24 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def flatten_dict_values_list(data: object) -> list:
+    """Flatten list or tuple elements stored across dictionary values safely.
+
+    Handles scalar values, nested lists, None values, and non-dict inputs without exception.
+    """
+    if not isinstance(data, dict):
+        return []
+    res = []
+    for k, v in data.items():
+        if v is None:
+            continue
+        if isinstance(v, (list, tuple)):
+            for sub in v:
+                if sub is not None:
+                    res.append(sub)
+        else:
+            res.append(v)
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFlattenDictValuesList:
+
+    def test_flattens_dict_values(self):
+        from helpers import flatten_dict_values_list
+        raw = {"k1": [1, 2], "k2": "single", "k3": (3, 4)}
+        assert flatten_dict_values_list(raw) == [1, 2, "single", 3, 4]
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import flatten_dict_values_list
+        assert flatten_dict_values_list(None) == []
+        assert flatten_dict_values_list("not_dict") == []
+        assert flatten_dict_values_list({"k1": None, "k2": [None]}) == []
+


### PR DESCRIPTION
Add flatten_dict_values_list utility function in helpers.py to safely flatten sequence values stored in dictionary keys, handle scalar values, drop None elements, and validate inputs without TypeError. Includes unit test suite.