### PR TITLE
fix(pixel): keep stale setup polls from overriding stop receipts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.jsx
@@ -29,6 +29,7 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
   const fingerprint = useRef('')
   const inflight = useRef(false)
   const polling = useRef(false)
+  const jobVersion = useRef(0)
   const controllers = useRef(new Set())
   const epoch = useRef(0)
   const notify = useRef(onReadyChange)
@@ -72,15 +73,16 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
   }, [refresh])
 
   const inspect = useCallback(async () => {
-    if (!jobId || polling.current) return
+    if (!jobId || polling.current || inflight.current) return
     polling.current = true
+    const version = jobVersion.current
     try {
       const result = await request('/status', { jobId })
       if (!validJob(result) || result.jobId !== jobId) throw new Error('Invalid setup job')
-      if (tracked.current !== jobId) return
+      if (tracked.current !== jobId || version !== jobVersion.current) return
       setJob(result); setError('')
       if (done.has(result.status)) await refresh()
-    } catch { if (tracked.current === jobId) setError('Setup status is unknown. Check the tracked setup; closing this panel does not stop it.') }
+    } catch { if (tracked.current === jobId && version === jobVersion.current) setError('Setup status is unknown. Check the tracked setup; closing this panel does not stop it.') }
     finally { polling.current = false }
   }, [jobId, request, refresh])
 
