### PR TITLE
fix(lifecycle): take the documented default when a prompt gets EOF

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -83,6 +83,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== restore refuses empty backup config ==="
 	@bash tests/test-restore-empty-config.sh
+	@bash tests/test-lifecycle-prompts-noninteractive.sh
 	@echo ""
 	@echo "=== atomic .env writes ==="
 	@bash tests/test-atomic-env-writes.sh

--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -262,7 +262,7 @@ delete_backup() {
         return 1
     fi
 
-    read -rp "Are you sure you want to delete backup $(basename "$target")? [y/N] " confirm
+    read -rp "Are you sure you want to delete backup $(basename "$target")? [y/N] " confirm || confirm=""
     if [[ "$confirm" =~ ^[Yy]$ ]]; then
         rm -rf "$target"
         log_success "Deleted backup: $(basename "$target")"
@@ -696,7 +696,7 @@ main() {
     if [[ "$has_compose" == "false" && ! -d "$ODS_DIR/data" ]]; then
         log_warn "This doesn't appear to be a ODS directory"
         log_warn "Expected: docker-compose.yml or data/ directory"
-        read -rp "Continue anyway? [y/N] " confirm
+        read -rp "Continue anyway? [y/N] " confirm || confirm=""
         if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
             exit 1
         fi

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -188,7 +188,7 @@ select_backup() {
     fi
 
     echo "Select a backup to restore (enter number):" >&2
-    read -r selection
+    read -r selection || selection=""
 
     local backups=()
     while IFS= read -r -d '' backup; do
@@ -197,7 +197,8 @@ select_backup() {
 
     local index=$((selection - 1))
     if [[ $index -lt 0 || $index -ge ${#backups[@]} ]]; then
-        log_error "Invalid selection: $selection"
+        # stdout is the captured backup ID; the error must reach the user.
+        log_error "Invalid selection: $selection" >&2
         return 1
     fi
 
@@ -536,7 +537,7 @@ do_restore() {
         log_warn "This will copy backup data into: $ODS_DIR"
         log_warn "Existing files may be overwritten."
         echo ""
-        read -rp "Type the backup ID ('$backup_id') to continue, or press Enter to cancel: " confirm
+        read -rp "Type the backup ID ('$backup_id') to continue, or press Enter to cancel: " confirm || confirm=""
         if [[ "$confirm" != "$backup_id" ]]; then
             log_info "Restore cancelled"
             return 0
@@ -650,7 +651,7 @@ main() {
     if [[ "$has_compose" == "false" && ! -d "$ODS_DIR/data" ]]; then
         log_warn "This doesn't appear to be a ODS directory"
         log_warn "Expected: docker-compose.yml or data/ directory"
-        read -rp "Continue anyway? [y/N] " confirm
+        read -rp "Continue anyway? [y/N] " confirm || confirm=""
         if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
             exit 1
         fi

--- a/ods/ods-uninstall.sh
+++ b/ods/ods-uninstall.sh
@@ -147,7 +147,7 @@ fi
 
 if [[ "$FORCE" != "true" ]]; then
     echo -e "${YELLOW}This will permanently remove ODS and its components.${NC}"
-    read -rp "Are you sure? Type 'yes' to confirm: " confirm
+    read -rp "Are you sure? Type 'yes' to confirm: " confirm || confirm=""
     if [[ "$confirm" != "yes" ]]; then
         log_info "Uninstall cancelled."
         exit 0

--- a/ods/tests/test-lifecycle-prompts-noninteractive.sh
+++ b/ods/tests/test-lifecycle-prompts-noninteractive.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+# ods-restore.sh, ods-backup.sh and ods-uninstall.sh prompts must take their
+# documented default when stdin is not a terminal.
+#
+# Each prompt is a bare `read -rp ... confirm` under `set -euo pipefail`; on
+# EOF read returns 1 and the script died before its own "cancelled" branch:
+# `ods-restore.sh <id> </dev/null` printed the overwrite warning and exited 1
+# without "Restore cancelled", and the interactive selection prompt died the
+# same way. Companion to the ods-cli fix (#3873).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ODS_RESTORE="$ROOT_DIR/ods-restore.sh"
+ODS_BACKUP="$ROOT_DIR/ods-backup.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+pass() { echo -e "${GREEN}✓${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "${RED}✗${NC} $1"; FAIL=$((FAIL + 1)); }
+
+[[ -f "$ODS_RESTORE" ]] || { echo "ods-restore.sh not found" >&2; exit 1; }
+[[ -f "$ODS_BACKUP" ]] || { echo "ods-backup.sh not found" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Fake install: the scripts source $ODS_DIR/lib/*.sh at startup and expect a
+# data/ directory; one complete config backup under .backups/.
+FAKE_ODS="$TMP/ods"
+BID="20260101-000000"
+B="$FAKE_ODS/.backups/$BID"
+mkdir -p "$FAKE_ODS/data/open-webui" "$FAKE_ODS/config" "$B/config" "$B/data/open-webui"
+cp -R "$ROOT_DIR/lib" "$FAKE_ODS/lib"
+echo "live-settings" > "$FAKE_ODS/config/settings.json"
+echo "backup-settings" > "$B/config/settings.json"
+echo "backup-user-data" > "$B/data/open-webui/data.txt"
+cat > "$B/manifest.json" <<'JSON'
+{
+  "manifest_version": "1.0",
+  "backup_date": "2026-01-01T00:00:00Z",
+  "backup_id": "20260101-000000",
+  "backup_type": "config",
+  "ods_version": "test",
+  "hostname": "test",
+  "description": "test",
+  "contents": {"user_data": true, "config": true, "cache": false}
+}
+JSON
+
+run_closed_stdin() {
+    # stdin closed: the non-interactive case.
+    local rc
+    set +e
+    out=$(ODS_DIR="$FAKE_ODS" bash "$@" </dev/null 2>&1)
+    rc=$?
+    set -e
+    return "$rc"
+}
+
+echo "Test 1: ods-restore.sh <id> with stdin closed cancels with a message"
+if run_closed_stdin "$ODS_RESTORE" "$BID"; then
+    if [[ "$out" == *"Restore cancelled"* ]] && [[ "$(cat "$FAKE_ODS/config/settings.json")" == "live-settings" ]]; then
+        pass "restore: exit 0, 'Restore cancelled', live config untouched"
+    else
+        fail "restore exited 0 but message/config wrong: $(printf '%s' "$out" | tail -n 2 | tr '\n' '|')"
+    fi
+else
+    fail "restore died with exit $? instead of cancelling: $(printf '%s' "$out" | tail -n 2 | tr '\n' '|')"
+fi
+
+echo "Test 2: ods-restore.sh (interactive selection) with stdin closed reports the empty selection"
+if run_closed_stdin "$ODS_RESTORE"; then
+    fail "selection prompt with no input should not succeed"
+else
+    if [[ "$out" == *"Invalid selection"* ]]; then
+        pass "selection: non-zero exit with 'Invalid selection', not a silent death"
+    else
+        fail "selection died silently: $(printf '%s' "$out" | tail -n 2 | tr '\n' '|')"
+    fi
+fi
+
+echo "Test 3: ods-backup.sh --delete <id> with stdin closed cancels and keeps the backup"
+if run_closed_stdin "$ODS_BACKUP" --delete "$BID"; then
+    if [[ "$out" == *"Deletion cancelled"* && -d "$B" ]]; then
+        pass "backup --delete: exit 0, 'Deletion cancelled', backup kept"
+    else
+        fail "backup --delete exited 0 but message/backup wrong (exists=$([[ -d "$B" ]] && echo yes || echo no)): $(printf '%s' "$out" | tail -n 2 | tr '\n' '|')"
+    fi
+else
+    fail "backup --delete died with exit $? (backup exists=$([[ -d "$B" ]] && echo yes || echo no)): $(printf '%s' "$out" | tail -n 2 | tr '\n' '|')"
+fi
+
+echo "Test 4: every prompt in the lifecycle scripts tolerates EOF"
+# Prompts are top-level `read -rp ...` / `read -r <var>` statements, not the
+# `while IFS= read -r` loops that consume command output.
+bare="$(grep -nE '^[[:space:]]*read -r' "$ODS_RESTORE" "$ODS_BACKUP" "$ROOT_DIR/ods-uninstall.sh" | grep -vE '<<<|read -ra? -d|read -ra ' | grep -vE '\|\| [a-z_]+=""' || true)"
+if [[ -z "$bare" ]]; then
+    pass "all interactive reads fall back to an empty reply on EOF"
+else
+    fail "reads without an EOF fallback:"$'\n'"$bare"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Same mechanism as #3873 / #3874, in the standalone lifecycle scripts. `ods-restore.sh`, `ods-backup.sh` and `ods-uninstall.sh` confirm destructive steps with a bare `read -rp ... confirm` under `set -euo pipefail`, each followed by an explicit "cancelled" branch that never ran when stdin was not a terminal: `read` returned 1 on EOF and the script exited 1 with no message -- `ods-restore.sh <id> </dev/null` printed the overwrite warning and vanished, `ods-backup.sh --delete <id>` the same. The interactive backup picker additionally hid its error even for a person at the keyboard: `select_backup` runs inside `backup_id=$(select_backup)`, and its `log_error "Invalid selection"` went to stdout, so the message was captured into the variable and never shown. Repro in #3875.

Change (one concern: a lifecycle-script prompt must take its documented default, visibly, when there is no terminal to answer it):

- **`ods-restore.sh`**: `read -r selection || selection=""` (`:191`) and `|| confirm=""` on the two confirmation prompts (`:539`, `:653`); `select_backup`'s error is sent to stderr (`:200`) like the table and prompt already are, so `Invalid selection: ...` reaches the user instead of the captured ID.
- **`ods-backup.sh`**: `|| confirm=""` on the `--delete` confirmation (`:265`) and the "doesn't appear to be an ODS directory" prompt (`:699`).
- **`ods-uninstall.sh`**: `|| confirm=""` on the typed `yes` confirmation (`:150`); an EOF now takes the "Uninstall cancelled." path instead of dying.
- **`tests/test-lifecycle-prompts-noninteractive.sh`** (new, in `make test` next to `test-restore-empty-config.sh`, same fixture: `lib/`, `data/`, one config backup under `.backups/`): `ods-restore.sh <id>` with stdin closed exits 0 with `Restore cancelled` and leaves the live config untouched; the picker with stdin closed exits non-zero with `Invalid selection` visible; `ods-backup.sh --delete <id>` with stdin closed exits 0 with `Deletion cancelled` and keeps the backup; and a contract that every interactive `read` in the three scripts carries the EOF fallback. All four fail on current `main`. `ods-uninstall.sh` is covered by the contract only -- its default target is the real install directory, so it is not executed by the test.

Fixes #3875.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- six one-token fallbacks that only take effect when `read` fails (EOF), plus one `>&2`. Interactive behaviour is unchanged: a real answer still sets the variable, and the decline branches were already written. No path becomes *more* permissive: every fallback is an empty reply, which each prompt treats as "no".
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11
# fixture install: lib/, data/, config/, one config backup under .backups/, stdin closed

# BEFORE (upstream/main 21f4b3a6)
$ ODS_DIR=$FAKE bash ods-restore.sh 20260101-000000 </dev/null ; echo rc=$?
[WARN] Existing files may be overwritten.
rc=1                                                  # no message
$ printf '99\n' | ODS_DIR=$FAKE bash ods-restore.sh   # invalid selection, interactive
Select a backup to restore (enter number):
                                                      # exit 1, error captured into backup_id, never shown
$ ODS_DIR=$FAKE bash ods-backup.sh --delete 20260101-000000 </dev/null ; echo rc=$?
rc=1                                                  # no message, backup kept

# AFTER (this branch)
$ ODS_DIR=$FAKE bash ods-restore.sh 20260101-000000 </dev/null   -> [INFO] Restore cancelled  (rc=0)
$ printf '99\n' | ODS_DIR=$FAKE bash ods-restore.sh              -> [ERROR] Invalid selection: 99  (rc=1)
$ ODS_DIR=$FAKE bash ods-backup.sh --delete 20260101-000000 </dev/null -> [INFO] Deletion cancelled  (rc=0)
$ bash tests/test-lifecycle-prompts-noninteractive.sh     -> Result: 4 passed, 0 failed
$ /bin/bash tests/test-lifecycle-prompts-noninteractive.sh -> same under Bash 3.2
# same test against main's scripts:                        -> 0 passed, 4 failed

# Neighbouring suites (unchanged results)
tests/test-restore-empty-config.sh, test-backup-integrity.sh, test-backup-restore-roundtrip.sh, test-update-script-backup.sh, test-backup-data-coverage.sh,
test-macos-uninstall-launchagents.sh, test-uninstall-compose-flags.sh -> pass.
tests/test-restore-safety-ux.sh fails identically on clean main: its fixture never copies lib/, and ods-restore.sh
sources $ODS_DIR/lib/rsync.sh at startup ("No such file or directory"); it is not wired into make test or CI.

$ shellcheck --exclude=SC1091,SC2034 --severity=error ods-restore.sh ods-backup.sh ods-uninstall.sh tests/test-lifecycle-prompts-noninteractive.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 <each script> -> default-severity warning counts unchanged (restore 2->2, backup 2->2, uninstall 0->0); new test clean
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- `ods-restore.sh` already has `-f/--force` and `ods-uninstall.sh` has `--force` for automation that *wants* to proceed; this PR is only about the unanswered prompt taking "no" visibly instead of dying.
- Searched open issues/PRs for "non-interactive", "stdin", "read -rp", "Restore cancelled", "Invalid selection": nothing touches these prompts. #3874 is the `ods-cli` half of the same concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

