### PR TITLE
perf(usage): bound and overlap runtime metric scrapes

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -401,13 +401,23 @@ def _request_token_spy_report(start: str, end: str, headers: dict[str, str]) -> 
 
 
 async def _fetch_local_runtime_counters() -> list[dict[str, Any]]:
+    urls = _configured_local_runtime_metrics_urls()
+    semaphore = asyncio.Semaphore(4)
+
+    async def fetch(url: str) -> str:
+        async with semaphore:
+            return await asyncio.to_thread(_request_text, url)
+
+    results = await asyncio.gather(*(fetch(url) for url in urls), return_exceptions=True)
     counters = []
-    for url in _configured_local_runtime_metrics_urls():
-        try:
-            metrics_text = await asyncio.to_thread(_request_text, url)
-        except (urllib.error.URLError, TimeoutError, OSError):
+    # Parse on the event loop in configured order: observation baselines are
+    # shared mutable state and must not be updated by worker threads.
+    for url, result in zip(urls, results):
+        if isinstance(result, (urllib.error.URLError, TimeoutError, OSError)):
             continue
-        parsed = _extract_llama_cpp_prometheus_counters(metrics_text, url)
+        if isinstance(result, BaseException):
+            raise result
+        parsed = _extract_llama_cpp_prometheus_counters(result, url)
         if parsed:
             counters.append(parsed)
     return counters

--- a/ods/extensions/services/dashboard-api/tests/test_usage_concurrent_scrapes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage_concurrent_scrapes.py
@@ -1,0 +1,69 @@
+"""Report-boundary proof of bounded, concurrent HTTP runtime scrapes."""
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Barrier, BrokenBarrierError, Lock, Thread
+from unittest.mock import AsyncMock
+
+
+def test_report_scrapes_in_bounded_waves_and_preserves_order(test_client, monkeypatch):
+    from routers import usage
+
+    barrier = Barrier(4)
+    lock = Lock()
+    state = {"active": 0, "peak": 0}
+    failures = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/failed":
+                self.send_error(503)
+                return
+            with lock:
+                state["active"] += 1
+                state["peak"] = max(state["peak"], state["active"])
+            try:
+                barrier.wait(timeout=2)
+            except BrokenBarrierError:
+                failures.append(self.path)
+            tokens = int(self.path[1:])
+            body = (
+                f"llamacpp:prompt_tokens_total {tokens}\n"
+                f"llamacpp:tokens_predicted_total {tokens * 2}\n"
+                "llamacpp:requests_total 3\n"
+            ).encode()
+            # This gauges concurrent upstream work, excluding response delivery.
+            with lock:
+                state["active"] -= 1
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    original = usage._empty_report("2026-05-01", "2026-05-02", status="ok")
+    monkeypatch.setattr(usage, "_fetch_token_spy_report", AsyncMock(return_value=original))
+    urls = [f"http://127.0.0.1:{server.server_port}/{i}" for i in range(1, 9)]
+    urls.append(f"http://127.0.0.1:{server.server_port}/failed")
+    monkeypatch.setenv("LOCAL_USAGE_METRICS_URLS", ",".join(urls))
+    try:
+        response = test_client.get(
+            "/api/usage/report?start=2026-05-01&end=2026-05-02",
+            headers=test_client.auth_headers,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert response.status_code == 200
+    assert failures == [], "Independent runtime requests never overlapped"
+    assert state["peak"] == 4
+    report = response.json()
+    assert report["summary"] == original["summary"]
+    local = report["source"]["local_runtime"]
+    assert local["included_in_totals"] is False
+    assert [item["input_tokens"] for item in local["counters"]] == list(range(1, 9))


### PR DESCRIPTION
When LOCAL_USAGE_METRICS_URLS contains several runtimes, /api/usage/report waits for each HTTP scrape in sequence. Scrape up to four runtimes concurrently while parsing responses in configured order on the event loop.

### Why this matters
Independent runtime waits no longer accumulate one endpoint at a time. The per-request concurrency bound avoids opening an unbounded number of simultaneous upstream requests. Existing per-endpoint timeouts, unavailable-endpoint omission, report totals, and shared observation-state ordering are preserved. Unexpected exceptions still propagate.

### Overlap check
Searched open/closed PRs for usage parallel/concurrency and usage.py with concurrent. #347 concerns dashboard performance and llama-server configuration; #810 is service-resource metrics. Neither changes this report scrape loop. #4002 fixes runtime identity when updating observations; this PR changes only fetch scheduling and can merge independently.

### Validation
A real threaded HTTP server exposes eight metrics endpoints and one HTTP 503 endpoint. A four-party barrier proves requests overlap in bounded waves; the public authenticated report preserves configured counter order and excludes cumulative observations from date-bounded totals. This regression fails on main. With existing test_usage.py: 22 passed. CI-select Ruff and git diff --check passed.

No live multi-runtime fleet benchmark was run. Four is a per-report bound; the shared executor still controls process-wide thread capacity. AI-assisted implementation; human review pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
