### PR TITLE
fix(dashboard-api): add dict remap keys bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,17 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_remap_keys_safe(d: dict, mapping: dict) -> dict:
+    """Safely rename dictionary keys based on a key transformation mapping."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    if mapping is None or not isinstance(mapping, dict):
+        return dict(d)
+    res = {}
+    for k, v in d.items():
+        new_k = mapping.get(k, k)
+        res[new_k] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictRemapKeysSafe:
+    def test_valid_remapping(self):
+        from helpers import dict_remap_keys_safe
+        data = {"old_a": 1, "old_b": 2, "c": 3}
+        mapping = {"old_a": "new_a", "old_b": "new_b"}
+        assert dict_remap_keys_safe(data, mapping) == {"new_a": 1, "new_b": 2, "c": 3}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_remap_keys_safe
+        assert dict_remap_keys_safe(None, {"a": "b"}) == {}
+        assert dict_remap_keys_safe({"a": 1}, None) == {"a": 1}
+


### PR DESCRIPTION
Add dict_remap_keys_safe helper function to safely transform dictionary key aliases with fallback handling.