### PR TITLE
fix(diagnostics): distinguish loaded models from configured metadata

### DIFF
--- a/ods/extensions/services/dashboard/src/components/settings/PixelDiagnostics.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelDiagnostics.jsx
@@ -23,11 +23,13 @@ export function summarizeCheck(id, data) {
     }
   }
   if (id === 'model') {
-    const name = text(data.inference?.loadedModel) || text(data.model?.name)
     if (!('inference' in data) && !('model' in data)) throw new Error('Invalid status')
+    // Modern status separates loaded runtime telemetry from configured metadata.
+    const runtime = 'inference' in data
+    const name = text(runtime ? data.inference?.loadedModel : data.model?.name)
     return { state: name ? 'Reported by ODS' : 'Not loaded', ok: Boolean(name),
       detail: 'Local model telemetry. A remote Pixel route may use a different model.',
-      rows: [['Local model', name || 'Not reported'], ['Context window', context(data.inference?.contextSize ?? data.model?.contextLength)]],
+      rows: [['Local model', name || 'Not reported'], ['Context window', context(runtime ? data.inference?.contextSize : data.model?.contextLength)]],
     }
   }
   if (typeof data.available !== 'boolean') throw new Error('Invalid status')

--- a/ods/extensions/services/dashboard/src/components/settings/PixelDiagnostics.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelDiagnostics.test.jsx
@@ -19,6 +19,27 @@ it('reports each real check independently and only performs reads', async () => 
   for (const [,options] of fetch.mock.calls) expect(options.method).toBeUndefined()
   expect(screen.getByRole('link', {name:'Access settings'})).toHaveAttribute('href','/settings?section=access')
 })
+it.each([null, ''])('does not substitute configured metadata for an unloaded runtime (%s)', async loadedModel => {
+  vi.stubGlobal('fetch', vi.fn(async path => path === '/api/status'
+    ? ok({ inference: { loadedModel, contextSize: null }, model: { name: 'Configured-only.gguf', contextLength: 65536 } })
+    : ok({ available: true })))
+  show()
+  const region = screen.getByRole('region', { name: 'ODS model' })
+  expect(await within(region).findByText('Not loaded')).toBeVisible()
+  expect(within(region).queryByText('Configured-only.gguf')).toBeNull()
+  expect(within(region).queryByText(`${(65536).toLocaleString()} tokens`)).toBeNull()
+  expect(within(region).getAllByText('Not reported')).toHaveLength(2)
+})
+
+it('retains legacy model telemetry when the response has no inference section', async () => {
+  vi.stubGlobal('fetch', vi.fn(async path => path === '/api/status'
+    ? ok({ model: { name: 'Legacy.gguf', contextLength: 32768 } }) : ok({ available: true })))
+  show()
+  const region = screen.getByRole('region', { name: 'ODS model' })
+  expect(await within(region).findByText('Legacy.gguf')).toBeVisible()
+  expect(within(region).getByText(`${(32768).toLocaleString()} tokens`)).toBeVisible()
+})
+
 it('clears stale success on refresh and allows retry after errors', async () => {
   const fetch = vi.fn(async path => path === '/api/status' ? ok({model:null}) : ok({available:true}))
   vi.stubGlobal('fetch', fetch)


### PR DESCRIPTION
## Why this matters
Pixel Diagnostics reports a configured model as loaded when `/api/status` contains `inference.loadedModel: null` together with `model.name`. It also substitutes the configured context length for an unknown runtime context. Operators can therefore see a positive model diagnostic while no model is loaded.

Use the inference section exclusively when present; retain the model-only interpretation for legacy responses. The producer in dashboard-api/main.py separates configured model metadata from runtime `loadedModel`/`contextSize`. A null or empty runtime value must remain unknown, not become a configured success.

## Regression and validation
- Rendered diagnostics fetching realistic modern status responses reproduces the false success for null and empty loadedModel. Both now display Not loaded and omit the configured name/context. A legacy model-only response remains supported.
- **7 focused PixelDiagnostics tests passed**, targeted ESLint zero errors, changed-file pre-commit and diff checks passed. Windows/Node 24.14.1; baseline full dashboard has 665 passing tests. Combined batch results are recorded below.
- No live model activation or hardware diagnosis performed. Shared local root/WSL sudo/BATS and pre-existing private-key-fixture/Windows-awk release-gate limitations are not claimed green.

## Overlap check
Searched open/closed PRs for `PixelDiagnostics`, `diagnostics model`, and examined the current beta inventory and founding #3818 file list. No existing PR fixes the configured-versus-runtime precedence in this component. Changed production file: dashboard/src/components/settings/PixelDiagnostics.jsx; public boundary: diagnostics page GET `/api/status` and displayed model/context.

## Compatibility and rollback
Round 2, PR 2/10, independent public-beta `31063fcb` base. Read-only UI correction shared by Linux, Windows and macOS clients; no controller, configuration or runtime mutation. Revert this commit to restore previous display behavior. No dependencies on other batch fixes.


## Final batch validation (2026-09-10)
Candidate SHA: f162a4712e1be03215d0305cb5f0b6672c150501. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
