### PR TITLE
fix(dashboard): mask local-override credentials named *_KEY

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -20,8 +20,12 @@ from host_agent_client import AgentClientError, request_json as request_agent_js
 
 _ENV_ASSIGNMENT_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 _ENV_COMMENTED_ASSIGNMENT_RE = re.compile(r"^\s*#\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+# Name heuristic for keys the schema does not describe (extension-written
+# local overrides such as LibreChat's CREDS_KEY / LIBRECHAT_MEILI_KEY /
+# GOOGLE_KEY). A trailing "_KEY" is a credential unless it is a PUBLIC_KEY
+# (excluded in _is_secret_field); "_KEY_PATH" / "_KEY_FILE" stay visible.
 _SENSITIVE_ENV_KEY_RE = re.compile(
-    r"(SECRET|(?:^|_)TOKEN(?:$|_)|PASSWORD|(?:^|_)PASS(?:$|_)|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|(?:^|_)SALT(?:$|_))"
+    r"(SECRET|(?:^|_)TOKEN(?:$|_)|PASSWORD|(?:^|_)PASS(?:$|_)|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|(?:^|_)SALT(?:$|_)|(?:^|_)KEY$)"
 )
 _GGUF_QUANTIZED_MODEL_RE = re.compile(
     r"(?:^|[-_.])q[2-8](?:_[a-z0-9]+)*(?:$|[-_.])",

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1420,3 +1420,66 @@ def test_env_example_keys_are_present_in_schema():
     schema_keys = set(schema.get("properties", {}))
 
     assert documented_keys - schema_keys == set()
+
+
+def test_api_settings_env_masks_extension_keys_outside_the_schema(test_client, settings_env_fixture):
+    """Extension-written credentials that the schema does not describe must be
+    masked by name. LibreChat's compose requires CREDS_KEY and
+    LIBRECHAT_MEILI_KEY in .env (``${CREDS_KEY:?...}``), so they exist as
+    local overrides; they used to come back in cleartext with secret=false.
+    """
+    env_path = settings_env_fixture["env_path"]
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8")
+        + "CREDS_KEY=creds-leak-value\n"
+        + "LIBRECHAT_MEILI_KEY=meili-leak-value\n"
+        + "GOOGLE_KEY=google-leak-value\n"
+        + "ODS_ROUTER_INTERNAL_KEY=router-leak-value\n"
+        + "LANGFUSE_PROJECT_PUBLIC_KEY=pk-lf-visible\n"
+        + "TLS_KEY_FILE=/etc/ods/tls.key\n",
+        encoding="utf-8",
+    )
+
+    response = test_client.get("/api/settings/env", headers=test_client.auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    body = json.dumps(payload)
+    for key, sentinel in (
+        ("CREDS_KEY", "creds-leak-value"),
+        ("LIBRECHAT_MEILI_KEY", "meili-leak-value"),
+        ("GOOGLE_KEY", "google-leak-value"),
+        ("ODS_ROUTER_INTERNAL_KEY", "router-leak-value"),
+    ):
+        assert payload["fields"][key]["secret"] is True, key
+        assert payload["fields"][key]["hasValue"] is True, key
+        assert payload["values"][key] == "", key
+        assert sentinel not in body, key
+    # Precision: a public key and a key *file path* are not credentials.
+    assert payload["fields"]["LANGFUSE_PROJECT_PUBLIC_KEY"]["secret"] is False
+    assert payload["values"]["LANGFUSE_PROJECT_PUBLIC_KEY"] == "pk-lf-visible"
+    assert payload["fields"]["TLS_KEY_FILE"]["secret"] is False
+    assert payload["values"]["TLS_KEY_FILE"] == "/etc/ods/tls.key"
+
+
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("CREDS_KEY", True),
+        ("GOOGLE_KEY", True),
+        ("OPENROUTER_KEY", True),
+        ("LIBRECHAT_MEILI_KEY", True),
+        ("ODS_FLEET_PROBE_KEY", True),
+        ("BEDROCK_AWS_SECRET_ACCESS_KEY", True),
+        ("LANGFUSE_PROJECT_PUBLIC_KEY", False),
+        ("SHIELD_API_KEY_PATH", True),   # already matched by API_KEY before this change
+        ("TLS_KEY_FILE", False),
+        ("LLAMA_ARG_CACHE_TYPE_K", False),
+        ("LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS", False),
+        ("KEYBOARD_LAYOUT", False),
+    ],
+)
+def test_is_secret_field_name_heuristic(key, expected):
+    from settings import _is_secret_field
+
+    assert _is_secret_field(key) is expected


