### PR TITLE
fix(dashboard-api): add list zip fill bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,27 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_zip_fill_safe(*sequences, fillvalue=None) -> list:
+    """Safely zip unequal length sequences substituting missing values."""
+    import itertools
+    if not sequences:
+        return []
+    valid = []
+    for s in sequences:
+        if s is None:
+            continue
+        if not isinstance(s, (list, tuple, set)):
+            try:
+                valid.append(list(s))
+            except TypeError:
+                continue
+        else:
+            valid.append(list(s))
+    if not valid:
+        return []
+    try:
+        return [list(t) for t in itertools.zip_longest(*valid, fillvalue=fillvalue)]
+    except Exception:
+        return []

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListZipFillSafe:
+    def test_valid_zip(self):
+        from helpers import list_zip_fill_safe
+        assert list_zip_fill_safe([1, 2], ["a"], fillvalue="-") == [[1, "a"], [2, "-"]]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_zip_fill_safe
+        assert list_zip_fill_safe(None) == []


### PR DESCRIPTION
Add list_zip_fill_safe helper function to safely zip unequal length sequences substituting missing values.