### PR TITLE
fix(preview): declare UTF-8 for published text responses

### DIFF
--- a/ods/extensions/services/pixel-agent/host/workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/host/workspace_preview.py
@@ -497,6 +497,20 @@ def snapshot_changes(previews: pathlib.Path, site_id: str, before_id: str | None
                        "changes":changes}, separators=(",", ":")).encode()
 
 
+def _preview_content_type(target: pathlib.Path, body: bytes) -> str:
+    content_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
+    if target.suffix.lower() in {".md", ".markdown"}:
+        content_type = "text/plain"
+    if content_type.startswith("text/") or content_type == "application/javascript":
+        try:
+            body.decode("utf-8")
+        except UnicodeDecodeError:
+            # Preserve browser encoding detection for non-UTF-8 publications.
+            return content_type
+        return content_type + "; charset=utf-8"
+    return content_type
+
+
 class PreviewHandler(http.server.BaseHTTPRequestHandler):
     server_version = "ODSPreview"
     sys_version = ""
@@ -571,12 +585,7 @@ class PreviewHandler(http.server.BaseHTTPRequestHandler):
             self.send_error(404)
             return
         target, body = result
-        content_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
-        # Markdown is documentation, not executable content.  Force
-        # text/plain so browsers never attempt HTML rendering of .md files.
-        suffix = pathlib.PurePosixPath(target.name).suffix.lower()
-        if suffix in {".md", ".markdown"}:
-            content_type = "text/plain; charset=utf-8"
+        content_type = _preview_content_type(target, body)
         self.send_response(200)
         self.send_header("Content-Type", content_type)
         self.send_header("Content-Length", str(len(body)))

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview_charset.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview_charset.py
@@ -1,0 +1,51 @@
+import http.client
+import hashlib
+import importlib.util
+import os
+import pathlib
+import tempfile
+import threading
+
+
+MODULE_PATH = pathlib.Path(__file__).parents[1] / "host" / "workspace_preview.py"
+SPEC = importlib.util.spec_from_file_location("workspace_preview", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(MODULE)
+
+
+def test_preview_http_declares_utf8_for_published_text_without_rewriting_bytes():
+    with tempfile.TemporaryDirectory() as temporary:
+        root = pathlib.Path(temporary)
+        workspace, previews = root / "workspace", root / "previews"
+        workspace.mkdir(mode=0o700)
+        previews.mkdir(mode=0o700)
+        site = workspace / "demo"
+        site.mkdir(mode=0o700)
+        content = {"index.html": "<h1>Tiếng Việt — 日本語</h1>".encode("utf-8"),
+                   "style.css": 'h1::after { content: "café"; }'.encode("utf-8"),
+                   "app.js": 'const message = "Olá";'.encode("utf-8"),
+                   "image.png": b"\x89PNG\r\n\x1a\n",
+                   "legacy.html": b'<meta charset="windows-1252"><p>caf\xe9</p>'}
+        for name, data in content.items():
+            (site / name).write_bytes(data)
+            (site / name).chmod(0o600)
+        receipt = MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+        with MODULE.PreviewHTTPServer(("127.0.0.1", 0), previews) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            try:
+                for name, data in content.items():
+                    connection = http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)
+                    connection.request("GET", f"/{receipt['siteId']}/{name}",
+                                       headers={"Host": f"{receipt['siteId']}.localhost:{server.server_port}"})
+                    response = connection.getresponse()
+                    assert response.status == 200
+                    expected_charset = None if name in {"image.png", "legacy.html"} else "utf-8"
+                    assert response.headers.get_content_charset() == expected_charset
+                    assert response.read() == data
+                    assert response.headers["X-Preview-SHA256"] == hashlib.sha256(data).hexdigest()
+                    connection.close()
+            finally:
+                server.shutdown()
+                thread.join(timeout=5)


### PR DESCRIPTION
## Why this matters
Pixel can publish UTF-8 HTML without an inline charset declaration, including `<h1>Tiếng Việt — 日本語</h1>`. The preview server sent bare `text/html`, leaving browsers to guess an encoding and allowing non-ASCII content to display incorrectly. Published CSS and classic JavaScript also lacked encoding metadata.

Declare UTF-8 for valid UTF-8 text and JavaScript responses. Preserve non-UTF-8 publications' encoding detection, keep binary MIME types untouched, and continue serving Markdown as inert plain text. The response bytes and SHA-256 are unchanged; this is response metadata, not source rewriting.

## Regression and validation
- Real HTTP publication/serving test covers HTML without meta charset, CSS, JavaScript, PNG, and legacy windows-1252 HTML. Before the fix, the Unicode HTML response has no declared charset; after the fix it declares UTF-8. Every response retains exact published bytes and digest.
- Ubuntu/WSL Python 3.14: `python -m pytest ods/extensions/services/pixel-agent/tests/test_workspace_preview.py ods/extensions/services/pixel-agent/tests/test_workspace_preview_charset.py -q`: **11 passed**.
- Diff and changed-file pre-commit checks passed. No live browser/Pixel end-to-end or installation upgrade run; shared local release-gate limitations remain for root/WSL-sensitive fixtures and existing private-key fixtures.

## Overlap check
Searched open/closed PRs for `preview charset`, inspected current beta preview changes and #3385/#4027's `workspace_preview.py`. No existing PR fixes this HTTP charset omission. Reachable path: Pixel publishes static files -> PreviewHandler `_send` -> TCP/Unix relay -> embedded browser preview.

## Compatibility and rollback
PR 8/10, independently based on public-beta `8c3a60f7`. Linux-host HTTP tests cover serving used by all browser clients; native macOS/Windows Pixel host setup is not qualified here. JSON content type stays unchanged. Revert the commit to restore prior headers. This and #4083 touch separate functions of the same module and use separate regression test locations; both merge orders and the full combined preview suite passed, as recorded below.
## Final batch validation (2026-09-10)
- This PR's final candidate `b1cefa187759c1f759310b8a4cd70e39117db664`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.