### PR TITLE
fix(dashboard-api): add dictionary key prefix stripper bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,25 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def strip_dict_key_prefix_safe(data: object, prefix: str = "") -> dict:
+    """Remove string prefix from dictionary keys safely.
+
+    Handles non-dict data, non-string keys, empty prefix, or None inputs without exception.
+    """
+    if not isinstance(data, dict):
+        return {}
+    if not prefix:
+        return dict(data)
+    pref_str = str(prefix)
+    res = {}
+    for k, v in data.items():
+        if k is None:
+            continue
+        key_str = str(k)
+        if key_str.startswith(pref_str):
+            key_str = key_str[len(pref_str):]
+        res[key_str] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStripDictKeyPrefixSafe:
+
+    def test_strips_key_prefixes(self):
+        from helpers import strip_dict_key_prefix_safe
+        raw = {"env_host": "localhost", "env_port": 8080, "name": "app"}
+        assert strip_dict_key_prefix_safe(raw, prefix="env_") == {"host": "localhost", "port": 8080, "name": "app"}
+
+    def test_handles_none_and_empty_prefix(self):
+        from helpers import strip_dict_key_prefix_safe
+        assert strip_dict_key_prefix_safe(None) == {}
+        assert strip_dict_key_prefix_safe({"a": 1}, prefix="") == {"a": 1}
+


### PR DESCRIPTION
Add strip_dict_key_prefix_safe utility function in helpers.py to safely strip key string prefixes from dictionary payloads with empty prefix and non-dict input guards. Includes unit test suite.