### PR TITLE
fix(simulate): record the real exit code of each installer run

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -80,6 +80,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== config migration (version check under set -e) ==="
 	@bash tests/test-migrate-config.sh
+	@echo "=== installer simulation harness records real exit codes ==="
+	@bash tests/test-simulate-installers-exit-codes.sh
 	@echo ""
 	@echo "=== restore refuses empty backup config ==="
 	@bash tests/test-restore-empty-config.sh

--- a/ods/scripts/simulate-installers.sh
+++ b/ods/scripts/simulate-installers.sh
@@ -28,16 +28,14 @@ chmod +x "${FAKEBIN}/curl"
 cd "$ROOT_DIR"
 
 # 1) Linux installer dry-run simulation
+# Capture the real status: inside `if ! cmd; then`, $? is the negated result
+# (always 0), which used to record every failed run as exit code 0.
 LINUX_EXIT=0
-if ! PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1; then
-  LINUX_EXIT=$?
-fi
+PATH="${FAKEBIN}:$PATH" bash install-core.sh --dry-run --non-interactive --skip-docker --force --summary-json "$LINUX_SUMMARY_JSON" >"$LINUX_LOG" 2>&1 || LINUX_EXIT=$?
 
 # 2) macOS installer MVP simulation
 MACOS_EXIT=0
-if ! bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1; then
-  MACOS_EXIT=$?
-fi
+bash installers/macos.sh --no-delegate --report "$MACOS_PREFLIGHT_JSON" --doctor-report "$MACOS_DOCTOR_JSON" >"$MACOS_LOG" 2>&1 || MACOS_EXIT=$?
 
 # 3) Windows scenario simulation via preflight engine (since pwsh may be unavailable in CI/sandbox)
 scripts/preflight-engine.sh \
@@ -55,9 +53,7 @@ scripts/preflight-engine.sh \
 
 # 4) Doctor snapshot for current machine context
 DOCTOR_EXIT=0
-if ! scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1; then
-  DOCTOR_EXIT=$?
-fi
+scripts/ods-doctor.sh "$DOCTOR_JSON" >/dev/null 2>&1 || DOCTOR_EXIT=$?
 
 PYTHON_CMD="python3"
 if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then

