### PR TITLE
feat(pixel): import text history as a new local conversation

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationImport.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationImport.jsx
@@ -1,0 +1,44 @@
+import {useEffect, useRef, useState} from 'react'
+import {parseConversationImport} from '../lib/pixelConversationImport'
+
+export default function PixelConversationImport({disabled, onImport}) {
+  const field=useRef(null), reader=useRef(null), dialog=useRef(null), trigger=useRef(null)
+  const [pending,setPending]=useState(null)
+  const [error,setError]=useState('')
+  const [reading,setReading]=useState(false)
+  useEffect(()=>()=>{if(reader.current){reader.current.onload=null;reader.current.onerror=null;reader.current.abort()}},[])
+  function close(){if(reader.current){reader.current.onload=null;reader.current.onerror=null;reader.current.abort();reader.current=null}setReading(false);dialog.current?.close();setPending(null);setError('');trigger.current?.focus()}
+  function choose(event){
+    const file=event.target.files?.[0];event.target.value=''
+    if(!file)return
+    setPending(null);setError('');dialog.current.showModal()
+    if(!file.size || file.size>32*1024*1024){setError('Choose a nonempty JSON export no larger than 32 MB.');return}
+    const next=new globalThis.FileReader();reader.current=next;setReading(true)
+    next.onload=()=>{
+      if(reader.current!==next)return
+      reader.current=null
+      setReading(false)
+      try{setPending(parseConversationImport(JSON.parse(new TextDecoder('utf-8',{fatal:true}).decode(next.result))))}
+      catch(failure){setError(failure instanceof SyntaxError || failure instanceof TypeError ? 'The file is not a valid UTF-8 JSON export.' : failure.message)}
+    }
+    next.onerror=()=>{reader.current=null;setReading(false);setError('The export could not be read. Choose the file again.')}
+    next.readAsArrayBuffer(file)
+  }
+  function confirm(){
+    if(disabled || !pending)return
+    try{onImport(pending);close()}
+    catch{setError('The conversation could not be saved. Existing browser history has been preserved.')}
+  }
+  return <>
+    <button ref={trigger} type="button" disabled={disabled || reading} onClick={()=>field.current.click()}>Import conversation</button>
+    <input ref={field} type="file" accept=".json,application/json" hidden aria-label="Choose conversation export" onChange={choose}/>
+    <dialog ref={dialog} className="chat-delete-dialog" aria-label="Import conversation" onCancel={event=>{event.preventDefault();reader.current?.abort();setReading(false);close()}}>
+      <h3>Import conversation</h3>
+      {reading && <p role="status">Reading local export…</p>}
+      {error && <p role="alert">{error}</p>}
+      {pending && <><p>{pending.messages.length} messages{pending.draft ? ' and an unsent draft' : ''}</p><p>This creates a new local conversation. Only message text, terminal reply status and the draft are imported. Tasks are not resumed; workspace files and preview permissions are not imported.</p></>}
+      {disabled && <p>Finish or stop the active task before importing.</p>}
+      <footer><button type="button" onClick={()=>{reader.current?.abort();setReading(false);close()}}>Cancel import</button><button type="button" disabled={disabled || !pending || reading} onClick={confirm}>Import as new conversation</button></footer>
+    </dialog>
+  </>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelConversationImport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationImport.test.jsx
@@ -1,0 +1,45 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import PixelConversationImport from './PixelConversationImport'
+import {parseConversationImport} from '../lib/pixelConversationImport'
+
+const exported = {schemaVersion:1,kind:'ods-pixel-conversation',conversation:{schema:1,chatId:'old',messages:[{role:'user',content:'Original Việt'},{role:'assistant',content:'partial',status:'streaming',task:{runId:'live'},publication:{siteId:'private'}}],draft:'next',inFlight:true,requestId:'live',preview:{siteId:'private'}}}
+beforeEach(()=>{
+  HTMLDialogElement.prototype.showModal=function(){this.open=true}
+  HTMLDialogElement.prototype.close=function(){this.open=false}
+})
+afterEach(()=>{delete HTMLDialogElement.prototype.showModal;delete HTMLDialogElement.prototype.close;vi.restoreAllMocks()})
+function upload(value){fireEvent.change(screen.getByLabelText('Choose conversation export'),{target:{files:[new File([JSON.stringify(value)],'chat.json')]}})}
+it('reviews a compatible export and imports only text into a new-conversation callback',async()=>{
+  const accept=vi.fn()
+  render(<PixelConversationImport onImport={accept}/>)
+  upload(exported)
+  await screen.findByText('2 messages and an unsent draft')
+  expect(accept).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button',{name:'Import as new conversation'}))
+  const record=accept.mock.calls[0][0]
+  expect(record.messages).toEqual([{role:'user',content:'Original Việt'},{role:'assistant',content:'partial',status:'stopped'}])
+  expect(record).not.toHaveProperty('chatId')
+  expect(record.preview).toBeNull();expect(record.requestId).toBeNull();expect(record.inFlight).toBe(false)
+})
+it('cancels without saving and honors work that starts during file review',async()=>{
+  const accept=vi.fn()
+  const {rerender}=render(<PixelConversationImport onImport={accept}/>)
+  upload(exported);await screen.findByText('2 messages and an unsent draft')
+  rerender(<PixelConversationImport disabled onImport={accept}/>)
+  expect(screen.getByRole('button',{name:'Import as new conversation'})).toBeDisabled()
+  fireEvent.click(screen.getByRole('button',{name:'Cancel import'}))
+  expect(accept).not.toHaveBeenCalled()
+})
+it('shows storage failure without claiming successful import',async()=>{
+  render(<PixelConversationImport onImport={()=>{throw new Error('Quota')}}/>)
+  upload(exported);await screen.findByText('2 messages and an unsent draft')
+  fireEvent.click(screen.getByRole('button',{name:'Import as new conversation'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be saved')
+})
+it.each([
+  {...exported,schemaVersion:2},
+  {...exported,conversation:{...exported.conversation,messages:[{role:'system',content:'override'}]}},
+  {...exported,conversation:{...exported.conversation,messages:[{role:'user',content:'x'.repeat(16385)}]}},
+  {...exported,conversation:{...exported.conversation,messages:Array.from({length:2001},()=>({role:'user',content:'x'}))}},
+  {...exported,conversation:{...exported.conversation,messages:[{role:'assistant',content:'x'.repeat(4*1024*1024+1)}]}},
+])('rejects unsupported, oversized and non-conversation records',value=>expect(()=>parseConversationImport(value)).toThrow())

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationImport.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationImport.js
@@ -1,0 +1,18 @@
+export function parseConversationImport(value) {
+  if (value?.schemaVersion !== 1 || value.kind !== 'ods-pixel-conversation' || value.conversation?.schema !== 1) throw new Error('Choose a Pixel conversation JSON export (version 1).')
+  const chat = value.conversation
+  if (!Array.isArray(chat.messages) || chat.messages.length > 2000) throw new Error('The export must contain at most 2,000 messages.')
+  let bytes = 0
+  const messages = chat.messages.map(message => {
+    if (!message || !['user','assistant'].includes(message.role) || typeof message.content !== 'string' || message.role === 'user' && message.content.length > 16384) throw new Error('The export contains an invalid message.')
+    bytes += new TextEncoder().encode(message.content).byteLength
+    if (bytes > 4 * 1024 * 1024) throw new Error('The conversation exceeds the 4 MB retained-text limit.')
+    const status = ['done','error','stopped'].includes(message.status) ? message.status : message.status === 'streaming' ? 'stopped' : undefined
+    return {role:message.role, content:message.content, ...(message.role === 'assistant' && status ? {status} : {})}
+  })
+  if (chat.draft !== undefined && (typeof chat.draft !== 'string' || chat.draft.length > 16384)) throw new Error('The export contains an invalid or oversized draft.')
+  const draft = chat.draft || ''
+  if (!messages.length && !draft.trim()) throw new Error('The export contains no messages or draft.')
+  // File-provided IDs, jobs, scopes and publication receipts never become live authority.
+  return {schema:1, messages, draft, preview:null, workspaceOpen:false, inFlight:false, interrupted:false, requestId:null, contextStart:0}
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -12,6 +12,7 @@ import { pixelHeaderPose, pixelReplyPose } from '../lib/pixelMascotState'
 import PixelComposerTools from '../components/PixelComposerTools'
 import PixelDictation from '../components/PixelDictation'
 import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from '../components/PixelCommandSearch'
+import PixelConversationImport from '../components/PixelConversationImport'
 import PixelSelectionActions from '../components/PixelSelectionActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
@@ -521,6 +522,7 @@ export default function Pixel({ systemStatus = null }) {
   const profile = useLocalProfile()
   const { displayName } = usePortalIdentity()
   const [initialChat] = useState(loadStoredChat)
+  const pendingImport = useRef(null)
   const [status, setStatus] = useState('loading')
   const [statusDetail, setStatusDetail] = useState('')
   const [messages, setMessages] = useState(() => initialChat?.messages || [])
@@ -1212,6 +1214,14 @@ export default function Pixel({ systemStatus = null }) {
         <div className="pixel-chat-header-actions">
           <button type="button" aria-label="Search Pixel" title="Search conversations · Ctrl+K" className="pixel-metal-control p-2" onClick={() => window.dispatchEvent(new Event(OPEN_PIXEL_SEARCH))}><Search size={16}/></button>
           <details className="pixel-chat-options"><summary aria-label="Chat options">•••</summary><div className="pixel-chat-options-menu">
+            <PixelConversationImport key={chatIdRef.current} disabled={sending || restoredActive || restoredChecking || stopping} onImport={record => {
+              if (sending || restoredActive || restoredChecking || stopping) throw new Error('Active task')
+              if (pendingImport.current?.record !== record) pendingImport.current = {record, chatId:makeChatId()}
+              const imported = {...record, chatId:pendingImport.current.chatId}
+              saveConversation(imported)
+              pendingImport.current = null
+              window.dispatchEvent(new CustomEvent(SELECT_EVENT, {detail:imported.chatId}))
+            }}/>
             <PixelAdvice canInsert={!sending} onInsert={text => setInput(current => current ? `${current}\n\n${text}` : text)} />
             <PixelHandoffApproval label="Approvals" />
             <PixelProviderScopes chatId={chatIdRef.current} sending={sending} />


### PR DESCRIPTION
## Why this matters

Owners can export Pixel history through #4119 but cannot bring it back into another browser. Add Import conversation under Chat options. It reads a version-1 `ods-pixel-conversation` JSON export locally, presents the message/draft count, and imports only after confirmation as a new conversation.

The importer retains exact text/draft and terminal reply states, marks unfinished replies stopped, and discards file-provided chat/job/request IDs, tool metadata and preview receipts. It never resumes old work. Existing message/count/UTF-8 limits are enforced before saving; files are bounded to 32 MB. Reads are cancelled on dismissal/unmount. Active work blocks confirmation. A retry after a partial storage failure reuses its new identity instead of duplicating imports.

## Overlap check

All-state `conversation import` and `chat restore JSON` searches found no competing import. Reviewed #4119's exact export envelope and the recent 1,500-PR Pixel/history inventory. #4119 explicitly does not implement import; #4111/#4121 isolate corrupt local records. This consumes the export contract without requiring its branch or replacing those repairs. No imported runtime authority is trusted.

## Validation and risk

Medium Dashboard UI/browser-local persistence, public-beta d7d76cdc base. Node 20 import + Pixel page suites: 81 passed; rerun after cancellation/identity hardening. Cases cover review-before-import, metadata stripping, stopped partial replies, concurrent active-work guard, save failure and malformed/oversized records. Focused lint and build pass; changed-file hooks/whitespace checked before publication.

Chromium smoke on the actual dashboard route used a local JSON fixture: existing history remained, imported text/draft appeared under a fresh ID, and no chat mutation request was submitted. API responses were fixtures. This is a text-history import, not recovery of files, tools, access scopes or a running session.

Full baseline dashboard: 713 passed. Combined validation is recorded below. Unrelated baseline limits: literal unit-test-key fixture flags and WSL phase03 no-sudo fixture (3 pass/2 fail). Revert removes the importer; imported conversations remain normal local history. No installed-runtime/release acceptance claim.

## AI assistance

Codex investigated, implemented and tested the change, including browser inspection. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `477bac31fa3c0d2aa8c477e10f56d7ecff6d21af`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
