### PR TITLE
Test/ods test full run coverage

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -168,6 +168,9 @@ test: ## Run unit and contract tests
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
 	@echo ""
+	@echo "=== ods-test.sh completes the run and emits JSON ==="
+	@bash tests/test-ods-test-full-run.sh
+	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh
 

--- a/ods/scripts/ods-test.sh
+++ b/ods/scripts/ods-test.sh
@@ -92,7 +92,13 @@ load_env() {
 }
 
 log() {
-    [[ "$VERBOSE" == "true" ]] && echo "$@" >&2
+    # Always returns 0. Callers use `cmd || log "..."` and `[[ c ]] && log "..."`
+    # purely as diagnostics; under `set -e` a non-zero status from the last
+    # command of either list would abort the whole suite mid-run.
+    if [[ "$VERBOSE" == "true" ]]; then
+        echo "$@" >&2
+    fi
+    return 0
 }
 
 # Portable millisecond timestamp (macOS BSD date lacks %N)
@@ -108,6 +114,14 @@ print_header() {
         echo "  Mission M8: Critical Path Testing"
         echo "========================================"
         echo ""
+    fi
+}
+
+print_section() {
+    # Suppressed under --json: stdout there must be one parseable document.
+    if [[ "$JSON_OUTPUT" != "true" ]]; then
+        echo ""
+        echo "> $1"
     fi
 }
 
