### PR TITLE
fix(macos): stop writing LLM_BACKEND twice into the generated .env

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -146,6 +146,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== macOS CLI .env quote handling ==="
 	@bash tests/test-macos-env-quote-strip.sh
+	@echo "=== macOS generated .env validates against the schema ==="
+	@bash tests/test-macos-env-schema.sh
 	@echo ""
 	@echo "=== macOS uninstall LaunchAgent cleanup ==="
 	@bash tests/test-macos-uninstall-launchagents.sh

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -532,7 +532,6 @@ ODS_MODE=local
 ODS_MODEL_SWITCHBOARD=${switchboard_mode}
 LLM_BACKEND=llama-server
 LLM_API_URL=${llm_api_url}
-LLM_BACKEND=llama-server
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=

--- a/ods/tests/test-macos-env-schema.sh
+++ b/ods/tests/test-macos-env-schema.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# The .env that installers/macos/lib/env-generator.sh writes must pass the
+# project's own schema validator (scripts/validate-env.sh): every key declared
+# in .env.schema.json, values of the declared types, and no key assigned twice.
+# Two commits each added `LLM_BACKEND=llama-server` to the heredoc, so every
+# macOS install failed validation with a duplicate-key error.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        [[ -x "$candidate" ]] && exec "$candidate" "$0" "$@"
+    done
+    echo "[FAIL] Bash 4+ is required" >&2
+    exit 1
+fi
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_GENERATOR="$ROOT_DIR/installers/macos/lib/env-generator.sh"
+VALIDATOR="$ROOT_DIR/scripts/validate-env.sh"
+SCHEMA="$ROOT_DIR/.env.schema.json"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$ENV_GENERATOR" ]] || fail "missing $ENV_GENERATOR"
+[[ -f "$VALIDATOR" ]] || fail "missing $VALIDATOR"
+command -v jq >/dev/null 2>&1 || fail "jq is required by validate-env.sh"
+
+# The generator only shells out for the Docker CPU budget and the hostname;
+# neither is a property of the file under test.
+STUB_DIR="$TMP_DIR/bin"
+mkdir -p "$STUB_DIR"
+printf '#!/bin/sh\nexit 1\n' > "$STUB_DIR/docker"
+printf '#!/bin/sh\necho ods-test-mac\n' > "$STUB_DIR/hostname"
+chmod +x "$STUB_DIR/docker" "$STUB_DIR/hostname"
+
+# Render the .env for one tier the way install-macos.sh does: constants,
+# tier map, then the generator with the tier's model variables resolved.
+generate_env() {
+    local tier="$1"
+    local install_dir="$2"
+    mkdir -p "$install_dir/config/searxng"
+    (
+        export PATH="$STUB_DIR:$PATH"
+        export ODS_INSTALL_DIR="$install_dir"
+        export HOME="$TMP_DIR/home"
+        # shellcheck source=/dev/null
+        . "$ROOT_DIR/installers/macos/lib/constants.sh"
+        # shellcheck source=/dev/null
+        . "$ROOT_DIR/installers/macos/lib/tier-map.sh"
+        # shellcheck source=/dev/null
+        . "$ENV_GENERATOR"
+        # shellcheck disable=SC2329  # called by generate_ods_env
+        calculate_llama_cpu_budget() { printf '4 1 8\n'; }
+        SYSTEM_RAM_GB=64
+        DOCKER_BACKEND="docker-desktop"
+        ODS_MODEL_SWITCHBOARD="enabled"
+        resolve_tier_config "$tier" || exit 3
+        generate_ods_env "$install_dir" "$tier" true
+    ) >"$install_dir/generate.log" 2>&1 \
+        || fail "generate_ods_env failed for tier $tier: $(tail -n 3 "$install_dir/generate.log")"
+    [[ -f "$install_dir/.env" ]] || fail "tier $tier produced no .env"
+}
+
+duplicate_keys() {
+    grep -E '^[A-Za-z_][A-Za-z0-9_]*=' "$1" \
+        | cut -d= -f1 \
+        | sort \
+        | uniq -d
+}
+
+for tier in 1 CLOUD; do
+    install_dir="$TMP_DIR/tier-$tier"
+    generate_env "$tier" "$install_dir"
+    env_file="$install_dir/.env"
+
+    dupes="$(duplicate_keys "$env_file")"
+    [[ -z "$dupes" ]] \
+        || fail "tier $tier .env assigns a key more than once: $(printf '%s' "$dupes" | tr '\n' ' ')"
+    [[ "$(grep -c '^LLM_BACKEND=' "$env_file")" -eq 1 ]] \
+        || fail "tier $tier .env must declare LLM_BACKEND exactly once"
+    pass "tier $tier: generated .env assigns every key once"
+
+    # validate-env.sh needs Bash 4+ (associative arrays); ods-cli runs it with
+    # "$BASH" for the same reason, so do not go through its /bin/bash shebang.
+    if ! output="$("$BASH" "$VALIDATOR" "$env_file" "$SCHEMA" 2>&1)"; then
+        fail "tier $tier .env does not validate against .env.schema.json: $(printf '%s' "$output" | grep -E 'ERROR|  - ' | head -n 4 | tr '\n' ' ')"
+    fi
+    pass "tier $tier: generated .env validates against .env.schema.json"
+done


