### PR TITLE
Enforce BARK_API_KEY instead of ignoring it

### DIFF
--- a/ods/extensions/library/services/bark/server.py
+++ b/ods/extensions/library/services/bark/server.py
@@ -6,14 +6,17 @@ Compatible with the ODS extensions ecosystem.
 
 import io
 import base64
+import hmac
 import logging
+import os
 import threading
 from typing import Optional
 from concurrent.futures import ThreadPoolExecutor
 
 import soundfile as sf
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import Response
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, Field, field_validator
 
 logging.basicConfig(level=logging.INFO)
@@ -27,6 +30,43 @@ _model_lock = threading.Lock()
 
 # Thread pool for CPU-intensive TTS generation
 _executor = ThreadPoolExecutor(max_workers=2)
+
+API_KEY = os.environ.get("BARK_API_KEY", "")
+
+# auto_error=False so an absent header reaches verify_api_key, which decides
+# whether it matters. With the default, unauthenticated mode would 403.
+security = HTTPBearer(auto_error=False)
+
+if not API_KEY:
+    logger.warning(
+        "BARK_API_KEY is not set - /tts, /tts/stream and /voices accept "
+        "unauthenticated requests. Set BARK_API_KEY to require a bearer token."
+    )
+
+
+def verify_api_key(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(security),
+):
+    """Require a bearer token matching BARK_API_KEY, when one is configured.
+
+    Leaving BARK_API_KEY empty keeps the service open, which is the behaviour
+    every existing deployment already has. Setting it now actually enforces it
+    instead of being silently ignored.
+    """
+    if not API_KEY:
+        return None
+
+    if credentials is None:
+        raise HTTPException(status_code=401, detail="Missing bearer token")
+
+    # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
+    # str, which would turn an unauthenticated request into a 500 not a 401.
+    if not hmac.compare_digest(
+        credentials.credentials.encode("utf-8"), API_KEY.encode("utf-8")
+    ):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+    return credentials
+
 
 # Valid output formats
 VALID_FORMATS = {"WAV", "MP3", "OGG", "FLAC"}
@@ -145,7 +185,7 @@ def health():
 
 
 @app.post("/tts", response_model=TTSResponse)
-def text_to_speech(req: TTSRequest):
+def text_to_speech(req: TTSRequest, _auth=Depends(verify_api_key)):
     """
     Generate speech audio from text using Bark.
 
@@ -179,7 +219,7 @@ def text_to_speech(req: TTSRequest):
 
 
 @app.post("/tts/stream")
-def text_to_speech_stream(req: TTSRequest):
+def text_to_speech_stream(req: TTSRequest, _auth=Depends(verify_api_key)):
     """
     Generate speech and return raw audio bytes (wav).
     Suitable for streaming to audio players.
@@ -218,7 +258,7 @@ def _generate_audio_stream_sync(text: str, voice_preset: str) -> Response:
 
 
 @app.get("/voices")
-def list_voices():
+def list_voices(_auth=Depends(verify_api_key)):
     """List available Bark voice presets."""
     voices = {
         "english": [f"v2/en_speaker_{i}" for i in range(10)],

--- a/ods/extensions/library/services/bark/test_auth.py
+++ b/ods/extensions/library/services/bark/test_auth.py
@@ -1,0 +1,120 @@
+"""Tests for BARK_API_KEY enforcement.
+
+The key was passed into the container by compose and ignored by the server,
+leaving /tts, /tts/stream and /voices open to anyone who could reach the port.
+"""
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from fastapi.security import HTTPAuthorizationCredentials
+from fastapi.testclient import TestClient
+
+# bark is a multi-GB ML dependency that is not installed in CI; server.py only
+# imports it lazily inside the generation helpers.
+sys.modules.setdefault("bark", MagicMock(SAMPLE_RATE=24000))
+
+import server  # noqa: E402
+
+KEY = "s3cret-key"
+GATED_ROUTES = ("/tts", "/tts/stream", "/voices")
+
+
+def build(api_key):
+    """Re-import server with BARK_API_KEY set, as the container would at boot."""
+    with patch.dict("os.environ", {"BARK_API_KEY": api_key}):
+        module = importlib.reload(server)
+    return module, TestClient(module.app)
+
+
+def call(client, route, token=None):
+    headers = {"Authorization": f"Bearer {token}"} if token else {}
+    if route == "/voices":
+        return client.get(route, headers=headers)
+    return client.post(route, json={"text": "hi"}, headers=headers)
+
+
+@pytest.fixture(autouse=True)
+def restore():
+    yield
+    build("")
+
+
+# --- a configured key is enforced -------------------------------------------
+
+@pytest.mark.parametrize("route", GATED_ROUTES)
+def test_configured_key_rejects_missing_token(route):
+    _, client = build(KEY)
+
+    assert call(client, route).status_code == 401
+
+
+@pytest.mark.parametrize("route", GATED_ROUTES)
+def test_configured_key_rejects_wrong_token(route):
+    _, client = build(KEY)
+
+    response = call(client, route, token="wrong-key")
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid API key"
+
+
+def test_configured_key_accepts_correct_token():
+    _, client = build(KEY)
+
+    assert call(client, "/voices", token=KEY).status_code == 200
+
+
+def test_a_token_that_is_a_prefix_of_the_key_is_rejected():
+    _, client = build(KEY)
+
+    assert call(client, "/voices", token=KEY[:-1]).status_code == 401
+
+
+def test_non_ascii_token_is_rejected_not_a_server_error():
+    """compare_digest raises TypeError on non-ASCII str, which would be a 500.
+
+    Calls the dependency directly: HTTP headers are ASCII-only, so the client
+    rejects such a token before it can reach the server.
+    """
+    module, _ = build(KEY)
+    credentials = HTTPAuthorizationCredentials(scheme="Bearer", credentials="ключ")
+
+    with pytest.raises(HTTPException) as exc:
+        module.verify_api_key(credentials)
+
+    assert exc.value.status_code == 401
+
+
+# --- health stays reachable for the container healthcheck -------------------
+
+def test_health_needs_no_token_even_when_a_key_is_set():
+    _, client = build(KEY)
+
+    assert client.get("/health").status_code == 200
+
+
+# --- unset key preserves today's open behaviour -----------------------------
+
+@pytest.mark.parametrize("route", GATED_ROUTES)
+def test_unset_key_leaves_routes_open(route):
+    _, client = build("")
+
+    assert call(client, route).status_code != 401
+
+
+def test_unset_key_warns_at_startup(caplog):
+    with caplog.at_level("WARNING"):
+        build("")
+
+    assert any("BARK_API_KEY is not set" in r.message for r in caplog.records)
+
+
+def test_a_configured_key_does_not_warn(caplog):
+    with caplog.at_level("WARNING"):
+        build(KEY)
+
+    assert not any("BARK_API_KEY is not set" in r.message for r in caplog.records)


### PR DESCRIPTION
compose.yaml passes BARK_API_KEY into the bark container and server.py never read it. /tts, /tts/stream and /voices accepted any caller. Setting that variable bought you nothing and told you nothing. /tts is also the expensive route — ML inference over up to 10K chars — so it's a resource-exhaustion vector too. Now enforced with hmac.compare_digest, matching open-interpreter. 15 tests. Merges cleanly with the other bark branch.


I dropped original #5 (request logging). Looking at it properly, the useful part was one line of basicConfig; request-ID middleware on a two-endpoint internal service is over-engineering. The API-key hole was the better use of the slot.