### PR TITLE
fix(dashboard): restore the offline agent monitor

### DIFF
--- a/ods/extensions/services/dashboard/.gitignore
+++ b/ods/extensions/services/dashboard/.gitignore
@@ -1,0 +1,3 @@
+
+playwright-report/
+test-results/

--- a/ods/extensions/services/dashboard/browser-tests/agents.spec.js
+++ b/ods/extensions/services/dashboard/browser-tests/agents.spec.js
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+
+// Exercise the exact shipped dashboard CSP, including its inline-script restriction.
+const nginx = readFileSync(new URL('../nginx.conf', import.meta.url), 'utf8')
+const csp = nginx.match(/add_header Content-Security-Policy "([^"]+)"/)[1]
+const metrics = {
+  cluster: { active_gpus: 2, total_gpus: 3, failover_ready: true },
+  agent: { session_count: 4, last_update: '2026-05-01T12:00:00Z' },
+  throughput: { current: 8, average: 6, history: [
+    { timestamp: '2026-05-01T11:59:55Z', tokens_per_sec: 4 },
+    { timestamp: '2026-05-01T12:00:00Z', tokens_per_sec: 8 },
+  ] },
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.route('**/*', async route => {
+    const url = new URL(route.request().url())
+    if (url.origin !== 'http://127.0.0.1:18244') return route.abort()
+    if (url.pathname === '/agents.html') {
+      const response = await route.fetch()
+      return route.fulfill({ response, headers: { ...response.headers(), 'content-security-policy': csp } })
+    }
+    return route.continue()
+  })
+})
+
+test('renders and refreshes local metrics without any CDN requests', async ({ page }) => {
+  const external = []
+  page.on('request', request => {
+    if (!request.url().startsWith('http://127.0.0.1:18244/')) external.push(request.url())
+  })
+  let sessions = 4
+  await page.route('**/api/agents/metrics', route => route.fulfill({
+    json: { ...metrics, agent: { ...metrics.agent, session_count: sessions } },
+  }))
+  await page.goto('/agents.html')
+  await expect(page.locator('#cluster')).toHaveText('2/3 GPUs')
+  await expect(page.locator('#sessions')).toHaveText('4')
+  await expect(page.locator('#throughput-current')).toHaveText('8.0')
+  await expect(page.locator('#throughput-line')).toHaveAttribute('points', '0,80 600,0')
+  sessions = 7
+  await page.getByRole('button', { name: 'Refresh metrics' }).click()
+  await expect(page.locator('#sessions')).toHaveText('7')
+  expect(external).toEqual([])
+})
+
+test('shows an API failure and recovers through the refresh action', async ({ page }) => {
+  let healthy = false
+  await page.route('**/api/agents/metrics', route => healthy
+    ? route.fulfill({ json: metrics })
+    : route.fulfill({ status: 503, json: { detail: 'unavailable' } }))
+  await page.goto('/agents.html')
+  await expect(page.getByRole('alert')).toContainText('HTTP 503')
+  healthy = true
+  await page.getByRole('button', { name: 'Refresh metrics' }).click()
+  await expect(page.locator('#sessions')).toHaveText('4')
+  await expect(page.getByRole('alert')).toBeHidden()
+})
+
+test('does not interpret metric values as HTML', async ({ page }) => {
+  await page.route('**/api/agents/metrics', route => route.fulfill({
+    json: { ...metrics, agent: { session_count: '<img src=x onerror=alert(1)>', last_update: '<script>bad()</script>' } },
+  }))
+  await page.goto('/agents.html')
+  await expect(page.locator('#sessions')).toHaveText('0')
+  await expect(page.locator('#agent-update')).toHaveText('Updated: N/A')
+  await expect(page.locator('img')).toHaveCount(0)
+})

--- a/ods/extensions/services/dashboard/package-lock.json
+++ b/ods/extensions/services/dashboard/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.0.0",
+        "@playwright/test": "^1.63.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1300,6 +1301,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
       "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
