### PR TITLE
fix(dashboard-api): add list group consecutive bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,21 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_group_consecutive_safe(items) -> list:
+    """Safely group consecutive identical elements into sublists."""
+    import itertools
+    if items is None:
+        return []
+    if not isinstance(items, (list, tuple, set)):
+        try:
+            items = list(items)
+        except TypeError:
+            return []
+    else:
+        items = list(items)
+    try:
+        return [list(g) for k, g in itertools.groupby(items)]
+    except Exception:
+        return []

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListGroupConsecutiveSafe:
+    def test_valid_grouping(self):
+        from helpers import list_group_consecutive_safe
+        assert list_group_consecutive_safe([1, 1, 2, 3, 3, 3]) == [[1, 1], [2], [3, 3, 3]]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_group_consecutive_safe
+        assert list_group_consecutive_safe(None) == []


### PR DESCRIPTION
Add list_group_consecutive_safe helper function to safely group consecutive identical elements into sublists.