### PR TITLE
fix(chat): bound restored activity and result lookups

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -565,10 +565,12 @@ export default function Pixel({ systemStatus = null }) {
     if (!interrupted || sending) return undefined
     const chatId = chatIdRef.current
     const requestId = requestIdRef.current
-    const controller = new AbortController()
+    let controller = null
     let disposed = false
     let timer = null
     async function checkActivity() {
+      controller = new AbortController()
+      const deadline = globalThis.setTimeout(() => controller.abort(), 15000)
       let state = 'unknown'
       try {
         if (requestId) {
@@ -618,7 +620,7 @@ export default function Pixel({ systemStatus = null }) {
           && ['active', 'terminal', 'unknown'].includes(data.state)) state = data.state
       } catch {
         // A failed lookup or edge restart is not evidence that work finished.
-      }
+      } finally { globalThis.clearTimeout(deadline) }
       if (disposed || chatIdRef.current !== chatId) return
       updateRestoredActivity(state)
       if (state !== 'terminal') timer = globalThis.setTimeout(checkActivity, 2000)
@@ -626,7 +628,7 @@ export default function Pixel({ systemStatus = null }) {
     checkActivity()
     return () => {
       disposed = true
-      controller.abort()
+      controller?.abort()
       if (timer !== null) globalThis.clearTimeout(timer)
     }
   }, [interrupted, sending, activityRefresh, updateRestoredActivity])

--- a/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
@@ -1444,6 +1444,39 @@ describe('Pixel', () => {
     }))
   }
 
+  it.each([false, true])('bounds a stalled recovery lookup and permits a fresh inspection (receipt=%s)', async retained => {
+    saveInterruptedChat()
+    if (retained) {
+      const saved = JSON.parse(localStorage.getItem('ods.pixel.chat.v1'))
+      localStorage.setItem('ods.pixel.chat.v1', JSON.stringify({...saved, requestId:'retained-attempt'}))
+    }
+    const signals = []
+    const endpoint = retained ? '/api/pixel/chat/result' : '/api/pixel/chat/activity'
+    globalThis.fetch.mockImplementation(async (url, options) => {
+      if (url === '/api/pixel/status') return response({available:true})
+      expect(url).toBe(endpoint)
+      expect(options.signal.aborted).toBe(false)
+      signals.push(options.signal)
+      if (signals.length === 1) return new Promise((resolve, reject) => {
+        options.signal.addEventListener('abort', () => reject(new globalThis.DOMException('aborted','AbortError')), {once:true})
+      })
+      return response(retained ? {state:'complete',events:'data: {"choices":[{"delta":{"content":"Recovered after timeout"}}]}\n\ndata: [DONE]\n\n'} : {state:'terminal'})
+    })
+    vi.useFakeTimers()
+    await act(async () => { render(<Pixel />) })
+    expect(signals).toHaveLength(1)
+    await act(async () => { await vi.advanceTimersByTimeAsync(15000) })
+    expect(signals[0].aborted).toBe(true)
+    expect(screen.getByRole('button',{name:'Check activity again'})).toBeEnabled()
+    expect(screen.getByText('Saved partial result')).toBeVisible()
+    await act(async () => { fireEvent.click(screen.getByRole('button',{name:'Check activity again'})) })
+    expect(signals).toHaveLength(2)
+    expect(signals[1]).not.toBe(signals[0])
+    expect(screen.getByPlaceholderText('Message Pixel...')).toBeEnabled()
+    expect(screen.getByText(retained ? 'Recovered after timeout' : 'Saved partial result')).toBeVisible()
+    expect(globalThis.fetch.mock.calls.some(([url]) => url === '/api/pixel/chat/stream')).toBe(false)
+  })
+
   it('restored activity tracks this chat from active to terminal without replay or stopped claims', async () => {
     saveInterruptedChat()
     let state = 'active'


### PR DESCRIPTION
## Why this matters
Reloading an interrupted chat starts a retained-result or legacy activity lookup with no deadline. If that read stalls, the page remains Checking indefinitely and never offers Check activity again. The existing two-second polling schedule is installed only after the read settles, so it cannot recover this case.

Bound each recovery inspection to 15 seconds and allocate a fresh AbortController for the next inspection. A timeout remains unknown, preserves saved messages and the attempt identity, and exposes the existing manual inspection/Stop actions. It does not claim completion or replay a prompt. Existing periodic status checks and host attempt admission remain unchanged.

## Regression and validation
- Two rendered Pixel-page regressions stall either `/api/pixel/chat/result` or legacy `/api/pixel/chat/activity`. Before the fix the signal never aborts. After 15 seconds, Check activity again is available; a fresh non-aborted request recovers the result/terminal state while no `/chat/stream` is posted.
- **75 Pixel page tests passed**, focused deadline cases rerun after the lint-only test namespace correction; targeted ESLint zero errors; changed-file pre-commit and diff checks passed. Windows/Node 24.14.1.
- No live browser/network outage or runtime job performed. Shared root/WSL release-gate and existing hook limitations remain explicit; combined batch validation is recorded below.

## Overlap check
Searched open/closed PRs for `chat result timeout`, `restored chat timeout`, `recovery lookup`, and `chat activity deadline`; reviewed current beta durable-recovery commits. No existing PR bounds the restored-chat fetches. This does not change the live SSE deadline or advice/runtime polling lifecycles. Production file: dashboard/src/pages/Pixel.jsx, restored interrupted-chat effect.

## Compatibility and rollback
Round 2, PR 9/10, independently based on public-beta `31063fcb`. Both retained-result and legacy activity paths are tested. No persisted schema or backend change; the owner must still inspect unknown work before proceeding, and the backend enforces attempt identity/admission. Revert this commit to restore unbounded reads. No upstream merge performed.


## Final batch validation (2026-09-10)
Candidate SHA: 921b78ee8a64a65459bd65ac73c563cbd706333d. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
