### PR TITLE
feat(pixel): organize conversations with names pins and archive

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
@@ -1,12 +1,16 @@
 import { useEffect, useRef, useState } from 'react'
 import { Plus, X } from 'lucide-react'
 import { CHAT_KEY, LIBRARY_EVENT, SELECT_EVENT, DELETE_EVENT, readConversations, conversationTitle } from '../lib/pixelConversations'
+import { conversationLabels } from '../lib/pixelConversationLabels'
+import PixelConversationOrganizer from './PixelConversationOrganizer'
 
 export default function PixelConversationNavigation({ collapsed }) {
   const [chats, setChats] = useState(readConversations)
   const [active, setActive] = useState('')
   const [pending, setPending] = useState(null)
   const [deleteError, setDeleteError] = useState('')
+  const [showArchived, setShowArchived] = useState(false)
+  const archiveToggle = useRef(null)
   const dialog = useRef(null)
   const trigger = useRef(null)
   useEffect(() => { if (pending) dialog.current?.showModal() }, [pending])
@@ -28,9 +32,13 @@ export default function PixelConversationNavigation({ collapsed }) {
     return () => { window.removeEventListener(LIBRARY_EVENT, refresh); window.removeEventListener('storage', refresh) }
   }, [])
   if (collapsed) return <button className="pixel-nav-item" aria-label="New task" title="New task" onClick={() => window.dispatchEvent(new Event('ods:pixel-new-task'))}><Plus size={16}/></button>
+  const labeled = chats.map(chat => ({chat, labels:conversationLabels(chat.chatId)}))
+  const visible = labeled.filter(item => item.labels.archived === showArchived)
+  const pinned = visible.filter(item => item.labels.pinned).map(item => item.chat)
+  const regular = visible.filter(item => !item.labels.pinned).map(item => item.chat)
   const chevron = <svg className="rail-chevron" viewBox="0 0 16 16" aria-hidden="true"><path d="m5 6 3 3 3-3"/></svg>
   function rows(items, empty) {
-    return <div className="rail-conversations">{items.length ? items.map(chat => <div className="conversation-row" key={chat.chatId}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={`${conversationTitle(chat)} · ${chat.messages.filter(item => item.role === 'user').length} turns`} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><strong>{conversationTitle(chat)}</strong>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button><button className="conversation-delete" aria-label={`Delete chat: ${conversationTitle(chat)}`} title="Delete chat" onClick={event => { trigger.current = event.currentTarget; setDeleteError(''); setPending(chat) }}><X size={13}/></button></div>) : <span className="rail-empty">{empty}</span>}</div>
+    return <div className="rail-conversations">{items.length ? items.map(chat => <div className="conversation-row" key={chat.chatId}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={`${conversationTitle(chat)} · ${chat.messages.filter(item => item.role === 'user').length} turns`} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><strong>{conversationTitle(chat)}</strong>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button><PixelConversationOrganizer chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()}/><button className="conversation-delete" aria-label={`Delete chat: ${conversationTitle(chat)}`} title="Delete chat" onClick={event => { trigger.current = event.currentTarget; setDeleteError(''); setPending(chat) }}><X size={13}/></button></div>) : <span className="rail-empty">{empty}</span>}</div>
   }
   return <div className="pixel-conversation-navigation">
     <dialog ref={dialog} className="chat-delete-dialog" aria-labelledby="delete-chat-title" onCancel={event => { event.preventDefault(); closeDelete() }}>
