### PR TITLE
fix(dashboard-api): add dictionary value min max bounds filter

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,31 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def filter_dict_numeric_values_range(
+    data: object, min_val: float | None = None, max_val: float | None = None
+) -> dict:
+    """Filter dictionary keys whose numeric values lie within [min_val, max_val] range safely.
+
+    Handles non-numeric values, None inputs, or non-dict objects without exception.
+    """
+    if not isinstance(data, dict):
+        return {}
+    res = {}
+    for k, v in data.items():
+        if k is None or v is None:
+            continue
+        try:
+            val = float(v)
+            if math.isnan(val) or math.isinf(val):
+                continue
+            if min_val is not None and val < min_val:
+                continue
+            if max_val is not None and val > max_val:
+                continue
+            res[str(k)] = v
+        except (ValueError, TypeError):
+            continue
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFilterDictNumericValuesRange:
+
+    def test_filters_numeric_range(self):
+        from helpers import filter_dict_numeric_values_range
+        raw = {"k1": 10, "k2": 50, "k3": 100, "k4": "invalid"}
+        assert filter_dict_numeric_values_range(raw, min_val=20, max_val=80) == {"k2": 50}
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import filter_dict_numeric_values_range
+        assert filter_dict_numeric_values_range(None) == {}
+        assert filter_dict_numeric_values_range("not_dict") == {}
+


### PR DESCRIPTION
Add filter_dict_numeric_values_range utility function in helpers.py to safely filter dictionary keys whose numeric values lie within min_val and max_val bounds with non-numeric and NaN/Inf guards. Includes unit test suite.