### PR TITLE
fix(update): prune backups safely when the backup path contains spaces

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -123,6 +123,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== ods-update.sh backup command ==="
 	@bash tests/test-update-script-backup.sh
+	@bash tests/test-update-backup-retention-spaces.sh
 	@bash tests/test-backup-data-coverage.sh
 	@echo ""
 	@echo "=== backup integrity and restore round-trip ==="

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -627,17 +627,18 @@ cmd_backup() {
     log_ok "Backup created: ${backup_path}"
     log_info "Files backed up: ${files_backed_up}"
     
-    # Cleanup old backups
-    local backup_dirs
-    backup_dirs=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
+    # Cleanup old backups. Read NUL-delimited paths: `for dir in $backup_dirs`
+    # word-split every path, so a BACKUP_DIR containing a space (a HOME like
+    # /mnt/c/Users/First Last) produced fragments — retention silently pruned
+    # nothing, and `rm -rf` ran against a partial path.
     local count=0
-    for dir in $backup_dirs; do
+    while IFS= read -r -d '' dir; do
         count=$((count + 1))
         if ((count > MAX_BACKUPS)); then
             log_info "Removing old backup: $(basename "$dir")"
             rm -rf "$dir"
         fi
-    done
+    done < <(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" -print0 | sort -zr)
 }
 
 #==============================================================================

--- a/ods/tests/test-update-backup-retention-spaces.sh
+++ b/ods/tests/test-update-backup-retention-spaces.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# `ods-update.sh backup` prunes old backups down to MAX_BACKUPS. The retention
+# loop used `for dir in $backup_dirs`, which word-splits every path, so a
+# BACKUP_DIR containing a space (HOME=/mnt/c/Users/First Last on Windows/WSL)
+# produced path fragments: retention silently pruned nothing, and `rm -rf` ran
+# against a partial path that could match an unintended directory.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${ODS_UPDATE_UNDER_TEST:-$ROOT_DIR/ods-update.sh}"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/ods-retention-XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+command -v jq >/dev/null 2>&1 || fail "jq is required by ods-update.sh"
+
+# HOME with a space -> BACKUP_DIR with a space. This is the whole point.
+FAKE_HOME="$TMP_DIR/My Home"
+BACKUPS="$FAKE_HOME/.ods/backups"
+INSTALL="$TMP_DIR/install"
+mkdir -p "$BACKUPS" "$INSTALL"
+cp "$TARGET" "$INSTALL/ods-update.sh"
+chmod +x "$INSTALL/ods-update.sh"
+printf 'GPU_BACKEND=cpu\n' > "$INSTALL/.env"
+printf '{"version":"2.6.0"}\n' > "$INSTALL/.version"
+printf 'services: {}\n' > "$INSTALL/docker-compose.yml"
+
+# Pre-existing backups, oldest first by name. With MAX_BACKUPS=2 the newest 2
+# survive (the run also creates one, so the oldest must be pruned).
+for stamp in 20250101-010101 20250202-020202 20250303-030303 20250404-040404; do
+    mkdir -p "$BACKUPS/backup-$stamp"
+    printf 'sentinel\n' > "$BACKUPS/backup-$stamp/marker.txt"
+done
+before=$(find "$BACKUPS" -maxdepth 1 -type d -name 'backup-*' | wc -l | tr -d ' ')
+[[ "$before" -eq 4 ]] || fail "fixture setup: expected 4 backups, got $before"
+
+# A sibling directory whose name is the first word of the spaced path. A
+# word-split `rm -rf` fragment would target this; it must survive untouched.
+mkdir -p "$TMP_DIR/My"
+printf 'do-not-delete\n' > "$TMP_DIR/My/canary.txt"
+
+set +e
+out="$(cd "$INSTALL" && HOME="$FAKE_HOME" MAX_BACKUPS=2 "$BASH" ./ods-update.sh backup 2>&1)"
+rc=$?
+set -e
+[[ $rc -eq 0 ]] || fail "ods-update.sh backup exited $rc: $(printf '%s' "$out" | tail -n 3 | tr '\n' ' ')"
+
+[[ -f "$TMP_DIR/My/canary.txt" ]] \
+    || fail "a word-split path fragment deleted an unrelated sibling directory"
+pass "no unrelated directory outside the backup dir was removed"
+
+remaining=$(find "$BACKUPS" -maxdepth 1 -type d -name 'backup-*' | wc -l | tr -d ' ')
+[[ "$remaining" -eq 2 ]] \
+    || fail "retention did not prune to MAX_BACKUPS=2 on a path with spaces (got $remaining dirs); backups were never removed"
+pass "retention prunes to MAX_BACKUPS when the backup path contains spaces"
+
+# The two survivors must be the newest by name, and the oldest must be gone.
+[[ ! -d "$BACKUPS/backup-20250101-010101" ]] \
+    || fail "the oldest backup was not pruned"
+[[ -d "$BACKUPS/backup-20250404-040404" ]] \
+    || fail "a recent backup was pruned instead of an old one"
+pass "the oldest backups are the ones removed"


### PR DESCRIPTION
## Summary

`cmd_backup`'s retention loop iterated the raw, word-split output of `find`:

```bash
backup_dirs=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
for dir in $backup_dirs; do ... rm -rf "$dir"
```

`BACKUP_DIR` is `$HOME/.ods/backups`, so a `HOME` containing a space (on Windows/WSL, `/mnt/c/Users/First Last`) split every path into fragments. Retention silently pruned nothing, and `rm -rf` ran against a partial path. Repro in #3330.

The data-loss risk the issue hypothesised is real and reproducible: with a backup dir of `.../My Home/.ods/backups`, the fragment `.../My` matched an unrelated sibling directory and **deleted it**. The new test asserts that sibling survives, and it fails on `main` on exactly that assertion.

Change (one concern: retention handles paths with spaces):

- **`ods-update.sh`**: read NUL-delimited paths (`find -print0 | sort -zr`, `while IFS= read -r -d ''`). Verified `sort -z` is supported by both macOS `sort` (2.3-Apple) and GNU coreutils.
- **`tests/test-update-backup-retention-spaces.sh`** (new, in `make test`): runs `ods-update.sh backup` with `HOME` set to a path containing a space and `MAX_BACKUPS=2`, asserting retention prunes to the limit, the oldest backups are the ones removed, and an unrelated sibling directory is untouched.

Fixes #3330.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low -- the loop body is unchanged; only how paths are read. Behaviour on a path without spaces is identical (verified: retention still prunes to `MAX_BACKUPS`).
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, jq 1.7, shellcheck 0.11

$ printf 'b\0a\0' | sort -zr    -> works on macOS sort 2.3-Apple (and GNU coreutils)

# BEFORE (upstream/main ods-update.sh, this branch's test)
$ ODS_UPDATE_UNDER_TEST=<main ods-update.sh> bash tests/test-update-backup-retention-spaces.sh
[FAIL] a word-split path fragment deleted an unrelated sibling directory

# AFTER (this branch)
$ bash tests/test-update-backup-retention-spaces.sh     (bash 5.3 and /bin/bash 3.2)
[PASS] no unrelated directory outside the backup dir was removed
[PASS] retention prunes to MAX_BACKUPS when the backup path contains spaces
[PASS] the oldest backups are the ones removed

# No regression on a path without spaces: 3 pre-existing + 1 new, MAX_BACKUPS=2 -> 2 remain
$ bash tests/test-update-script-backup.sh      -> PASS
$ bash tests/test-update-rollback-contract.sh  -> PASS
$ bash tests/test-backup-restore-cli.sh        -> PASS
$ bash tests/test-migrate-config.sh            -> PASS

$ shellcheck --exclude=SC1091,SC2034 --severity=error ods-update.sh tests/test-update-backup-retention-spaces.sh -> clean
$ shellcheck --exclude=SC1091,SC2034 ods-update.sh -> default-severity count unchanged (11 -> 11); new test 0
$ /bin/bash -n <changed files> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean
$ make -n test -> ok; git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- `scripts/migrate-config.sh:268` has the same word-splitting shape over migration paths (reported separately as #3002); deliberately not bundled here.
- The remaining `for x in $var` loops in these scripts iterate space-separated token lists (dependency names, compose service names), where word-splitting is intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

