### PR TITLE
fix(dashboard-api): add list element frequency counter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def count_list_element_frequencies(items: object) -> dict:
+    """Count item occurrences in sequence safely into item -> frequency dict.
+
+    Converts unhashable items or None values to string representations without TypeError.
+    """
+    if not isinstance(items, (list, tuple)):
+        return {}
+    res = {}
+    for item in items:
+        if item is None:
+            continue
+        try:
+            res[item] = res.get(item, 0) + 1
+        except TypeError:
+            key = str(item)
+            res[key] = res.get(key, 0) + 1
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestCountListElementFrequencies:
+
+    def test_counts_frequencies(self):
+        from helpers import count_list_element_frequencies
+        raw = ["a", "b", "a", "c", "b", "a"]
+        assert count_list_element_frequencies(raw) == {"a": 3, "b": 2, "c": 1}
+
+    def test_handles_none_and_unhashable_items(self):
+        from helpers import count_list_element_frequencies
+        assert count_list_element_frequencies(None) == {}
+        assert count_list_element_frequencies([1, [2], 1, [2]]) == {1: 2, "[2]": 2}
+


### PR DESCRIPTION
Add count_list_element_frequencies utility function in helpers.py to safely count item occurrences in sequences, handling unhashable objects and None values without TypeError. Includes unit test suite.