### PR TITLE
fix(dashboard-api): add list difference bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,26 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def list_difference_safe(seq1, seq2) -> list:
+    """Safely compute set difference preserving order of first sequence."""
+    if seq1 is None:
+        return []
+    if not isinstance(seq1, (list, tuple, set)):
+        try:
+            seq1 = list(seq1)
+        except TypeError:
+            return []
+    else:
+        seq1 = list(seq1)
+    if seq2 is None:
+        return list(seq1)
+    if not isinstance(seq2, (list, tuple, set)):
+        try:
+            s2_set = set(seq2)
+        except TypeError:
+            return list(seq1)
+    else:
+        s2_set = set(seq2)
+    return [x for x in seq1 if x not in s2_set]

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestListDifferenceSafe:
+    def test_valid_difference(self):
+        from helpers import list_difference_safe
+        assert list_difference_safe([1, 2, 3], [2]) == [1, 3]
+
+    def test_invalid_and_bounds(self):
+        from helpers import list_difference_safe
+        assert list_difference_safe(None, [1]) == []


### PR DESCRIPTION
Add list_difference_safe helper function to safely compute set difference preserving order of first sequence.