### PR TITLE
fix(ods-test): finish the run and emit the JSON document when checks fail

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -46,6 +46,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh
+	@echo "=== ods-test.sh completes and reports when checks fail ==="
+	@bash tests/test-ods-test-complete-run.sh
 	@echo "=== Docker rootless bind-mount ownership ==="
 	@bash tests/test-rootless-docker-ownership.sh
 	@echo ""

--- a/ods/scripts/ods-test.sh
+++ b/ods/scripts/ods-test.sh
@@ -93,11 +93,22 @@ load_env() {
 
 log() {
     [[ "$VERBOSE" == "true" ]] && echo "$@" >&2
+    # Always succeed: log is the last command of `[[ ... ]] && log` guards,
+    # and a non-zero status there aborts the run under set -e.
+    return 0
 }
 
 # Portable millisecond timestamp (macOS BSD date lacks %N)
 _now_ms() {
     python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
+# Section banner; silent in --json mode so stdout stays one JSON document.
+print_section() {
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        echo ""
+        echo "> $1"
+    fi
 }
 
 print_header() {
@@ -211,8 +222,7 @@ test_tcp() {
 #--------------------------------------------------------------------------
 
 test_docker() {
-    echo ""
-    echo "> Docker Infrastructure"
+    print_section "Docker Infrastructure"
     
     if ! command -v docker &>/dev/null; then
         record_result "Docker Available" "fail" "docker not installed"
@@ -236,11 +246,11 @@ test_docker() {
     running_count=$(timeout 10 docker ps --format '{{.Names}}' 2>/dev/null | wc -l)
     record_result "Running Containers" "pass" "$running_count containers"
     print_test "Running Containers" "pass" "$running_count containers"
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_gpu() {
-    echo ""
-    echo "> GPU Resources"
+    print_section "GPU Resources"
     
     if ! command -v nvidia-smi &>/dev/null; then
         record_result "NVIDIA GPU" "skip" "nvidia-smi not found"
@@ -273,14 +283,17 @@ test_gpu() {
         record_result "NVIDIA GPU" "fail" "no GPU detected"
         print_test "NVIDIA GPU" "fail" "not detected"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_llm() {
-    echo ""
-    echo "> LLM Inference (llama-server)"
+    print_section "LLM Inference (llama-server)"
 
-    test_http "LLM Health" "$LLM_URL/health" "200" || return 1
-    test_http "LLM Models API" "$LLM_URL/v1/models" "200"
+    # A failed check is already recorded; return 0 so the short-circuit only
+    # skips this section's dependent checks instead of aborting the whole run
+    # under set -e (which lost the summary and the --json document).
+    test_http "LLM Health" "$LLM_URL/health" "200" || return 0
+    test_http "LLM Models API" "$LLM_URL/v1/models" "200" || log "LLM models API check failed"
 
     if [[ "$QUICK_MODE" == "true" ]]; then
         record_result "LLM Inference" "skip" "quick mode"
@@ -308,13 +321,13 @@ test_llm() {
     else
         record_result "LLM Inference" "fail" "no content in response"
         print_test "LLM Inference" "fail"
-        return 1
+        return 0
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_tool_calling() {
-    echo ""
-    echo "> Tool Calling M8 Critical"
+    print_section "Tool Calling M8 Critical"
     
     if [[ "$QUICK_MODE" == "true" ]]; then
         record_result "Tool Calling" "skip" "quick mode"
@@ -338,13 +351,13 @@ test_tool_calling() {
         record_result "Tool Calling" "fail" "no tool_calls in response"
         print_test "Tool Calling" "fail" "no tool call"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_whisper() {
-    echo ""
-    echo "> Whisper Speech-to-Text"
+    print_section "Whisper Speech-to-Text"
     
-    test_tcp "Whisper Port" "$WHISPER_HOST" "$WHISPER_PORT"
+    test_tcp "Whisper Port" "$WHISPER_HOST" "$WHISPER_PORT" || log "Whisper port check failed"
     
     local health_url="http://${WHISPER_HOST}:${WHISPER_PORT}/health"
     local response
@@ -363,13 +376,13 @@ test_whisper() {
         test_http "Whisper HTTP" "http://${WHISPER_HOST}:${WHISPER_PORT}/" "200" || whisper_http_exit=$?
         [[ $whisper_http_exit -ne 0 ]] && log "Whisper HTTP check failed (exit $whisper_http_exit)"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_tts() {
-    echo ""
-    echo "> Kokoro TTS Text-to-Speech"
+    print_section "Kokoro TTS Text-to-Speech"
     
-    test_tcp "TTS Port" "$TTS_HOST" "$TTS_PORT"
+    test_tcp "TTS Port" "$TTS_HOST" "$TTS_PORT" || log "TTS port check failed"
     
     local voices_url="http://${TTS_HOST}:${TTS_PORT}/v1/audio/voices"
     local response
@@ -385,13 +398,13 @@ test_tts() {
         test_http "TTS API" "http://${TTS_HOST}:${TTS_PORT}/" "200" || tts_api_exit=$?
         [[ $tts_api_exit -ne 0 ]] && log "TTS API check failed (exit $tts_api_exit)"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_embeddings() {
-    echo ""
-    echo "> Embeddings TEI"
+    print_section "Embeddings TEI"
     
-    test_tcp "Embeddings Port" "$EMBEDDING_HOST" "$EMBEDDING_PORT"
+    test_tcp "Embeddings Port" "$EMBEDDING_HOST" "$EMBEDDING_PORT" || log "Embeddings port check failed"
     
     local health_url="http://${EMBEDDING_HOST}:${EMBEDDING_PORT}/health"
     local response
@@ -406,11 +419,11 @@ test_embeddings() {
         test_http "Embeddings API" "http://${EMBEDDING_HOST}:${EMBEDDING_PORT}/embed" "200" "POST" "$payload" || embeddings_api_exit=$?
         [[ $embeddings_api_exit -ne 0 ]] && log "Embeddings API check failed (exit $embeddings_api_exit)"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_voice_roundtrip() {
-    echo ""
-    echo "> Voice Round-Trip M8 Critical"
+    print_section "Voice Round-Trip M8 Critical"
     
     if [[ "$QUICK_MODE" == "true" ]]; then
         record_result "Voice Round-Trip" "skip" "quick mode"
@@ -461,7 +474,7 @@ test_voice_roundtrip() {
     if ! echo "$llm_response" | grep -q '"content"'; then
         record_result "Voice Round-Trip" "fail" "LLM step failed"
         print_test "Voice Round-Trip" "fail" "LLM failed"
-        return 1
+        return 0
     fi
     
     local tts_text="The weather today is sunny and 75 degrees."
@@ -482,11 +495,11 @@ test_voice_roundtrip() {
         record_result "Voice Round-Trip" "fail" "TTS step failed"
         print_test "Voice Round-Trip" "fail" "TTS failed"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_privacy_shield() {
-    echo ""
-    echo "> Privacy Shield M3"
+    print_section "Privacy Shield M3"
     
     local shield_url="http://localhost:${PRIVACY_SHIELD_PORT}"
     
@@ -512,16 +525,17 @@ test_privacy_shield() {
         record_result "Privacy Shield Proxy" "fail" "no response"
         print_test "Privacy Shield Proxy" "fail"
     fi
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 test_livekit() {
-    echo ""
-    echo "> LiveKit Voice Infrastructure"
+    print_section "LiveKit Voice Infrastructure"
     
-    test_tcp "LiveKit Port" "$LIVEKIT_HOST" "$LIVEKIT_PORT"
+    test_tcp "LiveKit Port" "$LIVEKIT_HOST" "$LIVEKIT_PORT" || log "LiveKit port check failed"
     livekit_health_exit=0
     test_http "LiveKit Health" "http://${LIVEKIT_HOST}:${LIVEKIT_PORT}/" "200" || livekit_health_exit=$?
     [[ $livekit_health_exit -ne 0 ]] && log "LiveKit health check failed (exit $livekit_health_exit)"
+    return 0  # results are tallied by record_result; never surface a status to set -e
 }
 
 #--------------------------------------------------------------------------

--- a/ods/tests/test-ods-test-complete-run.sh
+++ b/ods/tests/test-ods-test-complete-run.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# scripts/ods-test.sh must run every section and print its summary even when
+# a check fails, and `--json` must leave only the JSON document on stdout.
+#
+# Section functions returned 1 after a failed check; called as plain
+# statements under `set -e`, that aborted the whole run at the first failing
+# section (no summary in text mode, no document at all in --json mode), and
+# the section banners were printed regardless of --json.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        [[ -x "$candidate" ]] && exec "$candidate" "$0" "$@"
+    done
+    echo "[FAIL] Bash 4+ is required (service registry)" >&2
+    exit 1
+fi
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${ODS_TEST_UNDER_TEST:-$ROOT_DIR/scripts/ods-test.sh}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+
+# The script resolves lib/ and the service registry from its own parent
+# directory, so run it from a copy of the checkout's scripts/ directory.
+INSTALL="$TMP_DIR/install"
+mkdir -p "$INSTALL/scripts" "$INSTALL/bin" "$INSTALL/extensions/services"
+cp -R "$ROOT_DIR/lib" "$INSTALL/"
+cp "$TARGET" "$INSTALL/scripts/ods-test.sh"
+for manifest in "$ROOT_DIR"/extensions/services/*/manifest.yaml; do
+    svc="$(basename "$(dirname "$manifest")")"
+    mkdir -p "$INSTALL/extensions/services/$svc"
+    cp "$manifest" "$INSTALL/extensions/services/$svc/"
+done
+# Every probe targets a closed loopback port and fails immediately.
+cat > "$INSTALL/.env" <<'EOF'
+OLLAMA_PORT=1
+WEBUI_PORT=1
+WHISPER_PORT=1
+TTS_PORT=1
+EMBEDDINGS_PORT=1
+SHIELD_PORT=1
+LIVEKIT_PORT=1
+EOF
+printf '#!/bin/sh\necho "Cannot connect to the Docker daemon" >&2\nexit 1\n' > "$INSTALL/bin/docker"
+chmod +x "$INSTALL/bin/docker"
+
+run_target() {
+    (
+        cd "$INSTALL" || exit 1
+        ODS_DIR="$INSTALL" ENV_FILE="$INSTALL/.env" PATH="$INSTALL/bin:$PATH" \
+            "$BASH" scripts/ods-test.sh --quick "$@"
+    )
+}
+
+# Case 1: --json with failing checks still yields one JSON document that
+# covers every section.
+rc=0
+run_target --json >"$TMP_DIR/out.json" 2>"$TMP_DIR/err.txt" || rc=$?
+[[ "$rc" -eq 1 ]] || fail "--json with failing checks should exit 1, got $rc (stderr: $(head -n 2 "$TMP_DIR/err.txt" | tr '\n' ' '))"
+python3 - "$TMP_DIR/out.json" <<'PY' || fail "--json stdout is not a single JSON document; first line: $(head -n 1 "$TMP_DIR/out.json")"
+import json, sys
+doc = json.load(open(sys.argv[1]))
+names = [r["name"] for r in doc["results"]]
+assert doc["summary"]["failed"] > 0, doc["summary"]
+assert "LLM Health" in names, names
+assert "Privacy Shield Health" in names and "LiveKit Health" in names, names  # sections after the first failure
+PY
+pass "--json stdout is one JSON document covering sections after the first failed check"
+
+if grep -q '^> ' "$TMP_DIR/out.json"; then
+    fail "section banners leaked into --json stdout"
+fi
+pass "no section banners on stdout in --json mode"
+
+# Case 2: text mode reaches the summary after a failed section.
+rc=0
+run_target >"$TMP_DIR/out.txt" 2>&1 || rc=$?
+[[ "$rc" -eq 1 ]] || fail "text mode with failing checks should exit 1, got $rc"
+grep -q '> Privacy Shield M3' "$TMP_DIR/out.txt" || fail "text mode stopped before the Privacy Shield section"
+grep -qE 'Passed:.*Failed:' "$TMP_DIR/out.txt" || fail "text mode printed no summary line"
+pass "text mode runs every section and prints the summary"


### PR DESCRIPTION
## Summary

`scripts/ods-test.sh` (the validation suite; `--json` is documented "for automation") runs under `set -euo pipefail` and let a failed probe escape as a non-zero status in three ways: section functions returned 1 after a failed check, `test_http`/`test_tcp` were called as plain statements in five places, and the `[[ $x_exit -ne 0 ]] && log "..."` guard the other sections use aborted too, because `log()` returned 1 whenever verbose was off (the default). Any failing check therefore ended the run: no summary in text mode, and with `--json` only a few section banners (printed regardless of the mode) and no document at all. Repro in #3930.

Change (one concern: the suite finishes and reports when checks fail):

- **`scripts/ods-test.sh`**:
  - `log()` ends with `return 0`, so the existing `&& log` guards no longer trip `set -e`.
  - The five plain `test_http`/`test_tcp` calls get the same `|| log "... check failed"` guard the other calls already use.
  - Every section ends with an explicit `return 0`; the three early exits (`test_llm` x2, `test_voice_roundtrip`) return 0 so they keep skipping the section's dependent checks without aborting the run. Results were already tallied by `record_result`, and the final exit code already comes from the failure count, so a section's status was never a signal.
  - The ten banners go through a new `print_section`, silent in `--json` mode, so stdout is one JSON document.
- **`tests/test-ods-test-complete-run.sh`** (new, in `make test`): runs the script from a copy of the checkout against a fixture `.env` where every port is closed and a Docker shim whose daemon is down. Asserts `--json --quick` exits 1, stdout parses, the results include `LLM Health`, `Privacy Shield Health` and `LiveKit Health` (sections after the first failure), no `> ` banner is on stdout, and that text mode reaches the Privacy Shield section and prints the `Passed: ... Failed:` summary. Fails on current `main` (empty stdout, exit 1). Re-execs into Homebrew Bash on macOS like the other registry-dependent tests.

Fixes #3930.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- a run with every check passing is byte-identical (banners, per-check lines, summary, exit 0). The change only affects runs that already ended early: they now complete, report, and exit 1 as the header documents.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11, no Docker daemon

$ bash -c 'set -e; VERBOSE=false; log(){ [[ "$VERBOSE" == "true" ]] && echo "$@" >&2; }; x=1; [[ $x -ne 0 ]] && log failed; echo survived'
(exit 1, nothing printed)            # the existing guard pattern under set -e

# BEFORE (upstream/main 21f4b3a6 script, this branch's test)
$ ODS_TEST_UNDER_TEST=<main ods-test.sh> bash tests/test-ods-test-complete-run.sh
[FAIL] --json stdout is not a single JSON document; first line:      (stdout empty, exit 1)
# fixture install, text mode: run stops after "LLM Health [FAIL] HTTP 000000", no summary

# AFTER (this branch)
$ bash tests/test-ods-test-complete-run.sh          (bash 5.3, and via /bin/bash 3.2 -> re-exec)
[PASS] --json stdout is one JSON document covering sections after the first failed check
[PASS] no section banners on stdout in --json mode
[PASS] text mode runs every section and prints the summary
# --json --quick on the fixture: 15 results, summary.failed > 0, exit 1

$ shellcheck --exclude=SC1091,SC2034 --severity=error scripts/ods-test.sh tests/test-ods-test-complete-run.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 scripts/ods-test.sh -> default-severity count unchanged (0 -> 0); new test 0
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Found by running `--json` on an install with services down and parsing stdout, the same probe that found the health-check case in #3884.
- Not touched here: the `HTTP 000000` detail on a failed probe (`curl -w '%{http_code}'` prints `000` and the `|| echo "000"` fallback appends another); separate cosmetic nit.
- Searched open issues/PRs for "ods-test.sh", "ods-test json", "validation suite summary": nothing; no open PR touches this script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