### PR DESCRIPTION
## Summary

`GET /api/settings/env` masks a value only when its field is marked secret. For keys the schema does not describe -- the local overrides the Settings page deliberately exposes -- `_is_secret_field` decides by name, and its regex counts a trailing `_KEY` only as `API_KEY`, `PRIVATE_KEY` or `ENCRYPTION_KEY`. So the credentials extensions require in `.env` came back in cleartext: LibreChat's `CREDS_KEY` (its credential-encryption key), `LIBRECHAT_MEILI_KEY`, `GOOGLE_KEY`, `OPENROUTER_KEY`, and `ODS_ROUTER_INTERNAL_KEY` from `docker-compose.base.yml` all rendered as plain settings while `ods config show` and the support bundle already mask them. Repro in #3881.

Change (one concern: a local override named like a credential must be masked like one):

- **`extensions/services/dashboard-api/settings.py`**: add `(?:^|_)KEY$` to `_SENSITIVE_ENV_KEY_RE`. The existing `PUBLIC_KEY` exclusion in `_is_secret_field` still applies, and `_KEY_PATH` / `_KEY_FILE` names do not end in `_KEY`, so key file paths stay visible. Schema-described keys are unaffected (their `secret` flag wins before the regex runs).
- **`tests/test_settings_env.py`**: an API test with the LibreChat/router keys as local overrides (`secret: true`, `hasValue: true`, value blanked, sentinel absent from the payload) plus precision checks (`LANGFUSE_PROJECT_PUBLIC_KEY` and `TLS_KEY_FILE` stay visible), and a table test for `_is_secret_field` covering the new rule and the names that must not match (`LLAMA_ARG_CACHE_TYPE_K`, `LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS`, `KEYBOARD_LAYOUT`). Both fail on current `main`.

Fixes #3881.

False-positive check: across every `${VAR}` the compose stack references, the only `_KEY` names that are not credentials are `LANGFUSE_PROJECT_PUBLIC_KEY` (excluded) and `ODS_TALK_VISION_KEY`, which is a bearer token that #2697 marks `secret: true` in the schema (this rule masks it by name in the meantime). All 22 non-schema `*_KEY` variables (`AZURE_OPENAI_API_KEY`, `BEDROCK_AWS_SECRET_ACCESS_KEY`, `PAPERLESS_SECRET_KEY`, ...) are credentials.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- one regex alternative. The only behavioural change is that more local-override fields render masked; a masked field keeps its value on save (`_serialize_form_values` preserves secrets submitted blank), so nothing is lost. Schema-described fields are untouched.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build (API: full pytest suite, ruff with the CI flags, mypy; no UI change)
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Python 3.13 venv with the dashboard-api requirements

# BEFORE (upstream/main 21f4b3a6) -- FastAPI test client, repository settings fixture
GET /api/settings/env with CREDS_KEY / LIBRECHAT_MEILI_KEY / GOOGLE_KEY / OPENROUTER_KEY / ODS_ROUTER_INTERNAL_KEY in .env
  every one: secret=False, value returned in cleartext          (OPENAI_API_KEY: secret=True, value='')
$ pytest tests/test_settings_env.py -k "extension_keys or name_heuristic"   -> 6 failed, 7 passed (API test + 5 heuristic rows)

# AFTER (this branch)
$ pytest tests/test_settings_env.py                                          -> 104 passed
$ pytest tests                                                               -> 2151 passed, 1 skipped
$ ruff check --select E,F,W --ignore E501,E701,E731,E741,E402 settings.py tests/test_settings_env.py -> All checks passed!
$ mypy --ignore-missing-imports settings.py -> 5 errors in config.py / host_agent_client.py, identical on upstream/main (pre-existing)
$ git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Deliberately narrower than `ods config show`'s `*key*` rule: `KEYBOARD_LAYOUT`, `LLAMA_ARG_CACHE_TYPE_K` and `*_KEY_FILE` paths stay visible; the existing plural-`TOKENS` precision test still passes.
- `CREDS_IV` (LibreChat's encryption IV, paired with `CREDS_KEY`) is not matched by any surface's heuristic; left out here as it is not a key by name.
- Searched open issues/PRs for "cleartext", "_is_secret_field", "CREDS_KEY", "secret field mask": #2697 (schema flag for `ODS_TALK_VISION_KEY`) is the only related change and touches a different file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

