### PR TITLE
fix(dashboard-api): add list find indices bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,17 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_find_indices_safe(items, target) -> list:
+    """Safely find all zero-indexed positions of target value in sequence."""
+    if items is None:
+        return []
+    if not isinstance(items, (list, tuple, set)):
+        try:
+            items = list(items)
+        except TypeError:
+            return []
+    else:
+        items = list(items)
+    return [idx for idx, val in enumerate(items) if val == target]

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,14 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListFindIndicesSafe:
+    def test_valid_indices(self):
+        from helpers import list_find_indices_safe
+        assert list_find_indices_safe([1, 2, 1, 3, 1], 1) == [0, 2, 4]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_find_indices_safe
+        assert list_find_indices_safe(None, 1) == []
+        assert list_find_indices_safe("abc", "b") == [1]


### PR DESCRIPTION
Add list_find_indices_safe helper function to safely find all zero-indexed positions of target value in sequence.