### PR TITLE
fix(dashboard-api): add nested dictionary deep get bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,20 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_deep_get_safe(data: object, *keys: object, default: object = None) -> object:
+    """Retrieve a nested dictionary value by key path safely.
+
+    Handles None, non-dict intermediaries, missing keys, or empty key path without exception.
+    """
+    if not isinstance(data, dict) or not keys:
+        return default
+    current = data
+    for k in keys:
+        if not isinstance(current, dict):
+            return default
+        current = current.get(k, default)
+        if current is default:
+            return default
+    return current

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictDeepGetSafe:
+
+    def test_retrieves_nested_value(self):
+        from helpers import dict_deep_get_safe
+        data = {"a": {"b": {"c": 42}}}
+        assert dict_deep_get_safe(data, "a", "b", "c") == 42
+        assert dict_deep_get_safe(data, "a", "x", default="miss") == "miss"
+
+    def test_handles_none_and_non_dict(self):
+        from helpers import dict_deep_get_safe
+        assert dict_deep_get_safe(None, "key") is None
+        assert dict_deep_get_safe({"a": "string"}, "a", "b") is None


### PR DESCRIPTION
Add dict_deep_get_safe helper function for safe traversal of nested dictionaries with fallback defaults.