### PR TITLE
fix(dashboard-api): add dict compact none values bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,15 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_compact_none_values_safe(d: dict) -> dict:
+    """Safely strip all keys mapping to None values from a dictionary."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    res = {}
+    for k, v in d.items():
+        if v is not None:
+            res[k] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictCompactNoneValuesSafe:
+    def test_valid_compacting(self):
+        from helpers import dict_compact_none_values_safe
+        data = {"a": 1, "b": None, "c": "text", "d": None}
+        assert dict_compact_none_values_safe(data) == {"a": 1, "c": "text"}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_compact_none_values_safe
+        assert dict_compact_none_values_safe(None) == {}
+        assert dict_compact_none_values_safe([1, 2, 3]) == {}
+


### PR DESCRIPTION
Add dict_compact_none_values_safe helper function to cleanly prune key-value pairs where value is None from payload dictionaries.