### PR TITLE
fix(scripts): prevent os.getuid crash in preserve-active-model on Windows

### DIFF
--- a/ods/scripts/preserve-active-model.py
+++ b/ods/scripts/preserve-active-model.py
@@ -162,7 +162,7 @@ def load_verified_active_state(path: Path | None) -> dict[str, Any] | None:
             not stat.S_ISREG(info.st_mode)
             or stat.S_ISLNK(info.st_mode)
             or info.st_nlink != 1
-            or info.st_uid != os.getuid()
+            or (hasattr(os, "getuid") and info.st_uid != os.getuid())
             or info.st_mode & 0o022
             or info.st_size <= 0
             or info.st_size > 2 * 1024 * 1024


### PR DESCRIPTION
## Description

This PR fixes a hard crash on Windows in the new `preserve-active-model.py` upgrade script.

### Error & Context

The script currently calls `os.getuid()` unconditionally. Since `os.getuid()` is POSIX-only and is not available on Windows, executing or importing the script on a Windows host immediately raises:

```text
AttributeError: module 'os' has no attribute 'getuid'
```

This prevents the script from running at all on Windows, even though the UID verification itself is not applicable to non-POSIX platforms.

### Changes

This PR updates the UID check to safely verify that `os.getuid` is available before calling it:

```python
hasattr(os, "getuid")
```

On Windows and other non-POSIX platforms, the UID verification step is skipped instead of causing the script to crash.

This also matches the existing approach used elsewhere in the ODS codebase for safely handling `getuid` across platforms.

### Bug Report Details

* **OS:** Windows
* **Hardware:** Standard PC
* **Steps to Reproduce:**

  1. Open a Windows terminal.
  2. Run:

     ```bash
     python ods/scripts/preserve-active-model.py
     ```
  3. Observe the `AttributeError` caused by the unavailable `os.getuid()` function.

### Expected Behavior

The script should handle non-POSIX platforms gracefully and skip the UID verification when `os.getuid()` is unavailable.

### Actual Behavior

The script crashes immediately on Windows with an `AttributeError`.
