### PR TITLE
fix(dashboard-api): add string strip html tags bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,18 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def string_strip_html_tags_safe(text: str, default: str = "") -> str:
+    """Safely strip HTML tags from raw string input."""
+    import re
+    if text is None or not isinstance(text, str):
+        return default
+    if not text:
+        return default
+    try:
+        clean = re.sub(r'<[^>]*>', '', text)
+        return clean.strip()
+    except Exception:
+        return default
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,15 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestStringStripHtmlTagsSafe:
+    def test_valid_stripping(self):
+        from helpers import string_strip_html_tags_safe
+        assert string_strip_html_tags_safe("<p>Hello <b>World</b></p>") == "Hello World"
+
+    def test_invalid_and_bounds(self):
+        from helpers import string_strip_html_tags_safe
+        assert string_strip_html_tags_safe(None) == ""
+        assert string_strip_html_tags_safe(1234, default="none") == "none"
+


### PR DESCRIPTION
Add string_strip_html_tags_safe helper function to safely strip HTML tags from raw string input.