### PR TITLE
fix(dashboard-api): add safe parse boolean bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,24 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_parse_boolean(val, default: bool = False) -> bool:
+    """Safely parse truthy or falsy boolean representations."""
+    if val is None:
+        return default
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, (int, float)):
+        if math.isnan(val) or math.isinf(val):
+            return default
+        return bool(val)
+    if isinstance(val, str):
+        cleaned = val.strip().lower()
+        if cleaned in ("true", "1", "yes", "y", "on", "t", "enable", "enabled"):
+            return True
+        if cleaned in ("false", "0", "no", "n", "off", "f", "disable", "disabled"):
+            return False
+        return default
+    return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,19 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafeParseBoolean:
+    def test_valid_booleans(self):
+        from helpers import safe_parse_boolean
+        assert safe_parse_boolean("true") is True
+        assert safe_parse_boolean("YES") is True
+        assert safe_parse_boolean("0") is False
+        assert safe_parse_boolean(1) is True
+
+    def test_invalid_and_bounds(self):
+        from helpers import safe_parse_boolean
+        assert safe_parse_boolean(None) is False
+        assert safe_parse_boolean(float("nan"), default=True) is True
+        assert safe_parse_boolean("unknown", default=True) is True
+


### PR DESCRIPTION
Add safe_parse_boolean utility helper to parse boolean flags from string, numeric, and float values with fallback defaults.