### PR TITLE
fix(scopes): retain requested inspection across panel reopening

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelProviderScopes.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelProviderScopes.jsx
@@ -23,6 +23,7 @@ export default function PixelProviderScopes({ chatId, sending = false }) {
   const [uncertain, setUncertain] = useState(false)
   const [error, setError] = useState('')
   const active = useRef(false)
+  const queuedInspection = useRef(null)
   const generation = useRef(0)
   const controllers = useRef(new Set())
   const trigger = useRef(null)
@@ -33,7 +34,7 @@ export default function PixelProviderScopes({ chatId, sending = false }) {
     const pending = controllers.current
     generation.current++; setState(null); setConfiguration(null); setOpen(false)
     setReviewed(false); setCloud(false); setCost(false)
-    return () => { generation.current++; for (const controller of pending) controller.abort() }
+    return () => { generation.current++; queuedInspection.current = null; for (const controller of pending) controller.abort() }
   }, [chatId])
 
   const request = async (url, body) => {
@@ -47,8 +48,16 @@ export default function PixelProviderScopes({ chatId, sending = false }) {
     } finally { clearTimeout(timer); controllers.current.delete(controller) }
   }
 
+  function finishOperation() {
+    active.current = false; setBusy(false)
+    const next = queuedInspection.current
+    queuedInspection.current = null
+    if (next) void next()
+  }
+
   const load = async () => {
-    if (active.current) return
+    // Preserve one explicit reopen/reload request while an older operation settles.
+    if (active.current) { queuedInspection.current = load; return }
     active.current = true; setBusy(true); resetConsent()
     const current = generation.current
     try {
@@ -60,7 +69,7 @@ export default function PixelProviderScopes({ chatId, sending = false }) {
       setState(result); setConfiguration(providers.configuration); setUncertain(false); setError('')
     } catch {
       if (current === generation.current) { setUncertain(true); setError('Provider preferences unavailable. Reload before making changes.') }
-    } finally { active.current = false; setBusy(false) }
+    } finally { finishOperation() }
   }
 
   const target = configuration?.providers.find(provider => provider.id === configuration.roles?.handoff)
@@ -84,10 +93,10 @@ export default function PixelProviderScopes({ chatId, sending = false }) {
       if (current === generation.current) {
         setUncertain(true); setError('Change outcome uncertain. Reload to inspect saved state; do not repeat the action.')
       }
-    } finally { active.current = false; setBusy(false); resetConsent() }
+    } finally { finishOperation(); resetConsent() }
   }
 
-  const close = () => { generation.current++; setOpen(false); resetConsent(); trigger.current?.focus() }
+  const close = () => { generation.current++; queuedInspection.current = null; setOpen(false); resetConsent(); trigger.current?.focus() }
   const keys = event => {
     if (event.key === 'Escape') { event.preventDefault(); close() }
     if (event.key !== 'Tab') return

--- a/ods/extensions/services/dashboard/src/components/PixelProviderScopes.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelProviderScopes.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../test/test-utils'
 import PixelProviderScopes from './PixelProviderScopes.jsx'
@@ -80,4 +80,43 @@ it('prevents UI changes while a run is active and closes on chat identity change
   expect(screen.getByRole('button', { name: 'End task' })).toBeDisabled()
   rerender(createElement(PixelProviderScopes, { chatId: 'Chat_B', sending: false }))
   await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+})
+
+it.each(['inspection', 'mutation'])('honors a reopen inspection after an older %s settles', async operation => {
+  let finishOld
+  const pending = new Promise(resolve => { finishOld = resolve })
+  const {fetchMock} = await setup({mutate: async () => pending})
+  const handler = fetchMock.getMockImplementation()
+  let reads = 0
+  fetchMock.mockImplementation((url, options) => {
+    if (url.endsWith('/status')) {
+      reads++
+      if (operation === 'inspection' && reads === 1) return pending
+      return Promise.resolve(response({...initial(), taskId:null, revision:5}))
+    }
+    return handler(url, options)
+  })
+  fireEvent.click(screen.getByRole('button', {name:operation === 'inspection' ? 'Reload preferences' : 'Return from selected scope'}))
+  fireEvent.click(screen.getByRole('button', {name:'Close scope controls'}))
+  fireEvent.click(screen.getByRole('button', {name:'Handoff scope'}))
+  await act(async () => finishOld(response({...initial(), revision:2})))
+  await waitFor(() => expect(screen.getByRole('button', {name:'Begin task'})).toBeEnabled())
+  expect(screen.getByRole('button', {name:'End task'})).toBeDisabled()
+  expect(reads).toBe(operation === 'inspection' ? 2 : 1)
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/return'))).toHaveLength(operation === 'mutation' ? 1 : 0)
+  expect(screen.getByLabelText('I reviewed this recipient, duration and return behavior')).not.toBeChecked()
+})
+
+it('drops a queued inspection when the reopened panel is closed again', async () => {
+  let finishOld
+  const pending = new Promise(resolve => { finishOld = resolve })
+  const {fetchMock} = await setup({mutate: async () => pending})
+  fireEvent.click(screen.getByRole('button', {name:'Return from selected scope'}))
+  fireEvent.click(screen.getByRole('button', {name:'Close scope controls'}))
+  fireEvent.click(screen.getByRole('button', {name:'Handoff scope'}))
+  fireEvent.click(screen.getByRole('button', {name:'Close scope controls'}))
+  await act(async () => finishOld(response({...initial(), revision:2})))
+  expect(screen.queryByRole('dialog')).toBeNull()
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/status'))).toHaveLength(1)
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/return'))).toHaveLength(1)
 })


### PR DESCRIPTION
## Why this matters
Closing and reopening Handoff scope while an inspection or mutation is pending discards the older receipt by generation, but also discards the explicit reopen inspection because the operation guard is still occupied. The reopened panel can unlock with old task/preferences or remain without a loaded state until another manual reload.

Coalesce one explicitly requested inspection behind the existing operation. Drain it when that operation settles; discard it on close, chat change or unmount. Mutations remain serialized and are never replayed. This is a queued read requested by the user, not retry/backoff after failure.

## Regression and validation
- Deferred inspection and deferred mutation tests reproduce a reopened panel retaining the old active task. After resolution, a fresh status read now reports the ended task and correct controls; mutation count remains one and consent remains cleared.
- A third test closes the reopened panel again and verifies no queued read is sent afterwards.
- **9 focused tests passed**, targeted ESLint zero errors, changed-file pre-commit and diff checks passed. Windows/Node 24.14.1. No live provider selection or handoff performed; existing local release-gate environment/baseline limitations remain. Combined validation is recorded below.

## Overlap check
Searched open/closed PRs for `PixelProviderScopes`, `handoff scope reopen`, and `provider scope close`; inspected #3818's scope-control implementation. No existing PR repairs the dropped explicit inspection. Production path: open/reload scope controls -> `/api/pixel/provider-scopes/status` and provider GET -> displayed task and revision-guarded controls.

## Compatibility and rollback
Round 2, PR 7/10, independently based on public-beta `31063fcb`. No provider schema, mutation payload, cloud consent or backend admission changes. Shared browser UI. Revert to restore old reopen behavior. No upstream merge performed.


## Final batch validation (2026-09-10)
Candidate SHA: 9274f39b9c4502e76683e408c46fe7abbc346722. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
