### PR TITLE
test(pixel): gracefully skip POSIX-specific agent and inference tests on Windows

### DIFF
--- a/ods/extensions/services/pixel-agent/tests/test_access_bridge.py
+++ b/ods/extensions/services/pixel-agent/tests/test_access_bridge.py
@@ -1,3 +1,8 @@
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import contextlib
 import os
 from pathlib import Path

--- a/ods/extensions/services/pixel-agent/tests/test_access_bridge.py
+++ b/ods/extensions/services/pixel-agent/tests/test_access_bridge.py
@@ -1,6 +1,6 @@
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import contextlib

--- a/ods/extensions/services/pixel-agent/tests/test_access_deadlines.py
+++ b/ods/extensions/services/pixel-agent/tests/test_access_deadlines.py
@@ -1,7 +1,7 @@
 """Actual loopback sockets/process/pipe deadlines; no installed services."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 from concurrent.futures import ThreadPoolExecutor

--- a/ods/extensions/services/pixel-agent/tests/test_access_deadlines.py
+++ b/ods/extensions/services/pixel-agent/tests/test_access_deadlines.py
@@ -1,4 +1,9 @@
 """Actual loopback sockets/process/pipe deadlines; no installed services."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 from concurrent.futures import ThreadPoolExecutor
 import contextlib
 import json

--- a/ods/extensions/services/pixel-agent/tests/test_access_mode_config.py
+++ b/ods/extensions/services/pixel-agent/tests/test_access_mode_config.py
@@ -1,7 +1,7 @@
 """Roundtrip, isolation and malformed-baseline tests for access-mode changes."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import copy

--- a/ods/extensions/services/pixel-agent/tests/test_access_mode_config.py
+++ b/ods/extensions/services/pixel-agent/tests/test_access_mode_config.py
@@ -1,4 +1,9 @@
 """Roundtrip, isolation and malformed-baseline tests for access-mode changes."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import copy
 import json
 import os

--- a/ods/extensions/services/pixel-agent/tests/test_artifact_promoter.py
+++ b/ods/extensions/services/pixel-agent/tests/test_artifact_promoter.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import hashlib

--- a/ods/extensions/services/pixel-agent/tests/test_artifact_promoter.py
+++ b/ods/extensions/services/pixel-agent/tests/test_artifact_promoter.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import hashlib
 import importlib.util
 import json

--- a/ods/extensions/services/pixel-agent/tests/test_extension_manager.py
+++ b/ods/extensions/services/pixel-agent/tests/test_extension_manager.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import importlib.util

--- a/ods/extensions/services/pixel-agent/tests/test_extension_manager.py
+++ b/ods/extensions/services/pixel-agent/tests/test_extension_manager.py
@@ -3,6 +3,11 @@
 
 from __future__ import annotations
 
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import importlib.util
 import json
 import os

--- a/ods/extensions/services/pixel-agent/tests/test_openclaw_tool_recovery.py
+++ b/ods/extensions/services/pixel-agent/tests/test_openclaw_tool_recovery.py
@@ -1,5 +1,10 @@
 """Custody and retry behavior for the ODS-owned runtime repair installer."""
 
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import hashlib
 import importlib.util
 import json

--- a/ods/extensions/services/pixel-agent/tests/test_openclaw_tool_recovery.py
+++ b/ods/extensions/services/pixel-agent/tests/test_openclaw_tool_recovery.py
@@ -1,8 +1,8 @@
 """Custody and retry behavior for the ODS-owned runtime repair installer."""
 
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import hashlib

--- a/ods/extensions/services/pixel-agent/tests/test_pixel_access_mode.py
+++ b/ods/extensions/services/pixel-agent/tests/test_pixel_access_mode.py
@@ -1,4 +1,9 @@
 """Focused tests for the pixel_access_mode persistent controller."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import copy
 from pathlib import Path
 import fcntl

--- a/ods/extensions/services/pixel-agent/tests/test_pixel_access_mode.py
+++ b/ods/extensions/services/pixel-agent/tests/test_pixel_access_mode.py
@@ -1,7 +1,7 @@
 """Focused tests for the pixel_access_mode persistent controller."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import copy

--- a/ods/extensions/services/pixel-agent/tests/test_provider_transaction.py
+++ b/ods/extensions/services/pixel-agent/tests/test_provider_transaction.py
@@ -1,4 +1,9 @@
 """Real disposable filesystem transactions; callbacks are NOT runtime acceptance."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import json
 import sys
 import uuid

--- a/ods/extensions/services/pixel-agent/tests/test_provider_transaction.py
+++ b/ods/extensions/services/pixel-agent/tests/test_provider_transaction.py
@@ -1,7 +1,7 @@
 """Real disposable filesystem transactions; callbacks are NOT runtime acceptance."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import json

--- a/ods/extensions/services/pixel-agent/tests/test_settings_control_transport.py
+++ b/ods/extensions/services/pixel-agent/tests/test_settings_control_transport.py
@@ -1,4 +1,9 @@
 """Actual disposable Unix transport, not the installed root daemon."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import hashlib
 import json
 from pathlib import Path

--- a/ods/extensions/services/pixel-agent/tests/test_settings_control_transport.py
+++ b/ods/extensions/services/pixel-agent/tests/test_settings_control_transport.py
@@ -1,7 +1,7 @@
 """Actual disposable Unix transport, not the installed root daemon."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import hashlib

