### PR TITLE
fix(dashboard-api): add numeric safe lcm bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,18 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_safe_lcm_bounds(a, b, default: int = 1) -> int:
+    """Safely calculate least common multiple of two integer inputs."""
+    if a is None or b is None:
+        return default
+    try:
+        ia = int(a)
+        ib = int(b)
+        return math.lcm(ia, ib)
+    except (ValueError, TypeError, OverflowError, AttributeError):
+        try:
+            return abs(ia * ib) // math.gcd(ia, ib)
+        except Exception:
+            return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericSafeLcmBounds:
+    def test_valid_lcm(self):
+        from helpers import numeric_safe_lcm_bounds
+        assert numeric_safe_lcm_bounds(4, 6) == 12
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_safe_lcm_bounds
+        assert numeric_safe_lcm_bounds(None, 4) == 1


### PR DESCRIPTION
Add numeric_safe_lcm_bounds helper function to safely calculate least common multiple of two integer inputs.