### PR TITLE
fix(dashboard-api): add safe path relative to bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,19 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def safe_path_relative_to(path_str: str, base_str: str, default: str = "") -> str:
+    """Safely resolve relative path string between target and base path."""
+    import pathlib
+    if not path_str or not isinstance(path_str, (str, pathlib.Path)):
+        return default
+    if not base_str or not isinstance(base_str, (str, pathlib.Path)):
+        return default
+    try:
+        p = pathlib.Path(path_str)
+        b = pathlib.Path(base_str)
+        return str(p.relative_to(b))
+    except (ValueError, TypeError, RuntimeError, Exception):
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,15 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestSafePathRelativeTo:
+    def test_valid_relative_path(self):
+        from helpers import safe_path_relative_to
+        assert safe_path_relative_to("/a/b/c/d.txt", "/a/b") == "c/d.txt"
+
+    def test_invalid_and_bounds(self):
+        from helpers import safe_path_relative_to
+        assert safe_path_relative_to(None, "/a/b") == ""
+        assert safe_path_relative_to("/x/y", "/a/b", default="none") == "none"
+


### PR DESCRIPTION
Add safe_path_relative_to helper function to safely resolve relative filesystem paths without throwing exceptions.