### PR TITLE
feat(pixel): support a modifier-key send preference

### DIFF
--- a/ods/extensions/services/dashboard/src/lib/usePixelSendKey.js
+++ b/ods/extensions/services/dashboard/src/lib/usePixelSendKey.js
@@ -1,0 +1,26 @@
+import {useEffect, useState} from 'react'
+export const SEND_KEY_STORAGE = 'ods.pixel.send-key.v1'
+function read() {
+  try {return localStorage.getItem(SEND_KEY_STORAGE) === 'mod-enter' ? 'mod-enter' : 'enter'}
+  catch {return 'enter'}
+}
+export function shouldSendMessage(event, mode) {
+  if (event.key !== 'Enter' || event.shiftKey || event.altKey || event.nativeEvent?.isComposing || event.isComposing || event.keyCode === 229) return false
+  return mode === 'enter' || Boolean(event.ctrlKey || event.metaKey)
+}
+export function usePixelSendKey() {
+  const [mode,setMode]=useState(read)
+  const [error,setError]=useState('')
+  useEffect(()=>{
+    const refresh=event=>{if(event.key===SEND_KEY_STORAGE || event.key===null){setMode(read());setError('')}}
+    window.addEventListener('storage',refresh)
+    return()=>window.removeEventListener('storage',refresh)
+  },[])
+  function change(value){
+    if(!['enter','mod-enter'].includes(value))return
+    setMode(value)
+    try{localStorage.setItem(SEND_KEY_STORAGE,value);setError('')}
+    catch{setError('This shortcut applies to this tab, but could not be saved for next time.')}
+  }
+  return {mode,change,error}
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -22,6 +22,7 @@ import PanelResizeHandle from '../components/PanelResizeHandle.jsx'
 import PixelHandoffApproval from '../components/PixelHandoffApproval.jsx'
 import PixelProviderScopes from '../components/PixelProviderScopes.jsx'
 import { usePortalIdentity } from '../contexts/PortalIdentityContext'
+import {usePixelSendKey, shouldSendMessage} from '../lib/usePixelSendKey'
 import {
   AlertCircle,
   Bot,
@@ -521,6 +522,7 @@ export default function Pixel({ systemStatus = null }) {
   const profile = useLocalProfile()
   const { displayName } = usePortalIdentity()
   const [initialChat] = useState(loadStoredChat)
+  const sendKey = usePixelSendKey()
   const [status, setStatus] = useState('loading')
   const [statusDetail, setStatusDetail] = useState('')
   const [messages, setMessages] = useState(() => initialChat?.messages || [])
@@ -1212,6 +1214,8 @@ export default function Pixel({ systemStatus = null }) {
         <div className="pixel-chat-header-actions">
           <button type="button" aria-label="Search Pixel" title="Search conversations · Ctrl+K" className="pixel-metal-control p-2" onClick={() => window.dispatchEvent(new Event(OPEN_PIXEL_SEARCH))}><Search size={16}/></button>
           <details className="pixel-chat-options"><summary aria-label="Chat options">•••</summary><div className="pixel-chat-options-menu">
+            <label className="block p-2 text-xs">Send shortcut<select className="mt-1 block w-full rounded border border-theme-border bg-theme-bg p-2" aria-label="Send shortcut" value={sendKey.mode} onChange={event => sendKey.change(event.target.value)}><option value="enter">Enter to send</option><option value="mod-enter">Ctrl/⌘+Enter to send</option></select></label>
+            {sendKey.error && <p role="alert" className="p-2 text-xs">{sendKey.error}</p>}
             <PixelAdvice canInsert={!sending} onInsert={text => setInput(current => current ? `${current}\n\n${text}` : text)} />
             <PixelHandoffApproval label="Approvals" />
             <PixelProviderScopes chatId={chatIdRef.current} sending={sending} />
@@ -1402,8 +1406,7 @@ export default function Pixel({ systemStatus = null }) {
             value={input}
             onChange={(event) => setInput(event.target.value)}
             onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
-                if (event.nativeEvent?.isComposing) return
+              if (shouldSendMessage(event, sendKey.mode)) {
                 event.preventDefault()
                 sendMessage()
               }
@@ -1451,7 +1454,7 @@ export default function Pixel({ systemStatus = null }) {
             </div>
           </div>
           <div className="mt-1.5 flex items-center justify-between gap-3 px-1 text-[10px] text-theme-text-muted/70">
-            <span>{stopping ? 'Waiting for exact cancellation acknowledgement' : restoredActive ? 'Earlier work is active in this chat; Stop targets only this chat.' : sending ? `${displayName} is using the active ODS model and tools · ${workingElapsed} elapsed` : 'Enter to send • Shift+Enter for a new line'}</span>
+            <span>{stopping ? 'Waiting for exact cancellation acknowledgement' : restoredActive ? 'Earlier work is active in this chat; Stop targets only this chat.' : sending ? `${displayName} is using the active ODS model and tools · ${workingElapsed} elapsed` : sendKey.mode === 'mod-enter' ? 'Ctrl/⌘+Enter to send • Enter for a new line' : 'Enter to send • Shift+Enter for a new line'}</span>
           </div>
         </div>
         {inputOver && (

--- a/ods/extensions/services/dashboard/src/pages/PixelSendKey.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelSendKey.test.jsx
@@ -1,0 +1,48 @@
+import {fireEvent,screen,waitFor,act} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import Pixel from './Pixel'
+import {SEND_KEY_STORAGE,shouldSendMessage} from '../lib/usePixelSendKey'
+
+beforeEach(()=>{
+  localStorage.clear()
+  vi.stubGlobal('fetch',vi.fn(async url=>url==='/api/pixel/chat/stream' ? {ok:false,status:503,json:async()=>({detail:'fixture'})} : {ok:true,json:async()=>({available:true,model:'pixel/default'})}))
+})
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
+it('keeps Enter for newlines in modifier mode and sends once with Ctrl+Enter',async()=>{
+  render(<Pixel/>)
+  await screen.findByText('Available')
+  fireEvent.change(screen.getByLabelText('Send shortcut'),{target:{value:'mod-enter'}})
+  const field=screen.getByPlaceholderText('Message Portal...')
+  fireEvent.change(field,{target:{value:'Multiline\nprompt'}})
+  fireEvent.keyDown(field,{key:'Enter'})
+  expect(fetch.mock.calls.filter(([url])=>url==='/api/pixel/chat/stream')).toHaveLength(0)
+  expect(field).toHaveValue('Multiline\nprompt')
+  fireEvent.keyDown(field,{key:'Enter',ctrlKey:true})
+  await waitFor(()=>expect(fetch.mock.calls.filter(([url])=>url==='/api/pixel/chat/stream')).toHaveLength(1))
+  expect(localStorage.getItem(SEND_KEY_STORAGE)).toBe('mod-enter')
+})
+it('restores the preference and refreshes it from another tab without changing the draft',async()=>{
+  localStorage.setItem(SEND_KEY_STORAGE,'mod-enter')
+  render(<Pixel/>);await screen.findByText('Available')
+  expect(screen.getByLabelText('Send shortcut')).toHaveValue('mod-enter')
+  fireEvent.change(screen.getByPlaceholderText('Message Portal...'),{target:{value:'Keep this draft'}})
+  localStorage.setItem(SEND_KEY_STORAGE,'enter')
+  act(()=>window.dispatchEvent(new globalThis.StorageEvent('storage',{key:SEND_KEY_STORAGE})))
+  expect(screen.getByLabelText('Send shortcut')).toHaveValue('enter')
+  expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue('Keep this draft')
+})
+it('keeps a session preference usable when browser storage rejects the write',async()=>{
+  vi.stubGlobal('localStorage',{getItem:()=>null,setItem:()=>{throw new Error('blocked')},removeItem:()=>{}})
+  render(<Pixel/>);await screen.findByText('Available')
+  fireEvent.change(screen.getByLabelText('Send shortcut'),{target:{value:'mod-enter'}})
+  expect(screen.getByLabelText('Send shortcut')).toHaveValue('mod-enter')
+  expect(screen.getByText('This shortcut applies to this tab, but could not be saved for next time.')).toBeInTheDocument()
+})
+it.each([
+  [{key:'Enter',metaKey:true},'mod-enter',true],
+  [{key:'Enter',ctrlKey:true,shiftKey:true},'mod-enter',false],
+  [{key:'Enter',altKey:true},'enter',false],
+  [{key:'Enter',ctrlKey:true,nativeEvent:{isComposing:true}},'mod-enter',false],
+  [{key:'Enter',keyCode:229},'enter',false],
+  [{key:'Enter'},'enter',true],
+])('preserves composition/newline modifiers at the send boundary', (event,mode,expected)=>expect(shouldSendMessage(event,mode)).toBe(expected))


### PR DESCRIPTION
## Why this matters

People composing multiline prompts need a way to reserve Enter for newlines. Add a Chat options preference for Ctrl/⌘+Enter to send, while retaining Enter-to-send as the default and keeping the visible composer hint accurate. The selected shortcut persists locally and follows storage changes from other tabs.

Shift/Alt and IME composition never trigger sending. A rejected preference write leaves the selected shortcut usable in the current tab with visible feedback. The same existing send function still enforces status, length and in-flight guards.

## Overlap check

Searched all-state `send shortcut` and `Enter send` plus the recent 1,500-PR Pixel.jsx inventory; no matching preference exists. #4105 concerns IME in search and #4114 concerns command-menu navigation. This controls the composer send boundary without modifying search, dictation or backend submission semantics.

## Validation and risk

Medium Dashboard UI, public-beta d7d76cdc base. Node 20 shortcut and Pixel page suites: 82 passed. Page tests verify plain Enter submits zero requests in modifier mode, Ctrl+Enter submits exactly once, stored/cross-tab preference changes preserve the draft, and rejected storage writes leave a usable session preference. Boundary cases cover Command, Shift, Alt and composing/keyCode-229 events.

Production build, focused lint, whitespace and changed-file hooks checked before publication. Baseline dashboard: 713 passed; Combined validation is recorded below. Unrelated full-repo baseline limits are literal unit-test-key fixtures and the WSL phase03 no-sudo fixture (3 pass/2 fail). Revert restores the default shortcut; draft/history data remains intact. No host/runtime/release qualification claim.

## AI assistance

Codex investigated, implemented and tested the change. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `9a95392b55bea25bf5aa92469bd56573d7c8ee1f`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
