### PR TITLE
fix(dashboard-api): add string wrap text bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,19 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_wrap_text_safe(text: str, width: int = 70, default: str = "") -> str:
+    """Safely wrap text to specified width using standard textwrap rules."""
+    import textwrap
+    if text is None or not isinstance(text, str):
+        return default
+    if not text.strip():
+        return default
+    try:
+        if not isinstance(width, int) or width <= 0:
+            width = 70
+        return textwrap.fill(text, width=width)
+    except (ValueError, TypeError, OverflowError):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringWrapTextSafe:
+    def test_valid_wrapping(self):
+        from helpers import string_wrap_text_safe
+        sample = "Python line wrapping utility function for text formatting."
+        assert string_wrap_text_safe(sample, width=20).startswith("Python line wrapping")
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_wrap_text_safe
+        assert string_wrap_text_safe(None) == ""
+        assert string_wrap_text_safe(12345, default="err") == "err"
+        assert string_wrap_text_safe("hello world", width=-5).startswith("hello")
+


### PR DESCRIPTION
Add string_wrap_text_safe helper function to safely wrap string paragraphs with type checking and width bounds validation.