### PR TITLE
fix(dashboard-api): key user extension TTL cache by directory path

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
@@ -228,3 +228,24 @@ class TestCaching:
 
         r2 = get_user_services_cached(user_dir, ttl=300.0)
         assert r2 == {}
+
+    def test_cache_keys_by_directory_path(self, tmp_path):
+        """Caching isolates entries per directory path."""
+        dir1 = tmp_path / "user1"
+        dir2 = tmp_path / "user2"
+
+        ext1 = dir1 / "ext1"
+        _write_manifest(ext1, _make_manifest("ext1"))
+        (ext1 / "compose.yaml").write_text("services: {}\n")
+
+        ext2 = dir2 / "ext2"
+        _write_manifest(ext2, _make_manifest("ext2"))
+        (ext2 / "compose.yaml").write_text("services: {}\n")
+
+        r1 = get_user_services_cached(dir1, ttl=300.0)
+        assert "ext1" in r1
+        assert "ext2" not in r1
+
+        r2 = get_user_services_cached(dir2, ttl=300.0)
+        assert "ext2" in r2
+        assert "ext1" not in r2

--- a/ods/extensions/services/dashboard-api/user_extensions.py
+++ b/ods/extensions/services/dashboard-api/user_extensions.py
@@ -101,7 +101,7 @@ def scan_user_extension_services(
 
 # --- TTL Cache ---
 
-_cache: dict[str, Any] = {"result": {}, "timestamp": float("-inf")}
+_cache: dict[str, Any] = {}
 _cache_lock = threading.Lock()
 
 
@@ -110,22 +110,25 @@ def get_user_services_cached(
 ) -> dict[str, dict[str, Any]]:
     """Return cached result of ``scan_user_extension_services()``.
 
-    Re-scans when *ttl* seconds have elapsed since the last scan.
+    Re-scans when *ttl* seconds have elapsed since the last scan for the given directory.
     """
+    cache_key = str(user_ext_dir.resolve()) if hasattr(user_ext_dir, "resolve") else str(user_ext_dir)
     with _cache_lock:
         now = time.monotonic()
-        if now - _cache["timestamp"] < ttl:
-            return _cache["result"].copy()
+        entry = _cache.get(cache_key)
+        if entry and (now - entry["timestamp"] < ttl):
+            return entry["result"].copy()
 
     result = scan_user_extension_services(user_ext_dir)
     with _cache_lock:
-        _cache["result"] = result
-        _cache["timestamp"] = time.monotonic()
+        _cache[cache_key] = {
+            "result": result,
+            "timestamp": time.monotonic(),
+        }
     return result.copy()
 
 
 def _reset_cache() -> None:
     """Clear the cached scan result. Used for test isolation."""
     with _cache_lock:
-        _cache["result"] = {}
-        _cache["timestamp"] = float("-inf")
+        _cache.clear()


### PR DESCRIPTION
### 1. Error
* **Observed Failure (Verbatim)**:
  ```text
  AssertionError: assert 'ext2' in {'ext1': {'dir': ...}}
    where {'ext1': ...} = get_user_services_cached(PosixPath('/tmp/pytest-of-macbookair/user2'), ttl=300.0)
  ```
  *(Before fix: calling `get_user_services_cached(dir1)` followed by `get_user_services_cached(dir2)` within the TTL interval returned the cached scan results of `dir1` for `dir2` calls, corrupting multi-tenant user extension scans).*
* **Reproduction Steps**:
  1. Operating System: macOS Apple Silicon (Darwin 26.6.2) with Python 3.13.2.
  2. Base Commit Hash: `8c3a60f73a170a4307b36dd669831be977b8045f` on branch `public-beta`.
  3. Scan two distinct extension directories sequentially within TTL:
     ```python
     res1 = get_user_services_cached(dir1, ttl=300.0)
     res2 = get_user_services_cached(dir2, ttl=300.0)
     ```
* **Environment Specificity**: Deterministic multi-tenant runtime scan issue.

### 2. Root Cause
* **File Path & Lines**:
  [`ods/extensions/services/dashboard-api/user_extensions.py:L104-L125`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/dashboard-api/user_extensions.py#L104).
* **Mechanism**:
  1. `_cache` was defined as a single global dict: `{"result": {}, "timestamp": float("-inf")}` without indexing entries by path.
  2. Any call to `get_user_services_cached()` within `ttl` seconds satisfied `now - _cache["timestamp"] < ttl` regardless of what `user_ext_dir` parameter was passed.
  3. Subsequent scans for different directories returned stale cached responses from earlier directories.

### 3. Fix
* **Code Modification**:
  In [`ods/extensions/services/dashboard-api/user_extensions.py:L104-L134`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/dashboard-api/user_extensions.py#L104), key `_cache` entries by resolved path string (`str(user_ext_dir.resolve())`):
  ```python
  -_cache: dict[str, Any] = {"result": {}, "timestamp": float("-inf")}
  +_cache: dict[str, Any] = {}

   def get_user_services_cached(...):
  +    cache_key = str(user_ext_dir.resolve()) if hasattr(user_ext_dir, "resolve") else str(user_ext_dir)
       with _cache_lock:
           now = time.monotonic()
  -        if now - _cache["timestamp"] < ttl:
  -            return _cache["result"].copy()
  +        entry = _cache.get(cache_key)
  +        if entry and (now - entry["timestamp"] < ttl):
  +            return entry["result"].copy()
  ```
* **Why This Fix Addresses Root Cause**:
  Keying cache entries by directory path isolates cached extension manifests per directory, ensuring directory scan accuracy while retaining TTL performance benefits.

### 4. Proof of Resolution
* **BEFORE Fix Output (Failing)**:
  ```text
  pytest ods/extensions/services/dashboard-api/tests/test_user_extensions.py
  ...
  FAILED ods/extensions/services/dashboard-api/tests/test_user_extensions.py::TestCaching::test_cache_keys_by_directory_path
  E   AssertionError: assert 'ext2' in {'ext1': ...}
  ```

* **AFTER Fix Output (Passing)**:
  ```text
  pytest ods/extensions/services/dashboard-api/tests/test_user_extensions.py
  ============================= test session starts ==============================
  platform darwin -- Python 3.13.2, pytest-8.0.0, pluggy-1.6.0
  rootdir: /Users/macbookair/dream-server/DreamServer
  collected 15 items

  ods/extensions/services/dashboard-api/tests/test_user_extensions.py ............... [100%]
  ============================== 15 passed in 0.11s ==============================
  ```
