### PR TITLE
fix(dashboard-api): add zero division guard for model decode read throughput

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -924,6 +924,8 @@ def _predicted_from_calibration(model: dict[str, Any], metadata: dict[str, Any],
     if calibration_mb <= 0:
         return None
     target_mb = _model_decode_mb(model, metadata)
+    if target_mb <= 0:
+        return None
     predicted = max(base_tps * (calibration_mb / target_mb), 1.0)
     if not is_plausible_single_request_tps(predicted):
         return None


### PR DESCRIPTION
### 1. Error
**Observed Failure**: Performance oracle model throughput prediction raised `ZeroDivisionError: float division by zero` when evaluating models configured with `0` decode bandwidth.
**Reproduction Steps**:
1. Pass model metadata where `decode_read_mb` evaluates to `0.0`.
2. Invoke `_predicted_from_calibration(model, metadata, calibration_mb, base_tps)`.
3. Exception `ZeroDivisionError` is raised.
**Environment Specificity**: Dashboard API performance oracle module.

### 2. Root Cause
In `ods/extensions/services/dashboard-api/performance_oracle.py:L926`, `_predicted_from_calibration` calculated `predicted = max(base_tps * (calibration_mb / target_mb), 1.0)` directly after obtaining `target_mb = _model_decode_mb(model, metadata)` without verifying `target_mb > 0`.

### 3. Fix
Added an explicit `if target_mb <= 0: return None` boundary check before the floating point division, returning `None` gracefully for models with invalid or missing decode bandwidth telemetry.

### 4. Proof of Resolution
**BEFORE (Failing)**:
```text
ZeroDivisionError: float division by zero
  File "performance_oracle.py", line 926, in _predicted_from_calibration
    predicted = max(base_tps * (calibration_mb / target_mb), 1.0)
```

**AFTER (Passing)**:
```text
ods/extensions/services/dashboard-api/tests/test_performance_oracle.py ................................................... [100%]
================ 53 passed in 2.46s ================
```
