### PR TITLE
fix(pixel): refresh open search when conversation history changes

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Search, X, MessageSquare, Plus, Settings, ListChecks, Globe2 } from 'lucide-react'
-import { readConversations, conversationTitle, SELECT_EVENT } from '../lib/pixelConversations'
+import { readConversations, conversationTitle, SELECT_EVENT, LIBRARY_EVENT } from '../lib/pixelConversations'
 
 export const OPEN_PIXEL_SEARCH = 'ods:pixel-search'
 export default function PixelCommandSearch({ onInsert, onNewTask }) {
@@ -22,9 +22,18 @@ export default function PixelCommandSearch({ onInsert, onNewTask }) {
     const key = event => {
       if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') { event.preventDefault(); open() }
     }
+    const refresh = () => {
+      if (!dialog.current?.open) return
+      setChats(readConversations()); setIndex(0)
+    }
     window.addEventListener(OPEN_PIXEL_SEARCH, open)
     window.addEventListener('keydown', key)
-    return () => { window.removeEventListener(OPEN_PIXEL_SEARCH, open); window.removeEventListener('keydown', key) }
+    window.addEventListener(LIBRARY_EVENT, refresh)
+    window.addEventListener('storage', refresh)
+    return () => {
+      window.removeEventListener(OPEN_PIXEL_SEARCH, open); window.removeEventListener('keydown', key)
+      window.removeEventListener(LIBRARY_EVENT, refresh); window.removeEventListener('storage', refresh)
+    }
   }, [])
   const entries = [
     { title: 'New task', detail: 'Start a fresh conversation', icon: Plus, run: onNewTask },

--- a/ods/extensions/services/dashboard/src/components/PixelCommandSearch.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCommandSearch.test.jsx
@@ -1,7 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from './PixelCommandSearch'
-import { saveConversation, SELECT_EVENT } from '../lib/pixelConversations'
+import { saveConversation, deleteConversation, SELECT_EVENT } from '../lib/pixelConversations'
 
 beforeEach(() => {
   localStorage.clear()
@@ -29,4 +29,31 @@ test('handles empty results without issuing an action', () => {
   fireEvent.keyDown(screen.getByLabelText('Search conversations and actions'), {key:'Enter'})
   expect(create).not.toHaveBeenCalled()
   expect(screen.getByText('No matching conversations or actions.')).toBeVisible()
+})
+
+test('removes deleted conversations from an open search and never selects a stale result', () => {
+  saveConversation({schema:1,chatId:'removed',messages:[{role:'user',content:'Find this task'}]})
+  const selected = vi.fn()
+  window.addEventListener(SELECT_EVENT, selected)
+  render(<MemoryRouter><PixelCommandSearch onInsert={() => {}} onNewTask={() => {}}/></MemoryRouter>)
+  fireEvent(window, new Event(OPEN_PIXEL_SEARCH))
+  const input = screen.getByLabelText('Search conversations and actions')
+  fireEvent.change(input,{target:{value:'Find this task'}})
+  act(() => deleteConversation('removed'))
+  expect(screen.queryByRole('button',{name:/Find this task/})).toBeNull()
+  fireEvent.keyDown(input,{key:'Enter'})
+  expect(selected).not.toHaveBeenCalled()
+  expect(input).toHaveValue('Find this task')
+  window.removeEventListener(SELECT_EVENT, selected)
+})
+
+test('refreshes new saved results without clearing the open search query', () => {
+  render(<MemoryRouter><PixelCommandSearch onInsert={() => {}} onNewTask={() => {}}/></MemoryRouter>)
+  fireEvent(window, new Event(OPEN_PIXEL_SEARCH))
+  const input = screen.getByLabelText('Search conversations and actions')
+  fireEvent.change(input,{target:{value:'Newly saved'}})
+  localStorage.setItem('ods.pixel.conversations.v1',JSON.stringify([{schema:1,chatId:'newly-saved',messages:[{role:'user',content:'Newly saved task'}]}]))
+  fireEvent(window,new StorageEvent('storage',{key:'ods.pixel.conversations.v1'}))
+  expect(screen.getByRole('button',{name:/Newly saved task/})).toBeVisible()
+  expect(input).toHaveValue('Newly saved')
 })


### PR DESCRIPTION
## Why this matters
Pixel's command search snapshots history only when opened. If another tab deletes a matching chat, the open dialog continues to show and dispatch that deleted ID. Newly saved chats also remain unfindable until the dialog is closed and reopened.

While the dialog is open, refresh its results on the existing conversation-library event and cross-tab storage events. Preserve the query and reset the active result index so a removed row cannot remain selected. Remove the listeners on unmount; no polling or storage writes are added.

## Regression and validation
- Two component regressions failed on beta: a deleted result stayed selectable and a newly saved result was absent. The tests exercise same-window library notification and another tab's storage notification separately, preserve the typed query, and verify no stale selection event is dispatched.
- `npm test -- src/components/PixelCommandSearch.test.jsx --maxWorkers=2`: 4 passed.
- Full UI suite: 71 files / 663 tests passed; lint 0 errors (487 baseline warnings), build passed, diff check passed. Changed-file pre-commit before push.
- Candidate `54292586`, Windows/Node 24.14.1. No live Pixel execution was needed or claimed. Shared local release-gate caveats remain for unchanged root/WSL and private-key test fixtures.

## Overlap check
Searched open/closed upstream PRs for `PixelCommandSearch`, `conversation search deleted`, and `pixel draft`; reviewed the beta inventory and #4027's search implementation. No existing fix keeps open search results synchronized. This differs from #4078: that PR fixes persisted draft contents; this one fixes a stale UI snapshot even when storage is already correct. Production file: `ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx`.

## Compatibility
PR 5/10, independent public-beta `8c3a60f7` base. Uses the existing library event contract on all browser platforms; no backend or schema change. No merge dependency on #4078. Combined batch validation will exercise both. Revert the commit to restore prior search snapshot behavior.
## Final batch validation (2026-09-10)
- This PR's final candidate `54292586f9da910e6a3e3121781a317f69e864cc`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.