### PR TITLE
feat(pixel): inspect responsive preview viewports

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.jsx
@@ -1,0 +1,21 @@
+import {useState} from 'react'
+import './pixel-preview-viewport.css'
+
+const sizes = {phone:[375,667], tablet:[768,1024], desktop:[1280,800]}
+export default function PixelPreviewViewport({access, title, hidden}) {
+  const [size, setSize] = useState('fit')
+  const [rotated, setRotated] = useState(false)
+  const dimensions = sizes[size]
+  const [width, height] = dimensions ? (rotated ? [...dimensions].reverse() : dimensions) : ['100%', '100%']
+  return <section className="pixel-preview-viewport" hidden={hidden} aria-label="Preview viewport">
+    <div className="pixel-viewport-controls">
+      <label>Viewport <select aria-label="Preview viewport size" value={size} onChange={event => {setSize(event.target.value); setRotated(false)}}><option value="fit">Fit panel</option><option value="phone">Phone · 375 × 667</option><option value="tablet">Tablet · 768 × 1024</option><option value="desktop">Desktop · 1280 × 800</option></select></label>
+      <button type="button" disabled={!dimensions} aria-pressed={rotated} onClick={() => setRotated(value => !value)}>Rotate viewport</button>
+      {dimensions && <span role="status">{width} × {height} CSS pixels</span>}
+    </div>
+    <div className="pixel-viewport-stage">
+      <iframe src={access.frameUrl} title={title} hidden={hidden} sandbox={access.sandbox} data-preview-route={access.route} referrerPolicy="no-referrer" style={{width,height}}/>
+    </div>
+    {dimensions && <p className="pixel-viewport-note">Layout size only. Browser and touch behavior stay the same; scroll to inspect the full viewport.</p>}
+  </section>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.test.jsx
@@ -1,0 +1,34 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import PixelPreviewViewport from './PixelPreviewViewport'
+
+const access = {frameUrl:'/pixel-preview/site-'+'a'.repeat(24)+'/__ods_view__.html',sandbox:'allow-scripts allow-forms allow-downloads',route:'dashboard-relay'}
+it('changes actual frame dimensions without remounting or changing its authenticated route', () => {
+  render(<PixelPreviewViewport access={access} title="Interactive preview" hidden={false}/>)
+  const frame = screen.getByTitle('Interactive preview')
+  expect(frame.style.width).toBe('100%')
+  fireEvent.change(screen.getByLabelText('Preview viewport size'), {target:{value:'phone'}})
+  expect(frame.style.width).toBe('375px')
+  expect(frame.style.height).toBe('667px')
+  fireEvent.click(screen.getByRole('button', {name:'Rotate viewport'}))
+  expect(frame.style.width).toBe('667px')
+  expect(frame.style.height).toBe('375px')
+  expect(screen.getByTitle('Interactive preview')).toBe(frame)
+  expect(frame).toHaveAttribute('sandbox',access.sandbox)
+  expect(frame).toHaveAttribute('src',access.frameUrl)
+  expect(frame).toHaveAttribute('referrerpolicy','no-referrer')
+})
+it('retains the frame across inspector hiding and returns to fluid panel sizing', () => {
+  const {rerender} = render(<PixelPreviewViewport access={access} title="Interactive preview" hidden={false}/>)
+  fireEvent.change(screen.getByLabelText('Preview viewport size'), {target:{value:'desktop'}})
+  const frame = screen.getByTitle('Interactive preview')
+  expect(frame.style.width).toBe('1280px')
+  rerender(<PixelPreviewViewport access={access} title="Interactive preview" hidden/>)
+  expect(frame).toHaveAttribute('hidden')
+  expect(screen.queryByRole('region', {name:'Preview viewport'})).toBeNull()
+  rerender(<PixelPreviewViewport access={access} title="Interactive preview" hidden={false}/>)
+  expect(screen.getByTitle('Interactive preview')).toBe(frame)
+  expect(frame.style.width).toBe('1280px')
+  fireEvent.change(screen.getByLabelText('Preview viewport size'), {target:{value:'fit'}})
+  expect(frame.style.width).toBe('100%')
+  expect(screen.getByRole('button', {name:'Rotate viewport'})).toBeDisabled()
+})

--- a/ods/extensions/services/dashboard/src/components/pixel-preview-viewport.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-preview-viewport.css
@@ -1,0 +1,8 @@
+.pixel-preview-viewport { display:flex; flex:1; flex-direction:column; min-height:0; min-width:0; overflow:hidden; }
+.pixel-preview-viewport[hidden] { display:none; }
+.pixel-viewport-controls { display:flex; flex-wrap:wrap; align-items:center; gap:8px; padding:8px; color:var(--theme-text-secondary); font-size:11px; }
+.pixel-viewport-controls select,.pixel-viewport-controls button { padding:5px; border:1px solid #69717a; border-radius:5px; background:var(--theme-bg); color:inherit; }
+.pixel-viewport-controls button:disabled { opacity:.4; }
+.pixel-viewport-stage { flex:1; min-height:0; min-width:0; overflow:auto; background:#333; }
+.pixel-viewport-stage iframe { display:block; max-width:none; border:0; background:#fff; }
+.pixel-viewport-note { margin:0; padding:6px 8px; font-size:10px; color:var(--theme-text-muted); }

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -16,6 +16,7 @@ import PixelSelectionActions from '../components/PixelSelectionActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
 import PixelSnapshotChanges from '../components/PixelSnapshotChanges'
+import PixelPreviewViewport from '../components/PixelPreviewViewport'
 import { parseTaskActivity, parseTaskActivityFrame } from '../lib/pixelTaskActivity'
 import MetalMetricIcon from '../components/MetalMetricIcon'
 import PanelResizeHandle from '../components/PanelResizeHandle.jsx'
@@ -1506,15 +1507,11 @@ export default function Pixel({ systemStatus = null }) {
               </button>
               </div>
             </div>
-            {preview && <iframe
+            {preview && <PixelPreviewViewport
               key={`preview-${preview.siteId}-${previewRefresh}`}
-              src={previewAccess.frameUrl}
+              access={previewAccess}
               title={`Interactive ${displayName} preview`}
               hidden={previewCollapsed || previewTab !== 'preview'}
-              sandbox={previewAccess.sandbox}
-              data-preview-route={previewAccess.route}
-              referrerPolicy="no-referrer"
-              className="min-h-0 flex-1 border-0 bg-white"
             />}
             {!previewCollapsed && preview && previewTab === 'files' && <PixelTaskFiles key={`files-${preview.siteId}-${previewRefresh}`} preview={preview}/>}
             {!previewCollapsed && preview && previewTab === 'changes' && <div className="pixel-workspace-changes"><PixelSnapshotChanges key={`${preview.siteId}-${previewRefresh}`} preview={preview} before={[...messages].reverse().find(message=>message.publication?.siteId === preview.siteId)?.beforePublication || null} onPreview={()=>setPreviewTab('preview')}/></div>}


### PR DESCRIPTION
## Why this matters

Owners testing a generated site currently see only the available panel width. Add Fit/Phone/Tablet/Desktop viewport presets and rotation, so they can inspect responsive layouts without changing the host window. Fixed viewports scroll within the panel; Fit restores fluid sizing.

The same iframe node survives resizing, rotation and inspector hiding. Existing authenticated frame URL, sandbox, referrer policy and reload identity are preserved. The UI explicitly calls this layout sizing, not touch/browser/device emulation.

## Overlap check

Searched all-state `responsive preview`/`preview viewport` and the recent 1,500-PR Pixel.jsx inventory. #4066 fixes duplicate-frame identity on inspector reload; #4027 supplies the workbench. None adds viewport controls. The existing iframe's key remains on the new viewport component so publication/reload behavior is preserved; no proxy or network-access policy is changed.

## Validation and risk

Medium Dashboard UI; public-beta d7d76cdc base. Node 20 viewport + Pixel page suites: 75 passed, including preserved frame identity and relay/sandbox policy, inspector hiding, rotation and return to Fit. Production build, focused ESLint, whitespace and changed-file hooks are checked before publication.

Chromium smoke on the actual dashboard route with fixture APIs/preview measured the iframe at 375×667 CSS pixels. An interactive fixture counter remained at 1 after resize and rotation, proving no frame reload in this browser run. Screenshot visually inspected. This is not real mobile or installed inference qualification.

Baseline dashboard: 713 passed; Combined validation is recorded below. Existing unrelated full-repo limits are literal unit-test-key fixtures and the WSL phase03 no-sudo fixture (3 pass/2 fail). Revert restores the direct frame; published files/history are unchanged. Target public-beta, no release/deployment claim.

## AI assistance

Codex investigated, implemented and tested the change, including browser inspection. Independent human review remains outstanding.


## Final batch receipt (2026-09-11)

Exact PR head: `16010e1715e1644c03c3d603aebd9592ca643b8f`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
