### PR TITLE
feat(pixel): search retained replies and drafts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Search, X, MessageSquare, Plus, Settings, ListChecks, Globe2 } from 'lucide-react'
 import { readConversations, conversationTitle, SELECT_EVENT } from '../lib/pixelConversations'
+import { conversationExcerpt } from '../lib/pixelConversationSearch'
 
 export const OPEN_PIXEL_SEARCH = 'ods:pixel-search'
 export default function PixelCommandSearch({ onInsert, onNewTask }) {
@@ -31,8 +32,8 @@ export default function PixelCommandSearch({ onInsert, onNewTask }) {
     { title: 'Pixel settings', detail: 'Connections, access and sharing', icon: Settings, run: () => navigate('/pixel/settings') },
     { title: 'Plan deep work', detail: 'Draft milestones and completion checks', icon: ListChecks, run: () => onInsert('Build a durable plan for this goal, then show the milestones and exact completion criteria before work begins.') },
     { title: 'Research with evidence', detail: 'Draft a research request with citations', icon: Globe2, run: () => onInsert('Research this question using current sources, inline citations, and explicit evidence-versus-inference labels.') },
-    ...chats.map(chat => ({ title: conversationTitle(chat), detail: `${chat.messages.filter(item => item.role === 'user').length} turns · Saved locally`, icon: MessageSquare, run: () => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId })) })),
-  ].filter(item => `${item.title} ${item.detail}`.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase()))
+    ...chats.map(chat => ({ title: conversationTitle(chat), detail: `${chat.messages.filter(item => item.role === 'user').length} turns · Saved locally`, excerpt:conversationExcerpt(chat, query), icon: MessageSquare, run: () => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId })) })),
+  ].filter(item => item.excerpt || `${item.title} ${item.detail}`.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase()))
   function close() { dialog.current.close(); trigger.current?.focus?.() }
   function choose(entry) { if (entry) { close(); entry.run() } }
   return <dialog ref={dialog} className="pixel-command-dialog" aria-label="Search Pixel" onClick={event => { if (event.target === event.currentTarget) close() }} onCancel={() => trigger.current?.focus?.()}>
@@ -40,6 +41,6 @@ export default function PixelCommandSearch({ onInsert, onNewTask }) {
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') { event.preventDefault(); setIndex(value => entries.length ? (value + (event.key === 'ArrowDown' ? 1 : -1) + entries.length) % entries.length : 0) }
       if (event.key === 'Enter') { event.preventDefault(); choose(entries[index]) }
     }}/><button aria-label="Close search" onClick={close}><X size={16}/></button></div>
-    <div className="pixel-command-results">{entries.length ? entries.map((entry, at) => <button className={at === index ? 'is-active' : ''} key={`${entry.title}-${at}`} onFocus={() => setIndex(at)} onClick={() => choose(entry)}><entry.icon size={17}/><span><strong>{entry.title}</strong><small>{entry.detail}</small></span></button>) : <p>No matching conversations or actions.</p>}</div>
+    <div className="pixel-command-results">{entries.length ? entries.map((entry, at) => <button className={at === index ? 'is-active' : ''} key={`${entry.title}-${at}`} onFocus={() => setIndex(at)} onClick={() => choose(entry)}><entry.icon size={17}/><span><strong>{entry.title}</strong><small>{entry.detail}</small>{entry.excerpt && <small className="break-words whitespace-normal">{entry.excerpt}</small>}</span></button>) : <p>No matching conversations or actions.</p>}</div>
   </dialog>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelConversationContentSearch.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationContentSearch.test.jsx
