### PR TITLE
feat(agents): expose a bounded throughput history window

### DIFF
--- a/ods/extensions/services/dashboard-api/README.md
+++ b/ods/extensions/services/dashboard-api/README.md
@@ -106,7 +106,7 @@ Environment variables (set in `.env`):
 | `GET` | `/api/agents/metrics` | Yes | Full agent metrics (sessions, tokens, cost) |
 | `GET` | `/api/agents/metrics.html` | Yes | Agent metrics as HTML fragment (htmx) |
 | `GET` | `/api/agents/cluster` | Yes | Cluster health and GPU node status |
-| `GET` | `/api/agents/throughput` | Yes | Throughput stats (tokens/sec) |
+| `GET` | `/api/agents/throughput` | Yes | Throughput stats; optional history limit (1–180, default 30) |
 
 ### Privacy Shield
 
@@ -205,3 +205,22 @@ docker compose logs dashboard-api
 ## License
 
 Part of ODS — Local AI Infrastructure
+
+
+### Agent throughput history
+
+Authenticated clients can request more of the collector's retained samples with
+`GET /api/agents/throughput?limit=180`. The optional integer limit accepts 1–180;
+invalid values return HTTP 422. Omitting it preserves the 30-sample response
+used by existing clients.
+
+History is ordered oldest to newest and may contain fewer points than requested
+during startup, collection outages, or after retention pruning. At the nominal
+five-second collection interval, 180 samples cover approximately 15 minutes.
+This is an in-memory observation history, not a durable event or billing log.
+
+The limit affects only the history array. Current, average and peak remain
+statistics over the full retained window, so comparing different response limits
+does not change their meaning. Samples currently represent Token Spy's 24-hour
+output-token average, not instantaneous generation speed. Existing
+`/api/agents/metrics` responses keep their default 30-sample history.

--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -107,7 +107,7 @@ class ThroughputMetrics:
             if datetime.fromisoformat(p["timestamp"]) > cutoff
         ]
 
-    def get_stats(self) -> dict:
+    def get_stats(self, history_limit: int = 30) -> dict:
         """Get throughput statistics"""
         if not self.data_points:
             return {"current": 0, "average": 0, "peak": 0, "history": []}
@@ -117,7 +117,7 @@ class ThroughputMetrics:
             "current": values[-1] if values else 0,
             "average": sum(values) / len(values),
             "peak": max(values) if values else 0,
-            "history": self.data_points[-30:]  # Last 30 points
+            "history": self.data_points[-history_limit:]
         }
 
 

--- a/ods/extensions/services/dashboard-api/routers/agents.py
+++ b/ods/extensions/services/dashboard-api/routers/agents.py
@@ -1,8 +1,9 @@
 """Agent monitoring endpoints."""
 
 import html as html_mod
+from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import HTMLResponse
 
 from agent_monitor import get_full_agent_metrics, cluster_status, throughput
@@ -72,6 +73,9 @@ async def get_cluster_status(api_key: str = Depends(verify_api_key)):
 
 
 @router.get("/api/agents/throughput")
-async def get_throughput(api_key: str = Depends(verify_api_key)):
-    """Get throughput metrics (tokens/sec)."""
-    return throughput.get_stats()
+async def get_throughput(
+    limit: Annotated[int, Query(ge=1, le=180)] = 30,
+    api_key: str = Depends(verify_api_key),
+):
+    """Get throughput statistics and up to 180 retained observations."""
+    return throughput.get_stats(history_limit=limit)

--- a/ods/extensions/services/dashboard-api/tests/test_agent_history_query.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_history_query.py
@@ -1,0 +1,48 @@
+"""Operators can request retained history without changing summary semantics."""
+
+import pytest
+
+import agent_monitor
+from routers import agents
+
+
+@pytest.fixture()
+def populated_history(monkeypatch):
+    history = agent_monitor.ThroughputMetrics()
+    for value in range(100):
+        history.add_sample(float(value))
+    monkeypatch.setattr(agents, "throughput", history)
+    return history
+
+
+@pytest.mark.parametrize("limit", [1, 60, 180])
+def test_throughput_returns_requested_history_and_full_window_summary(
+    test_client, populated_history, limit
+):
+    response = test_client.get(
+        f"/api/agents/throughput?limit={limit}", headers=test_client.auth_headers
+    )
+    assert response.status_code == 200
+    result = response.json()
+    assert result["history"] == populated_history.data_points[-limit:]
+    assert result["current"] == 99
+    assert result["average"] == 49.5
+    assert result["peak"] == 99
+
+
+def test_default_history_contract_remains_thirty_samples(test_client, populated_history):
+    response = test_client.get("/api/agents/throughput", headers=test_client.auth_headers)
+    assert response.status_code == 200
+    assert response.json()["history"] == populated_history.data_points[-30:]
+
+
+@pytest.mark.parametrize("limit", ["0", "-1", "181", "1.5", "all"])
+def test_history_query_rejects_invalid_limits(test_client, limit):
+    response = test_client.get(
+        f"/api/agents/throughput?limit={limit}", headers=test_client.auth_headers
+    )
+    assert response.status_code == 422
+
+
+def test_extended_history_still_requires_authentication(test_client):
+    assert test_client.get("/api/agents/throughput?limit=180").status_code == 401


### PR DESCRIPTION
The collector retains approximately 15 minutes of throughput observations, but /api/agents/throughput exposes only the final 30 samples. Add an optional validated limit of 1–180 so operators can inspect more of the retained window.

### Why this matters
API consumers can retrieve a longer diagnostic timeline without changing existing clients or creating a durable telemetry store. The default remains 30 samples. Current/average/peak always describe the full retained window; limiting the response changes only the history array. Document startup/outage behavior and the 24-hour-average source of each sample.

### Overlap check
Searched open/closed PRs for throughput history and inspected #3500, which renders the existing final 30 points in a new dashboard page. #4013 repairs retention expiry; this adds a bounded query contract and does not change retention. #4063 adds Prometheus serialization, not history controls.

### Validation
Ten HTTP tests cover requested/default history, unchanged summaries, invalid limits and authentication. On main: eight fail and two compatibility checks pass. With test_agent_monitor.py and test_routers.py: 83 passed. CI-select Ruff and git diff --check passed.

No persistence or deployment changes. Combine with #4013 while preserving its read-time pruning. AI-assisted implementation; human review pending.

### Batch compatibility

The compatibility API tree passes 2,166 tests (1 skipped). This run explicitly includes existing fixture fix #3669: without it, 15 NVIDIA planning failures reproduce on clean main. The receipt identifies the tested tree and the history/Prometheus merge resolutions. [Validation receipt and merge order](https://github.com/0xacee/ODS/blob/4830533aab023080ec244c34213fd1e588fe8ba6/ODS-PR-BATCH-VALIDATION.md).

Ready for review based on the recorded local validation. GitHub has not reported hosted check results; this is not a hosted CI pass.
