### PR TITLE
fix(comfyui): persist the user directory so saved workflows survive a recreate

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -111,6 +111,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Manifest schema source of truth ==="
 	@bash tests/test-validate-manifest-schema.sh
+	@echo "=== ComfyUI user directory is persisted ==="
+	@bash tests/test-comfyui-user-dir-persisted.sh
 	@echo ""
 	@echo "=== macOS ods config show secret-mask ==="
 	@bash tests/test-macos-config-show-secret-mask.sh

--- a/ods/extensions/services/comfyui/README.md
+++ b/ods/extensions/services/comfyui/README.md
@@ -45,6 +45,7 @@ Environment variables (set in `.env`):
 | `./data/comfyui/output` | `/output` | Generated images output directory |
 | `./data/comfyui/input` | `/input` | Input images for img2img and inpainting |
 | `./data/comfyui/workflows` | `/workflows` | Workflow JSON templates (read-only) |
+| `./data/comfyui/user` | `/user` | Saved workflows and UI settings (persisted across recreates) |
 
 ### AMD
 

--- a/ods/extensions/services/comfyui/compose.nvidia.yaml
+++ b/ods/extensions/services/comfyui/compose.nvidia.yaml
@@ -14,6 +14,9 @@ services:
       - ./data/comfyui/output:/output:z
       - ./data/comfyui/input:/input:z
       - ./data/comfyui/workflows:/workflows:ro,z
+      # Saved workflows and UI settings. Without this they live only in the
+      # container layer and are lost on every recreate (e.g. `ods update`).
+      - ./data/comfyui/user:/user:z
     shm_size: '8g'
     deploy:
       resources:

--- a/ods/extensions/services/comfyui/startup.sh
+++ b/ods/extensions/services/comfyui/startup.sh
@@ -14,6 +14,7 @@ MODELS_MOUNT="/models"
 OUTPUT_MOUNT="/output"
 INPUT_MOUNT="/input"
 WORKFLOWS_MOUNT="/workflows"
+USER_MOUNT="/user"
 
 #-----------------------------------------------------------------------------
 # Create model subdirectories in bind mount (idempotent)
@@ -52,6 +53,29 @@ for pair in "output:${OUTPUT_MOUNT}" "input:${INPUT_MOUNT}"; do
     fi
     ln -s "$mount_path" "$target"
 done
+
+#-----------------------------------------------------------------------------
+# Persist ComfyUI's user directory (saved workflows + UI settings)
+#
+# ComfyUI writes everything the user creates under user/. Without a bind mount
+# that lives only in the container's writable layer and is destroyed on the
+# next recreate — which a routine `ods update` performs (compose down + up).
+# Mount outside the ComfyUI tree and symlink, exactly as output/ and input/ do.
+# Skipped when /user is not mounted, so an older compose file still works.
+#-----------------------------------------------------------------------------
+if [ -d "$USER_MOUNT" ]; then
+    user_target="${COMFYUI_DIR}/user"
+    if [ -L "$user_target" ]; then
+        rm "$user_target"
+    elif [ -d "$user_target" ]; then
+        # First start after this mount was introduced: carry over whatever the
+        # container already holds rather than discarding it. -n keeps anything
+        # already on the host authoritative.
+        cp -a -n "$user_target/." "$USER_MOUNT/" 2>/dev/null || true
+        rm -rf "$user_target"
+    fi
+    ln -s "$USER_MOUNT" "$user_target"
+fi
 
 #-----------------------------------------------------------------------------
 # Copy workflow templates (read-only mount → writable user dir)

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -873,7 +873,7 @@ else
         fi
         # NVIDIA ComfyUI also needs output/input/workflows bind-mount dirs
         if [[ "$GPU_BACKEND" == "nvidia" ]]; then
-            mkdir -p "$INSTALL_DIR/data/comfyui"/{output,input,workflows}
+            mkdir -p "$INSTALL_DIR/data/comfyui"/{output,input,workflows,user}
         fi
 
         SDXL_MODEL="sdxl_lightning_4step.safetensors"

