### PR TITLE
fix(dashboard-api): add list slice paginator bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def paginate_list_items_bounds(items: object, page: int = 1, page_size: int = 10) -> list:
+    """Paginate list items safely with page and page_size bounds protection.
+
+    Enforces minimum page of 1 and page_size of 1. Handles None and non-sequence inputs safely.
+    """
+    if not isinstance(items, (list, tuple)):
+        return []
+    if page < 1:
+        page = 1
+    if page_size < 1:
+        page_size = 10
+    start_idx = (page - 1) * page_size
+    if start_idx >= len(items):
+        return []
+    end_idx = start_idx + page_size
+    return list(items[start_idx:end_idx])
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,19 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestPaginateListItemsBounds:
+
+    def test_paginates_list_items(self):
+        from helpers import paginate_list_items_bounds
+        items = list(range(25))
+        assert paginate_list_items_bounds(items, page=1, page_size=10) == list(range(10))
+        assert paginate_list_items_bounds(items, page=3, page_size=10) == [20, 21, 22, 23, 24]
+
+    def test_handles_out_of_bounds_and_none_inputs(self):
+        from helpers import paginate_list_items_bounds
+        assert paginate_list_items_bounds(None) == []
+        assert paginate_list_items_bounds([1, 2], page=10, page_size=10) == []
+        assert paginate_list_items_bounds([1, 2, 3], page=0, page_size=0) == [1, 2, 3]
+


### PR DESCRIPTION
Add paginate_list_items_bounds utility function in helpers.py to safely paginate sequence items with minimum page/page_size enforcement and out-of-bounds guards. Includes unit test suite.