### PR TITLE
fix(agents): expire stale telemetry after collection failures

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -100,7 +100,10 @@ class ThroughputMetrics:
             "tokens_per_sec": tokens_per_sec
         })
 
-        # Prune old data
+        self._prune_expired()
+
+    def _prune_expired(self):
+        """Enforce retention even when the upstream stops producing samples."""
         cutoff = datetime.now(timezone.utc) - timedelta(minutes=self.history_minutes)
         self.data_points = [
             p for p in self.data_points
@@ -109,6 +112,7 @@ class ThroughputMetrics:
 
     def get_stats(self) -> dict:
         """Get throughput statistics"""
+        self._prune_expired()
         if not self.data_points:
             return {"current": 0, "average": 0, "peak": 0, "history": []}
 
@@ -151,6 +155,7 @@ async def _fetch_token_spy_metrics() -> None:
                     # seconds in that window to get an average tokens/sec.
                     total_out = sum(r.get("total_output_tokens", 0) or 0 for r in data)
                     throughput.add_sample(total_out / 86400.0)
+                    agent_metrics.last_update = datetime.now(timezone.utc)
                     logger.debug("Token Spy metrics: %d sessions, %d total output tokens",
                                len(data), total_out)
                 else:
@@ -172,8 +177,6 @@ async def collect_metrics():
 
             # Update agent session count and throughput from Token Spy
             await _fetch_token_spy_metrics()
-
-            agent_metrics.last_update = datetime.now(timezone.utc)
 
         except FileNotFoundError as e:
             logger.debug("Metrics collection failed: command not found - %s", e)

--- a/ods/extensions/services/dashboard-api/tests/test_agent_metrics_freshness.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_metrics_freshness.py
@@ -1,0 +1,85 @@
+"""Public metrics must not make an upstream outage look like fresh activity."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def clock_at(monkeypatch, monitor):
+    clock = SimpleNamespace(now=datetime(2026, 5, 1, tzinfo=timezone.utc))
+
+    class Clock(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return clock.now.astimezone(tz) if tz else clock.now.replace(tzinfo=None)
+
+    monkeypatch.setattr(monitor, "datetime", Clock)
+    return clock
+
+
+@pytest.mark.parametrize("endpoint", ["/api/agents/throughput", "/api/agents/metrics"])
+def test_expired_samples_leave_public_statistics_without_new_samples(
+    test_client, monkeypatch, endpoint,
+):
+    import agent_monitor as monitor
+
+    clock = clock_at(monkeypatch, monitor)
+    monkeypatch.setattr(monitor.throughput, "data_points", [])
+    monkeypatch.setattr(monitor.throughput, "history_minutes", 15)
+    monitor.throughput.add_sample(90)
+    clock.now += timedelta(minutes=10)
+    monitor.throughput.add_sample(20)
+    clock.now += timedelta(minutes=10)
+
+    def stats():
+        response = test_client.get(endpoint, headers=test_client.auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        return data["throughput"] if "throughput" in data else data
+
+    current = stats()
+    assert current["current"] == current["average"] == current["peak"] == 20
+    assert len(current["history"]) == 1
+    clock.now += timedelta(minutes=5)
+    assert stats() == {"current": 0, "average": 0, "peak": 0, "history": []}
+
+
+def test_failed_collection_does_not_refresh_last_success_time(test_client, monkeypatch):
+    import agent_monitor as monitor
+
+    clock = clock_at(monkeypatch, monitor)
+    monkeypatch.setattr(monitor.agent_metrics, "last_update", clock.now)
+    monkeypatch.setattr(monitor.agent_metrics, "session_count", 0)
+    monkeypatch.setattr(monitor.throughput, "data_points", [])
+    monkeypatch.setattr(monitor.cluster_status, "refresh", AsyncMock())
+    monkeypatch.setattr(monitor, "TOKEN_SPY_URL", "http://token-spy:8080")
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value=[{"total_output_tokens": 86400}])
+    session = MagicMock()
+    session.__aenter__.return_value = session
+    session.get.return_value.__aenter__.return_value = response
+    monkeypatch.setattr(monitor.aiohttp, "ClientSession", lambda **_kwargs: session)
+
+    async def one_collection():
+        async def stop_after_interval(delay):
+            assert delay == 5
+            raise asyncio.CancelledError
+        with monkeypatch.context() as context:
+            context.setattr(monitor.asyncio, "sleep", stop_after_interval)
+            with pytest.raises(asyncio.CancelledError):
+                await monitor.collect_metrics()
+
+    clock.now += timedelta(minutes=1)
+    asyncio.run(one_collection())
+    successful_at = clock.now.isoformat()
+    response.status = 503
+    clock.now += timedelta(minutes=1)
+    asyncio.run(one_collection())
+
+    result = test_client.get("/api/agents/metrics", headers=test_client.auth_headers)
+    assert result.status_code == 200
+    assert result.json()["agent"]["last_update"] == successful_at
+    assert result.json()["agent"]["session_count"] == 1


### PR DESCRIPTION
When Token Spy stops responding, the collector still advances last_update and throughput samples never expire unless another sample arrives. The metrics APIs can therefore show old activity with a fresh timestamp indefinitely.

## Why this matters
Advance the agent timestamp only after a successful telemetry update and enforce the existing retention window when reading throughput statistics. After an outage, retained session data keeps its real update time and expired throughput no longer contributes to current/average/peak/history.

## Overlap check
Searched open/closed throughput stale/expire/prune and agent last_update/freshness PRs. Compared #2374: it validates summary payloads but leaves the collector's unconditional timestamp update and read-time retention unchanged. #1841 makes timestamps UTC-aware; #2037 handles null timestamps in HTML formatting. This change preserves those contracts.

## Validation
- Dashboard API pytest: test_agent_metrics_freshness.py and test_agent_monitor.py — 22 passed.
- The three new regressions all fail with upstream agent_monitor.py.
- Ruff using Python CI rules and git diff --check: passed.

HTTP tests advance a controlled clock without adding samples and verify both public metrics endpoints at the retention boundary. A collector-loop test performs a successful receipt followed by HTTP 503 and verifies the last successful timestamp through the API. No wall-clock sleeps or live Token Spy/GPU were needed.

No stored-file migration or response-schema changes. Revert restores the old timestamp/retention behavior. AI assisted code, tests and analysis; independent human review remains pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
