### PR TITLE
fix(preview): preserve final newline edits in snapshot comparisons

### DIFF
--- a/ods/extensions/services/pixel-agent/host/workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/host/workspace_preview.py
@@ -439,6 +439,13 @@ PREVIEW_SCROLLBAR_STYLE = b'''<style data-ods-preview-scrollbars>
 </style>'''
 
 
+def _diff_row(kind: str, old_line: int | None, new_line: int | None, text: str) -> dict[str, Any]:
+    row = {"type": kind, "oldLine": old_line, "newLine": new_line, "text": text.rstrip("\r\n")}
+    if not text.endswith(("\r", "\n")):
+        row["noFinalNewline"] = True
+    return row
+
+
 def snapshot_changes(previews: pathlib.Path, site_id: str, before_id: str | None) -> bytes:
     """Compare verified publications, never infer edits from assistant prose.
 
@@ -468,19 +475,19 @@ def snapshot_changes(previews: pathlib.Path, site_id: str, before_id: str | None
         change = "published" if before_id is None else "deleted" if new is None else "created" if old is None else "modified"
         entry = {"path": path, "change": change, "additions": None, "deletions": None, "diff": [], "truncated": False}
         try:
-            a = [] if old is None else old.decode("utf-8").splitlines()
-            b = [] if new is None else new.decode("utf-8").splitlines()
-            if any(any(ord(c) < 32 and c != '\t' for c in line) for line in a + b) or len(a) + len(b) > 4000:
+            a = [] if old is None else old.decode("utf-8").splitlines(keepends=True)
+            b = [] if new is None else new.decode("utf-8").splitlines(keepends=True)
+            if any(any(ord(c) < 32 and c != '\t' for c in line.rstrip("\r\n")) for line in a + b) or len(a) + len(b) > 4000:
                 raise ValueError()
             additions = deletions = 0
             for kind, i, j, k, l in difflib.SequenceMatcher(None, a, b).get_opcodes():
                 if kind in {"replace", "delete"}: deletions += j - i
                 if kind in {"replace", "insert"}: additions += l - k
                 rows = []
-                if kind == "equal": rows = [{"type":"context", "oldLine":x+1, "newLine":k+x-i+1, "text":a[x]} for x in range(i,j)]
+                if kind == "equal": rows = [_diff_row("context", x+1, k+x-i+1, a[x]) for x in range(i,j)]
                 else:
-                    rows += [{"type":"remove", "oldLine":x+1, "newLine":None, "text":a[x]} for x in range(i,j)]
-                    rows += [{"type":"add", "oldLine":None, "newLine":x+1, "text":b[x]} for x in range(k,l)]
+                    rows += [_diff_row("remove", x+1, None, a[x]) for x in range(i,j)]
+                    rows += [_diff_row("add", None, x+1, b[x]) for x in range(k,l)]
                 for row in rows:
                     size = len(json.dumps(row, ensure_ascii=True).encode()) + 1
                     if size > remaining:

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
@@ -327,6 +327,45 @@ def test_published_changes_use_actual_verified_source_versions_and_keep_unknown_
         assert json.loads(MODULE.snapshot_changes(previews, new["siteId"], new["siteId"]))["changes"] == []
 
 
+def test_changes_http_preserves_final_newline_edits():
+    with tempfile.TemporaryDirectory() as temporary:
+        root = pathlib.Path(temporary)
+        workspace, previews = root / "workspace", root / "previews"
+        workspace.mkdir(mode=0o700)
+        previews.mkdir(mode=0o700)
+        site = workspace / "demo"
+        site.mkdir(mode=0o700)
+        entry = site / "index.html"
+        for old_text, new_text in [("<h1>Hi</h1>", "<h1>Hi</h1>\n"),
+                                   ("<h1>Hi</h1>\n", "<h1>Hi</h1>")]:
+            entry.write_text(old_text, encoding="utf-8")
+            entry.chmod(0o600)
+            old = MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+            entry.write_text(new_text, encoding="utf-8")
+            new = MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+            with MODULE.PreviewHTTPServer(("127.0.0.1", 0), previews) as server:
+                thread = threading.Thread(target=server.serve_forever, daemon=True)
+                thread.start()
+                try:
+                    connection = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+                    connection.request("GET", f"/{new['siteId']}/__ods_changes__/{old['siteId']}.json",
+                                       headers={"Host": f"{new['siteId']}.localhost:{server.server_port}"})
+                    response = connection.getresponse()
+                    payload = json.loads(response.read())
+                    connection.close()
+                    assert response.status == 200
+                    assert payload["sha256"] == new["sha256"]
+                    file = payload["changes"][0]
+                    assert (file["additions"], file["deletions"]) == (1, 1)
+                    assert [row["type"] for row in file["diff"]] == ["remove", "add"]
+                    assert [row["text"] for row in file["diff"]] == ["<h1>Hi</h1>"] * 2
+                    assert [row.get("noFinalNewline", False) for row in file["diff"]] == [
+                        not old_text.endswith("\n"), not new_text.endswith("\n")]
+                finally:
+                    server.shutdown()
+                    thread.join(timeout=5)
+
+
 def test_unix_http_preview_accepts_only_the_internal_relay_authority():
     with tempfile.TemporaryDirectory() as temporary:
         root = pathlib.Path(temporary)


### PR DESCRIPTION
## Why this matters
Publishing `<h1>Hi</h1>` and then the same file with a final newline creates different verified snapshots, but Changes reports zero added and zero removed lines. `splitlines()` discarded terminators before comparison, hiding the entire edit.

Compare lines with their terminators, then strip terminators only when serializing display text. Mark unterminated lines with the existing `noFinalNewline` field understood by Pixel's diff renderer and copy action. The diff now reports one removal and one addition for adding or removing the final newline. Snapshot bytes, hashes, bounds and publication custody remain unchanged.

## Regression and validation
- A real HTTP test publishes both versions, requests `__ods_changes__/<before>.json`, and checks counts, text, digest and newline markers in both directions. It failed on `8c3a60f7` with `(0, 0)` instead of `(1, 1)`.
- Ubuntu/WSL, Python 3.14: `python -m pytest ods/extensions/services/pixel-agent/tests/test_workspace_preview.py -q`: **11 passed**, including TCP and Unix HTTP preview serving and original publication checks.
- Changed-file pre-commit and `git diff --check`: passed. Candidate `75541359`.
- No live Pixel conversation or installation upgrade was performed. Shared full-release-gate limitations from the beta session remain; this is HTTP/service verification, not a fleet deployment claim.

## Overlap check
Searched open and closed PRs for `preview newline` and `snapshot changes lines`, and reviewed current beta PRs plus the preview implementation included by #3385/#4027. No existing PR repairs final-newline comparison. Production file: `ods/extensions/services/pixel-agent/host/workspace_preview.py`; public path: verified publication -> preview HTTP Changes endpoint -> dashboard `PixelSnapshotChanges`/`PixelFileChanges`.

## Compatibility
PR 6/10, independent public-beta `8c3a60f7` base. The qualified Linux Pixel host serves browser clients on all platforms; native Windows/macOS Pixel setup remains outside this test scope. Existing terminated-line rows retain their shape; the optional EOF marker already has a UI consumer. Reverting this commit changes only comparison output. Another planned preview HTTP charset fix touches the same module in a different function; both merge orders and combined tests will be checked before the batch is reported complete.
## Final batch validation (2026-09-10)
- This PR's final candidate `755413598fc527430d00dd05936a67eb880838d3`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.