### PR TITLE
fix(dashboard-api): add calculate percentage bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def calculate_percentage_safe(part: float, total: float, decimal_places: int = 1, default: float = 0.0) -> float:
+    """Safely calculate percentage (part / total * 100) with bounds checking."""
+    if part is None or total is None:
+        return default
+    if not isinstance(part, (int, float)) or not isinstance(total, (int, float)):
+        return default
+    if math.isnan(part) or math.isinf(part) or math.isnan(total) or math.isinf(total):
+        return default
+    if total <= 0:
+        return default
+    if part <= 0:
+        return 0.0
+    val = (part / total) * 100.0
+    val = min(100.0, max(0.0, val))
+    if isinstance(decimal_places, int) and decimal_places >= 0:
+        return round(val, decimal_places)
+    return val
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,20 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestCalculatePercentageSafe:
+    def test_valid_percentage(self):
+        from helpers import calculate_percentage_safe
+        assert calculate_percentage_safe(25, 100) == 25.0
+        assert calculate_percentage_safe(1, 3, decimal_places=2) == 33.33
+
+    def test_edge_cases_and_bounds(self):
+        from helpers import calculate_percentage_safe
+        assert calculate_percentage_safe(None, 100) == 0.0
+        assert calculate_percentage_safe(50, 0) == 0.0
+        assert calculate_percentage_safe(float("nan"), 100) == 0.0
+        assert calculate_percentage_safe(150, 100) == 100.0
+        assert calculate_percentage_safe(-10, 100) == 0.0
+        assert calculate_percentage_safe("50", 100, default=-1.0) == -1.0
+


### PR DESCRIPTION
Add calculate_percentage_safe helper function with division-by-zero protection, NaN/Inf bounds checking, and percentage normalization [0.0, 100.0].