### PR TITLE
fix(pixel): prevent duplicate preview frames on Files reload

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -1410,7 +1410,7 @@ export default function Pixel({ systemStatus = null }) {
               </div>
             </div>
             {preview && <iframe
-              key={`${preview.siteId}-${previewRefresh}`}
+              key={`preview-${preview.siteId}-${previewRefresh}`}
               src={previewAccess.frameUrl}
               title="Interactive Pixel preview"
               hidden={previewCollapsed || previewTab !== 'preview'}
@@ -1419,7 +1419,7 @@ export default function Pixel({ systemStatus = null }) {
               referrerPolicy="no-referrer"
               className="min-h-0 flex-1 border-0 bg-white"
             />}
-            {!previewCollapsed && preview && previewTab === 'files' && <PixelTaskFiles key={`${preview.siteId}-${previewRefresh}`} preview={preview}/>}
+            {!previewCollapsed && preview && previewTab === 'files' && <PixelTaskFiles key={`files-${preview.siteId}-${previewRefresh}`} preview={preview}/>}
             {!previewCollapsed && preview && previewTab === 'changes' && <div className="pixel-workspace-changes"><PixelSnapshotChanges key={`${preview.siteId}-${previewRefresh}`} preview={preview} before={[...messages].reverse().find(message=>message.publication?.siteId === preview.siteId)?.beforePublication || null} onPreview={()=>setPreviewTab('preview')}/></div>}
             {!previewCollapsed && previewTab === 'activity' && <PixelTaskActivity key={chatIdRef.current} messages={messages} sending={sending} elapsed={workingElapsed}/>}
             {!previewCollapsed && !preview && previewTab !== 'activity' && <section className="pixel-workspace-empty">

--- a/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
@@ -1823,6 +1823,10 @@ describe('Pixel', () => {
     fireEvent.click(screen.getByTitle('Reload preview'))
     await waitFor(()=>expect(requests()).toBe(before+1))
     expect(screen.getByRole('button',{name:tab,exact:true})).toHaveAttribute('aria-pressed','true')
+    expect(screen.getAllByTitle('Interactive Pixel preview')).toHaveLength(1)
+    fireEvent.click(screen.getByRole('button',{name:'Preview',exact:true}))
+    expect(screen.getAllByTitle('Interactive Pixel preview')).toHaveLength(1)
+    expect(screen.queryByRole('region',{name:'Task files'})).not.toBeInTheDocument()
   })
 
   it('renders assistant HTML as inert text', async () => {


### PR DESCRIPTION
﻿## Why this matters

In the public beta Pixel workspace, open a published preview, select **Files**, and click **Reload preview**. React leaves the previous iframe attached and mounts another one: the rendered workspace contains two `Interactive Pixel preview` frames. This leaks an obsolete preview instance when the operator refreshes the file inspector.

The iframe and its sibling `PixelTaskFiles` shared the same `siteId-refresh` React key. Give each sibling a distinct key prefix while retaining the site and refresh counter, so refresh still remounts both views and tab selection is preserved. The invariant is one preview iframe after inspector reload and after returning to Preview, with the Files inspector removed on tab exit.

## Regression evidence

Extend the existing public Pixel page test for Files and Changes reloads. It uses the actual components and mocked snapshot/status HTTP responses, then checks rendered iframe count and inspector cleanup. On unmodified beta `ed4432d0`, the Files case fails with **expected length 1, received 2**. With this patch both cases pass.

## Overlap check

Searched open and closed upstream PRs for `pixel`, `Pixel.jsx`, `PixelTaskFiles`, `preview inspector`, `preview duplicate iframe`, and `duplicate preview`, and reviewed the public-beta PR inventory (#4055â€“#4062, including closed #4056). Inspected the changed production file `ods/extensions/services/dashboard/src/pages/Pixel.jsx` in the related Portal/UI PRs #3385, #3818, and #4027. The current #4027 head `1be931c03e183998889c5065931420b3f61a72ce` still has the two identical sibling keys; none of those PRs provides this repair. This is a focused follow-up to the UI already integrated into public-beta, not a replacement for those feature PRs.

Based directly on public-beta `ed4432d0`; no main-only changes are included.

## Validation

Candidate: `7f68470dbdbb6b0afba3d20b5c0685aafde23488`.

- Windows, Node 24.14.1: targeted red/green regression (`npm test -- src/pages/Pixel.test.jsx -t 'reloads the active' --maxWorkers=2`); **2 passed** after the fix.
- `npm test -- --maxWorkers=4 --reporter=dot`: **70 files, 647 tests passed**.
- `npm run lint`: **0 errors**, 487 existing warnings; `npm run build`: passed.
- Ubuntu under WSL, native Linux checkout of the candidate: shell/Python lint passed; `make smoke` passed all four platform contracts; `make simulate` passed.
- `make bats`: 416 passed / 5 failed. The failures are in unchanged dispatch/path/preflight tests and expose this host's WSL detection, root execution, and available disk space; this is not a clean cross-platform runtime qualification.
- `make gate` stopped in `tests/test-installer-noninteractive-sudo.sh` with 3 passed / 2 failed. Running that exact test in a separate checkout of unmodified beta `ed4432d0` reproduces both failures (`no-sudo run promoted Docker to sudo`, `no-sudo run invoked raw sudo`). The overall release gate is **not green**.
- Full `pre-commit run --all-files`: gitleaks and large-file checks passed; private-key detection flagged two unchanged test files (`test-remote-provider-egress-policy.py`, `test_host_agent.py`); the Windows environment lacks `awk` for the heredoc hook. The shellcheck hook also reported a working-tree change while validation overlapped the commit; the candidate checkout is clean. Full pre-commit is **not green**. All applicable hooks pass when run on the two changed files.
- `git show --check HEAD`: passed.

## GitHub CI result

At candidate `7f68470dbdbb6b0afba3d20b5c0685aafde23488`, all 32 executed checks passed; four conditional review/security workflow jobs were skipped. This includes frontend lint/tests/build on hosted Ubuntu, Windows, and macOS runners (Node 20), the dashboard API, and integration-smoke. GitHub reports no merge conflicts. These CI results do not erase the local full-gate limitations above.

## Scope and limits

The same React code serves Linux, Windows, and macOS. This validates component behavior in jsdom and platform smoke contracts; no live Pixel/preview-server end-to-end run or installation upgrade was performed. No persisted format or backend lifecycle changes. Rollback is reverting this commit and rebuilding the dashboard, which restores the original duplicate-frame behavior.
## Final batch validation (2026-09-10)
- This PR's final candidate `7f68470dbdbb6b0afba3d20b5c0685aafde23488`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.