### PR TITLE
fix(dashboard-api): add dictionary key rename mapping bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def rename_dict_keys_safe(data: object, mapping: object = None) -> dict:
+    """Rename dictionary keys according to mapping dict safely.
+
+    Handles non-dict data/mapping, missing keys, or None inputs without exception.
+    """
+    if not isinstance(data, dict):
+        return {}
+    if not isinstance(mapping, dict) or not mapping:
+        return dict(data)
+    res = {}
+    for k, v in data.items():
+        if k is None:
+            continue
+        new_key = mapping.get(k, k)
+        if new_key is not None:
+            res[str(new_key)] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestRenameDictKeysSafe:
+
+    def test_renames_dict_keys(self):
+        from helpers import rename_dict_keys_safe
+        raw = {"old_a": 1, "old_b": 2, "unchanged": 3}
+        mapping = {"old_a": "new_a", "old_b": "new_b"}
+        assert rename_dict_keys_safe(raw, mapping) == {"new_a": 1, "new_b": 2, "unchanged": 3}
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import rename_dict_keys_safe
+        assert rename_dict_keys_safe(None) == {}
+        assert rename_dict_keys_safe({"a": 1}, None) == {"a": 1}
+


### PR DESCRIPTION
Add rename_dict_keys_safe utility function in helpers.py to safely rename dictionary keys according to a mapping dict with missing key and None input guards. Includes unit test suite.