### PR TITLE
fix(dashboard-api): add dictionary value list flattener bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def flatten_dict_list_values_safe(data: object) -> list:
+    """Flatten all list/tuple values in a dictionary into a single sequence safely.
+
+    Handles non-dict data, non-sequence values, or None without exception.
+    """
+    if not isinstance(data, dict):
+        return []
+    res = []
+    for k, v in data.items():
+        if k is None or v is None:
+            continue
+        if isinstance(v, (list, tuple, set)):
+            res.extend(v)
+        else:
+            res.append(v)
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFlattenDictListValuesSafe:
+
+    def test_flattens_dict_list_values(self):
+        from helpers import flatten_dict_list_values_safe
+        raw = {"k1": [1, 2], "k2": [3, 4], "k3": 5}
+        assert flatten_dict_list_values_safe(raw) == [1, 2, 3, 4, 5]
+
+    def test_handles_none_and_non_dict_inputs(self):
+        from helpers import flatten_dict_list_values_safe
+        assert flatten_dict_list_values_safe(None) == []
+        assert flatten_dict_list_values_safe("not_dict") == []
+


### PR DESCRIPTION
Add flatten_dict_list_values_safe utility function in helpers.py to safely flatten sequence values in dictionary payloads into a single list with None and non-sequence guards. Includes unit test suite.