--- a/ods/extensions/services/pixel-agent/tests/test_settings_transaction.py
+++ b/ods/extensions/services/pixel-agent/tests/test_settings_transaction.py
@@ -1,7 +1,7 @@
 """Disposable POSIX owner transactions, NOT installed runtime acceptance."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import hashlib

--- a/ods/extensions/services/pixel-agent/tests/test_settings_transaction.py
+++ b/ods/extensions/services/pixel-agent/tests/test_settings_transaction.py
@@ -1,4 +1,9 @@
 """Disposable POSIX owner transactions, NOT installed runtime acceptance."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import hashlib
 import json
 import os

--- a/ods/extensions/services/pixel-agent/tests/test_settings_worker_protocol.py
+++ b/ods/extensions/services/pixel-agent/tests/test_settings_worker_protocol.py
@@ -1,4 +1,9 @@
 """Actual disposable subprocess pipes; no root services or runtime acceptance."""
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import io
 import json
 from pathlib import Path

--- a/ods/extensions/services/pixel-agent/tests/test_settings_worker_protocol.py
+++ b/ods/extensions/services/pixel-agent/tests/test_settings_worker_protocol.py
@@ -1,7 +1,7 @@
 """Actual disposable subprocess pipes; no root services or runtime acceptance."""
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import io

--- a/ods/extensions/services/pixel-agent/tests/test_system_observe.py
+++ b/ods/extensions/services/pixel-agent/tests/test_system_observe.py
@@ -1,3 +1,8 @@
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import importlib.util
 import socket
 import pathlib

--- a/ods/extensions/services/pixel-agent/tests/test_system_observe.py
+++ b/ods/extensions/services/pixel-agent/tests/test_system_observe.py
@@ -1,6 +1,6 @@
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import importlib.util

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
@@ -1,3 +1,8 @@
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import http.client
 import hashlib
 import importlib.util

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
@@ -1,6 +1,6 @@
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import http.client

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview_git.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview_git.py
@@ -8,6 +8,11 @@ nosniff.  .env and arbitrary hidden files remain blocked.  Source tree is
 never mutated.
 """
 
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import http.client
 import importlib.util
 import os
@@ -807,3 +812,4 @@ def test_metadata_is_never_opened_or_traversed_and_alias_is_rejected():
         (site / "assets").symlink_to(site / ".git", target_is_directory=True)
         with pytest.raises(MODULE.PreviewError, match="unsafe"):
             MODULE.publish_snapshot(workspace, previews, site.name, os.getuid())
+

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview_git.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview_git.py
@@ -9,8 +9,8 @@ never mutated.
 """
 
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import http.client

--- a/ods/extensions/services/pixel-inference/tests/test_inference_sharing.py
+++ b/ods/extensions/services/pixel-inference/tests/test_inference_sharing.py
@@ -1,6 +1,6 @@
 import sys
-import pytest
 if sys.platform == "win32":
+    import pytest
     pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
 
 import asyncio

--- a/ods/extensions/services/pixel-inference/tests/test_inference_sharing.py
+++ b/ods/extensions/services/pixel-inference/tests/test_inference_sharing.py
@@ -1,3 +1,8 @@
+import sys
+import pytest
+if sys.platform == "win32":
+    pytest.skip("Pixel services require a POSIX environment", allow_module_level=True)
+
 import asyncio
 import importlib.util
 import json


### PR DESCRIPTION
## Description

Following up on the `pixel-edge` Windows test skips, this PR addresses identical test collection crashes in `pixel-agent` and `pixel-inference`.

### Error & Context

Running the test suites locally on Windows results in large stack traces and complete test collection failures for the new Pixel services.

Several test files globally import POSIX-only modules such as:

* `pwd`
* `fcntl`

Since these modules are unavailable on Windows, pytest fails during test collection with:

```text
ModuleNotFoundError: No module named 'pwd'
ModuleNotFoundError: No module named 'fcntl'
```

### Changes

This PR adds a module-level Windows check using:

```python
pytest.skip(..., allow_module_level=True)
```

to all 15 Python test files across `pixel-agent` and `pixel-inference`.

This allows pytest to skip the affected test modules before attempting to import Windows-incompatible dependencies.

As a result, the test suites now skip cleanly and quietly on Windows instead of producing collection errors or blocking local development.

### Bug Report Details

* **OS:** Windows
* **Hardware:** Standard PC
* **Steps to Reproduce:**

  1. Open a Windows terminal.
  2. Run:

     ```bash
     pytest ods/extensions/services/pixel-agent/tests/
     ```

     or:

     ```bash
     pytest ods/extensions/services/pixel-inference/tests/
     ```
  3. Observe the `ModuleNotFoundError` failures during test collection.

### Expected Behavior

POSIX-dependent Pixel Agent and Pixel Inference tests should be skipped on Windows rather than failing during test collection.

### Actual Behavior

Pytest attempts to import Windows-incompatible modules, causing test collection to fail with `ModuleNotFoundError`.
