### PR TITLE
fix(dashboard-api): add list partition by bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,28 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_partition_by_safe(items, predicate=None) -> tuple:
+    """Safely split list elements into match and non-match tuple groups."""
+    if items is None:
+        return ([], [])
+    if not isinstance(items, (list, tuple, set)):
+        try:
+            items = list(items)
+        except TypeError:
+            return ([], [])
+    else:
+        items = list(items)
+    if predicate is None or not callable(predicate):
+        predicate = bool
+    matching, non_matching = [], []
+    for item in items:
+        try:
+            if predicate(item):
+                matching.append(item)
+            else:
+                non_matching.append(item)
+        except Exception:
+            non_matching.append(item)
+    return (matching, non_matching)

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,15 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListPartitionBySafe:
+    def test_valid_partition(self):
+        from helpers import list_partition_by_safe
+        m, nm = list_partition_by_safe([1, 2, 3, 4], lambda x: x % 2 == 0)
+        assert m == [2, 4]
+        assert nm == [1, 3]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_partition_by_safe
+        assert list_partition_by_safe(None) == ([], [])


### PR DESCRIPTION
Add list_partition_by_safe helper function to safely split list elements into match and non-match tuple groups.