### PR TITLE
fix(dictation): retain the final transcript when stopping capture

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelDictation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDictation.jsx
@@ -6,12 +6,14 @@ export default function PixelDictation({ disabled, conversationId, onInsert }) {
   const insert = useRef(onInsert)
   insert.current = onInsert
   const [listening, setListening] = useState(false)
+  const [finishing, setFinishing] = useState(false)
   const [notice, setNotice] = useState('')
   const stop = () => {
     const active = recognition.current
     recognition.current = null
     active?.abort()
     setListening(false)
+    setFinishing(false)
   }
   useEffect(() => () => {
     const active = recognition.current
@@ -20,7 +22,7 @@ export default function PixelDictation({ disabled, conversationId, onInsert }) {
   }, [])
   useEffect(() => { stop() }, [disabled, conversationId])
   function start() {
-    if (listening) { stop(); return }
+    if (listening) { recognition.current?.stop(); setFinishing(true); return }
     if (disabled) return
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
     if (!SpeechRecognition) { setNotice('Dictation is not supported by this browser. You can still type your message.'); return }
@@ -35,17 +37,17 @@ export default function PixelDictation({ disabled, conversationId, onInsert }) {
       const text = Array.from(event.results).filter(result => result.isFinal !== false).map(result => result[0]?.transcript || '').join(' ').trim()
       if (text) insert.current(`${text} `)
     }
-    active.onend = () => { if (recognition.current === active) { recognition.current = null; setListening(false) } }
+    active.onend = () => { if (recognition.current === active) { recognition.current = null; setListening(false); setFinishing(false) } }
     active.onerror = event => {
       if (recognition.current !== active) return
       setNotice(event.error === 'not-allowed' ? 'Microphone access was not granted. Nothing was added to your message.' : 'Dictation could not finish. Your existing draft is unchanged.')
-      recognition.current = null; setListening(false)
+      recognition.current = null; setListening(false); setFinishing(false)
     }
     try { active.start(); setListening(true) } catch { recognition.current = null; setNotice('Dictation could not start in this browser.') }
   }
   return <div className="pixel-dictation">
-    <button type="button" disabled={disabled} aria-label={listening ? 'Stop dictation' : 'Dictate message'} aria-pressed={listening} title="Browser dictation may use your browser provider’s online speech service. Audio is not sent to the ODS model." onClick={start}>{listening ? <Square size={15}/> : <Mic size={16}/>}</button>
-    {listening && <span role="status">Listening…</span>}
+    <button type="button" disabled={disabled || finishing} aria-label={listening ? 'Stop dictation' : 'Dictate message'} aria-pressed={listening} title="Browser dictation may use your browser provider’s online speech service. Audio is not sent to the ODS model." onClick={start}>{listening ? <Square size={15}/> : <Mic size={16}/>}</button>
+    {listening && <span role="status">{finishing ? 'Finishing dictation…' : 'Listening…'}</span>}
     {notice && <span role="status" className="pixel-dictation-notice">{notice}</span>}
   </div>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelDictation.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDictation.test.jsx
@@ -3,7 +3,7 @@ import PixelDictation from './PixelDictation'
 
 afterEach(() => { delete window.SpeechRecognition; delete window.webkitSpeechRecognition })
 function speech() {
-  const instance = {start:vi.fn(),abort:vi.fn()}
+  const instance = {start:vi.fn(),stop:vi.fn(),abort:vi.fn()}
   window.SpeechRecognition = function () { return instance }
   return instance
 }
@@ -33,6 +33,32 @@ test('reports unsupported browsers without changing the draft', () => {
   fireEvent.click(screen.getByRole('button',{name:'Dictate message'}))
   expect(screen.getByRole('status')).toHaveTextContent('not supported')
   expect(insert).not.toHaveBeenCalled()
+})
+
+test('Stop finishes captured speech and accepts its final transcript', () => {
+  const instance = speech(), insert = vi.fn()
+  render(<PixelDictation onInsert={insert} conversationId="one"/>)
+  fireEvent.click(screen.getByRole('button',{name:'Dictate message'}))
+  fireEvent.click(screen.getByRole('button',{name:'Stop dictation'}))
+  expect(instance.stop).toHaveBeenCalledOnce()
+  expect(instance.abort).not.toHaveBeenCalled()
+  expect(screen.getByRole('status')).toHaveTextContent('Finishing dictation')
+  act(() => instance.onresult({results:[Object.assign([{transcript:'Keep my last words'}],{isFinal:true})]}))
+  expect(insert).toHaveBeenCalledWith('Keep my last words ')
+  act(() => instance.onend())
+  expect(screen.getByRole('button',{name:'Dictate message'})).toBeEnabled()
+})
+
+test('switching conversation after Stop still discards the pending transcript', () => {
+  const instance = speech(), insert = vi.fn()
+  const view = render(<PixelDictation onInsert={insert} conversationId="one"/>)
+  fireEvent.click(screen.getByRole('button',{name:'Dictate message'}))
+  fireEvent.click(screen.getByRole('button',{name:'Stop dictation'}))
+  view.rerender(<PixelDictation onInsert={insert} conversationId="two"/>)
+  act(() => instance.onresult({results:[Object.assign([{transcript:'Old conversation'}],{isFinal:true})]}))
+  expect(insert).not.toHaveBeenCalled()
+  expect(instance.abort).toHaveBeenCalledOnce()
+  expect(screen.getByRole('button',{name:'Dictate message'})).toBeEnabled()
 })
 test('reports denied permission and aborts recognition on unmount', () => {
   const instance = speech()


### PR DESCRIPTION
## Why this matters
Clicking Stop dictation called SpeechRecognition.abort(), which discards recognition instead of producing the final transcript from captured audio. A user who manually ends an utterance can therefore lose their last words.

Use stop() for the explicit Stop action, keep the recognizer identity until its final result/end event, and show Finishing dictation while awaiting that result. Conversation changes, disabled state and unmount still abort and discard late transcripts. No text is sent automatically.

The [Web Speech API method contract](https://webaudio.github.io/web-speech-api/#speechreco-methods) distinguishes stop (finish already captured audio) from abort (no result). This PR follows that distinction; browser support and online speech-service disclosure remain unchanged.

## Regression and validation
- A rendered dictation test clicks Start/Stop and delivers the final browser result: before the fix stop() is never called; afterwards the final words reach onInsert. A second test changes conversation while finishing and verifies the old transcript is discarded and the recognizer aborted.
- **6 focused tests passed**, targeted ESLint zero errors, changed-file pre-commit and diff checks passed. Candidate `a0bcf0c0`; Windows/Node 24.14.1. No real microphone/browser speech service used; this validates browser-event handling, not recognition quality.
- Combined batch validation follows; existing root/WSL and full-repository hook limitations remain explicitly unverified/failed.

## Overlap check
Searched open/closed PRs for `dictation stop`, `dictation abort`, and reviewed #4027's dictation implementation/files. No existing PR repairs manual-stop transcript loss. A separate possible cumulative-results issue was discarded because continuous=false permits only one final result; it is not included here.

## Compatibility and rollback
Round 2, PR 5/10, independent public-beta `31063fcb` base. Shared browser UI; lifecycle cancellation remains abort-based, so results cannot leak into a new conversation. No API or storage changes. Revert the commit to restore prior stop behavior.


## Final batch validation (2026-09-10)
Candidate SHA: a0bcf0c0467b539110902ad49c4cdbbb838c79fc. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
