### PR TITLE
fix(token-spy): add non-dict item type guards in request filters

### DIFF
--- a/ods/extensions/services/token-spy/filters.py
+++ b/ods/extensions/services/token-spy/filters.py
@@ -104,7 +104,10 @@ def _filter_tools(body: dict, cfg: dict, result: FilterResult,
     removed_names = []
 
     for tool in tools:
-        name = tool.get("function", {}).get("name", "")
+        if not isinstance(tool, dict):
+            continue
+        func = tool.get("function")
+        name = func.get("name", "") if isinstance(func, dict) else ""
         if mode == "allowlist":
             if name in allowlist:
                 kept.append(tool)
@@ -334,6 +337,8 @@ def _group_into_units(messages: list[dict]) -> list[list[dict]]:
     current_unit = []
 
     for msg in messages:
+        if not isinstance(msg, dict):
+            continue
         role = msg.get("role", "")
         if role == "user" and current_unit:
             units.append(current_unit)

--- a/ods/extensions/services/token-spy/tests/test_filters.py
+++ b/ods/extensions/services/token-spy/tests/test_filters.py
@@ -1,0 +1,55 @@
+"""Unit tests for Token Spy request filters non-dict and type bounds guards."""
+
+import importlib.util
+from pathlib import Path
+from uuid import uuid4
+import pytest
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+def _load_filters_module():
+    filters_path = TOKEN_SPY_DIR / "filters.py"
+    spec = importlib.util.spec_from_file_location(
+        f"filters_{uuid4().hex}", filters_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+filters_mod = _load_filters_module()
+apply_filters = filters_mod.apply_filters
+FilterResult = filters_mod.FilterResult
+_group_into_units = filters_mod._group_into_units
+
+
+def test_apply_filters_with_non_dict_tool_entries():
+    """Verify that non-dict entries in tools list do not raise AttributeError."""
+    body = {
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [None, "invalid_str", {"type": "function", "function": {"name": "search_db"}}],
+    }
+    filter_settings = {
+        "enabled": True,
+        "tools": {
+            "enabled": True,
+            "mode": "blocklist",
+            "blocklist": ["search_db"],
+        },
+    }
+    filtered_body, result = apply_filters(body, filter_settings)
+    assert isinstance(result, FilterResult)
+    assert result.tools_removed == 1
+
+
+def test_group_into_units_with_non_dict_messages():
+    """Verify that non-dict items in messages list are safely skipped."""
+    messages = [
+        None,
+        "string message",
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello!"},
+    ]
+    units = _group_into_units(messages)
+    assert len(units) == 1
+    assert len(units[0]) == 2
+    assert units[0][0]["role"] == "user"

--- a/ods/extensions/services/token-spy/tests/test_filters.py
+++ b/ods/extensions/services/token-spy/tests/test_filters.py
@@ -3,7 +3,6 @@
 import importlib.util
 from pathlib import Path
 from uuid import uuid4
-import pytest
 
 TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
### 1. Error
* **Observed Failure (Verbatim)**:
  ```text
  AttributeError: 'NoneType' object has no attribute 'get'
      at name = tool.get("function", {}).get("name", "") (filters.py:107)
  AttributeError: 'str' object has no attribute 'get'
      at role = msg.get("role", "") (filters.py:337)
  ```
  *(Before fix: Token Spy request filter routines assumed `tools` list items and `messages` list items were always valid Python `dict` instances. When clients or middleware forwarded payloads containing malformed array elements such as `None` or string literals, the filter handler crashed with an unhandled `AttributeError`).*
* **Reproduction Steps**:
  1. Operating System: Cross-platform POSIX / macOS runtime with Python 3.13.2.
  2. Base Commit Hash: `8c3a60f73a170a4307b36dd669831be977b8045f` on branch `main`.
  3. Send JSON payload with invalid array items to request filter handler:
     ```python
     from ods.extensions.services.token_spy.filters import apply_filters
     apply_filters({"tools": [None, "invalid"], "messages": [None]}, {"enabled": True, "tools": {"enabled": True}})
     ```
* **Environment Specificity**: Deterministic across all deployment runtimes.

### 2. Root Cause
* **File Path & Lines**:
  [`ods/extensions/services/token-spy/filters.py:L107-L115, L337-L345`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/token-spy/filters.py#L107).
* **Mechanism**:
  1. Un-guarded call `tool.get("function", {})` assumes `isinstance(tool, dict)`.
  2. Un-guarded call `msg.get("role", "")` in `_group_into_units()` assumes `isinstance(msg, dict)`.
  3. When malformed payloads contain non-dict values (such as `None` or raw strings), dereferencing `.get()` raises `AttributeError`.

### 3. Fix
* **Code Modification**:
  In [`ods/extensions/services/token-spy/filters.py`](file:///Users/macbookair/dream-server/DreamServer/ods/extensions/services/token-spy/filters.py), add `isinstance(tool, dict)` and `isinstance(msg, dict)` defensive type guards before accessing dictionary keys:
  ```python
  for tool in tools:
      if not isinstance(tool, dict):
          continue
      func = tool.get("function")
      name = func.get("name", "") if isinstance(func, dict) else ""
  ```
  And in `_group_into_units()`:
  ```python
  for msg in messages:
      if not isinstance(msg, dict):
          continue
      role = msg.get("role", "")
  ```
* **Why This Fix Addresses Root Cause**:
  Defensively skips non-dict array elements, preventing `AttributeError` runtime crashes while keeping valid tool schemas and conversation history intact.

### 4. Proof of Resolution
* **BEFORE Fix Output (Failing)**:
  ```text
  pytest ods/extensions/services/token-spy/tests/test_filters.py
  ...
  E   AttributeError: 'NoneType' object has no attribute 'get'
  ```

* **AFTER Fix Output (Passing)**:
  ```text
  pytest ods/extensions/services/token-spy/tests/test_filters.py
  ============================= test session starts ==============================
  platform darwin -- Python 3.13.2, pytest-8.0.0, pluggy-1.6.0
  rootdir: /Users/macbookair/dream-server/DreamServer
  plugins: anyio-4.12.1, asyncio-0.23.5, zarr-3.3.0
  asyncio: mode=Mode.STRICT
  collected 2 items

  ods/extensions/services/token-spy/tests/test_filters.py ..               [100%]

  ============================== 2 passed in 0.03s ===============================
  ```
