### PR TITLE
fix(dashboard-api): add safe float moving average calculator bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,31 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def calculate_simple_moving_average_safe(data: object, window_size: int = 3) -> list:
+    """Calculate simple moving average over numeric sequence data safely.
+
+    Handles non-numeric values, window_size <= 0, None, or non-sequences without exception.
+    """
+    if not isinstance(data, (list, tuple)):
+        return []
+    w = max(1, int(window_size))
+    nums = []
+    for item in data:
+        if item is None:
+            continue
+        try:
+            val = float(item)
+            if not math.isnan(val) and not math.isinf(val):
+                nums.append(val)
+        except (ValueError, TypeError):
+            continue
+    if len(nums) < w:
+        return []
+    res = []
+    for i in range(len(nums) - w + 1):
+        window = nums[i:i + w]
+        res.append(round(sum(window) / w, 4))
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestCalculateSimpleMovingAverageSafe:
+
+    def test_calculates_moving_average(self):
+        from helpers import calculate_simple_moving_average_safe
+        assert calculate_simple_moving_average_safe([10, 20, 30, 40, 50], window_size=3) == [20.0, 30.0, 40.0]
+
+    def test_handles_none_and_small_sequence(self):
+        from helpers import calculate_simple_moving_average_safe
+        assert calculate_simple_moving_average_safe(None) == []
+        assert calculate_simple_moving_average_safe([1, 2], window_size=3) == []
+


### PR DESCRIPTION
Add calculate_simple_moving_average_safe utility function in helpers.py to safely calculate moving averages over numeric sequence data with non-numeric, NaN/Inf, and small window size guards. Includes unit test suite.