### PR TITLE
fix(dashboard-api): add sanitize email address bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,19 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def sanitize_email_address_safe(email: str, default: str = "") -> str:
+    """Safely sanitize and validate email address string."""
+    if email is None or not isinstance(email, str):
+        return default
+    cleaned = email.strip()
+    if not cleaned or cleaned.count("@") != 1:
+        return default
+    local_part, domain_part = cleaned.split("@")
+    if not local_part or not domain_part:
+        return default
+    if "." not in domain_part or domain_part.startswith(".") or domain_part.endswith("."):
+        return default
+    return f"{local_part}@{domain_part.lower()}"
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,21 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSanitizeEmailAddressSafe:
+    def test_valid_emails(self):
+        from helpers import sanitize_email_address_safe
+        assert sanitize_email_address_safe("user@EXAMPLE.COM") == "user@example.com"
+        assert sanitize_email_address_safe("  admin@test.org  ") == "admin@test.org"
+
+    def test_invalid_and_bounds(self):
+        from helpers import sanitize_email_address_safe
+        assert sanitize_email_address_safe(None) == ""
+        assert sanitize_email_address_safe(123) == ""
+        assert sanitize_email_address_safe("no_at_sign.com") == ""
+        assert sanitize_email_address_safe("two@@at.com") == ""
+        assert sanitize_email_address_safe("@domain.com") == ""
+        assert sanitize_email_address_safe("user@") == ""
+        assert sanitize_email_address_safe("user@domain", default="invalid") == "invalid"
+


### PR DESCRIPTION
Add sanitize_email_address_safe utility helper with defensive type checking, whitespace trimming, single @ symbol validation, and bounds safety.