### PR TITLE
fix(beta): open the workspace when browser storage access is denied

### DIFF
--- a/ods/extensions/services/dashboard/src/App.jsx
+++ b/ods/extensions/services/dashboard/src/App.jsx
@@ -23,7 +23,7 @@ const PixelSettings = lazy(() => import('./pages/PixelSettings'))
 
 function getStorageValue(storage, key) {
   try {
-    return storage?.getItem(key)
+    return globalThis[storage]?.getItem(key)
   } catch {
     return null
   }
@@ -31,7 +31,7 @@ function getStorageValue(storage, key) {
 
 function setStorageValue(storage, key, value) {
   try {
-    storage?.setItem(key, value)
+    globalThis[storage]?.setItem(key, value)
   } catch {
     // Ignore storage failures in private windows or restricted environments.
   }
@@ -67,11 +67,11 @@ function App() {
   // API call fails, so the normal app shell is the safe default.
   const { firstRun, refresh: refreshFirstRun } = useFirstRun()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
-    return getStorageValue(globalThis.localStorage, 'ods-sidebar-collapsed') === 'true'
+    return getStorageValue('localStorage', 'ods-sidebar-collapsed') === 'true'
   })
 
   useEffect(() => {
-    setStorageValue(globalThis.localStorage, 'ods-sidebar-collapsed', String(sidebarCollapsed))
+    setStorageValue('localStorage', 'ods-sidebar-collapsed', String(sidebarCollapsed))
   }, [sidebarCollapsed])
 
   const dismissFirstRun = useCallback(() => {
@@ -106,7 +106,7 @@ function App() {
     return (
       <div className="min-h-screen bg-theme-bg text-theme-text">
         {!splashDone && <SplashScreen onComplete={() => {
-          setStorageValue(globalThis.sessionStorage, 'ods-splash-shown', '1')
+          setStorageValue('sessionStorage', 'ods-splash-shown', '1')
           setSplashDone(true)
         }} />}
         <Suspense fallback={
@@ -123,7 +123,7 @@ function App() {
   return (
     <div className={`pixel-app flex min-h-screen bg-theme-bg text-theme-text relative ${sidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
       {!splashDone && <SplashScreen onComplete={() => {
-        setStorageValue(globalThis.sessionStorage, 'ods-splash-shown', '1')
+        setStorageValue('sessionStorage', 'ods-splash-shown', '1')
         setSplashDone(true)
       }} />}
       <Sidebar

--- a/ods/extensions/services/dashboard/src/App.test.jsx
+++ b/ods/extensions/services/dashboard/src/App.test.jsx
@@ -177,3 +177,15 @@ describe('App', () => {
     expect(globalThis.fetch).not.toHaveBeenCalledWith('/api/auth/admin-session', expect.anything())
   })
 })
+
+test.each(['localStorage', 'sessionStorage'])('opens the beta workspace when %s access is denied', async storage => {
+  const getter = vi.spyOn(window, storage, 'get').mockImplementation(() => {
+    throw new window.DOMException('Storage denied', 'SecurityError')
+  })
+  try {
+    render(<App />)
+    expect(await screen.findByLabelText('Portal draft')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', {name:'Collapse sidebar'}))
+    expect(screen.getByRole('button', {name:'Expand sidebar'})).toBeVisible()
+  } finally { getter.mockRestore() }
+})


### PR DESCRIPTION
## Why this matters

Opening the beta dashboard in a browser that throws SecurityError when accessing localStorage crashes before the existing try/catch. sessionStorage access also crashes splash completion. Resolve each storage property inside the guarded boundary so the session remains usable.

## Validation

Candidate: d37efe73e00c0a254fcd804dfdb3c1bf108958de. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/App.test.jsx
- App.test.jsx: baseline fails both denied-storage cases; fixed suite passes.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local React boundary tests; no live Pixel service or packaged WebView was exercised. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed search for App.jsx storage found #1157 and #1165, the original first-boot/PWA features. #3841 guards the PWA hook only; this fixes the reachable App shell and splash handlers.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