@@ -209,10 +223,16 @@ test_tcp() {
 #--------------------------------------------------------------------------
 # Service Test Suites
 #--------------------------------------------------------------------------
+# Every section below ends with an explicit `return 0`, and every probe call
+# is guarded. A section's exit status is NOT a signal: results are tallied by
+# record_result and the run's exit code comes from FAILED_TESTS. Under
+# `set -euo pipefail` an unguarded non-zero status from a probe would abort the
+# whole suite at the first failing check, so the summary would never print and
+# `--json` would emit no document at all.
+#--------------------------------------------------------------------------
 
 test_docker() {
-    echo ""
-    echo "> Docker Infrastructure"
+    print_section "Docker Infrastructure"
     
     if ! command -v docker &>/dev/null; then
         record_result "Docker Available" "fail" "docker not installed"
@@ -236,11 +256,12 @@ test_docker() {
     running_count=$(timeout 10 docker ps --format '{{.Names}}' 2>/dev/null | wc -l)
     record_result "Running Containers" "pass" "$running_count containers"
     print_test "Running Containers" "pass" "$running_count containers"
+
+    return 0
 }
 
 test_gpu() {
-    echo ""
-    echo "> GPU Resources"
+    print_section "GPU Resources"
     
     if ! command -v nvidia-smi &>/dev/null; then
         record_result "NVIDIA GPU" "skip" "nvidia-smi not found"
@@ -273,14 +294,17 @@ test_gpu() {
         record_result "NVIDIA GPU" "fail" "no GPU detected"
         print_test "NVIDIA GPU" "fail" "not detected"
     fi
+
+    return 0
 }
 
 test_llm() {
-    echo ""
-    echo "> LLM Inference (llama-server)"
+    print_section "LLM Inference (llama-server)"
 
-    test_http "LLM Health" "$LLM_URL/health" "200" || return 1
-    test_http "LLM Models API" "$LLM_URL/v1/models" "200"
+    # A down LLM skips the checks that depend on it; the failure is already
+    # recorded, and the run must continue to the remaining sections.
+    test_http "LLM Health" "$LLM_URL/health" "200" || return 0
+    test_http "LLM Models API" "$LLM_URL/v1/models" "200" || log "LLM Models API check failed"
 
     if [[ "$QUICK_MODE" == "true" ]]; then
         record_result "LLM Inference" "skip" "quick mode"
@@ -289,7 +313,7 @@ test_llm() {
     fi
 
     local model_id
-    model_id=$(curl -s --max-time 10 "$LLM_URL/v1/models" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+    model_id=$(curl -s --max-time 10 "$LLM_URL/v1/models" 2>/dev/null | grep -o '"id":"[^"]*"' | head -1 | cut -d'"' -f4 || echo "")
     model_id="${model_id:-local}"
 
     local payload="{\"model\": \"$model_id\", \"messages\": [{\"role\": \"user\", \"content\": \"Say hello\"}], \"max_tokens\": 10}"
@@ -298,23 +322,23 @@ test_llm() {
     response=$(curl -s --max-time 30 \
         -X POST "$LLM_URL/v1/chat/completions" \
         -H "Content-Type: application/json" \
-        -d "$payload" 2>/dev/null)
+        -d "$payload" 2>/dev/null || echo "")
 
     if echo "$response" | grep -q '"content"'; then
         local tokens_used
-        tokens_used=$(echo "$response" | grep -o '"total_tokens":[0-9]*' | cut -d: -f2)
+        tokens_used=$(echo "$response" | grep -o '"total_tokens":[0-9]*' | cut -d: -f2 || echo "")
         record_result "LLM Inference" "pass" "${tokens_used} tokens"
         print_test "LLM Inference" "pass" "${tokens_used} tokens"
     else
         record_result "LLM Inference" "fail" "no content in response"
         print_test "LLM Inference" "fail"
-        return 1
     fi
+
+    return 0
 }
 
 test_tool_calling() {
-    echo ""
-    echo "> Tool Calling M8 Critical"
+    print_section "Tool Calling M8 Critical"
     
     if [[ "$QUICK_MODE" == "true" ]]; then
         record_result "Tool Calling" "skip" "quick mode"
@@ -329,7 +353,7 @@ test_tool_calling() {
     response=$(curl -s --max-time 30 \
         -X POST "$LLM_URL/v1/chat/completions" \
         -H "Content-Type: application/json" \
-        -d "$payload" 2>/dev/null)
+        -d "$payload" 2>/dev/null || echo "")
     
     if echo "$response" | grep -q '"tool_calls"'; then
         record_result "Tool Calling" "pass" "function called"
@@ -338,13 +362,14 @@ test_tool_calling() {
         record_result "Tool Calling" "fail" "no tool_calls in response"
         print_test "Tool Calling" "fail" "no tool call"
     fi
+
+    return 0
 }
 
 test_whisper() {
-    echo ""
-    echo "> Whisper Speech-to-Text"
+    print_section "Whisper Speech-to-Text"
     
-    test_tcp "Whisper Port" "$WHISPER_HOST" "$WHISPER_PORT"
+    test_tcp "Whisper Port" "$WHISPER_HOST" "$WHISPER_PORT" || log "Whisper port check failed"
     
     local health_url="http://${WHISPER_HOST}:${WHISPER_PORT}/health"
     local response
@@ -363,13 +388,14 @@ test_whisper() {
         test_http "Whisper HTTP" "http://${WHISPER_HOST}:${WHISPER_PORT}/" "200" || whisper_http_exit=$?
         [[ $whisper_http_exit -ne 0 ]] && log "Whisper HTTP check failed (exit $whisper_http_exit)"
     fi
+
+    return 0
 }
 
 test_tts() {
-    echo ""
-    echo "> Kokoro TTS Text-to-Speech"
+    print_section "Kokoro TTS Text-to-Speech"
     
-    test_tcp "TTS Port" "$TTS_HOST" "$TTS_PORT"
+    test_tcp "TTS Port" "$TTS_HOST" "$TTS_PORT" || log "TTS port check failed"
     
     local voices_url="http://${TTS_HOST}:${TTS_PORT}/v1/audio/voices"
     local response
@@ -377,7 +403,7 @@ test_tts() {
     
     if echo "$response" | grep -q '"voices"'; then
         local voice_count
-        voice_count=$(echo "$response" | grep -o '"voice_id"' | wc -l)
+        voice_count=$(echo "$response" | grep -o '"voice_id"' | wc -l || echo 0)
         record_result "TTS Voices" "pass" "$voice_count voices"
         print_test "TTS Voices" "pass" "$voice_count voices"
     else
@@ -385,13 +411,14 @@ test_tts() {
         test_http "TTS API" "http://${TTS_HOST}:${TTS_PORT}/" "200" || tts_api_exit=$?
         [[ $tts_api_exit -ne 0 ]] && log "TTS API check failed (exit $tts_api_exit)"
     fi
+
+    return 0
 }
 
 test_embeddings() {
-    echo ""
-    echo "> Embeddings TEI"
+    print_section "Embeddings TEI"
     
-    test_tcp "Embeddings Port" "$EMBEDDING_HOST" "$EMBEDDING_PORT"
+    test_tcp "Embeddings Port" "$EMBEDDING_HOST" "$EMBEDDING_PORT" || log "Embeddings port check failed"
     
     local health_url="http://${EMBEDDING_HOST}:${EMBEDDING_PORT}/health"
     local response
@@ -406,11 +433,12 @@ test_embeddings() {
         test_http "Embeddings API" "http://${EMBEDDING_HOST}:${EMBEDDING_PORT}/embed" "200" "POST" "$payload" || embeddings_api_exit=$?
         [[ $embeddings_api_exit -ne 0 ]] && log "Embeddings API check failed (exit $embeddings_api_exit)"
     fi
+
+    return 0
 }
 
 test_voice_roundtrip() {
-    echo ""
-    echo "> Voice Round-Trip M8 Critical"
+    print_section "Voice Round-Trip M8 Critical"
     
     if [[ "$QUICK_MODE" == "true" ]]; then
         record_result "Voice Round-Trip" "skip" "quick mode"
@@ -456,12 +484,12 @@ test_voice_roundtrip() {
     llm_response=$(curl -s --max-time 15 \
         -X POST "$LLM_URL/v1/chat/completions" \
         -H "Content-Type: application/json" \
-        -d "$llm_payload" 2>/dev/null)
+        -d "$llm_payload" 2>/dev/null || echo "")
     
     if ! echo "$llm_response" | grep -q '"content"'; then
         record_result "Voice Round-Trip" "fail" "LLM step failed"
         print_test "Voice Round-Trip" "fail" "LLM failed"
-        return 1
+        return 0
     fi
     
     local tts_text="The weather today is sunny and 75 degrees."
@@ -470,7 +498,7 @@ test_voice_roundtrip() {
     tts_response=$(curl -s --max-time 15 \
         -X POST "http://${TTS_HOST}:${TTS_PORT}/v1/audio/speech" \
         -H "Content-Type: application/json" \
-        -d "$tts_payload" 2>/dev/null)
+        -d "$tts_payload" 2>/dev/null || echo "")
     
     end_time=$(_now_ms)
     duration_ms=$(( end_time - start_time ))
@@ -482,11 +510,12 @@ test_voice_roundtrip() {
         record_result "Voice Round-Trip" "fail" "TTS step failed"
         print_test "Voice Round-Trip" "fail" "TTS failed"
     fi
+
+    return 0
 }
 
 test_privacy_shield() {
-    echo ""
-    echo "> Privacy Shield M3"
+    print_section "Privacy Shield M3"
     
     local shield_url="http://localhost:${PRIVACY_SHIELD_PORT}"
     
@@ -512,16 +541,19 @@ test_privacy_shield() {
         record_result "Privacy Shield Proxy" "fail" "no response"
         print_test "Privacy Shield Proxy" "fail"
     fi
+
+    return 0
 }
 
 test_livekit() {
-    echo ""
-    echo "> LiveKit Voice Infrastructure"
+    print_section "LiveKit Voice Infrastructure"
     
-    test_tcp "LiveKit Port" "$LIVEKIT_HOST" "$LIVEKIT_PORT"
+    test_tcp "LiveKit Port" "$LIVEKIT_HOST" "$LIVEKIT_PORT" || log "LiveKit port check failed"
     livekit_health_exit=0
     test_http "LiveKit Health" "http://${LIVEKIT_HOST}:${LIVEKIT_PORT}/" "200" || livekit_health_exit=$?
     [[ $livekit_health_exit -ne 0 ]] && log "LiveKit health check failed (exit $livekit_health_exit)"
+
+    return 0
 }
 
 #--------------------------------------------------------------------------

--- a/ods/tests/test-ods-test-full-run.sh
+++ b/ods/tests/test-ods-test-full-run.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Test: scripts/ods-test.sh completes the run and emits one JSON document
+# ============================================================================
+# Regression: the suite runs under `set -euo pipefail`, and a failed probe used
+# to escape as a non-zero status four ways — a section's `return 1`, a bare
+# test_http/test_tcp call, a `[[ c ]] && log "..."` guard (log() returned 1
+# whenever --verbose was off, and the list returns 1 when the condition is
+# false), and an unguarded `var=$(curl ...)` capture. Any one of them aborted
+# the run at the first failing check, so the summary never printed and --json
+# produced a truncated, unparseable document.
+#
+# The script is exercised end-to-end against a fixture install whose every port
+# is closed, which is the state of any machine where the stack is not up yet.
+#
+# Usage: bash tests/test-ods-test-full-run.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ODS_TEST="$SCRIPT_DIR/scripts/ods-test.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+pass() { echo -e "${GREEN}✓${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "${RED}✗${NC} $1"; FAILED=$((FAILED + 1)); }
+info() { echo -e "${BLUE}ℹ${NC} $1"; }
+
+[[ -f "$ODS_TEST" ]] || { echo "scripts/ods-test.sh not found"; exit 1; }
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 required to parse the --json document"
+    exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ods-test-full-run.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+# Fixture install: the script sources lib/safe-env.sh for load_env_file, and
+# lib/service-registry.sh only when present. Omitting the registry keeps the
+# fixture free of the Bash 4 requirement that file imposes; port resolution
+# then falls through to the env overrides set below.
+FAKE="$TMP/ods"
+mkdir -p "$FAKE/lib" "$FAKE/scripts"
+cp "$SCRIPT_DIR/lib/safe-env.sh" "$FAKE/lib/"
+cp "$ODS_TEST" "$FAKE/scripts/"
+: > "$FAKE/.env"
+
+# Ports nothing listens on, so every probe fails the way a not-yet-started
+# stack does. High and fixed so a stray listener is implausible.
+run_suite() {
+    ODS_DIR="$FAKE" \
+    ENV_FILE="$FAKE/.env" \
+    LLM_HOST=127.0.0.1        LLM_PORT=59401 \
+    WHISPER_HOST=127.0.0.1    WHISPER_PORT=59402 \
+    TTS_HOST=127.0.0.1        TTS_PORT=59403 \
+    EMBEDDING_HOST=127.0.0.1  EMBEDDING_PORT=59404 \
+    LIVEKIT_HOST=127.0.0.1    LIVEKIT_PORT=59405 \
+    PRIVACY_SHIELD_PORT=59406 \
+    bash "$FAKE/scripts/ods-test.sh" "$@"
+}
+
+# Sections that only run after the LLM check fails. Before the fix the run
+# aborted there, so their absence is the regression this test exists for.
+LATE_SECTIONS=(
+    "Whisper Speech-to-Text"
+    "Kokoro TTS Text-to-Speech"
+    "Embeddings TEI"
+    "Privacy Shield M3"
+    "LiveKit Voice Infrastructure"
+)
+LATE_RESULTS=(
+    "Whisper Port"
+    "TTS Port"
+    "Embeddings Port"
+    "Privacy Shield Health"
+    "LiveKit Port"
+)
+
+# ---------------------------------------------------------------------------
+info "Text mode reaches the summary with every section run"
+# ---------------------------------------------------------------------------
+text_exit=0
+run_suite > "$TMP/text.out" 2>"$TMP/text.err" || text_exit=$?
+
+if [[ $text_exit -eq 1 ]]; then
+    pass "text mode exits 1 when checks fail (documented contract)"
+else
+    fail "text mode should exit 1, got $text_exit"
+    sed -n '1,40p' "$TMP/text.out"
+fi
+
+if grep -q "SOME TESTS FAILED" "$TMP/text.out"; then
+    pass "text mode prints the summary"
+else
+    fail "text mode never printed the summary (run aborted early)"
+fi
+
+missing_section=""
+for section in "${LATE_SECTIONS[@]}"; do
+    grep -qF "> $section" "$TMP/text.out" || missing_section="$section"
+done
+if [[ -z "$missing_section" ]]; then
+    pass "text mode runs every section after the first failure"
+else
+    fail "text mode never reached section: $missing_section"
+fi
+
+# ---------------------------------------------------------------------------
+info "--json emits exactly one parseable document covering every section"
+# ---------------------------------------------------------------------------
+json_exit=0
+run_suite --json > "$TMP/out.json" 2>"$TMP/json.err" || json_exit=$?
+
+if [[ $json_exit -eq 1 ]]; then
+    pass "--json exits 1 when checks fail"
+else
+    fail "--json should exit 1, got $json_exit"
+fi
+
+if grep -q '^> ' "$TMP/out.json"; then
+    fail "--json wrote section banners to stdout (document is not pure JSON)"
+else
+    pass "--json keeps section banners off stdout"
+fi
+
+if python3 - "$TMP/out.json" "${LATE_RESULTS[@]}" <<'PY'
+import json
+import sys
+
+path, expected = sys.argv[1], sys.argv[2:]
+with open(path, encoding="utf-8") as handle:
+    doc = json.load(handle)
+
+names = {r["name"] for r in doc["results"]}
+missing = [n for n in expected if n not in names]
+if missing:
+    print(f"missing from --json results: {missing}", file=sys.stderr)
+    raise SystemExit(1)
+
+summary = doc["summary"]
+if summary["total"] != len(doc["results"]):
+    print(f"summary.total {summary['total']} != {len(doc['results'])} results", file=sys.stderr)
+    raise SystemExit(1)
+if summary["failed"] <= 0 or summary["success"] is not False:
+    print(f"expected failures with success=false, got {summary}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+then
+    pass "--json is one valid document with the later sections and a consistent summary"
+else
+    fail "--json document invalid or truncated"
+    echo "--- stdout ---"; sed -n '1,25p' "$TMP/out.json"
+fi
+
+# ---------------------------------------------------------------------------
+info "--json --quick also completes"
+# ---------------------------------------------------------------------------
+quick_exit=0
+run_suite --json --quick > "$TMP/quick.json" 2>/dev/null || quick_exit=$?
+if [[ $quick_exit -eq 1 ]] && python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$TMP/quick.json" 2>/dev/null; then
+    pass "--json --quick emits a valid document and exits 1"
+else
+    fail "--json --quick did not emit a valid document (exit $quick_exit)"
+fi
+
+# ---------------------------------------------------------------------------
+info "Every --service target reaches its summary"
+# ---------------------------------------------------------------------------
+bad_service=""
+for service in docker gpu llm tool-calling whisper tts embeddings \
+               voice-roundtrip privacy-shield livekit; do
+    svc_exit=0
+    run_suite --service "$service" > "$TMP/svc.out" 2>/dev/null || svc_exit=$?
+    if [[ $svc_exit -gt 1 ]]; then
+        bad_service="$service (exit $svc_exit)"
+    elif ! grep -qE "TESTS (PASSED|FAILED)" "$TMP/svc.out"; then
+        bad_service="$service (no summary)"
+    fi
+done
+if [[ -z "$bad_service" ]]; then
+    pass "all --service targets complete and print a summary"
+else
+    fail "--service target did not complete: $bad_service"
+fi
+
+# ---------------------------------------------------------------------------
+info "log() succeeds when --verbose is off"
+# ---------------------------------------------------------------------------
+# log() is the tail of `[[ c ]] && log "..."` guards. Returning non-zero there
+# aborts the section under set -e, so assert the contract directly.
+if bash -c "
+    set -euo pipefail
+    VERBOSE=false
+    $(sed -n '/^log() {/,/^}/p' "$ODS_TEST")
+    log 'quiet'
+    echo reached
+" 2>/dev/null | grep -q reached; then
+    pass "log() returns 0 when VERBOSE=false"
+else
+    fail "log() returns non-zero when VERBOSE=false (aborts sections under set -e)"
+fi
+
+echo ""
+echo "Passed: $PASSED  Failed: $FAILED"
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## FIX : https://github.com/Osmantic/ODS/issues/3930

##Summary
Regression coverage for the previous PR, which fixed `ods-test.sh` aborting at
the first failing check.

`tests/test-ods-test-full-run.sh` copies the real script into a fixture install
whose every port is closed — the state of any machine where the stack is not up
yet — and asserts:

- text mode exits 1 and prints the summary
- all sections after the first failure actually run
- `--json` is one parseable document containing those later sections, with a
  summary consistent with its own results array
- `--json` writes no section banners to stdout
- `--json --quick` completes
- all ten `--service` targets reach a summary
- `log()` returns 0 when `--verbose` is off (asserted directly, since it is the
  tail of the `[[ c ]] && log "..."` guards)

## Proof it regresses
Against the pre-fix script: **2 passed, 7 failed**, naming each symptom —
missing summary, unreached `LiveKit Voice Infrastructure`, banners on stdout,
invalid `--json`, `--json --quick` truncated, `--service livekit` no summary,
`log()` non-zero. Green against the fix.