### PR TITLE
feat(pixel): save and reuse personal prompts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelComposerTools.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelComposerTools.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { AtSign, Slash, ShieldCheck, ListChecks, Globe2, CheckCheck } from 'lucide-react'
 import PixelMascot from './PixelMascot'
+import PixelPromptLibrary from './PixelPromptLibrary'
 
 const commands = [
   { title: 'Plan', detail: 'Milestones and completion checks', icon: ListChecks, text: 'Plan this outcome with milestones and exact completion criteria: ' },
@@ -30,6 +31,7 @@ export default function PixelComposerTools({ disabled, input, onInsert }) {
       {(menu === 'sources' ? sources : commands).map(item => <button type="button" key={item.title} aria-label={`${item.title} ${item.detail}`} onClick={() => { setMenu(null); onInsert(item.text) }}><item.icon size={17}/><span><strong>{item.title}</strong><small>{item.detail}</small></span></button>)}
     </div>}
     <button type="button" disabled={disabled} aria-label="Mention source" aria-expanded={menu === 'sources'} onClick={event => toggle('sources', event)}><AtSign size={16}/></button>
+    <PixelPromptLibrary input={input} disabled={disabled} onInsert={onInsert}/>
     <button type="button" disabled={disabled} aria-label="Open prompt commands" aria-expanded={menu === 'commands'} onClick={event => toggle('commands', event)}><Slash size={16}/></button>
     <Link to="/models" className="pixel-composer-agent"><PixelMascot/><span>Pixel agent</span></Link>
     <Link to="/pixel/settings?section=access" title="Pixel access settings"><ShieldCheck size={15}/><span>Permissions</span></Link>

--- a/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
@@ -1,0 +1,63 @@
+import {useEffect, useRef, useState} from 'react'
+import {readSavedPrompts, writeSavedPrompt} from '../lib/pixelSavedPrompts'
+
+export default function PixelPromptLibrary({input, disabled, onInsert}) {
+  const dialog = useRef(null), trigger = useRef(null), previous = useRef(null)
+  const [items, setItems] = useState([])
+  const [editing, setEditing] = useState(null)
+  const [removing, setRemoving] = useState(null)
+  const [error, setError] = useState('')
+  function refresh() {
+    try {setItems(readSavedPrompts()); setError('')}
+    catch {setError('Saved prompts could not be read. Existing browser data has been preserved.')}
+  }
+  useEffect(() => {
+    const update = () => {if (dialog.current?.open) refresh()}
+    window.addEventListener('storage', update)
+    return () => window.removeEventListener('storage', update)
+  }, [])
+  function close() {dialog.current?.close(); setEditing(null); setRemoving(null); trigger.current?.focus()}
+  function edit(item) {previous.current = item; setEditing(item || {id:'prompt-'+Date.now().toString(36)+'-'+Math.random().toString(36).slice(2, 10), title:'', text:input}); setError('')}
+  function save(event) {
+    event.preventDefault()
+    try {setItems(writeSavedPrompt({...editing, title:editing.title.trim()}, previous.current)); setEditing(null); setError('')}
+    catch (failure) {setError(failure.message)}
+  }
+  function remove() {
+    try {setItems(writeSavedPrompt(removing, removing, true)); setRemoving(null); setError('')}
+    catch (failure) {setError(failure.message)}
+  }
+  const fieldClass = 'my-2 block w-full rounded border border-theme-border bg-theme-bg p-2 text-theme-text'
+  const buttonClass = 'rounded border border-theme-border px-3 py-2 text-xs hover:bg-theme-surface-hover disabled:opacity-40'
+  return <>
+    <button ref={trigger} type="button" disabled={disabled} aria-label="Saved prompts" onClick={() => {refresh(); dialog.current.showModal()}}>Saved prompts</button>
+    <dialog ref={dialog} className="chat-delete-dialog" style={{maxHeight:'calc(100dvh - 32px)', overflowY:'auto'}} aria-label="Saved prompts" onCancel={event => {event.preventDefault(); close()}}>
+      <h3>Saved prompts</h3><p>Reusable text stored in this browser. Insert a prompt into your draft, then review it before sending.</p>
+      {error && <p role="alert">{error}</p>}
+      {editing ? <form onSubmit={save}>
+        <label>Prompt name<input autoFocus className={fieldClass} maxLength={80} value={editing.title} onChange={event => setEditing({...editing, title:event.target.value})}/></label>
+        <label>Prompt text<textarea className={fieldClass} rows={6} maxLength={16000} value={editing.text} onChange={event => setEditing({...editing, text:event.target.value})}/></label>
+        <footer><button type="button" onClick={() => {setEditing(null); setError('')}}>Cancel edit</button><button type="submit">Save prompt</button></footer>
+      </form> : removing ? <div>
+        <p>Delete saved prompt “{removing.title}”? Existing conversations are kept.</p>
+        <footer><button type="button" autoFocus onClick={() => setRemoving(null)}>Keep prompt</button><button type="button" onClick={remove}>Delete prompt</button></footer>
+      </div> : <>
+        <button className={buttonClass} type="button" onClick={() => edit(null)}>Save a new prompt</button>
+        {!items.length && <p>No saved prompts yet. Start with your current draft or write a new one.</p>}
+        <ul>{items.map(item => {
+          const fits = input.length + item.text.length + 1 <= 16384
+          return <li key={item.id} className="my-3 rounded border border-theme-border p-2">
+            <strong>{item.title}</strong><p className="whitespace-pre-wrap break-words">{item.text.slice(0, 160)}{item.text.length > 160 ? '…' : ''}</p>
+            <div className="mt-2 flex flex-wrap gap-2">
+            <button className={buttonClass} type="button" disabled={disabled || !fits} aria-label={`Insert prompt: ${item.title}`} onClick={() => {onInsert(item.text); close()}}>Insert</button>
+            <button className={buttonClass} type="button" aria-label={`Edit prompt: ${item.title}`} onClick={() => edit(item)}>Edit</button>
+            <button className={buttonClass} type="button" aria-label={`Delete prompt: ${item.title}`} onClick={() => {setRemoving(item); setError('')}}>Delete</button>
+            </div>
+            {!fits && <p>Shorten the current draft before inserting this prompt.</p>}
+          </li>
+        })}</ul>
+      </>}
+      <footer><button type="button" onClick={close}>Close prompts</button></footer>
+    </dialog>
+  </>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.test.jsx
@@ -1,0 +1,66 @@
+import {render, screen, fireEvent, within} from '@testing-library/react'
+import {MemoryRouter} from 'react-router-dom'
+import PixelComposerTools from './PixelComposerTools'
+import {readSavedPrompts, SAVED_PROMPTS_KEY} from '../lib/pixelSavedPrompts'
+
+beforeEach(() => {
+  localStorage.clear()
+  HTMLDialogElement.prototype.showModal = function () {this.open = true}
+  HTMLDialogElement.prototype.close = function () {this.open = false}
+})
+afterEach(() => {vi.restoreAllMocks(); delete HTMLDialogElement.prototype.showModal; delete HTMLDialogElement.prototype.close})
+function mount(input = 'Review this carefully\nKeep the evidence.') {
+  const insert = vi.fn()
+  render(<MemoryRouter><PixelComposerTools input={input} disabled={false} onInsert={insert}/></MemoryRouter>)
+  fireEvent.click(screen.getByRole('button', {name:'Saved prompts'}))
+  return insert
+}
+function create() {
+  fireEvent.click(screen.getByRole('button', {name:'Save a new prompt'}))
+  fireEvent.change(screen.getByLabelText('Prompt name'), {target:{value:'Review'}})
+  fireEvent.click(screen.getByRole('button', {name:'Save prompt'}))
+}
+it('saves the current draft, edits it, then explicitly inserts reusable text', () => {
+  const insert = mount()
+  create()
+  expect(insert).not.toHaveBeenCalled()
+  expect(readSavedPrompts()[0].text).toBe('Review this carefully\nKeep the evidence.')
+  fireEvent.click(screen.getByRole('button', {name:'Edit prompt: Review'}))
+  fireEvent.change(screen.getByLabelText('Prompt text'), {target:{value:'Revised\nUnicode: Việt'}})
+  fireEvent.click(screen.getByRole('button', {name:'Save prompt'}))
+  fireEvent.click(screen.getByRole('button', {name:'Insert prompt: Review'}))
+  expect(insert).toHaveBeenCalledWith('Revised\nUnicode: Việt')
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+it('confirms deletion and preserves prompts on cancel', () => {
+  mount(); create()
+  fireEvent.click(screen.getByRole('button', {name:'Delete prompt: Review'}))
+  fireEvent.click(screen.getByRole('button', {name:'Keep prompt'}))
+  expect(readSavedPrompts()).toHaveLength(1)
+  fireEvent.click(screen.getByRole('button', {name:'Delete prompt: Review'}))
+  fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', {name:'Delete prompt', exact:true}))
+  expect(readSavedPrompts()).toEqual([])
+})
+it('preserves a conflicting edit from another tab', () => {
+  mount(); create()
+  fireEvent.click(screen.getByRole('button', {name:'Edit prompt: Review'}))
+  const current = readSavedPrompts()
+  localStorage.setItem(SAVED_PROMPTS_KEY, JSON.stringify([{...current[0], text:'Other tab'}]))
+  fireEvent.click(screen.getByRole('button', {name:'Save prompt'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('changed in another tab')
+  expect(readSavedPrompts()[0].text).toBe('Other tab')
+})
+it('does not overwrite malformed storage', () => {
+  localStorage.setItem(SAVED_PROMPTS_KEY, '{bad')
+  mount(); create()
+  expect(screen.getByRole('alert')).toBeVisible()
+  expect(localStorage.getItem(SAVED_PROMPTS_KEY)).toBe('{bad')
+})
+it('bounds library size and refuses an insertion exceeding the current draft budget', () => {
+  localStorage.setItem(SAVED_PROMPTS_KEY, JSON.stringify(Array.from({length:30}, (_, index) => ({id:'p-'+index, title:'Prompt '+index, text:'x'.repeat(1000)}))))
+  mount('a'.repeat(16000))
+  expect(screen.getByRole('button', {name:'Insert prompt: Prompt 0'})).toBeDisabled()
+  create()
+  expect(screen.getByRole('alert')).toHaveTextContent('up to 30 prompts')
+  expect(readSavedPrompts()).toHaveLength(30)
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelSavedPrompts.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelSavedPrompts.js
@@ -1,0 +1,21 @@
+export const SAVED_PROMPTS_KEY = 'ods.pixel.saved-prompts.v1'
+const valid = item => item && typeof item.id === 'string' && /^[a-z0-9-]{1,80}$/.test(item.id)
+  && typeof item.title === 'string' && item.title.trim().length > 0 && item.title.length <= 80
+  && typeof item.text === 'string' && item.text.trim().length > 0 && item.text.length <= 16000
+
+export function readSavedPrompts() {
+  const items = JSON.parse(localStorage.getItem(SAVED_PROMPTS_KEY) || '[]')
+  if (!Array.isArray(items) || items.length > 30 || !items.every(valid) || new Set(items.map(item => item.id)).size !== items.length) throw new Error('Saved prompts could not be read. Existing data was preserved.')
+  return items
+}
+
+export function writeSavedPrompt(value, previous = null, remove = false) {
+  const items = readSavedPrompts()
+  const current = items.find(item => item.id === value.id)
+  if (previous ? !current || current.title !== previous.title || current.text !== previous.text : current) throw new Error('This prompt changed in another tab. Cancel and reopen it before saving.')
+  const next = remove ? items.filter(item => item.id !== value.id) : current ? items.map(item => item.id === value.id ? value : item) : [...items, value]
+  if (next.length > 30) throw new Error('You can save up to 30 prompts. Remove one before adding another.')
+  if (!remove && !valid(value)) throw new Error('Enter a name (up to 80 characters) and prompt text (up to 16,000 characters).')
+  localStorage.setItem(SAVED_PROMPTS_KEY, JSON.stringify(next))
+  return next
+}


### PR DESCRIPTION
## Why this matters

Pixel has fixed prompt commands but no owner-defined reusable prompts. Add a browser-local library beside the composer commands. Owners can seed a prompt from their draft, edit its name/text, insert it for review, and confirm deletion without changing existing conversations.

The library is bounded to 30 prompts, 80-character names and 16,000-character bodies. Insertion respects the current composer budget and active-work state. Saves reload current storage and reject stale edits/deletions; malformed data is not replaced with an empty library. Text remains inert and insertion never sends a request.

## Overlap check

Searched all-state `prompt templates`, `saved prompts`, and the recent 1,500-PR inventory for PixelComposerTools.jsx. #4114 addresses keyboard focus in built-in commands; #4027 supplies the workbench; #3403 is an unrelated prompt sanitizer and #690 removes resource filler. None implements a personal browser-local prompt library. The separate control preserves built-in command behavior.

## Validation and risk

Medium Dashboard UI; base public-beta d7d76cdc. Node 20 library/composer tests: 8 passed. Coverage exercises draft seeding, editing/insertion, delete confirmation/cancel, stale-tab refusal, corrupt-storage preservation, collection bounds and insertion-budget refusal.

Production build and focused ESLint pass. Changed-file hooks and whitespace are checked before publication. Chromium smoke on the actual dashboard route with fixture APIs passed at 1365×900 and 390×844: save a draft as a prompt, insert without losing the draft, reopen on mobile; zero page errors. Screenshots were visually inspected and action spacing corrected. APIs were fixtures, not live inference.

Baseline dashboard suite: 713 passed. Combined validation is recorded below. Existing unrelated repo-wide limits are literal unit-test-key fixtures caught by the private-key hook and the WSL phase03 no-sudo fixture (3 pass/2 fail).

Prompts stay in this browser and are not a server backup. Reverting removes the UI; stored prompt records and conversations remain intact. No host mutation or runtime qualification claim. Target public-beta, not stable.

## AI assistance

Codex investigated, implemented and tested this change, including browser inspection. Independent human review remains outstanding.


## Final batch receipt (2026-09-11)

Exact PR head: `c611570c493ca448bd08a45c936dd5e03ccffc86`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
