### PR TITLE
fix: guard lib/validate-dependencies.sh against Bash 3.2

### DIFF
--- a/ods/lib/validate-dependencies.sh
+++ b/ods/lib/validate-dependencies.sh
@@ -6,6 +6,18 @@
 # Expects: SERVICE_IDS, SERVICE_DEPENDS, SERVICE_COMPOSE (from service-registry.sh)
 # Provides: validate_service_dependencies()
 
+# Bash 4+ required for the associative array used to track enabled services.
+# macOS ships Bash 3.2 — users must install a modern shell (e.g. via Homebrew).
+# Without this guard the declaration below fails with "local: -A: invalid
+# option" and, under set -e, aborts the caller with no indication that the
+# shell version is at fault.
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: validate-dependencies.sh requires Bash 4.0+ (current: $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # Validate that all service dependencies are satisfied
 # Returns 0 if all dependencies are met, 1 if any are missing
 validate_service_dependencies() {

--- a/ods/tests/test-bash32-guards.sh
+++ b/ods/tests/test-bash32-guards.sh
@@ -15,7 +15,14 @@ fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
 first_line() {
     local pattern="$1"
     local file="$2"
-    grep -n "$pattern" "$file" | head -n 1 | cut -d: -f1
+    local match
+    # A no-match is a normal outcome here, not an error: callers read an empty
+    # result as "not found" and report which file failed. Handle grep's exit
+    # status explicitly so set -e/pipefail cannot kill the suite mid-run and
+    # leave the operator with no message at all.
+    if match="$(grep -n "$pattern" "$file" | head -n 1)"; then
+        printf '%s\n' "${match%%:*}"
+    fi
 }
 
 assert_guard_before_declare() {
@@ -24,13 +31,16 @@ assert_guard_before_declare() {
     local label="$3"
     local guard_line declare_line
 
+    # Both spellings need Bash 4: `declare -A` at file scope and `local -A`
+    # inside a function. Matching only the former let lib/validate-dependencies.sh
+    # ship an unguarded associative array.
     guard_line="$(first_line 'BASH_VERSINFO\[0\] < 4' "$file")"
-    declare_line="$(first_line 'declare -A' "$file")"
+    declare_line="$(first_line 'declare -A\|local -A' "$file")"
 
     if [[ -n "$guard_line" && -n "$declare_line" && "$guard_line" -lt "$declare_line" ]]; then
-        pass "$label guard appears before declare -A"
+        pass "$label guard appears before first associative-array declaration"
     else
-        fail "$label guard must appear before first declare -A"
+        fail "$label guard must appear before first declare -A / local -A"
     fi
 
     if [[ "$mode" == "sourced" ]]; then
@@ -49,6 +59,7 @@ assert_guard_before_declare() {
 }
 
 assert_guard_before_declare "$ROOT_DIR/lib/progress.sh" sourced "lib/progress.sh"
+assert_guard_before_declare "$ROOT_DIR/lib/validate-dependencies.sh" sourced "lib/validate-dependencies.sh"
 assert_guard_before_declare "$ROOT_DIR/installers/phases/03-features.sh" sourced "03-features.sh"
 assert_guard_before_declare "$ROOT_DIR/scripts/pre-download.sh" direct "pre-download.sh"
 assert_guard_before_declare "$ROOT_DIR/scripts/ods-test-functional.sh" direct "ods-test-functional.sh"
@@ -63,6 +74,26 @@ if grep -q '"$BASH" "$INSTALL_DIR/scripts/validate-manifests.sh"' "$ROOT_DIR/ods
     pass "ods-cli config validate runs validate-manifests.sh through active Bash"
 else
     fail "ods-cli config validate should run validate-manifests.sh through active Bash"
+fi
+
+# Repo-wide sweep so a new associative array cannot be added without a guard.
+# Shipped code only: tests and vendored trees run under a known-good shell.
+unguarded=()
+while IFS= read -r candidate; do
+    case "$candidate" in
+        */tests/*|*/node_modules/*|*/memory-shepherd/*) continue ;;
+    esac
+    # health-check.sh guards with `[ "${BASH_VERSINFO[0]}" -lt 4 ]` and re-execs
+    # under Homebrew bash, so accept either spelling of the version test.
+    if ! grep -qE 'BASH_VERSINFO\[0\] < 4|BASH_VERSINFO\[0\]\}" -lt 4' "$candidate"; then
+        unguarded+=("${candidate#"$ROOT_DIR/"}")
+    fi
+done < <(grep -rl 'declare -A\|local -A' --include='*.sh' "$ROOT_DIR" | sort)
+
+if [[ ${#unguarded[@]} -eq 0 ]]; then
+    pass "every shipped script using an associative array has a Bash 4+ guard"
+else
+    fail "unguarded associative arrays: ${unguarded[*]}"
 fi
 
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Problem
`lib/validate-dependencies.sh` declares `local -A enabled_services` — a Bash 4
associative array — with no version guard. Every other shipped script using
associative arrays has one (`service-registry.sh`, `progress.sh`,
`validate-env.sh`, `03-features.sh`, `pre-download.sh`,
`ods-test-functional.sh`, `health-check.sh`).

On macOS's stock Bash 3.2:

    lib/validate-dependencies.sh: line 16: local: -A: invalid option
    local: usage: local name[=value] ...

Under the installer's `set -euo pipefail` that aborts the run with a message
pointing at nothing, instead of the project's standard "requires Bash 4.0+ …
brew install bash".

`tests/test-bash32-guards.sh` exists to prevent exactly this, but greps for
`declare -A` only. This file is the tree's sole use of `local -A`, so it was
invisible to the contract.

## Fix
- `lib/validate-dependencies.sh`: add the house-standard guard, matching
  `service-registry.sh` including `return 1 2>/dev/null || exit 1`.
- `tests/test-bash32-guards.sh`:
  - matcher recognises `local -A` as well as `declare -A`
  - `lib/validate-dependencies.sh` added to the checked list
  - repo-wide sweep so a *new* unguarded associative array fails the gate,
    rather than only files someone remembered to enumerate (accepts
    `health-check.sh`'s `[ "${BASH_VERSINFO[0]}" -lt 4 ]` re-exec idiom;
    skips tests/ and vendored trees, which run under a known-good shell)