### PR TITLE
fix: safe version string parsing with explicit error handling

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -143,6 +143,25 @@ def _normalize_version(value: Optional[str]) -> str:
     return (value or "").strip().lstrip("v")
 
 
+def _parse_version_parts(version: str) -> list[int]:
+    """Parse version string into comparable integer parts [major, minor, patch].
+
+    Safely handles malformed versions by returning [0, 0, 0] for unparseable input.
+    This ensures explicit failures rather than silent defaulting to no-update.
+    """
+    if not version:
+        return [0, 0, 0]
+    try:
+        parts = [int(x) for x in version.split(".") if x.isdigit()]
+        if not parts:
+            logger.warning(f"Version string contains no digits: {version}")
+            return [0, 0, 0]
+        return (parts + [0, 0, 0])[:3]
+    except (ValueError, AttributeError, TypeError):
+        logger.warning(f"Failed to parse version string: {version}")
+        return [0, 0, 0]
+
+
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     current = _normalize_version(current)
     result = {
@@ -163,10 +182,8 @@ def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     result["changelog_url"] = payload.get("changelog_url")
     result["checked_at"] = payload.get("checked_at") or result["checked_at"]
 
-    current_parts = [int(x) for x in current.split(".") if x.isdigit()][:3]
-    latest_parts = [int(x) for x in latest.split(".") if x.isdigit()][:3]
-    current_parts += [0] * (3 - len(current_parts))
-    latest_parts += [0] * (3 - len(latest_parts))
+    current_parts = _parse_version_parts(current)
+    latest_parts = _parse_version_parts(latest)
     result["update_available"] = latest_parts > current_parts
     return result
 
@@ -302,9 +319,7 @@ async def get_update_dry_run():
         latest = _normalize_version(data.get("tag_name")) or None
         changelog_url = data.get("html_url") or None
         if latest:
-            def _parts(v: str) -> list[int]:
-                return ([int(x) for x in v.split(".") if x.isdigit()][:3] + [0, 0, 0])[:3]
-            update_available = _parts(latest) > _parts(current)
+            update_available = _parse_version_parts(latest) > _parse_version_parts(current)
     except (httpx.HTTPError, httpx.TimeoutException, OSError, json.JSONDecodeError, ValueError) as e:
         version_check_error = f"Could not reach GitHub: {e}"
 

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -242,6 +242,74 @@ def test_releases_manifest_with_mocked_github(test_client):
     assert data["releases"][0]["version"] == "1.5.0"
     assert data["releases"][1]["prerelease"] is True
     assert "checked_at" in data
+
+
+# ---------------------------------------------------------------------------
+# Bug #4: Safe version string parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_version_parts_valid_versions():
+    """_parse_version_parts handles valid semantic versions correctly."""
+    from routers.updates import _parse_version_parts
+
+    assert _parse_version_parts("2.6.0") == [2, 6, 0]
+    assert _parse_version_parts("1.0.0") == [1, 0, 0]
+    assert _parse_version_parts("10.20.30") == [10, 20, 30]
+
+
+def test_parse_version_parts_partial_versions():
+    """_parse_version_parts pads partial versions with zeros."""
+    from routers.updates import _parse_version_parts
+
+    assert _parse_version_parts("2.6") == [2, 6, 0]
+    assert _parse_version_parts("2") == [2, 0, 0]
+    assert _parse_version_parts("1.2.3.4") == [1, 2, 3]  # truncates to 3 parts
+
+
+def test_parse_version_parts_malformed_no_digits():
+    """_parse_version_parts returns [0, 0, 0] for versions with no digits."""
+    from routers.updates import _parse_version_parts
+
+    assert _parse_version_parts("vvv") == [0, 0, 0]
+    assert _parse_version_parts("abc") == [0, 0, 0]
+    assert _parse_version_parts("") == [0, 0, 0]
+
+
+def test_parse_version_parts_mixed_content():
+    """_parse_version_parts extracts digits from mixed alphanumeric versions."""
+    from routers.updates import _parse_version_parts
+
+    assert _parse_version_parts("v2.6.0") == [2, 6, 0]
+    assert _parse_version_parts("2.6.0-rc1") == [2, 6, 0]  # ignores suffix
+    assert _parse_version_parts("v2.x.0") == [2, 0, 0]  # 'x' filtered out
+
+
+def test_parse_version_parts_empty_and_whitespace():
+    """_parse_version_parts handles empty and whitespace-only strings safely."""
+    from routers.updates import _parse_version_parts
+
+    assert _parse_version_parts("") == [0, 0, 0]
+    assert _parse_version_parts("   ") == [0, 0, 0]
+
+
+def test_build_version_result_with_malformed_version():
+    """_build_version_result correctly compares malformed versions."""
+    from routers.updates import _build_version_result
+
+    # Malformed current, valid latest → update available
+    result = _build_version_result("vvv", {"latest": "2.0.0"})
+    assert result["current"] == "vvv"
+    assert result["latest"] == "2.0.0"
+    assert result["update_available"] is True  # [0,0,0] < [2,0,0]
+
+    # Both malformed → no update
+    result = _build_version_result("vvv", {"latest": "zzz"})
+    assert result["update_available"] is False  # [0,0,0] == [0,0,0]
+
+    # Valid current, malformed latest → no update
+    result = _build_version_result("2.0.0", {"latest": "vvv"})
+    assert result["update_available"] is False  # [2,0,0] > [0,0,0]
     datetime.fromisoformat(data["checked_at"])  # valid ISO-8601 (regression: no trailing "Z" after the offset)
 
 


### PR DESCRIPTION
## Summary
Replaced inline version parsing with a centralized helper function
that explicitly logs and handles malformed version strings, eliminating
silent failures that could mask parsing errors.

## Problem
- Version parsing was duplicated in 2 places with inline list comprehensions
- Malformed versions (no digits) silently became [0,0,0]
- No logging of parse failures, making diagnostics difficult
- Silent failures could mask genuine update availability

## Solution
Created _parse_version_parts() helper that:
1. Validates version strings contain at least one digit
2. Logs warnings for unparseable versions
3. Returns [0,0,0] only on actual parse failures (explicit)
4. Pads partial versions with zeros (e.g., "2.6" → [2,6,0])
5. Truncates to 3 parts for semantic versioning

Refactored both call sites to use the helper.