### PR TITLE
fix(dashboard-api): add list slice head tail extractor bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,16 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def extract_list_head_tail_bounds(items: object, count: int = 1) -> dict:
+    """Extract head and tail elements from sequence of specified count safely.
+
+    Handles count larger than sequence length, None, negative count, or non-sequences.
+    """
+    if not isinstance(items, (list, tuple)):
+        return {"head": [], "tail": []}
+    n = max(0, int(count))
+    lst = list(items)
+    return {"head": lst[:n], "tail": lst[-n:] if n > 0 else []}
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestExtractListHeadTailBounds:
+
+    def test_extracts_head_and_tail(self):
+        from helpers import extract_list_head_tail_bounds
+        assert extract_list_head_tail_bounds([1, 2, 3, 4, 5], count=2) == {"head": [1, 2], "tail": [4, 5]}
+
+    def test_handles_none_and_out_of_bounds_count(self):
+        from helpers import extract_list_head_tail_bounds
+        assert extract_list_head_tail_bounds(None) == {"head": [], "tail": []}
+        assert extract_list_head_tail_bounds([1, 2], count=10) == {"head": [1, 2], "tail": [1, 2]}
+


### PR DESCRIPTION
Add extract_list_head_tail_bounds utility function in helpers.py to safely extract head and tail slices of specified count from sequences with out-of-bounds count and non-sequence guards. Includes unit test suite.