### PR TITLE
fix(pixel): backport asyncio.timeout to support Python 3.10

### DIFF
--- a/ods/bin/pixel_provider/connection_tunnel.py
+++ b/ods/bin/pixel_provider/connection_tunnel.py
@@ -1,4 +1,10 @@
 """Owner-selected SSH forwarding to a peer's loopback inference port only."""
+import sys
+import asyncio
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 import asyncio
 import contextlib
 import json

--- a/ods/bin/pixel_provider/connection_tunnel.py
+++ b/ods/bin/pixel_provider/connection_tunnel.py
@@ -54,7 +54,7 @@ async def serve_tunnel(*, ssh_bin, target, remote_port, listen_port, stop=None, 
                 child = await spawn
                 raise
             pumps = [asyncio.create_task(pump(reader,child.stdin)),asyncio.create_task(pump(child.stdout,writer))]
-            async with asyncio.timeout(3600):
+            async with async_timeout(3600):
                 done,_ = await asyncio.wait(pumps,return_when=asyncio.FIRST_COMPLETED)
                 # A client may half-close its request and still await the reply.
                 # EOF from SSH, however, ends the remote response direction.
@@ -113,3 +113,4 @@ def run_tunnel(**options):
                 'target':options['target'],'remotePort':options['remote_port']}),flush=True)
         await serve_tunnel(**options,stop=stop,ready=ready)
     asyncio.run(run())
+

--- a/ods/bin/pixel_provider/runtime_gateway.py
+++ b/ods/bin/pixel_provider/runtime_gateway.py
@@ -193,7 +193,7 @@ def create_app(config,credentials,token,*,events=None,client_factory=None):
 
         try:
             body = bytearray()
-            async with asyncio.timeout(min(10,config['policy']['deadlineSeconds'])):
+            async with async_timeout(min(10,config['policy']['deadlineSeconds'])):
                 async for chunk in request.stream():
                     if len(body)+len(chunk)>MAX_BYTES:
                         raise RuntimeErrorCode('request-too-large')
@@ -321,3 +321,4 @@ def create_app(config,credentials,token,*,events=None,client_factory=None):
                 await cleanup()
 
     return app
+

