### PR TITLE
fix(usage): isolate same-host runtime counter observations

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -15,9 +15,8 @@ from pathlib import Path
 from typing import Any
 
 import aiohttp
-from fastapi import APIRouter, Depends, Query
-
 from config import EXTENSIONS_DIR, SERVICES, USER_EXTENSIONS_DIR, read_live_env_value
+from fastapi import APIRouter, Depends, Query
 from helpers import check_service_health, get_cached_services
 from security import verify_api_key
 
@@ -448,7 +447,9 @@ def _extract_llama_cpp_prometheus_counters(metrics_text: str, url: str) -> dict[
     request_count_note = None
     if not request_metric_available:
         observed = _observe_runtime_request_delta(
-            key=f"llama.cpp:{service}:{_runtime_model_name()}",
+            # Multiple runtimes can share a hostname (different ports or paths).
+            # Keep observation baselines scoped to the configured endpoint.
+            key=f"llama.cpp:{url}:{_runtime_model_name()}",
             input_tokens=input_tokens,
             output_tokens=output_tokens,
         )

--- a/ods/extensions/services/dashboard-api/tests/test_usage_endpoint_identity.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage_endpoint_identity.py
@@ -1,0 +1,71 @@
+"""HTTP regression for independent local runtime observation baselines."""
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from unittest.mock import AsyncMock
+
+
+@contextmanager
+def metrics_server(initial_tokens):
+    counters = {"tokens": initial_tokens}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = (
+                f"llamacpp:prompt_tokens_total {counters['tokens']}\n"
+                f"llamacpp:tokens_predicted_total {counters['tokens']}\n"
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            # In-process test server; pytest assertions are the output.
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/metrics", counters
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_report_keeps_same_host_runtime_baselines_independent(test_client, monkeypatch):
+    from routers import usage
+
+    monkeypatch.setattr(usage, "_LOCAL_RUNTIME_REQUEST_STATE", {})
+    monkeypatch.setattr(usage, "_runtime_model_name", lambda: "shared-model.gguf")
+    original_report = usage._empty_report("2026-05-01", "2026-05-02", status="ok")
+    monkeypatch.setattr(usage, "_fetch_token_spy_report", AsyncMock(return_value=original_report))
+
+    with metrics_server(10) as (first_url, first), metrics_server(100) as (second_url, second):
+        monkeypatch.setenv("LOCAL_USAGE_METRICS_URLS", f"{first_url},{second_url}")
+
+        def report():
+            response = test_client.get(
+                "/api/usage/report?start=2026-05-01&end=2026-05-02",
+                headers=test_client.auth_headers,
+            )
+            assert response.status_code == 200
+            data = response.json()
+            # Cumulative observations must remain outside date-bounded totals.
+            assert data["summary"] == original_report["summary"]
+            local = data["source"]["local_runtime"]
+            assert local["included_in_totals"] is False
+            return [counter["requests"] for counter in local["counters"]]
+
+        assert report() == [0, 0]
+        first["tokens"] = 20
+        second["tokens"] = 110
+        assert report() == [1, 1]
+        # Restarting one runtime must not reset the other runtime's history.
+        first["tokens"] = 1
+        second["tokens"] = 120
+        assert report() == [0, 2]


### PR DESCRIPTION
Configure two local metrics URLs on the same hostname but different ports. Usage currently keys the observed request baseline by hostname and model, so the first scrape of the second runtime is counted as a request, and subsequent scrapes reset or inflate each other's history.

## Why this matters
Scope the observation baseline to the configured metrics endpoint. Two local llama.cpp servers now initialize independently; resetting one does not discard the other's observed history. These observations remain excluded from date-bounded billing totals.

## Overlap check
Searched open and closed PRs for usage counter endpoint, metrics port, and routers/usage.py counter. #1761 adds helper coverage; #2128 enables native Windows metrics; #1932 and #2035 concern host telemetry and routed Token Spy events. None fixes same-host observation identity.

## Validation
- Dashboard API pytest: tests/test_usage_endpoint_identity.py and tests/test_usage.py — 22 passed.
- The new test fails against upstream: the initial report is [0, 1] instead of [0, 0].
- Ruff on changed files and git diff --check: passed.

The regression starts two real local HTTP metrics servers, requests the authenticated report endpoint, advances both counters, resets one, and checks [0,0] -> [1,1] -> [0,2]. No live llama.cpp or GPU was required/exercised. The existing request count remains an observed-delta estimate, not a per-request billing record.

No response schema or stored files change. Revert restores hostname-based in-memory observation keys. AI assisted implementation, tests and analysis; independent human review remains pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
