### PR TITLE
fix(dashboard-api): add safe environment list parser bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -12,3 +12,18 @@ def strip_matching_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def parse_env_list_safe(val: object, delimiter: str = ",") -> list:
+    """Parse delimited environment string into stripped item list safely.
+
+    Handles None, empty strings, non-string inputs, and custom delimiters without exception.
+    """
+    if val is None:
+        return []
+    val_str = str(val).strip()
+    if not val_str:
+        return []
+    delim = delimiter if delimiter else ","
+    return [item.strip() for item in val_str.split(delim) if item.strip()]
+

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -24,3 +24,17 @@ from env_values import strip_matching_quotes
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):
     assert strip_matching_quotes(raw) == expected
+
+
+class TestParseEnvListSafe:
+
+    def test_parses_delimited_lists(self):
+        from env_values import parse_env_list_safe
+        assert parse_env_list_safe("a, b, c") == ["a", "b", "c"]
+        assert parse_env_list_safe("x; y; z", delimiter=";") == ["x", "y", "z"]
+
+    def test_handles_none_and_empty_inputs(self):
+        from env_values import parse_env_list_safe
+        assert parse_env_list_safe(None) == []
+        assert parse_env_list_safe("  ") == []
+


### PR DESCRIPTION
Add parse_env_list_safe utility function in env_values.py to safely parse delimited environment string values into clean item lists with custom delimiter and empty string protection. Includes unit test suite.