### PR TITLE
feat(pixel): navigate long conversations by turn

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelTurnNavigation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTurnNavigation.jsx
@@ -1,0 +1,16 @@
+export default function PixelTurnNavigation({messages, onNavigate}) {
+  const turns = messages.flatMap((message,index) => message.role === 'user' ? [{index,text:message.content}] : [])
+  if (turns.length < 2) return null
+  return <div className="p-2 text-xs">
+    <label>Conversation outline
+      <select aria-label="Jump to conversation turn" value="" className="mt-1 block w-full min-w-0 rounded border border-theme-border bg-theme-bg p-2" onChange={event => {
+        const selected = turns.find(turn => String(turn.index) === event.target.value)
+        if (selected) {onNavigate(selected.index); event.currentTarget.closest('details')?.removeAttribute('open')}
+      }}>
+        <option value="" disabled>Jump to a prompt…</option>
+        {turns.map((turn,index) => <option key={turn.index} value={turn.index}>Turn {index+1} · {turn.text.trim().slice(0,80) || 'Empty prompt'}</option>)}
+      </select>
+    </label>
+    <button type="button" onClick={event => {onNavigate(messages.length-1); event.currentTarget.closest('details')?.removeAttribute('open')}}>Go to latest message</button>
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -15,6 +15,7 @@ import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from '../components/PixelComman
 import PixelSelectionActions from '../components/PixelSelectionActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
+import PixelTurnNavigation from '../components/PixelTurnNavigation'
 import PixelSnapshotChanges from '../components/PixelSnapshotChanges'
 import { parseTaskActivity, parseTaskActivityFrame } from '../lib/pixelTaskActivity'
 import MetalMetricIcon from '../components/MetalMetricIcon'
@@ -1212,6 +1213,11 @@ export default function Pixel({ systemStatus = null }) {
         <div className="pixel-chat-header-actions">
           <button type="button" aria-label="Search Pixel" title="Search conversations · Ctrl+K" className="pixel-metal-control p-2" onClick={() => window.dispatchEvent(new Event(OPEN_PIXEL_SEARCH))}><Search size={16}/></button>
           <details className="pixel-chat-options"><summary aria-label="Chat options">•••</summary><div className="pixel-chat-options-menu">
+            <PixelTurnNavigation messages={messages} onNavigate={index => {
+              const row = scrollRef.current?.parentElement?.querySelector(`[data-pixel-message-index="${index}"]`)
+              row?.scrollIntoView?.({block:'start', behavior:'auto'})
+              row?.focus?.({preventScroll:true})
+            }}/>
             <PixelAdvice canInsert={!sending} onInsert={text => setInput(current => current ? `${current}\n\n${text}` : text)} />
             <PixelHandoffApproval label="Approvals" />
             <PixelProviderScopes chatId={chatIdRef.current} sending={sending} />
@@ -1345,7 +1351,7 @@ export default function Pixel({ systemStatus = null }) {
           </div>
         )}
         {messages.map((message, index) => (
-          <div key={index} data-pixel-response={message.role === 'assistant' ? '' : undefined} className={`mx-auto flex min-w-0 w-full max-w-5xl ${message.role === 'user' ? 'justify-end gap-2' : 'justify-start'}`}>
+          <div key={index} data-pixel-message-index={index} tabIndex={-1} data-pixel-response={message.role === 'assistant' ? '' : undefined} className={`mx-auto flex min-w-0 w-full max-w-5xl ${message.role === 'user' ? 'justify-end gap-2' : 'justify-start'}`}>
             {message.role === 'assistant' && <PixelMascot state={pixelReplyPose(message, sending && index === messages.length - 1)} settled={message.status !== 'streaming'} className="pixel-reply-character" />}
             <div className={`min-w-0 max-w-[min(85%,48rem)] rounded-2xl px-4 py-3 text-sm leading-6 [overflow-wrap:anywhere] ${
               message.role === 'user'

--- a/ods/extensions/services/dashboard/src/pages/PixelTurnNavigation.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelTurnNavigation.test.jsx
@@ -1,0 +1,29 @@
+import {render} from '../test/test-utils'
+import {screen,fireEvent} from '@testing-library/react'
+import Pixel from './Pixel'
+import {saveConversation} from '../lib/pixelConversations'
+
+beforeEach(()=>{
+  localStorage.clear()
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>({available:true,model:'pixel/default'})})))
+  globalThis.HTMLElement.prototype.scrollIntoView=vi.fn()
+})
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks();delete globalThis.HTMLElement.prototype.scrollIntoView})
+it('navigates duplicate prompts by message identity and focuses the chosen turn',async()=>{
+  saveConversation({schema:1,chatId:'outline',messages:Array.from({length:12},(_,index)=>({role:index%2?'assistant':'user',content:index%2?'Reply '+index:'Repeated prompt'}))})
+  const {container}=render(<Pixel/>);await screen.findByText('Available')
+  fireEvent.change(screen.getByLabelText('Jump to conversation turn'),{target:{value:'6'}})
+  const target=container.querySelector('[data-pixel-message-index="6"]')
+  expect(target).toHaveFocus()
+  expect(target.scrollIntoView).toHaveBeenCalledWith({block:'start',behavior:'auto'})
+  expect(screen.getByLabelText('Jump to conversation turn')).toHaveValue('')
+  fireEvent.click(screen.getByRole('button',{name:'Go to latest message',hidden:true}))
+  expect(container.querySelector('[data-pixel-message-index="11"]')).toHaveFocus()
+  expect(fetch.mock.calls.some(([url])=>url==='/api/pixel/chat/stream')).toBe(false)
+})
+it('keeps short conversations uncluttered and does not modify a draft while navigating',async()=>{
+  saveConversation({schema:1,chatId:'short',messages:[{role:'user',content:'One prompt'}],draft:'Keep draft'})
+  render(<Pixel/>);await screen.findByText('Available')
+  expect(screen.queryByLabelText('Jump to conversation turn')).toBeNull()
+  expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue('Keep draft')
+})


### PR DESCRIPTION
## Why this matters

Long Pixel conversations retain up to 2,000 messages but have no way to jump to an earlier turn. Add a conversation outline under Chat options, labeled by turn number and prompt, plus Go to latest message. Navigation scrolls/focuses the exact message row and closes the options menu without changing history, draft or execution state.

Repeated prompt text is distinguished by its actual message index. Short one-turn conversations omit the outline. Message rows become programmatically focusable without adding them to normal Tab order.

## Overlap check

Searched all-state `turn navigation` and `jump conversation` plus the recent 1,500-PR Pixel.jsx inventory. #4142 searches across conversations; #4027 supplies the original chat. Neither provides intra-conversation navigation. This adds row targets and a separate options control without changing search or task submission.

## Validation and risk

Medium Dashboard UI, public-beta d7d76cdc base. Node 20 turn-navigation + Pixel page suites: 75 passed. Tests navigate repeated prompts to the correct focused row, return to the last message, verify zero chat submissions, and retain a draft while omitting controls for short history. Production build and focused lint pass; whitespace/changed-file hooks checked before publication.

Baseline dashboard: 713 passed; Combined validation is recorded below. Unrelated baseline limits are literal unit-test-key fixtures and the WSL phase03 no-sudo fixture (3 pass/2 fail). Revert removes navigation only; local conversation format is unchanged. No installed-runtime/release claim.

## AI assistance

Codex investigated, implemented and tested the change. Independent human review remains outstanding. Target public-beta; no deployment or merge implied.


## Final batch receipt (2026-09-11)

Exact PR head: `d91d52040989c3729c5901f386f82fba542ed6e8`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
