### PR TITLE
test(pixel-edge): gracefully skip POSIX-specific tests on Windows

### DIFF
--- a/ods/extensions/services/pixel-edge/tests/test_edge_entrypoint.py
+++ b/ods/extensions/services/pixel-edge/tests/test_edge_entrypoint.py
@@ -1,3 +1,7 @@
+import sys
+import pytest
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='Pixel Edge requires a POSIX environment')
+
 from pathlib import Path
 import sys
 import tempfile
@@ -44,3 +48,4 @@ class ProvisionTests(unittest.TestCase):
 
 
 if __name__ == "__main__": unittest.main()
+

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -1,3 +1,7 @@
+import sys
+import pytest
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='Pixel Edge requires a POSIX environment')
+
 """Tests for pixel_edge — upstream Unix socket + edge proxy routes."""
 
 import asyncio
@@ -1590,3 +1594,4 @@ class TestChatActivity(BaseEdgeTest):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/ods/extensions/services/pixel-edge/tests/test_transition_gate.py
+++ b/ods/extensions/services/pixel-edge/tests/test_transition_gate.py
@@ -1,3 +1,7 @@
+import sys
+import pytest
+pytestmark = pytest.mark.skipif(sys.platform == 'win32', reason='Pixel Edge requires a POSIX environment')
+
 """Gate qualification uses actual edge HTTP admission and held upstream streams."""
 
 import asyncio
@@ -314,3 +318,4 @@ os._exit(0)
         with self.assertRaises(OSError):
             initialize(self.directory.name)
         self.assertEqual(Path(self.directory.name, "transition.json").read_bytes(), before)
+


### PR DESCRIPTION
## Description

This PR gracefully skips the `pixel-edge` tests on Windows to prevent false-negative test failures and stalled local development.

### What I Tried

While exploring and validating the `public-beta` branch locally, I ran the Pixel Edge test suite:

```bash
pytest ods/extensions/services/pixel-edge/tests/
```

The suite currently crashes on native Windows environments due to several Linux/POSIX-specific dependencies.

### Errors & Context

The test suite fails with OS-specific exceptions instead of skipping:

* `NotImplementedError: create_unix_server` — Unix Domain Sockets via `aiohttp` are not natively supported.
* `GateError: unsafe_state_directory` — relies on the POSIX `fcntl` module.
* `OSError: [WinError 1314] A required privilege is not held by the client` — strict symlink privilege requirements on Windows.

As noted in the beta announcement:

> "Pixel’s installer still requires a qualified Linux environment with systemd."

Since these components inherently depend on Linux/POSIX utilities, the associated tests should not be executed on native Windows environments.

### Changes

This PR adds:

```python
@pytest.mark.skipif(sys.platform == 'win32')
```

to the relevant test classes.

This allows the tests to be cleanly skipped on Windows rather than producing confusing failures for Windows contributors.

### Bug Report Details

* **OS:** Windows
* **Hardware:** Standard PC / native Windows environment
* **Steps to Reproduce:**

  1. Check out the `public-beta` branch.
  2. Open a native Windows terminal.
  3. Run:

     ```bash
     pytest ods/extensions/services/pixel-edge/tests/
     ```
  4. Observe the OS-specific test failures.

### Expected Behavior

On Windows, Linux/POSIX-dependent Pixel Edge tests should be skipped rather than failing.

### Actual Behavior

The tests execute and fail with OS-specific exceptions, making the test suite appear broken on Windows.