@@ -1,0 +1,60 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import {MemoryRouter} from 'react-router-dom'
+import PixelCommandSearch from './PixelCommandSearch'
+import {saveConversation, SELECT_EVENT} from '../lib/pixelConversations'
+
+beforeEach(() => {
+  localStorage.clear()
+  HTMLDialogElement.prototype.showModal = function () {this.open = true}
+  HTMLDialogElement.prototype.close = function () {this.open = false}
+})
+afterEach(() => {delete HTMLDialogElement.prototype.showModal; delete HTMLDialogElement.prototype.close})
+const chat = (id, messages, draft = '') => saveConversation({schema:1, chatId:id, messages, draft})
+function search(query) {
+  render(<MemoryRouter><PixelCommandSearch onInsert={() => {}} onNewTask={() => {}}/></MemoryRouter>)
+  fireEvent.keyDown(window, {key:'k', ctrlKey:true})
+  fireEvent.change(screen.getByLabelText('Search conversations and actions'), {target:{value:query}})
+}
+
+it('finds a later reply and selects its exact conversation despite identical titles', () => {
+  chat('first', [{role:'user', content:'Analyze this'}, {role:'assistant', content:'Budget: 42 euros'}])
+  chat('second', [{role:'user', content:'Analyze this'}, {role:'assistant', content:'Different result'}])
+  const selected = vi.fn()
+  window.addEventListener(SELECT_EVENT, selected)
+  try {
+    search('42 EUROS')
+    expect(screen.getByText('Reply: Budget: 42 euros')).toBeVisible()
+    fireEvent.keyDown(screen.getByLabelText('Search conversations and actions'), {key:'Enter'})
+    expect(selected).toHaveBeenCalledOnce()
+    expect(selected.mock.calls[0][0].detail).toBe('first')
+  } finally {window.removeEventListener(SELECT_EVENT, selected)}
+})
+
+it('searches beyond the 80-character title and shows a bounded matching excerpt', () => {
+  chat('long', [{role:'user', content:'a'.repeat(500) + ' exact phrase ' + 'b'.repeat(500)}])
+  search('exact phrase')
+  const snippet = screen.getByText(/Message: ….*exact phrase/)
+  expect(snippet.textContent.length).toBeLessThan(200)
+  expect(snippet.textContent.endsWith('…')).toBe(true)
+})
+
+it('searches draft text without issuing a model request or changing it', () => {
+  chat('draft', [{role:'user', content:'Earlier task'}], 'Hẹn gặp lại tomorrow')
+  const before = localStorage.getItem('ods.pixel.chat.v1')
+  search('gặp lại')
+  expect(screen.getByText('Draft: Hẹn gặp lại tomorrow')).toBeVisible()
+  expect(localStorage.getItem('ods.pixel.chat.v1')).toBe(before)
+})
+
+it('treats literal regular-expression syntax and HTML as inert text', () => {
+  chat('literal', [{role:'user', content:'Read result'}, {role:'assistant', content:'<img src=x onerror=bad()> [a.*]'}])
+  search('[a.*]')
+  expect(screen.getByText(/Reply: <img/)).toBeVisible()
+  expect(document.querySelector('img')).toBeNull()
+})
+
+it('does not match a metadata-only value or create synthetic conversation content', () => {
+  saveConversation({schema:1, chatId:'meta', messages:[{role:'user', content:'Task', task:{detail:'hiddenmagic'}}]})
+  search('hiddenmagic')
+  expect(screen.getByText('No matching conversations or actions.')).toBeVisible()
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationSearch.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationSearch.js
@@ -1,0 +1,18 @@
+/** Match retained text only: task metadata and model prose about files aren't an index. */
+export function conversationExcerpt(chat, query) {
+  const needle = query.trim().toLocaleLowerCase()
+  if (!needle) return null
+  const fields = [
+    ...(Array.isArray(chat.messages) ? chat.messages : []).filter(message => ['user', 'assistant'].includes(message?.role) && typeof message.content === 'string')
+      .map(message => ({label:message.role === 'user' ? 'Message' : 'Reply', text:message.content})),
+    {label:'Draft', text:typeof chat.draft === 'string' ? chat.draft : ''},
+  ]
+  for (const {label, text} of fields) {
+    const at = text.toLocaleLowerCase().indexOf(needle)
+    if (at < 0) continue
+    const start = Math.max(0, at - 48)
+    const end = Math.min(text.length, start + Math.max(180, needle.length))
+    return `${label}: ${start ? '…' : ''}${text.slice(start, end).replace(/\s+/g, ' ')}${end < text.length ? '…' : ''}`
+  }
+  return null
+}


### PR DESCRIPTION
## Why this matters

Pixel search only matches the first 80 title characters and generic metadata. An owner remembering a figure from a later reply cannot find that conversation. Extend the existing search dialog to retained user/assistant text and unsent drafts, and show a bounded matching excerpt labeled Message, Reply or Draft. Selection still uses the exact chat ID.

Matching is literal and case-insensitive; excerpts render as inert React text. This searches browser-retained text, not unpublished files, tool metadata or a server index. It preserves the existing action search and issues no model request.

## Overlap check

Searched all-state `conversation full text`/`Pixel search` PRs and the recent 1,500-PR file inventory. #4081 refreshes live history, #4105 guards IME selection, and #4112 preserves repeated-shortcut sessions. Those fix search lifecycle/keyboard behavior, not content matching. The implementation changes entry construction/filtering and adds an excerpt helper; it does not replace those event-handler fixes. #4027 is the existing workbench.

## Risk and validation

Medium dashboard UI, based on public-beta d7d76cdc. Node 20 search suites: 7 passed. Regression cases exercise later replies with duplicate titles, text beyond title truncation, Unicode draft matches, literal regex/HTML and rejection of metadata-only matches. Production build and focused ESLint (zero errors) pass; changed-file hooks and whitespace are checked before publication.

The beta baseline dashboard suite passed 713 tests. Combined validation is recorded below. Existing full-repo limitations remain the private-key hook's literal unit-test-key fixtures and WSL phase03 no-sudo fixture failure; neither is modified. No installed inference/hardware claim.

Revert restores title-only search without altering saved conversations. Cross-PR composition is recorded below. Target public-beta; no stable release or deployment implied.

## AI assistance

Codex investigated, implemented and tested this change. Independent human review remains outstanding.


## Final batch receipt (2026-09-11)

Exact PR head: `bed14196ca6f3626ef6a7c1c89b2ecaed9297077`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
