### PR TITLE
fix(advice): preserve terminal job receipts across stale polls

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
@@ -29,6 +29,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
   const [submitting, setSubmitting] = useState(false)
   const inFlight = useRef(false)
   const polling = useRef(false)
+  const jobVersion = useRef(0)
   const controllers = useRef(new Set())
   const panel = useRef(null)
   const trigger = useRef(null)
@@ -83,14 +84,15 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
   }
 
   const inspect = useCallback(async () => {
-    if (!jobId || polling.current) return
+    if (!jobId || polling.current || inFlight.current) return
     polling.current = true
+    const version = jobVersion.current
     try {
       const value = await request('/api/pixel/advice/status', { jobId })
       if (value.jobId !== jobId || !['running', 'cancelling', ...terminal].includes(value.status)) throw new Error('Invalid job')
-      if (trackedId.current !== jobId) return
+      if (trackedId.current !== jobId || version !== jobVersion.current) return
       setJob(value); setError('')
-    } catch { if (trackedId.current === jobId) setError('Job status is unknown. Check this job before starting another; a call may have occurred.') }
+    } catch { if (trackedId.current === jobId && version === jobVersion.current) setError('Job status is unknown. Check this job before starting another; a call may have occurred.') }
     finally { polling.current = false }
   }, [jobId, request])
 
@@ -106,6 +108,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
       || new TextEncoder().encode(capsule).length > 16384 || capsule.includes('\0')
       || (advisor.kind === 'cloud' && (!cloud || !cost))) return
     inFlight.current = true; setSubmitting(true); setError('')