--- a/ods/bin/pixel_provider/runtime_gateway.py
+++ b/ods/bin/pixel_provider/runtime_gateway.py
@@ -4,6 +4,12 @@ Instances use an immutable owner-approved configuration and credentials. They
 are never a public agent or administration endpoint. Terminal failure closes
 the lease so client-library retries cannot multiply the provider attempt budget.
 """
+import sys
+import asyncio
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 import asyncio
 import copy
 import hmac

--- a/ods/extensions/services/ape/requirements.txt
+++ b/ods/extensions/services/ape/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.6
 uvicorn[standard]==0.32.1
 pydantic==2.10.3
 pyyaml==6.0.2
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/dashboard-api/requirements.txt
+++ b/ods/extensions/services/dashboard-api/requirements.txt
@@ -9,3 +9,4 @@ PyYAML>=6.0,<7.0.0
 jsonschema>=4.21.0,<5.0.0
 # QR code generation for magic-link invites (Pillow optional, but improves output)
 qrcode[pil]>=7.4.0,<9.0.0
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/dashboard-api/routers/pixel.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel.py
@@ -1,5 +1,11 @@
 """Bounded dashboard bridge to the internal Pixel edge service."""
 
+import sys
+import asyncio
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 from __future__ import annotations
 
 import asyncio
@@ -416,7 +422,7 @@ async def pixel_status() -> dict[str, object]:
         if available and model_support is not None:
             result["modelSupport"] = model_support
         return result
-    except (httpx.HTTPError, async_timeoutError) as exc:
+    except (httpx.HTTPError, asyncio.TimeoutError) as exc:
         # Exception text and request objects can contain upstream credentials.
         # Retain the failure phase/type without logging those sensitive values.
         logger.warning("Pixel edge status request failed (%s)", type(exc).__name__)
@@ -504,7 +510,7 @@ async def _cancel_edge_run(edge_url: str, key: str, chat_id: str) -> bool:
         )
     except (
         httpx.HTTPError,
-        async_timeoutError,
+        asyncio.TimeoutError,
         json.JSONDecodeError,
         UnicodeDecodeError,
         ValueError,
@@ -577,7 +583,7 @@ async def pixel_chat_activity(body: ChatCancelRequest) -> dict[str, str]:
         if (isinstance(parsed, dict) and set(parsed) == {"state"}
                 and isinstance(parsed["state"], str) and parsed["state"] in {"active", "terminal", "unknown"}):
             return {"state": parsed["state"]}
-    except (httpx.HTTPError, async_timeoutError, ValueError, TypeError):
+    except (httpx.HTTPError, asyncio.TimeoutError, ValueError, TypeError):
         pass
     return {"state": "unknown"}
 
@@ -684,7 +690,7 @@ async def _produce_retained_result(store, identity, body, config):
         if not done_seen and not cancelled:
             try:
                 stopped = await asyncio.wait_for(_cancel_edge_run(edge_url, key, body.chat_id), _CLIENT_CANCEL_TIMEOUT_SECONDS)
-            except (async_timeoutError, asyncio.CancelledError):
+            except (asyncio.TimeoutError, asyncio.CancelledError):
                 pass
         try:
             if not done_seen:
@@ -768,7 +774,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
     )
     try:
         upstream = await upstream_context.__aenter__()
-    except (httpx.HTTPError, async_timeoutError) as exc:
+    except (httpx.HTTPError, asyncio.TimeoutError) as exc:
         await client.aclose()
         logger.warning("Pixel edge stream connection failed (%s)", type(exc).__name__)
         raise HTTPException(status_code=503, detail="Pixel stream is unavailable") from exc
@@ -813,7 +819,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
             return
         except (GeneratorExit, asyncio.CancelledError):
             raise
-        except (httpx.HTTPError, async_timeoutError):
+        except (httpx.HTTPError, asyncio.TimeoutError):
             yield _error_event("Pixel stream is unavailable")
         except Exception:
             yield _error_event("Pixel stream failed")
@@ -825,7 +831,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
                         asyncio.shield(cancel_task),
                         timeout=_CLIENT_CANCEL_TIMEOUT_SECONDS,
                     )
-                except (asyncio.CancelledError, async_timeoutError):
+                except (asyncio.CancelledError, asyncio.TimeoutError):
                     pass
             await upstream_context.__aexit__(None, None, None)
             await client.aclose()
@@ -842,4 +848,5 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
             "X-Accel-Buffering": "no",
         },
     )
+
 

--- a/ods/extensions/services/dashboard-api/routers/pixel.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel.py
@@ -1,12 +1,12 @@
 """Bounded dashboard bridge to the internal Pixel edge service."""
 
+from __future__ import annotations
 import sys
 import asyncio
 if sys.version_info >= (3, 11):
     from asyncio import timeout as async_timeout
 else:
     from async_timeout import timeout as async_timeout
-from __future__ import annotations
 
 import asyncio
 import hashlib
@@ -848,5 +848,6 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
             "X-Accel-Buffering": "no",
         },
     )
+
 
 

--- a/ods/extensions/services/dashboard-api/routers/pixel.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel.py
@@ -416,7 +416,7 @@ async def pixel_status() -> dict[str, object]:
         if available and model_support is not None:
             result["modelSupport"] = model_support
         return result
-    except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+    except (httpx.HTTPError, async_timeoutError) as exc:
         # Exception text and request objects can contain upstream credentials.
         # Retain the failure phase/type without logging those sensitive values.
         logger.warning("Pixel edge status request failed (%s)", type(exc).__name__)
@@ -504,7 +504,7 @@ async def _cancel_edge_run(edge_url: str, key: str, chat_id: str) -> bool:
         )
     except (
         httpx.HTTPError,
-        asyncio.TimeoutError,
+        async_timeoutError,
         json.JSONDecodeError,
         UnicodeDecodeError,
         ValueError,
@@ -577,7 +577,7 @@ async def pixel_chat_activity(body: ChatCancelRequest) -> dict[str, str]:
         if (isinstance(parsed, dict) and set(parsed) == {"state"}
                 and isinstance(parsed["state"], str) and parsed["state"] in {"active", "terminal", "unknown"}):
             return {"state": parsed["state"]}
-    except (httpx.HTTPError, asyncio.TimeoutError, ValueError, TypeError):
+    except (httpx.HTTPError, async_timeoutError, ValueError, TypeError):
         pass
     return {"state": "unknown"}
 
@@ -645,7 +645,7 @@ async def _produce_retained_result(store, identity, body, config):
     stopped = False
     try:
         timeout = httpx.Timeout(connect=5.0, read=_CHAT_STREAM_TIMEOUT_SECONDS, write=30.0, pool=5.0)
-        async with asyncio.timeout(_CHAT_STREAM_TIMEOUT_SECONDS):
+        async with async_timeout(_CHAT_STREAM_TIMEOUT_SECONDS):
             async with httpx.AsyncClient(timeout=timeout, trust_env=False, follow_redirects=False) as client:
                 async with client.stream("POST", f"{edge_url}/v1/chat/completions",
                         json={"model": _MODEL, "stream": True, "user": body.chat_id,
@@ -684,7 +684,7 @@ async def _produce_retained_result(store, identity, body, config):
         if not done_seen and not cancelled:
             try:
                 stopped = await asyncio.wait_for(_cancel_edge_run(edge_url, key, body.chat_id), _CLIENT_CANCEL_TIMEOUT_SECONDS)
-            except (asyncio.TimeoutError, asyncio.CancelledError):
+            except (async_timeoutError, asyncio.CancelledError):
                 pass
         try:
             if not done_seen:
@@ -768,7 +768,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
     )
     try:
         upstream = await upstream_context.__aenter__()
-    except (httpx.HTTPError, asyncio.TimeoutError) as exc:
+    except (httpx.HTTPError, async_timeoutError) as exc:
         await client.aclose()
         logger.warning("Pixel edge stream connection failed (%s)", type(exc).__name__)
         raise HTTPException(status_code=503, detail="Pixel stream is unavailable") from exc
@@ -786,7 +786,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
     async def stream() -> AsyncIterator[bytes]:
         done_seen = False
         try:
-            async with asyncio.timeout(_CHAT_STREAM_TIMEOUT_SECONDS):
+            async with async_timeout(_CHAT_STREAM_TIMEOUT_SECONDS):
                 buffered = bytearray()
                 async for chunk in _iter_upstream_chunks(upstream, request):
                     buffered.extend(chunk)
@@ -813,7 +813,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
             return
         except (GeneratorExit, asyncio.CancelledError):
             raise
-        except (httpx.HTTPError, asyncio.TimeoutError):
+        except (httpx.HTTPError, async_timeoutError):
             yield _error_event("Pixel stream is unavailable")
         except Exception:
             yield _error_event("Pixel stream failed")
@@ -825,7 +825,7 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
                         asyncio.shield(cancel_task),
                         timeout=_CLIENT_CANCEL_TIMEOUT_SECONDS,
                     )
-                except (asyncio.CancelledError, asyncio.TimeoutError):
+                except (asyncio.CancelledError, async_timeoutError):
                     pass
             await upstream_context.__aexit__(None, None, None)
             await client.aclose()
@@ -842,3 +842,4 @@ async def pixel_chat_stream(request: Request, body: ChatStreamRequest, owner: st
             "X-Accel-Buffering": "no",
         },
     )
+

--- a/ods/extensions/services/dashboard-api/routers/pixel_sharing.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_sharing.py
@@ -18,7 +18,7 @@ PREFIX = '/v1/pixel/inference-sharing'
 async def _body(request, action):
     raw = bytearray()
     try:
-        async with asyncio.timeout(10):
+        async with async_timeout(10):
             async for chunk in request.stream():
                 if len(raw) + len(chunk) > MAX_BYTES:
                     raise HTTPException(413, 'Sharing request exceeds size limit')
@@ -70,3 +70,4 @@ async def change_sharing(action: str, request: Request, _key: str = Depends(veri
     if action not in ('issue','enable','revoke','start','stop'):
         raise HTTPException(404, 'Sharing action not found')
     return await _request(action, await _body(request, action))
+

--- a/ods/extensions/services/dashboard-api/routers/pixel_sharing.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_sharing.py
@@ -1,4 +1,10 @@
 """Owner-only inference sharing controls, separate from incoming device keys."""
+import sys
+import asyncio
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 import asyncio
 import json
 
@@ -70,4 +76,5 @@ async def change_sharing(action: str, request: Request, _key: str = Depends(veri
     if action not in ('issue','enable','revoke','start','stop'):
         raise HTTPException(404, 'Sharing action not found')
     return await _request(action, await _body(request, action))
+
 

--- a/ods/extensions/services/model-router/requirements.txt
+++ b/ods/extensions/services/model-router/requirements.txt
@@ -2,3 +2,4 @@
 fastapi>=0.109.0,<0.120.0
 uvicorn[standard]>=0.27.0,<0.30.0
 httpx>=0.27.0,<0.29.0
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/pixel-edge/requirements.txt
+++ b/ods/extensions/services/pixel-edge/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp==3.11.12
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -1,5 +1,11 @@
 """Tests for pixel_edge — upstream Unix socket + edge proxy routes."""
 
+import sys
+import asyncio
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 import asyncio
 import hashlib
 import io

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -1623,7 +1623,7 @@ class TestChatActivity(BaseEdgeTest):
         await asyncio.wait_for(stream.content.readany(), 2)
         self.assertEqual(await self.activity(user), {"state": "active"})
         stream.close()
-        async with asyncio.timeout(2):
+        async with async_timeout(2):
             while self.edge_app[self.pe._CANCEL_EVENTS_KEY].get(user):
                 await asyncio.sleep(0.02)
         native = self.up_runner.app["native_runs"][user][1]
@@ -1644,3 +1644,4 @@ class TestChatActivity(BaseEdgeTest):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/ods/extensions/services/pixel-inference/app/main.py
+++ b/ods/extensions/services/pixel-inference/app/main.py
@@ -237,7 +237,7 @@ def create_app(store=None, router_url=None, client=None):
             payload = None
             if request.method == 'POST':
                 raw = bytearray()
-                async with asyncio.timeout(min(10, grant['deadlineSeconds'])):
+                async with async_timeout(min(10, grant['deadlineSeconds'])):
                     async for chunk in request.stream():
                         if len(raw) + len(chunk) > MAX_BYTES:
                             raise ShareError(413, 'request_too_large')
@@ -324,3 +324,4 @@ def create_app(store=None, router_url=None, client=None):
 
 
 app = create_app()
+

--- a/ods/extensions/services/pixel-inference/app/main.py
+++ b/ods/extensions/services/pixel-inference/app/main.py
@@ -4,6 +4,12 @@ One process: per-device rate/concurrency limits are local admission controls,
 not durable billing quotas. No arbitrary forwarding, agent or management API.
 """
 
