### PR TITLE
fix(dashboard-api): add dict key by value bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,13 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_key_by_value_safe(d: dict, target_val, default=None):
+    """Safely perform reverse lookup finding first key matching target value."""
+    if d is None or not isinstance(d, dict):
+        return default
+    for k, v in d.items():
+        if v == target_val:
+            return k
+    return default

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,13 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictKeyByValueSafe:
+    def test_valid_lookup(self):
+        from helpers import dict_key_by_value_safe
+        assert dict_key_by_value_safe({"a": 1, "b": 2}, 2) == "b"
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_key_by_value_safe
+        assert dict_key_by_value_safe(None, 1, default="missing") == "missing"


### PR DESCRIPTION
Add dict_key_by_value_safe helper function to safely perform reverse lookup finding first key matching target value.