### PR TITLE
fix(dashboard-api): add numeric safe log10 bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,19 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def numeric_safe_log10_bounds(val, default: float = 0.0) -> float:
+    """Safely calculate log10 with domain and overflow guards."""
+    if val is None:
+        return default
+    try:
+        v = float(val)
+        if math.isnan(v) or math.isinf(v) or v <= 0:
+            return default
+        res = math.log10(v)
+        if math.isnan(res) or math.isinf(res):
+            return default
+        return float(res)
+    except (ValueError, TypeError, OverflowError):
+        return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,14 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestNumericSafeLog10Bounds:
+    def test_valid_log10(self):
+        from helpers import numeric_safe_log10_bounds
+        assert numeric_safe_log10_bounds(100) == 2.0
+
+    def test_invalid_and_bounds(self):
+        from helpers import numeric_safe_log10_bounds
+        assert numeric_safe_log10_bounds(-10) == 0.0
+        assert numeric_safe_log10_bounds(None) == 0.0


### PR DESCRIPTION
Add numeric_safe_log10_bounds helper function to safely calculate log10 with domain and overflow guards.