### PR TITLE
fix(dashboard): make the plugin template buildable and importable

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -167,6 +167,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
+	@echo "=== dashboard plugin template is buildable ==="
+	@bash tests/test-dashboard-plugin-template.sh
 	@echo ""
 	@echo "=== session cleanup lifecycle ==="
 	@bash tests/test-session-cleanup.sh

--- a/ods/docs/BUILD-ON-ODS-SERVER.md
+++ b/ods/docs/BUILD-ON-ODS-SERVER.md
@@ -46,7 +46,7 @@ Useful starting files:
 - `extensions/templates/compose-template.yaml`
 - `extensions/templates/compose-gpu-swap.yaml`
 - `extensions/templates/compose-gpu-only.yaml`
-- `extensions/templates/dashboard-plugin-template.js`
+- `extensions/templates/dashboard-plugin-template.jsx`
 
 The core contract is simple: a service manifest describes what the service is,
 and a compose fragment describes how it runs. The registry, CLI, dashboard,

--- a/ods/extensions/library/README.md
+++ b/ods/extensions/library/README.md
@@ -154,7 +154,7 @@ Everything you need to build your own extension:
 | `compose-template.yaml` | Compose fragment with best practices |
 | `compose-gpu-only.yaml` | GPU-only service pattern (no CPU fallback) |
 | `compose-gpu-swap.yaml` | CPU base + GPU overlay pattern |
-| `dashboard-plugin-template.js` | Dashboard UI plugin scaffold |
+| `dashboard-plugin-template.jsx` | Dashboard UI plugin scaffold |
 
 ## Schema
 

--- a/ods/extensions/library/templates/dashboard-plugin-template.jsx
+++ b/ods/extensions/library/templates/dashboard-plugin-template.jsx
@@ -1,8 +1,18 @@
 // Dashboard extension template.
-// Copy this file and import it from your plugin entrypoint.
+//
+// Copy this file into the dashboard's plugin directory and import it from your
+// plugin entrypoint:
+//
+//   cp extensions/templates/dashboard-plugin-template.jsx \
+//      extensions/services/dashboard/src/plugins/my-extension.jsx
+//
+// It is a .jsx file because it defines a component inline: vite only applies
+// the React/JSX transform to .jsx and .tsx, so JSX in a .js file fails to
+// parse at build time. The `./registry` import below resolves once the file
+// sits next to registry.js in src/plugins/ (see core.js for the same imports).
 
 import { Sparkles } from 'lucide-react'
