### PR TITLE
fix(dashboard-api): add nested dictionary deep get bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1146,3 +1146,22 @@ def get_ram_metrics() -> dict:
     elif _system == "Darwin":
         return _get_ram_metrics_sysctl()
     return {"used_gb": 0, "total_gb": 0, "percent": 0}
+
+
+def dict_deep_get_safe(d: dict | None, keys: list | str, default: any = None) -> any:
+    """Safely retrieve nested dictionary value using list of keys or dot-separated string.
+    Returns default on missing keys or non-dict nodes.
+    """
+    if not isinstance(d, dict) or d is None:
+        return default
+    if isinstance(keys, str):
+        keys = [k.strip() for k in keys.split(".") if k.strip()]
+    if not isinstance(keys, (list, tuple)) or not keys:
+        return default
+    curr = d
+    for k in keys:
+        if not isinstance(curr, dict) or k not in curr:
+            return default
+        curr = curr[k]
+    return curr
+

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1607,3 +1607,18 @@ class TestDirSizeGb:
         # Verify older items were evicted
         first_path = tmp_path / "test_dir_0"
         assert _dir_size_cache.get(first_path) is None
+
+
+class TestDictDeepGetSafe:
+    def test_valid_deep_get(self):
+        from helpers import dict_deep_get_safe
+        data = {"a": {"b": {"c": 42}}}
+        assert dict_deep_get_safe(data, ["a", "b", "c"]) == 42
+        assert dict_deep_get_safe(data, "a.b.c") == 42
+
+    def test_invalid_inputs(self):
+        from helpers import dict_deep_get_safe
+        assert dict_deep_get_safe(None, "a.b") is None
+        assert dict_deep_get_safe({"a": 1}, "a.b", default="fallback") == "fallback"
+        assert dict_deep_get_safe("not dict", "a.b") is None
+


### PR DESCRIPTION
### Summary
Adds `dict_deep_get_safe` in `ods/extensions/services/dashboard-api/helpers.py` to securely perform multi-level nested key lookups in dictionary hierarchies.

### Problem Addressed
Traversing nested configuration objects (e.g. `config[agents][settings][timeout]`) throws `KeyError` or `AttributeError` if intermediate keys are missing or contain non-dictionary values (like `None` or `list`).

### Key Changes
- **Safe Path Traversal**: Accepts dot-separated string paths (e.g. `"agents.settings.timeout"`) or key lists/tuples.
- **Type Auditing**: Verifies that each intermediate node is a dictionary before attempting child key resolution.
- **Default Fallback**: Instantly returns specified `default` value without raising exceptions when key paths are broken.

### Verification
- Added `TestDictDeepGetSafe` in `ods/extensions/services/dashboard-api/tests/test_helpers.py`.
- Tested with deep nested dicts, non-existent key paths, scalar intermediate nodes, and custom defaults using `pytest`.