### PR TITLE
feat(pixel): download verified published files

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.jsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react'
+import { loadArtifactBytes } from '../lib/pixelArtifacts'
+
+export default function PixelArtifactDownload({ preview, file }) {
+  const [state, setState] = useState('idle')
+  const pending = useRef(null)
+  useEffect(() => () => { pending.current?.abort(); pending.current = null }, [])
+
+  async function download() {
+    if (pending.current) return
+    const controller = new AbortController()
+    pending.current = controller
+    setState('loading')
+    const timeout = setTimeout(() => controller.abort(), 12000)
+    try {
+      const bytes = await loadArtifactBytes(preview, file, controller.signal)
+      if (controller.signal.aborted) return
+      const url = URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }))
+      const link = document.createElement('a')
+      link.href = url
+      link.download = file.path.split('/').at(-1)
+      document.body.append(link)
+      try { link.click() } finally {
+        link.remove()
+        // Give the browser a task to consume the URL before releasing it.
+        setTimeout(() => URL.revokeObjectURL(url), 1000)
+      }
+      setState('saved')
+    } catch {
+      if (pending.current === controller) setState('error')
+    } finally {
+      clearTimeout(timeout)
+      if (pending.current === controller) pending.current = null
+    }
+  }
+  return <span>
+    <button type="button" onClick={download} disabled={state === 'loading'} aria-label={`Download ${file.path}`}>{state === 'loading' ? 'Verifying download…' : 'Download'}</button>
+    {state === 'saved' && <small role="status">Verified download started</small>}
+    {state === 'error' && <small role="alert">Download could not be verified. Try again.</small>}
+  </span>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.test.jsx
@@ -1,8 +1,11 @@
 import { webcrypto, createHash } from 'node:crypto'
+import { Buffer } from 'node:buffer'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import PixelPreviewSource from './PixelPreviewSource'
 
-const data = new Uint8Array([0, 255, 13, 10, 42])
+// Node 20 WebCrypto requires a buffer from its own realm, like fetch supplies.
+const data = Buffer.alloc(5)
+data.set([0, 255, 13, 10, 42])
 const file = { path: 'assets/result.bin', bytes: data.length, sha256: createHash('sha256').update(data).digest('hex') }
 const preview = { siteId: 'site-' + 'a'.repeat(24) }
 let blobs, clicks
@@ -23,7 +26,7 @@ it('downloads original verified binary bytes from the public source control', as
   expect(clicks).toEqual([{name:'result.bin', href:'blob:download'}])
   expect(blobs[0].type).toBe('application/octet-stream')
   const bytes = await new Promise(resolve => { const reader = new globalThis.FileReader(); reader.onload = () => resolve(new Uint8Array(reader.result)); reader.readAsArrayBuffer(blobs[0]) })
-  expect(bytes).toEqual(data)
+  expect([...bytes]).toEqual([...data])
   expect(document.querySelector('a[download]')).toBeNull()
   await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:download'), {timeout:2000})
 })

