### PR TITLE
fix(dashboard-api): add string word wrap bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,18 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_word_wrap_safe(text: str, width: int = 80) -> list:
+    """Safely split text into lines not exceeding maximum line character width."""
+    import textwrap
+    if text is None or not isinstance(text, str):
+        return []
+    if not text:
+        return []
+    if not isinstance(width, int) or width <= 0:
+        width = 80
+    try:
+        return textwrap.wrap(text, width=width)
+    except Exception:
+        return [text]

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,14 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringWordWrapSafe:
+    def test_valid_wrap(self):
+        from helpers import string_word_wrap_safe
+        lines = string_word_wrap_safe("alpha beta gamma delta", width=10)
+        assert len(lines) >= 2
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_word_wrap_safe
+        assert string_word_wrap_safe(None) == []


### PR DESCRIPTION
Add string_word_wrap_safe helper function to safely split text into lines not exceeding maximum line character width.