### PR TITLE
Release the interpreter subprocess on every stream exit path

### DIFF
--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """FastAPI server wrapper for Open Interpreter"""
 
+import collections
 import hmac
 import json
 import logging
@@ -8,6 +9,7 @@ import os
 import re
 import subprocess
 import tempfile
+import threading
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException
@@ -24,6 +26,16 @@ DATA_DIR = Path("/app/data")
 DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 MAX_MESSAGE_LENGTH = 32000
+
+# A streamed run gets the same wall-clock budget as a blocking one.
+STREAM_TIMEOUT_SECONDS = 300
+# Grace period between SIGTERM and SIGKILL for a runner that will not exit.
+TERMINATE_GRACE_SECONDS = 5
+# Non-SSE runner output kept for the failure log, bounded so a chatty
+# runner cannot grow this without limit.
+STDERR_TAIL_LINES = 20
+
+logger = logging.getLogger("open-interpreter")
 
 security = HTTPBearer()
 
@@ -151,6 +163,77 @@ def chat(req: ChatRequest, _auth=Depends(verify_api_key)):
         os.unlink(script_path)
 
 
+def _cleanup_process(proc):
+    """Stop proc if it is still running and close its pipes.
+
+    Called from the generator's finally block, which also runs when the client
+    disconnects mid-stream and the generator is closed.
+    """
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=TERMINATE_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            logger.warning("Runner ignored SIGTERM after %ds; killing", TERMINATE_GRACE_SECONDS)
+            proc.kill()
+            proc.wait()
+
+    for stream in (proc.stdin, proc.stdout):
+        if stream is not None and not stream.closed:
+            stream.close()
+
+
+def _stream_interpreter(script_path, config):
+    """Yield SSE frames from the runner subprocess.
+
+    The subprocess, its pipes and the temp script are released on every exit
+    path, including a client disconnect (which closes this generator) and a
+    runner that never terminates on its own.
+    """
+    try:
+        proc = subprocess.Popen(
+            ["python", script_path],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+    except OSError:
+        os.unlink(script_path)
+        raise
+
+    # The read loop below blocks indefinitely on a silent pipe, so the deadline
+    # has to be enforced from outside it.
+    watchdog = threading.Timer(STREAM_TIMEOUT_SECONDS, proc.kill)
+    watchdog.start()
+    tail = collections.deque(maxlen=STDERR_TAIL_LINES)
+
+    try:
+        proc.stdin.write(config)
+        proc.stdin.close()
+
+        for line in proc.stdout:
+            if line.startswith("SSE: "):
+                yield f"data: {line[5:]}\n\n"
+            else:
+                tail.append(line.rstrip("\n"))
+
+        returncode = proc.wait()
+        if returncode != 0:
+            # Headers are already sent, so the status code cannot change here;
+            # signal the failure in-band instead of ending the stream silently.
+            logger.error(
+                "Interpreter runner failed (exit %d): %s",
+                returncode, " | ".join(tail),
+            )
+            yield 'event: error\ndata: {"error": "Interpreter execution failed"}\n\n'
+    finally:
+        watchdog.cancel()
+        _cleanup_process(proc)
+        os.unlink(script_path)
+
+
 @app.post("/chat/stream")
 def chat_stream(req: ChatRequest, _auth=Depends(verify_api_key)):
     """Stream Open Interpreter output."""
@@ -164,29 +247,10 @@ def chat_stream(req: ChatRequest, _auth=Depends(verify_api_key)):
         f.write(_STREAM_RUNNER_SCRIPT)
         script_path = f.name
 
-    def generate():
-        try:
-            proc = subprocess.Popen(
-                ["python", script_path],
-                stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-            )
-
-            proc.stdin.write(config)
-            proc.stdin.close()
-
-            for line in proc.stdout:
-                if line.startswith("SSE: "):
-                    yield f"data: {line[5:]}\n\n"
-
-            proc.wait()
-        finally:
-            os.unlink(script_path)
-
-    return StreamingResponse(generate(), media_type="text/event-stream")
+    return StreamingResponse(
+        _stream_interpreter(script_path, config),
+        media_type="text/event-stream",
+    )
 
 
 if __name__ == "__main__":

--- a/ods/extensions/library/services/open-interpreter/test_stream_lifecycle.py
+++ b/ods/extensions/library/services/open-interpreter/test_stream_lifecycle.py
@@ -1,0 +1,156 @@
+"""Subprocess lifecycle tests for the Open Interpreter stream endpoint.
+
+These cover the paths where the runner subprocess would otherwise be left
+running: a client that disconnects mid-stream, and a runner that ignores
+SIGTERM or never exits on its own.
+"""
+
+import pathlib
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# server.py calls DATA_DIR.mkdir() at import time against the hardcoded
+# container path /app/data, so importing it on a host needs mkdir stubbed.
+with patch.object(pathlib.Path, "mkdir"):
+    import server
+
+
+def fake_proc(lines=(), *, returncode=0, alive=True):
+    """A Popen stand-in. `alive` drives poll(): None means still running."""
+    proc = MagicMock()
+    # A MagicMock, not a bare iterator: the code both iterates it and closes it.
+    proc.stdout = MagicMock(closed=False)
+    proc.stdout.__iter__.return_value = iter(lines)
+    proc.stdin = MagicMock(closed=False)
+    proc.poll.return_value = None if alive else returncode
+    proc.wait.return_value = returncode
+    return proc
+
+
+def drain(gen):
+    return list(gen)
+
+
+# --- client disconnects mid-stream -----------------------------------------
+
+def test_terminates_runner_when_client_disconnects():
+    proc = fake_proc(["SSE: a\n", "SSE: b\n", "SSE: c\n"])
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"):
+        gen = server._stream_interpreter("/tmp/runner.py", "{}")
+        # NB: "SSE: a\n"[5:] keeps the newline, so the frame carries an extra
+        # blank line. That framing quirk predates this change; see notes.
+        assert next(gen) == "data: a\n\n\n"
+        gen.close()  # Starlette closes the generator when the client goes away
+
+    proc.terminate.assert_called_once()
+
+
+def test_removes_temp_script_when_client_disconnects():
+    proc = fake_proc(["SSE: a\n", "SSE: b\n"])
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink") as unlink:
+        gen = server._stream_interpreter("/tmp/runner.py", "{}")
+        next(gen)
+        gen.close()
+
+    unlink.assert_called_once_with("/tmp/runner.py")
+
+
+def test_closes_pipes_when_client_disconnects():
+    proc = fake_proc(["SSE: a\n", "SSE: b\n"])
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"):
+        gen = server._stream_interpreter("/tmp/runner.py", "{}")
+        next(gen)
+        gen.close()
+
+    proc.stdout.close.assert_called_once()
+
+
+# --- runner that will not die ----------------------------------------------
+
+def test_kills_runner_that_ignores_sigterm():
+    proc = fake_proc(["SSE: a\n", "SSE: b\n"])
+    # Only the post-SIGTERM wait times out; the wait after SIGKILL returns.
+    proc.wait.side_effect = [subprocess.TimeoutExpired(cmd="python", timeout=5), -9]
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"):
+        gen = server._stream_interpreter("/tmp/runner.py", "{}")
+        next(gen)
+        gen.close()
+
+    proc.kill.assert_called_once()
+
+
+def test_arms_watchdog_and_cancels_it_on_normal_completion():
+    proc = fake_proc(["SSE: a\n"], alive=False)
+    timer = MagicMock()
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.threading, "Timer", return_value=timer) as timer_cls, \
+         patch.object(server.os, "unlink"):
+        drain(server._stream_interpreter("/tmp/runner.py", "{}"))
+
+    timer_cls.assert_called_once_with(server.STREAM_TIMEOUT_SECONDS, proc.kill)
+    timer.start.assert_called_once()
+    timer.cancel.assert_called_once()
+
+
+# --- exit status ------------------------------------------------------------
+
+def test_emits_error_frame_when_runner_exits_nonzero():
+    proc = fake_proc(["SSE: a\n", "Traceback: boom\n"], returncode=1, alive=False)
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"):
+        frames = drain(server._stream_interpreter("/tmp/runner.py", "{}"))
+
+    assert frames[0] == "data: a\n\n\n"
+    assert frames[-1].startswith("event: error")
+
+
+def test_no_error_frame_on_clean_exit():
+    proc = fake_proc(["SSE: a\n"], returncode=0, alive=False)
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"):
+        frames = drain(server._stream_interpreter("/tmp/runner.py", "{}"))
+
+    assert frames == ["data: a\n\n\n"]
+
+
+def test_does_not_signal_an_already_exited_runner():
+    proc = fake_proc(["SSE: a\n"], alive=False)
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"):
+        drain(server._stream_interpreter("/tmp/runner.py", "{}"))
+
+    proc.terminate.assert_not_called()
+    proc.kill.assert_not_called()
+
+
+# --- other exit paths -------------------------------------------------------
+
+def test_removes_temp_script_when_spawn_fails():
+    with patch.object(server.subprocess, "Popen", side_effect=OSError("no python")), \
+         patch.object(server.os, "unlink") as unlink:
+        with pytest.raises(OSError):
+            drain(server._stream_interpreter("/tmp/runner.py", "{}"))
+
+    unlink.assert_called_once_with("/tmp/runner.py")
+
+
+def test_failure_log_tail_is_bounded():
+    noise = [f"line {i}\n" for i in range(200)]
+    proc = fake_proc(noise, returncode=1, alive=False)
+    with patch.object(server.subprocess, "Popen", return_value=proc), \
+         patch.object(server.os, "unlink"), \
+         patch.object(server.logger, "error") as log_error:
+        drain(server._stream_interpreter("/tmp/runner.py", "{}"))
+
+    logged = log_error.call_args[0][2]
+    assert len(logged.split(" | ")) == server.STDERR_TAIL_LINES


### PR DESCRIPTION
/chat/stream left an orphaned interpreter process on every client disconnect, had no timeout, and failed silently on non-zero exit. Adds guaranteed cleanup (SIGTERM→SIGKILL), a watchdog, and an SSE error frame. 10 tests, all of which fail against the unfixed code.