### PR TITLE
fix(preview): cancel unread bodies rejected by artifact checks

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
@@ -30,3 +30,20 @@ it('rejects arbitrary source destinations before fetching', async () => {
   expect(await screen.findByRole('alert')).toBeVisible()
   expect(fetch).not.toHaveBeenCalled()
 })
+
+it.each(['oversized', 'failed'])('cancels an unread %s response when source verification rejects it', async reason => {
+  const cancel = vi.fn().mockResolvedValue(undefined)
+  const getReader = vi.fn()
+  const arrayBuffer = vi.fn()
+  vi.stubGlobal('fetch', vi.fn(async () => ({
+    ok: reason !== 'failed',
+    headers: new globalThis.Headers({'Content-Length': String(reason === 'oversized' ? 4 * 1024 * 1024 + 1 : 512)}),
+    body: {cancel, getReader}, arrayBuffer,
+  })))
+  render(<PixelPreviewSource preview={preview}/>)
+  expect(await screen.findByRole('alert')).toHaveTextContent('could not be verified')
+  expect(cancel).toHaveBeenCalledOnce()
+  expect(getReader).not.toHaveBeenCalled()
+  expect(arrayBuffer).not.toHaveBeenCalled()
+  expect(screen.getByRole('button',{name:'Copy code'})).toBeDisabled()
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
@@ -5,7 +5,11 @@ export const isArtifactPath = value => typeof value === 'string' && value.length
   && value.split('/').every(part => /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(part))
 
 export async function readBoundedBytes(response, maximum) {
-  if (!response.ok || Number(response.headers?.get('Content-Length')) > maximum) throw new Error('Unavailable artifact')
+  if (!response.ok || Number(response.headers?.get('Content-Length')) > maximum) {
+    // Rejecting headers must also release the unread network response.
+    await response.body?.cancel()
+    throw new Error('Unavailable artifact')
+  }
   if (!response.body?.getReader) {
     const data = await response.arrayBuffer()
     if (data.byteLength > maximum) throw new Error('Oversized artifact')


### PR DESCRIPTION
## Why this matters
Opening a Pixel source/file artifact starts a fetch with a deadline. When the HTTP status is unsuccessful or Content-Length exceeds the permitted size, the reader rejects before consuming the response. Its caller then clears the deadline, leaving the unread response body without an explicit cancellation. Cancel that body before reporting the existing unavailable-artifact error.

The invariant is that rejecting an artifact at the header boundary releases its unread response and never reads or offers its content for copying. Successful bounded reads retain their existing behavior.

## Regression and validation
- Rendered PixelPreviewSource tests cover oversized and unsuccessful fetch responses, asserting body cancellation exactly once, no reader/arrayBuffer use, and no enabled Copy action. Both failed before the fix because cancel was never called.
- Focused PixelPreviewSource/PixelTaskFiles suite: **13 passed**. Full dashboard suite: **663 passed**. ESLint: zero errors (487 existing warnings); production build and changed-file pre-commit checks passed.
- Candidate: `711a7b04`, independently based on public-beta `8c3a60f7`. No live Pixel/browser installation end-to-end run. The shared local release gate has root/WSL-sensitive fixture failures and existing private-key test fixtures; these are not claimed green.

## Overlap check
Searched open and closed upstream PRs for `artifact cancel` and `preview response cancel`; reviewed related #3385, #3818, and #3312 and the changed `pixelArtifacts.js` production readers. Their artifact verification/bounding work does not cancel these unread header-rejected bodies. This is independent of the preview server newline and charset fixes in this batch.

## Compatibility and rollback
PR 9/10. The shared browser reader serves the source, task-file, and file-change artifact views on every client platform. Revert this commit to restore the previous rejection path. No persisted state or API schema changes. Combined-batch validation is recorded below.
## Final batch validation (2026-09-10)
- This PR's final candidate `711a7b0409b0a06c96512b5fb0baf6e7bfd96375`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.