### PR TITLE
fix(dashboard-api): add numeric safe modulo bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,17 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_safe_modulo_bounds(a, b, default: float = 0.0) -> float:
+    """Safely compute remainder of division with zero division guard."""
+    if a is None or b is None:
+        return default
+    try:
+        fa = float(a)
+        fb = float(b)
+        if math.isnan(fa) or math.isinf(fa) or math.isnan(fb) or math.isinf(fb) or fb == 0:
+            return default
+        return float(fa % fb)
+    except (ValueError, TypeError, ZeroDivisionError):
+        return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericSafeModuloBounds:
+    def test_valid_modulo(self):
+        from helpers import numeric_safe_modulo_bounds
+        assert numeric_safe_modulo_bounds(10, 3) == 1.0
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_safe_modulo_bounds
+        assert numeric_safe_modulo_bounds(10, 0) == 0.0


### PR DESCRIPTION
Add numeric_safe_modulo_bounds helper function to safely compute remainder of division with zero division guard.