### PR TITLE
feat(pixel): copy original messages and reuse prompts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelMessageActions.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelMessageActions.jsx
@@ -1,0 +1,36 @@
+import {useEffect, useRef, useState} from 'react'
+
+export default function PixelMessageActions({content, role, canReuse, onReuse}) {
+  const [state, setState] = useState('idle')
+  const generation = useRef(0)
+  const busy = useRef(false)
+  const manual = useRef(null)
+  useEffect(() => {generation.current++; busy.current = false; setState('idle'); return () => {generation.current++}}, [content])
+  async function copy() {
+    if (busy.current) return
+    const current = generation.current
+    busy.current = true; setState('copying')
+    let timer
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('Clipboard unavailable')
+      await Promise.race([
+        navigator.clipboard.writeText(content),
+        new Promise((_, reject) => {timer = setTimeout(() => reject(new Error('Clipboard timed out')), 5000)}),
+      ])
+      if (current === generation.current) setState('copied')
+    } catch {if (current === generation.current) setState('manual')}
+    finally {clearTimeout(timer); if (current === generation.current) busy.current = false}
+  }
+  return <div className="mt-3 text-xs text-theme-text-muted" role="group" aria-label={`${role === 'user' ? 'Prompt' : 'Reply'} actions`}>
+    <div className="flex flex-wrap gap-3">
+      <button type="button" disabled={state === 'copying'} onClick={copy}>{state === 'copying' ? 'Copying…' : role === 'assistant' ? 'Copy Markdown' : 'Copy message'}</button>
+      {role === 'user' && <button type="button" disabled={!canReuse} title={canReuse ? 'Append this prompt to the draft without sending' : 'Finish active work or shorten the draft before reusing this prompt'} onClick={() => onReuse(content)}>Reuse prompt</button>}
+      {state === 'copied' && <span role="status">Copied</span>}
+    </div>
+    {state === 'manual' && <div>
+      <p role="alert">Clipboard unavailable. Select the original text below and copy it manually.</p>
+      <textarea ref={manual} aria-label="Original message text" readOnly value={content} rows={4} className="my-2 w-full rounded border border-theme-border bg-theme-bg p-2" onFocus={event => event.target.select()}/>
+      <button type="button" onClick={() => {manual.current.focus(); manual.current.select()}}>Select original text</button>
+    </div>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelMessageActions.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelMessageActions.test.jsx
@@ -1,0 +1,51 @@
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react'
+import PixelMessageActions from './PixelMessageActions'
+
+beforeEach(() => Object.defineProperty(navigator, 'clipboard', {configurable:true, get:() => undefined}))
+afterEach(() => {vi.restoreAllMocks(); vi.useRealTimers(); delete navigator.clipboard})
+it('copies the exact original Markdown including fences, links and Unicode', async () => {
+  const copy = vi.fn().mockResolvedValue(undefined)
+  vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue({writeText:copy})
+  const content = '# Kết quả\n\n[Source](https://example.com)\n```py\nprint(42)\n```\n'
+  render(<PixelMessageActions role="assistant" content={content}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Copy Markdown'}))
+  await screen.findByText('Copied')
+  expect(copy).toHaveBeenCalledWith(content)
+  expect(screen.queryByRole('button', {name:'Reuse prompt'})).toBeNull()
+})
+it('offers selectable original text when clipboard is unavailable', async () => {
+  vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue(undefined)
+  render(<PixelMessageActions role="assistant" content={'# Exact\n\n**text**'}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Copy Markdown'}))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard unavailable')
+  fireEvent.click(screen.getByRole('button', {name:'Select original text'}))
+  const field = screen.getByLabelText('Original message text')
+  expect(field).toHaveValue('# Exact\n\n**text**')
+  expect(field.selectionEnd).toBe(field.value.length)
+})
+it('reuses a user prompt only through the draft callback and honors its guard', () => {
+  const reuse = vi.fn()
+  const {rerender} = render(<PixelMessageActions role="user" content="Analyze this" canReuse onReuse={reuse}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Reuse prompt'}))
+  expect(reuse).toHaveBeenCalledWith('Analyze this')
+  rerender(<PixelMessageActions role="user" content="Analyze this" canReuse={false} onReuse={reuse}/>)
+  expect(screen.getByRole('button', {name:'Reuse prompt'})).toBeDisabled()
+})
+it('does not transfer an old clipboard receipt to replaced message content', async () => {
+  let finish
+  vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue({writeText:() => new Promise(resolve => {finish=resolve})})
+  const {rerender} = render(<PixelMessageActions role="assistant" content="old"/>)
+  fireEvent.click(screen.getByRole('button', {name:'Copy Markdown'}))
+  rerender(<PixelMessageActions role="assistant" content="new"/>)
+  await act(async () => finish())
+  await waitFor(() => expect(screen.getByRole('button', {name:'Copy Markdown'})).toBeEnabled())
+  expect(screen.queryByText('Copied')).toBeNull()
+})
+it('makes stalled clipboard permission requests recoverable', async () => {
+  vi.useFakeTimers()
+  vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue({writeText:() => new Promise(() => {})})
+  render(<PixelMessageActions role="assistant" content="Keep this"/>)
+  fireEvent.click(screen.getByRole('button', {name:'Copy Markdown'}))
+  await act(async () => vi.advanceTimersByTimeAsync(5001))
+  expect(screen.getByLabelText('Original message text')).toHaveValue('Keep this')
+})

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -13,6 +13,7 @@ import PixelComposerTools from '../components/PixelComposerTools'
 import PixelDictation from '../components/PixelDictation'
 import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from '../components/PixelCommandSearch'
 import PixelSelectionActions from '../components/PixelSelectionActions'
+import PixelMessageActions from '../components/PixelMessageActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
 import PixelSnapshotChanges from '../components/PixelSnapshotChanges'
@@ -1377,6 +1378,7 @@ export default function Pixel({ systemStatus = null }) {
               ) : (
                 <span className="break-words whitespace-pre-wrap">{message.content}</span>
               )}
+              {message.content && message.status !== 'streaming' && <PixelMessageActions key={`${chatIdRef.current}-${index}-${message.role}`} content={message.content} role={message.role} canReuse={!isDisabled && input.length + message.content.length + 1 <= MAX_INPUT_LEN} onReuse={insertComposerText}/>}
               {message.status === 'streaming' && !message.content && (
                 <span role="status" className="inline-flex items-start gap-2 text-theme-text-muted">
                   <span>


### PR DESCRIPTION
## Why this matters

Owners currently have to select rendered chat text manually, losing Markdown source, or retype an earlier prompt. Add actions to completed messages: copy the exact original text/Markdown, and append a prior user prompt to the current draft for review. Reuse obeys the existing active-work and message-length guards and never resubmits a task automatically.

Unavailable/denied/stalled clipboard requests expose a selectable plain-text field. Duplicate copy clicks are guarded and an old asynchronous receipt cannot mark different message content copied. Streaming responses do not expose an incomplete copy action.

## Overlap check

Searched all-state `Pixel copy response`, `copy message`, `reuse prompt` and `Pixel reply`, and inspected the recent 1,500-PR inventory. #4113 handles approval-command copying and #4107 handles verified-source clipboard feedback; #4119 exports a whole conversation. This serves individual chat-message reuse, preserves raw Markdown and does not touch command approvals or export formats. #400 concerns repository skills.

## Validation and risk

Medium Dashboard UI; public-beta d7d76cdc base. Node 20 message-actions plus Pixel page suites: 78 passed. Tests cover exact Unicode/Markdown, manual selection when clipboard is absent, reuse guards, stale copy completion and a five-second stalled clipboard request. Production build, focused ESLint (zero errors) and diff whitespace pass; changed-file hooks are checked before publication.

Full baseline dashboard: 713 passed. Combined validation is recorded below. Existing repo-wide baseline failures remain the private-key hook's literal unit-test-key fixtures and WSL phase03 no-sudo fixture. No backend or installer file is changed.

Reverting only removes the controls. Clipboard permission and browser download policies remain user controlled. No host/inference changes or installed-runtime acceptance claim. Target public-beta; no deployment or merge implied.

## AI assistance

Codex investigated, implemented and tested this change. Independent human review remains outstanding.


## Final batch receipt (2026-09-11)

Exact PR head: `93cb05550000bb60e825f49cb8478830a8436e39`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.

Current-product note: upstream merged this PR, then removed its copy/reuse controls in #4207 (`cfd58cb2`). The integration preserves that maintainer decision and does not claim those controls remain available.