--- a/ods/tests/test-simulate-installers-exit-codes.sh
+++ b/ods/tests/test-simulate-installers-exit-codes.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# scripts/simulate-installers.sh feeds each run's exit code into summary.json,
+# SUMMARY.md and the golden-path evidence that `make gate` and CI publish. It
+# captured them with `if ! cmd; then X=$?; fi`, where $? is the negated
+# result of the `!` pipeline and therefore always 0, so every failed dry-run
+# was recorded as exit code 0. Run the harness against a stub tree whose
+# installers fail with distinct codes and check the codes it records.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HARNESS="${ODS_SIMULATE_UNDER_TEST:-$ROOT_DIR/scripts/simulate-installers.sh}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$HARNESS" ]] || fail "missing $HARNESS"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required by the harness"
+
+# Stub tree: the harness resolves everything relative to its own parent
+# directory and runs the installers from there.
+TREE="$TMP_DIR/tree"
+mkdir -p "$TREE/scripts" "$TREE/installers" "$TREE/lib" "$TREE/config"
+cp "$HARNESS" "$TREE/scripts/simulate-installers.sh"
+cp "$ROOT_DIR/lib/python-cmd.sh" "$TREE/lib/"
+cp "$ROOT_DIR/config/golden-paths.json" "$TREE/config/"
+
+cat > "$TREE/install-core.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "stub linux dry-run: failing on purpose"
+exit 3
+EOF
+cat > "$TREE/installers/macos.sh" <<'EOF'
+#!/usr/bin/env bash
+report=""; doctor=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report) report="$2"; shift 2 ;;
+        --doctor-report) doctor="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '{"summary":{"blockers":0,"warnings":0}}\n' > "$report"
+printf '{"summary":{}}\n' > "$doctor"
+echo "stub macos installer: failing on purpose"
+exit 4
+EOF
+cat > "$TREE/scripts/preflight-engine.sh" <<'EOF'
+#!/usr/bin/env bash
+report=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --report) report="$2"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+printf '{"summary":{"blockers":0,"warnings":0}}\n' > "$report"
+EOF
+cat > "$TREE/scripts/ods-doctor.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '{"summary":{"runtime_ready":false}}\n' > "$1"
+exit 5
+EOF
+chmod +x "$TREE"/install-core.sh "$TREE"/installers/macos.sh "$TREE"/scripts/*.sh
+
+OUT="$TMP_DIR/out"
+if ! (cd "$TREE" && bash scripts/simulate-installers.sh "$OUT") >"$TMP_DIR/harness.log" 2>&1; then
+    fail "harness did not complete against the stub tree: $(tail -n 3 "$TMP_DIR/harness.log")"
+fi
+[[ -f "$OUT/summary.json" ]] || fail "harness wrote no summary.json"
+
+linux_exit="$(jq -r '.runs.linux_dryrun.exit_code' "$OUT/summary.json")"
+macos_exit="$(jq -r '.runs.macos_installer_mvp.exit_code' "$OUT/summary.json")"
+doctor_exit="$(jq -r '.runs.doctor_snapshot.exit_code' "$OUT/summary.json")"
+[[ "$linux_exit" == "3" ]] || fail "summary.json records linux_dryrun exit_code=$linux_exit, the stub exited 3"
+[[ "$macos_exit" == "4" ]] || fail "summary.json records macos_installer_mvp exit_code=$macos_exit, the stub exited 4"
+[[ "$doctor_exit" == "5" ]] || fail "summary.json records doctor_snapshot exit_code=$doctor_exit, the stub exited 5"
+pass "summary.json records the real exit code of each failed run"
+
+grep -qx -- '- Exit code: 3' "$OUT/SUMMARY.md" || fail "SUMMARY.md does not show the Linux dry-run exit code 3"
+grep -qx -- '- Exit code: 4' "$OUT/SUMMARY.md" || fail "SUMMARY.md does not show the macOS installer exit code 4"
+pass "SUMMARY.md shows the real exit codes"
+
+# A failed macOS run with a clean preflight must not count as a passing
+# golden path; it did when the exit code was recorded as 0.
+apple_status="$(jq -r '.scenarios[] | select(.simulation_run == "macos_installer_mvp") | .status' "$OUT/golden-paths.json" | head -n 1)"
+[[ "$apple_status" == "fail" ]] || fail "golden path backed by the failed macOS run is '$apple_status', expected fail"
+pass "golden-path evidence fails when its simulation run failed"


### PR DESCRIPTION
## Summary

`scripts/simulate-installers.sh` captured each run's status with `if ! cmd; then X=$?; fi`. Inside that branch `$?` is the negated result of the `!` pipeline, so it is always 0 and every failed Linux dry-run, macOS installer run or doctor snapshot was written to `summary.json`, `SUMMARY.md` and the golden-path evidence as exit code 0. `run_status()` treats `exit_code == 0` as half of "ok", so a run that emitted its log signals (or a clean preflight) and then failed was published as a passing golden path. `validate-sim-summary.py` only checks the type, so the wrong values pass validation and reach the CI artifact. Repro in #3924.

Change (one concern: the harness records the real exit code of each run):

- **`scripts/simulate-installers.sh`**: the three captures become `cmd || X=$?`. Same commands, same redirections, no other change.
- **`tests/test-simulate-installers-exit-codes.sh`** (new, in `make test` after the config-migration test): runs the harness against a stub tree (copy of the harness, `lib/python-cmd.sh`, `config/golden-paths.json`) whose `install-core.sh`, `installers/macos.sh` and `scripts/ods-doctor.sh` exit 3, 4 and 5 while writing the JSON reports the harness expects, then asserts those codes reach `summary.json` and `SUMMARY.md`, and that the golden path backed by the failed macOS run is `fail`. Fails on current `main` with `linux_dryrun exit_code=0, the stub exited 3`.

Fixes #3924.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- three status captures; the harness still completes and still writes every artifact, it just records what the runs returned. On a host where a run fails, `SUMMARY.md` and the golden-path evidence now say so, which is the point.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, jq 1.7, shellcheck 0.11

$ bash -c 'if ! bash -c "exit 3"; then echo "captured: $?"; fi'   -> captured: 0

# BEFORE (upstream/main 21f4b3a6 harness, this branch's test)
$ ODS_SIMULATE_UNDER_TEST=<main simulate-installers.sh> bash tests/test-simulate-installers-exit-codes.sh
[FAIL] summary.json records linux_dryrun exit_code=0, the stub exited 3
# real harness run on this Mac (Linux dry-run aborts under stock Bash): summary.json {"linux":0,"macos":0,"doctor":0}

# AFTER (this branch)
$ bash tests/test-simulate-installers-exit-codes.sh          (bash 5.3 and /bin/bash 3.2)
[PASS] summary.json records the real exit code of each failed run
[PASS] SUMMARY.md shows the real exit codes
[PASS] golden-path evidence fails when its simulation run failed
$ bash scripts/simulate-installers.sh <scratch dir>           -> rc=0; summary.json {"linux":1,"macos":0,"doctor":1}; SUMMARY.md "Exit code: 1" for those runs
$ python3 scripts/validate-sim-summary.py <that summary.json> -> still validates (the harness runs it itself)

$ shellcheck --exclude=SC1091,SC2034 --severity=error scripts/simulate-installers.sh tests/test-simulate-installers-exit-codes.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 (default severity): harness 0 -> 0; new test 0
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Found by running `make simulate` on a host where the Linux dry-run cannot run and reading `SUMMARY.md` next to its log.
- The test does not touch the real installers; it copies the harness into a stub tree so it runs in about a second and is independent of the host.
- Searched open issues/PRs for "simulate exit code", "simulate-installers": nothing; no open PR touches the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

