### PR TITLE
fix(pre-download): tolerate EOF on the --tier confirmation prompt

### DIFF
--- a/ods/scripts/pre-download.sh
+++ b/ods/scripts/pre-download.sh
@@ -284,7 +284,12 @@ download_tier() {
     warn "Estimated download time: ${est_minutes}-$((est_minutes * 2)) minutes (depends on connection)"
     echo ""
     
-    read -p "Continue? [Y/n] " -n 1 -r
+    # Tolerate EOF on stdin (CI, a pipe, nohup, </dev/null): read fails and,
+    # under `set -e`, would abort the whole script here before any download —
+    # silently, with no message. A tier passed via --tier is explicit intent,
+    # so treat closed stdin the same as the prompt's own default ([Y/n]): the
+    # existing ^[Nn]$ check below still cancels on an explicit "n".
+    read -p "Continue? [Y/n] " -n 1 -r || REPLY=""
     echo
     if [[ $REPLY =~ ^[Nn]$ ]]; then
         echo "Cancelled."


### PR DESCRIPTION
FIX : https://github.com/Osmantic/ODS/issues/3945

## Problem
`pre-download.sh` documents `--tier` as non-interactive:

    ./pre-download.sh --tier edge        # Download edge tier models

But `download_tier()` prompts unconditionally:

    read -p "Continue? [Y/n] " -n 1 -r

Under `set -euo pipefail`, a closed stdin makes `read` return non-zero,
and `set -e` aborts the script at that line — silently, before any
download:

    $ ./pre-download.sh --tier nano </dev/null; echo "exit=$?"
    exit=1

Isolated mechanism:

    $ bash -c 'set -euo pipefail; read -p "Continue? [Y/n] " -n 1 -r </dev/null; echo reached'
    (exit 1, "reached" never prints)

## Fix
`read -p "Continue? [Y/n] " -n 1 -r || REPLY=""` — a tier passed on the
command line is explicit intent, and the prompt already defaults to yes.
The existing `[[ $REPLY =~ ^[Nn]$ ]]` check is unchanged, so a piped `n`
still cancels.

`interactive_menu` (no `--tier`) is unaffected: its own earlier prompt
(`Select tier to download ...`) still requires a terminal and aborts
first on closed stdin — verified directly.