### PR TITLE
feat(beta): export complete Pixel conversations as local JSON

### DIFF
--- a/ods/docs/PIXEL.md
+++ b/ods/docs/PIXEL.md
@@ -738,3 +738,19 @@ alone is not proof of live usability.
 | Generated secrets and pinned source | `installers/phases/06-directories.sh` |
 | Health and operator handoff | `installers/phases/12-health.sh`, `installers/phases/13-summary.sh` |
 | Focused integration tests | `tests/test-pixel-*.sh` and each service's `tests/` directory |
+
+## Export a browser-local conversation
+
+In the expanded conversation sidebar, use the **Export chat** download control
+on a conversation row. It downloads an ods-pixel-<chat-id>.json file with the
+complete retained messages, unsent draft, and saved task/publication metadata.
+The model's per-request context limit does not truncate this export.
+
+Export reads the latest browser-local record without sending a request to Pixel,
+switching chats, or stopping a running task. Treat an export made during a run as
+a snapshot of what this browser has observed so far. Workspace files, published
+asset bytes, Docker volumes, and server configuration are not included.
+
+Keep the file private if the conversation contains sensitive content. This is a
+portable JSON archive for inspection and backup; automatic import is not
+implemented, and it does not replace an installation or volume backup.

--- a/ods/extensions/services/dashboard/src/components/PixelConversationExport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationExport.test.jsx
@@ -1,0 +1,50 @@
+
+import {Blob as NodeBlob} from 'node:buffer'
+import {render,screen,fireEvent} from '@testing-library/react'
+import PixelConversationNavigation from './PixelConversationNavigation'
+import {saveConversation,readConversations,SELECT_EVENT} from '../lib/pixelConversations'
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubGlobal('Blob',NodeBlob)
+  vi.stubGlobal('URL',{createObjectURL:vi.fn(() => 'blob:local-export'),revokeObjectURL:vi.fn()})
+  vi.spyOn(window.HTMLAnchorElement.prototype,'click').mockImplementation(() => {})
+})
+afterEach(() => {vi.restoreAllMocks();vi.unstubAllGlobals();vi.useRealTimers()})
+test('exports complete retained history and metadata without selecting or truncating it',async () => {
+  vi.useFakeTimers()
+  const messages=Array.from({length:80},(_,index) => ({role:index%2 ? 'assistant' : 'user',content:'Turn '+index}))
+  saveConversation({schema:1,chatId:'export-test',messages,draft:'Unsent draft',inFlight:true,requestId:'retained-request'})
+  const chat=readConversations()[0]
+  const before=localStorage.getItem('ods.pixel.conversations.v1')
+  const select=vi.fn()
+  window.addEventListener(SELECT_EVENT,select)
+  try {
+    render(<PixelConversationNavigation collapsed={false}/>)
+    fireEvent.click(screen.getByRole('button',{name:'Export chat: Turn 0'}))
+    expect(URL.createObjectURL).toHaveBeenCalledOnce()
+    const blob=URL.createObjectURL.mock.calls[0][0]
+    expect(blob.type).toBe('application/json')
+    const exported=JSON.parse(await blob.text())
+    expect(exported.kind).toBe('ods-pixel-conversation')
+    expect(exported.schemaVersion).toBe(1)
+    expect(exported.conversation).toEqual(chat)
+    expect(exported.conversation.messages).toHaveLength(80)
+    const anchor=window.HTMLAnchorElement.prototype.click.mock.instances[0]
+    expect(anchor.download).toBe('ods-pixel-export-test.json')
+    expect(anchor.href).toBe('blob:local-export')
+    expect(anchor.isConnected).toBe(false)
+    expect(select).not.toHaveBeenCalled()
+    expect(localStorage.getItem('ods.pixel.conversations.v1')).toBe(before)
+    vi.advanceTimersByTime(1000)
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:local-export')
+  } finally {window.removeEventListener(SELECT_EVENT,select)}
+})
+test('reports download failure while preserving the conversation', () => {
+  saveConversation({schema:1,chatId:'export-test',messages:[{role:'user',content:'Keep me'}]})
+  URL.createObjectURL.mockImplementation(() => {throw new Error('Unavailable')})
+  render(<PixelConversationNavigation collapsed={false}/>)
+  fireEvent.click(screen.getByRole('button',{name:'Export chat: Keep me'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be exported')
+  expect(readConversations()).toHaveLength(1)
+  expect(window.HTMLAnchorElement.prototype.click).not.toHaveBeenCalled()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
@@ -1,12 +1,15 @@
 import { useEffect, useRef, useState } from 'react'
-import { Plus, X } from 'lucide-react'
+import { Download, Plus, X } from 'lucide-react'
 import { CHAT_KEY, LIBRARY_EVENT, SELECT_EVENT, DELETE_EVENT, readConversations, conversationTitle } from '../lib/pixelConversations'
+
+import { exportConversation } from '../lib/pixelConversationExport'
 
 export default function PixelConversationNavigation({ collapsed }) {
   const [chats, setChats] = useState(readConversations)
   const [active, setActive] = useState('')
   const [pending, setPending] = useState(null)
   const [deleteError, setDeleteError] = useState('')
+  const [exportError, setExportError] = useState('')
   const dialog = useRef(null)
   const trigger = useRef(null)
   useEffect(() => { if (pending) dialog.current?.showModal() }, [pending])
@@ -30,9 +33,13 @@ export default function PixelConversationNavigation({ collapsed }) {
   if (collapsed) return <button className="pixel-nav-item" aria-label="New task" title="New task" onClick={() => window.dispatchEvent(new Event('ods:pixel-new-task'))}><Plus size={16}/></button>
   const chevron = <svg className="rail-chevron" viewBox="0 0 16 16" aria-hidden="true"><path d="m5 6 3 3 3-3"/></svg>
   function rows(items, empty) {
-    return <div className="rail-conversations">{items.length ? items.map(chat => <div className="conversation-row" key={chat.chatId}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={`${conversationTitle(chat)} · ${chat.messages.filter(item => item.role === 'user').length} turns`} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><strong>{conversationTitle(chat)}</strong>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button><button className="conversation-delete" aria-label={`Delete chat: ${conversationTitle(chat)}`} title="Delete chat" onClick={event => { trigger.current = event.currentTarget; setDeleteError(''); setPending(chat) }}><X size={13}/></button></div>) : <span className="rail-empty">{empty}</span>}</div>
+    return <div className="rail-conversations">{items.length ? items.map(chat => <div className="conversation-row" key={chat.chatId}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={`${conversationTitle(chat)} · ${chat.messages.filter(item => item.role === 'user').length} turns`} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><strong>{conversationTitle(chat)}</strong>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button><button className="conversation-delete" aria-label={`Delete chat: ${conversationTitle(chat)}`} title="Delete chat" onClick={event => { trigger.current = event.currentTarget; setDeleteError(''); setPending(chat) }}><X size={13}/></button><button type="button" className="conversation-export" aria-label={'Export chat: ' + conversationTitle(chat)} title="Export this conversation as JSON" onClick={() => {
+      try { exportConversation(chat.chatId); setExportError('') }
+      catch { setExportError('This conversation could not be exported. Your saved history is unchanged.') }
+    }}><Download size={13}/></button></div>) : <span className="rail-empty">{empty}</span>}</div>
   }
   return <div className="pixel-conversation-navigation">
+    {exportError && <p role="alert">{exportError}</p>}
     <dialog ref={dialog} className="chat-delete-dialog" aria-labelledby="delete-chat-title" onCancel={event => { event.preventDefault(); closeDelete() }}>
       <h3 id="delete-chat-title">Delete this chat?</h3>
       <p>{pending && conversationTitle(pending)}</p>

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationExport.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationExport.js
@@ -1,0 +1,24 @@
+import { readConversations } from './pixelConversations'
+
+export function exportConversation(chatId) {
+  // Read at click time so a sidebar snapshot cannot export an older draft.
+  const conversation = readConversations().find(chat => chat.chatId === chatId)
+  if (!conversation) throw new Error('Conversation unavailable')
+  const archive = {
+    schemaVersion: 1,
+    kind: 'ods-pixel-conversation',
+    exportedAt: new Date().toISOString(),
+    conversation,
+  }
+  const url = URL.createObjectURL(new Blob([JSON.stringify(archive, null, 2)], {type:'application/json'}))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = 'ods-pixel-' + conversation.chatId + '.json'
+  try {
+    document.body.append(anchor)
+    anchor.click()
+  } finally {
+    anchor.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+}

--- a/ods/extensions/services/dashboard/src/wallpaper-themes.css
+++ b/ods/extensions/services/dashboard/src/wallpaper-themes.css
@@ -94,3 +94,10 @@
   :root[data-wallpaper] .portal-chat { background:#111820ed; }
 }
 @media(prefers-reduced-motion:reduce) { .wallpaper-thumbnail { transition:none; } }
+
+/* Keep export separate from conversation selection and deletion. */
+.pixel-original-sections .conversation-row .conversation-link { padding-right:35px; }
+.conversation-export { position:absolute; right:4px; top:50%; transform:translateY(-50%); width:26px; height:26px; display:grid; place-items:center; opacity:0; color:#aeb5be; border:0; border-radius:5px; background:transparent; pointer-events:none; }
+.conversation-row:hover .conversation-export,.conversation-row:focus-within .conversation-export { opacity:1; pointer-events:auto; }
+.conversation-export:hover { color:#fff; background:#ffffff12; }
+@media(hover:none) { .conversation-export { opacity:1; pointer-events:auto; } }


### PR DESCRIPTION
## Why this matters

Beta users need a portable copy of browser-local conversations before changing installations or browser profiles. Add an explicit per-conversation JSON download containing the full retained history, draft and task/publication metadata, with no model-context truncation or network request.

## Validation

Candidate: cf3bff32c9c63a2e43aa67a4111fabda2e1baf2e. Base: public-beta at 31063fcbb602859698317698b0a22d53406290ec.

- From ods/extensions/services/dashboard: npm test -- --maxWorkers=4 src/components/PixelConversationExport.test.jsx src/components/PixelConversationNavigation.test.jsx
- New export boundary: 2 expected failures before implementation; tests verify 80 messages, exact retained metadata, file name/MIME, URL cleanup, no selection or storage mutation, and visible failure recovery. Navigation suite also passes.
- This candidate passes npm run build. Changed-source lint and diff whitespace checks pass.
- [Batch integration and compatibility receipt](https://github.com/0xacee/ODS/blob/test/ods-public-beta-ten-pr-integration/ODS-PUBLIC-BETA-VALIDATION.md) records the shared-file merge checks and browser evidence.

Local download boundary tests inspect actual serialized Blob bytes. Export is a browser snapshot, not server/workspace backup; automatic import is not implemented. Hosted checks and live public-beta qualification are separate from these local results.

## Overlap check

All-author open/closed export conversation searches found #3845 for ODS Talk (ODSTalk.jsx), plus broad Portal feature PRs #3385/#3818. This export serves the distinct Pixel browser-local library in pixelConversations.js. Checked the production Pixel and sidebar paths; no export exists there.

## Review scope

Dashboard UI/browser-local behavior. Ready for review; this does not authorize merging or release deployment. No host lifecycle, provider authentication, or server-side execution policy is changed.

AI-assisted: Codex investigated the production path, drafted code/tests, reviewed the diff, and ran the listed local checks. Independent human review remains outstanding.
