### PR TITLE
fix(dashboard-api): add string whitespace stripper bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,17 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def strip_string_whitespace_bounds(text: object) -> str:
+    """Strip leading, trailing, and internal multi-spaces from text string safely.
+
+    Returns empty string for None or non-string inputs.
+    """
+    if text is None:
+        return ""
+    val = str(text).strip()
+    if not val:
+        return ""
+    return " ".join(val.split())
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStripStringWhitespaceBounds:
+
+    def test_strips_whitespace(self):
+        from helpers import strip_string_whitespace_bounds
+        assert strip_string_whitespace_bounds("  hello   world  ") == "hello world"
+
+    def test_handles_none_and_non_string_inputs(self):
+        from helpers import strip_string_whitespace_bounds
+        assert strip_string_whitespace_bounds(None) == ""
+        assert strip_string_whitespace_bounds(12345) == "12345"
+


### PR DESCRIPTION
Add strip_string_whitespace_bounds utility function in helpers.py to safely strip leading, trailing, and internal multi-spaces from text strings with None and non-string input guards. Includes unit test suite.