### PR TITLE
fix(dashboard-api): add safe timestamp format bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_timestamp_format(ts, fmt: str = "%Y-%m-%dT%H:%M:%SZ", default: str = "") -> str:
+    """Safely format Unix timestamp (seconds) into ISO UTC string."""
+    from datetime import datetime, timezone
+    if ts is None:
+        return default
+    try:
+        if isinstance(ts, float) and (math.isnan(ts) or math.isinf(ts)):
+            return default
+        val = float(ts)
+        if val < 0 or val > 4102444800:
+            return default
+        dt = datetime.fromtimestamp(val, tz=timezone.utc)
+        return dt.strftime(fmt)
+    except (ValueError, TypeError, OverflowError, OSError):
+        return default
+
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafeTimestampFormat:
+    def test_valid_formatting(self):
+        from helpers import safe_timestamp_format
+        assert safe_timestamp_format(1700000000) == "2023-11-14T22:13:20Z"
+        assert safe_timestamp_format("1700000000") == "2023-11-14T22:13:20Z"
+
+    def test_invalid_and_bounds(self):
+        from helpers import safe_timestamp_format
+        assert safe_timestamp_format(None) == ""
+        assert safe_timestamp_format(float("nan")) == ""
+        assert safe_timestamp_format(-100) == ""
+        assert safe_timestamp_format("invalid_ts", default="err") == "err"
+


### PR DESCRIPTION
Add safe_timestamp_format utility helper for converting Unix timestamps into ISO UTC strings with strict range validation and exception handling.