### PR TITLE
fix(privacy-shield): add non-string type guards in pii detector scrub and restore

### DIFF
--- a/ods/extensions/services/privacy-shield/pii_scrubber.py
+++ b/ods/extensions/services/privacy-shield/pii_scrubber.py
@@ -75,6 +75,8 @@ class PIIDetector:
         Scrub PII from text, replace with tokens.
         Returns scrubbed text.
         """
+        if not isinstance(text, str):
+            return ""
         scrubbed = text
 
         for pii_type, pattern in self.PATTERNS.items():
@@ -109,6 +111,8 @@ class PIIDetector:
         Restore PII from tokens in text.
         Returns restored text.
         """
+        if not isinstance(text, str):
+            return ""
         restored = text
         for token, original in self.pii_map.items():
             restored = restored.replace(token, original)


### PR DESCRIPTION
### 1. Error
**Observed Failure**: Passing `None` or non-string object types to `PIIDetector.scrub()` or `PIIDetector.restore()` raised unhandled `TypeError` or `AttributeError` exceptions.
**Reproduction Steps**:
1. Instantiate `detector = PIIDetector()`.
2. Call `detector.scrub(None)` or `detector.restore(12345)`.
3. Exception `TypeError: expected string or bytes-like object` is raised.
**Environment Specificity**: Privacy Shield PII scrubber component.

### 2. Root Cause
In `ods/extensions/services/privacy-shield/pii_scrubber.py:L73, L107`, `scrub()` and `restore()` performed regex matching (`pattern.findall(scrubbed)`) and string replacement (`restored.replace(...)`) directly on input argument `text` without validating `isinstance(text, str)`.

### 3. Fix
Added defensive `if not isinstance(text, str): return ""` input validation guards at the entry of both `scrub()` and `restore()` methods to safely prevent exception propagation.

### 4. Proof of Resolution
**BEFORE (Failing)**:
```text
TypeError: expected string or bytes-like object, got 'NoneType'
  File "pii_scrubber.py", line 81, in scrub
    matches = pattern.findall(scrubbed)
```

**AFTER (Passing)**:
```text
ods/extensions/services/privacy-shield/tests/test_pii_scrubber.py ............................. [100%]
============================== 29 passed in 0.04s ==============================
```
