### PR TITLE
fix(dashboard-api): add numeric exponential decay bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,23 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_exponential_decay_safe(initial_val, decay_rate, time_steps, min_val: float = 0.0) -> float:
+    """Safely calculate exponential decay values for telemetry and metrics algorithms."""
+    if initial_val is None or decay_rate is None or time_steps is None:
+        return float(min_val or 0.0)
+    try:
+        v0 = float(initial_val)
+        r = float(decay_rate)
+        t = float(time_steps)
+        m = float(min_val or 0.0)
+        if math.isnan(v0) or math.isinf(v0) or math.isnan(r) or math.isinf(r) or math.isnan(t) or math.isinf(t):
+            return m
+        decayed = v0 * math.exp(-abs(r) * max(0.0, t))
+        if math.isnan(decayed) or math.isinf(decayed):
+            return m
+        return max(m, float(decayed))
+    except (ValueError, TypeError, OverflowError, ZeroDivisionError):
+        return float(min_val or 0.0)
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericExponentialDecaySafe:
+    def test_valid_exponential_decay(self):
+        from helpers import numeric_exponential_decay_safe
+        res = numeric_exponential_decay_safe(100, 0.1, 10)
+        assert 35.0 < res < 37.0
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_exponential_decay_safe
+        assert numeric_exponential_decay_safe(None, 0.1, 5) == 0.0
+        assert numeric_exponential_decay_safe(100, float("nan"), 5, min_val=1.0) == 1.0
+


### PR DESCRIPTION
Add numeric_exponential_decay_safe helper function to safely calculate exponential decay values for telemetry and metrics algorithms.