### PR TITLE
fix(dashboard-api): add list interleave sequences bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,30 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_interleave_sequences_safe(*sequences) -> list:
+    """Safely interleave elements from multiple input sequences into a single combined list."""
+    if not sequences:
+        return []
+    valid_seqs = []
+    for seq in sequences:
+        if seq is None:
+            continue
+        if not isinstance(seq, (list, tuple, set)):
+            try:
+                valid_seqs.append(list(seq))
+            except TypeError:
+                continue
+        else:
+            valid_seqs.append(list(seq))
+    if not valid_seqs:
+        return []
+    res = []
+    max_len = max(len(s) for s in valid_seqs)
+    for i in range(max_len):
+        for seq in valid_seqs:
+            if i < len(seq):
+                res.append(seq[i])
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,17 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListInterleaveSequencesSafe:
+    def test_valid_interleaving(self):
+        from helpers import list_interleave_sequences_safe
+        s1 = [1, 3, 5]
+        s2 = [2, 4]
+        assert list_interleave_sequences_safe(s1, s2) == [1, 2, 3, 4, 5]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_interleave_sequences_safe
+        assert list_interleave_sequences_safe(None, [1, 2]) == [1, 2]
+        assert list_interleave_sequences_safe(123) == []
+


### PR DESCRIPTION
Add list_interleave_sequences_safe helper function to safely interleave elements from multiple input sequences into a single combined list.