### PR TITLE
fix(dashboard-api): add list deduplicate order bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,29 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_list_deduplicate_preserve_order(items) -> list:
+    """Safely deduplicate elements in a sequence while preserving insertion order."""
+    if items is None:
+        return []
+    if not isinstance(items, (list, tuple, set)):
+        try:
+            items = list(items)
+        except TypeError:
+            return []
+    seen = set()
+    result = []
+    for item in items:
+        try:
+            key = item
+            if key not in seen:
+                seen.add(key)
+                result.append(item)
+        except TypeError:
+            key = str(item)
+            if key not in seen:
+                seen.add(key)
+                result.append(item)
+    return result
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafeListDeduplicatePreserveOrder:
+    def test_valid_deduplication(self):
+        from helpers import safe_list_deduplicate_preserve_order
+        assert safe_list_deduplicate_preserve_order([3, 1, 2, 1, 3, 4]) == [3, 1, 2, 4]
+        assert safe_list_deduplicate_preserve_order([{"a": 1}, {"a": 1}]) == [{"a": 1}]
+
+    def test_invalid_and_bounds(self):
+        from helpers import safe_list_deduplicate_preserve_order
+        assert safe_list_deduplicate_preserve_order(None) == []
+        assert safe_list_deduplicate_preserve_order(12345) == []
+


### PR DESCRIPTION
Add safe_list_deduplicate_preserve_order utility helper to remove duplicate sequence items while preserving original insertion order.