@@ -98,6 +100,7 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
   async function prepare() {
     if (!available || !consent || busy || disabled || inflight.current) return
     inflight.current = true; setSubmitting(true); setError('')
+    jobVersion.current++
     let id
     try {
       id = globalThis.crypto.randomUUID(); localStorage.setItem(key, id)
@@ -113,7 +116,8 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
   }
 
   async function stop() {
-    if (!jobId) return
+    if (!jobId || inflight.current) return
+    inflight.current = true; setSubmitting(true); jobVersion.current++
     try {
       const result = await request('/cancel', { jobId })
       if (!validJob(result) || result.jobId !== jobId) throw new Error('Invalid setup job')
@@ -121,6 +125,7 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
       setJob(result); setError('')
       if (done.has(result.status)) await refresh()
     } catch { if (tracked.current === jobId) setError('Stop setup is unconfirmed. Check the tracked setup again.') }
+    finally { inflight.current = false; setSubmitting(false) }
   }
 
   function forget() {
@@ -151,7 +156,7 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
       <p role="status">Setup: {job?.status || 'unknown'}</p>
       <div className="flex flex-wrap gap-2">
         <button type="button" className={button} onClick={inspect}>Check setup</button>
-        {!done.has(job?.status) && <button type="button" className={button} onClick={stop}>Stop setup</button>}
+        {!done.has(job?.status) && <button type="button" className={button} disabled={submitting} onClick={stop}>Stop setup</button>}
         {(done.has(job?.status) || error) && <button type="button" className={button} disabled={submitting} onClick={forget}>Forget tracking (does not stop setup)</button>}
       </div>
       {job?.status === 'failed' && <p>Setup failed or runtime custody changed. Refresh readiness and check host Python/venv availability. Old runtime files and job evidence are retained.</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.test.jsx
@@ -40,6 +40,28 @@ it('requires explicit consent and submits only the server candidate ID once', as
   expect(localStorage.getItem(storage)).toBe(id)
 })
 
+it('defers status reads and stop until the prepare receipt arrives', async () => {
+  let resolvePrepare
+  const pendingPrepare = new Promise(resolve => { resolvePrepare = resolve })
+  const { fetchMock } = await setup(async url => {
+    if (url.endsWith('/prepare')) return pendingPrepare
+    return response(url.endsWith('advice-runtime') ? state() : job())
+  })
+  fireEvent.click(screen.getByLabelText(consent))
+  fireEvent.click(screen.getByRole('button', { name: 'Prepare private runtime' }))
+  await screen.findByText('Tracked setup: ' + id)
+  fireEvent.click(screen.getByRole('button', { name: 'Check setup' }))
+  const stop = screen.getByRole('button', { name: 'Stop setup' })
+  expect(stop).toBeDisabled()
+  fireEvent.click(stop)
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/status') || url.endsWith('/cancel'))).toHaveLength(0)
+  await act(async () => resolvePrepare(response(job())))
+  await screen.findByText('Setup: running')
+  expect(screen.getByRole('button', { name: 'Stop setup' })).toBeEnabled()
+  await waitFor(() => expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/status'))).toHaveLength(1))
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/prepare'))).toHaveLength(1)
+})
+
 it('reload adopts durable setup without automatically preparing again', async () => {
   const { fetchMock } = await setup(async url => response(url.endsWith('advice-runtime') ? { ...state(), job: job() } : job()))
   await screen.findByText('Setup: running')

--- a/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor, act } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../test/test-utils'
 import PixelAdviceRuntime from './PixelAdviceRuntime.jsx'
@@ -84,6 +84,31 @@ it('late stop reports completed publication without claiming rollback', async ()
   await screen.findByText('Runtime: ready on Tower2')
   expect(onReadyChange).toHaveBeenLastCalledWith(true)
   expect(screen.queryByText('Setup: cancelled')).not.toBeInTheDocument()
+})
+
+it.each(['running', 'error'])('ignores a stale %s status read after a completed stop receipt', async late => {
+  localStorage.setItem(storage, id)
+  let resolveStatus
+  let rejectStatus
+  const delayedStatus = new Promise((resolve, reject) => { resolveStatus = resolve; rejectStatus = reject })
+  const { fetchMock, onReadyChange } = await setup(async url => {
+    if (url.endsWith('/status')) return delayedStatus
+    if (url.endsWith('/cancel')) return response(job('completed'))
+    return response(state('ready'))
+  })
+  await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => url.endsWith('/status'))).toBe(true))
+  fireEvent.click(screen.getByRole('button', {name:'Stop setup'}))
+  fireEvent.click(screen.getByRole('button', {name:'Stop setup'}))
+  await screen.findByText('Setup: completed')
+  await act(async () => {
+    if (late === 'error') rejectStatus(new Error('Old read failed'))
+    else resolveStatus(response(job('running')))
+  })
+  expect(screen.getByText('Setup: completed')).toBeVisible()
+  expect(screen.queryByRole('button', {name:'Stop setup'})).toBeNull()
+  expect(onReadyChange).toHaveBeenLastCalledWith(true)
+  expect(screen.queryByRole('alert')).toBeNull()
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/cancel'))).toHaveLength(1)
 })
 
 it('unavailable venv shows operator remediation and cannot prepare', async () => {


### PR DESCRIPTION
## Why this matters
An advisory-runtime status poll can start before the operator clicks Stop and arrive after Stop reports completed publication. The old `running` receipt overwrites `completed`, restores the Stop button, and incorrectly resumes polling. A late failed read similarly replaces the known result with an uncertainty error.

Version status reads across setup mutations and ignore receipts/errors from earlier versions. Serialize Prepare/Stop writes through the existing in-flight guard and disable Stop while a mutation is awaiting its receipt. Polling resumes after that bounded request completes, including after an ambiguous failure; setup requests are never automatically replayed.

## Regression and validation
- Component regression first reproduced `Setup: completed` reverting to `Setup: running` after resolving a deferred poll. Two cases now verify stale running/error responses cannot replace a completed Stop receipt, and repeated Stop clicks issue exactly one cancel request.
- `npx vitest run src/components/PixelAdviceRuntime.test.jsx`: 10 passed, including follow-up `1a6dff1e` covering manual/automatic status reads and disabled Stop while Prepare is unresolved, followed by polling after its receipt.
- Full UI suite: 71 files / 663 passed; lint 0 errors (487 baseline warnings), build and diff checks passed. Changed-file pre-commit before push.
- Candidate `1a6dff1e` (production fix `eafc4c83` plus the regression follow-up); Windows/Node 24.14.1. The earlier 663-test full run precedes the added follow-up test; final combined validation below includes it. No live runtime installation performed. Shared root/WSL-sensitive local release-gate and existing secret-fixture caveats remain.
- An earlier hosted Python 3.12 inference job failed on the baseline router fixture race (409 expected, 503 observed). PR #4093 independently repairs and deterministically reproduces that fixture issue. GitHub denied manual rerun without upstream admin rights. The meaningful UI test follow-up also triggered a fresh complete CI run; final status is recorded below.

## Overlap check
Searched open and closed PRs for `advice runtime cancel` and `advice runtime status stale`; reviewed #3818 and the current beta inventory. No existing PR protects this component's job receipt ordering. Production file: `ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.jsx`; UI setup/stop -> host durable job -> status polling -> displayed state/readiness callback.

## Compatibility and rollback
PR 7/10, independent public-beta `8c3a60f7` base. The shared React component serves all browser platforms. Approval, job IDs, persisted recovery and backend job cancellation are preserved. Stop now waits for an outstanding Prepare/Stop HTTP request (existing 12-second timeout), rather than overlapping it. No migration; revert this commit to restore prior request ordering. No shared-file dependency on other batch changes; combined validation is recorded below.
## Final batch validation (2026-09-10)
- This PR's final candidate `1a6dff1e376db3c68931205bce706654d508bcb8`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.