### PR TITLE
fix(dashboard-api): add string remove accents bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,15 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_remove_accents_safe(text: str, default: str = "") -> str:
+    """Safely strip diacritics and accent marks from unicode string."""
+    import unicodedata
+    if text is None or not isinstance(text, str):
+        return default
+    try:
+        nfkd = unicodedata.normalize('NFKD', text)
+        return "".join([c for c in nfkd if not unicodedata.combining(c)])
+    except Exception:
+        return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringRemoveAccentsSafe:
+    def test_valid_removal(self):
+        from helpers import string_remove_accents_safe
+        assert string_remove_accents_safe("café crêpe") == "cafe crepe"
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_remove_accents_safe
+        assert string_remove_accents_safe(None) == ""


### PR DESCRIPTION
Add string_remove_accents_safe helper function to safely strip diacritics and accent marks from unicode string.