### PR TITLE
fix(dashboard-api): add list sum average statistics bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,32 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def calculate_numeric_list_stats(data: object) -> dict:
+    """Calculate count, sum, min, max, average of numeric list elements safely.
+
+    Filters non-numeric values, NaN, and Inf. Returns default zeroed dict for empty/None inputs.
+    """
+    default = {"count": 0, "sum": 0.0, "min": 0.0, "max": 0.0, "average": 0.0}
+    if not isinstance(data, (list, tuple)) or not data:
+        return default
+    valid = []
+    for item in data:
+        try:
+            val = float(item)
+            if not math.isnan(val) and not math.isinf(val):
+                valid.append(val)
+        except (ValueError, TypeError):
+            continue
+    if not valid:
+        return default
+    total = sum(valid)
+    return {
+        "count": len(valid),
+        "sum": round(total, 4),
+        "min": round(min(valid), 4),
+        "max": round(max(valid), 4),
+        "average": round(total / len(valid), 4),
+    }
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,23 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestCalculateNumericListStats:
+
+    def test_calculates_numeric_stats(self):
+        from helpers import calculate_numeric_list_stats
+        assert calculate_numeric_list_stats([10, 20, 30]) == {
+            "count": 3,
+            "sum": 60.0,
+            "min": 10.0,
+            "max": 30.0,
+            "average": 20.0,
+        }
+
+    def test_handles_none_and_non_numeric_inputs(self):
+        from helpers import calculate_numeric_list_stats
+        default = {"count": 0, "sum": 0.0, "min": 0.0, "max": 0.0, "average": 0.0}
+        assert calculate_numeric_list_stats(None) == default
+        assert calculate_numeric_list_stats(["abc", None]) == default
+


### PR DESCRIPTION
Add calculate_numeric_list_stats utility function in helpers.py to calculate count, sum, min, max, and average of numeric sequence elements with NaN/Inf filtering and empty input guards. Includes unit test suite.