### PR TITLE
fix(dashboard-api): add dictionary key existence validator bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,17 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def validate_dict_required_keys(data: object, required_keys: object = ()) -> bool:
+    """Verify dictionary contains all non-None required key specifications safely.
+
+    Returns False if data is non-dict, required_keys is non-sequence, or any required key is missing/None.
+    """
+    if not isinstance(data, dict) or not isinstance(required_keys, (list, tuple, set)):
+        return False
+    for key in required_keys:
+        if key not in data or data[key] is None:
+            return False
+    return True
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,19 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestValidateDictRequiredKeys:
+
+    def test_validates_required_keys(self):
+        from helpers import validate_dict_required_keys
+        raw = {"host": "localhost", "port": 8080, "name": "service"}
+        assert validate_dict_required_keys(raw, ["host", "port"]) is True
+        assert validate_dict_required_keys(raw, ["host", "missing"]) is False
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import validate_dict_required_keys
+        assert validate_dict_required_keys(None, ["host"]) is False
+        assert validate_dict_required_keys({"host": None}, ["host"]) is False
+        assert validate_dict_required_keys("not_dict", ["host"]) is False
+


### PR DESCRIPTION
Add validate_dict_required_keys utility function in helpers.py to safely verify presence of required non-None keys in dictionary payloads with type guards. Includes unit test suite.