### PR TITLE
fix(dashboard-api): add safe float parser default bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -1,4 +1,4 @@
-"""Small, dependency-free helpers for values read from ODS ``.env`` files."""
+import math
 
 
 def strip_matching_quotes(value: str) -> str:
@@ -12,3 +12,27 @@ def strip_matching_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def parse_env_float_safe(
+    val: object, default: float = 0.0, min_val: float | None = None, max_val: float | None = None
+) -> float:
+    """Parse environment float values safely with min/max bounds clamping.
+
+    Returns default on None, non-numeric strings, NaN, or Inf values.
+    """
+    if val is None:
+        return default
+    try:
+        parsed = float(str(val).strip())
+        if math.isnan(parsed) or math.isinf(parsed):
+            return default
+    except (ValueError, TypeError):
+        return default
+
+    if min_val is not None and parsed < min_val:
+        return min_val
+    if max_val is not None and parsed > max_val:
+        return max_val
+    return parsed
+

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -24,3 +24,19 @@ from env_values import strip_matching_quotes
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):
     assert strip_matching_quotes(raw) == expected
+
+
+class TestParseEnvFloatSafe:
+
+    def test_parses_float_values(self):
+        from env_values import parse_env_float_safe
+        assert parse_env_float_safe("3.14") == 3.14
+        assert parse_env_float_safe(2.5) == 2.5
+
+    def test_handles_none_and_bounds_clamping(self):
+        from env_values import parse_env_float_safe
+        assert parse_env_float_safe(None, default=1.0) == 1.0
+        assert parse_env_float_safe("nan", default=1.0) == 1.0
+        assert parse_env_float_safe("0.5", min_val=1.0) == 1.0
+        assert parse_env_float_safe("10.0", max_val=5.0) == 5.0
+


### PR DESCRIPTION
Add parse_env_float_safe utility function in env_values.py to safely parse float values from environment variables with min/max bounds clamping and NaN/Inf/None protection. Includes unit test suite.