### PR TITLE
fix(dashboard-api): add dictionary key case converter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def convert_dict_keys_to_lowercase(data: object) -> dict:
+    """Convert dictionary keys recursively to lowercase string format safely.
+
+    Handles non-string keys, None values, nested dictionaries, or non-dict inputs without exception.
+    """
+    if not isinstance(data, dict):
+        return {}
+    res = {}
+    for k, v in data.items():
+        if k is None:
+            continue
+        key_str = str(k).lower()
+        if isinstance(v, dict):
+            res[key_str] = convert_dict_keys_to_lowercase(v)
+        else:
+            res[key_str] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestConvertDictKeysToLowercase:
+
+    def test_converts_dict_keys_lowercase(self):
+        from helpers import convert_dict_keys_to_lowercase
+        raw = {"PORT": 8080, "Nested": {"HOST": "localhost"}}
+        assert convert_dict_keys_to_lowercase(raw) == {"port": 8080, "nested": {"host": "localhost"}}
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import convert_dict_keys_to_lowercase
+        assert convert_dict_keys_to_lowercase(None) == {}
+        assert convert_dict_keys_to_lowercase("not_dict") == {}
+


### PR DESCRIPTION
Add convert_dict_keys_to_lowercase utility function in helpers.py to recursively convert dictionary keys to lowercase with non-string key and None value guards. Includes unit test suite.