+    jobVersion.current++
     let id
     try {
       id = crypto.randomUUID()
@@ -131,13 +134,15 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
   }
 
   async function stop() {
-    if (!jobId) return
+    if (!jobId || inFlight.current) return
+    inFlight.current = true; setSubmitting(true); jobVersion.current++
     try {
       const value = await request('/api/pixel/advice/cancel', { jobId })
       if (value.jobId !== jobId) throw new Error('Invalid job')
       if (trackedId.current !== jobId) return
       setJob(value); setError('')
     } catch { if (trackedId.current === jobId) setError('Stop is not confirmed. Keep this job ID and check again.') }
+    finally { inFlight.current = false; setSubmitting(false) }
   }
 
   function forget() {
@@ -161,7 +166,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
           {job && <p className="text-sm">Configured advisor: {job.providerLabel} · {job.model} · revision {job.revision}. Cost: unknown.</p>}
           <div className="flex flex-wrap gap-2">
             <button className={button} onClick={inspect}>Check job</button>
-            {!terminal.has(job?.status) && <button className={button} onClick={stop}>Stop advice</button>}
+            {!terminal.has(job?.status) && <button className={button} disabled={submitting} onClick={stop}>Stop advice</button>}
             {(terminal.has(job?.status) || error) && <button className={button} disabled={submitting} onClick={forget}>Forget tracking (does not stop the request)</button>}
           </div>
           <p className="text-xs">Closing this panel does not cancel the request. Stop is separate. An interrupted job is never replayed automatically; a new request may incur another charge.</p>

--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../test/test-utils'
 import PixelAdvice from './PixelAdvice.jsx'
@@ -89,6 +89,41 @@ it('reload recovers only opaque ID, checks status and can stop an active job', a
   fireEvent.click(screen.getByRole('button', { name: 'Stop advice' }))
   await screen.findByText('Advice: cancelled')
   expect(fetchMock.mock.calls.find(([url]) => url.endsWith('/cancel'))[1].body).toBe(JSON.stringify({ jobId: id }))
+})
+
+it.each(['running', 'error'])('preserves completed advice when a stale %s poll settles after Stop', async late => {
+  localStorage.setItem(key, id)
+  let resolvePoll, rejectPoll
+  const poll = new Promise((resolve, reject) => { resolvePoll = resolve; rejectPoll = reject })
+  const { fetchMock } = await setup({ post: async url => url.endsWith('/status') ? poll : response(job()) })
+  await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => url.endsWith('/status'))).toBe(true))
+  fireEvent.click(screen.getByRole('button', { name: 'Stop advice' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Stop advice' }))
+  await screen.findByText('Advice: completed')
+  await act(async () => {
+    if (late === 'error') rejectPoll(new Error('Old status failed'))
+    else resolvePoll(response(job('running')))
+  })
+  expect(screen.getByText('Advice: completed')).toBeVisible()
+  expect(screen.getByText('<img src=x onerror=alert(1)> Advice')).toBeVisible()
+  expect(screen.queryByRole('alert')).toBeNull()
+  expect(screen.queryByRole('button', { name: 'Stop advice' })).toBeNull()
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/cancel'))).toHaveLength(1)
+})
+
+it('does not poll or stop a request before its start receipt arrives', async () => {
+  let resolveStart
+  const pending = new Promise(resolve => { resolveStart = resolve })
+  const { fetchMock } = await setup({ post: async url => url.endsWith('/start') ? pending : response(job('running')) })
+  fireEvent.change(screen.getByLabelText('Capsule to send'), { target: { value: 'Review this' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Send reviewed capsule' }))
+  await screen.findByRole('button', { name: 'Check job' })
+  fireEvent.click(screen.getByRole('button', { name: 'Check job' }))
+  expect(screen.getByRole('button', { name: 'Stop advice' })).toBeDisabled()
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/status'))).toHaveLength(0)
+  await act(async () => resolveStart(response(job('running'))))
+  await screen.findByText('Advice: running')
+  expect(screen.getByRole('button', { name: 'Stop advice' })).toBeEnabled()
 })
 
 it('closing panel does not start, stop, or change the chat', async () => {


### PR DESCRIPTION
## Why this matters
In Ask for advice, a status request can return after Stop reports a completed advisory answer. Its older running response removes that answer and restores Stop; an older failed response reports uncertainty over a known result. Start also publishes the tracked ID before its receipt arrives, allowing polling and Stop to race the start.

Serialize advisory Start/Stop through the existing in-flight guard and version status reads across mutations. Ignore obsolete results/errors, retain the completed answer, and never automatically replay a potentially billable start. The existing 12-second request deadline bounds the UI wait; backend cancellation and approvals remain unchanged.

## Regression and validation
- Three rendered-component regressions fail on public-beta `31063fcb`: stale running/error after a completed Stop and an enabled Stop before Start returns. After the fix, all **10 PixelAdvice tests pass**, including duplicate Stop suppression and preserved answer text.
- Full dashboard: **668 tests / 71 files passed**; ESLint **0 errors, 488 existing warnings**; production build, changed-file pre-commit and diff checks passed. Windows, Node 24.14.1.
- Candidate `914bdd0149668e0aff141c1d068b18d16ae69731`. No live advisor call or billing test. Shared local root/WSL sudo/BATS and pre-existing private-key-fixture/Windows-awk release-gate limitations remain; combined batch validation is recorded below.

## Overlap check
Searched open/closed upstream PRs for `advice stale`, `advice cancel`, and reviewed #3818's files plus #4084. #4084 changes PixelAdviceRuntime (private Python runtime installation); this PR changes PixelAdvice (bounded advisor inference jobs) and its separate `/api/pixel/advice/{start,status,cancel}` lifecycle. Neither branch repairs the other's production consumer; no shared files. This is not a replacement for #4084.

## Compatibility and rollback
Round 2, PR 1/10; independent public-beta `31063fcb` base. Shared browser code on all client platforms. Opaque persisted job IDs, explicit capsule/cloud/cost consent, result insertion, and ambiguous-start recovery remain intact. Revert this commit to restore previous UI ordering. No migrations or server changes; no merge performed.


## Final batch validation (2026-09-10)
Candidate SHA: 914bdd0149668e0aff141c1d068b18d16ae69731. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
