### PR TITLE
fix(dashboard-api): add string mask email bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,20 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_mask_email_safe(email: str, default: str = "") -> str:
+    """Safely obfuscate email username portion for privacy preservation."""
+    if email is None or not isinstance(email, str):
+        return default
+    if "@" not in email:
+        return default
+    try:
+        user, domain = email.split("@", 1)
+        if len(user) <= 2:
+            masked_user = "*" * len(user)
+        else:
+            masked_user = user[0] + "*" * (len(user) - 2) + user[-1]
+        return f"{masked_user}@{domain}"
+    except Exception:
+        return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,14 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringMaskEmailSafe:
+    def test_valid_masking(self):
+        from helpers import string_mask_email_safe
+        assert string_mask_email_safe("user@example.com") == "u**r@example.com"
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_mask_email_safe
+        assert string_mask_email_safe(None) == ""
+        assert string_mask_email_safe("invalid-email") == ""


### PR DESCRIPTION
Add string_mask_email_safe helper function to safely obfuscate email username portion for privacy preservation.