### PR TITLE
fix(dashboard-api): add dict filter by keys bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,21 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_filter_by_keys_safe(d: dict | None, allowed_keys: list | tuple | set | None, exclude: bool = False) -> dict:
+    """Safely filter a dictionary keeping or excluding specific keys.
+    Returns empty dict on invalid dictionary input.
+    """
+    if not isinstance(d, dict):
+        return {}
+    if not isinstance(allowed_keys, (list, tuple, set)):
+        return dict(d) if not exclude else {}
+    try:
+        keys_set = set(allowed_keys)
+        if exclude:
+            return {k: v for k, v in d.items() if k not in keys_set}
+        return {k: v for k, v in d.items() if k in keys_set}
+    except Exception:
+        return {}
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictFilterByKeysSafe:
+    def test_valid_filter(self):
+        from helpers import dict_filter_by_keys_safe
+        d = {"a": 1, "b": 2, "c": 3}
+        assert dict_filter_by_keys_safe(d, ["a", "b"]) == {"a": 1, "b": 2}
+        assert dict_filter_by_keys_safe(d, ["a"], exclude=True) == {"b": 2, "c": 3}
+
+    def test_invalid_inputs(self):
+        from helpers import dict_filter_by_keys_safe
+        assert dict_filter_by_keys_safe(None, ["a"]) == {}
+        assert dict_filter_by_keys_safe({"a": 1}, None) == {"a": 1}
+


### PR DESCRIPTION
Add dict_filter_by_keys_safe helper function to cleanly filter dictionary key-value pairs by inclusion/exclusion sets.