### PR TITLE
fix(dashboard-api): add dictionary key prefix stripper bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def strip_dict_key_prefixes(data: object, prefix: str = "") -> dict:
+    """Strip prefix string from dictionary keys safely.
+
+    Handles non-string keys, None values, or non-dict inputs without exception.
+    """
+    if not isinstance(data, dict):
+        return {}
+    res = {}
+    for k, v in data.items():
+        if k is None:
+            continue
+        key_str = str(k)
+        if prefix and key_str.startswith(prefix):
+            key_str = key_str[len(prefix):]
+        res[key_str] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStripDictKeyPrefixes:
+
+    def test_strips_prefix_from_keys(self):
+        from helpers import strip_dict_key_prefixes
+        raw = {"ODS_PORT": 8080, "ODS_HOST": "localhost", "OTHER": "val"}
+        assert strip_dict_key_prefixes(raw, prefix="ODS_") == {"PORT": 8080, "HOST": "localhost", "OTHER": "val"}
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import strip_dict_key_prefixes
+        assert strip_dict_key_prefixes(None) == {}
+        assert strip_dict_key_prefixes("not_dict") == {}
+


### PR DESCRIPTION
Add strip_dict_key_prefixes utility function in helpers.py to safely strip string prefixes from dictionary keys while handling non-string keys, None inputs, and empty prefixes without exception. Includes unit test suite.