### PR TITLE
feat(pixel): navigate retained preview publications

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.jsx
@@ -1,0 +1,19 @@
+export default function PixelPreviewHistory({previews, selected, onSelect}) {
+  const versions = [...new Map(previews.map(preview => [preview.siteId,preview])).values()]
+  const currentListed = versions.some(preview => preview.siteId === selected.siteId)
+  if (versions.length + (currentListed ? 0 : 1) < 2) return null
+  const latest = versions.at(-1)
+  return <div className="border-b border-theme-border p-2 text-xs text-theme-text-secondary">
+    <label className="flex flex-wrap items-center gap-2">Published version
+      <select aria-label="Published version" className="min-w-0 flex-1 rounded border border-theme-border bg-theme-bg p-1" value={selected.siteId} onChange={event => {
+        const preview = versions.find(item => item.siteId === event.target.value)
+        if (preview) onSelect(preview)
+      }}>
+        {!currentListed && <option value={selected.siteId}>Current preview · {selected.relativeDirectory}</option>}
+        {versions.map((preview,index) => <option key={preview.siteId} value={preview.siteId}>Publication {index+1} · {preview.relativeDirectory}{preview.siteId===latest.siteId?' · Latest retained':''}</option>)}
+      </select>
+      {selected.siteId !== latest.siteId && <button type="button" onClick={() => onSelect(latest)}>Show latest publication</button>}
+    </label>
+    {selected.siteId !== latest.siteId && <p className="mt-1">{currentListed ? 'Viewing an earlier saved publication.' : 'Viewing a publication outside retained turn history.'} Workspace files are unchanged.</p>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -16,6 +16,7 @@ import PixelSelectionActions from '../components/PixelSelectionActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
 import PixelSnapshotChanges from '../components/PixelSnapshotChanges'
+import PixelPreviewHistory from '../components/PixelPreviewHistory'
 import { parseTaskActivity, parseTaskActivityFrame } from '../lib/pixelTaskActivity'
 import MetalMetricIcon from '../components/MetalMetricIcon'
 import PanelResizeHandle from '../components/PanelResizeHandle.jsx'
@@ -1506,6 +1507,7 @@ export default function Pixel({ systemStatus = null }) {
               </button>
               </div>
             </div>
+            {!previewCollapsed && preview && <PixelPreviewHistory previews={messages.map(message => messagePublication(message).publication).filter(Boolean)} selected={preview} onSelect={publication => {setPreview(publication); setPreviewRefresh(0)}}/>}
             {preview && <iframe
               key={`preview-${preview.siteId}-${previewRefresh}`}
               src={previewAccess.frameUrl}

--- a/ods/extensions/services/dashboard/src/pages/PixelPreviewHistory.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelPreviewHistory.test.jsx
@@ -1,0 +1,36 @@
+import {render} from '../test/test-utils'
+import {screen,fireEvent,waitFor} from '@testing-library/react'
+import Pixel from './Pixel'
+import {saveConversation} from '../lib/pixelConversations'
+
+function publication(digit) {
+  const sha256=digit.repeat(64),siteId='site-'+sha256.slice(0,24)
+  return {schemaVersion:1,kind:'ods-pixel-workspace-preview',relativeDirectory:'demo',siteId,sha256,entrySha256:'f'.repeat(64),files:1,bytes:20,port:9437,url:`http://${siteId}.localhost:9437/${siteId}/`}
+}
+const first=publication('a'), latest=publication('b')
+beforeEach(()=>{
+  localStorage.clear()
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>({available:true,model:'pixel/default'}),arrayBuffer:async()=>new TextEncoder().encode('{}').buffer})))
+})
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
+function seed(extra=[]) {
+  saveConversation({schema:1,chatId:'versions',messages:[{role:'user',content:'Build a page'},{role:'assistant',content:'First result',publication:first},{role:'user',content:'Improve it'},{role:'assistant',content:'Second result',publication:latest,beforePublication:first},...extra],preview:latest,workspaceOpen:true})
+}
+it('opens an earlier verified publication and returns to latest without submitting work',async()=>{
+  seed();render(<Pixel/>);await screen.findByText('Available')
+  const selector=screen.getByLabelText('Published version')
+  expect(selector).toHaveValue(latest.siteId)
+  fireEvent.change(selector,{target:{value:first.siteId}})
+  expect(screen.getByTitle('Interactive Portal preview')).toHaveAttribute('src',`/pixel-preview/${first.siteId}/__ods_view__.html`)
+  expect(screen.getByText(/Workspace files are unchanged/)).toBeVisible()
+  fireEvent.click(screen.getByRole('button',{name:'Show latest publication'}))
+  expect(screen.getByTitle('Interactive Portal preview')).toHaveAttribute('src',`/pixel-preview/${latest.siteId}/__ods_view__.html`)
+  expect(fetch.mock.calls.some(([url])=>url==='/api/pixel/chat/stream')).toBe(false)
+  await waitFor(()=>expect(JSON.parse(localStorage.getItem('ods.pixel.chat.v1')).messages).toHaveLength(4))
+})
+it('deduplicates retained snapshots and excludes malformed publication metadata',async()=>{
+  seed([{role:'assistant',content:'Repeated',publication:latest},{role:'assistant',content:'Invalid',publication:{...publication('c'),url:'https://invalid.example/'}}])
+  render(<Pixel/>);await screen.findByText('Available')
+  const options=screen.getByLabelText('Published version').querySelectorAll('option')
+  expect([...options].map(option=>option.value)).toEqual([first.siteId,latest.siteId])
+})


### PR DESCRIPTION
## Why this matters

After revising a generated site, owners need to revisit earlier published results without scrolling back through every reply. Add a publication selector to the workspace, deduplicated from retained verified publication records, plus a return-to-latest control. Viewing an older publication explicitly leaves workspace files unchanged.

The selector uses the existing publication validator and authenticated preview path. Malformed metadata creates no option. The selected publication drives the existing Preview/Files/Changes inspectors and persists through the existing local chat state; no rollback, publish or chat mutation is performed.

## Overlap check

Searched all-state `preview history` and `snapshot selector`, and the recent 1,500-PR Pixel.jsx inventory. #4027 supplies per-reply preview links and #4066 fixes iframe identity on reload; neither exposes a central publication history. #4148 adds viewport sizing. This adds selection over retained records without changing preview validation, comparison generation or those iframe controls.

## Validation and risk

Medium Dashboard UI, public-beta d7d76cdc base. Node 20 publication-history + Pixel page suites: 75 passed. Public-page tests select old/latest relay URLs without chat submissions, preserve message history, deduplicate repeated publications and exclude invalid URLs. Focused lint/build pass; whitespace and changed-file hooks checked before publication.

Baseline dashboard: 713 passed; Combined validation is recorded below. Existing full-repo limits: literal unit-test-key fixture flags and WSL phase03 no-sudo fixture (3 pass/2 fail). “Latest” describes retained conversation publications, not a server-wide inventory. Missing server snapshots remain subject to existing verification errors. Revert removes navigation without changing artifacts or history. No installed-runtime/release claim.

## AI assistance

Codex investigated, implemented and tested the change. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `4581bda5336a0347eb20c5d5d3598aef443f5825`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
