### PR TITLE
fix(installer): do not copy templated system units into the user scope

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -46,6 +46,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-doctor rootless subordinate IDs ==="
 	@bash tests/test-ods-doctor-rootless-subid.sh
+	@echo "=== phase 10 skips templated system units in the user scope ==="
+	@bash tests/test-phase10-skip-templated-user-units.sh
 	@echo "=== Docker rootless bind-mount ownership ==="
 	@bash tests/test-rootless-docker-ownership.sh
 	@echo ""

--- a/ods/installers/phases/10-amd-tuning.sh
+++ b/ods/installers/phases/10-amd-tuning.sh
@@ -77,9 +77,15 @@ elif [[ "$GPU_BACKEND" == "amd" ]] && ! $DRY_RUN; then
     if [[ -d "$INSTALL_DIR/scripts/systemd" ]]; then
         for _unit in "$INSTALL_DIR/scripts/systemd"/*.service "$INSTALL_DIR/scripts/systemd"/*.timer; do
             [[ -f "$_unit" ]] || continue
-            case "$(basename "$_unit")" in
-                ods-host-agent.service|ods-ap-mode.service) continue ;;
-            esac
+            # Skip system-scope units: they carry __PLACEHOLDER__ tokens that
+            # phase 07 renders when installing to /etc/systemd/system
+            # (ods-host-agent, ods-ap-mode, ods-mdns). Copying them raw here
+            # drops an unrendered, non-functional unit into the user scope that
+            # also survives uninstall. Detect them by their placeholders rather
+            # than a name list, which previously missed ods-mdns.service.
+            if grep -q '__[A-Z0-9_]\{1,\}__' "$_unit"; then
+                continue
+            fi
             cp "$_unit" "$SYSTEMD_USER_DIR/" 2>/dev/null || true
         done
     fi

--- a/ods/tests/test-phase10-skip-templated-user-units.sh
+++ b/ods/tests/test-phase10-skip-templated-user-units.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Phase 10 (AMD tuning) copies scripts/systemd/*.{service,timer} into the
+# user systemd dir for the maintenance timers. System-scope units
+# (ods-host-agent, ods-ap-mode, ods-mdns) are templates with __PLACEHOLDER__
+# tokens that phase 07 renders into /etc/systemd/system; copying them raw
+# drops a broken, unrendered unit into the user scope (and it survives
+# uninstall). The old skip list named only ods-host-agent and ods-ap-mode,
+# so ods-mdns.service leaked. This extracts the real copy block from the
+# phase and checks which units it installs.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHASE="${ODS_PHASE10_UNDER_TEST:-$ROOT_DIR/installers/phases/10-amd-tuning.sh}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$PHASE" ]] || fail "missing $PHASE"
+
+# Extract the real "copy user-level systemd units" block (the `if [[ -d
+# "$INSTALL_DIR/scripts/systemd" ]]; then ... fi`) from the phase, so the test
+# exercises the shipped code rather than a copy of it.
+block="$(awk '
+    /if \[\[ -d "\$INSTALL_DIR\/scripts\/systemd" \]\]; then/ {grab=1}
+    grab {print}
+    grab && /^    fi$/ {exit}
+' "$PHASE")"
+[[ -n "$block" ]] || fail "could not extract the systemd-copy block from $PHASE"
+
+# Fixture: a scripts/systemd dir with one placeholder (system-scope) unit and
+# two plain user units, mirroring the real shipped set.
+INSTALL_DIR="$TMP_DIR/install"
+SYSTEMD_USER_DIR="$TMP_DIR/user-systemd"
+mkdir -p "$INSTALL_DIR/scripts/systemd" "$SYSTEMD_USER_DIR"
+cat > "$INSTALL_DIR/scripts/systemd/ods-mdns.service" <<'EOF'
+[Service]
+User=__INSTALL_USER__
+ExecStart=__PYTHON3__ __INSTALL_DIR__/bin/ods-mdns.py
+EOF
+printf '[Timer]\nOnCalendar=daily\n' > "$INSTALL_DIR/scripts/systemd/memory-shepherd-workspace.timer"
+printf '[Service]\nExecStart=/bin/true\n' > "$INSTALL_DIR/scripts/systemd/openclaw-session-cleanup.service"
+
+export INSTALL_DIR SYSTEMD_USER_DIR
+bash -c "$block"
+
+[[ ! -e "$SYSTEMD_USER_DIR/ods-mdns.service" ]] \
+    || fail "ods-mdns.service (a __PLACEHOLDER__ system unit) was copied into the user systemd dir"
+pass "templated system unit ods-mdns.service is not copied into the user scope"
+
+[[ -f "$SYSTEMD_USER_DIR/memory-shepherd-workspace.timer" ]] \
+    || fail "memory-shepherd-workspace.timer (a plain user unit) was not copied"
+[[ -f "$SYSTEMD_USER_DIR/openclaw-session-cleanup.service" ]] \
+    || fail "openclaw-session-cleanup.service (a plain user unit) was not copied"
+pass "plain user units are still copied"
+
+# No unrendered placeholder may reach the user scope.
+if grep -rql '__[A-Z0-9_]\{1,\}__' "$SYSTEMD_USER_DIR" 2>/dev/null; then
+    fail "an unrendered __PLACEHOLDER__ unit reached the user systemd dir: $(grep -rl '__[A-Z0-9_]\{1,\}__' "$SYSTEMD_USER_DIR")"
+fi
+pass "no unrendered placeholder unit reached the user systemd dir"


### PR DESCRIPTION
## Summary

Phase 10 (AMD tuning) installs the maintenance timers by copying every unit under `scripts/systemd/` into the user systemd dir, skipping system units. Its comment says to skip units carrying `__PLACEHOLDER__` path substitutions, but the skip list named only `ods-host-agent.service` and `ods-ap-mode.service`. `ods-mdns.service` carries the same tokens (phase 07 renders and installs it to `/etc/systemd/system`), so on AMD installs phase 10 dropped an unrendered `ods-mdns.service` into `~/.config/systemd/user/` — a broken unit it never enables, which also survives uninstall (`ods-uninstall.sh`'s user-unit list omits it). Repro in #3972.

Change (one concern: templated system units stay out of the user scope):

- **`installers/phases/10-amd-tuning.sh`**: skip a unit when its file still contains `__PLACEHOLDER__` tokens, instead of a name list. This covers `ods-host-agent`, `ods-ap-mode`, `ods-mdns`, and any future templated unit, and implements the block's existing comment. Plain user units (`memory-shepherd-*`, `openclaw-session-cleanup`) have no such tokens and still copy.
- **`tests/test-phase10-skip-templated-user-units.sh`** (new, in `make test`): extracts the real copy block from the phase with `awk` and runs it against a fixture `scripts/systemd/` (one placeholder unit + two plain units), asserting the placeholder unit is not copied, the plain units are, and no unrendered `__PLACEHOLDER__` unit reaches the user dir. Fails on current `main`.

Fixes #3972.

Related: #3890 removes the system-scope `ods-mdns.service` on uninstall; this keeps the stray user-scope copy from being created in the first place.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- the loop now skips three templated system units (two already skipped by name, plus `ods-mdns`) and copies the same plain user units as before. Detection is by file content, so a newly added templated unit is handled automatically.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, shellcheck 0.11

$ for u in scripts/systemd/*.service; do echo "$(grep -c '__[A-Z_]*__' "$u") $(basename "$u")"; done
  5 ods-host-agent.service | 2 ods-ap-mode.service | 5 ods-mdns.service | 0 for memory-shepherd/openclaw units

# BEFORE (upstream/main 21f4b3a6 phase, this branch's test)
$ ODS_PHASE10_UNDER_TEST=<main 10-amd-tuning.sh> bash tests/test-phase10-skip-templated-user-units.sh
[FAIL] ods-mdns.service (a __PLACEHOLDER__ system unit) was copied into the user systemd dir

# AFTER (this branch)
$ bash tests/test-phase10-skip-templated-user-units.sh          (bash 5.3 and /bin/bash 3.2)
[PASS] templated system unit ods-mdns.service is not copied into the user scope
[PASS] plain user units are still copied
[PASS] no unrendered placeholder unit reached the user systemd dir

$ shellcheck --exclude=SC1091,SC2034 --severity=error installers/phases/10-amd-tuning.sh tests/test-phase10-skip-templated-user-units.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 installers/phases/10-amd-tuning.sh -> default-severity count unchanged (4 -> 4); new test 0
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Found by auditing what the installer copies into the user systemd scope against what the uninstaller removes (the same audit that produced #3890). `ods-mdns.service` is the only shipped placeholder unit the phase-10 skip list missed.
- The test extracts the phase's real copy block rather than re-implementing it, so it guards the shipped code.
- Searched open issues/PRs for "phase 10 systemd", "user systemd ods-mdns", "10-amd-tuning": nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