@@ -41,15 +49,17 @@ export default function PixelConversationNavigation({ collapsed }) {
       <footer><button autoFocus onClick={closeDelete}>Cancel</button><button onClick={confirmDelete}>Delete chat</button></footer>
     </dialog>
     <button className="pixel-nav-item" onClick={() => window.dispatchEvent(new Event('ods:pixel-new-task'))}><Plus size={16}/><span>New task</span></button>
+    <button ref={archiveToggle} className="pixel-nav-item" type="button" aria-pressed={showArchived} onClick={() => setShowArchived(value => !value)}>{showArchived ? 'Show active conversations' : `Archived (${labeled.filter(item => item.labels.archived).length})`}</button>
     <div className="pixel-original-sections">
+      {pinned.length > 0 && <details className="rail-section" open><summary>Pinned{chevron}</summary>{rows(pinned, '')}</details>}
       <details className="rail-section" open>
         <summary>Projects{chevron}</summary>
         <details className="rail-project" open>
           <summary><svg className="rail-folder" viewBox="0 0 20 20" aria-hidden="true"><path d="M3 6V4.8A1.3 1.3 0 0 1 4.3 3.5h4l2 2h5.4A1.3 1.3 0 0 1 17 6.8V8M4 16.5h11.3a1.5 1.5 0 0 0 1.5-1.2L18 9.2A1 1 0 0 0 17 8H5.2a1.5 1.5 0 0 0-1.5 1.2L2.5 15A1.3 1.3 0 0 0 4 16.5Z"/></svg><span>Playground</span>{chevron}</summary>
-          {rows(chats.slice(0, 5), 'No conversations yet')}
+          {rows(regular.slice(0, 5), showArchived ? 'No archived conversations' : 'No conversations yet')}
         </details>
       </details>
-      <details className="rail-section" open><summary>Recent{chevron}</summary>{rows(chats.slice(5), 'No older conversations')}</details>
+      <details className="rail-section" open><summary>Recent{chevron}</summary>{rows(regular.slice(5), 'No older conversations')}</details>
     </div>
   </div>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelConversationOrganizer.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationOrganizer.jsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react'
+import { conversationLabels, saveConversationLabels } from '../lib/pixelConversationLabels'
+
+export default function PixelConversationOrganizer({chat, title, onSaved}) {
+  const dialog = useRef(null)
+  const trigger = useRef(null)
+  const original = useRef(null)
+  const [editing, setEditing] = useState(null)
+  const [error, setError] = useState('')
+  useEffect(() => { if (editing) dialog.current?.showModal() }, [Boolean(editing)])
+  function close() { dialog.current?.close(); setEditing(null); setError(''); trigger.current?.focus() }
+  function save(event) {
+    event.preventDefault()
+    try { saveConversationLabels(chat.chatId, editing, original.current); close(); onSaved?.() }
+    catch (failure) { setError(failure.message || 'Labels could not be saved. Your conversation is unchanged.') }
+  }
+  return <>
+    <button ref={trigger} type="button" className="conversation-delete" aria-label={`Organize chat: ${title}`} title="Rename, pin or archive" onClick={() => {setError(''); original.current = conversationLabels(chat.chatId); setEditing(original.current)}}>…</button>
+    {editing && <dialog ref={dialog} className="chat-delete-dialog" aria-label="Organize conversation" onCancel={event => {event.preventDefault(); close()}}>
+      <form onSubmit={save}>
+        <h3>Organize conversation</h3>
+        <label>Conversation name<input className="mt-2 block w-full rounded border border-theme-border bg-theme-bg px-3 py-2 text-theme-text" autoFocus maxLength={80} value={editing.title} placeholder="Use the first message" onChange={event => setEditing({...editing, title:event.target.value})}/></label>
+        <p>Leave the name empty to use the first message. Labels are saved in this browser.</p>
+        <label className="my-2 flex items-center gap-2"><input type="checkbox" checked={editing.pinned} onChange={event => setEditing({...editing, pinned:event.target.checked})}/>Pin conversation</label>
+        <label className="my-2 flex items-center gap-2"><input type="checkbox" checked={editing.archived} onChange={event => setEditing({...editing, archived:event.target.checked})}/>Archive conversation</label>
+        <p>Archiving hides it from the main list. It keeps all messages and does not stop running work.</p>
+        {error && <p role="alert">{error}</p>}
+        <footer><button type="button" onClick={close}>Cancel</button><button type="submit">Save labels</button></footer>
+      </form>
+    </dialog>}
+  </>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelConversationOrganizer.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationOrganizer.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { conversationLabels, saveConversationLabels } from '../lib/pixelConversationLabels'
+import './pixel-conversation-organizer.css'
 
 export default function PixelConversationOrganizer({chat, title, onSaved}) {
   const dialog = useRef(null)
@@ -15,7 +16,7 @@ export default function PixelConversationOrganizer({chat, title, onSaved}) {
     catch (failure) { setError(failure.message || 'Labels could not be saved. Your conversation is unchanged.') }
   }
   return <>
-    <button ref={trigger} type="button" className="conversation-delete" aria-label={`Organize chat: ${title}`} title="Rename, pin or archive" onClick={() => {setError(''); original.current = conversationLabels(chat.chatId); setEditing(original.current)}}>…</button>
+    <button ref={trigger} type="button" className="conversation-organize" aria-label={`Organize chat: ${title}`} title="Rename, pin or archive" onClick={() => {setError(''); original.current = conversationLabels(chat.chatId); setEditing(original.current)}}>…</button>
     {editing && <dialog ref={dialog} className="chat-delete-dialog" aria-label="Organize conversation" onCancel={event => {event.preventDefault(); close()}}>
       <form onSubmit={save}>
         <h3>Organize conversation</h3>

--- a/ods/extensions/services/dashboard/src/components/PixelConversationOrganizer.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationOrganizer.test.jsx
@@ -1,0 +1,85 @@
+import {act, fireEvent, render, screen, within} from '@testing-library/react'
+import PixelConversationNavigation from './PixelConversationNavigation'
+import {CHAT_KEY, saveConversation, readConversations, conversationTitle} from '../lib/pixelConversations'
+import {saveConversationLabels, conversationLabels} from '../lib/pixelConversationLabels'
+
+const chat = {schema:1, chatId:'one', messages:[{role:'user', content:'Original prompt'}], inFlight:true, draft:'Keep draft'}
+beforeEach(() => {
+  localStorage.clear()
+  HTMLDialogElement.prototype.showModal = function () {this.open = true}
+  HTMLDialogElement.prototype.close = function () {this.open = false}
+  saveConversation(chat)
+})
+afterEach(() => {vi.restoreAllMocks(); delete HTMLDialogElement.prototype.showModal; delete HTMLDialogElement.prototype.close})
+const open = () => fireEvent.click(screen.getByRole('button', {name:/Organize chat:/}))
+const save = () => fireEvent.click(screen.getByRole('button', {name:'Save labels'}))
+
+it('renames and pins a chat without modifying active work, draft or message history', () => {
+  const before = localStorage.getItem(CHAT_KEY)
+  const {unmount} = render(<PixelConversationNavigation/>)
+  open()
+  fireEvent.change(screen.getByLabelText('Conversation name'), {target:{value:'  Budget research  '}})
+  fireEvent.click(screen.getByLabelText('Pin conversation'))
+  save()
+  expect(screen.getByRole('button', {name:/^Budget research/})).toBeVisible()
+  expect(screen.getByText('Pinned')).toBeVisible()
+  expect(localStorage.getItem(CHAT_KEY)).toBe(before)
+  act(() => saveConversation({...chat, messages:[...chat.messages, {role:'assistant', content:'New reply'}]}))
+  expect(conversationTitle(readConversations()[0])).toBe('Budget research')
+  unmount()
+  render(<PixelConversationNavigation/>)
+  expect(screen.getByText('Pinned')).toBeVisible()
+  expect(readConversations()[0].inFlight).toBe(true)
+})
+
+it('archives and restores the same conversation without deleting or stopping it', () => {
+  render(<PixelConversationNavigation/>)
+  open(); fireEvent.click(screen.getByLabelText('Archive conversation')); save()
+  expect(screen.queryByRole('button', {name:/^Original prompt/})).toBeNull()
+  fireEvent.click(screen.getByRole('button', {name:'Archived (1)'}))
+  expect(screen.getByRole('button', {name:/^Original prompt/})).toBeVisible()
+  open(); fireEvent.click(screen.getByLabelText('Archive conversation')); save()
+  fireEvent.click(screen.getByRole('button', {name:'Show active conversations'}))
+  expect(screen.getByRole('button', {name:/^Original prompt/})).toBeVisible()
+  expect(readConversations()[0].messages).toEqual(chat.messages)
+})
+
+it('does not overwrite a newer label change from another tab', () => {
+  render(<PixelConversationNavigation/>)
+  open()
+  fireEvent.change(screen.getByLabelText('Conversation name'), {target:{value:'My edit'}})
+  act(() => saveConversationLabels('one', {title:'Other tab', pinned:false, archived:false}))
+  save()
+  expect(screen.getByRole('alert')).toHaveTextContent('Labels changed in another tab')
+  expect(conversationLabels('one').title).toBe('Other tab')
+})
+
+it('shows failed writes and preserves unreadable metadata', () => {
+  localStorage.setItem('ods.pixel.chat-labels.v1.one', '{broken')
+  render(<PixelConversationNavigation/>)
+  open(); save()
+  expect(screen.getByRole('alert')).toBeVisible()
+  expect(localStorage.getItem('ods.pixel.chat-labels.v1.one')).toBe('{broken')
+  expect(readConversations()).toHaveLength(1)
+})
+
+it('resets to the automatic name and synchronizes storage events', () => {
+  saveConversationLabels('one', {title:'Custom', pinned:false, archived:false})
+  render(<PixelConversationNavigation/>)
+  open()
+  fireEvent.change(screen.getByLabelText('Conversation name'), {target:{value:''}})
+  save()
+  expect(screen.getByRole('button', {name:/^Original prompt/})).toBeVisible()
+  localStorage.setItem('ods.pixel.chat-labels.v1.one', JSON.stringify({title:'Remote edit', pinned:false, archived:false}))
+  act(() => window.dispatchEvent(new Event('storage')))
+  expect(screen.getByRole('button', {name:/^Remote edit/})).toBeVisible()
+})
+
+it('cancels without persisting labels or selecting another conversation', () => {
+  render(<PixelConversationNavigation/>)
+  open()
+  fireEvent.change(screen.getByLabelText('Conversation name'), {target:{value:'Discard this'}})
+  fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', {name:'Cancel'}))
+  expect(conversationLabels('one').title).toBe('')
+  expect(screen.getByRole('button', {name:'Organize chat: Original prompt'})).toHaveFocus()
+})

--- a/ods/extensions/services/dashboard/src/components/pixel-conversation-organizer.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-conversation-organizer.css
@@ -1,4 +1,4 @@
-.pixel-conversation-navigation .conversation-row .conversation-link { padding-left:64px; }
+.pixel-conversation-navigation .pixel-original-sections .conversation-row .conversation-link { padding-left:64px; }
 .conversation-organize { position:absolute; left:32px; top:50%; transform:translateY(-50%); width:26px; height:26px; display:grid; place-items:center; opacity:0; color:#aeb5be; border:0; border-radius:5px; background:transparent; pointer-events:none; }
 .conversation-row:hover .conversation-organize,.conversation-row:focus-within .conversation-organize { opacity:1; pointer-events:auto; }
 .conversation-organize:hover { color:#fff; background:#ffffff12; }

--- a/ods/extensions/services/dashboard/src/components/pixel-conversation-organizer.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-conversation-organizer.css
@@ -1,0 +1,5 @@
+.pixel-conversation-navigation .conversation-row .conversation-link { padding-left:64px; }
+.conversation-organize { position:absolute; left:32px; top:50%; transform:translateY(-50%); width:26px; height:26px; display:grid; place-items:center; opacity:0; color:#aeb5be; border:0; border-radius:5px; background:transparent; pointer-events:none; }
+.conversation-row:hover .conversation-organize,.conversation-row:focus-within .conversation-organize { opacity:1; pointer-events:auto; }
+.conversation-organize:hover { color:#fff; background:#ffffff12; }
+@media(hover:none) { .conversation-organize { opacity:1; pointer-events:auto; } }

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationLabels.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationLabels.js
@@ -1,0 +1,24 @@
+const PREFIX = 'ods.pixel.chat-labels.v1.'
+const defaults = {title:'', pinned:false, archived:false}
+
+function load(chatId) {
+  if (!/^[A-Za-z0-9_-]{1,128}$/.test(chatId)) throw new Error('Invalid conversation identity')
+  const value = JSON.parse(localStorage.getItem(PREFIX + chatId) || 'null')
+  if (value === null) return {...defaults}
+  if (typeof value.title !== 'string' || value.title.length > 80 || typeof value.pinned !== 'boolean' || typeof value.archived !== 'boolean') {
+    throw new Error('Saved labels could not be read. Existing data was preserved.')
+  }
+  return {title:value.title, pinned:value.pinned, archived:value.archived}
+}
+
+export function conversationLabels(chatId) {
+  try { return load(chatId) } catch { return {...defaults} }
+}
+
+export function saveConversationLabels(chatId, labels, expected) {
+  const current = load(chatId) // Refuse to overwrite unreadable metadata.
+  if (expected && Object.keys(defaults).some(key => current[key] !== expected[key])) throw new Error('Labels changed in another tab. Cancel and reopen to review the latest labels.')
+  if (typeof labels.title !== 'string' || labels.title.trim().length > 80 || typeof labels.pinned !== 'boolean' || typeof labels.archived !== 'boolean') throw new Error('Invalid conversation labels')
+  localStorage.setItem(PREFIX + chatId, JSON.stringify({...labels, title:labels.title.trim()}))
+  window.dispatchEvent(new Event('ods:pixel-conversations-changed'))
+}

--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.js
@@ -1,3 +1,5 @@
+import { conversationLabels } from './pixelConversationLabels'
+
 export const CHAT_KEY = 'ods.pixel.chat.v1'
 const LIBRARY_KEY = 'ods.pixel.conversations.v1'
 export const LIBRARY_EVENT = 'ods:pixel-conversations-changed'
@@ -51,7 +53,7 @@ export function saveConversation(chat) {
 }
 
 export function conversationTitle(chat) {
-  return chat.messages.find(message => message.role === 'user' && typeof message.content === 'string')?.content.trim().slice(0, 80) || chat.draft?.trim().slice(0, 80) || 'Untitled conversation'
+  return conversationLabels(chat.chatId).title || chat.messages.find(message => message.role === 'user' && typeof message.content === 'string')?.content.trim().slice(0, 80) || chat.draft?.trim().slice(0, 80) || 'Untitled conversation'
 }
 
 export function deleteConversation(chatId) {


### PR DESCRIPTION
## Why this matters

Long-lived Pixel users need to find important tasks without deleting their history. Add a single organizer for custom names, pins and reversible archiving, exposed beside each conversation. Pinned conversations get their own section; an Archived toggle exposes the retained archive and its restore controls. Empty names restore the first-message title.

Labels use separate per-conversation browser records, so streaming/history saves cannot overwrite a rename or change execution state. Archived tasks keep messages, drafts and active work. A stale edit is rejected if another tab changed its labels. Corrupt metadata or failed writes stay visible and are not overwritten. Cancel restores focus to its trigger; save returns focus to the stable archive/list toggle even if the row moved.

## Overlap check

Searched all-state `conversation rename` and `chat pin archive` PRs and the latest 1,500-PR inventory for PixelConversationNavigation.jsx and pixelConversations.js. #4119 exports conversations, #4111/#4121 isolate malformed history, #4078 handles cleared drafts, and #4027 supplies the workbench. None implements labels or reversible archive. This feature preserves the existing history format and deletion/selection events; it does not replace or duplicate those repairs.

## Risk and validation

Medium dashboard UI. Target public-beta d7d76cdc; candidate bcaf3daf.

- Node 20: organizer, navigation, conversation storage and command-search suites: 19 tests passed.
- Boundary tests cover rename/pin through streaming saves and remount, archive/restore with active work, conflicting cross-tab edits, corrupt metadata preservation, automatic-title reset, storage-event refresh and cancellation focus.
- Production build, focused ESLint (zero errors), changed-file pre-commit hooks, and `git diff --check`: passed.
- Full beta baseline: 713 dashboard tests passed. Combined validation is recorded below.
- Unchanged baseline gate limits: private-key scanner flags literal unit-test-key fixtures; the WSL Bash gate's phase03 no-sudo fixture reports 3 pass/2 fail. No installer or fixture code is changed here.

Labels are local to the browser and are not part of server/workspace backups. Reverting the commit leaves conversation data intact; unused label keys are harmless. No host/inference lifecycle or release qualification claim.

## AI assistance

Codex investigated, implemented, reviewed and tested this change. Independent human review remains outstanding; no deployment or merge is implied.


## Final batch receipt (2026-09-11)

Exact PR head: `bcaf3daf67d4d6cc3f951a2a32e92359394bebf9`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.

Follow-ups `07126e3f` and `bcaf3daf` corrected organizer placement before merge; current upstream moves it to the right. Actual current-layout browser checks confirm non-overlapping actions/title and successful rename/pin.
