### PR TITLE
fix(beta): recover unavailable approval-command clipboard access

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Pixel.approval-copy.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.approval-copy.test.jsx
@@ -1,0 +1,42 @@
+
+import {render,screen,fireEvent,waitFor,act} from '@testing-library/react'
+import {OperationsApprovalCard} from './Pixel'
+const jobId='ops-1788127319657-f3262c99a419'
+const planHash='e'.repeat(64)
+const command='/opt/ods/bin/ods-pixel-approve '+jobId+' '+planHash+' --confirm'
+const content='Pixel prepared a protected ODS host command plan, but external approval is required. No command was executed. Job: '+jobId+'. Plan SHA-256: '+planHash+'.'
+beforeEach(() => {
+  vi.stubGlobal('fetch',vi.fn(async () => ({ok:true,json:async () => ({
+    schemaVersion:1,kind:'ods-pixel-operations-status',jobId,planHash,status:'awaiting-approval',
+    riskTier:'break-glass',approvalRequired:true,updatedAt:'2026-09-03T02:00:00Z',approvalCommand:command,
+  })})))
+})
+afterEach(() => {vi.unstubAllGlobals();vi.restoreAllMocks()})
+test.each(['missing','denied'])('provides the verified command for manual copy when clipboard is %s',async mode => {
+  const previous=Object.getOwnPropertyDescriptor(navigator,'clipboard')
+  Object.defineProperty(navigator,'clipboard',{configurable:true,value:mode === 'missing' ? undefined : {writeText:vi.fn().mockRejectedValue(new Error('denied'))}})
+  try {
+    render(<OperationsApprovalCard content={content}/>)
+    fireEvent.click(await screen.findByRole('button',{name:'Copy secure approval command'}))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard access failed')
+    expect(screen.getByRole('textbox',{name:'Secure approval command'})).toHaveValue(command)
+    expect(screen.queryByText('Copied')).toBeNull()
+    expect(fetch.mock.calls.every(([,options]) => !options?.method || options.method === 'GET')).toBe(true)
+  } finally {if(previous) Object.defineProperty(navigator,'clipboard',previous);else delete navigator.clipboard}
+})
+test('waits for clipboard confirmation and prevents repeated writes',async () => {
+  let resolve
+  const writeText=vi.fn(() => new Promise(done => {resolve=done}))
+  const previous=Object.getOwnPropertyDescriptor(navigator,'clipboard')
+  Object.defineProperty(navigator,'clipboard',{configurable:true,value:{writeText}})
+  try {
+    render(<OperationsApprovalCard content={content}/>)
+    const copy=await screen.findByRole('button',{name:'Copy secure approval command'})
+    fireEvent.click(copy);fireEvent.click(copy)
+    expect(copy).toBeDisabled()
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Copied')).toBeNull()
+    await act(async () => resolve())
+    await waitFor(() => expect(screen.getByRole('button',{name:'Copied'})).toBeEnabled())
+  } finally {if(previous) Object.defineProperty(navigator,'clipboard',previous);else delete navigator.clipboard}
+})

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -238,7 +238,7 @@ export function resolvePreviewAccess(preview) {
 
 function ApprovalCommand({command}) {
   const [state, setState] = useState('idle')
-  const active = useRef(false)
+  const active = useRef(true)
   const pending = useRef(false)
   useEffect(() => { active.current = true; return () => { active.current = false } }, [])
   async function copy() {

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -235,11 +235,42 @@ export function resolvePreviewAccess(preview) {
   }
 }
 
+
+function ApprovalCommand({command}) {
+  const [state, setState] = useState('idle')
+  const active = useRef(false)
+  const pending = useRef(false)
+  useEffect(() => { active.current = true; return () => { active.current = false } }, [])
+  async function copy() {
+    if (pending.current) return
+    pending.current = true
+    setState('pending')
+    try {
+      if (!globalThis.navigator?.clipboard?.writeText) throw new Error('Clipboard unavailable')
+      await navigator.clipboard.writeText(command)
+      if (active.current) setState('copied')
+    } catch {
+      if (active.current) setState('error')
+    } finally { pending.current = false }
+  }
+  return <>
+    <button type="button" onClick={copy} disabled={state === 'pending'}
+      className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-1.5 text-xs font-medium text-amber-200 transition hover:bg-amber-400/15">
+      {state === 'copied' ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      {state === 'copied' ? 'Copied' : state === 'pending' ? 'Copying…' : 'Copy secure approval command'}
+    </button>
+    {state === 'error' && <div>
+      <p role="alert" className="mt-2 text-xs">Clipboard access failed. Select and copy the verified command manually.</p>
+      <textarea aria-label="Secure approval command" readOnly value={command}
+        className="mt-2 w-full rounded border border-theme-border bg-theme-bg p-2 font-mono text-xs" />
+    </div>}
+  </>
+}
+
 export function OperationsApprovalCard({ content }) {
   const receipt = parseApprovalReceipt(content)
   const [projection, setProjection] = useState(null)
   const [verification, setVerification] = useState(receipt ? 'loading' : 'absent')
-  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     if (!receipt) return undefined
@@ -293,16 +324,6 @@ export function OperationsApprovalCard({ content }) {
 
   if (!receipt) return null
 
-  const copyCommand = async () => {
-    if (!projection?.approvalCommand) return
-    try {
-      await globalThis.navigator?.clipboard?.writeText(projection.approvalCommand)
-      setCopied(true)
-      globalThis.setTimeout(() => setCopied(false), 2000)
-    } catch {
-      setCopied(false)
-    }
-  }
 
   if (verification === 'loading' || verification === 'absent') {
     return (
@@ -349,14 +370,7 @@ export function OperationsApprovalCard({ content }) {
           </dl>
           {awaiting && projection.approvalCommand && (
             <>
-              <button
-                type="button"
-                onClick={copyCommand}
-                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-amber-400/30 bg-amber-400/10 px-3 py-1.5 text-xs font-medium text-amber-200 transition hover:bg-amber-400/15"
-              >
-                {copied ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
-                {copied ? 'Copied' : 'Copy secure approval command'}
-              </button>
+              <ApprovalCommand key={projection.approvalCommand} command={projection.approvalCommand} />
               <p className="mt-2 flex items-start gap-1.5 text-[10px] leading-4 text-theme-text-muted">
                 <Terminal className="mt-0.5 h-3 w-3 shrink-0" />
                 Run it in a real terminal. Pixel will require fresh password-backed administrator authentication, show the complete protected plan, and ask for a one-time challenge.


### PR DESCRIPTION
## Why this matters

On a LAN HTTP origin without Clipboard API, optional chaining reports Copied without copying anything. A rejected clipboard write provides no recovery. Show a selectable host-verified command on failure, await actual success, and prevent duplicate pending writes.

## Validation

Candidate: 3335e70c6040c38d30e1945f6c27eb50539d4bc6. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/pages/Pixel.approval-copy.test.jsx
- Approval-card boundary: 3 baseline regressions; 3 pass after fix, including missing/denied clipboard and delayed confirmation. Requests remain read-only.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local React boundary tests; no live Pixel service or packaged WebView was exercised. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed search for approvalCommand clipboard found no matching fix. This changes only presentation of an already verified broker command; approval authentication and execution stay in the existing terminal workflow.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
