### PR TITLE
feat(pixel): add bounded text-file input to the composer

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelTextFileInput.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTextFileInput.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react'
+
+const EXTENSIONS = /\.(txt|md|markdown|csv|tsv|json|jsonl|yaml|yml|toml|xml|html|css|js|jsx|ts|tsx|py|sh|log)$/i
+const MAX_BYTES = 16 * 1024
+
+function quotedFile(name, text) {
+  const fence = '`'.repeat(Math.max(2, ...[...text.matchAll(/`+/g)].map(match => match[0].length)) + 1)
+  return `\n\nFile: ${JSON.stringify(name)}\n${fence}text\n${text}\n${fence}\n`
+}
+
+export default function PixelTextFileInput({ input, disabled, limit, onInsert }) {
+  const field = useRef(null)
+  const reader = useRef(null)
+  const [file, setFile] = useState(null)
+  const [error, setError] = useState('')
+  const [reading, setReading] = useState(false)
+  useEffect(() => () => { if (reader.current) { reader.current.onload = null; reader.current.onerror = null; reader.current.abort() } }, [])
+
+  function choose(event) {
+    const selected = event.target.files?.[0]
+    event.target.value = ''
+    if (!selected) return
+    reader.current?.abort()
+    setFile(null); setError(''); setReading(false)
+    if (!EXTENSIONS.test(selected.name)) { setError('Choose a text, code, JSON or CSV file. PDF, images and archives are not supported here.'); return }
+    if (!selected.size || selected.size > MAX_BYTES) { setError('Choose a nonempty text file no larger than 16 KB.'); return }
+    const next = new globalThis.FileReader()
+    reader.current = next
+    setReading(true)
+    next.onload = () => {
+      setReading(false)
+      try {
+        const text = new TextDecoder('utf-8', {fatal:true}).decode(next.result)
+        if (text.includes('\0')) throw new Error('Binary content')
+        setFile({name:selected.name, text:quotedFile(selected.name, text)})
+      } catch { setError('The file must contain valid UTF-8 text, without binary bytes.') }
+    }
+    next.onerror = () => { setReading(false); setError('The file could not be read. Choose it again.') }
+    next.readAsArrayBuffer(selected)
+  }
+  const fits = file && input.length + file.text.length + 1 <= limit
+  return <div className="pixel-text-file-input text-xs text-theme-text-secondary">
+    <input ref={field} type="file" aria-label="Choose text file" accept=".txt,.md,.csv,.tsv,.json,.jsonl,.yaml,.yml,.toml,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.sh,.log" hidden disabled={disabled} onChange={choose}/>
+    <button type="button" className="pixel-metal-control rounded px-2 py-1" disabled={disabled || reading} onClick={() => field.current?.click()}>Add text file</button>
+    {reading && <span role="status">Reading local file…</span>}
+    {error && <p role="alert">{error}</p>}
+    {file && <div role="group" aria-label="Review text file">
+      <p>{file.name} · Text will be inserted into your draft. It is sent to the selected model only when you send the message.</p>
+      {!fits && <p role="alert">The file and draft exceed the message limit. Shorten the draft or choose a smaller file.</p>}
+      <button type="button" disabled={disabled || !fits} onClick={() => { onInsert(file.text); setFile(null) }}>Insert file text</button>
+      <button type="button" onClick={() => setFile(null)}>Discard file</button>
+    </div>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelTextFileInput.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTextFileInput.test.jsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import PixelTextFileInput from './PixelTextFileInput'
+
+const upload = file => fireEvent.change(screen.getByLabelText('Choose text file'), {target:{files:[file]}})
+const props = {input:'Analyze this', limit:16384, disabled:false}
+it('stages exact Unicode/CRLF text without sending and inserts only on confirmation', async () => {
+  const insert = vi.fn()
+  render(<PixelTextFileInput {...props} onInsert={insert}/>)
+  const text = 'Tên,Giá\r\nTrà,12\r\n```\n'
+  upload(new File([text], 'costs.csv', {type:'text/csv'}))
+  await screen.findByRole('group', {name:'Review text file'})
+  expect(insert).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', {name:'Insert file text'}))
+  expect(insert).toHaveBeenCalledWith(`\n\nFile: "costs.csv"\n\`\`\`\`text\n${text}\n\`\`\`\`\n`)
+  expect(screen.queryByRole('group')).toBeNull()
+})
+
+it.each([
+  [new File(['pdf'], 'report.pdf'), /not supported/],
+  [new File(['x'.repeat(16385)], 'large.txt'), /16 KB/],
+  [new File([], 'empty.txt'), /nonempty/],
+  [new File([new Uint8Array([255])], 'bad.txt'), /valid UTF-8/],
+  [new File(['hello\0'], 'binary.txt'), /binary bytes/],
+])('rejects unsupported or invalid inputs without changing the draft', async (file, message) => {
+  const insert = vi.fn()
+  render(<PixelTextFileInput {...props} onInsert={insert}/>)
+  upload(file)
+  expect(await screen.findByRole('alert')).toHaveTextContent(message)
+  expect(insert).not.toHaveBeenCalled()
+})
+
+it('rechecks the current draft budget and working state before insertion', async () => {
+  const insert = vi.fn()
+  const {rerender} = render(<PixelTextFileInput {...props} onInsert={insert}/>)
+  upload(new File(['hello'], 'a.txt'))
+  await screen.findByRole('group')
+  rerender(<PixelTextFileInput {...props} input={'x'.repeat(16380)} onInsert={insert}/>)
+  expect(screen.getByRole('button', {name:'Insert file text'})).toBeDisabled()
+  rerender(<PixelTextFileInput {...props} disabled onInsert={insert}/>)
+  expect(screen.getByRole('button', {name:'Insert file text'})).toBeDisabled()
+  fireEvent.click(screen.getByRole('button', {name:'Discard file'}))
+  expect(insert).not.toHaveBeenCalled()
+})
+
+it('drops a pending local read when the conversation unmounts', () => {
+  const insert = vi.fn(), abort = vi.fn()
+  let reader
+  vi.stubGlobal('FileReader', class { constructor() { reader = this } readAsArrayBuffer() {} abort = abort })
+  try {
+    const {unmount} = render(<PixelTextFileInput {...props} onInsert={insert}/>)
+    upload(new File(['hello'], 'a.txt'))
+    unmount()
+    expect(abort).toHaveBeenCalledOnce()
+    expect(reader.onload).toBeNull()
+    expect(insert).not.toHaveBeenCalled()
+  } finally { vi.unstubAllGlobals() }
+})

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -10,6 +10,7 @@ import UserAvatar from '../components/UserAvatar'
 import {useLocalProfile} from '../lib/localProfile'
 import { pixelHeaderPose, pixelReplyPose } from '../lib/pixelMascotState'
 import PixelComposerTools from '../components/PixelComposerTools'
+import PixelTextFileInput from '../components/PixelTextFileInput'
 import PixelDictation from '../components/PixelDictation'
 import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from '../components/PixelCommandSearch'
 import PixelSelectionActions from '../components/PixelSelectionActions'
@@ -1443,6 +1444,7 @@ export default function Pixel({ systemStatus = null }) {
           </div>
           </div>
           {stopError && <p role="alert" className="mt-1.5 px-1 text-xs text-amber-300">{stopError}</p>}
+          <PixelTextFileInput key={chatIdRef.current} input={input} disabled={isDisabled} limit={MAX_INPUT_LEN} onInsert={insertComposerText}/>
           <div className="pixel-composer-secondary">
             <PixelComposerTools input={input} disabled={isDisabled} onInsert={insertComposerText} />
             <div className="pixel-composer-limits">


### PR DESCRIPTION
## Why this matters

Pixel's Mention source menu is not an uploader. Owners currently have to open a local CSV, JSON, log or code file in another application and paste it manually. Add an explicit bounded text-file picker to the composer: read a local UTF-8 file, review its name and insert its complete text into the draft. Sending still requires the normal Send action.

The picker rejects unsupported document/image/archive formats, empty or over-16-KB files, invalid UTF-8 and NUL bytes. It accounts for framing and the current draft against the existing 16,384-character input limit. Code fences adapt to embedded backticks; CRLF and Unicode remain intact. Reads are disposed when switching conversations. The UI explains that selected-model transmission happens on Send; this is not a workspace upload or a vision/PDF claim.

## Overlap check

Searched all-state upstream `Pixel upload` and `text attachment` PRs and the recent 1,500-PR production-file inventory. #1334 adds attachments to ODS Talk; #1573 is native RAG; #3063 guards duplicate Talk submissions. #4114 affects keyboard prompt commands. This adds a separate local-text intake control on Pixel.jsx without replacing those paths. It addresses the bounded first increment of ingestion described in the beta community handoff.

## Validation and risk

Medium, Dashboard UI; target public-beta at d7d76cdc. Candidate 4de76884.

- Focused text-input and Pixel page suites: 81 tests passed on local Node 24; repeated on CI's Node 20 before publication.
- Tests exercise file-selection and confirmation, Unicode/CRLF, embedded fences, five invalid-file cases, changing draft budget, active-work guards and cleanup on conversation unmount.
- Focused ESLint: zero errors. Production build and `git diff --check`: passed.
- Baseline full dashboard: 713 passed. Combined validation is recorded below.
- Repo-wide baseline limitations: private-key hook detects existing literal unit-test-key fixtures; WSL Bash gate stops in the unchanged phase03 no-sudo fixture (3 pass, 2 fail). Changed-file hooks are checked separately.

Revert removes the picker; inserted text remains ordinary editable conversation content. No server storage, host execution or model-routing contract changes. Installed hardware/vision/document parsing are not qualified by these browser tests.

## AI assistance

Codex investigated, implemented and validated the change. Independent human review remains outstanding; no merge or deployment authorization is implied.


## Final batch receipt (2026-09-11)

Exact PR head: `4de7688459a1659e31aef512cc4687ce7c25a559`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
