### PR TITLE
fix(schema): declare the Intel Arc keys the installer writes to .env

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -875,6 +875,21 @@
       "description": "GID of the 'render' group on the host (used in container group_add for AMD GPU access)",
       "default": 992
     },
+    "ONEAPI_DEVICE_SELECTOR": {
+      "type": "string",
+      "description": "oneAPI device filter for the Intel Arc (SYCL) llama-server build. Phase 06 writes 'level_zero:gpu' when GPU_BACKEND=sycl so the runtime binds the Arc GPU through Level Zero; see docs/INTEL-ARC-GUIDE.md.",
+      "default": "level_zero:gpu"
+    },
+    "SYCL_CACHE_PERSISTENT": {
+      "type": "integer",
+      "description": "Persist the SYCL kernel JIT cache across container starts (1 = on). Phase 06 writes it for GPU_BACKEND=sycl; without it every llama-server start recompiles kernels (~30s).",
+      "default": 1
+    },
+    "ZES_ENABLE_SYSMAN": {
+      "type": "integer",
+      "description": "Enable Level Zero Sysman so the Intel Arc runtime can report GPU memory (1 = on). Phase 06 writes it for GPU_BACKEND=sycl.",
+      "default": 1
+    },
     "HSA_OVERRIDE_GFX_VERSION": {
       "type": "string",
       "description": "ROCm HSA gfx-target override (HSA-version format, e.g. '11.5.1' for gfx1151). Phase 06 sets this only when the detected gfx target is gfx1151 (Strix Halo, not in ROCm's native support list). Leave unset on natively-supported parts (gfx942/MI300X, gfx90a/MI250, gfx1100/RX 7900) — setting it on those crashes model-load with HSA_STATUS_ERROR_INVALID_ISA."

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -503,6 +503,25 @@ else
 ' ' ')"
 fi
 
+# 22. Keys the Linux installer itself writes for Intel Arc (GPU_BACKEND=sycl,
+# installers/phases/06-directories.sh INTEL_ENV block) must be declared, or
+# `ods config validate` reports them as unknown on every Arc install.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/arc.env"
+cat >> "$TMP_DIR/arc.env" <<'EOF'
+ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+SYCL_CACHE_PERSISTENT=1
+ZES_ENABLE_SYSMAN=1
+EOF
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/arc.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 0 ]]; then
+    pass "Installer-written Intel Arc keys validate cleanly"
+else
+    fail "Intel Arc keys should validate, got exit $r: $(echo "$out" | grep -iE 'ONEAPI|SYCL|ZES' | tr '\n' ' ')"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

On Intel Arc installs (`GPU_BACKEND=sycl`) phase 06 writes `ONEAPI_DEVICE_SELECTOR`, `SYCL_CACHE_PERSISTENT` and `ZES_ENABLE_SYSMAN` into `.env` (the `INTEL_ENV` block, `installers/phases/06-directories.sh:1014-1023`), `docker-compose.arc.yml` consumes them and `docs/INTEL-ARC-GUIDE.md` documents them -- but `.env.schema.json` never declared them, and `validate-env.sh` treats unknown keys as errors. So `ods config validate` failed on every fresh Arc install with keys the installer itself produced. Repro in #3885.

Change (one concern: keys the installer writes must be declared in the schema):

- **`.env.schema.json`**: declare the three keys next to the AMD GPU keys (`VIDEO_GID` / `RENDER_GID` / `HSA_OVERRIDE_GFX_VERSION`), with the types and defaults phase 06 writes (`level_zero:gpu`, `1`, `1`) and descriptions taken from the Intel Arc guide.
- **`tests/test-validate-env.sh`**: case 22, in the style of the Brave Search case 21 -- a valid `.env` plus the three installer-written lines must validate cleanly against the real schema. Fails on current `main` with the three "Unknown keys" errors.

Fixes #3885.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- three additive schema entries. Nothing that validated before stops validating; the dashboard Settings page gains three described fields on Arc installs instead of three "local override" rows. No installer or runtime code changes.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build (API settings/router tests, which read the schema)
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3, jq 1.7, Python 3.13 venv

# BEFORE (upstream/main 21f4b3a6) -- install dir seeded from the checkout + the three INTEL_ENV lines
$ ods config validate
[ERROR] Unknown keys not defined in schema:
  - ONEAPI_DEVICE_SELECTOR (line 606)
  - ZES_ENABLE_SYSMAN (line 608)
  - SYCL_CACHE_PERSISTENT (line 607)

# AFTER (this branch)
$ jq -e '.properties.ONEAPI_DEVICE_SELECTOR, .properties.SYCL_CACHE_PERSISTENT, .properties.ZES_ENABLE_SYSMAN' .env.schema.json -> present, valid JSON
$ bash tests/test-validate-env.sh                     -> Result: 46 passed, 0 failed
# same suite against main's schema:                    -> case 22 FAIL ("Intel Arc keys should validate, got exit 2: ONEAPI_DEVICE_SELECTOR ... ZES_ENABLE_SYSMAN ... SYCL_CACHE_PERSISTENT")
$ python3 tests/contracts/test-port-contracts.py      -> [PASS] canonical port contract parity
$ bash tests/test-secret-security.sh                  -> Results: 26 passed, 0 failed, 2 skipped
$ bash tests/test-validate-manifest-schema.sh         -> Manifest schema source-of-truth tests passed
$ scripts/validate-env.sh .env.example                -> unchanged: exit 2 with the same 6 pre-existing minLength placeholder errors
$ pytest extensions/services/dashboard-api/tests/test_settings_env.py tests/test_routers.py -> 145 passed
$ shellcheck --exclude=SC1091,SC2034 --severity=error tests/test-validate-env.sh -> clean; /bin/bash -n -> ok; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Found by diffing every key the installers write against the schema; these three are the only Linux-installer keys missing. `GPU_BACKEND`'s description still lists "nvidia, amd, apple, or cpu" without `sycl` -- left alone here as a separate wording nit.
- Searched open issues/PRs for "ONEAPI", "SYCL", "ZES_ENABLE_SYSMAN", "schema unknown keys": #2976 (offline-mode keys) is the same class for different keys and does not touch these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

