### PR TITLE
fix(dashboard-api): add dict map values bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,19 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_map_values_safe(d: dict, mapper=None) -> dict:
+    """Safely transform all values in a dictionary using a callable mapping function."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    if mapper is None or not callable(mapper):
+        return dict(d)
+    res = {}
+    for k, v in d.items():
+        try:
+            res[k] = mapper(v)
+        except Exception:
+            res[k] = v
+    return res
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,16 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictMapValuesSafe:
+    def test_valid_mapping(self):
+        from helpers import dict_map_values_safe
+        data = {"a": 1, "b": 2}
+        assert dict_map_values_safe(data, lambda x: x * 10) == {"a": 10, "b": 20}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_map_values_safe
+        assert dict_map_values_safe(None) == {}
+        assert dict_map_values_safe({"a": "text"}, lambda x: int(x)) == {"a": "text"}
+


### PR DESCRIPTION
Add dict_map_values_safe helper function to safely transform all values in a dictionary using a callable mapping function.