### PR TITLE
fix(dashboard-api): add dictionary value transformer bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def transform_dict_values_safe(data: object, func: object) -> dict:
+    """Apply callable transformation function to dictionary values safely.
+
+    Catches transformation exceptions per key and preserves original value on failure.
+    Handles non-dict inputs or non-callable func safely.
+    """
+    if not isinstance(data, dict) or not callable(func):
+        return {}
+    res = {}
+    for k, v in data.items():
+        if k is None:
+            continue
+        try:
+            res[str(k)] = func(v)
+        except Exception:
+            res[str(k)] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestTransformDictValuesSafe:
+
+    def test_transforms_dict_values(self):
+        from helpers import transform_dict_values_safe
+        raw = {"k1": "10", "k2": "20", "k3": "invalid"}
+        assert transform_dict_values_safe(raw, int) == {"k1": 10, "k2": 20, "k3": "invalid"}
+
+    def test_handles_none_and_non_callable(self):
+        from helpers import transform_dict_values_safe
+        assert transform_dict_values_safe(None, int) == {}
+        assert transform_dict_values_safe({"a": 1}, None) == {}
+


### PR DESCRIPTION
Add transform_dict_values_safe utility function in helpers.py to safely apply callable transformations across dictionary values with per-key exception safety and non-callable input guards. Includes unit test suite.