### PR TITLE
feat(agents): expose authenticated Prometheus snapshots

### DIFF
--- a/ods/docs/AGENT-PROMETHEUS.md
+++ b/ods/docs/AGENT-PROMETHEUS.md
@@ -1,0 +1,36 @@
+# Scraping agent monitoring with Prometheus
+
+The dashboard API exposes its cached agent snapshot at
+`GET /api/agents/metrics.prom`. It requires the same Bearer API key as
+`/api/agents/metrics` and returns Prometheus text format 0.0.4. Scraping does
+not call upstream services or start another collector.
+
+Point a Prometheus scrape job at the dashboard API's reachable address, set
+`metrics_path: /api/agents/metrics.prom`, and configure Bearer authorization
+with the dashboard API key. Keep that key in your existing secret storage.
+The endpoint does not change ODS port bindings or expose a public listener.
+
+| Gauge | Meaning |
+| --- | --- |
+| `ods_agent_summary_entries` | Number of entries in the last Token Spy summary, not necessarily live sessions |
+| `ods_cluster_gpus` | Node count in the last cluster snapshot |
+| `ods_cluster_healthy_gpus` | Healthy node count in that snapshot |
+| `ods_cluster_failover_ready` | 1 when that snapshot has more than one healthy node, otherwise 0 |
+| `ods_agent_output_tokens_per_second_24h` | Latest sampled output-token total divided by the 24-hour summary window |
+| `ods_agent_throughput_sample_timestamp_seconds` | Unix timestamp of that observation |
+
+All values are gauges. Do not apply `rate()` to them. The output-token rate
+is a **24-hour average**, not instantaneous generation speed. Throughput and
+its timestamp are omitted until a retained observation exists; a successful
+zero observation is exported as zero. Use
+`time() - ods_agent_throughput_sample_timestamp_seconds` to inspect observation
+age. An absent timestamp means no retained observation, not confirmed inactivity.
+
+These metrics mirror cached data. A successful scrape means the dashboard API
+answered; it does not prove Token Spy or the cluster proxy is reachable.
+Cluster values have no observation timestamp in the current collector.
+Queue depth and error rate are omitted because the collector has no source
+for those placeholder fields. No session identifiers or node labels are emitted.
+
+Wire format: [Prometheus exposition formats](https://prometheus.io/docs/instrumenting/exposition_formats/).
+Remove the scrape job to stop collecting; this endpoint writes no persistent state.

--- a/ods/extensions/services/dashboard-api/routers/agents.py
+++ b/ods/extensions/services/dashboard-api/routers/agents.py
@@ -1,9 +1,10 @@
 """Agent monitoring endpoints."""
 
 import html as html_mod
+from datetime import datetime
 
 from fastapi import APIRouter, Depends
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 
 from agent_monitor import get_full_agent_metrics, cluster_status, throughput
 from security import verify_api_key
@@ -75,3 +76,31 @@ async def get_cluster_status(api_key: str = Depends(verify_api_key)):
 async def get_throughput(api_key: str = Depends(verify_api_key)):
     """Get throughput metrics (tokens/sec)."""
     return throughput.get_stats()
+
+
+@router.get("/api/agents/metrics.prom", response_class=Response)
+async def get_agent_prometheus_metrics(api_key: str = Depends(verify_api_key)):
+    """Expose the cached agent snapshot in Prometheus text format 0.0.4."""
+    metrics = get_full_agent_metrics()
+    cluster, agent, tp = metrics["cluster"], metrics["agent"], metrics["throughput"]
+    gauges = [
+        ("ods_agent_summary_entries", "Entries in the last Token Spy summary.", agent["session_count"]),
+        ("ods_cluster_gpus", "Nodes in the last cluster status snapshot.", cluster["total_gpus"]),
+        ("ods_cluster_healthy_gpus", "Healthy nodes in the last cluster snapshot.", cluster["active_gpus"]),
+        ("ods_cluster_failover_ready", "Whether the last cluster snapshot has multiple healthy nodes.", int(cluster["failover_ready"])),
+    ]
+    if tp["history"]:
+        gauges.extend([
+            ("ods_agent_output_tokens_per_second_24h", "Output tokens per second averaged over the Token Spy 24 hour summary window.", tp["current"]),
+            ("ods_agent_throughput_sample_timestamp_seconds", "Unix time of the last retained Token Spy throughput observation.", datetime.fromisoformat(tp["history"][-1]["timestamp"]).timestamp()),
+        ])
+    # All names and HELP strings are constants; no user-controlled labels.
+    text = "".join(
+        f"# HELP {name} {help_text}\n# TYPE {name} gauge\n{name} {value}\n"
+        for name, help_text, value in gauges
+    )
+    return Response(
+        text,
+        media_type="text/plain; version=0.0.4",
+        headers={"Cache-Control": "no-store"},
+    )

--- a/ods/extensions/services/dashboard-api/tests/test_agent_prometheus.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_prometheus.py
@@ -1,0 +1,74 @@
+"""Scrapes use the same authenticated agent snapshot as the JSON API."""
+
+from datetime import datetime
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+import pytest
+
+import agent_monitor
+from routers import agents
+from security import DASHBOARD_API_KEY
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    monitor = agent_monitor.ThroughputMetrics()
+    monkeypatch.setattr(agent_monitor, "throughput", monitor)
+    monkeypatch.setattr(agent_monitor, "agent_metrics", agent_monitor.AgentMetrics())
+    monkeypatch.setattr(agent_monitor, "cluster_status", agent_monitor.ClusterStatus())
+    app = FastAPI()
+    app.include_router(agents.router)
+    with TestClient(app) as client:
+        yield client
+
+
+def test_scrape_requires_bearer_credentials(client):
+    assert client.get("/api/agents/metrics.prom").status_code == 401
+    assert client.get("/api/agents/metrics.prom", headers={
+        "Authorization": "Bearer incorrect"
+    }).status_code == 403
+
+
+def test_scrape_exports_snapshot_without_placeholder_metrics(client):
+    agent_monitor.agent_metrics.session_count = 4
+    cluster = agent_monitor.cluster_status
+    cluster.total_gpus, cluster.active_gpus, cluster.failover_ready = 3, 2, True
+    agent_monitor.throughput.add_sample(1.25)
+    sampled_at = datetime.fromisoformat(
+        agent_monitor.throughput.data_points[-1]["timestamp"]
+    ).timestamp()
+    response = client.get("/api/agents/metrics.prom", headers={
+        "Authorization": f"Bearer {DASHBOARD_API_KEY}"
+    })
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "text/plain; version=0.0.4; charset=utf-8"
+    assert response.headers["cache-control"] == "no-store"
+    assert response.text.endswith("\n")
+    lines = response.text.splitlines()
+    samples = dict(line.split() for line in lines if not line.startswith("#"))
+    assert samples == {
+        "ods_agent_summary_entries": "4",
+        "ods_cluster_gpus": "3",
+        "ods_cluster_healthy_gpus": "2",
+        "ods_cluster_failover_ready": "1",
+        "ods_agent_output_tokens_per_second_24h": "1.25",
+        "ods_agent_throughput_sample_timestamp_seconds": str(sampled_at),
+    }
+    for name in samples:
+        assert f"# TYPE {name} gauge" in lines
+        assert sum(line.startswith(f"# HELP {name} ") for line in lines) == 1
+    assert "queue_depth" not in response.text
+    assert "error_rate" not in response.text
+
+
+def test_scrape_distinguishes_no_observation_from_observed_zero(client):
+    headers = {"Authorization": f"Bearer {DASHBOARD_API_KEY}"}
+    empty = client.get("/api/agents/metrics.prom", headers=headers)
+    assert empty.status_code == 200
+    assert "ods_agent_output_tokens_per_second_24h" not in empty.text
+    assert "ods_agent_throughput_sample_timestamp_seconds" not in empty.text
+    agent_monitor.throughput.add_sample(0.0)
+    observed = client.get("/api/agents/metrics.prom", headers=headers)
+    assert "ods_agent_output_tokens_per_second_24h 0.0\n" in observed.text
+    assert "ods_agent_throughput_sample_timestamp_seconds " in observed.text


### PR DESCRIPTION
ODS agent metrics are available as JSON/HTML but cannot be scraped directly by Prometheus. Add an authenticated, read-only text-format endpoint and document every gauge's source and limitations.

### Why this matters
Operators can collect ODS agent and cluster snapshots using their existing monitoring stack. Throughput is explicitly named as a 24-hour average; missing observations remain absent rather than being presented as measured zero. The observation timestamp supports freshness checks. Placeholder queue/error fields and identifying labels are omitted.

### Overlap check
Searched open and closed PRs for Prometheus, agent metrics, and agents.py. #1761, #1822 and #2032 concern incoming runtime-counter parsing, not an exporter. #2037 and #2939 concern the HTML endpoint. This change does not change collection or retention (#4013); it reads the same snapshot and remains independently useful.

### Validation
Three authenticated HTTP regression tests failed against main's missing endpoint, then passed. Tests cover authorization, exact content type, gauge values/metadata, and absent versus measured-zero observations. Together with test_agent_monitor.py: 22 passed. CI-select Ruff and git diff --check passed.

Scrapes perform no network calls or persistent writes. Existing cached cluster values have no freshness timestamp; the documentation calls this out. No live Prometheus server or hardware validation was performed. Removing the scrape job is sufficient rollback. AI-assisted implementation; human review pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
