### PR TITLE
fix(dashboard-api): add string pad spaces aligner bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,24 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def pad_string_align_bounds(
+    text: object, width: int = 0, align: str = "left", fillchar: str = " "
+) -> str:
+    """Pad string to target width with specified alignment (left/right/center) safely.
+
+    Handles None, non-string text, negative width, or invalid fillchar without exception.
+    """
+    if text is None:
+        val = ""
+    else:
+        val = str(text)
+    w = max(0, int(width))
+    fc = fillchar[0] if fillchar else " "
+    if align == "right":
+        return val.rjust(w, fc)
+    elif align == "center":
+        return val.center(w, fc)
+    return val.ljust(w, fc)
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestPadStringAlignBounds:
+
+    def test_pads_string_alignment(self):
+        from helpers import pad_string_align_bounds
+        assert pad_string_align_bounds("test", width=8, align="left") == "test    "
+        assert pad_string_align_bounds("test", width=8, align="right", fillchar="*") == "****test"
+
+    def test_handles_none_and_negative_width(self):
+        from helpers import pad_string_align_bounds
+        assert pad_string_align_bounds(None, width=5) == "     "
+        assert pad_string_align_bounds("abc", width=-1) == "abc"
+


### PR DESCRIPTION
Add pad_string_align_bounds utility function in helpers.py to safely pad strings with left, right, or center alignment, fill character selection, negative width, and None guards. Includes unit test suite.