### PR TITLE
fix(dashboard-api): add list element index locator bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,18 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def find_list_element_indices(items: object, target: object) -> list:
+    """Locate all 0-based indices of target element in sequence safely.
+
+    Handles None, target missing, or non-sequence inputs without exception.
+    """
+    if not isinstance(items, (list, tuple)):
+        return []
+    res = []
+    for idx, item in enumerate(items):
+        if item == target:
+            res.append(idx)
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFindListElementIndices:
+
+    def test_finds_element_indices(self):
+        from helpers import find_list_element_indices
+        assert find_list_element_indices(["a", "b", "a", "c", "a"], "a") == [0, 2, 4]
+
+    def test_handles_none_and_missing_target(self):
+        from helpers import find_list_element_indices
+        assert find_list_element_indices(None, "a") == []
+        assert find_list_element_indices([1, 2, 3], 99) == []
+


### PR DESCRIPTION
Add find_list_element_indices utility function in helpers.py to safely locate all 0-based indices of target elements in sequence with missing target and non-sequence guards. Includes unit test suite.