### PR TITLE
fix(macos): let config show/edit run without a Docker runtime

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -114,6 +114,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh
+	@bash tests/test-macos-config-without-docker.sh
 	@echo ""
 	@echo "=== CLI preset restore user extensions ==="
 	@bash tests/test-cli-preset-restore-user-extensions.sh

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -94,7 +94,10 @@ test_docker_running() {
     return 0
 }
 
-test_install() {
+# Install-directory checks only. Commands that read or edit local files
+# (config show / config edit) use this so they keep working while the Docker
+# runtime is down -- which is exactly when a user needs to look at .env.
+test_install_dir() {
     if [[ ! -d "$INSTALL_DIR" ]]; then
         ai_err "ODS not found at ${INSTALL_DIR}."
         ai "Invoke from inside the install dir (bash <install>/ods-macos.sh status), export ODS_HOME=<install>, or run the installer."
@@ -106,6 +109,12 @@ test_install() {
         ai_err "docker-compose.base.yml not found in ${INSTALL_DIR}"
         exit 1
     fi
+}
+
+# Install directory plus a reachable Docker runtime, for commands that talk
+# to compose.
+test_install() {
+    test_install_dir
     test_docker_running || exit 1
 }
 
@@ -912,7 +921,7 @@ cmd_logs() {
 }
 
 cmd_config_show() {
-    test_install
+    test_install_dir
 
     echo ""
     echo -e "  ${GRN}Configuration${NC}"
@@ -1070,7 +1079,7 @@ case "$COMMAND" in
         ACTION="${1:-show}"
         case "$ACTION" in
             edit)
-                test_install
+                test_install_dir
                 ${EDITOR:-nano} "${INSTALL_DIR}/.env"
                 ;;
             *)

--- a/ods/tests/test-macos-config-without-docker.sh
+++ b/ods/tests/test-macos-config-without-docker.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# macOS `ods config show` / `ods config edit` must work while the Docker
+# runtime is down. Both only read or open the local .env, but they went
+# through test_install(), whose Docker probe made them exit with
+# "Docker Desktop is not running." -- so the one moment a user needs to look
+# at or fix .env (the stack will not come up) was the moment they could not.
+# Commands that actually talk to compose (status, start, ...) keep the gate.
+#
+# Run from repo root:  bash ods/tests/test-macos-config-without-docker.sh
+# Or from ods:         bash tests/test-macos-config-without-docker.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$ROOT_DIR/installers/macos/ods-macos.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n" "$1"; FAILED=$((FAILED + 1)); }
+
+[[ -f "$CLI" ]] || { echo "ods-macos.sh not found at $CLI" >&2; exit 1; }
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# A docker CLI whose daemon is unreachable: `docker info` fails.
+SHIM_DIR="$TEMP_DIR/bin"
+mkdir -p "$SHIM_DIR"
+printf '#!/bin/sh\necho "Cannot connect to the Docker daemon" >&2\nexit 1\n' > "$SHIM_DIR/docker"
+chmod +x "$SHIM_DIR/docker"
+
+INSTALL_SCAFFOLD="$TEMP_DIR/install"
+mkdir -p "$INSTALL_SCAFFOLD"
+touch "$INSTALL_SCAFFOLD/docker-compose.base.yml"
+printf 'OLLAMA_PORT=11434\nLLM_MODEL=some-model\nDASHBOARD_API_KEY=leak-key-value\n' > "$INSTALL_SCAFFOLD/.env"
+
+run_cli() {
+    ODS_HOME="$INSTALL_SCAFFOLD" PATH="$SHIM_DIR:$PATH" EDITOR=true \
+        bash "$CLI" "$@" 2>&1 | sed 's/\x1b\[[0-9;]*m//g'
+    return "${PIPESTATUS[0]}"
+}
+
+echo ""
+echo "=== macOS CLI config commands without a Docker runtime ==="
+echo ""
+
+out=$(run_cli config show); rc=$?
+if [[ $rc -eq 0 && "$out" == *"LLM_MODEL=some-model"* && "$out" != *"Docker Desktop is not running"* ]]; then
+    pass "config show works with Docker down (rc=0, .env displayed)"
+else
+    fail "config show rc=$rc: $(printf '%s' "$out" | head -n 2 | tr '\n' '|')"
+fi
+if [[ "$out" != *"leak-key-value"* ]]; then
+    pass "config show still masks secrets"
+else
+    fail "config show leaked a secret value"
+fi
+
+out=$(run_cli config edit); rc=$?
+if [[ $rc -eq 0 && "$out" != *"Docker Desktop is not running"* ]]; then
+    pass "config edit works with Docker down (EDITOR=true, rc=0)"
+else
+    fail "config edit rc=$rc: $(printf '%s' "$out" | head -n 2 | tr '\n' '|')"
+fi
+
+out=$(run_cli status); rc=$?
+if [[ $rc -ne 0 && "$out" == *"Docker Desktop is not running"* ]]; then
+    pass "status still requires a Docker runtime (gate unchanged)"
+else
+    fail "status rc=$rc should still be gated on Docker: $(printf '%s' "$out" | head -n 2 | tr '\n' '|')"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

On macOS, `ods config show` and `ods config edit` refused to run unless the Docker runtime was up (`[XX] Docker Desktop is not running.`), although neither talks to Docker: both go through `test_install()`, which checks the install directory and then unconditionally probes the daemon. So the moment a user needs to look at or fix `.env` -- the stack will not come up, or Docker is stopped to change a port -- was the moment the CLI would not let them. The Linux `ods config show` has no such gate, and `tests/test-macos-config-show-secret-mask.sh` had been shimming `docker info` to exit 0 to get past it. Repro in #3879.

Change (one concern: local-file commands must not require a Docker runtime):

- **`installers/macos/ods-macos.sh`**: split `test_install()` into `test_install_dir()` (install directory and compose file present) and `test_install()` (`test_install_dir` + `test_docker_running`, i.e. exactly what every existing caller had). `cmd_config_show` and the `config edit` branch call `test_install_dir`; the seven compose-driving callers (`status`, `start`, `stop`, `restart`, `logs`, `chat`, `update`) are untouched.
- **`tests/test-macos-config-without-docker.sh`** (new, in `make test` next to the secret-mask test): runs the CLI with a `docker` shim whose `info` fails and asserts `config show` succeeds with `.env` displayed and secrets still masked, `config edit` (with `EDITOR=true`) succeeds, and `status` is still refused with the Docker message. Fails on current `main` (both config commands exit 1 with the Docker message).

Fixes #3879.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- a function split with identical behaviour for every existing caller, plus two call sites moved to the directory-only check. No output or masking logic changes (the existing secret-mask suite still passes).
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11, no Docker daemon

# BEFORE (upstream/main 21f4b3a6) -- install dir seeded from the checkout
$ ods-macos.sh config show
  [XX] Docker Desktop is not running.
$ ods-macos.sh config edit
  [XX] Docker Desktop is not running.

# AFTER (this branch)
$ bash tests/test-macos-config-without-docker.sh
  ✓ PASS config show works with Docker down (rc=0, .env displayed)
  ✓ PASS config show still masks secrets
  ✓ PASS config edit works with Docker down (EDITOR=true, rc=0)
  ✓ PASS status still requires a Docker runtime (gate unchanged)
# same test against main's CLI: config show / config edit FAIL with the Docker message

$ bash tests/test-macos-config-show-secret-mask.sh -> Result: 15 passed, 0 failed (its docker-info shim now merely redundant)
$ bash tests/test-macos-env-quote-strip.sh        -> Result: 9 passed, 0 failed
$ bash tests/test-macos-direct-bind-bridge.sh, tests/test-macos-uninstall-launchagents.sh -> pass

$ shellcheck --exclude=SC1091,SC2034 --severity=error installers/macos/ods-macos.sh tests/test-macos-config-without-docker.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 installers/macos/ods-macos.sh -> default-severity warning count unchanged (0 -> 0); new test clean
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- The Docker-down message says "Docker Desktop is not running" although the macOS installer provisions Colima; left as is here (different concern).
- `tests/test-macos-config-show-secret-mask.sh` keeps its `docker info` shim; it is harmless now and the suite passes unchanged.
- Searched open issues/PRs for "config show", "Docker Desktop is not running", "test_install": nothing touches this gate. #3787 / #3791 (mine, `installers/macos.sh`) are a different file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