--- a/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.test.jsx
@@ -1,0 +1,55 @@
+import { webcrypto, createHash } from 'node:crypto'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+
+const data = new Uint8Array([0, 255, 13, 10, 42])
+const file = { path: 'assets/result.bin', bytes: data.length, sha256: createHash('sha256').update(data).digest('hex') }
+const preview = { siteId: 'site-' + 'a'.repeat(24) }
+let blobs, clicks
+beforeEach(() => {
+  blobs = []; clicks = []
+  vi.stubGlobal('crypto', webcrypto)
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true, arrayBuffer:async () => data.buffer})))
+  vi.spyOn(URL, 'createObjectURL').mockImplementation(blob => { blobs.push(blob); return 'blob:download' })
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () { clicks.push({name:this.download, href:this.href}) })
+})
+afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+it('downloads original verified binary bytes from the public source control', async () => {
+  render(<PixelPreviewSource preview={preview} file={file}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Download assets/result.bin'}))
+  await screen.findByText('Verified download started')
+  expect(clicks).toEqual([{name:'result.bin', href:'blob:download'}])
+  expect(blobs[0].type).toBe('application/octet-stream')
+  const bytes = await new Promise(resolve => { const reader = new globalThis.FileReader(); reader.onload = () => resolve(new Uint8Array(reader.result)); reader.readAsArrayBuffer(blobs[0]) })
+  expect(bytes).toEqual(data)
+  expect(document.querySelector('a[download]')).toBeNull()
+  await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:download'), {timeout:2000})
+})
+
+it('rejects a tampered file and allows an explicit retry', async () => {
+  fetch.mockResolvedValue({ok:true, arrayBuffer:async () => new Uint8Array([1]).buffer})
+  render(<PixelPreviewSource preview={preview} file={file}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Download assets/result.bin'}))
+  await screen.findByText('Download could not be verified. Try again.')
+  expect(clicks).toEqual([])
+  fetch.mockResolvedValue({ok:true, arrayBuffer:async () => data.buffer})
+  fireEvent.click(screen.getByRole('button', {name:'Download assets/result.bin'}))
+  await screen.findByText('Verified download started')
+  expect(clicks).toHaveLength(1)
+})
+
+it('deduplicates clicks and discards a download when its source is replaced', async () => {
+  let finish
+  fetch.mockImplementation(() => new Promise(resolve => { finish = resolve }))
+  const {rerender} = render(<PixelPreviewSource preview={preview} file={file}/>)
+  const button = screen.getByRole('button', {name:'Download assets/result.bin'})
+  fireEvent.click(button); fireEvent.click(button)
+  expect(fetch).toHaveBeenCalledTimes(2) // source inspection + one download
+  const resolveDownload = finish
+  rerender(<PixelPreviewSource preview={{siteId:'site-'+'b'.repeat(24)}} file={file}/>)
+  resolveDownload({ok:true, arrayBuffer:async () => data.buffer})
+  await waitFor(() => expect(screen.getByRole('button', {name:'Download assets/result.bin'})).toBeEnabled())
+  expect(clicks).toEqual([])
+})

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { loadArtifactBytes } from '../lib/pixelArtifacts'
 import { PixelCodeLines, PixelLanguageBadge } from './PixelCodeBlock'
+import PixelArtifactDownload from './PixelArtifactDownload'
 
 const TEXT_LANGUAGES = {html:'html',htm:'html',css:'css',scss:'scss',js:'javascript',mjs:'javascript',cjs:'javascript',jsx:'javascript',ts:'typescript',tsx:'typescript',py:'python',sh:'bash',yml:'yaml',yaml:'yaml',toml:'ini',json:'json',svg:'xml',xml:'xml',md:'markdown',markdown:'markdown',txt:'text',map:'json',csv:'text',tsv:'text'}
 
@@ -41,7 +42,7 @@ export default function PixelPreviewSource({ preview, file }) {
     {binarySize !== null && <p role="status">Binary asset. Its bytes are verified; no text source is available.</p>}
     {error && <div role="alert"><p>{error}</p><button type="button" onClick={() => setAttempt(value => value + 1)}>Retry source</button></div>}
     <div className="pixel-code-block">
-      <header className="code-block-header"><PixelLanguageBadge path={path}/><span title={path}>{path}</span>{language && <button type="button" aria-label="Copy code" onClick={copy} disabled={source === null}>{copied ? 'Copied' : 'Copy'}</button>}</header>
+      <header className="code-block-header"><PixelLanguageBadge path={path}/><span title={path}>{path}</span><PixelArtifactDownload key={`${preview.siteId}/${path}/${expectedDigest}`} preview={preview} file={{path, sha256:expectedDigest, bytes:file?.bytes}}/>{language && <button type="button" aria-label="Copy code" onClick={copy} disabled={source === null}>{copied ? 'Copied' : 'Copy'}</button>}</header>
       {source !== null && <pre tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre>}
     </div>
     {(source !== null || binarySize !== null) && <p className="pixel-source-verification">Published snapshot · SHA-256 verified{binarySize !== null ? ` · ${binarySize.toLocaleString()} bytes` : ''}</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelTaskFiles.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTaskFiles.test.jsx
@@ -20,7 +20,7 @@ it('filters all published files, opens verified nested source and returns to the
   fireEvent.click(screen.getByRole('button',{name:/assets\/app.js/}))
   await waitFor(() => expect(screen.getByRole('button',{name:'Copy code'})).toBeEnabled())
   expect(container.querySelector('pre').textContent).toContain(js)
-  expect(screen.getByRole('button',{name:/assets\/app.js/})).toHaveAttribute('aria-current','true')
+  expect(screen.getByRole('button',{name:/^assets\/app.js/})).toHaveAttribute('aria-current','true')
   expect(screen.getByRole('searchbox')).toHaveValue('app.js')
   expect(fetch).toHaveBeenLastCalledWith(`/pixel-preview/${preview.siteId}/assets/app.js`,expect.objectContaining({cache:'no-store'}))
   fireEvent.click(screen.getByRole('button',{name:'All files'}))


### PR DESCRIPTION
## Why this matters

Pixel's Files panel can inspect text, but gives owners no way to retrieve a published binary asset. Add Download to the source header for every file. The download reuses the authenticated preview relay, checks byte length and SHA-256, and saves the original bytes with the leaf filename.

Duplicate clicks share one pending operation. Switching the file or snapshot cancels the old operation. A failed verification creates no download and exposes an explicit retry. Object URLs are released after the browser consumes them. This is a single-file download, not a workspace backup.

## Overlap check

Searched open and closed upstream PRs for `artifact download` and `verified download`, and inspected the recent 1,500-PR file inventory for PixelPreviewSource.jsx and pixelArtifacts.js. #4107 addresses clipboard receipts; #4092 cancels rejected response bodies; #4027 supplies the existing workbench. None adds a verified download control. #1999/#900 concern model downloads. This change uses the existing artifact verifier without modifying it.

## Risk and validation

Medium: dashboard UI. Base public-beta d7d76cdc; candidate e8b3c3f3.

- `npm test -- --maxWorkers=2 src/components/PixelArtifactDownload.test.jsx src/components/PixelPreviewSource.test.jsx`: 6 passed. Public source control tests verify exact binary Blob bytes, filename, URL cleanup, tamper rejection/retry, duplicate clicks and snapshot replacement.
- Focused ESLint: zero errors. `npm run build`: passed. `git diff --check`: passed.
- Baseline dashboard suite: 713 tests passed. Combined validation is recorded below.
- Full pre-commit scan: gitleaks, large-file and shellcheck passed; private-key hook flags existing literal `unit-test-key` fixtures in test_host_agent.py and test-remote-provider-egress-policy.py. Neither file is changed here.
- Follow-up e8b3c3f3 fixes test fixtures for Node 20 WebCrypto and scopes the existing file-row assertion now that Download also names the file. The exact Node 20 full dashboard suite passes: 716 tests. The three affected component suites pass 14 tests. Changed-file pre-commit hooks pass.
- Full Bash gate on unchanged beta d7d76cdc stops in test-phase03-multigpu-tty.sh: its no-sudo fixture reports Docker promoted to sudo under this WSL environment (3 pass, 2 fail). No installer file is changed. No installed hardware or release acceptance is claimed.

Revert this commit to remove the control; saved files and server state require no migration. Browser download policy may still prompt or block saving. Target: public-beta, not the stable release lane. No host lifecycle or inference changes.

## AI assistance

Codex investigated, implemented and tested this change. Independent human review remains outstanding. This PR does not authorize deployment or merge.


## Final batch receipt (2026-09-11)

Exact PR head: `e8b3c3f3fbeebff2f61d5a8311e99c1f25c90d2b`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
