### PR TITLE
fix(beta): isolate malformed retained conversations without discarding data

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.test.jsx
@@ -35,3 +35,16 @@ test('deletes after confirmation and shows refusal errors without hiding the cha
   expect(screen.queryByRole('button',{name:'Disposable test',exact:true})).not.toBeInTheDocument()
   window.removeEventListener(DELETE_EVENT,handle)
 })
+
+test.each([null, {role:'user', content:42}])('keeps the sidebar usable beside malformed retained messages: %j', message => {
+  const good = readConversations()[0]
+  const broken = {schema:1, chatId:'broken', messages:[message], updatedAt:1}
+  const original = JSON.stringify([broken,good])
+  localStorage.setItem('ods.pixel.conversations.v1',original)
+  render(<PixelConversationNavigation collapsed={false}/>)
+  expect(screen.getByRole('button',{name:'Disposable test',exact:true})).toBeVisible()
+  expect(localStorage.getItem('ods.pixel.conversations.v1')).toBe(original)
+  expect(() => saveConversation({...good,draft:'New draft'})).toThrow(/preserved/)
+  expect(() => deleteConversation(good.chatId)).toThrow(/preserved/)
+  expect(localStorage.getItem('ods.pixel.conversations.v1')).toBe(original)
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.js
@@ -12,6 +12,8 @@ function storedArray(key) {
 const deletedIds = () => storedArray(DELETED_KEY)
 export const isConversationDeleted = chatId => deletedIds().includes(chatId)
 const valid = item => item?.schema === 1 && /^[A-Za-z0-9_-]{1,128}$/.test(item.chatId || '') && Array.isArray(item.messages)
+  && item.messages.every(message => message && ['user', 'assistant'].includes(message.role) && typeof message.content === 'string')
+  && (item.draft === undefined || typeof item.draft === 'string')
 
 function currentConversation() {
   try {
@@ -22,8 +24,10 @@ function currentConversation() {
   }
 }
 
-function loadConversations() {
-  const entries = storedArray(LIBRARY_KEY).filter(valid)
+function loadConversations(strict = false) {
+  const stored = storedArray(LIBRARY_KEY)
+  if (strict && stored.some(item => !valid(item))) throw new Error('Saved chat history contains invalid records. Existing browser data has been preserved.')
+  const entries = stored.filter(valid)
   const current = currentConversation()
   if (valid(current) && current.messages.length && !entries.some(item => item.chatId === current.chatId)) entries.push(current)
   const deleted = deletedIds()
@@ -38,7 +42,7 @@ export function saveConversation(chat) {
   if (!valid(chat)) throw new Error('Invalid conversation')
   if (deletedIds().includes(chat.chatId)) throw new Error('This conversation was deleted in another tab. Start a new chat.')
   // A read error is not an empty library. Never overwrite unreadable history.
-  const entries = loadConversations()
+  const entries = loadConversations(true)
   const previous = entries.find(item => item.chatId === chat.chatId)
   const value = { ...previous, ...chat, updatedAt: Date.now() }
   if (value.messages.length || value.draft?.trim()) {
@@ -55,7 +59,7 @@ export function conversationTitle(chat) {
 }
 
 export function deleteConversation(chatId) {
-  const entries = loadConversations()
+  const entries = loadConversations(true)
   const chat = entries.find(item => item.chatId === chatId)
   if (!chat) return
   if (chat.inFlight || chat.interrupted) throw new Error('Stop or resume this task before deleting its conversation.')


### PR DESCRIPTION
## Why this matters

A null message or non-string content in a retained conversation crashes the globally mounted sidebar. Validate the message and draft shapes before rendering; retain readable conversations while refusing writes/deletes that would erase malformed records.

## Validation

Candidate: 8253ac9e16629b0b1f178d090357c018a0f8ee91. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/components/PixelConversationNavigation.test.jsx src/lib/pixelConversations.test.js
- Sidebar boundary regressions fail on unmodified beta; navigation and conversation library suites pass after the fix.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local React boundary tests; no live Pixel service or packaged WebView was exercised. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed searches for pixelConversations and PixelConversationNavigation found #4078, which removes cleared draft-only records. This change concerns malformed record shapes and preservation of their original storage bytes.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
