### PR TITLE
fix(dashboard-api): add numeric harmonic mean bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,26 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_harmonic_mean_safe(numbers, default: float = 0.0) -> float:
+    """Safely calculate harmonic mean of positive numbers."""
+    if numbers is None or not isinstance(numbers, (list, tuple, set)):
+        return default
+    clean = []
+    for n in numbers:
+        try:
+            v = float(n)
+            if not (math.isnan(v) or math.isinf(v)) and v > 0:
+                clean.append(v)
+        except (ValueError, TypeError):
+            continue
+    if not clean:
+        return default
+    try:
+        sum_recip = sum(1.0 / x for x in clean)
+        if sum_recip == 0:
+            return default
+        return float(len(clean) / sum_recip)
+    except Exception:
+        return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,14 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericHarmonicMeanSafe:
+    def test_valid_mean(self):
+        from helpers import numeric_harmonic_mean_safe
+        assert round(numeric_harmonic_mean_safe([1, 4, 4]), 2) == 2.0
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_harmonic_mean_safe
+        assert numeric_harmonic_mean_safe(None) == 0.0
+        assert numeric_harmonic_mean_safe([-1, 0]) == 0.0


### PR DESCRIPTION
Add numeric_harmonic_mean_safe helper function to safely calculate harmonic mean of positive numbers.