### PR TITLE
feat(pixel): preview Markdown drafts before sending

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelDraftPreview.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDraftPreview.jsx
@@ -1,0 +1,20 @@
+import {useState} from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import './pixel-draft-preview.css'
+
+const components = {
+  a:({children, href}) => <span className="underline" title={href}>{children}</span>,
+  img:({alt}) => <span>[Image: {alt || 'untitled'}]</span>,
+  input:({checked}) => <input type="checkbox" checked={Boolean(checked)} readOnly disabled/>,
+}
+export default function PixelDraftPreview({input}) {
+  const [open,setOpen]=useState(false)
+  return <div className="pixel-draft-preview">
+    <button type="button" disabled={!input.trim() && !open} aria-expanded={open} onClick={()=>setOpen(value=>!value)}>{open?'Hide draft preview':'Preview draft'}</button>
+    {open && <section aria-label="Draft Markdown preview">
+      <p className="pixel-draft-note">Preview only. Links and external images stay inactive.</p>
+      {input.trim() ? <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{input}</ReactMarkdown> : <p>Your draft is empty.</p>}
+    </section>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelDraftPreview.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDraftPreview.test.jsx
@@ -1,0 +1,33 @@
+import {render,screen,fireEvent} from '@testing-library/react'
+import PixelDraftPreview from './PixelDraftPreview'
+
+it('previews headings, lists, code and GFM tables while preserving the draft source',()=>{
+  const input='# Plan\n\n- One\n- Two\n\n```js\nconst x = 1\n```\n\n| A | B |\n|---|---|\n| 1 | 2 |'
+  render(<PixelDraftPreview input={input}/>)
+  fireEvent.click(screen.getByRole('button',{name:'Preview draft'}))
+  expect(screen.getByRole('heading',{name:'Plan',level:1})).toBeVisible()
+  expect(screen.getAllByRole('listitem')).toHaveLength(2)
+  expect(screen.getByRole('table')).toBeVisible()
+  expect(screen.getByText('const x = 1')).toBeVisible()
+  expect(input).toContain('```js')
+})
+it('does not fetch images, activate links or execute raw HTML',()=>{
+  const {container}=render(<PixelDraftPreview input={'![photo](https://example.com/private.png)\n[link](https://example.com)\n<script>bad()</script>'}/>)
+  fireEvent.click(screen.getByRole('button',{name:'Preview draft'}))
+  expect(screen.getByText('[Image: photo]')).toBeVisible()
+  expect(container.querySelector('img')).toBeNull()
+  expect(container.querySelector('a')).toBeNull()
+  expect(container.querySelector('script')).toBeNull()
+})
+it('updates an open preview and allows closing it after the draft is cleared',()=>{
+  const {rerender}=render(<PixelDraftPreview input='**Original**'/>)
+  fireEvent.click(screen.getByRole('button',{name:'Preview draft'}))
+  rerender(<PixelDraftPreview input='## Updated'/> )
+  expect(screen.getByRole('heading',{name:'Updated'})).toBeVisible()
+  expect(screen.queryByText('Original')).toBeNull()
+  rerender(<PixelDraftPreview input=''/> )
+  expect(screen.getByText('Your draft is empty.')).toBeVisible()
+  fireEvent.click(screen.getByRole('button',{name:'Hide draft preview'}))
+  expect(screen.queryByRole('region')).toBeNull()
+  expect(screen.getByRole('button',{name:'Preview draft'})).toBeDisabled()
+})

--- a/ods/extensions/services/dashboard/src/components/pixel-draft-preview.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-draft-preview.css
@@ -1,0 +1,14 @@
+.pixel-draft-preview { margin:4px 0; font-size:12px; color:var(--theme-text-secondary); }
+.pixel-draft-preview > button { padding:4px 6px; border-radius:5px; }
+.pixel-draft-preview > button:disabled { opacity:.4; }
+.pixel-draft-preview > section { max-height:240px; overflow:auto; margin:5px 0; padding:12px; border:1px solid var(--theme-border); border-radius:8px; overflow-wrap:anywhere; }
+.pixel-draft-preview :is(h1,h2,h3) { margin:10px 0 6px; font-weight:600; }
+.pixel-draft-preview h1 { font-size:20px; }
+.pixel-draft-preview h2 { font-size:17px; }
+.pixel-draft-preview p { margin:6px 0; }
+.pixel-draft-preview ul { list-style:disc; padding-left:20px; }
+.pixel-draft-preview ol { list-style:decimal; padding-left:20px; }
+.pixel-draft-preview pre { overflow:auto; padding:8px; border:1px solid var(--theme-border); white-space:pre; }
+.pixel-draft-preview table { border-collapse:collapse; }
+.pixel-draft-preview :is(th,td) { padding:6px; border:1px solid var(--theme-border); }
+.pixel-draft-preview .pixel-draft-note { color:var(--theme-text-muted); font-size:10px; }

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -10,6 +10,7 @@ import UserAvatar from '../components/UserAvatar'
 import {useLocalProfile} from '../lib/localProfile'
 import { pixelHeaderPose, pixelReplyPose } from '../lib/pixelMascotState'
 import PixelComposerTools from '../components/PixelComposerTools'
+import PixelDraftPreview from '../components/PixelDraftPreview'
 import PixelDictation from '../components/PixelDictation'
 import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from '../components/PixelCommandSearch'
 import PixelSelectionActions from '../components/PixelSelectionActions'
@@ -1443,6 +1444,7 @@ export default function Pixel({ systemStatus = null }) {
           </div>
           </div>
           {stopError && <p role="alert" className="mt-1.5 px-1 text-xs text-amber-300">{stopError}</p>}
+          <PixelDraftPreview key={chatIdRef.current} input={input}/>
           <div className="pixel-composer-secondary">
             <PixelComposerTools input={input} disabled={isDisabled} onInsert={insertComposerText} />
             <div className="pixel-composer-limits">


### PR DESCRIPTION
## Why this matters

Long prompts often contain lists, code fences and tables that are hard to verify in the compact composer. Add an optional, bounded-height Markdown draft preview before Send. It stays synchronized with the editable draft and resets when the conversation changes.

Previewing has no send/save callback. Raw HTML stays inert, image references render as text placeholders, and links are inactive, so opening the preview cannot fetch remote draft resources. GFM tables/task lists use existing dependencies. Clearing a draft leaves the preview closable.

## Overlap check

Searched all-state `draft markdown preview` and `composer preview` and the recent 1,500-PR Pixel.jsx inventory; no matching feature exists. #4078 handles cleared-draft persistence, #4114 handles prompt-command keyboard use, and #4027 supplies the composer. This adds a separate presentation control without changing those paths or the send payload.

## Validation and risk

Medium Dashboard UI, public-beta d7d76cdc base. Node 20 draft-preview + Pixel page suites: 76 passed. Tests cover headings/lists/fences/GFM tables, inert links/images/HTML, live draft updates and closing an emptied preview. Production build and focused lint (zero errors) pass; whitespace/changed-file hooks are checked before publication.

Baseline dashboard: 713 passed; browser/Combined validation is recorded below. Unrelated baseline gate limits: literal unit-test-key fixture flags and WSL phase03 no-sudo fixture (3 pass/2 fail). Revert removes preview only; the draft and outbound text format remain unchanged. No installed-runtime/release claim.

## AI assistance

Codex investigated, implemented and tested the change. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `dbd3b1cb608fbe85db4f04d35919593e21c99fb3`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
