### PR TITLE
fix(dashboard-api): add list unique sorted order bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,20 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_unique_sorted_safe(items: object, reverse: bool = False) -> list:
+    """Return unique items from sequence in sorted order safely.
+
+    Handles None, non-sequence, unhashable, or mixed-type inputs without exception.
+    """
+    if not isinstance(items, (list, tuple, set)):
+        return []
+    seen = []
+    for item in items:
+        if item is not None and item not in seen:
+            seen.append(item)
+    try:
+        return sorted(seen, reverse=bool(reverse))
+    except TypeError:
+        return seen

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListUniqueSortedSafe:
+
+    def test_returns_unique_sorted_items(self):
+        from helpers import list_unique_sorted_safe
+        assert list_unique_sorted_safe([3, 1, 2, 1, 3]) == [1, 2, 3]
+        assert list_unique_sorted_safe([3, 1, 2], reverse=True) == [3, 2, 1]
+
+    def test_handles_none_and_non_sequence(self):
+        from helpers import list_unique_sorted_safe
+        assert list_unique_sorted_safe(None) == []
+        assert list_unique_sorted_safe("not_a_list") == []


### PR DESCRIPTION
Add list_unique_sorted_safe utility function for safely extracting sorted unique list values.