### PR TITLE
fix(dashboard-api): add safe environment integer default parser bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/env_values.py
+++ b/ods/extensions/services/dashboard-api/env_values.py
@@ -12,3 +12,24 @@ def strip_matching_quotes(value: str) -> str:
     if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
         return value[1:-1]
     return value
+
+
+def parse_env_int_safe(
+    val: object, default: int = 0, min_val: int | None = None, max_val: int | None = None
+) -> int:
+    """Parse integer environment value with min/max bounds clamping safely.
+
+    Returns default value for invalid format, NaN/float inputs, or None without exception.
+    """
+    if val is None:
+        return default
+    try:
+        res = int(float(str(val).strip()))
+        if min_val is not None and res < min_val:
+            res = min_val
+        if max_val is not None and res > max_val:
+            res = max_val
+        return res
+    except (ValueError, TypeError, OverflowError):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_env_values.py
+++ b/ods/extensions/services/dashboard-api/tests/test_env_values.py
@@ -24,3 +24,17 @@ from env_values import strip_matching_quotes
 )
 def test_strip_matching_quotes_removes_exactly_one_complete_pair(raw, expected):
     assert strip_matching_quotes(raw) == expected
+
+
+class TestParseEnvIntSafe:
+
+    def test_parses_integer_env_values(self):
+        from env_values import parse_env_int_safe
+        assert parse_env_int_safe("8080") == 8080
+        assert parse_env_int_safe("100", min_val=0, max_val=50) == 50
+
+    def test_handles_none_and_invalid_inputs(self):
+        from env_values import parse_env_int_safe
+        assert parse_env_int_safe(None, default=80) == 80
+        assert parse_env_int_safe("invalid", default=3000) == 3000
+


### PR DESCRIPTION
Add parse_env_int_safe utility function in env_values.py to safely parse integer environment values with default fallback and min/max bounds clamping. Includes unit test suite.