### PR TITLE
fix(dashboard-api): add list chunk overlapping bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,27 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_chunk_overlapping_safe(items, size: int = 2, step: int = 1) -> list:
+    """Safely generate sliding window / overlapping sublists from a sequence."""
+    if items is None:
+        return []
+    if not isinstance(items, (list, tuple, set)):
+        try:
+            items = list(items)
+        except TypeError:
+            return []
+    else:
+        items = list(items)
+    if not isinstance(size, int) or size <= 0:
+        size = 2
+    if not isinstance(step, int) or step <= 0:
+        step = 1
+    chunks = []
+    for i in range(0, len(items), step):
+        chunk = items[i:i + size]
+        if chunk:
+            chunks.append(chunk)
+    return chunks
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListChunkOverlappingSafe:
+    def test_valid_sliding_window(self):
+        from helpers import list_chunk_overlapping_safe
+        nums = [1, 2, 3, 4]
+        assert list_chunk_overlapping_safe(nums, size=2, step=1) == [[1, 2], [2, 3], [3, 4], [4]]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_chunk_overlapping_safe
+        assert list_chunk_overlapping_safe(None) == []
+        assert list_chunk_overlapping_safe([1, 2], size=-1, step=0) == [[1, 2], [2]]
+


### PR DESCRIPTION
Add list_chunk_overlapping_safe helper function for sliding window sublist generation with guard against invalid step/size.