### PR TITLE
fix(dashboard-api): add list flatten nested bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_flatten_nested_safe(items, max_depth: int = 5) -> list:
+    """Safely flatten nested lists/tuples up to maximum recursion depth."""
+    if items is None:
+        return []
+    if not isinstance(items, (list, tuple, set)):
+        return [items]
+    if not isinstance(max_depth, int) or max_depth < 0:
+        max_depth = 5
+    res = []
+    def _flatten(seq, depth):
+        for item in seq:
+            if isinstance(item, (list, tuple, set)) and depth < max_depth:
+                _flatten(item, depth + 1)
+            else:
+                res.append(item)
+    _flatten(items, 0)
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListFlattenNestedSafe:
+    def test_valid_flattening(self):
+        from helpers import list_flatten_nested_safe
+        nested = [1, [2, [3, 4]], 5]
+        assert list_flatten_nested_safe(nested) == [1, 2, 3, 4, 5]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_flatten_nested_safe
+        assert list_flatten_nested_safe(None) == []
+        assert list_flatten_nested_safe(42) == [42]
+        assert list_flatten_nested_safe([1, [2]], max_depth=0) == [1, [2]]
+


### PR DESCRIPTION
Add list_flatten_nested_safe helper function for flattening arbitrarily nested sequence types up to a safe maximum depth limit.