### PR TITLE
fix(dashboard-api): add safe environment integer parser bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -12,3 +12,26 @@ def strip_matching_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def parse_env_integer_safe(
+    val: object, default: int = 0, min_val: int | None = None, max_val: int | None = None
+) -> int:
+    """Parse environment integer values safely with bounds checking.
+
+    Returns default on None or invalid non-integer string representations.
+    Clamps value to min_val/max_val if provided.
+    """
+    if val is None:
+        return default
+    try:
+        parsed = int(str(val).strip())
+    except (ValueError, TypeError):
+        return default
+
+    if min_val is not None and parsed < min_val:
+        return min_val
+    if max_val is not None and parsed > max_val:
+        return max_val
+    return parsed
+

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -24,3 +24,19 @@ from env_values import strip_matching_quotes
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):
     assert strip_matching_quotes(raw) == expected
+
+
+class TestParseEnvIntegerSafe:
+
+    def test_parses_integer_values(self):
+        from env_values import parse_env_integer_safe
+        assert parse_env_integer_safe("8080") == 8080
+        assert parse_env_integer_safe(42) == 42
+
+    def test_handles_none_and_bounds_clamping(self):
+        from env_values import parse_env_integer_safe
+        assert parse_env_integer_safe(None, default=80) == 80
+        assert parse_env_integer_safe("invalid", default=80) == 80
+        assert parse_env_integer_safe("10", min_val=20) == 20
+        assert parse_env_integer_safe("100", max_val=50) == 50
+


### PR DESCRIPTION
Add parse_env_integer_safe utility function in env_values.py to safely parse integer values from environment variables, clamp to min_val/max_val limits, and fallback cleanly on None or malformed strings. Includes unit test suite.