### PR TITLE
fix(access): keep inspection and mutation receipts truthful

### DIFF
--- a/ods/extensions/services/dashboard/src/components/settings/PixelAccessCard.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelAccessCard.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 const modeName = mode => mode === 'full-access' ? 'Full Access' : mode === 'sandboxed' ? 'Safer mode' : 'Not verified'
 
@@ -8,17 +8,25 @@ export default function PixelAccessCard({ showHeading = true }) {
   const [changing, setChanging] = useState(false)
   const [confirming, setConfirming] = useState(false)
   const [confirmed, setConfirmed] = useState(false)
-  const refresh = useCallback(async () => {
+  const [stale, setStale] = useState(true)
+  const inspection = useRef(0)
+  const mutation = useRef(false)
+  const refresh = useCallback(async ({forChange = false, preserveError = false} = {}) => {
+    if (mutation.current && !forChange) return
+    const version = ++inspection.current
+    setStale(true)
     try {
       const response = await fetch('/api/pixel/access-mode')
       if (!response.ok) throw new Error()
       const value = await response.json()
+      if (version !== inspection.current) return
       setStatus(value)
-      setError('')
+      setStale(false)
+      if (!preserveError) setError('')
       return value
-    } catch { setError('Pixel access status is unavailable. No effective mode has been verified.') }
+    } catch { if (version === inspection.current) setError('Pixel access status is unavailable. No effective mode has been verified.') }
   }, [])
-  useEffect(() => { void refresh() }, [refresh])
+  useEffect(() => { void refresh(); return () => { inspection.current++ } }, [refresh])
   useEffect(() => {
     if (!status?.pending && !status?.busy) return undefined
     const timer = setInterval(() => { void refresh() }, 5000)
@@ -26,12 +34,13 @@ export default function PixelAccessCard({ showHeading = true }) {
   }, [status?.pending, status?.busy, refresh])
 
   async function change(mode) {
-    if (!status?.revision || changing || (mode === 'full-access' && !confirmed)) return
+    if (!status?.revision || stale || mutation.current || (mode === 'full-access' && !confirmed)) return
+    mutation.current = true
     setChanging(true); setError('')
     try {
       // Runs can change the inspection revision while Settings remains open.
       // The host still checks this revision atomically before changing access.
-      const current = await refresh()
+      const current = await refresh({forChange: true})
       if (!current?.available || !current?.revision) {
         setError('Current access status could not be verified. No change was requested. Refresh the status before trying again.')
         return
@@ -46,11 +55,11 @@ export default function PixelAccessCard({ showHeading = true }) {
       setStatus(await response.json()); setConfirming(false); setConfirmed(false)
     } catch {
       setError('The change was not verified. Refresh the status and restore safer mode if recovery is required.')
-      await refresh()
-    } finally { setChanging(false) }
+      await refresh({forChange: true, preserveError: true})
+    } finally { mutation.current = false; setChanging(false) }
   }
 
-  const disabled = changing || !status?.available || status?.busy || !status?.revision
+  const disabled = changing || stale || !status?.available || status?.busy || !status?.revision
   return <section aria-labelledby="pixel-access-title" className="rounded-xl border border-white/10 bg-white/[0.03] p-5 space-y-3">
     <div className="flex items-center justify-between gap-4">
       <h2 id="pixel-access-title" className={showHeading ? 'font-semibold' : 'sr-only'}>Pixel access</h2>
@@ -60,7 +69,7 @@ export default function PixelAccessCard({ showHeading = true }) {
     <p className="text-sm text-gray-400">Full Access keeps the owner’s UID and existing group permissions, privilege restrictions, and protected program files. Existing owner permissions may include service administration. Current support: Linux or WSL with systemd.</p>
     {status ? <dl className="grid grid-cols-2 gap-2 text-sm">
       <dt>Configured</dt><dd>{modeName(status.configured_mode)}</dd>
-      <dt>Effective</dt><dd>{status.runtime_verified ? modeName(status.effective_mode) : 'Not verified'}</dd>
+      <dt>Effective</dt><dd>{!stale && status.runtime_verified ? modeName(status.effective_mode) : 'Not verified'}</dd>
       <dt>Platform</dt><dd>{status.surface}</dd>
     </dl> : !error ? <p role="status">Inspecting Pixel access…</p> : null}
     {!status?.available && status ? <p role="status">{status.pending

--- a/ods/extensions/services/dashboard/src/components/settings/PixelAccessCard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelAccessCard.test.jsx
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import {afterEach, describe, expect, it, vi} from 'vitest'
 import PixelAccessCard from './PixelAccessCard'
 
@@ -7,6 +7,50 @@ const safe = {available: true, surface: 'linux-systemd', configured_mode: 'sandb
 afterEach(() => vi.unstubAllGlobals())
 
 describe('Pixel access confirmation and effective status', () => {
+  it('withdraws effective-mode proof after a failed inspection and requires a fresh receipt', async () => {
+    const verified = {...safe, runtime_verified: true, effective_mode: 'sandboxed'}
+    const fetch = vi.fn().mockResolvedValueOnce({ok: true, json: async () => verified}).mockResolvedValue({ok: false})
+    vi.stubGlobal('fetch', fetch)
+    render(<PixelAccessCard />)
+    await waitFor(() => expect(screen.getByText('Effective').nextElementSibling).toHaveTextContent('Safer mode'))
+    fireEvent.click(screen.getByRole('button', {name: 'Refresh status'}))
+    await screen.findByRole('alert')
+    expect(screen.getByText('Effective').nextElementSibling).toHaveTextContent('Not verified')
+    expect(screen.getByRole('button', {name: 'Enable Full Access'})).toBeDisabled()
+    fetch.mockResolvedValue({ok: true, json: async () => verified})
+    fireEvent.click(screen.getByRole('button', {name: 'Refresh status'}))
+    await waitFor(() => expect(screen.getByRole('button', {name: 'Enable Full Access'})).toBeEnabled())
+    expect(screen.getByText('Effective').nextElementSibling).toHaveTextContent('Safer mode')
+  })
+
+  it('ignores an older failed read after a newer verified inspection', async () => {
+    let finishOld
+    const old = new Promise(resolve => {finishOld = resolve})
+    const fetch = vi.fn().mockResolvedValueOnce({ok: true, json: async () => safe})
+      .mockReturnValueOnce(old).mockResolvedValue({ok: true, json: async () => ({...safe, runtime_verified: true, effective_mode: 'sandboxed'})})
+    vi.stubGlobal('fetch', fetch)
+    render(<PixelAccessCard />)
+    await screen.findByText('Not verified')
+    fireEvent.click(screen.getByRole('button', {name: 'Refresh status'}))
+    fireEvent.click(screen.getByRole('button', {name: 'Refresh status'}))
+    await waitFor(() => expect(screen.getByText('Effective').nextElementSibling).toHaveTextContent('Safer mode'))
+    await act(async () => finishOld({ok: false}))
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.getByText('Effective').nextElementSibling).toHaveTextContent('Safer mode')
+  })
+
+  it('keeps a rejected change visible after the recovery inspection succeeds', async () => {
+    const fetch = vi.fn(async (_url, options) => options ? {ok: false, status: 409} : {ok: true, json: async () => safe})
+    vi.stubGlobal('fetch', fetch)
+    render(<PixelAccessCard />)
+    await screen.findByText('Not verified')
+    fireEvent.click(screen.getByRole('button', {name: 'Verify safer mode'}))
+    await waitFor(() => expect(fetch).toHaveBeenCalledTimes(4))
+    await waitFor(() => expect(screen.queryByText(/Changing access and checking/)).toBeNull())
+    expect(screen.getByRole('alert')).toHaveTextContent('The change was not verified')
+    expect(fetch.mock.calls.filter(call => call[1]?.method === 'POST')).toHaveLength(1)
+  })
+
   it('ends the inspection message after failure and clears the error on retry', async () => {
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce({ok: false}).mockResolvedValue({ok: true, json: async () => safe}))
     render(<PixelAccessCard />)


### PR DESCRIPTION
## Why this matters
After a successful access inspection, a failed refresh leaves the previous effective mode displayed as verified and keeps controls enabled. An older failed read can also overwrite a newer successful inspection. Separately, a rejected access change is immediately followed by a successful GET which clears the only mutation error, making the refusal disappear.

Version inspection responses, withdraw effective-mode proof while inspection is pending or failed, and retain the rejected-change message through its recovery read. Serialize mutations and their internal inspections with a ref guard so background reads cannot race the transaction. Existing explicit Full Access consent, revision preflight, host admission, and safer-mode recovery remain authoritative.

## Regression and validation
- Three rendered access-card regressions fail before the fix: stale proof after failed refresh, late read error after fresh proof, and vanished rejected-change error after recovery GET.
- **15 focused tests passed**, including consent gates, newly busy host, missing revision, pending-transition safer-mode recovery and no automatic mutation replay. Targeted ESLint zero errors; changed-file pre-commit and diff checks passed.
- Windows/Node 24.14.1. No actual permission change or gateway restart performed. Shared local root/WSL sudo/BATS and existing private-key-fixture/Windows-awk release-gate limits remain; combined validation is recorded below.

## Overlap check
Searched open/closed PRs for `PixelAccessCard`, `pixel access`, `access stale`, and `access status failed`; reviewed #4077 and foundational #3818. #4077 changes host migration parsing, not client receipt ordering. No existing PR fixes this component's inspection/mutation evidence. Production path: access panel -> GET/POST `/api/pixel/access-mode` -> configured/effective display and action gates.

## Review, compatibility and rollback
Round 2, PR 3/10, independent public-beta `31063fcb` base. Kept in draft for independent human review of the permission-control surface and live safer-mode/refused-change probes. Automated UI checks do not qualify a live Full Access transition. Shared UI across client platforms; host remains Linux/WSL systemd-qualified. No host policy or storage format changes. Revert this commit to restore prior UI behavior.


## Final batch validation (2026-09-10)
Candidate SHA: dbb881a02c68b0a6b78217f38c755dbec8251818. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
