### PR TITLE
fix(dashboard-api): add mask sensitive str bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,25 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def mask_sensitive_str_safe(val: str, unmasked_prefix: int = 4, unmasked_suffix: int = 4, mask_char: str = "*") -> str:
+    """Safely mask sensitive strings (API keys, secrets) preserving prefix and suffix."""
+    if val is None or not isinstance(val, str):
+        return ""
+    if not val:
+        return ""
+    if not isinstance(unmasked_prefix, int) or unmasked_prefix < 0:
+        unmasked_prefix = 0
+    if not isinstance(unmasked_suffix, int) or unmasked_suffix < 0:
+        unmasked_suffix = 0
+    if not isinstance(mask_char, str) or not mask_char:
+        mask_char = "*"
+    length = len(val)
+    if length <= (unmasked_prefix + unmasked_suffix):
+        return mask_char * length
+    prefix = val[:unmasked_prefix]
+    suffix = val[length - unmasked_suffix:] if unmasked_suffix > 0 else ""
+    masked_part = mask_char * (length - unmasked_prefix - unmasked_suffix)
+    return f"{prefix}{masked_part}{suffix}"
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestMaskSensitiveStrSafe:
+    def test_valid_masking(self):
+        from helpers import mask_sensitive_str_safe
+        assert mask_sensitive_str_safe("sk-1234567890abcdef", 3, 4) == "sk-************cdef"
+        assert mask_sensitive_str_safe("secretkey", 2, 2, "#") == "se#####ey"
+
+    def test_invalid_and_bounds(self):
+        from helpers import mask_sensitive_str_safe
+        assert mask_sensitive_str_safe(None) == ""
+        assert mask_sensitive_str_safe(12345) == ""
+        assert mask_sensitive_str_safe("short", 10, 10) == "*****"
+


### PR DESCRIPTION
Add mask_sensitive_str_safe utility helper for masking sensitive API keys/tokens with configurable prefix, suffix, and mask character.