### PR TITLE
fix(history): isolate malformed conversations without erasing data

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationHistoryRecovery.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationHistoryRecovery.test.jsx
@@ -1,0 +1,26 @@
+import {act, render, screen} from '@testing-library/react'
+import PixelConversationNavigation from './PixelConversationNavigation'
+import {readConversations, saveConversation} from '../lib/pixelConversations'
+
+const library = 'ods.pixel.conversations.v1'
+const healthy = {schema:1,chatId:'healthy-chat',messages:[{role:'user',content:'Keep this conversation'}]}
+beforeEach(() => localStorage.clear())
+afterEach(() => localStorage.clear())
+
+it.each([
+  {messages:[null]},
+  {messages:[42]},
+  {messages:[{role:'user',content:{damaged:true}}]},
+  {messages:[],draft:42},
+])('isolates unreadable history without deleting the stored entry (%j)', damaged => {
+  const broken = {schema:1,chatId:'damaged-chat',...damaged}
+  const raw = JSON.stringify([broken, healthy])
+  localStorage.setItem(library, raw)
+  render(<PixelConversationNavigation collapsed={false}/>)
+  expect(screen.getByRole('button',{name:/^Keep this conversation/})).toBeVisible()
+  expect(readConversations().map(chat => chat.chatId)).toEqual(['healthy-chat'])
+  expect(localStorage.getItem(library)).toBe(raw)
+  // Saving another healthy chat must not silently delete damaged browser data.
+  act(() => saveConversation({schema:1,chatId:'new-chat',messages:[{role:'user',content:'New work'}]}))
+  expect(JSON.parse(localStorage.getItem(library))).toContainEqual(broken)
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.js
@@ -31,7 +31,11 @@ function loadConversations() {
 }
 
 export function readConversations() {
-  try { return loadConversations() } catch { return [] }
+  try {
+    // Isolate unreadable entries in the view; preserve their raw storage on save.
+    return loadConversations().filter(chat => (chat.draft == null || typeof chat.draft === 'string')
+      && chat.messages.every(message => message && ['user', 'assistant'].includes(message.role) && typeof message.content === 'string'))
+  } catch { return [] }
 }
 
 export function saveConversation(chat) {


### PR DESCRIPTION
## Why this matters
The conversation library validates only that messages is an array. A damaged stored entry such as messages:[null] or a numeric draft can therefore reach sidebar title rendering and crash the conversation navigation. Other invalid message bodies appear as selectable chats even though Pixel cannot load them.

Filter unreadable entries only in the read-only conversation view. Keep valid neighboring chats usable and preserve damaged raw entries in browser storage, including when a different healthy conversation is saved. This is corruption resilience, not a security claim or automatic data repair.

## Regression and validation
- Four actual navigation-rendering cases seed stored null/numeric messages, non-string message content, and a non-string draft beside a healthy chat. Before the fix they crash rendering or expose unreadable entries. Afterwards healthy navigation works, raw storage is unchanged, and saving new work retains the damaged entry for recovery.
- **17 focused history/navigation/search tests passed**, targeted ESLint zero errors, changed-file pre-commit and diff checks passed. Windows/Node 24.14.1. No production browser data was modified. Combined validation is recorded below; local release-gate baseline/environment limits remain explicit.

## Overlap check
Searched open/closed PRs for `conversation malformed`, `conversation corrupt messages`, and `pixelConversations`; reviewed #4027 and #4078. #4078 removes intentionally erased valid drafts in saveConversation; this PR filters unreadable entries only in readConversations and preserves the storage/write path. These are separate behaviors in the same module; both merge orders produce the same tree, with combined behavior tested below.

## Compatibility and rollback
Round 2, PR 10/10, independent public-beta `31063fcb`. Existing schema, tombstones, active pointer and persistence behavior are unchanged. Shared browser UI. Revert this commit to restore previous rendering; no data restoration is needed because no damaged entries are deleted. No upstream merge performed.


## Final batch validation (2026-09-10)
Candidate SHA: 71bc44b5dc70761654690060fb9861abe9970141. GitHub checks at this head: **32 passed, 4 skipped**, no pending/failing checks.

All ten round-2 PRs combine at `02a5626b1888a970163ed8916e4f4d65d52258ed`. Combining both ten-PR batches (including the already-adopted #4066 fix) yields `2518f1f52cb7a3f2360430c45687a404623b5b78`: **703 UI tests / 74 files passed**, production build passed, ESLint 0 errors / 492 warnings; **86 preview/model-router Python tests passed**. Changed-file hooks and diff checks passed. Host: Windows/Node 24.14.1; backend and shell checks: WSL Ubuntu, root, Python 3.14.

All four shell smoke scenarios passed. Full local `make gate` stopped at two sudo assertions, also reproduced on unchanged beta `31063fcb`. BATS: 416/421 passed; all five failures reproduced in the corresponding 33-test baseline subset (WSL detection, root permissions/preflight, low disk space). Simulation returned 0 but its Linux NVIDIA golden path failed at the root preflight; simulated Windows/macOS paths passed. Full-repository hooks still flag two unchanged test-key fixtures and lack Windows `awk`; changed-file hooks passed. These results do not establish hardware or live Pixel end-to-end readiness.

Cross-batch shared-file pairs #4105/#4081, #4107/#4092, and #4121/#4078 merge in either order with identical trees. Round-2 fixes are independently based on beta; consider the earlier #4093 fixture-race fix first for combined CI stability. #4104 remains draft pending independent human review and declared live permission probes. No upstream merge was performed.
