### PR TITLE
docs(backup): state the real default backup type in --help

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -168,7 +168,7 @@ Commands:
 OPTIONS:
     -h, --help              Show this help message
     -o, --output DIR        Custom backup directory (default: .backups/)
-    -t, --type TYPE         Backup type: full, user-data, config (default: full)
+    -t, --type TYPE         Backup type: full, user-data, config (default: user-data)
     -c, --compress          Compress backup to .tar.gz
     -l, --list              List existing backups
     -d, --delete ID         Delete specific backup by ID


### PR DESCRIPTION
## Summary

The `-t, --type` line in `ods-backup.sh --help` said the default backup type is `full`, while `main()` sets `backup_type="user-data"` and the BACKUP TYPES list and the examples in the same help text already say `user-data`. A user reading only the options block would expect a plain `ods backup` to include models and caches. Repro in #3893.

Change (one concern: the help text states the real default):

- **`ods-backup.sh`**: `(default: full)` -> `(default: user-data)` on the `-t, --type` line. No behaviour change.

Fixes #3893.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: None -- one word inside a heredoc help string.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), stock /bin/bash 3.2, shellcheck 0.11, upstream/main 21f4b3a6

$ grep -n 'backup_type="user-data"' ods-backup.sh   -> 608 (the default main() applies)
$ ods-backup.sh --help | grep -n default
    -t, --type TYPE         Backup type: full, user-data, config (default: user-data)
    user-data   Backup only user data volumes (default)
    ods-backup.sh                          # Backup (default: user-data)
$ bash tests/test-backup-restore-cli.sh              -> PASS
$ shellcheck --exclude=SC1091,SC2034 --severity=error ods-backup.sh -> clean; /bin/bash -n -> ok; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Noticed while working on #3891 (the full backup's cache tier, PR #3892); kept separate because it is help text only.
- Searched open issues/PRs for "backup help default", "default: full": nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