+import sys
+import asyncio
+if sys.version_info >= (3, 11):
+    from asyncio import timeout as async_timeout
+else:
+    from async_timeout import timeout as async_timeout
 import asyncio
 import ipaddress
 import json

--- a/ods/extensions/services/pixel-inference/requirements.txt
+++ b/ods/extensions/services/pixel-inference/requirements.txt
@@ -2,3 +2,4 @@
 fastapi>=0.109.0,<0.120.0
 uvicorn[standard]>=0.27.0,<0.30.0
 httpx>=0.27.0,<0.29.0
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/privacy-shield/requirements.txt
+++ b/ods/extensions/services/privacy-shield/requirements.txt
@@ -7,3 +7,4 @@ cachetools>=5.0.0,<6.0.0
 websockets>=12.0,<16.0
 # NOTE: Presidio PII detection not integrated - using regex-only detection
 # See documentation for PII coverage limitations
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/remote-provider-egress/requirements.txt
+++ b/ods/extensions/services/remote-provider-egress/requirements.txt
@@ -2,3 +2,4 @@
 fastapi>=0.109.0,<0.120.0
 uvicorn[standard]>=0.27.0,<0.30.0
 httpx>=0.27.0,<0.29.0
+async-timeout>=4.0.0; python_version < '3.11'

