### PR TITLE
Stop the GUI installer sending feature ids the backend rejects

### DIFF
--- a/installer/src/pages/Features.tsx
+++ b/installer/src/pages/Features.tsx
@@ -11,6 +11,12 @@ interface FeatureOption {
   description: string;
   default: boolean;
   vramNote?: string;
+  /**
+   * The feature id understood by the `start_install` command, or null when the
+   * installer has no flag for it and always installs it. Only non-null ids may
+   * be sent — the Rust side rejects anything outside its allowlist.
+   */
+  installerFlag: string | null;
 }
 
 const FEATURES: FeatureOption[] = [
@@ -20,6 +26,7 @@ const FEATURES: FeatureOption[] = [
     description:
       "AI chat interface with a powerful language model running locally.",
     default: true,
+    installerFlag: null,
   },
   {
     id: "voice",
@@ -27,6 +34,7 @@ const FEATURES: FeatureOption[] = [
     description: "Speech-to-text and text-to-speech for voice conversations.",
     default: false,
     vramNote: "Adds ~1GB VRAM usage",
+    installerFlag: "voice",
   },
   {
     id: "workflows",
@@ -34,6 +42,7 @@ const FEATURES: FeatureOption[] = [
     description:
       "n8n workflow automation and OpenClaw AI agents for complex tasks.",
     default: false,
+    installerFlag: "workflows",
   },
   {
     id: "rag",
@@ -41,6 +50,7 @@ const FEATURES: FeatureOption[] = [
     description:
       "Vector search with Qdrant for retrieval-augmented generation.",
     default: false,
+    installerFlag: "rag",
   },
   {
     id: "image_gen",
@@ -48,13 +58,15 @@ const FEATURES: FeatureOption[] = [
     description: "Generate images locally with ComfyUI and FLUX.",
     default: false,
     vramNote: "Requires 8GB+ VRAM",
+    installerFlag: "image_gen",
   },
   {
     id: "search",
     name: "Private Search",
     description:
       "Self-hosted search engine (SearXNG) with no tracking or ads.",
-    default: false,
+    default: true,
+    installerFlag: null,
   },
 ];
 
@@ -64,8 +76,8 @@ export default function Features({ onNext }: Props) {
   );
 
   const toggle = (id: string) => {
-    // Chat is always enabled
-    if (id === "chat") return;
+    // Features without an installer flag are always installed.
+    if (!FEATURES.find((f) => f.id === id)?.installerFlag) return;
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -78,6 +90,14 @@ export default function Features({ onNext }: Props) {
     setSelected(new Set(FEATURES.map((f) => f.id)));
   };
 
+  // Send only ids the installer has a flag for; `start_install` rejects the rest.
+  const submit = () =>
+    onNext(
+      FEATURES.filter((f) => f.installerFlag && selected.has(f.id)).map(
+        (f) => f.installerFlag as string,
+      ),
+    );
+
   return (
     <div className="flex flex-col items-center justify-center h-full px-8">
       <h2 className="text-2xl font-bold mb-2">Choose Features</h2>
@@ -88,7 +108,7 @@ export default function Features({ onNext }: Props) {
       <div className="w-full max-w-md space-y-2 mb-6">
         {FEATURES.map((feature) => {
           const isSelected = selected.has(feature.id);
-          const isRequired = feature.id === "chat";
+          const isRequired = feature.installerFlag === null;
           return (
             <button
               key={feature.id}
@@ -137,7 +157,7 @@ export default function Features({ onNext }: Props) {
         <Button variant="ghost" onClick={selectAll}>
           Select All
         </Button>
-        <Button onClick={() => onNext(Array.from(selected))}>
+        <Button onClick={submit}>
           Install
         </Button>
       </div>


### PR DESCRIPTION
The Features page offered "chat" and "search" as selectable ids and
passed the raw selection to start_install. Neither is in the Rust
ALLOWED_FEATURES allowlist, and "chat" is selected by default, so
validate_install_request rejected the very first request with
"Unsupported feature: chat" and no install could ever start. "Select
All" hit the same wall via "search".

Neither is an installer flag: chat is the core stack, and Private
Search is ENABLE_PERPLEXICA=true by default in install-core.sh with no
flag to change it. So the frontend catalog, not the allowlist, was
wrong.

Give FeatureOption an explicit installerFlag, null for features the
installer always installs. toggle() and the "(always included)" badge
now key off that instead of a hardcoded "chat", and submit() sends only
flagged ids — so chat and search cannot reach start_install by any
path, Select All included. Also flip search to default:true, since it
is always installed and showing it unchecked was inaccurate.

The Rust allowlist is unchanged; it is the boundary on what gets handed
to a shell script and it was already correct.