### PR TITLE
fix(pixel-agent): shorten test socket path prefix to prevent POSIX sockaddr_un path length overflow

### DIFF
--- a/ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs
@@ -40,7 +40,7 @@ import {
   gatewayFetch,
 } from "../host/pixel_ingress.mjs";
 
-const DIR = path.join(os.tmpdir(), `pixel-ingress-test-${process.pid}-${Date.now()}`);
+const DIR = path.join(os.tmpdir(), `px-ing-${process.pid}-${Date.now()}`);
 fs.mkdirSync(DIR, { recursive: true });
 const SOCKET = path.join(DIR, "pixel-ingress.sock");
 const TOKEN = "test-gateway-token-0123456789abcdef";


### PR DESCRIPTION
### 1. Error
* **Observed Failure (Verbatim)**:
  ```text
  ✖ start retains a selected remote runtime when Docker is unavailable (1.140917ms)
    Error: listen EINVAL: invalid argument /var/folders/r8/c4gq7jkd36x517pm6zd062mm0000gn/T/pixel-ingress-test-99990-1788981836770/remote-start.sock
        at Server.setupListenHandle [as _listen2] (node:net:1987:21)
        at listenInCluster (node:net:2066:12)
        at Server.listen (node:net:2188:5)
        at file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/host/pixel_ingress.mjs:1434:12
        at new Promise (<anonymous>)
        at listenUnix (file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/host/pixel_ingress.mjs:1423:10)
        at start (file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/host/pixel_ingress.mjs:1452:11)
        at TestContext.<anonymous> (file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs:1665:19)
        at Test.runInAsyncScope (node:async_hooks:227:14)
        at Test.run (node:internal/test_runner/test:1306:25) {
      code: 'EINVAL',
      errno: -22,
      syscall: 'listen',
      address: '/var/folders/r8/c4gq7jkd36x517pm6zd062mm0000gn/T/pixel-ingress-test-99990-1788981836770/remote-start.sock',
      port: -1,
      pixelStartupStage: 'socket-listen'
    }
  ```
* **Reproduction Steps**:
  1. Operating System: macOS Apple Silicon (Darwin 26.6.2) / POSIX environments using standard temp directories (`/var/folders/.../T/`).
  2. Commit Hash: `7dde42bf020fa50709beee785ef06f06f0d6b458` on branch `public-beta`.
  3. Execute Node.js test runner:
     ```bash
     node --test ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs
     ```

### 2. Root Cause
* **File Path & Lines**:
  [`ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs:L43`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs#L43) & [`L1663`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs#L1663).
* **Mechanism**:
  1. `pixel_ingress.test.mjs` initializes temporary test directory `DIR`:
     ```javascript
     const DIR = path.join(os.tmpdir(), `pixel-ingress-test-${process.pid}-${Date.now()}`);
     ```
  2. Test `"start retains a selected remote runtime when Docker is unavailable"` (Line 1653) appends socket filename:
     ```javascript
     const sock = path.join(DIR, "remote-start.sock");
     ```
  3. On macOS, `os.tmpdir()` resolves to `/var/folders/.../T/` (49 chars). Combined with `pixel-ingress-test-<PID>-<TIMESTAMP>` (41 chars) and `/remote-start.sock` (17 chars), the generated socket path length is **105 to 107 characters**.
  4. In POSIX and macOS BSD kernel specifications (`sys/un.h`), `sockaddr_un.sun_path` is strictly capped at **104 bytes**. Passing a 105+ byte socket path to Node's `net.Server.listen()` causes the underlying OS `bind()` / `listen()` syscall to fail with `EINVAL` (Invalid Argument).

### 3. Fix
* **Code Modification**:
  In [`ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs:L43`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs#L43), shorten the temporary directory prefix from `pixel-ingress-test-` (19 chars) to `px-ing-` (7 chars):
  ```javascript
  -const DIR = path.join(os.tmpdir(), `pixel-ingress-test-${process.pid}-${Date.now()}`);
  +const DIR = path.join(os.tmpdir(), `px-ing-${process.pid}-${Date.now()}`);
  ```
* **Why This Fix Addresses Root Cause**:
  Shortening the directory prefix reduces total socket path length by 12 characters (from 105 chars down to 93 chars), guaranteeing the path stays well within the POSIX `sockaddr_un` 104-byte buffer limit across all operating systems without affecting socket cleanup or test isolation.

### 4. Proof of Resolution
* **BEFORE Fix Output (Failing)**:
  ```text
  node --test ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs
  ...
  ℹ tests 57
  ℹ pass 56
  ℹ fail 1
  ✖ start retains a selected remote runtime when Docker is unavailable (1.140917ms)
    Error: listen EINVAL: invalid argument /var/folders/r8/.../remote-start.sock
  ```

* **AFTER Fix Output (Passing)**:
  ```text
  node --test ods/extensions/services/pixel-agent/tests/pixel_ingress.test.mjs
  ...
  ✔ start retains a selected remote runtime when Docker is unavailable (1.591334ms)
  ✔ start writes a safe status projection when docker is unavailable (1.374583ms)
  ✔ upstream error and wrong content type never reflect an upstream secret (6.381459ms)
  ℹ tests 57
  ℹ suites 0
  ℹ pass 57
  ℹ fail 0
  ℹ cancelled 0
  ℹ skipped 0
  ℹ todo 0
  ℹ duration_ms 2846.743417
  ```
