### PR TITLE
fix(dashboard-api): add string titlecase converter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,20 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def convert_string_to_titlecase_safe(text: object) -> str:
+    """Convert space/underscore/hyphen delimited text to Title Case safely.
+
+    Handles None, non-string input, or empty strings without exception.
+    """
+    if text is None:
+        return ""
+    val = str(text).strip()
+    if not val:
+        return ""
+    words = val.replace("_", " ").replace("-", " ").split()
+    if not words:
+        return ""
+    return " ".join(w.capitalize() for w in words)
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestConvertStringToTitlecaseSafe:
+
+    def test_converts_to_title_case(self):
+        from helpers import convert_string_to_titlecase_safe
+        assert convert_string_to_titlecase_safe("hello_world_test") == "Hello World Test"
+        assert convert_string_to_titlecase_safe("user-first-name") == "User First Name"
+
+    def test_handles_none_and_empty_inputs(self):
+        from helpers import convert_string_to_titlecase_safe
+        assert convert_string_to_titlecase_safe(None) == ""
+        assert convert_string_to_titlecase_safe("  ") == ""
+


### PR DESCRIPTION
Add convert_string_to_titlecase_safe utility function in helpers.py to safely convert space, underscore, or hyphen delimited text to Title Case with None and non-string input guards. Includes unit test suite.