### PR TITLE
fix(dashboard-api): add numeric normalize ratio bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,24 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_normalize_ratio_safe(val, min_val=0.0, max_val=1.0, default: float = 0.0) -> float:
+    """Safely normalize a numeric value to a 0.0 - 1.0 ratio based on min/max bounds."""
+    if val is None:
+        return default
+    try:
+        if isinstance(val, float) and (math.isnan(val) or math.isinf(val)):
+            return default
+        v = float(val)
+        mn = float(min_val)
+        mx = float(max_val)
+        if math.isnan(v) or math.isnan(mn) or math.isnan(mx) or math.isinf(v) or math.isinf(mn) or math.isinf(mx):
+            return default
+        if mx <= mn:
+            return default
+        clamped = max(mn, min(v, mx))
+        return (clamped - mn) / (mx - mn)
+    except (ValueError, TypeError, ZeroDivisionError, OverflowError):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericNormalizeRatioSafe:
+    def test_valid_normalization(self):
+        from helpers import numeric_normalize_ratio_safe
+        assert numeric_normalize_ratio_safe(50, 0, 100) == 0.5
+        assert numeric_normalize_ratio_safe(150, 0, 100) == 1.0
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_normalize_ratio_safe
+        assert numeric_normalize_ratio_safe(None) == 0.0
+        assert numeric_normalize_ratio_safe(float("nan")) == 0.0
+        assert numeric_normalize_ratio_safe(5, 10, 10) == 0.0
+


### PR DESCRIPTION
Add numeric_normalize_ratio_safe helper function to scale numbers into normalized floating point ratios within min/max bounds.