### PR TITLE
fix(dashboard-api): add filter dictionary by keys bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,21 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def filter_dictionary_by_keys_safe(d: dict, keys, allow_none: bool = True) -> dict:
+    """Safely extract specified keys from a dictionary with optional None filtering."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    if keys is None:
+        return {}
+    if not isinstance(keys, (list, tuple, set)):
+        keys = [keys]
+    result = {}
+    for k in keys:
+        if k in d:
+            val = d[k]
+            if allow_none or val is not None:
+                result[k] = val
+    return result
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestFilterDictionaryByKeysSafe:
+    def test_valid_filtering(self):
+        from helpers import filter_dictionary_by_keys_safe
+        data = {"a": 1, "b": None, "c": 3}
+        assert filter_dictionary_by_keys_safe(data, ["a", "c"]) == {"a": 1, "c": 3}
+        assert filter_dictionary_by_keys_safe(data, ["a", "b"], allow_none=False) == {"a": 1}
+
+    def test_invalid_inputs_and_bounds(self):
+        from helpers import filter_dictionary_by_keys_safe
+        assert filter_dictionary_by_keys_safe(None, ["a"]) == {}
+        assert filter_dictionary_by_keys_safe({"a": 1}, None) == {}
+        assert filter_dictionary_by_keys_safe("not_a_dict", ["a"]) == {}
+


### PR DESCRIPTION
Add filter_dictionary_by_keys_safe helper function for robust dictionary key extraction with allow_none option and type validation.