### PR TITLE
ci(matrix-smoke): fail the phase syntax step when a phase does not parse

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -206,9 +206,18 @@ jobs:
         run: |
           bash -n install-core.sh
           bash -n installers/lib/packaging.sh
+          # A step exits with the status of its last command, so the loop
+          # must carry a failed check out instead of ending on an echo.
+          status=0
           for f in installers/phases/*.sh; do
-            bash -n "$f" && echo "  OK: $f" || echo "  FAIL: $f"
+            if bash -n "$f"; then
+              echo "  OK: $f"
+            else
+              echo "  FAIL: $f"
+              status=1
+            fi
           done
+          exit "$status"
 
   macos-smoke:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary

The `distro-matrix` job's "Test installer bash syntax" step checked `installers/phases/*.sh` with `bash -n "$f" && echo OK || echo FAIL` inside a loop. A `run:` step exits with the status of its last command, which was the `echo`, so a phase with a syntax error printed `FAIL` and the step still passed on all six distros. Only the two explicit `bash -n` lines above the loop could fail it. Repro in #3927.

Change (one concern: the step fails when a phase does not parse):

- **`.github/workflows/matrix-smoke.yml`**: the loop records a status and the step exits with it after listing every file, so the per-file OK/FAIL output stays as it was.

Fixes #3927.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: None to the product; the step can now go red for the condition it checks. `lint-shell` already catches parse errors through ShellCheck's error severity, so no currently-green run turns red from this change (every phase parses on `main`).
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3, PyYAML

# BEFORE: the step body from upstream/main, run against a phases dir with one good and one broken file
  OK: phases/01-good.sh
  FAIL: phases/02-broken.sh
step rc=0

# AFTER: the step body from this branch (extracted from the YAML with PyYAML and run with bash -c), same files
OK: installers/phases/01-good.sh
  FAIL: installers/phases/02-broken.sh
step rc=1
# and against the real installers/phases/*.sh on main: all OK, step rc=0

$ python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/matrix-smoke.yml"))' -> parses; jobs unchanged
$ git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Found while auditing gate scripts for statuses that cannot propagate, right after #3925 (the same class in the simulation harness). This is the only `&& echo ... || echo` step in the workflows.
- Searched open issues/PRs for "matrix-smoke", "bash syntax step": nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

