### PR TITLE
fix(pixel): stop cleared drafts from reappearing in history

### DIFF
--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.js
@@ -41,10 +41,14 @@ export function saveConversation(chat) {
   const entries = loadConversations()
   const previous = entries.find(item => item.chatId === chat.chatId)
   const value = { ...previous, ...chat, updatedAt: Date.now() }
+  const remaining = entries.filter(item => item.chatId !== value.chatId)
   if (value.messages.length || value.draft?.trim()) {
-    const next = [value, ...entries.filter(item => item.chatId !== value.chatId)]
+    const next = [value, ...remaining]
     // Never silently evict an older conversation when browser storage fills up.
     localStorage.setItem(LIBRARY_KEY, JSON.stringify(next))
+  } else if (previous) {
+    // An erased unsent draft must not survive in the sidebar's saved library.
+    localStorage.setItem(LIBRARY_KEY, JSON.stringify(remaining))
   }
   localStorage.setItem(CHAT_KEY, JSON.stringify(value))
   window.dispatchEvent(new Event(LIBRARY_EVENT))

--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.test.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.test.js
@@ -23,6 +23,19 @@ test('updates a conversation without creating duplicate entries', () => {
   expect(conversationTitle(readConversations()[0])).toBe('Keep me')
 })
 
+test('clearing an unsent draft removes its saved text without deleting other chats', () => {
+  saveConversation(chat('sent', 'Keep this conversation'))
+  saveConversation({ schema: 1, chatId: 'draft', messages: [], draft: 'Discard this text' })
+  saveConversation({ schema: 1, chatId: 'draft', messages: [], draft: '' })
+  expect(readConversations().map(item => item.chatId)).toEqual(['sent'])
+  expect(JSON.parse(localStorage.getItem(CHAT_KEY)).draft).toBe('')
+  saveConversation({ schema: 1, chatId: 'next', messages: [], draft: '' })
+  expect(readConversations().map(item => item.chatId)).toEqual(['sent'])
+  // Erasing a draft is not deletion: the same active chat can be edited again.
+  saveConversation({ schema: 1, chatId: 'draft', messages: [], draft: 'Replacement' })
+  expect(conversationTitle(readConversations().find(item => item.chatId === 'draft'))).toBe('Replacement')
+})
+
 test('rejects invalid identities', () => {
   expect(() => saveConversation(chat('../bad', 'test'))).toThrow()
 })


### PR DESCRIPTION
## Why this matters
Pixel autosaves the composer to both the active-chat pointer and conversation library. Typing an unsent draft, erasing it, then opening another task leaves the erased text in the library; selecting the old entry resurrects text the user discarded. An empty save updated only the pointer, leaving the previous library entry untouched.

Remove an existing draft-only entry when its content becomes empty. Other chats remain intact, and the active chat can be edited again without a deletion tombstone.

## Regression and validation
- Storage-boundary regression fails on beta `8c3a60f7` with an extra `draft` entry, then passes after the fix. Checks reopening history, preserving another conversation, and editing the erased draft again.
- `npm test -- src/lib/pixelConversations.test.js --maxWorkers=2`: 10 passed.
- Full dashboard suite: 71 files / 662 tests passed; lint: 0 errors, 487 baseline warnings; production build passed.
- `git diff --check` passed. Changed-file pre-commit hooks checked before push.

## Overlap check
Searched open and closed PRs for `pixel draft` and the beta PR inventory. Reviewed the library introduced by #4027 and the related #3385/#3818/#3951 feature work. None removes cleared draft entries; this is a follow-up to the UI integrated into public-beta. Production file: `ods/extensions/services/dashboard/src/lib/pixelConversations.js`; caller: Pixel's composer autosave effect and sidebar history reader.

## Compatibility and limits
Independent branch from public-beta `8c3a60f7`; same browser code on Linux/Windows/macOS. No storage schema change, no chat deletion, no server mutation. Local UI validation ran on Windows/Node 24.14.1; live Pixel end-to-end is untested. Shared release-gate limitations from this beta test session include the root/WSL sudo and BATS fixtures and unchanged private-key test fixtures; no claim of a fully green local release gate. Revert this commit to restore prior behavior. This is PR 2/10 of the beta batch; merge independently. Combined compatibility is recorded below.
## Final batch validation (2026-09-10)
- This PR's final candidate `d1b00d4651ff462ae33808ad4be3bb461df44147`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.