### PR TITLE
fix(dashboard-api): add string mask sensitive bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_mask_sensitive_safe(text: str, unmasked_suffix_len: int = 4, mask_char: str = "*") -> str:
+    """Safely mask sensitive strings (API keys, cards) preserving trailing unmasked suffix characters."""
+    if text is None or not isinstance(text, str):
+        return ""
+    if not text:
+        return ""
+    if not isinstance(unmasked_suffix_len, int) or unmasked_suffix_len < 0:
+        unmasked_suffix_len = 4
+    if not isinstance(mask_char, str) or not mask_char:
+        mask_char = "*"
+    mask_char = mask_char[0]
+    n = len(text)
+    if n <= unmasked_suffix_len:
+        return mask_char * n
+    masked_count = n - unmasked_suffix_len
+    return (mask_char * masked_count) + text[-unmasked_suffix_len:]
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,15 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringMaskSensitiveSafe:
+    def test_valid_masking(self):
+        from helpers import string_mask_sensitive_safe
+        assert string_mask_sensitive_safe("1234567890", unmasked_suffix_len=4) == "******7890"
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_mask_sensitive_safe
+        assert string_mask_sensitive_safe(None) == ""
+        assert string_mask_sensitive_safe("abc", unmasked_suffix_len=4) == "***"
+


### PR DESCRIPTION
Add string_mask_sensitive_safe helper function to safely mask sensitive strings (API keys, cards) preserving trailing unmasked suffix characters.