### PR TITLE
perf(voice): overlap independent service health probes

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/voice.py
+++ b/ods/extensions/services/dashboard-api/routers/voice.py
@@ -1,5 +1,6 @@
 """Voice services status endpoint (stub)."""
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Depends
@@ -28,30 +29,22 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
     from helpers import check_service_health
     from config import SERVICES
 
-    services_status = {}
-    for svc_key, display_name in [("whisper", "stt"), ("tts", "tts")]:
-        cfg = SERVICES.get(svc_key)
-        if cfg:
-            try:
-                result = await check_service_health(svc_key, cfg)
-                services_status[display_name] = {"status": result.status}
-            except Exception:
-                logger.warning("Health check failed for %s", svc_key, exc_info=True)
-                services_status[display_name] = {"status": "unavailable"}
+    voice_services = [("whisper", "stt"), ("tts", "tts"), ("livekit", "livekit")]
+    services_status = {name: {"status": NOT_CONFIGURED} for _, name in voice_services}
+    configured = [(key, name, SERVICES[key]) for key, name in voice_services if SERVICES.get(key)]
+    results = await asyncio.gather(
+        *(check_service_health(key, cfg) for key, _, cfg in configured),
+        return_exceptions=True,
+    )
+    for (key, name, _), result in zip(configured, results):
+        if isinstance(result, Exception):
+            # Preserve the existing per-service error verdict and diagnostic.
+            logger.warning("Health check failed for %s", key, exc_info=(type(result), result, result.__traceback__))
+            services_status[name] = {"status": "unavailable"}
+        elif isinstance(result, BaseException):
+            raise result
         else:
-            services_status[display_name] = {"status": NOT_CONFIGURED}
-
-    # LiveKit is optional and not in SERVICES by default
-    livekit_cfg = SERVICES.get("livekit")
-    if livekit_cfg:
-        try:
-            result = await check_service_health("livekit", livekit_cfg)
-            services_status["livekit"] = {"status": result.status}
-        except Exception:
-            logger.warning("Health check failed for livekit", exc_info=True)
-            services_status["livekit"] = {"status": "unavailable"}
-    else:
-        services_status["livekit"] = {"status": NOT_CONFIGURED}
+            services_status[name] = {"status": result.status}
 
     # An uninstalled optional service is not a failure, so it sits out the
     # verdict. Everything that IS installed still has to be healthy.

--- a/ods/extensions/services/dashboard-api/tests/test_voice_concurrent_health.py
+++ b/ods/extensions/services/dashboard-api/tests/test_voice_concurrent_health.py
@@ -1,0 +1,111 @@
+"""Probe the real HTTP health boundary through the authenticated voice route."""
+
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Barrier, BrokenBarrierError, Thread
+from unittest.mock import AsyncMock
+
+import aiohttp
+from fastapi import FastAPI
+import httpx
+import pytest
+
+from routers import voice
+from security import DASHBOARD_API_KEY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_livekit", [False, True])
+async def test_voice_status_overlaps_configured_http_probes(monkeypatch, with_livekit):
+    services = ["whisper", "tts"] + (["livekit"] if with_livekit else [])
+    rendezvous = Barrier(len(services))
+    missed = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            try:
+                rendezvous.wait(timeout=2)
+            except BrokenBarrierError:
+                missed.append(self.path)
+            self.send_response(503 if self.path == "/livekit" else 200)
+            self.send_header("Content-Length", "0")
+            self.end_headers()
+
+        def log_message(self, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setattr("config.SERVICES", {
+        name: {"name": name, "host": "127.0.0.1", "port": server.server_port, "health": f"/{name}"}
+        for name in services
+    })
+    app = FastAPI()
+    app.include_router(voice.router)
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as session:
+            monkeypatch.setattr("helpers._get_aio_session", AsyncMock(return_value=session))
+            async with httpx.AsyncClient(
+                transport=httpx.ASGITransport(app=app), base_url="http://test"
+            ) as client:
+                response = await client.get("/api/voice/status", headers={
+                    "Authorization": f"Bearer {DASHBOARD_API_KEY}"
+                })
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+    assert response.status_code == 200
+    assert missed == [], "Configured voice services were probed sequentially"
+    assert response.json()["available"] is (not with_livekit)
+    assert response.json()["services"] == {
+        "stt": {"status": "healthy"},
+        "tts": {"status": "healthy"},
+        "livekit": {"status": "unhealthy" if with_livekit else "not_configured"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_preserves_other_service_verdicts(monkeypatch, caplog):
+    from types import SimpleNamespace
+
+    async def check(service, _config):
+        if service == "whisper":
+            raise RuntimeError("Probe fixture failure")
+        return SimpleNamespace(status="healthy")
+
+    monkeypatch.setattr("config.SERVICES", {"whisper": {"name": "STT"}, "tts": {"name": "TTS"}})
+    monkeypatch.setattr("helpers.check_service_health", check)
+    result = await voice.voice_status(api_key="test")
+    assert result["available"] is False
+    assert result["services"]["stt"]["status"] == "unavailable"
+    assert result["services"]["tts"]["status"] == "healthy"
+    assert "Health check failed for whisper" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_cancelled_request_cancels_all_active_probes(monkeypatch):
+    import asyncio
+
+    ready = asyncio.Event()
+    started, finished = set(), set()
+
+    async def check(service, _config):
+        started.add(service)
+        if len(started) == 2:
+            ready.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            finished.add(service)
+
+    monkeypatch.setattr("config.SERVICES", {"whisper": {"name": "STT"}, "tts": {"name": "TTS"}})
+    monkeypatch.setattr("helpers.check_service_health", check)
+    request = asyncio.create_task(voice.voice_status(api_key="test"))
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=2)
+    finally:
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+    assert finished == {"whisper", "tts"}


### PR DESCRIPTION
/api/voice/status waits for Whisper, TTS, and optional LiveKit sequentially, accumulating independent probe delays. Start the configured probes together while preserving each service's verdict and the required/optional availability rules.

### Why this matters
Operational voice checks, including ods/test-stack.sh, finish after the slowest configured probe instead of waiting for their delays to accumulate. At most three services are queried. Request cancellation cancels all active probes; a failed probe retains the existing unavailable verdict without hiding healthy peers.

### Overlap check
Searched open/closed PRs for voice concurrency/parallel and routers/voice.py. #137 parallelizes other dashboard queries. #2044/#2936 handle health-result shape validation and #1885 adds logging; none change probe scheduling. The existing per-service exception behavior and logs are retained.

### Validation
Two public authenticated HTTP tests use real local health servers and a rendezvous barrier, with and without LiveKit; both fail against sequential main and pass here. Additional tests cover exception isolation and cancellation. With test_voice.py: 9 passed. CI-select Ruff and git diff --check passed.

No live STT/TTS/LiveKit latency benchmark was performed. AI-assisted implementation; human review pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