@@ -1408,9 +1424,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1425,9 +1438,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1442,9 +1452,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1459,9 +1466,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1476,9 +1480,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1493,9 +1494,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1510,9 +1508,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1527,9 +1522,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1544,9 +1536,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1561,9 +1550,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1578,9 +1564,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1595,9 +1578,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1612,9 +1592,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4651,6 +4628,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/ods/extensions/services/dashboard/package.json
+++ b/ods/extensions/services/dashboard/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:browser": "playwright test"
   },
   "dependencies": {
     "gsap": "^3.12.7",
@@ -22,6 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.0.0",
+    "@playwright/test": "^1.63.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/ods/extensions/services/dashboard/playwright.config.js
+++ b/ods/extensions/services/dashboard/playwright.config.js
@@ -1,0 +1,12 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './browser-tests',
+  workers: 1,
+  use: { baseURL: 'http://127.0.0.1:18244' },
+  webServer: {
+    command: 'npm run dev -- --host 127.0.0.1 --port 18244',
+    url: 'http://127.0.0.1:18244',
+    reuseExistingServer: false,
+  },
+})

--- a/ods/extensions/services/dashboard/public/agents.css
+++ b/ods/extensions/services/dashboard/public/agents.css
@@ -1,0 +1,20 @@
+:root { color-scheme: dark; font-family: system-ui, sans-serif; background: #10131a; color: #e6eaf0; }
+* { box-sizing: border-box; }
+body { margin: 0; }
+main { max-width: 1100px; margin: auto; padding: 2rem; }
+nav { display: flex; gap: 1.5rem; margin-bottom: 2rem; }
+a { color: #91baff; }
+header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; flex-wrap: wrap; }
+h1 { margin: 0; }
+h2 { font-size: 1rem; font-weight: 500; color: #b7c1d0; }
+p { color: #b7c1d0; }
+button { background: #234d91; color: white; border: 1px solid #6b9be8; border-radius: .5rem; padding: .7rem 1rem; cursor: pointer; }
+button:disabled { opacity: .6; cursor: wait; }
+button:focus-visible, a:focus-visible { outline: 3px solid #9fc6ff; outline-offset: 3px; }
+.metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; }
+article, .history { background: #1b2230; border: 1px solid #344052; border-radius: .75rem; padding: 1.25rem; }
+strong { font-size: 1.75rem; }
+.history { margin-top: 1rem; }
+svg { width: 100%; height: 180px; color: #70a6ff; overflow: visible; }
+#error { color: #ffb8b8; }
+@media (max-width: 500px) { main { padding: 1rem; } }

--- a/ods/extensions/services/dashboard/public/agents.html
+++ b/ods/extensions/services/dashboard/public/agents.html
@@ -1,149 +1,33 @@
 <!DOCTYPE html>
-<html lang="en" data-theme="dark">
+<html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Agent Monitor | ODS</title>
-    <script src="https://unpkg.com/htmx.org@1.9.10" integrity="sha384-YwQSRkoBOUtKKVfHQ8C2zCPslUZHuxiPHts6X/xQCuGHipTtRXd7ImqS1VTLlpiT" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1" integrity="sha384-9nhczxUqK87bcKHh20fSQcTGD4qq5GhayNYSYWqwBkINBhOfQLg/P5HG5lF1urn4" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css" integrity="sha384-L1dWfspMTHU/ApYnFiMz2QID/PlP1xCW9visvBdbEkOLkSSWsP6ZJWhPw6apiXxU" crossorigin="anonymous">
-    <style>
-        .metric-card {
-            background: var(--card-background-color);
-            border-radius: var(--border-radius);
-            padding: 1.5rem;
-            margin-bottom: 1rem;
-        }
-        .metric-value {
-            font-size: 2rem;
-            font-weight: bold;
-            color: var(--primary);
-        }
-        .metric-label {
-            font-size: 0.875rem;
-            color: var(--muted-color);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-        .status-ok { color: #22c55e; }
-        .status-warn { color: #f59e0b; }
-        .status-error { color: #ef4444; }
-        .chart-container {
-            position: relative;
-            height: 200px;
-            margin-top: 1rem;
-        }
-        .refresh-indicator {
-            display: inline-block;
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            background: #22c55e;
-            margin-left: 0.5rem;
-            animation: pulse 2s infinite;
-        }
-        @keyframes pulse {
-            0%, 100% { opacity: 1; }
-            50% { opacity: 0.5; }
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Agent Monitor | ODS</title>
+  <link rel="stylesheet" href="/agents.css">
+  <script type="module" src="/agents.js"></script>
 </head>
 <body>
-    <main class="container">
-        <nav>
-            <ul>
-                <li><strong>🤖 Agent Monitor</strong></li>
-            </ul>
-            <ul>
-                <li><a href="/">Dashboard</a></li>
-                <li><a href="/models">Models</a></li>
-                <li><a href="/agents">Agents</a></li>
-            </ul>
-        </nav>
-
-        <header style="margin-bottom: 2rem;">
-            <h1>Agent Swarm Status 
-                <span class="refresh-indicator"></span>
-            </h1>
-            <p>Real-time monitoring of local AI agents and GPU utilization</p>
-        </header>
-
-        <!-- Auto-refresh metrics every 5 seconds -->
-        <div hx-get="/api/agents/metrics" 
-             hx-trigger="load, every 5s"
-             hx-swap="innerHTML"
-             id="metrics-container">
-            <p>Loading metrics...</p>
-        </div>
-
-        <!-- Throughput Chart -->
-        <section class="metric-card">
-            <h3>Throughput (tokens/sec)</h3>
-            <div class="chart-container">
-                <canvas id="throughputChart"></canvas>
-            </div>
-        </section>
-    </main>
-
-    <script>
-        // Initialize throughput chart
-        const ctx = document.getElementById('throughputChart').getContext('2d');
-        const throughputChart = new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: [],
-                datasets: [{
-                    label: 'Tokens/sec',
-                    data: [],
-                    borderColor: '#3b82f6',
-                    backgroundColor: 'rgba(59, 130, 246, 0.1)',
-                    tension: 0.4,
-                    fill: true
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                scales: {
-                    y: {
-                        beginAtZero: true,
-                        grid: { color: 'rgba(255, 255, 255, 0.1)' }
-                    },
-                    x: {
-                        grid: { display: false }
-                    }
-                },
-                plugins: {
-                    legend: { display: false }
-                }
-            }
-        });
-
-        // Update chart with new data
-        function updateChart(history) {
-            if (!history || history.length === 0) return;
-            
-            const labels = history.map((h, i) => `-${30-i}s`);
-            const data = history.map(h => h.tokens_per_sec);
-            
-            throughputChart.data.labels = labels;
-            throughputChart.data.datasets[0].data = data;
-            throughputChart.update('none');
-        }
-
-        // Listen for HTMX after-swap event to update chart
-        document.body.addEventListener('htmx:afterSwap', function(evt) {
-            if (evt.detail.target.id === 'metrics-container') {
-                try {
-                    const data = JSON.parse(evt.detail.xhr.response);
-                    if (data.throughput && data.throughput.history) {
-                        updateChart(data.throughput.history);
-                    }
-                } catch (e) {
-                    console.error('Failed to parse metrics:', e);
-                }
-            }
-        });
-    </script>
+  <main>
+    <nav aria-label="Main"><a href="/">Dashboard</a><a href="/models">Models</a></nav>
+    <header>
+      <div><h1>Agent Monitor</h1><p>Local agent and GPU activity</p></div>
+      <button id="refresh" type="button">Refresh metrics</button>
+    </header>
+    <p id="refresh-status" role="status">Loading metrics...</p>
+    <p id="error" role="alert" hidden></p>
+    <section class="metrics" aria-label="Agent metrics">
+      <article><h2>Cluster</h2><strong id="cluster">—</strong><p id="failover">Waiting for status</p></article>
+      <article><h2>Active sessions</h2><strong id="sessions">—</strong><p id="agent-update">Waiting for status</p></article>
+      <article><h2>Throughput</h2><strong><span id="throughput-current">—</span> tok/s</strong><p>Average: <span id="throughput-average">—</span> tok/s</p></article>
+    </section>
+    <section class="history">
+      <h2>Throughput history</h2>
+      <svg viewBox="0 0 600 160" role="img" aria-label="Recent throughput samples" preserveAspectRatio="none">
+        <polyline id="throughput-line" fill="none" stroke="currentColor" stroke-width="2" vector-effect="non-scaling-stroke"></polyline>
+      </svg>
+      <p id="history-summary">No samples yet</p>
+    </section>
+  </main>
 </body>
 </html>

--- a/ods/extensions/services/dashboard/public/agents.js
+++ b/ods/extensions/services/dashboard/public/agents.js
@@ -1,0 +1,82 @@
+const byId = id => document.getElementById(id)
+const number = value => typeof value === 'number' && Number.isFinite(value) ? Math.max(0, value) : 0
+const time = value => {
+  if (typeof value !== 'string' || !value) return 'N/A'
+  const date = new Date(value)
+  return Number.isFinite(date.getTime()) ? date.toLocaleTimeString() : 'N/A'
+}
+
+function renderMetrics(metrics) {
+  const cluster = metrics.cluster || {}
+  const agent = metrics.agent || {}
+  const throughput = metrics.throughput || {}
+  byId('cluster').textContent = `${number(cluster.active_gpus)}/${number(cluster.total_gpus)} GPUs`
+  byId('failover').textContent = cluster.failover_ready === true ? 'Failover ready' : 'Failover unavailable'
+  byId('sessions').textContent = String(number(agent.session_count))
+  byId('agent-update').textContent = `Updated: ${time(agent.last_update)}`
+  byId('throughput-current').textContent = number(throughput.current).toFixed(1)
+  byId('throughput-average').textContent = number(throughput.average).toFixed(1)
+
+  const history = Array.isArray(throughput.history) ? throughput.history.slice(-30) : []
+  const samples = history.filter(sample => sample && Number.isFinite(sample.tokens_per_sec))
+  const maximum = Math.max(1, ...samples.map(sample => number(sample.tokens_per_sec)))
+  const points = samples.map((sample, index) => {
+    const x = samples.length > 1 ? index * 600 / (samples.length - 1) : 300
+    return `${x},${160 - number(sample.tokens_per_sec) * 160 / maximum}`
+  })
+  byId('throughput-line').setAttribute('points', points.join(' '))
+  byId('history-summary').textContent = samples.length
+    ? `${samples.length} samples, ${time(samples[0].timestamp)} – ${time(samples[samples.length - 1].timestamp)}`
+    : 'No samples yet'
+}
+
+let active = true
+let pending = false
+let timer
+let controller
+const refresh = byId('refresh')
+
+async function loadMetrics() {
+  if (pending || !active) return
+  pending = true
+  clearTimeout(timer)
+  refresh.disabled = true
+  controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 8000)
+  try {
+    const response = await fetch('/api/agents/metrics', { signal: controller.signal })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
+    const metrics = await response.json()
+    if (!metrics || typeof metrics !== 'object' || Array.isArray(metrics)) throw new Error('Invalid metrics response')
+    if (!active) return
+    renderMetrics(metrics)
+    byId('error').hidden = true
+    byId('refresh-status').textContent = `Last refreshed: ${new Date().toLocaleTimeString()}`
+  } catch (error) {
+    if (!active) return
+    byId('error').textContent = `Agent metrics unavailable: ${error.message}. Use Refresh metrics to try again.`
+    byId('error').hidden = false
+    byId('refresh-status').textContent = 'Metrics could not be refreshed'
+  } finally {
+    clearTimeout(timeout)
+    pending = false
+    if (active) {
+      refresh.disabled = false
+      timer = setTimeout(loadMetrics, 5000)
+    }
+  }
+}
+
+refresh.addEventListener('click', loadMetrics)
+window.addEventListener('pagehide', () => {
+  active = false
+  clearTimeout(timer)
+  controller?.abort()
+})
+loadMetrics()
+window.addEventListener('pageshow', event => {
+  if (event.persisted) {
+    active = true
+    loadMetrics()
+  }
+})


### PR DESCRIPTION
The shipped /agents.html page depends on CDN scripts/styles and initializes its chart in inline JavaScript that the dashboard CSP blocks. Its HTMX request also inserts the JSON metrics response as HTML.

## Why this matters
Make the standalone monitor work offline with local CSS and a small local module. Render the existing authenticated JSON metrics with textContent, draw throughput history with native SVG, and show refresh failures with a usable refresh action. Polling is sequential, bounded by an eight-second request timeout, and stopped when leaving the page.

## Overlap check
Searched open/closed agents.html, Agent Monitor offline, and agents.html CSP PRs. #128/#129 introduced earlier security hardening; neither removes the page's CDN/inline dependency or fixes JSON rendering. No API or authentication contract changes.

## Validation
- Clean npm ci: passed.
- npm run test:browser: 3 Chromium tests passed; all three fail with upstream agents.html.
- npm run lint, explicit ESLint on new JS/config/tests, and npm run build: passed.
- git diff --check: passed.

Tests serve the page with the exact CSP extracted from nginx.conf, block all external origins, verify metrics/chart updates, recover from HTTP 503, and ensure metric strings cannot become HTML. The API response is a fixture; no live agent fleet was exercised. Build output includes the local static assets.

Run browser tests from ods/extensions/services/dashboard after npm ci and npx playwright install --with-deps chromium. Reverting restores the previous page without any data migration. AI assisted implementation, tests and analysis; independent human review remains pending.

### Batch compatibility

The combined dashboard passes 258 Vitest tests, all three Chromium scenarios, lint and production build. Its files are unchanged between the tested snapshot and the final integration artifact. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
