### PR TITLE
fix(dashboard-api): add list chunk size partitioner bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,15 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def partition_list_into_chunks_bounds(items: object, chunk_size: int = 5) -> list:
+    """Partition sequence items into list of sub-lists of specified chunk_size safely.
+
+    Enforces minimum chunk_size of 1. Handles None and non-sequence inputs safely.
+    """
+    if not isinstance(items, (list, tuple)):
+        return []
+    size = max(1, int(chunk_size))
+    return [list(items[i:i + size]) for i in range(0, len(items), size)]
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestPartitionListIntoChunksBounds:
+
+    def test_partitions_list_chunks(self):
+        from helpers import partition_list_into_chunks_bounds
+        assert partition_list_into_chunks_bounds([1, 2, 3, 4, 5, 6, 7], chunk_size=3) == [[1, 2, 3], [4, 5, 6], [7]]
+
+    def test_handles_none_and_invalid_chunk_sizes(self):
+        from helpers import partition_list_into_chunks_bounds
+        assert partition_list_into_chunks_bounds(None) == []
+        assert partition_list_into_chunks_bounds([1, 2], chunk_size=0) == [[1], [2]]
+


### PR DESCRIPTION
Add partition_list_into_chunks_bounds utility function in helpers.py to safely partition sequence elements into sub-lists of chunk_size with minimum chunk_size enforcement and non-sequence guards. Includes unit test suite.