### PR TITLE
fix(beta): update sharing controls when device keys expire

### DIFF
--- a/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.jsx
@@ -15,6 +15,7 @@ export default function PixelSharingSettings() {
   const [error, setError] = useState('')
   const [notice, setNotice] = useState('')
   const [confirm, setConfirm] = useState(null)
+  const [clock, setClock] = useState(Date.now)
   const mounted = useRef(false)
   const pending = useRef(false)
   const controller = useRef(null)
@@ -81,10 +82,26 @@ export default function PixelSharingSettings() {
 
   const config = snapshot?.configuration
   const route = snapshot?.activeRoute
+  const now = Math.max(clock, Date.now())
+  useEffect(() => {
+    const future = config?.devices.filter(device => !device.revoked)
+      .map(device => device.expiresAt * 1000).filter(expires => expires > now) || []
+    if (!future.length) return undefined
+    // Browser timers cannot represent the entire maximum key lifetime.
+    const timer = setTimeout(() => setClock(Date.now()), Math.min(2147483647, Math.min(...future) - now + 1))
+    return () => clearTimeout(timer)
+  }, [config, now])
+  useEffect(() => {
+    const expiresAt = issued?.configuration.devices.find(device => device.id === issued.credential.id)?.expiresAt
+    if (issued && expiresAt * 1000 <= now) {
+      setIssued(null)
+      setNotice('The newly issued device key has expired. Create a new key to connect.')
+    }
+  }, [issued, now])
   const locked = busy || stale || !snapshot
   const validLabel = typeof label === 'string' && /^[\x20-\x7e]{1,256}$/.test(label) && label === label.trim()
   const validDays = Number.isInteger(days) && days >= 1 && days <= 365
-  const activeDevice = config?.devices.some(device => !device.revoked && device.expiresAt * 1000 > Date.now()
+  const activeDevice = config?.devices.some(device => !device.revoked && device.expiresAt * 1000 > now
     && device.catalogId === route?.catalogId && device.runtimeModelId === route?.runtimeModelId)
 
   function issue() {
@@ -153,7 +170,7 @@ export default function PixelSharingSettings() {
       </div>}
       <ul className="space-y-2" aria-label="Inference devices">
         {config.devices.map(device => <li key={device.id} className="flex flex-wrap items-center justify-between gap-3 rounded border border-theme-border p-3 text-sm">
-          <div><p className="font-medium">{device.label}</p><p className="text-theme-text-muted">{device.runtimeModelId} · {device.revoked ? 'Revoked' : device.expiresAt * 1000 <= Date.now() ? 'Expired' : `Expires ${new Date(device.expiresAt * 1000).toLocaleDateString()}`}</p></div>
+          <div><p className="font-medium">{device.label}</p><p className="text-theme-text-muted">{device.runtimeModelId} · {device.revoked ? 'Revoked' : device.expiresAt * 1000 <= now ? 'Expired' : `Expires ${new Date(device.expiresAt * 1000).toLocaleDateString()}`}</p></div>
           <button className={buttonStyle} disabled={locked || device.revoked} onClick={() => request('revoke', { expectedRevision: config.revision, deviceId: device.id })}>Revoke {device.label}</button>
         </li>)}
       </ul>

--- a/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelSharingSettings.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../../test/test-utils'
 import PixelSharingSettings from './PixelSharingSettings'
@@ -129,4 +129,28 @@ it.each(['http://tower/v1', 'https://user:secret@tower/v1', 'https://tower/v1?ke
 })
 it.each(['https://tower.example/v1', 'http://localhost:5000/v1', 'http://127.0.0.1:4005/v1', 'http://[::1]:4005/v1'])('accepts explicit secure/tunneled URL %s', value => {
   expect(connectionBaseUrl(value)).toBe(value)
+})
+
+it('expires the retained key and device admission at their deadlines without another request', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(now*1000)
+  try {
+    const first={...device(),expiresAt:now+2}
+    const second={...device(),id:'device-'+'c'.repeat(16),label:'Second laptop',expiresAt:now+4}
+    let view
+    await act(async () => {view=setup(snapshot(),() => response({...issued(),configuration:{...issued().configuration,devices:[first,second]}}))})
+    fireEvent.change(screen.getByLabelText('Device label'),{target:{value:'Laptop'}})
+    await act(async () => fireEvent.click(screen.getByRole('button',{name:'Create device key'})))
+    expect(screen.getByLabelText('Device API key')).toBeVisible()
+    await act(async () => vi.advanceTimersByTime(2001))
+    expect(screen.queryByLabelText('Device API key')).toBeNull()
+    expect(screen.getByRole('button',{name:'Start sharing'})).toBeEnabled()
+    expect(screen.getAllByText(/GLM · Expired/)).toHaveLength(1)
+    await act(async () => vi.advanceTimersByTime(2000))
+    expect(screen.getByRole('button',{name:'Start sharing'})).toBeDisabled()
+    expect(screen.getAllByText(/GLM · Expired/)).toHaveLength(2)
+    expect(view.fetchMock).toHaveBeenCalledTimes(2)
+    view.unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  } finally {vi.useRealTimers()}
 })


### PR DESCRIPTION
## Why this matters

Leaving Model sharing open past a key deadline keeps an expired one-time key visible and Start sharing enabled. Schedule the nearest unrevoked-device deadline, remove the expired issued key, and update admission/labels without sending mutations or polling the host.

## Validation

Candidate: 060a640aba36623079dd8359b34f14bd4ef473dc. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/components/settings/PixelSharingSettings.test.jsx
- Sharing component: deadline regression fails on beta; fixed suite passes, including two successive expirations, no extra requests, and timer cleanup.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local component tests cover clock transitions and read-only UI updates. Server-side key expiry enforcement is unchanged; no live sharing service was started. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed search for PixelSharingSettings expired found no matching fix. #4080 changes the advertised connection port; this changes deadline-driven UI state only.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
