### PR TITLE
feat(pixel): filter and expand multi-file change reviews

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelChangeReview.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelChangeReview.test.jsx
@@ -1,0 +1,43 @@
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
+import PixelFileChanges from './PixelFileChanges'
+
+const changes = [
+  {path:'src/app.js',change:'modified',additions:1,deletions:0,truncated:false,diff:[{type:'add',text:'console.log(42)',oldLine:null,newLine:1}]},
+  {path:'src/new.js',change:'created',additions:1,deletions:0,truncated:true,diff:[{type:'add',text:'export default 1',oldLine:null,newLine:1}]},
+  {path:'old.css',change:'deleted',additions:0,deletions:1,truncated:false,diff:[{type:'remove',text:'.old {}',oldLine:1,newLine:null}]},
+]
+it('combines changed-file and operation filters while preserving the full change set', () => {
+  const original = JSON.stringify(changes)
+  render(<PixelFileChanges changes={changes}/>)
+  fireEvent.change(screen.getByLabelText('Filter changed files'), {target:{value:'src/'}})
+  expect(screen.getByText('Showing 2 of 3 changed files')).toBeVisible()
+  fireEvent.change(screen.getByLabelText('Change kind'), {target:{value:'created'}})
+  expect(screen.queryByText('Edited src/app.js')).toBeNull()
+  expect(screen.getByText('Created src/new.js')).toBeVisible()
+  expect(screen.getByText('Showing 1 of 3 changed files')).toBeVisible()
+  fireEvent.click(screen.getByRole('button', {name:'Clear change filters'}))
+  expect(screen.getByText('Deleted old.css')).toBeVisible()
+  expect(JSON.stringify(changes)).toBe(original)
+})
+it('expands/collapses visible changes, keeps truncation warnings and preserves preview identity', async () => {
+  const preview = vi.fn()
+  const {container} = render(<PixelFileChanges changes={changes} onPreview={preview}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Expand all changes'}))
+  await waitFor(() => expect(container.querySelectorAll('details[open]')).toHaveLength(3))
+  expect(screen.getByText(/Only part of this diff is displayed/)).toBeVisible()
+  fireEvent.click(screen.getByRole('button', {name:'Preview src/app.js'}))
+  expect(preview).toHaveBeenCalledWith(changes[0])
+  expect(screen.queryByRole('button', {name:'Preview old.css'})).toBeNull()
+  fireEvent.click(screen.getByRole('button', {name:'Collapse all changes'}))
+  await waitFor(() => expect(container.querySelectorAll('details[open]')).toHaveLength(0))
+})
+it('shows recoverable empty filter results and keeps a single-file diff usable', () => {
+  const {rerender} = render(<PixelFileChanges changes={changes}/>)
+  fireEvent.change(screen.getByLabelText('Change kind'), {target:{value:'published'}})
+  expect(screen.getByText('No changed files match these filters.')).toBeVisible()
+  rerender(<PixelFileChanges changes={[changes[0]]}/>)
+  expect(screen.getByLabelText('Change kind')).toHaveValue('published')
+  fireEvent.click(screen.getByRole('button', {name:'Clear change filters'}))
+  expect(screen.getByText('Edited src/app.js')).toBeVisible()
+  expect(screen.queryByLabelText('Filter changed files')).toBeNull()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelFileChanges.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelFileChanges.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Pencil } from 'lucide-react'
 import { fileLanguage, PixelCodeLines, PixelLanguageBadge } from './PixelCodeBlock'
 import './pixel-file-changes.css'
@@ -45,8 +45,9 @@ function DiffLines({rows, path}) {
   }}/>
 }
 
-function FileChange({file, onPreview}) {
+function FileChange({file, onPreview, expansion}) {
   const [open, setOpen] = useState(false)
+  useEffect(() => {if (expansion) setOpen(expansion.open)}, [expansion])
   const [copyState, setCopyState] = useState('Copy')
   const rows = Array.isArray(file.diff) ? file.diff : []
   const hasCounts = count(file.additions) && count(file.deletions)
@@ -75,6 +76,21 @@ function FileChange({file, onPreview}) {
 
 /** Receives verified changes only. Does not derive counts from truncated rows. */
 export default function PixelFileChanges({changes = [], onPreview}) {
+  const [query, setQuery] = useState('')
+  const [kind, setKind] = useState('')
+  const [expansion, setExpansion] = useState(null)
   if (!changes.length) return null
-  return <div className="pixel-file-changes" aria-label="File changes">{changes.map(file => <FileChange key={file.path} file={file} onPreview={onPreview}/>)}</div>
+  const shown = changes.filter(file => file.path.toLowerCase().includes(query.toLowerCase()) && (!kind || file.change === kind))
+  return <div className="pixel-file-changes" aria-label="File changes">
+    {(changes.length > 1 || query || kind) && <div className="my-2 flex flex-wrap items-center gap-2 text-xs">
+      <input type="search" aria-label="Filter changed files" placeholder="Find a changed file…" className="min-w-0 rounded border border-theme-border bg-theme-bg p-2" value={query} onChange={event => setQuery(event.target.value)}/>
+      <select aria-label="Change kind" className="rounded border border-theme-border bg-theme-bg p-2" value={kind} onChange={event => setKind(event.target.value)}><option value="">All changes</option>{Object.entries(LABELS).map(([value, label]) => <option value={value} key={value}>{label}</option>)}</select>
+      <button type="button" onClick={() => setExpansion({open:true})}>Expand all changes</button>
+      <button type="button" onClick={() => setExpansion({open:false})}>Collapse all changes</button>
+      {(query || kind) && <button type="button" onClick={() => {setQuery(''); setKind('')}}>Clear change filters</button>}
+      <span role="status">Showing {shown.length} of {changes.length} changed files</span>
+    </div>}
+    {!shown.length && <p role="status">No changed files match these filters.</p>}
+    {shown.map(file => <FileChange key={file.path} file={file} onPreview={onPreview} expansion={expansion}/>)}
+  </div>
 }


### PR DESCRIPTION
## Why this matters

Reviewing a generated project currently requires opening every changed file individually. Add path/operation filters and expand/collapse-all controls to multi-file diffs. The visible-file count keeps the full change count in view; clearing filters restores the complete review. Active filters stay accessible even when the incoming set shrinks to one file.

This only controls presentation of verified changes. Per-file counts, truncation warnings, unavailable-line notices and exact preview callbacks remain intact. Deleted files still have no preview action; expanding does not invent omitted context.

## Overlap check

Searched all-state `diff filter` and `expand changes` and the recent 1,500-PR inventory for PixelFileChanges.jsx. #4027 supplies the original diff view. #4083 repairs final-newline comparison and #4116 repairs source text fidelity; neither provides a multi-file review workflow. No verifier or diff-generation algorithm is changed.

## Validation and risk

Medium Dashboard UI, public-beta d7d76cdc base. Node 20 review/file-diff/snapshot suites: 15 passed, including combined filters, no mutation of the verified set, expand/collapse, truncated-diff notices, preview identity, deleted-file restrictions and single-file filter recovery. Focused ESLint has zero errors; production build, whitespace and changed-file hooks are checked before publication.

Baseline dashboard: 713 passed; Combined validation is recorded below. Unrelated full-repo baseline limits are the literal unit-test-key fixture flags and the WSL phase03 no-sudo fixture (3 pass/2 fail). No backend, host or installer changes. Revert restores individual review controls without changing artifacts or history. No installed-runtime qualification claim.

## AI assistance

Codex investigated, implemented and tested the change. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `7e2c9d6d9a5cd9d2d0785ac9cf94d60d2974dac8`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
