### PR TITLE
Run the bark container as a non-root user

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -30,6 +30,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-hermes-slash-worker-prune.sh
 	@python3 tests/contracts/test-hermes-worker-guardrails.py
 	@echo ""
+	@echo "=== Extension library container hardening ==="
+	@bash tests/contracts/test-library-container-hardening.sh
+	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
 	@bash tests/test-external-services.sh

--- a/ods/extensions/library/services/bark/Dockerfile
+++ b/ods/extensions/library/services/bark/Dockerfile
@@ -3,6 +3,11 @@
 # on amd64; the compose.nvidia.yaml overlay provides GPU device access.
 FROM python:3.10-slim
 
+# Run as a non-root user, matching the other services in this library.
+# The uid is fixed so bind-mounted data keeps a stable owner across rebuilds.
+RUN groupadd --gid 10002 bark \
+    && useradd --uid 10002 --gid 10002 --create-home --shell /bin/bash bark
+
 WORKDIR /app
 
 # Install system dependencies
@@ -27,10 +32,21 @@ RUN pip install --no-cache-dir \
 # Copy the API server
 COPY server.py /app/server.py
 
+# bark resolves its model cache from the home directory. Older releases use
+# expanduser("~/.cache"), newer ones honour XDG_CACHE_HOME; both are set to the
+# same path so the ~5GB download lands in the mounted volume either way.
+ENV HOME=/home/bark
+ENV XDG_CACHE_HOME=/home/bark/.cache
+
+RUN mkdir -p /home/bark/.cache/suno /app/output \
+    && chown -R bark:bark /home/bark /app
+
+USER bark
+
 # Pre-download models at build time into the image layer
 # (models are ~5GB; they will be cached in the volume on first run if not pre-baked)
 # We skip baking them into the image to keep build size manageable.
-# On first startup the container will download them to /root/.cache/suno/bark_v0
+# On first startup the container downloads them to /home/bark/.cache/suno/bark_v0
 
 EXPOSE 9200
 

--- a/ods/extensions/library/services/bark/compose.yaml
+++ b/ods/extensions/library/services/bark/compose.yaml
@@ -16,8 +16,10 @@ services:
       - SUNO_OFFLOAD_CPU=${BARK_OFFLOAD_CPU:-false}
       - BARK_API_KEY=${BARK_API_KEY:-}
     volumes:
-      # Bark model cache — persists ~5GB of downloaded models
-      - ./data/bark/models:/root/.cache/suno
+      # Bark model cache — persists ~5GB of downloaded models.
+      # Target must match XDG_CACHE_HOME in the Dockerfile, or the models are
+      # re-downloaded outside the volume on every start.
+      - ./data/bark/models:/home/bark/.cache/suno
       # Audio output directory
       - ./data/bark/output:/app/output
     healthcheck:

--- a/ods/tests/contracts/test-library-container-hardening.sh
+++ b/ods/tests/contracts/test-library-container-hardening.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# ============================================================================
+# Extension library container hardening contract
+# ============================================================================
+# Every service in extensions/library that ships a Dockerfile must run as a
+# non-root user, and any bind mount into that user's home must point at the
+# path the image actually uses. A mismatch is silent: the container starts,
+# then re-downloads its model cache outside the volume on every restart.
+#
+# Usage: ./tests/contracts/test-library-container-hardening.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB_DIR="$ROOT_DIR/extensions/library/services"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "  [FAIL] $1"; FAILED=$((FAILED + 1)); }
+
+echo "[contract] extension library container hardening"
+
+[[ -d "$LIB_DIR" ]] || { echo "[FAIL] missing $LIB_DIR"; exit 1; }
+
+shopt -s nullglob
+dockerfiles=("$LIB_DIR"/*/Dockerfile)
+shopt -u nullglob
+
+[[ ${#dockerfiles[@]} -gt 0 ]] || { echo "[FAIL] no Dockerfiles found under $LIB_DIR"; exit 1; }
+
+for dockerfile in "${dockerfiles[@]}"; do
+    service="$(basename "$(dirname "$dockerfile")")"
+
+    # 1. A USER directive must exist and must not be root.
+    user_line="$(grep -E '^USER ' "$dockerfile" | tail -1 || true)"
+    if [[ -z "$user_line" ]]; then
+        fail "$service: no USER directive — container runs as root"
+        continue
+    fi
+
+    user_name="$(awk '{print $2}' <<<"$user_line")"
+    if [[ "$user_name" == "root" || "$user_name" == "0" ]]; then
+        fail "$service: USER is $user_name"
+        continue
+    fi
+    pass "$service: runs as non-root ($user_name)"
+
+    # 2. That user must exist in the image.
+    if grep -qE "useradd|adduser" "$dockerfile"; then
+        pass "$service: creates its runtime user"
+    else
+        fail "$service: USER $user_name is never created"
+    fi
+
+    # 3. Any host mount into a home directory must match the image's cache path.
+    compose="$(dirname "$dockerfile")/compose.yaml"
+    [[ -f "$compose" ]] || continue
+
+    xdg="$(grep -E '^ENV XDG_CACHE_HOME=' "$dockerfile" | tail -1 | cut -d= -f2- || true)"
+    [[ -n "$xdg" ]] || continue
+
+    # Mount targets that live under a home directory, per the compose file.
+    while read -r target; do
+        [[ -n "$target" ]] || continue
+        if [[ "$target" == "$xdg"* ]]; then
+            pass "$service: cache mount $target matches XDG_CACHE_HOME"
+        else
+            fail "$service: mount $target is under /home but XDG_CACHE_HOME is $xdg"
+        fi
+    done < <(grep -oE ':/home/[^ "]+' "$compose" | sed 's/^://' || true)
+
+    # 4. Nothing should still be mounting into /root once we are non-root.
+    if grep -qE ':/root/' "$compose"; then
+        fail "$service: compose still mounts into /root while USER is $user_name"
+    else
+        pass "$service: no leftover /root mounts"
+    fi
+done
+
+echo
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
bark was the only service in the library without a USER directive — it ran as root while audiocraft, gaia and open-interpreter all drop privileges. no-new-privileges: true was already set, but that only blocks escalation from root; it doesn't stop the process being root.

Moving off root also moves the model cache, since bark derives it from $HOME. I set HOME and XDG_CACHE_HOME to the same path — older bark uses expanduser("~/.cache"), newer honours XDG — and pointed the compose mount at it.

Added a contract test covering all four services, not just bark: no USER, USER root, a user that's never created, or a leftover /root mount all fail it. I verified it catches both regressions by reintroducing them. Also wired it into make test — that target lists tests explicitly rather than discovering them, so a new file there would otherwise never run in CI.

Two caveats on this one

Docker wasn't available here, so I never built or ran the image. Static checks only. This is the one PR of the six I can't claim is verified end-to-end — the cache-path reasoning depends on bark 0.1.5's internals, which I couldn't inspect. The HOME + XDG_CACHE_HOME belt-and-braces makes it robust either way, but a real build is worth doing before merge.

It's a breaking upgrade for existing installs. ./data/bark is currently root-owned because the container that created it was root. Before restarting: