### PR TITLE
docs(migration): name the real update command in the OpenClaw guide

### DIFF
--- a/ods/docs/MIGRATION-OPENCLAW-TO-HERMES.md
+++ b/ods/docs/MIGRATION-OPENCLAW-TO-HERMES.md
@@ -42,7 +42,7 @@ ods enable openclaw      # still available (deprecated)
 
 Ports do not conflict — Hermes is internal on 9119 and is reached through hermes-proxy on 9120; OpenClaw is on 7860.
 
-The default at install time has flipped: `install.sh` no longer enables OpenClaw without `--openclaw`. Existing installs that already had `ENABLE_OPENCLAW=true` keep it enabled through `ods upgrade`; nothing is removed for you.
+The default at install time has flipped: `install.sh` no longer enables OpenClaw without `--openclaw`. Existing installs that already had `ENABLE_OPENCLAW=true` keep it enabled through `ods update`; nothing is removed for you.
 
 ## Clean-cut migration
 
@@ -67,7 +67,7 @@ ods disable openclaw
 mv data/openclaw data/openclaw.archive.$(date +%Y%m%d)
 ```
 
-If you want to keep using OpenClaw, you can — until the next release. After that, `ods upgrade` will remove the OpenClaw extension and warn (not error) if `ENABLE_OPENCLAW=true` is still set.
+If you want to keep using OpenClaw, you can — until the next release. After that, `ods update` will remove the OpenClaw extension and warn (not error) if `ENABLE_OPENCLAW=true` is still set.
 
 ## n8n flows that target OpenClaw
 


### PR DESCRIPTION
## Summary

`docs/MIGRATION-OPENCLAW-TO-HERMES.md` told users twice (lines 45 and 70) that `ods upgrade` carries an install through the OpenClaw transition. The CLI has no such command: `ods-cli` dispatches only `update|u` (line 6583) and answers `ods upgrade` with `Unknown command: upgrade`. Every other document (`QUICKSTART.md`, `docs/FAQ.md`, `docs/INSTALLER-ARCHITECTURE.md`, `ods help`) already says `ods update`. Repro in #3887.

Change (one concern: the migration guide names the real command):

- **`docs/MIGRATION-OPENCLAW-TO-HERMES.md`**: `ods upgrade` -> `ods update` on both lines. No other wording touched.

Fixes #3887.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: None -- two words in one Markdown file.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3, upstream/main 21f4b3a6

$ grep -nE '^\s*(update|upgrade)[|)]' ods-cli        -> 6583:    update|u)    shift; cmd_update "$@" ;;
$ ods upgrade                                        -> ✗ Unknown command: upgrade. Run 'ods help' for usage.
$ ods help | grep -n 'update\|upgrade'               -> "update [--force] [--rebuild-images]", "ods update --dry-run"; no "upgrade"
$ grep -rn 'ods upgrade' docs/ README.md QUICKSTART.md -> 0 matches after the change
$ bash tests/test-install-docs.sh                     -> [PASS] Install commands and provenance guidance are consistent
$ git diff --check                                    -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Searched open issues/PRs for "ods upgrade" and "MIGRATION-OPENCLAW-TO-HERMES": nothing touches this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

