### PR TITLE
feat(pixel): filter and sort published file inventories

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelFileBrowser.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelFileBrowser.test.jsx
@@ -1,0 +1,54 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import PixelTaskFiles from './PixelTaskFiles'
+
+const files = [
+  {path:'index.html', bytes:20, sha256:'a'.repeat(64)},
+  {path:'assets/app10.js', bytes:100, sha256:'b'.repeat(64)},
+  {path:'assets/app2.js', bytes:100, sha256:'c'.repeat(64)},
+  {path:'assets/photo.PNG', bytes:200, sha256:'d'.repeat(64)},
+  {path:'LICENSE', bytes:10, sha256:'e'.repeat(64)},
+]
+const preview = {siteId:'site-'+'a'.repeat(24),sha256:'a'.repeat(64),entrySha256:files[0].sha256,files:5,bytes:430}
+beforeEach(() => vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(JSON.stringify({schemaVersion:1,...preview,files})).buffer}))))
+afterEach(() => {vi.unstubAllGlobals(); vi.restoreAllMocks()})
+const paths = () => screen.getAllByRole('listitem').map(item => item.querySelector('span').textContent)
+
+it('combines type/path filters, reports visible bytes and clears filters without a refetch', async () => {
+  render(<PixelTaskFiles preview={preview}/>)
+  await screen.findByRole('button', {name:/index.html/})
+  fireEvent.change(screen.getByLabelText('File type'), {target:{value:'js'}})
+  expect(paths()).toEqual(['assets/app10.js', 'assets/app2.js'])
+  expect(screen.getByText('Showing 2 of 5 files · 200 bytes')).toBeVisible()
+  fireEvent.change(screen.getByLabelText('Filter task files'), {target:{value:'app2'}})
+  expect(paths()).toEqual(['assets/app2.js'])
+  fireEvent.click(screen.getByRole('button', {name:'Clear file filters'}))
+  expect(paths()).toEqual(files.map(file => file.path))
+  expect(fetch).toHaveBeenCalledOnce()
+})
+
+it('sorts numeric filenames and equal-size ties deterministically without mutating the manifest', async () => {
+  render(<PixelTaskFiles preview={preview}/>)
+  await screen.findByRole('button', {name:/index.html/})
+  fireEvent.change(screen.getByLabelText('Sort task files'), {target:{value:'largest'}})
+  expect(paths()).toEqual(['assets/photo.PNG','assets/app2.js','assets/app10.js','index.html','LICENSE'])
+  fireEvent.change(screen.getByLabelText('Sort task files'), {target:{value:'smallest'}})
+  expect(paths()[0]).toBe('LICENSE')
+  fireEvent.change(screen.getByLabelText('Sort task files'), {target:{value:'name'}})
+  expect(paths().slice(0,2)).toEqual(['assets/app2.js','assets/app10.js'])
+  fireEvent.change(screen.getByLabelText('Sort task files'), {target:{value:'published'}})
+  expect(paths()).toEqual(files.map(file => file.path))
+})
+
+it('supports extensionless files and keeps an absent filter visible after snapshot replacement', async () => {
+  const {rerender} = render(<PixelTaskFiles preview={preview}/>)
+  await screen.findByRole('button', {name:/index.html/})
+  fireEvent.change(screen.getByLabelText('File type'), {target:{value:'(no extension)'}})
+  expect(paths()).toEqual(['LICENSE'])
+  const next = {...preview,siteId:'site-'+'b'.repeat(24),files:1,bytes:20}
+  fetch.mockResolvedValue({ok:true,arrayBuffer:async () => new TextEncoder().encode(JSON.stringify({schemaVersion:1,...next,files:[files[0]]})).buffer})
+  rerender(<PixelTaskFiles preview={next}/>)
+  await screen.findByText('No files match your search.')
+  expect(screen.getByLabelText('File type')).toHaveValue('(no extension)')
+  fireEvent.click(screen.getByRole('button', {name:'Clear file filters'}))
+  expect(paths()).toEqual(['index.html'])
+})

--- a/ods/extensions/services/dashboard/src/components/PixelTaskFiles.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTaskFiles.jsx
@@ -4,12 +4,19 @@ import { loadSnapshotFiles } from '../lib/pixelArtifacts'
 import PixelPreviewSource from './PixelPreviewSource'
 import { PixelLanguageBadge } from './PixelCodeBlock'
 
+const fileType = file => {
+  const name = file.path.split('/').at(-1)
+  return name.includes('.') ? name.split('.').at(-1).toLowerCase() : '(no extension)'
+}
+
 export default function PixelTaskFiles({preview}) {
   const [files, setFiles] = useState(null)
   const [error, setError] = useState(false)
   const [attempt, setAttempt] = useState(0)
   const [filter, setFilter] = useState('')
   const [selected, setSelected] = useState(null)
+  const [type, setType] = useState('')
+  const [sort, setSort] = useState('published')
   useEffect(() => {
     let current = true
     const controller = new AbortController()
@@ -20,13 +27,26 @@ export default function PixelTaskFiles({preview}) {
     }).catch(() => { if (current) setError(true) }).finally(() => clearTimeout(timer))
     return () => { current = false; controller.abort(); clearTimeout(timer) }
   }, [preview.siteId, preview.sha256, preview.entrySha256, preview.bytes, preview.files, attempt])
