### PR TITLE
fix(dashboard-api): add safe float ratio percentage calculator bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,20 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def calculate_ratio_percentage_safe(numerator: object, denominator: object, precision: int = 2) -> float:
+    """Calculate percentage ratio (numerator / denominator * 100) safely.
+
+    Returns 0.0 if denominator is 0, None, non-numeric, or if numerator/denominator are NaN/Inf.
+    """
+    try:
+        num = float(numerator)
+        den = float(denominator)
+        if den == 0.0 or math.isnan(num) or math.isnan(den) or math.isinf(num) or math.isinf(den):
+            return 0.0
+        ratio = (num / den) * 100.0
+        return round(ratio, max(0, int(precision)))
+    except (ValueError, TypeError, ZeroDivisionError):
+        return 0.0
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestCalculateRatioPercentageSafe:
+
+    def test_calculates_ratio_percentage(self):
+        from helpers import calculate_ratio_percentage_safe
+        assert calculate_ratio_percentage_safe(25, 100) == 25.0
+        assert calculate_ratio_percentage_safe(1, 3, precision=2) == 33.33
+
+    def test_handles_zero_denominator_and_none(self):
+        from helpers import calculate_ratio_percentage_safe
+        assert calculate_ratio_percentage_safe(10, 0) == 0.0
+        assert calculate_ratio_percentage_safe(None, 100) == 0.0
+


### PR DESCRIPTION
Add calculate_ratio_percentage_safe utility function in helpers.py to safely calculate percentage ratio with zero denominator, None value, non-numeric, and NaN/Inf guards. Includes unit test suite.