### PR TITLE
docs(schema): list every GPU_BACKEND value the installer writes

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -180,7 +180,7 @@ GGUF_FILE=Qwen3.5-9B-Q4_K_M.gguf
 # Context window size (tokens)
 CTX_SIZE=16384
 
-# GPU backend: nvidia or amd
+# GPU backend set by the installer: nvidia, amd, apple, cpu, jetson, or sycl (Intel Arc)
 GPU_BACKEND=nvidia
 
 # Unified system RAM in GB (macOS Apple Silicon only — written by env-generator.sh).

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -396,7 +396,7 @@
     },
     "GPU_BACKEND": {
       "type": "string",
-      "description": "GPU backend: nvidia, amd, apple, or cpu",
+      "description": "GPU backend the installer detected: nvidia, amd, apple, cpu, jetson, or sycl (Intel Arc via oneAPI; detection may also record intel)",
       "default": "nvidia"
     },
     "N_GPU_LAYERS": {


### PR DESCRIPTION
## Summary

The two places that document `GPU_BACKEND`'s values listed a subset: the schema description (shown on the dashboard Settings page) said "nvidia, amd, apple, or cpu" and the `.env.example` comment said "nvidia or amd", while `installers/lib/detection.sh` and `tier-map.sh` also write `jetson`, `intel` and `sycl` (Intel Arc), and the Arc guide tells users their `.env` carries `GPU_BACKEND=sycl`. Repro in #3901.

Change (one concern: the documented value list matches what the installer writes):

- **`.env.schema.json`**: `GPU_BACKEND.description` now lists nvidia, amd, apple, cpu, jetson, sycl (Intel Arc via oneAPI) and notes that detection may also record intel.
- **`.env.example`**: the comment above `GPU_BACKEND=nvidia` lists the same set.

No `enum` is involved, so validation behaviour is unchanged.

Fixes #3901.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [x] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: None -- a description string and a comment line.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build (API settings/router tests, which load the schema)
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3, jq 1.7, Python 3.13 venv, upstream/main 21f4b3a6

$ grep -n 'GPU_BACKEND="' installers/lib/detection.sh installers/lib/tier-map.sh
  detection.sh:304 jetson, :352 nvidia, :409 intel, :440 amd, :240/:277/:523 cpu; tier-map.sh:76,:89,:219,:230 sycl
$ jq empty .env.schema.json                              -> valid
$ bash tests/test-validate-env.sh                        -> Result: 45 passed, 0 failed
$ python3 tests/contracts/test-port-contracts.py         -> [PASS] canonical port contract parity
$ bash tests/test-secret-security.sh                     -> All secret management security checks passed!
$ pytest extensions/services/dashboard-api/tests/test_settings_env.py tests/test_routers.py -> 145 passed
$ git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Noted while adding the Intel Arc keys to the schema in #3886; kept separate because it is wording only.
- Searched open issues/PRs for "GPU_BACKEND description", "sycl schema", "jetson schema": nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

