### PR TITLE
fix(dashboard-api): add dict pick keys bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,12 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_pick_keys_safe(d: dict, keys: list) -> dict:
+    """Safely extract specified subset of keys into new dictionary."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    if keys is None or not isinstance(keys, (list, tuple, set)):
+        return {}
+    return {k: d[k] for k in keys if k in d}

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictPickKeysSafe:
+    def test_valid_pick(self):
+        from helpers import dict_pick_keys_safe
+        assert dict_pick_keys_safe({"a": 1, "b": 2, "c": 3}, ["a", "c"]) == {"a": 1, "c": 3}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_pick_keys_safe
+        assert dict_pick_keys_safe(None, ["a"]) == {}


### PR DESCRIPTION
Add dict_pick_keys_safe helper function to safely extract key subsets from dictionaries with default fallback support.