### PR TITLE
fix(dashboard-api): add safe json parse bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,20 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_json_parse(json_str, default=None):
+    """Safely parse JSON string or bytes with fallback default value."""
+    if json_str is None:
+        return default
+    if not isinstance(json_str, (str, bytes, bytearray)):
+        return default
+    try:
+        if isinstance(json_str, (bytes, bytearray)):
+            json_str = json_str.decode("utf-8", errors="ignore")
+        if not json_str.strip():
+            return default
+        return json.loads(json_str)
+    except (json.JSONDecodeError, TypeError, ValueError, UnicodeDecodeError):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafeJsonParse:
+    def test_valid_json(self):
+        from helpers import safe_json_parse
+        assert safe_json_parse('{"status": "ok"}') == {"status": "ok"}
+        assert safe_json_parse(b'[1, 2, 3]') == [1, 2, 3]
+
+    def test_invalid_json_bounds(self):
+        from helpers import safe_json_parse
+        assert safe_json_parse(None) is None
+        assert safe_json_parse(12345, default={}) == {}
+        assert safe_json_parse("invalid json{") is None
+        assert safe_json_parse("   ", default="empty") == "empty"
+


### PR DESCRIPTION
Add safe_json_parse utility helper to handle string/bytes JSON decoding safely with exception catching and fallback default value.