### PR TITLE
fix(dashboard-api): add list rotate bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_rotate_safe(items, steps: int = 1) -> list:
+    """Safely rotate sequence elements left or right by step count."""
+    if items is None:
+        return []
+    if not isinstance(items, (list, tuple, set)):
+        try:
+            items = list(items)
+        except TypeError:
+            return []
+    else:
+        items = list(items)
+    if not items:
+        return []
+    if not isinstance(steps, int):
+        steps = 1
+    steps = steps % len(items)
+    return items[steps:] + items[:steps]

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListRotateSafe:
+    def test_valid_rotation(self):
+        from helpers import list_rotate_safe
+        assert list_rotate_safe([1, 2, 3, 4], steps=1) == [2, 3, 4, 1]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_rotate_safe
+        assert list_rotate_safe(None) == []


### PR DESCRIPTION
Add list_rotate_safe helper function to safely rotate sequence elements left or right by step count.