### PR TITLE
fix(dashboard-api): add dict rename keys prefix bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,16 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_rename_keys_prefix_safe(d: dict, prefix: str = "", default: dict = None) -> dict:
+    """Safely prepend a string prefix to all dictionary keys."""
+    if d is None or not isinstance(d, dict):
+        return default if default is not None else {}
+    if not prefix or not isinstance(prefix, str):
+        prefix = ""
+    res = {}
+    for k, v in d.items():
+        res[f"{prefix}{k}"] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictRenameKeysPrefixSafe:
+    def test_valid_prefixing(self):
+        from helpers import dict_rename_keys_prefix_safe
+        data = {"a": 1, "b": 2}
+        assert dict_rename_keys_prefix_safe(data, "meta_") == {"meta_a": 1, "meta_b": 2}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_rename_keys_prefix_safe
+        assert dict_rename_keys_prefix_safe(None) == {}
+        assert dict_rename_keys_prefix_safe("invalid", default={"err": 1}) == {"err": 1}
+


### PR DESCRIPTION
Add dict_rename_keys_prefix_safe helper function to safely prepend key namespaces to dictionary objects.