### PR TITLE
fix(dashboard-api): add key value dict searcher bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,21 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def search_dict_by_value_substring(data: object, target: str = "") -> dict:
+    """Search dictionary keys whose string values contain target substring safely.
+
+    Handles non-dict inputs, None values, or empty target strings without exception.
+    """
+    if not isinstance(data, dict) or not target:
+        return {}
+    target_str = str(target).lower()
+    res = {}
+    for k, v in data.items():
+        if k is None or v is None:
+            continue
+        if target_str in str(v).lower():
+            res[str(k)] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSearchDictByValueSubstring:
+
+    def test_searches_by_value_substring(self):
+        from helpers import search_dict_by_value_substring
+        raw = {"k1": "apple pie", "k2": "banana split", "k3": "pineapple"}
+        assert search_dict_by_value_substring(raw, target="apple") == {"k1": "apple pie", "k3": "pineapple"}
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import search_dict_by_value_substring
+        assert search_dict_by_value_substring(None) == {}
+        assert search_dict_by_value_substring("not_dict") == {}
+


### PR DESCRIPTION
Add search_dict_by_value_substring utility function in helpers.py to safely search dictionary keys matching value target substrings with None and non-dict input guards. Includes unit test suite.