### PR TITLE
test(pixel): fix PYTEST_CURRENT_TEST Windows environment variable size limit crash

### DIFF
--- a/ods/tests/pixel_inference/test_connection_import_host.py
+++ b/ods/tests/pixel_inference/test_connection_import_host.py
@@ -50,7 +50,7 @@ def test_actual_owner_and_metadata_chain_without_saved_settings(owner):
     ('invalid', 'wrong', 403), ('{}', 'synthetic-provider-test-key', 400),
     ('{"bundle":"{}","bundle":"{}","confirmedEndpoint":"https://example.org/v1"}', 'synthetic-provider-test-key', 400),
     ('x' * 65537, 'synthetic-provider-test-key', 413),
-])
+], ids=['invalid-token', 'empty-dict', 'duplicate-keys', 'payload-too-large'])
 def test_denial_and_bad_input_never_spawn_probe(owner, body, token, status, monkeypatch):
     from pixel_provider import connection_import
     def forbidden(*args, **kwargs):
@@ -58,3 +58,4 @@ def test_denial_and_bad_input_never_spawn_probe(owner, body, token, status, monk
     monkeypatch.setattr(connection_import.subprocess, 'run', forbidden)
     assert request(owner, body, token)[0] == status
     assert list(owner[1].iterdir()) == []
+


### PR DESCRIPTION
## Description

The newly added `ods/tests/pixel_inference/test_connection_import_host.py` contains a parametrized test case with a 65,537-character payload (`"x" * 65537`) to verify rejection of oversized input.

On Windows, this causes the entire pytest run to crash before any tests can execute.

### Error & Context

The `test_denial_and_bad_input_never_spawn_probe` test is parametrized with the large payload. During test collection and setup, pytest automatically updates the `PYTEST_CURRENT_TEST` environment variable with the current test name and its parameters.

Because Windows imposes a **32,767-character limit on environment variables**, pytest attempts to pass the entire 65K-character payload through `PYTEST_CURRENT_TEST`, causing `os.putenv` to fail:

```text id="p6n7y2"
File "C:\...\Python310\lib\os.py", line 685, in __setitem__
    putenv(key, value)
ValueError: the environment variable is longer than 32767 characters
```

This hard-crashes the test suite before the affected test—or any other tests—can execute.

### Environment / Device

* **OS:** Windows (Docker Desktop with WSL2 backend)
* **Python:** 3.10.x
* **Hardware:** Local desktop development environment

### Fix

This PR adds explicit, concise IDs to the `pytest.mark.parametrize` decorator.

For example:

```python
ids=["payload-too-large"]
```

By providing explicit IDs, pytest uses the short label when constructing the test name instead of stringifying the entire 65K-character payload.

This preserves the original test input and rejection logic while avoiding Windows' environment-variable size limitation.

### How to Test

1. Pull the branch locally on a Windows machine.
2. Run:

   ```bash
   pytest ods/tests/pixel_inference/test_connection_import_host.py
   ```
3. Verify that pytest successfully collects the test.
4. Confirm the test passes or skips as expected without triggering the `os.putenv` environment-variable error.

### Expected Behavior

The test should collect and execute normally on Windows while still testing the 65,537-character payload.

### Actual Behavior

Pytest attempts to include the entire payload in `PYTEST_CURRENT_TEST`, exceeding Windows' 32,767-character environment-variable limit and causing the test suite to crash during setup.
