### PR TITLE
test(router): publish fixture state atomically for concurrent readers

### DIFF
--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -93,7 +93,11 @@ def router(tmp_path, monkeypatch):
         doc["seq"] = route_seq if seq is None else seq
         if mutate:
             mutate(doc)
-        state_path.write_text(json.dumps(doc), encoding="utf-8")
+        # Match Switchboard's publication boundary so concurrent requests never
+        # observe the destination between truncation and a completed write.
+        staged = state_path.with_name(f".{state_path.name}.{uuid.uuid4().hex}.tmp")
+        staged.write_text(json.dumps(doc), encoding="utf-8")
+        staged.replace(state_path)
         mod._state_cache["mtime"] = None
 
     client = TestClient(mod.app)

--- a/ods/extensions/services/model-router/tests/test_state_publication_fixture.py
+++ b/ods/extensions/services/model-router/tests/test_state_publication_fixture.py
@@ -1,0 +1,32 @@
+"""The concurrent router fixture must publish complete state like Switchboard."""
+
+from pathlib import Path
+
+from test_router import router  # noqa: F401
+
+
+def test_requests_keep_the_previous_route_while_fixture_writes_replacement(router, monkeypatch):
+    mod, client, write_state, calls = router
+    write_state()
+    responses = []
+    original_write = Path.write_text
+
+    def observe_during_write(path, data, **kwargs):
+        if path.parent != mod.STATE_PATH.parent:
+            return original_write(path, data, **kwargs)
+        # Deterministically exercise the truncate/write window seen in CI.
+        with path.open("w", **kwargs) as handle:
+            responses.append(client.post("/v1/chat/completions", json={
+                "model": "ods/current", "messages": [{"role": "user", "content": "synthetic"}],
+            }))
+            return handle.write(data)
+
+    monkeypatch.setattr(Path, "write_text", observe_during_write)
+    write_state(runtime="Replacement.gguf", route_seq=8)
+    assert [response.status_code for response in responses] == [200]
+    assert [call["model"] for call in calls] == ["Concrete.gguf"]
+    response = client.post("/v1/chat/completions", json={
+        "model": "ods/current", "messages": [{"role": "user", "content": "synthetic"}],
+    })
+    assert response.status_code == 200
+    assert [call["model"] for call in calls] == ["Concrete.gguf", "Replacement.gguf"]


### PR DESCRIPTION
## Why this matters
The public-beta Pixel inference CI failed in `test_queued_pin_cannot_run_on_replacement_model`: a request expected to reject an obsolete pin with HTTP 409 instead returned HTTP 503. [Observed Python 3.12 failure](https://github.com/Osmantic/ODS/actions/runs/34435752813/job/102740341914).

The model-router fixture publishes state with write_text directly to STATE_PATH. A concurrent HTTP request can read the file after truncation but before the completed write, unlike Switchboard's production atomic replacement boundary. Publish fixture documents through a unique temporary sibling and replace the destination atomically. Keep support for deliberately malformed fixture documents and preserve the existing queued-pin 409 assertion.

## Regression and validation
- A deterministic regression pauses publication immediately after its write target is opened and issues a real TestClient chat request. Before this fix it returns **503**; afterwards it returns **200** using the complete old model, followed by **200** using the replacement model after publication.
- Ubuntu/WSL Python 3.14: `python -m pytest ods/extensions/services/model-router/tests -q --disable-warnings`: **74 passed**.
- Changed-file pre-commit and diff checks passed. Candidate: `0b360152`, based independently on public-beta `8c3a60f7`.
- This is a test-fixture race repair grounded in a measured release-check failure. It does not change production router or Switchboard behavior, and does not claim live inference/hardware validation. The unrelated shared root/WSL release-gate and pre-existing private-key-fixture limitations remain.

## Overlap check
Searched open/closed upstream PRs for `model-router atomic fixture`, `queued pin`, and `test_shared_route_pinning`; inspected #3385, #1914, and #1776 and current `tests/test_router.py`. Those introduce/extend routing contracts or branding; none repairs the fixture's non-atomic publication. Production contract reference: `ods/bin/model_switchboard/state.py:atomic_write_state`; the fixture intentionally cannot call its validation because some tests publish invalid documents.

## Compatibility and rollback
PR 10/10. No production file or persisted production format changes. Atomic replacement uses a sibling in the same temporary directory and unique names for concurrent publishers. Prefer merging this fixture repair before rerunning other beta inference checks. The functional fixes in this batch are otherwise independently applicable; combined validation is recorded below. Revert this commit to restore the previous fixture implementation.
## Final batch validation (2026-09-10)
- This PR's final candidate `0b360152592be478d61405e9258ff5d42cebfc17`: **32 hosted checks passed, 4 workflow-skipped, zero failed/pending**. All ten batch PRs reached this result; skipped jobs were not disabled by this work.
- Synthetic integration `00fca48d4bb35afe59f718bcc529887c99da1063` combines #4078, #4079, #4080, #4081, #4083, #4084 (including `1a6dff1e`), #4085, #4092, and #4093 on public-beta `8c3a60f7`. #4066's fix is already adopted in that base. All nine new branches applied without conflicts.
- Combined Windows/Node 24.14.1 dashboard: **672 tests / 71 files passed**, ESLint **0 errors / 487 existing warnings**, production build passed. Ubuntu/WSL Python 3.14: **86 passed** (12 HTTP preview tests + 74 model-router tests). Changed-file pre-commit and diff checks passed.
- Shared-module pair #4083/#4085 merges in either order to identical tree `d12a41c9044881ac76d2805f3b83c2eddc1c11c0`; the combined HTTP suite covers both fixes. Prefer #4093 first to eliminate the baseline CI fixture race, then the independent functional fixes in any order. No upstream merge was performed.
- Exact-integration native Linux clone: smoke contracts for Linux AMD/NVIDIA, WSL and macOS plus installer simulation passed. `make gate` remains locally red on two sudo assertions, reproduced on untouched `8c3a60f7`; BATS is **416/421**, with five root/WSL/low-disk environment failures in unchanged paths. Full-repo pre-commit passes gitleaks, large files and ShellCheck, but flags unchanged private-key test fixtures and lacks Windows `awk`. These are explicit validation gaps, not passing release gates.
- No live installation upgrade, Pixel runtime provisioning, hardware inference qualification, or browser end-to-end run. The integration SHA is a local compatibility receipt, not a hosted-CI or deployment receipt.