### PR TITLE
fix(dashboard-api): add string character filter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,18 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def filter_string_allowed_chars(text: object, allowed: str = "") -> str:
+    """Filter string characters keeping only those in allowed set safely.
+
+    Handles None, non-string text, or empty allowed set without exception.
+    """
+    if text is None:
+        return ""
+    val = str(text)
+    if not allowed:
+        return val
+    allowed_set = set(allowed)
+    return "".join(ch for ch in val if ch in allowed_set)
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFilterStringAllowedChars:
+
+    def test_filters_allowed_chars(self):
+        from helpers import filter_string_allowed_chars
+        assert filter_string_allowed_chars("hello-world_123!", allowed="abcdefghijklmnopqrstuvwxyz") == "helloworld"
+
+    def test_handles_none_and_empty_allowed(self):
+        from helpers import filter_string_allowed_chars
+        assert filter_string_allowed_chars(None) == ""
+        assert filter_string_allowed_chars("test") == "test"
+


### PR DESCRIPTION
Add filter_string_allowed_chars utility function in helpers.py to safely filter string characters against allowed set with None and empty set guards. Includes unit test suite.