### PR TITLE
fix(dashboard-api): add dict deep merge bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,18 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_deep_merge_safe(d1: dict, d2: dict) -> dict:
+    """Safely perform recursive deep merge of dictionary objects."""
+    if not isinstance(d1, dict):
+        d1 = {}
+    if not isinstance(d2, dict):
+        d2 = {}
+    res = dict(d1)
+    for k, v in d2.items():
+        if k in res and isinstance(res[k], dict) and isinstance(v, dict):
+            res[k] = dict_deep_merge_safe(res[k], v)
+        else:
+            res[k] = v
+    return res

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,15 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictDeepMergeSafe:
+    def test_valid_merge(self):
+        from helpers import dict_deep_merge_safe
+        a = {"x": {"a": 1}}
+        b = {"x": {"b": 2}, "y": 3}
+        assert dict_deep_merge_safe(a, b) == {"x": {"a": 1, "b": 2}, "y": 3}
+
+    def test_invalid_and_bounds(self):
+        from helpers import dict_deep_merge_safe
+        assert dict_deep_merge_safe(None, {"a": 1}) == {"a": 1}


### PR DESCRIPTION
Add dict_deep_merge_safe helper function to safely perform recursive deep merge of dictionary objects.