### PR TITLE
fix(sharing): use the advertised port in connection settings

### DIFF
--- a/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.jsx
@@ -9,7 +9,8 @@ export default function PixelSharingSettings() {
   const [label, setLabel] = useState('')
   const [days, setDays] = useState(30)
   const [issued, setIssued] = useState(null)
-  const [baseUrl, setBaseUrl] = useState('http://127.0.0.1:4005/v1')
+  const [baseUrl, setBaseUrl] = useState('')
+  const baseUrlEdited = useRef(false)
   const [busy, setBusy] = useState(false)
   const [stale, setStale] = useState(false)
   const [error, setError] = useState('')
@@ -39,10 +40,12 @@ export default function PixelSharingSettings() {
       if (!response.ok) throw new Error('Sharing request failed')
       const result = await response.json()
       const next = readSharing(result)
+      const defaultUrl = `http://127.0.0.1:${next.transport.port}/v1`
       if (action && next.configuration.revision !== payload.expectedRevision + 1) throw new Error('Unknown revision')
-      if (action === 'issue') connectionBundle(result, 'http://127.0.0.1:4005/v1')
+      if (action === 'issue') connectionBundle(result, defaultUrl)
       if (!current()) return
       setSnapshot(next)
+      if (!baseUrlEdited.current) setBaseUrl(defaultUrl)
       setStale(false)
       if (action === 'issue') {
         setIssued(result)
@@ -145,7 +148,7 @@ export default function PixelSharingSettings() {
       {issued && <div className="rounded-lg border border-theme-border p-4 space-y-3">
         <h3 className="font-medium">One-time connection settings</h3>
         <p className="text-sm text-theme-text-muted">On your laptop, forward this host’s 127.0.0.1:{snapshot.transport.port} through authenticated SSH, or use your explicitly configured HTTPS ingress. The key grants inference only, not SSH or computer access.</p>
-        <label className="block text-sm">Laptop connection URL<input className={inputStyle} value={baseUrl} onChange={event => setBaseUrl(event.target.value)} spellCheck={false} /></label>
+        <label className="block text-sm">Laptop connection URL<input className={inputStyle} value={baseUrl} onChange={event => { baseUrlEdited.current = true; setBaseUrl(event.target.value) }} spellCheck={false} /></label>
         <label className="block text-sm">Device API key<input className={inputStyle} type="password" value={issued.credential.key} readOnly autoComplete="off" /></label>
         <p className="text-sm">OpenAI-compatible model: <code>ods/shared</code>. Test the connection on the client before choosing it as Pixel’s leader.</p>
         <button className={buttonStyle} onClick={copyConnection}>Copy connection settings</button>{' '}

--- a/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.test.jsx
@@ -73,6 +73,22 @@ it('rejects a plaintext remote URL without sending a key to the clipboard', asyn
   expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
 })
 
+it('uses the advertised sharing port and preserves an edited client URL on reload', async () => {
+  const withPort = value => ({...value,transport:{...value.transport,port:4405}})
+  setup(withPort(snapshot()), () => response(withPort(issued())))
+  await createKey()
+  expect(screen.getByLabelText('Laptop connection URL')).toHaveValue('http://127.0.0.1:4405/v1')
+  fireEvent.click(screen.getByRole('button',{name:'Copy connection settings'}))
+  await waitFor(() => expect(navigator.clipboard.writeText).toHaveBeenCalledOnce())
+  expect(JSON.parse(navigator.clipboard.writeText.mock.calls[0][0]).baseUrl).toBe('http://127.0.0.1:4405/v1')
+  fireEvent.change(screen.getByLabelText('Laptop connection URL'),{target:{value:'https://my-ingress.example/v1'}})
+  fireEvent.click(screen.getByRole('button',{name:'Reload sharing'}))
+  await waitFor(() => expect(screen.getByRole('button',{name:'Reload sharing'})).toBeEnabled())
+  // Issue again after reloading a snapshot without the retained one-time key.
+  await createKey()
+  expect(screen.getByLabelText('Laptop connection URL')).toHaveValue('https://my-ingress.example/v1')
+})
+
 it('revocation removes the retained one-time key', async () => {
   setup(snapshot(), url => response(url.endsWith('/issue') ? issued() : snapshot(2, [{ ...device(), revoked: true }])))
   await createKey()


### PR DESCRIPTION
## Why this matters
With `PIXEL_INFERENCE_PORT=4405`, the host advertises port 4405 and the sharing panel tells the operator to forward that port, but its suggested connection URL and copied bundle still use 4005. A matching-port tunnel therefore connects the client to the wrong port.

Derive the suggested loopback URL from the validated host transport receipt. Once the operator edits the client URL (for a differently mapped local tunnel or HTTPS ingress), preserve it across reload and subsequent credential creation.

## Regression and validation
- Component test creates a device key on an advertised non-default port and verifies both the form and copied connection JSON. It then edits the URL, reloads and creates another key to verify the override survives. Before the fix: expected port 4405, received 4005.
- `npm test -- src/components/settings/PixelSharingSettings.test.jsx --maxWorkers=2`: 19 passed.
- Full dashboard suite: 71 files / 662 tests passed. Lint: 0 errors, 487 baseline warnings; build passed. Changed-file pre-commit and diff checks run before push.
- Candidate: `79bb2ed6`; Windows/Node 24.14.1 local component validation. No live remote-client connection or Pixel setup was performed. The shared local release-gate caveats (root/WSL fixtures and existing private-key fixtures) remain.

## Overlap check
Searched open/closed PRs for `sharing port` and reviewed the beta inventory and #3818/#4027 implementations. No existing repair covers this copied URL. Production path: `.env` `PIXEL_INFERENCE_PORT` -> host-agent sharing probe -> `/api/pixel/inference-sharing` -> `PixelSharingSettings.jsx` -> clipboard bundle. The override is documented in `ods/docs/pixel/CONNECTIONS-ROUTING-ACCESS.md` and published in the transport receipt.

## Compatibility
PR 4/10, independently based on public-beta `8c3a60f7`; default 4005 remains unchanged. All browser platforms share this component. No credentials are persisted or transmitted by the URL suggestion; key issuance and existing confirmation remain backend-owned. Revert the commit to restore the prior suggestion. No merge dependency on the other batch PRs; combined validation is recorded below.
## Final batch validation (2026-09-10)
- This PR's final candidate `79bb2ed67564cc918046ccfe69f621eacc62541c`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.