### PR TITLE
fix(dashboard-api): add numeric safe gcd bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,15 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_safe_gcd_bounds(a, b, default: int = 1) -> int:
+    """Safely calculate greatest common divisor of two numeric inputs."""
+    if a is None or b is None:
+        return default
+    try:
+        ia = int(a)
+        ib = int(b)
+        return math.gcd(ia, ib)
+    except (ValueError, TypeError, OverflowError):
+        return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericSafeGcdBounds:
+    def test_valid_gcd(self):
+        from helpers import numeric_safe_gcd_bounds
+        assert numeric_safe_gcd_bounds(12, 18) == 6
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_safe_gcd_bounds
+        assert numeric_safe_gcd_bounds(None, 10) == 1


### PR DESCRIPTION
Add numeric_safe_gcd_bounds helper function to safely calculate greatest common divisor of two numeric inputs.