--- a/ods/tests/test-comfyui-user-dir-persisted.sh
+++ b/ods/tests/test-comfyui-user-dir-persisted.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ComfyUI saves workflows and UI settings under $COMFYUI_DIR/user. That path
+# was not bind-mounted, so everything a user created lived only in the
+# container's writable layer and was destroyed on the next recreate — which a
+# routine `ods update` performs (docker compose down + up). This asserts the
+# user directory is persisted to the host and that startup.sh links it before
+# the workflow templates are copied into it.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE="${ODS_COMFYUI_COMPOSE_UNDER_TEST:-$ROOT_DIR/extensions/services/comfyui/compose.nvidia.yaml}"
+STARTUP="${ODS_COMFYUI_STARTUP_UNDER_TEST:-$ROOT_DIR/extensions/services/comfyui/startup.sh}"
+PHASE="${ODS_PHASE11_UNDER_TEST:-$ROOT_DIR/installers/phases/11-services.sh}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+for f in "$COMPOSE" "$STARTUP" "$PHASE"; do [[ -f "$f" ]] || fail "missing $f"; done
+
+# 1. The user directory must be bind-mounted, and writable (not ro).
+mount_line="$(grep -E '^\s*-\s*\./data/comfyui/user:' "$COMPOSE" || true)"
+[[ -n "$mount_line" ]] \
+    || fail "compose.nvidia.yaml does not bind-mount ./data/comfyui/user; saved workflows stay in the container layer"
+grep -qE ':ro(,|$|[[:space:]])' <<<"$mount_line" \
+    && fail "the user directory is mounted read-only: $mount_line"
+pass "the ComfyUI user directory is bind-mounted read-write"
+
+# 2. startup.sh must link it, and do so before copying workflow templates in.
+grep -q 'USER_MOUNT=' "$STARTUP" || fail "startup.sh defines no USER_MOUNT"
+link_at="$(grep -n 'ln -s "\$USER_MOUNT"' "$STARTUP" | head -1 | cut -d: -f1)"
+copy_at="$(grep -n 'WORKFLOWS_MOUNT"/\*.json' "$STARTUP" | head -1 | cut -d: -f1)"
+[[ -n "$link_at" ]] || fail "startup.sh never links \$COMFYUI_DIR/user to the mount"
+[[ -n "$copy_at" ]] || fail "could not locate the workflow-template copy in startup.sh"
+[[ "$link_at" -lt "$copy_at" ]] \
+    || fail "startup.sh copies workflow templates (line $copy_at) before linking the user dir (line $link_at); templates would land in the container layer"
+pass "startup.sh links the user directory before seeding workflow templates"
+
+# 3. The installer must pre-create the host directory alongside the others.
+grep -qE 'mkdir -p "\$INSTALL_DIR/data/comfyui"/\{[^}]*\buser\b[^}]*\}' "$PHASE" \
+    || fail "phase 11 does not create data/comfyui/user, so Docker would auto-create it as root"
+pass "the installer pre-creates data/comfyui/user"
+
+# 4. Behavioural: run startup.sh's user-persistence block against a fixture.
+block="$(awk '/^if \[ -d "\$USER_MOUNT" \]; then$/{grab=1} grab{print} grab && /^fi$/{exit}' "$STARTUP")"
+[[ -n "$block" ]] || fail "could not extract the user-persistence block from startup.sh"
+
+COMFYUI_DIR="$TMP_DIR/comfyui"; USER_MOUNT="$TMP_DIR/user-mount"
+mkdir -p "$COMFYUI_DIR/user/default/workflows" "$USER_MOUNT"
+printf 'saved-by-user\n' > "$COMFYUI_DIR/user/default/workflows/my-workflow.json"
+printf 'ui-settings\n'   > "$COMFYUI_DIR/user/default/comfy.settings.json"
+export COMFYUI_DIR USER_MOUNT
+bash -c "set -euo pipefail; $block"
+
+[[ -L "$COMFYUI_DIR/user" ]] \
+    || fail "startup.sh did not replace \$COMFYUI_DIR/user with a symlink to the mount"
+[[ "$(readlink "$COMFYUI_DIR/user")" == "$USER_MOUNT" ]] \
+    || fail "\$COMFYUI_DIR/user points at $(readlink "$COMFYUI_DIR/user"), expected $USER_MOUNT"
+pass "startup.sh points the ComfyUI user directory at the persisted mount"
+
+[[ -f "$USER_MOUNT/default/workflows/my-workflow.json" ]] \
+    || fail "a workflow already in the container was discarded instead of migrated to the host"
+[[ "$(cat "$USER_MOUNT/default/workflows/my-workflow.json")" == "saved-by-user" ]] \
+    || fail "the migrated workflow's contents changed"
+[[ -f "$USER_MOUNT/default/comfy.settings.json" ]] \
+    || fail "UI settings were not migrated to the host"
+pass "existing container-side workflows and settings are migrated, not discarded"
+
+# 5. Re-running must be idempotent and must not clobber host state.
+printf 'host-wins\n' > "$USER_MOUNT/default/workflows/my-workflow.json"
+bash -c "set -euo pipefail; $block"
+[[ "$(cat "$USER_MOUNT/default/workflows/my-workflow.json")" == "host-wins" ]] \
+    || fail "a restart overwrote host-side workflow state"
+[[ -L "$COMFYUI_DIR/user" ]] || fail "the symlink did not survive a restart"
+pass "restarting keeps the host copy authoritative"


