### PR TITLE
fix(dashboard-api): add normalize port number bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,19 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def normalize_port_number_safe(port, default: int = 8080) -> int:
+    """Safely validate and normalize server port numbers [1..65535]."""
+    if port is None:
+        return default
+    try:
+        if isinstance(port, float) and (math.isnan(port) or math.isinf(port)):
+            return default
+        val = int(port)
+        if 1 <= val <= 65535:
+            return val
+        return default
+    except (ValueError, TypeError, OverflowError):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNormalizePortNumberSafe:
+    def test_valid_ports(self):
+        from helpers import normalize_port_number_safe
+        assert normalize_port_number_safe(80) == 80
+        assert normalize_port_number_safe("443") == 443
+
+    def test_invalid_ports_and_bounds(self):
+        from helpers import normalize_port_number_safe
+        assert normalize_port_number_safe(None) == 8080
+        assert normalize_port_number_safe(0) == 8080
+        assert normalize_port_number_safe(70000) == 8080
+        assert normalize_port_number_safe("invalid_port", default=3000) == 3000
+


### PR DESCRIPTION
Add normalize_port_number_safe utility helper for safe port validation [1..65535] and default fallback handling.