### PR TITLE
fix(installer): preserve keyboard orientation across wizard steps

### DIFF
--- a/installer/.gitignore
+++ b/installer/.gitignore
@@ -7,3 +7,5 @@ src-tauri/gen/
 *.dmg
 *.AppImage
 *.deb
+playwright-report/
+test-results/

--- a/installer/package-lock.json
+++ b/installer/package-lock.json
@@ -13,6 +13,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.63.0",
         "@tauri-apps/cli": "2.10.1",
         "@types/react": "^18.3.1",
         "@types/react-dom": "^18.3.1",
@@ -849,6 +850,21 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -948,9 +964,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -965,9 +978,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -982,9 +992,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -999,9 +1006,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1016,9 +1020,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1033,9 +1034,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1050,9 +1048,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1067,9 +1062,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1084,9 +1076,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1101,9 +1090,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1118,9 +1104,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1135,9 +1118,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1152,9 +1132,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1344,9 +1321,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1364,9 +1338,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1384,9 +1355,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1404,9 +1372,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -1424,9 +1389,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0 OR MIT",
       "optional": true,
       "os": [
@@ -2354,6 +2316,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/postcss": {

--- a/installer/package.json
+++ b/installer/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "tauri": "tauri"
+    "tauri": "tauri",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@tauri-apps/api": "2.10.1",
@@ -15,6 +16,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.63.0",
     "@tauri-apps/cli": "2.10.1",
     "@types/react": "^18.3.1",
     "@types/react-dom": "^18.3.1",

--- a/installer/playwright.config.ts
+++ b/installer/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/*.browser.ts",
+  workers: 1,
+  use: { baseURL: "http://127.0.0.1:18243" },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 18243",
+    url: "http://127.0.0.1:18243",
+    reuseExistingServer: false,
+  },
+});

--- a/installer/src/App.tsx
+++ b/installer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Welcome from "./pages/Welcome";
 import SystemCheck from "./pages/SystemCheck";
 import Prerequisites from "./pages/Prerequisites";
@@ -35,12 +35,28 @@ const STEPS: WizardStep[] = [
   "complete",
 ];
 
+const STEP_LABELS: Record<WizardStep, string> = {
+  welcome: "Welcome",
+  system_check: "System check",
+  prerequisites: "Prerequisites",
+  gpu: "GPU selection",
+  features: "Feature selection",
+  installing: "Installation",
+  complete: "Complete",
+  error: "Installation error",
+};
+
 export default function App() {
   const [step, setStep] = useState<WizardStep>("welcome");
   const [state, setState] = useState<WizardState>({
     tier: 1,
     features: [],
   });
+
+  const contentRef = useRef<HTMLElement>(null);
+  useEffect(() => {
+    contentRef.current?.focus();
+  }, [step]);
 
   const stepIndex = STEPS.indexOf(step);
   const progress =
@@ -54,7 +70,15 @@ export default function App() {
     <div className="flex flex-col h-screen bg-gray-950">
       {/* Progress bar */}
       {step !== "welcome" && step !== "error" && (
-        <div className="h-1 bg-gray-800">
+        <div
+          className="h-1 bg-gray-800"
+          role="progressbar"
+          aria-label="Setup progress"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={progress}
+          aria-valuetext={`Step ${stepIndex + 1} of ${STEPS.length}: ${STEP_LABELS[step]}`}
+        >
           <div
             className="h-full bg-ods-500 transition-all duration-500"
             style={{ width: `${progress}%` }}
@@ -63,7 +87,12 @@ export default function App() {
       )}
 
       {/* Content */}
-      <div className="flex-1 overflow-y-auto">
+      <main
+        ref={contentRef}
+        tabIndex={-1}
+        aria-label={`ODS setup: ${STEP_LABELS[step]}`}
+        className="flex-1 overflow-y-auto"
+      >
         {step === "welcome" && <Welcome onNext={() => goTo("system_check")} />}
         {step === "system_check" && (
           <SystemCheck
@@ -118,7 +147,7 @@ export default function App() {
             onRetry={() => goTo("system_check")}
           />
         )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/installer/tests/wizard-focus.browser.ts
+++ b/installer/tests/wizard-focus.browser.ts
@@ -1,0 +1,65 @@
+import { expect, test } from "@playwright/test";
+
+for (const outcome of ["complete", "error"]) {
+  test(`keyboard focus follows setup through ${outcome}`, async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(window, "__TAURI_INTERNALS__", {
+        value: { invoke: async (command: string) => {
+          if (command === "check_system") return {
+            system: { os_version: "Test Linux", arch: "x86_64" }, requirements: [],
+            docker: { installed: true, running: true, version: "test" },
+          };
+          if (command === "check_prerequisites") return { all_met: true };
+          if (command === "detect_gpu") return {
+            gpu: { vendor: "nvidia", name: "Test GPU", vram_mb: 24576 },
+            recommended_tier: 3, tier_description: "Test tier",
+          };
+          if (command === "get_install_progress") return {
+            phase: "installing", percent: 25, message: "Installing", error: null,
+          };
+          if (command === "start_install") return new Promise((resolve, reject) => {
+            Object.assign(window, {
+              finishInstall: (success: boolean) => success
+                ? resolve("done") : reject(new Error("Fixture failure")),
+            });
+          });
+          throw new Error(`Unexpected command: ${command}`);
+        } },
+      });
+    });
+    await page.goto("/");
+    const main = page.getByRole("main");
+    await expect(main).toBeFocused();
+    await expect(main).toHaveAccessibleName("ODS setup: Welcome");
+    await page.keyboard.press("Tab");
+    await expect(page.getByRole("button", { name: "Get Started" })).toBeFocused();
+    await page.keyboard.press("Enter");
+
+    for (const label of ["System check", "Prerequisites", "GPU selection"]) {
+      await expect(main).toBeFocused();
+      await expect(main).toHaveAccessibleName(`ODS setup: ${label}`);
+      await expect(page.getByRole("progressbar")).toHaveAttribute("aria-valuetext", new RegExp(label));
+      const next = page.getByRole("button", { name: "Continue", exact: true });
+      await expect(next).toBeVisible();
+      await next.focus();
+      await page.keyboard.press("Enter");
+    }
+    await expect(main).toBeFocused();
+    await expect(main).toHaveAccessibleName("ODS setup: Feature selection");
+    await page.getByRole("button", { name: "Install", exact: true }).focus();
+    await page.keyboard.press("Enter");
+    await expect(main).toBeFocused();
+    await expect(main).toHaveAccessibleName("ODS setup: Installation");
+    await page.evaluate((success) => {
+      (window as unknown as { finishInstall: (success: boolean) => void }).finishInstall(success);
+    }, outcome === "complete");
+    await expect(main).toBeFocused();
+    await expect(main).toHaveAccessibleName(`ODS setup: ${outcome === "complete" ? "Complete" : "Installation error"}`);
+    if (outcome === "error") {
+      await page.getByRole("button", { name: "Try Again" }).focus();
+      await page.keyboard.press("Enter");
+      await expect(main).toBeFocused();
+      await expect(main).toHaveAccessibleName("ODS setup: System check");
+    }
+  });
+}


