### PR TITLE
fix(remote-provider): diagnose invalid persisted text

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
+++ b/ods/extensions/services/dashboard-api/routers/remote_provider_status.py
@@ -179,6 +179,8 @@ def _read_route_state() -> dict[str, Any]:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
         return _state_response(exists=False, valid=True)
+    except UnicodeError:
+        return _state_response(exists=True, valid=False, errors=["routing state is not valid UTF-8"])
     except OSError as exc:
         return _state_response(exists=True, valid=False, errors=[f"read failed: {exc}"])
 
@@ -366,6 +368,11 @@ def _read_peer_token() -> str:
             "missing_peer_token",
             "Remote ODS peer token custody is not configured.",
         ) from exc
+    except UnicodeError as exc:
+        raise _peer_model_error(
+            "invalid_peer_token",
+            "Remote ODS peer token custody is invalid.",
+        ) from exc
     except OSError as exc:
         raise _peer_model_error(
             "peer_token_unreadable",
@@ -373,7 +380,7 @@ def _read_peer_token() -> str:
             status_code=503,
         ) from exc
     token = value.strip()
-    if not token or any(ord(char) < 32 or ord(char) == 127 for char in token):
+    if not token or not token.isascii() or any(ord(char) < 32 or ord(char) == 127 for char in token):
         raise _peer_model_error(
             "invalid_peer_token",
             "Remote ODS peer token custody is invalid.",

--- a/ods/extensions/services/dashboard-api/tests/test_remote_provider_text_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_remote_provider_text_state.py
@@ -1,0 +1,52 @@
+"""Invalid persisted text remains diagnostic at the HTTP boundary."""
+
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.mark.parametrize("raw", [b"\xff", b"\xc3", b"\xff\xfe{\x00}\x00"])
+def test_invalid_route_encoding_is_diagnostic(test_client, monkeypatch, tmp_path, raw):
+    from routers import remote_provider_status as rps
+
+    path = tmp_path / "routing-state.json"
+    path.write_bytes(raw)
+    monkeypatch.setattr(rps, "_state_path", lambda: path)
+    monkeypatch.setattr(rps, "_fetch_egress_health", AsyncMock(return_value={"reachable": True, "ready": True}))
+    monkeypatch.setattr(rps, "_fetch_ssh_supervisor_status", AsyncMock(return_value={"ready": False}))
+    response = test_client.get("/api/remote-provider/status", headers=test_client.auth_headers)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "invalid"
+    assert data["routeState"]["exists"] is True
+    assert data["routeState"]["valid"] is False
+    assert data["routeState"]["provider"] is None
+    assert data["availableActions"]["test"] is False
+    assert data["availableActions"]["remove"] is True
+    assert path.read_bytes() == raw
+
+
+@pytest.mark.parametrize("raw", [b"\xff", "秘密".encode(), b"token\nvalue"])
+def test_invalid_peer_token_is_rejected_before_network(test_client, monkeypatch, tmp_path, raw):
+    from routers import remote_provider_status as rps
+
+    state_path = tmp_path / "routing-state.json"
+    state_path.write_text(json.dumps({
+        "schema": "ods.remote-routing-state.v1",
+        "enabled": True,
+        "provider": {"transport": "direct"},
+        "peer": {"controlBaseUrl": "https://peer.example.test", "transport": "direct"},
+    }))
+    token_path = tmp_path / "peer-token"
+    token_path.write_bytes(raw)
+    monkeypatch.setattr(rps, "_state_path", lambda: state_path)
+    monkeypatch.setattr(rps, "_peer_token_path", lambda: token_path)
+    client = Mock(side_effect=AssertionError("invalid credentials must not reach the network"))
+    monkeypatch.setattr(rps.httpx, "AsyncClient", client)
+
+    response = test_client.get("/api/remote-provider/peer/models", headers=test_client.auth_headers)
+    assert response.status_code == 409
+    assert response.json()["detail"]["reason"] == "invalid_peer_token"
+    client.assert_not_called()
+    assert token_path.read_bytes() == raw


### PR DESCRIPTION
A routing-state file containing invalid UTF-8 raises out of the status endpoint instead of returning its existing invalid-state diagnostic. A corrupt or non-ASCII peer-token file similarly escapes validation and can fail during HTTP header encoding.

## Why this matters
Keep invalid local text within the established diagnostic contract: routing status remains readable and removable, while peer operations return invalid_peer_token before constructing a network client. The files are preserved for operator recovery.

## Overlap check
Searched open and closed remote-provider encoding/Unicode and peer-token ASCII PRs. #2049 handles a different reader, model_state.py. #3842 normalizes Lemonade URLs. Neither changes remote_provider_status.py's persisted route/token reads.

## Validation
- Dashboard API pytest: test_remote_provider_text_state.py and test_remote_provider_status.py — 32 passed.
- New tests against upstream: 5 fail and the existing control-character rejection case passes.
- Ruff using the repository Python CI selection (E,F,W with its existing ignores), plus git diff --check: passed.

HTTP tests use actual files containing invalid/truncated UTF-8, UTF-16 data, a non-ASCII token, and an embedded newline. They verify diagnostic status/actions, no outgoing client construction for invalid credentials, and unchanged file bytes. Existing valid-peer tests also pass. This is local configuration error handling; live remote infrastructure was not exercised.

No persisted format changes or automatic repairs. AI assisted implementation, tests and analysis; independent human review remains pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
