### PR TITLE
fix(dashboard): mask trailing _KEY credential overrides in settings API (#3881)

### DIFF
--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -21,7 +21,7 @@ from host_agent_client import AgentClientError, request_json as request_agent_js
 _ENV_ASSIGNMENT_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 _ENV_COMMENTED_ASSIGNMENT_RE = re.compile(r"^\s*#\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 _SENSITIVE_ENV_KEY_RE = re.compile(
-    r"(SECRET|(?:^|_)TOKEN(?:$|_)|PASSWORD|(?:^|_)PASS(?:$|_)|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|(?:^|_)SALT(?:$|_))"
+    r"(SECRET|(?:^|_)TOKEN(?:$|_)|PASSWORD|(?:^|_)PASS(?:$|_)|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|(?:^|_)SALT(?:$|_)|(?:^|_)KEY$)"
 )
 _GGUF_QUANTIZED_MODEL_RE = re.compile(
     r"(?:^|[-_.])q[2-8](?:_[a-z0-9]+)*(?:$|[-_.])",

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -1420,3 +1420,32 @@ def test_env_example_keys_are_present_in_schema():
     schema_keys = set(schema.get("properties", {}))
 
     assert documented_keys - schema_keys == set()
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("CREDS_KEY", True),
+        ("LIBRECHAT_MEILI_KEY", True),
+        ("GOOGLE_KEY", True),
+        ("OPENROUTER_KEY", True),
+        ("ODS_ROUTER_INTERNAL_KEY", True),
+        ("LITELLM_KEY", True),
+        ("KEY", True),
+        ("OPENAI_API_KEY", True),
+        ("LANGFUSE_PROJECT_PUBLIC_KEY", False),
+        ("ODS_FLEET_PROBE_KEY_PATH", False),
+        ("REMOTE_LLM_SSH_KEY_FILE", False),
+        ("MAX_KEY_LENGTH", False),
+    ],
+)
+def test_is_secret_field_masks_trailing_key_overrides(key, expected):
+    """Un-schematized local overrides ending in _KEY must be marked secret.
+
+    Regression test for issue #3881: GET /api/settings/env exposed extension
+    credentials in cleartext because the sensitive regex heuristic ignored
+    trailing _KEY names.
+    """
+    from settings import _is_secret_field
+
+    assert _is_secret_field(key) is expected


### PR DESCRIPTION
Fixes #3881

### Summary
* **What changed**: Added `(?:^|_)KEY$` pattern to `_SENSITIVE_ENV_KEY_RE` in `settings.py` so un-schematized local environment overrides ending in `_KEY` are recognized as secrets and masked in `GET /api/settings/env`.
* **Why it changed**: Previously, extension credential variables ending in `_KEY` (such as `CREDS_KEY`, `LIBRECHAT_MEILI_KEY`, `GOOGLE_KEY`, `OPENROUTER_KEY`, `ODS_ROUTER_INTERNAL_KEY`, `LITELLM_KEY`) were returned in cleartext because the regex heuristic only checked for specific prefixes (`API_KEY`, `PRIVATE_KEY`, `ENCRYPTION_KEY`).

### Tests
* **Executed**: `pytest tests/test_settings_env.py`
* **Result**: `103 passed in 1.22s` (added parameterized test cases covering `_KEY` secret masking and unmasked file path/public key exclusions).