### PR TITLE
fix(dashboard-api): add dict compact nulls bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,10 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_compact_nulls_safe(d: dict) -> dict:
+    """Safely remove key-value entries with None values from dictionary."""
+    if d is None or not isinstance(d, dict):
+        return {}
+    return {k: v for k, v in d.items() if v is not None}

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictCompactNullsSafe:
+    def test_valid_compact(self):
+        from helpers import dict_compact_nulls_safe
+        assert dict_compact_nulls_safe({"a": 1, "b": None}) == {"a": 1}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_compact_nulls_safe
+        assert dict_compact_nulls_safe(None) == {}


### PR DESCRIPTION
Add dict_compact_nulls_safe helper function to safely remove key-value entries with None values from dictionary.