### PR TITLE
fix(dashboard-api): add string count words bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,16 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_count_words_safe(text: str, default: int = 0) -> int:
+    """Safely count total whitespace-delimited words in a string."""
+    if text is None or not isinstance(text, str):
+        return default
+    if not text.strip():
+        return 0
+    try:
+        return len(text.split())
+    except (ValueError, TypeError, OverflowError):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringCountWordsSafe:
+    def test_valid_word_counts(self):
+        from helpers import string_count_words_safe
+        assert string_count_words_safe("The quick brown fox jumps") == 5
+        assert string_count_words_safe("   single   ") == 1
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_count_words_safe
+        assert string_count_words_safe(None) == 0
+        assert string_count_words_safe(12345, default=-1) == -1
+        assert string_count_words_safe("   ") == 0
+


### PR DESCRIPTION
Add string_count_words_safe helper function to count words in string inputs with type safety and fallback defaults.