### PR TITLE
fix(dashboard-api): add list item frequency counter bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def count_list_item_frequencies_safe(items: object) -> dict:
+    """Count occurrence frequencies of hashable sequence items safely.
+
+    Filters unhashable or None items without exception. Returns empty dict for non-sequences.
+    """
+    if not isinstance(items, (list, tuple, set)):
+        return {}
+    res = {}
+    for item in items:
+        if item is None:
+            continue
+        try:
+            res[item] = res.get(item, 0) + 1
+        except TypeError:
+            continue
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestCountListItemFrequenciesSafe:
+
+    def test_counts_frequencies(self):
+        from helpers import count_list_item_frequencies_safe
+        assert count_list_item_frequencies_safe(["a", "b", "a", "c", "b", "a"]) == {"a": 3, "b": 2, "c": 1}
+
+    def test_handles_unhashable_and_none_items(self):
+        from helpers import count_list_item_frequencies_safe
+        assert count_list_item_frequencies_safe([1, None, [1, 2], 1]) == {1: 2}
+        assert count_list_item_frequencies_safe(None) == {}
+


### PR DESCRIPTION
Add count_list_item_frequencies_safe utility function in helpers.py to safely count occurrence frequencies of sequence items with unhashable element and non-sequence guards. Includes unit test suite.