### PR TITLE
fix(beta): preserve verified source text through syntax highlighting

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelCodeBlock.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCodeBlock.jsx
@@ -34,8 +34,13 @@ export function PixelCodeLines({source, language = 'text', renderLine}) {
   const text = String(source).replace(/\n$/u, '')
   const rows = text.split('\n')
   const render = tokens => rows.map((row, index) => {
-    const content = tokens?.[index]?.map((token, part) => <span className={token.className || undefined} key={part}>{token.text}</span>) || row || ' '
-    return renderLine ? renderLine(content, index) : <span className="code-line" data-line={index + 1} key={index}><span className="code-line-content">{content}{index < rows.length - 1 ? '\n' : ''}</span></span>
+    // Markdown highlighting can normalize CRLF and other source text.
+    // Use tokens only when they reproduce this verified source line exactly.
+    const lineTokens = tokens?.[index]
+    const content = lineTokens?.map(token => token.text).join('') === row
+      ? lineTokens.map((token, part) => <span className={token.className || undefined} key={part}>{token.text}</span>)
+      : row
+    return renderLine ? renderLine(content, index) : <span className="code-line" data-line={index + 1} key={index}><span className="code-line-content">{content}{index < rows.length - 1 || String(source).endsWith('\n') ? '\n' : ''}</span></span>
   })
   if (text.length > 128 * 1024 || language === 'text') return <code>{render()}</code>
   const fence = '`'.repeat([...text.matchAll(/`+/g)].reduce((max,match) => Math.max(max,match[0].length),2) + 1)

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
@@ -30,3 +30,17 @@ it('rejects arbitrary source destinations before fetching', async () => {
   expect(await screen.findByRole('alert')).toBeVisible()
   expect(fetch).not.toHaveBeenCalled()
 })
+
+it.each([
+  ['index.html','<p>First</p>\n\n'],
+  ['index.html','<p>First</p>\r\n<p>Second</p>\r\n'],
+  ['notes.txt','First\n\nLast\n'],
+  ['notes.txt','\n'],
+])('preserves verified whitespace when manually selecting %s source',async (path,text) => {
+  const bytes=new TextEncoder().encode(text)
+  const digest=createHash('sha256').update(bytes).digest('hex')
+  vi.stubGlobal('fetch',vi.fn(async () => ({ok:true,arrayBuffer:async () => bytes.buffer})))
+  const {container}=render(<PixelPreviewSource preview={{...preview,entrySha256:digest}} file={{path,sha256:digest,bytes:bytes.byteLength}}/>)
+  await waitFor(() => expect(screen.getByRole('button',{name:'Copy code'})).toBeEnabled())
+  expect(container.querySelector('pre code').textContent).toBe(text)
+})


### PR DESCRIPTION
## Why this matters

The verified source viewer drops final newlines, inserts spaces into empty plaintext lines, and normalizes CRLF through Markdown highlighting. Manual selection therefore differs from the SHA-256-verified source. Preserve the exact source text and use highlighted tokens only when their text matches.

## Validation

Candidate: 76cc5efc9f578d12839107545d41f39823753dab. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/components/PixelPreviewSource.test.jsx src/components/PixelFileChanges.test.jsx
- Published-source boundary: 4 added whitespace cases fail on beta, 7 tests pass after fixing the renderer. Existing file-change rendering suite also passes.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local React boundary tests; no live Pixel service or packaged WebView was exercised. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed searches for PixelCodeBlock and PixelPreviewSource found no matching fix. #4083 fixes server-side snapshot comparison of final newlines; this independently preserves source-view text and does not change comparison counts.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
