### PR TITLE
fix(cli): take the documented default when a prompt gets EOF

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -92,6 +92,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
+	@bash tests/test-cli-prompts-noninteractive.sh
 	@bash tests/test-unix-restart-recreate-env.sh
 	@echo ""
 	@echo "=== ods-cli install directory resolution ==="

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -663,7 +663,7 @@ _check_version_compat() {
         if [[ "$force" == "true" ]]; then
             warn "--force specified: proceeding with downgrade."
         else
-            read -p "  Proceed with downgrade? [y/N] " -n 1 -r
+            read -p "  Proceed with downgrade? [y/N] " -n 1 -r || REPLY=""
             echo ""
             if [[ ! $REPLY =~ ^[Yy]$ ]]; then
                 log "Update cancelled."
@@ -716,7 +716,7 @@ _check_version_compat() {
         if [[ "$force" == "true" ]]; then
             warn "--force specified: skipping confirmation."
         else
-            read -p "  Proceed with v${_COMPAT_INSTALLED_VER} → v${_COMPAT_TARGET_VER} anyway? [y/N] " -n 1 -r
+            read -p "  Proceed with v${_COMPAT_INSTALLED_VER} → v${_COMPAT_TARGET_VER} anyway? [y/N] " -n 1 -r || REPLY=""
             echo ""
             if [[ ! $REPLY =~ ^[Yy]$ ]]; then
                 log "Update cancelled."
@@ -2793,7 +2793,7 @@ cmd_enable() {
             warn "$service_id may not work with GPU backend: $current_backend"
             warn "  Supported backends: $gpu_backends"
             warn "  Current backend: $current_backend"
-            read -p "  Continue anyway? [y/N] " -n 1 -r
+            read -p "  Continue anyway? [y/N] " -n 1 -r || REPLY=""
             echo
             if [[ ! $REPLY =~ ^[Yy]$ ]]; then
                 log "Cancelled."
@@ -2818,7 +2818,7 @@ cmd_enable() {
         done
         if [[ ${#missing[@]} -gt 0 ]]; then
             warn "$service_id depends on disabled services: ${missing[*]}"
-            read -p "  Enable them too? [Y/n] " -n 1 -r
+            read -p "  Enable them too? [Y/n] " -n 1 -r || REPLY=""
             echo
             if [[ ! $REPLY =~ ^[Nn]$ ]]; then
                 for dep in "${missing[@]}"; do
@@ -2896,7 +2896,7 @@ cmd_disable() {
     done
     if [[ ${#dependents[@]} -gt 0 ]]; then
         warn "These enabled extensions depend on $service_id: ${dependents[*]}"
-        read -p "  Continue anyway? [y/N] " -n 1 -r
+        read -p "  Continue anyway? [y/N] " -n 1 -r || REPLY=""
         echo
         [[ ! $REPLY =~ ^[Yy]$ ]] && { log "Cancelled."; return 1; }
     fi
@@ -2977,7 +2977,7 @@ cmd_purge() {
     log ""
 
     local _confirm
-    read -p "  Type '$service_id' to confirm deletion: " -r _confirm
+    read -p "  Type '$service_id' to confirm deletion: " -r _confirm || _confirm=""
     if [[ "$_confirm" != "$service_id" ]]; then
         log "Purge cancelled."
         return 0
@@ -3168,7 +3168,7 @@ META
                 echo ""
             fi
 
-            read -p "Restore this preset? This will overwrite current .env. [y/N] " -n 1 -r
+            read -p "Restore this preset? This will overwrite current .env. [y/N] " -n 1 -r || REPLY=""
             echo ""
             [[ $REPLY =~ ^[Yy]$ ]] || { log "Cancelled."; return 0; }
 
@@ -3245,7 +3245,7 @@ META
             local preset_dir="${PRESETS_DIR}/${name}"
             [[ -d "$preset_dir" ]] || error "Preset not found: $name"
 
-            read -p "Delete preset '${name}'? [y/N] " -n 1 -r
+            read -p "Delete preset '${name}'? [y/N] " -n 1 -r || REPLY=""
             echo ""
             [[ $REPLY =~ ^[Yy]$ ]] || { log "Cancelled."; return 0; }
 
@@ -3303,7 +3303,7 @@ META
             # Check if preset already exists
             if [[ -d "${PRESETS_DIR}/${archive_name}" ]]; then
                 warn "Preset '${archive_name}' already exists"
-                read -p "Overwrite? [y/N] " -n 1 -r
+                read -p "Overwrite? [y/N] " -n 1 -r || REPLY=""
                 echo ""
                 [[ $REPLY =~ ^[Yy]$ ]] || { log "Cancelled."; return 0; }
                 rm -rf "${PRESETS_DIR}/${archive_name}"
@@ -4738,7 +4738,7 @@ cmd_rollback() {
     log "Rolling back to pre-update state${target:+ (snapshot: $target)}..."
     echo ""
     warn "This will restore configuration from before the last update."
-    read -p "Continue with rollback? [y/N] " -n 1 -r
+    read -p "Continue with rollback? [y/N] " -n 1 -r || REPLY=""
     echo ""
 
     if [[ ! $REPLY =~ ^[Yy]$ ]]; then

--- a/ods/tests/test-cli-prompts-noninteractive.sh
+++ b/ods/tests/test-cli-prompts-noninteractive.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# ods-cli confirmation prompts must take their documented default when stdin
+# is not a terminal (CI, cron, the dashboard, `ods ... </dev/null`).
+#
+# Every prompt is `read -p ... -n 1 -r` under `set -euo pipefail`. On EOF,
+# read returns 1 and the command died with exit 1 and no output -- before the
+# "Cancelled." branch right below it could run. `ods preset load x` printed
+# the preset details and then vanished; `ods rollback` and the update
+# compatibility prompts behaved the same way.
+#
+# Run from repo root:  bash ods/tests/test-cli-prompts-noninteractive.sh
+# Or from ods:         bash tests/test-cli-prompts-noninteractive.sh
+
+set -euo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    for _modern_bash in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        # The probe must expand in the candidate shell, not this one.
+        # shellcheck disable=SC2016
+        if [ -x "$_modern_bash" ] && [ "$("$_modern_bash" -c 'echo "${BASH_VERSINFO[0]}"')" -ge 4 ]; then
+            exec "$_modern_bash" "$0" "$@"
+        fi
+    done
+    echo "[SKIP] ods-cli requires Bash 4+; this host only has Bash ${BASH_VERSION} (brew install bash)"
+    echo "Result: 0 passed, 0 failed, 1 skipped"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ODS_CLI="$ROOT_DIR/ods-cli"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+run_ods() {
+    # Through "$BASH", stdin closed: this is the non-interactive case.
+    local output rc
+    set +e
+    output=$(ODS_HOME="$INSTALL_DIR" NO_COLOR=1 "$BASH" "$ODS_CLI" "$@" </dev/null 2>&1)
+    rc=$?
+    set -e
+    printf '%s\n' "$rc"
+    printf '%s\n' "$output"
+}
+
+# Minimal install: compose base file for check_install, the real extension
+# manifests for sr_load, one saved preset.
+mkdir -p "$INSTALL_DIR/presets/keepme" "$INSTALL_DIR/extensions"
+cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+ln -s "$ROOT_DIR/extensions/services" "$INSTALL_DIR/extensions/services"
+printf 'ODS_MODE=local\nLLM_MODEL=current-model\n' > "$INSTALL_DIR/.env"
+printf 'ODS_MODE=local\nLLM_MODEL=preset-model\n' > "$INSTALL_DIR/presets/keepme/env"
+printf 'name=keepme\ncreated=2026-09-08T00:00:00Z\n' > "$INSTALL_DIR/presets/keepme/meta.txt"
+: > "$INSTALL_DIR/presets/keepme/extensions.list"
+
+echo "Test 1: 'ods preset delete' with stdin closed declines with a message and keeps the preset"
+result="$(run_ods preset delete keepme)"
+rc="${result%%$'\n'*}"
+output="${result#*$'\n'}"
+if [[ "$rc" -eq 0 && "$output" == *"Cancelled."* && -d "$INSTALL_DIR/presets/keepme" ]]; then
+    pass "preset delete: exit 0, 'Cancelled.', preset kept"
+else
+    fail "preset delete: rc=$rc, preset exists=$([[ -d "$INSTALL_DIR/presets/keepme" ]] && echo yes || echo no), output: $(printf '%s' "$output" | tail -n 2 | tr '\n' '|')"
+fi
+
+echo "Test 2: 'ods preset load' with stdin closed declines with a message and leaves .env alone"
+result="$(run_ods preset load keepme)"
+rc="${result%%$'\n'*}"
+output="${result#*$'\n'}"
+if [[ "$rc" -eq 0 && "$output" == *"Cancelled."* ]] && grep -q '^LLM_MODEL=current-model$' "$INSTALL_DIR/.env"; then
+    pass "preset load: exit 0, 'Cancelled.', .env untouched"
+else
+    fail "preset load: rc=$rc, LLM_MODEL=$(grep '^LLM_MODEL=' "$INSTALL_DIR/.env"), output: $(printf '%s' "$output" | tail -n 2 | tr '\n' '|')"
+fi
+
+echo "Test 3: every confirmation prompt in ods-cli tolerates EOF"
+# A `read` that returns 1 on EOF aborts the command under set -e before the
+# decline branch runs; each prompt must fall back to an empty reply.
+bare="$(grep -nE 'read -p ' "$ODS_CLI" | grep -vE '\|\| (REPLY|_confirm)=""' || true)"
+if [[ -z "$bare" ]]; then
+    pass "all $(grep -cE 'read -p ' "$ODS_CLI") prompts fall back to an empty reply on EOF"
+else
+    fail "prompts without an EOF fallback:"$'\n'"$bare"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Every confirmation prompt in `ods-cli` is a bare `read -p ... -n 1 -r` under `set -euo pipefail`, each followed by an explicit decline branch. With stdin not a terminal (CI, cron, the host agent, `</dev/null`, a pipe) `read` returns 1 on EOF and `set -e` ends the command before that branch runs: exit 1, no message. `ods preset load x` printed the preset details and then vanished; `preset delete`, `rollback`, `purge`, `enable`'s dependency prompts and both `update` compatibility prompts behave the same way. Repro in #3873.

Change (one concern: a prompt must take its documented default when there is no terminal to answer it):

- **`ods-cli`**: the ten prompts (`:666, 719, 2796, 2821, 2899, 2980, 3171, 3248, 3306, 4741`) get `|| REPLY=""` (`|| _confirm=""` for the typed purge confirmation), so EOF is an empty reply and the decline branch that already exists runs: `[y/N]` prompts print their "Cancelled." / "Update cancelled." and return as they do today for `n`; the `[Y/n]` dependency prompt proceeds, which is what an empty answer means there. No change for interactive use -- a real keypress still sets `REPLY`.
- **`tests/test-cli-prompts-noninteractive.sh`** (new, in `make test` next to `test-ods-cli-pipefail-tolerance.sh`, same harness: minimal install, `ods-cli` run through `"$BASH"` with stdin closed): `preset delete` exits 0 with "Cancelled." and keeps the preset; `preset load` exits 0 with "Cancelled." and leaves `.env` untouched; and a contract that every `read -p` in `ods-cli` carries the EOF fallback. All three fail on current `main`.

Fixes #3873.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- ten one-token additions that only take effect when `read` fails (EOF). Interactive behaviour is byte-identical; the decline branches were already written and are now reachable.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11

# BEFORE (upstream/main 21f4b3a6) -- minimal install, one saved preset, stdin closed
$ ods preset load keepme </dev/null ; echo rc=$?
━━━ Loading Preset: keepme ━━━
  name: keepme
  created: 2026-09-08T00:00:00Z
rc=1                                          # no message, nothing restored
$ ods preset delete keepme </dev/null ; echo rc=$?
rc=1                                          # no message, preset kept

# AFTER (this branch)
$ ods preset load keepme </dev/null ; echo rc=$?
...
Cancelled.
rc=0
$ bash tests/test-cli-prompts-noninteractive.sh   -> Result: 3 passed, 0 failed
# same test against main's ods-cli:                -> 0 passed, 3 failed (rc=1 silent, rc=1 silent, 10 prompts without fallback)

# Other ods-cli suites, identical on branch and clean main
tests/test-ods-cli-pipefail-tolerance.sh 14 passed, 1 skipped; tests/test-cli-install-dir-resolution.sh PASS;
tests/test-cli-preset-restore-user-extensions.sh (2/7) and tests/test-cli-user-extension-deps.sh (5/10) fail identically on both (macOS host, pre-existing)

$ shellcheck --exclude=SC1091,SC2034 --severity=error ods-cli tests/test-cli-prompts-noninteractive.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 ods-cli -> default-severity warning count unchanged (32 -> 32); new test clean at default severity
$ awk -f scripts/check-heredoc-backticks.awk <changed files> -> clean; /bin/bash -n -> ok; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Chosen over a `--yes` flag on purpose: the goal is that the existing decline branches run, not that automation can auto-confirm destructive actions. `remote-provider peer-models delete` already has its own `--yes` and is unaffected.
- Searched open issues/PRs for "non-interactive", "stdin", "read -p", "Cancelled": #2809 guards a `read` in `demo-offline.sh`; nothing touches these `ods-cli` prompts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

