### PR TITLE
Remove module-level mkdir that breaks imports outside the container

### DIFF
--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -20,8 +20,6 @@ app = FastAPI(title="Open Interpreter API")
 LLM_API_URL = os.environ.get("LLM_API_URL", "http://localhost:8000")
 API_KEY = os.environ.get("OPEN_INTERPRETER_API_KEY", "")
 AUTO_RUN = os.environ.get("OPEN_INTERPRETER_AUTO_RUN", "false").lower() == "true"
-DATA_DIR = Path("/app/data")
-DATA_DIR.mkdir(parents=True, exist_ok=True)
 
 MAX_MESSAGE_LENGTH = 32000
 

--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -8,7 +8,6 @@ import os
 import re
 import subprocess
 import tempfile
-from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.responses import StreamingResponse

--- a/ods/extensions/library/services/open-interpreter/test_import_safety.py
+++ b/ods/extensions/library/services/open-interpreter/test_import_safety.py
@@ -1,0 +1,35 @@
+"""Test that open-interpreter server can be imported outside the container."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+
+def test_server_imports_without_app_data_mkdir():
+    """The module-level code must not call mkdir on /app/data.
+
+    server.py runs in a container where /app exists (the Dockerfile creates it),
+    but outside the container (e.g., in CI tests) that path doesn't exist and
+    mkdir would fail. Moving the mkdir call out of module scope lets the server
+    be imported outside its container.
+    """
+    # If the server tries to mkdir /app/data, this patch catches it and raises.
+    with patch.object(Path, "mkdir", side_effect=RuntimeError("mkdir called")):
+        try:
+            # Import should succeed even with mkdir blocked.
+            spec = __import__("importlib.util").util.spec_from_file_location(
+                "server", Path(__file__).parent / "server.py"
+            )
+            spec.loader.exec_module(__import__("importlib.util").util.module_from_spec(spec))
+        except RuntimeError as e:
+            if "mkdir called" in str(e):
+                raise AssertionError(
+                    "server.py still calls mkdir at module import time; "
+                    "the Dockerfile's 'RUN mkdir' should be the only source"
+                ) from e
+            raise
+
+
+if __name__ == "__main__":
+    test_server_imports_without_app_data_mkdir()
+    print("✓ server imports safely")

--- a/ods/extensions/library/services/open-interpreter/test_import_safety.py
+++ b/ods/extensions/library/services/open-interpreter/test_import_safety.py
@@ -1,6 +1,5 @@
 """Test that open-interpreter server can be imported outside the container."""
 
-import sys
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
The server module called Path("/app/data").mkdir() at module scope, which fails when imported outside the container because /app doesn't exist. The Dockerfile already creates it via RUN mkdir -p /app/data, so the import-time call was redundant — and it locked the module to the running container only.

I removed both the mkdir call and the unused DATA_DIR constant. The directory still exists at runtime (Dockerfile creates it), so production is unchanged.

Added test_import_safety.py to guard against reintroduction — it patches Path.mkdir and verifies the module imports cleanly even with it blocked.
