### PR TITLE
fix(health-check): make --json emit only the JSON document on stdout

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -68,6 +68,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-safe-env.sh
 	@bash tests/test-phase06-secret-generation.sh
 	@echo ""
+	@echo "=== health-check.sh --json output contract ==="
+	@bash tests/test-health-check-json-output.sh
+	@echo ""
 	@echo "=== QR code helper LAN detection ==="
 	@bash tests/test-qrcode-helper.sh
 	@echo ""

--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -29,6 +29,11 @@ for arg in "$@"; do
         --quiet) QUIET=true ;;
     esac
 done
+# --json is for machines: stdout must be the JSON document and nothing else,
+# so the human banner and per-check lines (all routed through log) are off.
+if $JSON_OUTPUT; then
+    QUIET=true
+fi
 
 # Config (defaults; .env overrides after load_env_file below)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" 

--- a/ods/tests/test-health-check-json-output.sh
+++ b/ods/tests/test-health-check-json-output.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# `health-check.sh --json` must write only the JSON document to stdout.
+#
+# The human banner and per-check lines go through log(), which was gated on
+# --quiet alone, so `--json` printed "ODS Health Check", the check table and
+# then the JSON -- and any consumer parsing stdout failed on line 1.
+#
+# Run from repo root:  bash ods/tests/test-health-check-json-output.sh
+# Or from ods:         bash tests/test-health-check-json-output.sh
+set -uo pipefail
+
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    for _modern_bash in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        # The probe must expand in the candidate shell, not this one.
+        # shellcheck disable=SC2016
+        if [ -x "$_modern_bash" ] && [ "$("$_modern_bash" -c 'echo "${BASH_VERSINFO[0]}"')" -ge 4 ]; then
+            exec "$_modern_bash" "$0" "$@"
+        fi
+    done
+    echo "[SKIP] health-check.sh requires Bash 4+ (service registry); this host only has Bash ${BASH_VERSION}"
+    echo "Result: 0 passed, 0 failed, 1 skipped"
+    exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+HC="$ROOT_DIR/scripts/health-check.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+command -v python3 >/dev/null 2>&1 || { echo "python3 required"; exit 1; }
+[[ -f "$HC" ]] || { echo "health-check.sh not found"; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+# Fixture install: only .env is read from INSTALL_DIR; the registry and libs
+# come from the checkout. Every probe targets loopback and fails fast.
+mkdir -p "$TMP/install"
+printf 'OLLAMA_PORT=1\nWEBUI_PORT=1\n' > "$TMP/install/.env"
+# A docker CLI whose daemon is unreachable, so container checks fail cleanly.
+mkdir -p "$TMP/bin"
+printf '#!/bin/sh\necho "Cannot connect to the Docker daemon" >&2\nexit 1\n' > "$TMP/bin/docker"
+chmod +x "$TMP/bin/docker"
+
+echo "Test 1: --json stdout parses as a JSON document"
+set +e
+INSTALL_DIR="$TMP/install" TIMEOUT=1 PATH="$TMP/bin:$PATH" "$BASH" "$HC" --json > "$TMP/out.json" 2> "$TMP/err.txt"
+rc=$?
+set -e
+if python3 - "$TMP/out.json" <<'PY'
+import json, sys
+doc = json.load(open(sys.argv[1]))
+assert isinstance(doc, dict) and "status" in doc and "services" in doc, doc.keys()
+PY
+then
+    pass "--json stdout is a single JSON document (status + services present; exit $rc reflects check results)"
+else
+    fail "--json stdout is not valid JSON; first line: $(head -n 1 "$TMP/out.json")"
+fi
+
+echo "Test 2: no human banner or check lines on stdout in --json mode"
+if grep -qE 'ODS Health Check|━━|✓|✗' "$TMP/out.json"; then
+    fail "human output found on stdout in --json mode"
+else
+    pass "stdout carries only the document"
+fi
+
+echo "Test 3: default (human) mode still prints the banner"
+set +e
+human="$(INSTALL_DIR="$TMP/install" TIMEOUT=1 PATH="$TMP/bin:$PATH" "$BASH" "$HC" 2>&1)"
+set -e
+if [[ "$human" == *"ODS Health Check"* ]]; then
+    pass "human mode unchanged"
+else
+    fail "human mode lost its banner"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

`scripts/health-check.sh --json` printed the human banner and every per-check line before the JSON object, so `health-check.sh --json | jq ...` (or any consumer parsing stdout) failed on line 1. The human lines go through `log()`, which only `--quiet` silences; `--json` only stripped colours and appended the document at the end. Repro in #3883.

Change (one concern: `--json` stdout must be one JSON document):

- **`scripts/health-check.sh`**: after argument parsing, `--json` sets `QUIET=true`, so `log()` (banner, check table, trailing blank line) is silent in JSON mode. The JSON block, exit codes and the default human mode are unchanged; `--json --quiet` keeps working.
- **`tests/test-health-check-json-output.sh`** (new, in `make test` before the QR-code test): runs the script with `--json` against a fixture install (`INSTALL_DIR` with a minimal `.env`, `TIMEOUT=1`, a `docker` shim whose daemon is unreachable so container checks fail fast), parses stdout with `json.load` and asserts `status`/`services` are present, asserts no banner or check-table text is on stdout, and asserts the default mode still prints the banner. Fails on current `main` (first stdout line is the banner rule).

Fixes #3883.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- one assignment that only takes effect with `--json`. Human mode is byte-identical (Test 3 and the existing `tests/test-health-check.sh` suite pass unchanged).
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11, no Docker daemon

# BEFORE (upstream/main 21f4b3a6)
$ scripts/health-check.sh --json > out.json ; head -2 out.json
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  ODS Health Check
$ python3 -c 'import json; json.load(open("out.json"))'   -> JSONDecodeError: Expecting value: line 1 column 1

# AFTER (this branch)
$ bash tests/test-health-check-json-output.sh
[PASS] --json stdout is a single JSON document (status + services present; exit 2 reflects check results)
[PASS] stdout carries only the document
[PASS] human mode unchanged
# same test against main's script: Test 1 and Test 2 FAIL (first line is the banner rule)
$ bash tests/test-health-check.sh                 -> Result: 15 passed, 0 failed (existing suite, unchanged)

$ shellcheck --exclude=SC1091,SC2034 --severity=error scripts/health-check.sh tests/test-health-check-json-output.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 scripts/health-check.sh -> default-severity warning count unchanged (4 -> 4); new test clean
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Routing `log()` to stderr in JSON mode would also work, but the header already documents `--quiet` as "no human output", so tying `--json` to it keeps one switch and keeps stderr free for real errors.
- Searched open issues/PRs for "health-check --json", "health-check.sh json", "JSON_OUTPUT": nothing touches this output path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

