### PR TITLE
test(dashboard): fix flaky timeout in Settings.test.jsx

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.test.jsx
@@ -101,7 +101,7 @@ describe('Settings', () => {
   })
   it('preserves unsaved provider edits during a system refresh', async () => {
     const { fetchMock } = renderSettings()
-    await screen.findByText('No providers configured.')
+    await screen.findByText('No providers configured.', {}, { timeout: 3000 })
     fireEvent.change(screen.getByLabelText('New provider ID'), { target: { value: 'unsaved' } })
     fireEvent.change(screen.getByLabelText('New provider label'), { target: { value: 'Unsaved provider' } })
     fireEvent.click(screen.getByRole('button', { name: 'Add provider', exact: true }))


### PR DESCRIPTION
## Description

This PR addresses a flaky UI test timeout in `Settings.test.jsx` that occasionally occurs during frontend validation of the `public-beta` interface.

### What I Tried

While validating the frontend changes locally, I ran the Dashboard's Vitest test suite:

```bash
npm test
```

### Error & Context

The following test occasionally failed with a timeout:

**Test:** `preserves unsaved provider edits during a system refresh`

```text
Error: await screen.findByText('No providers configured.') timed out.
```

The flake appears to be related to the component rendering lifecycle. The UI depends on mocked API requests, such as `/api/pixel/providers`, resolving before the expected DOM state is rendered. Under local or CI load, this can result in a slight delay between the mocked response and the DOM update.

### Changes

This PR increases the timeout passed to `findByText` for the affected assertion.

This provides additional time for the mocked API request and subsequent DOM update to complete, reducing intermittent test failures without changing the test's expected behavior.

### Bug Report Details

* **OS:** Windows
* **Hardware:** Standard PC
* **Steps to Reproduce:**

  1. Navigate to `ods/extensions/services/dashboard`.
  2. Run:

     ```bash
     npm run test
     ```
  3. Observe the intermittent timeout in `Settings.test.jsx`.

### Expected Behavior

The test should reliably wait for the expected UI state to render and pass consistently in both local and CI environments.

### Actual Behavior

The test occasionally times out while waiting for:

```text
No providers configured.
```