-  const shown = files?.filter(file => file.path.toLowerCase().includes(filter.toLowerCase())) || []
+  const types = [...new Set([...(files || []).map(fileType), type].filter(Boolean))].sort()
+  const shown = files?.filter(file => file.path.toLowerCase().includes(filter.toLowerCase()) && (!type || fileType(file) === type)) || []
+  if (sort !== 'published') shown.sort((a, b) => {
+    const names = a.path.localeCompare(b.path, undefined, {numeric:true})
+    if (sort === 'largest') return b.bytes - a.bytes || names
+    if (sort === 'smallest') return a.bytes - b.bytes || names
+    return sort === 'reverse-name' ? -names : names
+  })
   return <section className="pixel-task-files pixel-original-files" aria-label="Task files">
     <div className="pixel-file-toolbar"><Search size={14}/><input type="search" aria-label="Filter task files" placeholder="Find a file…" value={filter} onChange={event => setFilter(event.target.value)}/></div>
+    <div className="flex flex-wrap items-center gap-2 px-3 pb-2 text-xs">
+      <label>Type <select className="rounded border border-theme-border bg-theme-bg p-1" aria-label="File type" value={type} onChange={event => setType(event.target.value)}><option value="">All types</option>{types.map(value => <option key={value} value={value}>{value}</option>)}</select></label>
+      <label>Sort <select className="rounded border border-theme-border bg-theme-bg p-1" aria-label="Sort task files" value={sort} onChange={event => setSort(event.target.value)}><option value="published">Published order</option><option value="name">Name A–Z</option><option value="reverse-name">Name Z–A</option><option value="largest">Largest first</option><option value="smallest">Smallest first</option></select></label>
+      {(filter || type) && <button type="button" onClick={() => {setFilter(''); setType('')}}>Clear file filters</button>}
+    </div>
     <p className="pixel-file-caption">{preview.relativeDirectory}<span>{files ? `${files.length} published files` : 'Published files'}</span></p>
     {error ? <div role="alert" className="pixel-file-empty"><p>Task files could not be verified.</p><button type="button" onClick={() => setAttempt(value => value + 1)}>Try again</button></div>
       : !files ? <p role="status" className="pixel-file-empty">Verifying published files…</p>
         : <>
+          <p className="pixel-file-caption" role="status">Showing {shown.length} of {files.length} files · {shown.reduce((total, file) => total + file.bytes, 0).toLocaleString()} bytes</p>
           <ul className="pixel-task-file-list">{shown.map(file => {
             return <li key={file.path}><button type="button" aria-current={selected?.path === file.path ? 'true' : undefined} onClick={() => setSelected(file)}><PixelLanguageBadge path={file.path}/><span>{file.path}</span><small>{file.bytes < 1024 ? `${file.bytes} B` : `${(file.bytes / 1024).toFixed(1)} KB`}</small></button></li>
           })}</ul>


### PR DESCRIPTION
## Why this matters

Owners reviewing a generated site need to isolate code/assets and locate oversized files. Extend the existing verified Files panel with file-type filtering, numeric filename sorting, size sorting, visible-file/byte totals and one-step filter clearing. Published order remains the default and can be restored exactly.

All operations use the already verified manifest, never fetch extra content or mutate it. Type and path filters compose. A selected type remains visible if a replacement snapshot lacks it, so a hidden stale filter cannot masquerade as “All types.” Source selection and verification stay on the existing path.

## Overlap check

Searched all-state `task files sort` and `file type filter` PRs and the recent 1,500-PR inventory for PixelTaskFiles.jsx. Only the broad workbench #4027 owns this surface; it has path search but no type/size controls. #4066 fixes panel identity/reload and #4139 adds verified downloads. This feature changes manifest presentation without replacing either mechanism.

## Validation and risk

Medium Dashboard UI, public-beta d7d76cdc base. Node 20 file-browser and existing TaskFiles suites: 11 passed. Regression tests exercise combined filters, visible-byte totals, no extra fetch, numeric names/equal-size ties, original-order restoration, extensionless files and stale filter recovery across snapshots. Focused lint and production build pass. Changed-file hooks and whitespace are checked before publication.

Baseline dashboard: 713 tests passed. Combined validation is recorded below. Unrelated baseline limits: private-key hook flags literal unit-test-key fixtures; WSL phase03 no-sudo fixture reports 3 pass/2 fail. No installer/backend changes.

Reverting restores the old view without changing files or browser history. Byte totals describe published files, not workspace disk use or download/compression sizes. No installed-runtime or release acceptance claim.

## AI assistance

Codex investigated, implemented and tested the change. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `4a6a7025041b8b3a19606c509d100b434a8be34f`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