### PR DESCRIPTION
Switching wizard steps removes the active button without moving focus into the next page. Keyboard and screen-reader users lose their position, including after an asynchronous installation result.

### Why this matters
Give the content a named main landmark and focus it when the step changes. Expose the existing setup progress as a progressbar with the current step name. Async loading keeps focus on a stable region instead of requiring a heading that may not exist yet.

### Overlap check
Searched open/closed PRs for installer focus, App.tsx focus, and installer accessibility. #3998 exposes feature checkbox state; this change handles navigation between pages. #4000 repairs clipping and resets scroll on navigation. Both can coexist: preserve its step key on the new main element. The Playwright setup and lockfile are identical to #4000.

### Validation
Two Chromium tests traverse the rendered wizard using keyboard activation through success and through failure/retry. They assert focus, accessible step labels and progress text at each transition. Both fail on main and pass on this branch. Clean npm ci, TypeScript/Vite build, and git diff --check passed.

Native commands are mocked; real assistive-technology announcements and native WebView behavior still need human validation. AI-assisted implementation; human review pending.

### Batch compatibility

The combined installer passes 25 Vitest tests and production build. The compatibility snapshot with existing #3703/#3704/#3731 also passes all four Chromium scenarios. Shared package scripts/dependencies and GPU/focus/prerequisite merge resolutions are recorded in the receipt. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
