### PR TITLE
fix(ods-test): report a failed probe as HTTP 000, not 000000

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -46,6 +46,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh
+	@echo "=== ods-test.sh reports HTTP 000 for a failed probe ==="
+	@bash tests/test-ods-test-http-code.sh
 	@echo "=== Docker rootless bind-mount ownership ==="
 	@bash tests/test-rootless-docker-ownership.sh
 	@echo ""

--- a/ods/scripts/ods-test.sh
+++ b/ods/scripts/ods-test.sh
@@ -165,15 +165,17 @@ test_http() {
     start_time=$(_now_ms)
 
     if [[ -n "$payload" && "$method" == "POST" ]]; then
+        # curl prints "000" itself when no response arrives, so a fallback in
+        # the substitution would append a second "000" ("HTTP 000000").
         response_code=$(curl -s -o /dev/null -w "%{http_code}" \
             --max-time "$custom_timeout" \
             -X POST "$url" \
             -H "Content-Type: application/json" \
-            -d "$payload" 2>/dev/null || echo "000")
+            -d "$payload" 2>/dev/null) || response_code="000"
     else
         response_code=$(curl -s -o /dev/null -w "%{http_code}" \
             --max-time "$custom_timeout" \
-            "$url" 2>/dev/null || echo "000")
+            "$url" 2>/dev/null) || response_code="000"
     fi
     
     end_time=$(_now_ms)

--- a/ods/tests/test-ods-test-http-code.sh
+++ b/ods/tests/test-ods-test-http-code.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# A probe that gets no HTTP response must be reported as "HTTP 000", not
+# "HTTP 000000": curl already prints "000" for -w '%{http_code}' when the
+# connection fails, and the old `|| echo "000"` inside the command
+# substitution appended a second one.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+    for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        [[ -x "$candidate" ]] && exec "$candidate" "$0" "$@"
+    done
+    echo "[FAIL] Bash 4+ is required (service registry)" >&2
+    exit 1
+fi
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${ODS_TEST_UNDER_TEST:-$ROOT_DIR/scripts/ods-test.sh}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+command -v curl >/dev/null 2>&1 || fail "curl is required"
+
+INSTALL="$TMP_DIR/install"
+mkdir -p "$INSTALL/scripts" "$INSTALL/bin" "$INSTALL/extensions/services"
+cp -R "$ROOT_DIR/lib" "$INSTALL/"
+cp "$TARGET" "$INSTALL/scripts/ods-test.sh"
+for manifest in "$ROOT_DIR"/extensions/services/*/manifest.yaml; do
+    svc="$(basename "$(dirname "$manifest")")"
+    mkdir -p "$INSTALL/extensions/services/$svc"
+    cp "$manifest" "$INSTALL/extensions/services/$svc/"
+done
+printf 'OLLAMA_PORT=1\nWEBUI_PORT=1\n' > "$INSTALL/.env"
+printf '#!/bin/sh\necho "Cannot connect to the Docker daemon" >&2\nexit 1\n' > "$INSTALL/bin/docker"
+chmod +x "$INSTALL/bin/docker"
+
+# Only the LLM section is needed: its health probe hits a closed port.
+out="$TMP_DIR/out.txt"
+(
+    cd "$INSTALL" || exit 1
+    ODS_DIR="$INSTALL" ENV_FILE="$INSTALL/.env" PATH="$INSTALL/bin:$PATH" \
+        "$BASH" scripts/ods-test.sh --service llm
+) >"$out" 2>&1 || true
+
+grep -q 'LLM Health.*\[FAIL\]' "$out" || fail "the LLM health probe did not fail against a closed port: $(grep 'LLM Health' "$out" | head -n 1)"
+if grep -q 'HTTP 000000' "$out"; then
+    fail "a failed probe is reported as 'HTTP 000000' (doubled fallback): $(grep 'LLM Health' "$out" | head -n 1)"
+fi
+grep -q 'LLM Health.*HTTP 000$' "$out" || fail "expected 'HTTP 000' on the failed LLM health line: $(grep 'LLM Health' "$out" | head -n 1)"
+pass "a probe with no HTTP response is reported as HTTP 000"


### PR DESCRIPTION
## Summary

`test_http` in `scripts/ods-test.sh` captured the status with `$(curl -s -o /dev/null -w "%{http_code}" ... || echo "000")`. When the connection fails curl already prints `000` for `%{http_code}` and then exits non-zero, so the fallback inside the substitution appended a second `000`, and every unreachable service showed `HTTP 000000` in the text output and in the `--json` `details` field. Repro in #3933.

Change (one concern: a failed probe reports curl's own `000`):

- **`scripts/ods-test.sh`**: both branches of `test_http` assign the fallback outside the substitution, `response_code=$(curl ...) || response_code="000"`. Same command, same options.
- **`tests/test-ods-test-http-code.sh`** (new, in `make test`): runs `--service llm` from a copy of the checkout against a closed port and asserts the LLM Health line reads `HTTP 000` and never `HTTP 000000`. Fails on current `main`.

Fixes #3933.

Independent of #3931 (different hunks of the same script; both apply cleanly to `main`).

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: None to behaviour -- the pass/fail decision compares `response_code` to the expected code and `000000` never matched anyway; only the reported string changes.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, curl 8, shellcheck 0.11

$ out=$(curl -s -o /dev/null -w "%{http_code}" --max-time 2 http://127.0.0.1:1/ 2>/dev/null || echo "000"); echo "'$out'"   -> '000000'

# BEFORE (upstream/main 21f4b3a6 script, this branch's test)
$ ODS_TEST_UNDER_TEST=<main ods-test.sh> bash tests/test-ods-test-http-code.sh
[FAIL] a failed probe is reported as 'HTTP 000000' (doubled fallback):   LLM Health  [FAIL] HTTP 000000

# AFTER (this branch)
$ bash tests/test-ods-test-http-code.sh          (bash 5.3, and via /bin/bash 3.2 -> re-exec)
[PASS] a probe with no HTTP response is reported as HTTP 000

$ shellcheck --exclude=SC1091,SC2034 --severity=error scripts/ods-test.sh tests/test-ods-test-http-code.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 scripts/ods-test.sh -> default-severity count unchanged (0 -> 0); new test 0
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Noticed in the output while working on #3930; kept separate because it is a reporting detail with its own test.
- Searched open issues/PRs for "000000", "http_code fallback": nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