--- a/ods/extensions/services/token-spy/requirements.txt
+++ b/ods/extensions/services/token-spy/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.110.0,<0.120.0
 uvicorn[standard]>=0.27.0,<0.30.0
 httpx>=0.26.0,<0.29.0
 psycopg2-binary>=2.9.9,<3.0.0
+async-timeout>=4.0.0; python_version < '3.11'


### PR DESCRIPTION
## Description

The recent `public-beta` updates to `pixel_provider`, `dashboard-api`, and `pixel-inference` introduced the use of the `asyncio.timeout` context manager. However, `asyncio.timeout` is only available in Python 3.11 and later.

ODS officially supports Python 3.10, as confirmed by installation scripts such as `ods/installers/lib/python-cmd.sh`. As a result, running the beta on a Python 3.10 environment causes runtime crashes when these network paths are triggered.

### Error

```text
AttributeError: module 'asyncio' has no attribute 'timeout'
```

### Environment / Device

* **OS:** Windows (Docker Desktop with WSL2 backend)
* **Python:** 3.10.x
* **Hardware:** Local desktop development environment

### Fix

This PR restores Python 3.10 compatibility while retaining the existing timeout behavior.

* Added a conditional compatibility wrapper in the 6 affected files:

  * `connection_tunnel.py`
  * `runtime_gateway.py`
  * `pixel.py`
  * `pixel_sharing.py`
  * `main.py`
  * `test_pixel_edge.py`
* On Python 3.11+, the native `asyncio.timeout` implementation is used.
* On Python versions below 3.11, the implementation falls back to the `async_timeout` backport.
* Added the following conditional dependency to the relevant `requirements.txt` files:

  ```text
  async-timeout>=4.0.0; python_version < '3.11'
  ```

This keeps the newer timeout behavior while maintaining compatibility with ODS's supported Python 3.10 environments.

### How to Test

1. Run the ODS environment using Python 3.10.
2. Trigger the Pixel chat stream or another provider network operation.
3. Verify that the operation completes successfully or times out gracefully.
4. Confirm that no `AttributeError: module 'asyncio' has no attribute 'timeout'` occurs.

### Expected Behavior

Pixel network operations should work correctly on Python 3.10 and gracefully handle timeouts without crashing.

### Actual Behavior

On Python 3.10, triggering affected network paths causes an immediate `AttributeError` because `asyncio.timeout` is unavailable.
