### PR TITLE
fix(dashboard-api): add dict invert bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,16 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_invert_safe(d: dict) -> dict:
+    """Safely invert dictionary keys and values for unqiue value maps."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    res = {}
+    for k, v in d.items():
+        try:
+            res[v] = k
+        except TypeError:
+            continue
+    return res

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictInvertSafe:
+    def test_valid_invert(self):
+        from helpers import dict_invert_safe
+        assert dict_invert_safe({"a": 1, "b": 2}) == {1: "a", 2: "b"}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_invert_safe
+        assert dict_invert_safe(None) == {}


### PR DESCRIPTION
Add dict_invert_safe helper function to safely invert dictionary keys and values for unique value maps.