### PR TITLE
fix(dashboard-api): add string format template replacer bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,24 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_format_template_replacer(template: object, kwargs: object) -> str:
+    """Safely replace {key} placeholders in template string with kwargs dict.
+
+    Ignores missing keys or formatting errors without raising KeyError or ValueError.
+    """
+    if template is None:
+        return ""
+    tpl = str(template)
+    if not tpl or not isinstance(kwargs, dict):
+        return tpl
+    res = tpl
+    for k, v in kwargs.items():
+        if k is None or v is None:
+            continue
+        placeholder = f"{{{k}}}"
+        if placeholder in res:
+            res = res.replace(placeholder, str(v))
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafeFormatTemplateReplacer:
+
+    def test_replaces_placeholders(self):
+        from helpers import safe_format_template_replacer
+        assert safe_format_template_replacer("Hello {name}, welcome to {place}!", {"name": "Alice", "place": "ODS"}) == "Hello Alice, welcome to ODS!"
+
+    def test_handles_none_and_non_dict_kwargs(self):
+        from helpers import safe_format_template_replacer
+        assert safe_format_template_replacer(None, {"name": "Alice"}) == ""
+        assert safe_format_template_replacer("Hello {name}", None) == "Hello {name}"
+


### PR DESCRIPTION
Add safe_format_template_replacer utility function in helpers.py to safely replace placeholder variables in string templates using kwargs dict with KeyError and format exception protection. Includes unit test suite.