### PR DESCRIPTION
## Summary

ComfyUI writes everything the user creates — workflows saved from the UI, and the settings beside them — under `$COMFYUI_DIR/user`. That path was not bind-mounted, so it lived only in the container's writable layer and was destroyed on the next recreate. `ods-update.sh:440-444` runs `docker compose down --remove-orphans` then `up -d`, so a routine update silently deleted every saved workflow. Repro in #3763.

The read-only `/workflows` mount is a different thing and is not the bug: `startup.sh:57-63` treats it as a *template source* and copies `*.json` out of it into `$COMFYUI_DIR/user/default/workflows` — exactly the ephemeral path. Making `/workflows` writable would not persist anything, because ComfyUI never writes there.

Change (one concern: the ComfyUI user directory survives a recreate):

- **`compose.nvidia.yaml`**: mount `./data/comfyui/user` at `/user`, outside the ComfyUI tree — the same shape `output` and `input` already use.
- **`startup.sh`**: symlink `$COMFYUI_DIR/user` to that mount, *before* the workflow templates are copied, so templates land in the persisted directory too. On the first start after the mount appears it migrates whatever the container already holds (`cp -a -n`, so anything already on the host stays authoritative) instead of discarding it. The whole block is skipped when `/user` is not mounted, so an older compose file keeps working.
- **`installers/phases/11-services.sh`**: pre-create the host directory alongside `output/input/workflows`, so Docker does not auto-create it as root and leave the uid-1000 container unable to write.
- **`README.md`**: document the new volume.
- **`tests/test-comfyui-user-dir-persisted.sh`** (new, in `make test`).

Fixes #3763.

Note on the other open PR for this issue: #3769 flips `/workflows` from `ro,z` to `rw,z`. That does not address the defect, for the reason above — ComfyUI does not write to `/workflows`. If it lands, the issue closes while the data loss remains.

## Release Lane

- [ ] Stable hotfix targeting `release/2.6.x`
- [x] Mainline change targeting `public-beta` (the active development branch)
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low-to-medium — it adds a bind mount to a running service. Ownership is handled by the two mechanisms already in place for this directory: phase 11 creates it as the install user (as it already does for `output`/`input`/`workflows`), and `lib/rootless-ownership.sh:367-369` already repairs `data/comfyui` recursively to `1000:1000` on rootless installs, which covers the new subdirectory. `startup.sh` degrades to today's behaviour when `/user` is absent.
- I do not have a Docker host, so this is validated by rendering the stack and by running `startup.sh`'s persistence block directly against a fixture; it has not been exercised against a live ComfyUI container.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because:

Commands/results:

```text
# macOS 15.7 (Intel), Homebrew Bash 5.3 + stock /bin/bash 3.2, Docker CLI 29 (compose config only)

# BEFORE (clean upstream/main worktree, this branch's test)
$ bash tests/test-comfyui-user-dir-persisted.sh
[FAIL] compose.nvidia.yaml does not bind-mount ./data/comfyui/user; saved workflows stay in the container layer

# AFTER (this branch)  -- bash 5.3 and /bin/bash 3.2
[PASS] the ComfyUI user directory is bind-mounted read-write
[PASS] startup.sh links the user directory before seeding workflow templates
[PASS] the installer pre-creates data/comfyui/user
[PASS] startup.sh points the ComfyUI user directory at the persisted mount
[PASS] existing container-side workflows and settings are migrated, not discarded
[PASS] restarting keeps the host copy authoritative

# Resolved NVIDIA stack renders the new mount read-write next to the others
  .../data/comfyui/workflows -> /workflows  ro=True
  .../data/comfyui/user      -> /user       ro=False

$ shellcheck --exclude=SC1091,SC2034 --severity=error startup.sh 11-services.sh <new test> -> clean
$ /bin/bash -n <changed shell files> -> ok; python -c 'yaml.safe_load(compose)' -> ok
$ make -n test -> ok (new test wired); git diff --check -> clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- Worth a live check on a GPU host before merge, specifically: that an existing install's workflows migrate on the first start, and that the directory is writable under both rootful and rootless Docker.
- `compose.amd.yaml` is unaffected — it mounts the whole `/opt/ComfyUI` tree, so user state already persists there.
- The migration uses `cp -a -n`; the image is `nvidia/cuda:12.8.0-runtime-ubuntu22.04`, so GNU coreutils flags are available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