### PR DESCRIPTION
## Summary

`installers/macos/lib/env-generator.sh` wrote `LLM_BACKEND=llama-server` twice into every `.env` it generated (heredoc lines 533 and 535, added by two independent commits, 00a9ad29 and 2b5c7d66). `scripts/validate-env.sh` treats a repeated key as an error, so a fresh macOS install failed the project's own schema validation with `LLM_BACKEND: duplicate assignment at lines 20:22`. Nothing validated the macOS-generated `.env` against `.env.schema.json`. Repro in #3895.

Change (one concern: the macOS-generated `.env` passes the schema validator):

- **`installers/macos/lib/env-generator.sh`**: drop the second `LLM_BACKEND=llama-server` line. The first stays where it was, between `ODS_MODEL_SWITCHBOARD` and `LLM_API_URL`. Same value, so no runtime change.
- **`tests/test-macos-env-schema.sh`** (new, in `make test` after the macOS quote-strip test): renders the `.env` for tier `1` and tier `CLOUD` through the real generator (constants + tier map + generator, with the Docker CPU-budget and `hostname` lookups stubbed, the same setup `test-macos-installer-transitions.sh` uses), asserts no key is assigned twice and `LLM_BACKEND` appears exactly once, then runs `validate-env.sh` on the file with `$BASH` (the validator needs Bash 4+, as `ods-cli` already accounts for). Re-execs into Homebrew Bash on macOS like the other macOS tests. Fails on current `main` with `assigns a key more than once: LLM_BACKEND`.

Fixes #3895.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- one deleted heredoc line whose value the surviving line already sets; readers (Compose, safe-env, the dashboard parser) all took the last value, which is identical.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation (apple stack `docker compose config -q` on every generated file)
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, jq 1.7, Docker CLI 29 (compose config only), shellcheck 0.11

# BEFORE (clean export of upstream/main 21f4b3a6 + this test)
$ bash tests/test-macos-env-schema.sh
[FAIL] tier 1 .env assigns a key more than once: LLM_BACKEND
# every macOS tier (0-4, CLOUD) x profile (qwen, gemma4) generated on main:
$ bash scripts/validate-env.sh <generated .env> .env.schema.json -> exit 2, "LLM_BACKEND: duplicate assignment at lines 20:22" (12/12)

# AFTER (this branch)
$ bash tests/test-macos-env-schema.sh          (bash 5.3, and via /bin/bash 3.2 -> re-exec)
[PASS] tier 1: generated .env assigns every key once
[PASS] tier 1: generated .env validates against .env.schema.json
[PASS] tier CLOUD: generated .env assigns every key once
[PASS] tier CLOUD: generated .env validates against .env.schema.json
# same 12 tier/profile files regenerated on this branch: validate-env.sh exit 0 (12/12);
# resolve-compose-stack.sh --gpu-backend apple + docker compose config -q: exit 0 (12/12)
$ bash tests/test-macos-installer-transitions.sh  -> PASS
$ bash tests/test-macos-env-quote-strip.sh        -> PASS
$ bash tests/test-macos-direct-bind-bridge.sh     -> PASS
$ bash tests/test-macos-config-show-secret-mask.sh -> PASS

$ shellcheck --exclude=SC1091,SC2034 --severity=error installers/macos/lib/env-generator.sh tests/test-macos-env-schema.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 (default severity): env-generator.sh 3 -> 3; new test 0
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Found by rendering the macOS `.env` for every tier and profile and running it through `validate-env.sh` and `docker compose config`; the duplicate was the only finding, and the new test is the Linux `test-validate-env.sh` case 21/22 idea applied to the macOS writer.
- The test needs `jq` (the validator's dependency) and skips nothing; it runs in about a second.
- Searched open issues/PRs for "LLM_BACKEND duplicate", "Duplicate key errors", "macos env-generator": nothing, and no open PR touches `env-generator.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

