### PR TITLE
fix(dashboard-api): strip whitespace when parsing environment integer values in hermes_bridge

### DIFF
--- a/ods/extensions/services/dashboard-api/hermes_bridge.py
+++ b/ods/extensions/services/dashboard-api/hermes_bridge.py
@@ -46,7 +46,7 @@ DEFAULT_TIMEOUT_SECONDS = 180
 
 
 def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
-    raw = os.environ.get(name, "")
+    raw = os.environ.get(name, "").strip()
     if raw.isdigit():
         return max(minimum, int(raw))
     return default
@@ -88,10 +88,7 @@ def _base_url() -> str:
 
 
 def _request_timeout() -> int:
-    raw = os.environ.get("ODS_TALK_HERMES_TIMEOUT", "")
-    if raw.isdigit():
-        return max(10, int(raw))
-    return DEFAULT_TIMEOUT_SECONDS
+    return _env_int("ODS_TALK_HERMES_TIMEOUT", DEFAULT_TIMEOUT_SECONDS, minimum=10)
 
 
 def talk_session_key(cookie_value: str) -> str:

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1184,5 +1184,8 @@ def test_ods_talk_hermes_timeout_is_env_configurable(monkeypatch):
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "900")
     assert hermes_bridge._request_timeout() == 900
 
+    monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", " 600 ")
+    assert hermes_bridge._request_timeout() == 600
+
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "5")
     assert hermes_bridge._request_timeout() == 10


### PR DESCRIPTION
### 1. Error
* **Observed Failure (Verbatim)**:
  ```text
  AssertionError: assert 180 == 600
    where 180 = _request_timeout()
  ```
  *(Before fix: passing environment variables containing padded whitespace, e.g. `ODS_TALK_HERMES_TIMEOUT=" 600 "`, caused `raw.isdigit()` in `_env_int()` to return `False`, falling back to the default timeout value `180` instead of parsing `600`).*
* **Reproduction Steps**:
  1. Operating System: macOS Apple Silicon (Darwin 26.6.2) with Python 3.13.2.
  2. Base Commit Hash: `8c3a60f73a170a4307b36dd669831be977b8045f` on branch `public-beta`.
  3. Set padded environment variable and inspect parsed timeout:
     ```python
     os.environ["ODS_TALK_HERMES_TIMEOUT"] = " 600 "
     timeout = _request_timeout()
     ```
* **Environment Specificity**: Deterministic across containerized environments where environment variables are loaded with trailing or leading whitespace.

### 2. Root Cause
* **File Path & Lines**:
  [`ods/extensions/services/dashboard-api/hermes_bridge.py:L48-L53, L90-L94`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/dashboard-api/hermes_bridge.py#L48).
* **Mechanism**:
  1. `_env_int()` retrieved raw environment strings via `os.environ.get(name, "")` without calling `.strip()`.
  2. Python's `str.isdigit()` returns `False` if any leading or trailing whitespace characters exist (e.g. `" 600 ".isdigit() == False`).
  3. Consequently, valid integer environment variables with whitespace failed the `.isdigit()` check, silently reverting to default values. Furthermore, `_request_timeout()` duplicated environment parsing logic instead of calling `_env_int()`.

### 3. Fix
* **Code Modification**:
  In [`ods/extensions/services/dashboard-api/hermes_bridge.py:L48, L90`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/dashboard-api/hermes_bridge.py#L48), strip whitespace in `_env_int()` and reuse `_env_int()` inside `_request_timeout()`:
  ```python
   def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
  -    raw = os.environ.get(name, "")
  +    raw = os.environ.get(name, "").strip()
       if raw.isdigit():
           return max(minimum, int(raw))
       return default

   def _request_timeout() -> int:
  -    raw = os.environ.get("ODS_TALK_HERMES_TIMEOUT", "")
  -    if raw.isdigit():
  -        return max(10, int(raw))
  -    return DEFAULT_TIMEOUT_SECONDS
  +    return _env_int("ODS_TALK_HERMES_TIMEOUT", DEFAULT_TIMEOUT_SECONDS, minimum=10)
  ```
* **Why This Fix Addresses Root Cause**:
  Stripping whitespace ensures robust integer parsing across all environment formats, and refactoring `_request_timeout()` eliminates code duplication.

### 4. Proof of Resolution
* **BEFORE Fix Output (Failing)**:
  ```text
  pytest ods/extensions/services/dashboard-api/tests/test_talk.py -k test_ods_talk_hermes_timeout_is_env_configurable
  ...
  E   AssertionError: assert 180 == 600
  ```

* **AFTER Fix Output (Passing)**:
  ```text
  pytest ods/extensions/services/dashboard-api/tests/test_talk.py -k test_ods_talk_hermes_timeout_is_env_configurable
  ============================= test session starts ==============================
  platform darwin -- Python 3.13.2, pytest-8.0.0, pluggy-1.6.0
  rootdir: /Users/macbookair/dream-server/DreamServer
  collected 117 items / 116 deselected / 1 selected

  ods/extensions/services/dashboard-api/tests/test_talk.py .               [100%]
  ==================== 1 passed, 116 deselected in 0.42s =====================
  ```
