### PR TITLE
fix(beta): clear hidden navigation filters on sidebar collapse

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelNavigation.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelNavigation.test.jsx
@@ -64,3 +64,16 @@ describe('Pixel workspace navigation', () => {
     window.removeEventListener('ods:pixel-new-task', handler)
   })
 })
+
+it('clears a navigation filter when the sidebar is collapsed externally', () => {
+  const view=show('/')
+  fireEvent.click(screen.getByRole('button',{name:'Search'}))
+  fireEvent.change(screen.getByLabelText('Search navigation'),{target:{value:'Models'}})
+  expect(screen.queryByRole('link',{name:'Extensions'})).toBeNull()
+  view.rerender(<MemoryRouter initialEntries={['/']}><Sidebar status={{}} collapsed onToggle={() => {}}/></MemoryRouter>)
+  expect(screen.queryByLabelText('Search navigation')).toBeNull()
+  expect(screen.getByRole('link',{name:'Extensions'})).toBeVisible()
+  view.rerender(<MemoryRouter initialEntries={['/']}><Sidebar status={{}} collapsed={false} onToggle={() => {}}/></MemoryRouter>)
+  expect(screen.getByRole('button',{name:'Search'})).toHaveAttribute('aria-expanded','false')
+  expect(screen.getByRole('link',{name:'Dashboard'})).toBeVisible()
+})

--- a/ods/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/ods/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -17,6 +17,9 @@ export default function Sidebar({ status, collapsed, onToggle }) {
   const pixelMode = pathname.startsWith('/pixel')
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
+  useEffect(() => {
+    if (collapsed) { setSearchOpen(false); setQuery('') }
+  }, [collapsed])
   const [apiLinks, setApiLinks] = useState([])
   const [serviceTokens, setServiceTokens] = useState({})
   useEffect(() => {


### PR DESCRIPTION
## Why this matters

Search for Models and collapse the sidebar: the search field disappears while the filter continues hiding other destinations. Clear the filter when collapse makes the field unavailable, so all navigation remains reachable.

## Validation

Candidate: 36944bb7fd7664eaf5809005d8aaddb92570817b. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/components/PixelNavigation.test.jsx
- Pixel navigation: new collapse/reopen regression fails on beta; 7 tests pass with the fix.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local React boundary tests; no live Pixel service or packaged WebView was exercised. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed searches for Sidebar.jsx collapse found no matching PR. Existing keyboard-search behavior covers Escape, not parent-driven collapse.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
