### PR TITLE
fix(dashboard-api): add dictionary key presence checker bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,17 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def has_dict_any_keys_safe(data: object, keys: object = ()) -> bool:
+    """Check if dictionary contains at least one non-None key specification safely.
+
+    Returns False if data is non-dict or keys sequence is empty/non-sequence.
+    """
+    if not isinstance(data, dict) or not isinstance(keys, (list, tuple, set)):
+        return False
+    for k in keys:
+        if k in data and data[k] is not None:
+            return True
+    return False
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestHasDictAnyKeysSafe:
+
+    def test_checks_any_keys_present(self):
+        from helpers import has_dict_any_keys_safe
+        raw = {"host": "localhost", "port": 8080}
+        assert has_dict_any_keys_safe(raw, ["missing", "port"]) is True
+        assert has_dict_any_keys_safe(raw, ["missing1", "missing2"]) is False
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import has_dict_any_keys_safe
+        assert has_dict_any_keys_safe(None, ["host"]) is False
+        assert has_dict_any_keys_safe({"host": None}, ["host"]) is False
+


### PR DESCRIPTION
Add has_dict_any_keys_safe utility function in helpers.py to safely check if dictionary contains any specified keys with None key and non-dict input guards. Includes unit test suite.