-import { registerRoutes, registerExternalLinks } from '../../dashboard/src/plugins/registry'
+import { registerRoutes, registerExternalLinks } from './registry'
 
 function MyExtensionPage() {
   return (

--- a/ods/extensions/templates/README.md
+++ b/ods/extensions/templates/README.md
@@ -13,7 +13,7 @@ copy them into `extensions/services/<your-service>/` and rename the manifest to
 | `compose-template.yaml` | Your service has one normal Docker Compose definition |
 | `compose-gpu-swap.yaml` | Your service has a CPU base image and GPU-specific image tags |
 | `compose-gpu-only.yaml` | Your service only runs with a GPU and needs backend-specific compose files |
-| `dashboard-plugin-template.js` | Your service needs a dashboard plugin entry point |
+| `dashboard-plugin-template.jsx` | Your service needs a dashboard plugin entry point |
 
 ## Copy Path
 

--- a/ods/extensions/templates/dashboard-plugin-template.jsx
+++ b/ods/extensions/templates/dashboard-plugin-template.jsx
@@ -1,8 +1,18 @@
 // Dashboard extension template.
-// Copy this file and import it from your plugin entrypoint.
+//
+// Copy this file into the dashboard's plugin directory and import it from your
+// plugin entrypoint:
+//
+//   cp extensions/templates/dashboard-plugin-template.jsx \
+//      extensions/services/dashboard/src/plugins/my-extension.jsx
+//
+// It is a .jsx file because it defines a component inline: vite only applies
+// the React/JSX transform to .jsx and .tsx, so JSX in a .js file fails to
+// parse at build time. The `./registry` import below resolves once the file
+// sits next to registry.js in src/plugins/ (see core.js for the same imports).
 
 import { Sparkles } from 'lucide-react'
-import { registerRoutes, registerExternalLinks } from '../../dashboard/src/plugins/registry'
+import { registerRoutes, registerExternalLinks } from './registry'
 
 function MyExtensionPage() {
   return (

--- a/ods/tests/test-dashboard-plugin-template.sh
+++ b/ods/tests/test-dashboard-plugin-template.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# The dashboard plugin template must be buildable and importable as shipped.
+#
+# It previously lived in a .js file while defining a component inline (vite
+# only applies the JSX transform to .jsx/.tsx) and imported the plugin
+# registry through a relative path that resolved nowhere from either of its
+# two locations, so a copied template could never build.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DASH_SRC="$ROOT_DIR/extensions/services/dashboard/src"
+TEMPLATES=(
+    "$ROOT_DIR/extensions/templates/dashboard-plugin-template.jsx"
+    "$ROOT_DIR/extensions/library/templates/dashboard-plugin-template.jsx"
+)
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+# 1. A template that contains JSX must not be a .js file.
+for legacy in "$ROOT_DIR/extensions/templates/dashboard-plugin-template.js" \
+              "$ROOT_DIR/extensions/library/templates/dashboard-plugin-template.js"; do
+    [[ ! -e "$legacy" ]] \
+        || fail "$legacy still exists: JSX in a .js file is not transformed by vite"
+done
+for t in "${TEMPLATES[@]}"; do
+    [[ -f "$t" ]] || fail "missing template: $t"
+done
+pass "the JSX plugin template ships as .jsx, not .js"
+
+# 2. Its registry import must resolve once the template sits in src/plugins/.
+for t in "${TEMPLATES[@]}"; do
+    spec="$(grep -oE "from '[^']*registry'" "$t" | head -1 | sed -E "s/from '([^']*)'/\1/")"
+    [[ -n "$spec" ]] || fail "$t does not import the plugin registry"
+    case "$spec" in
+        ./*) rel="${spec#./}" ;;
+        *)   fail "$t imports the registry as '$spec'; a template copied into src/plugins/ must use './registry'" ;;
+    esac
+    resolved=""
+    for ext in .js .jsx .ts .tsx; do
+        [[ -f "$DASH_SRC/plugins/${rel}${ext}" ]] && { resolved="$DASH_SRC/plugins/${rel}${ext}"; break; }
+    done
+    [[ -n "$resolved" ]] \
+        || fail "$t imports '$spec', which does not resolve to a file under $DASH_SRC/plugins/"
+done
+pass "the registry import resolves at the documented destination (src/plugins/)"
+
+# 3. The symbols it imports must actually be exported by the registry.
+registry="$DASH_SRC/plugins/registry.js"
+for sym in registerRoutes registerExternalLinks; do
+    grep -qE "^export (function|const) $sym\b" "$registry" \
+        || fail "registry.js does not export $sym, which the template imports"
+done
+pass "the template imports only symbols the registry exports"
+
+# 4. The two shipped copies must not drift apart.
+cmp -s "${TEMPLATES[0]}" "${TEMPLATES[1]}" \
+    || fail "the two template copies have diverged: $(printf '%s ' "${TEMPLATES[@]}")"
+pass "both template copies are identical"
+
+# 5. Guard the convention that produced the bug: no .js under the dashboard
+#    source tree may contain JSX elements.
+offenders=""
+while IFS= read -r f; do
+    grep -qE '</[A-Za-z][A-Za-z0-9]*>|<[A-Z][A-Za-z0-9]* [a-zA-Z-]+=' "$f" && offenders+="$f "
+done < <(find "$DASH_SRC" -name '*.js' -not -path '*/node_modules/*')
+[[ -z "$offenders" ]] || fail "JSX found in .js file(s), which vite will not transform: $offenders"
+pass "no .js file under the dashboard source contains JSX"


### PR DESCRIPTION
## Summary

`extensions/templates/dashboard-plugin-template.js`, and its byte-identical copy under `extensions/library/templates/`, could not be built or imported — so the documented way to add a dashboard page did not work at all. Repro in #3994.

Two independent faults:

1. **JSX in a `.js` file.** The template defines a component inline, but vite applies the React/JSX transform to `.jsx` and `.tsx` only, so a copied template fails to parse at build time. The convention already held everywhere else: none of the 24 `.js` files under the dashboard source contain JSX, while all 50 JSX-bearing files are `.jsx`.
2. **The registry import resolves nowhere.** `from '../../dashboard/src/plugins/registry'` resolves to `extensions/dashboard/src/plugins/registry` from one copy and `dashboard/src/plugins/registry` from the other. Neither exists; the registry is at `extensions/services/dashboard/src/plugins/registry.js`.

Change (one concern: the shipped plugin template builds and imports):

- Ship both copies as **`.jsx`** and import **`./registry`**, which resolves once the file is copied next to `registry.js` in `src/plugins/` — the destination the header now documents, matching how `core.js` imports the same module.
- Live references follow the rename: `docs/BUILD-ON-ODS-SERVER.md` and the two template READMEs. The entries in `docs/COMPOSABILITY-EXECUTION-BOARD.md` are left alone — they are a historical record of what was added at the time, not current guidance.
- **`tests/test-dashboard-plugin-template.sh`** (new, in `make test`): asserts the template is not a `.js`, its registry import resolves at the documented destination, the symbols it imports are exported by `registry.js`, both copies stay identical, and no `.js` under the dashboard source contains JSX (guarding the class that caused fault 1).

Fixes #3994.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low. The templates are starter files, loaded by nothing at runtime — `grep` finds no code that imports them. Nothing in the shipped dashboard bundle changes; only the template files and the docs that point at them.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3

# Faults verified against upstream/main before the change
$ find . -path '*/plugins/registry*'      -> extensions/services/dashboard/src/plugins/registry.js
$ ls extensions/library/templates/../../dashboard/src/plugins/registry.js  -> MISSING (both copies)
$ cmp extensions/{library/,}templates/dashboard-plugin-template.js         -> byte-identical
# convention: strict JSX-tag scan over the dashboard source
  .js files containing JSX: 0 of 24   |   .jsx files: 50

# BEFORE (clean upstream/main worktree, this branch's test)
$ bash tests/test-dashboard-plugin-template.sh
[FAIL] .../extensions/templates/dashboard-plugin-template.js still exists: JSX in a .js file is not transformed by vite

# AFTER (this branch)
$ bash tests/test-dashboard-plugin-template.sh
[PASS] the JSX plugin template ships as .jsx, not .js
[PASS] the registry import resolves at the documented destination (src/plugins/)
[PASS] the template imports only symbols the registry exports
[PASS] both template copies are identical
[PASS] no .js file under the dashboard source contains JSX

$ grep -rn 'dashboard-plugin-template\.js\b' --include='*.md' .   -> only the two historical changelog lines
$ shellcheck --exclude=SC1091,SC2034 --severity=error tests/test-dashboard-plugin-template.sh -> clean
$ /bin/bash -n <new test> -> ok; awk -f scripts/check-heredoc-backticks.awk -> clean
$ make -n test -> ok (new test wired); git diff --check -> clean
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- I could not run `npm run build` here (no `node_modules` in the checkout), so fault 1 is evidenced by the repo's own convention and vite's `.jsx`/`.tsx` transform scope rather than a build log. Fault 2 is a filesystem fact and is what the new test asserts most directly.
- The two byte-identical copies are kept in sync by the test rather than deduplicated, since collapsing them touches the extension-library layout and is a separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

