### PR TITLE
fix(preview): reconcile clipboard feedback after repeated copies

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewClipboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewClipboard.test.jsx
@@ -1,0 +1,39 @@
+import {webcrypto, createHash} from 'node:crypto'
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+
+const source = '<!doctype html><h1>Exact clipboard content</h1>'
+const preview = {siteId:'site-'+'a'.repeat(24),entrySha256:createHash('sha256').update(source).digest('hex')}
+beforeEach(() => vi.stubGlobal('crypto', webcrypto))
+afterEach(() => {vi.unstubAllGlobals();vi.restoreAllMocks()})
+
+it('clears a clipboard refusal after a successful retry without refetching source', async () => {
+  const writeText = vi.fn().mockRejectedValueOnce(new Error('Clipboard denied')).mockResolvedValueOnce(undefined)
+  vi.stubGlobal('navigator', {clipboard: {writeText}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
+  render(<PixelPreviewSource preview={preview}/>)
+  const copy = screen.getByRole('button',{name:'Copy code'})
+  await waitFor(() => expect(copy).toBeEnabled())
+  fireEvent.click(copy)
+  expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard access failed')
+  fireEvent.click(copy)
+  await waitFor(() => expect(copy).toHaveTextContent('Copied'))
+  expect(screen.queryByRole('alert')).toBeNull()
+  expect(writeText).toHaveBeenNthCalledWith(2, source)
+  expect(fetch).toHaveBeenCalledOnce()
+})
+
+it('does not retain Copied feedback when a later clipboard write fails', async () => {
+  const writeText = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Clipboard denied'))
+  vi.stubGlobal('navigator', {clipboard: {writeText}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
+  render(<PixelPreviewSource preview={preview}/>)
+  const copy = screen.getByRole('button',{name:'Copy code'})
+  await waitFor(() => expect(copy).toBeEnabled())
+  fireEvent.click(copy)
+  await waitFor(() => expect(copy).toHaveTextContent('Copied'))
+  fireEvent.click(copy)
+  await screen.findByRole('alert')
+  expect(copy).not.toHaveTextContent('Copied')
+  expect(copy).toBeEnabled()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -33,8 +33,8 @@ export default function PixelPreviewSource({ preview, file }) {
     return () => { current = false; controller.abort(); clearTimeout(timeout) }
   }, [preview.siteId, path, expectedDigest, file?.bytes, language, attempt])
   async function copy() {
-    try { await navigator.clipboard.writeText(source); setCopied(true) }
-    catch { setError('Clipboard access failed. You can select and copy the code manually.') }
+    try { await navigator.clipboard.writeText(source); setCopied(true); setError('') }
+    catch { setCopied(false); setError('Clipboard access failed. You can select and copy the code manually.') }
   }
   return <section className="pixel-preview-source pixel-original-source" aria-label={path === 'index.html' ? 'Published HTML source' : `Source: ${path}`}>
     {source === null && binarySize === null && !error && <p role="status">Verifying source…</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
@@ -1,5 +1,5 @@
 import { webcrypto, createHash } from 'node:crypto'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import PixelPreviewSource from './PixelPreviewSource'
 const source = '<!doctype html><button onclick="alert(1)">Click</button>\n```\n<script>bad()</script>'
 const preview = { siteId:'site-'+'a'.repeat(24), entrySha256:createHash('sha256').update(source).digest('hex') }
@@ -29,35 +29,4 @@ it('rejects arbitrary source destinations before fetching', async () => {
   render(<PixelPreviewSource preview={{...preview,siteId:'../../settings'}}/>)
   expect(await screen.findByRole('alert')).toBeVisible()
   expect(fetch).not.toHaveBeenCalled()
-})
-
-it('clears a clipboard refusal after a successful retry without refetching source', async () => {
-  const writeText = vi.fn().mockRejectedValueOnce(new Error('Clipboard denied')).mockResolvedValueOnce(undefined)
-  vi.stubGlobal('navigator', {clipboard: {writeText}})
-  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
-  render(<PixelPreviewSource preview={preview}/>)
-  const copy = screen.getByRole('button',{name:'Copy code'})
-  await waitFor(() => expect(copy).toBeEnabled())
-  fireEvent.click(copy)
-  expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard access failed')
-  fireEvent.click(copy)
-  await waitFor(() => expect(copy).toHaveTextContent('Copied'))
-  expect(screen.queryByRole('alert')).toBeNull()
-  expect(writeText).toHaveBeenNthCalledWith(2, source)
-  expect(fetch).toHaveBeenCalledOnce()
-})
-
-it('does not retain Copied feedback when a later clipboard write fails', async () => {
-  const writeText = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Clipboard denied'))
-  vi.stubGlobal('navigator', {clipboard: {writeText}})
-  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
-  render(<PixelPreviewSource preview={preview}/>)
-  const copy = screen.getByRole('button',{name:'Copy code'})
-  await waitFor(() => expect(copy).toBeEnabled())
-  fireEvent.click(copy)
-  await waitFor(() => expect(copy).toHaveTextContent('Copied'))
-  fireEvent.click(copy)
-  await screen.findByRole('alert')
-  expect(copy).not.toHaveTextContent('Copied')
-  expect(copy).toBeEnabled()
 })

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
@@ -1,5 +1,5 @@
 import { webcrypto, createHash } from 'node:crypto'
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import PixelPreviewSource from './PixelPreviewSource'
 const source = '<!doctype html><button onclick="alert(1)">Click</button>\n```\n<script>bad()</script>'
 const preview = { siteId:'site-'+'a'.repeat(24), entrySha256:createHash('sha256').update(source).digest('hex') }
@@ -29,4 +29,35 @@ it('rejects arbitrary source destinations before fetching', async () => {
   render(<PixelPreviewSource preview={{...preview,siteId:'../../settings'}}/>)
   expect(await screen.findByRole('alert')).toBeVisible()
   expect(fetch).not.toHaveBeenCalled()
+})
+
+it('clears a clipboard refusal after a successful retry without refetching source', async () => {
+  const writeText = vi.fn().mockRejectedValueOnce(new Error('Clipboard denied')).mockResolvedValueOnce(undefined)
+  vi.stubGlobal('navigator', {clipboard: {writeText}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
+  render(<PixelPreviewSource preview={preview}/>)
+  const copy = screen.getByRole('button',{name:'Copy code'})
+  await waitFor(() => expect(copy).toBeEnabled())
+  fireEvent.click(copy)
+  expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard access failed')
+  fireEvent.click(copy)
+  await waitFor(() => expect(copy).toHaveTextContent('Copied'))
+  expect(screen.queryByRole('alert')).toBeNull()
+  expect(writeText).toHaveBeenNthCalledWith(2, source)
+  expect(fetch).toHaveBeenCalledOnce()
+})
+
+it('does not retain Copied feedback when a later clipboard write fails', async () => {
+  const writeText = vi.fn().mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error('Clipboard denied'))
+  vi.stubGlobal('navigator', {clipboard: {writeText}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
+  render(<PixelPreviewSource preview={preview}/>)
+  const copy = screen.getByRole('button',{name:'Copy code'})
+  await waitFor(() => expect(copy).toBeEnabled())
+  fireEvent.click(copy)
+  await waitFor(() => expect(copy).toHaveTextContent('Copied'))
+  fireEvent.click(copy)
+  await screen.findByRole('alert')
+  expect(copy).not.toHaveTextContent('Copied')
+  expect(copy).toBeEnabled()
 })


### PR DESCRIPTION
## Why this matters
The verified source viewer retains a clipboard-error alert after a successful second copy. The inverse sequence also leaves Copied on the button after a later clipboard refusal. Users receive contradictory feedback and may unnecessarily reload already verified source.

Reconcile both feedback fields with each settled clipboard outcome: success clears the old clipboard error; failure clears the old Copied state. Keep verified source and manual-copy access intact.

## Regression and validation
- Two rendered source-view regressions reproduce refusal->success and success->refusal. Both failed on beta. They assert current outcome, exact source bytes copied, no redundant source fetch and continued availability of the copy action.
- **13 focused source/task-file tests passed**, targeted ESLint zero errors, changed-file pre-commit and diff checks passed. Windows/Node 24.14.1. Browser clipboard is mocked; no real clipboard or live Pixel session used.
- Combined validation is recorded below; shared release-gate environment/baseline limitations remain explicit.

## Overlap check
Searched open/closed PRs for `preview clipboard stale`, `clipboard retry`, `preview source`, and examined #4027/#4092. #4092 cancels rejected artifact HTTP bodies in pixelArtifacts.js; it does not repair clipboard UI state. This PR changes PixelPreviewSource.jsx and adds distinct regression cases; regressions now live in PixelPreviewClipboard.test.jsx and combine cleanly with #4092 in either order.

## Compatibility and rollback
Round 2, PR 6/10; independent public-beta `31063fcb`. No source-verification, network, persistence, or API contract changes. Shared client UI; revert to restore old feedback. No upstream merge performed.

Follow-up 5abee54d moves clipboard regressions into their own file to avoid a test-append conflict with #4092. Production behavior is unchanged; all 13 focused source/task-file tests passed again.


## Final batch validation (2026-09-10)
Candidate SHA: 5abee54d46f8fcc8061e42a1298ceb6115de453c. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
