### PR TITLE
Stop Continue skipping prerequisites all_met counts

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -34,6 +34,8 @@ pub struct PrerequisiteStatus {
     pub git_installed: bool,
     pub docker_installed: bool,
     pub docker_running: bool,
+    /// Counted by all_met, so the page has to be able to show it as a blocker.
+    pub compose_installed: bool,
     pub wsl2_needed: bool,
     pub wsl2_installed: bool,
     pub all_met: bool,
@@ -64,6 +66,7 @@ pub fn check_prerequisites() -> PrerequisiteStatus {
         git_installed: git,
         docker_installed: docker_status.installed,
         docker_running: docker_status.running,
+        compose_installed: docker_status.compose_installed,
         wsl2_needed,
         wsl2_installed,
         all_met,

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -39,6 +39,7 @@ export interface PrerequisiteStatus {
   git_installed: boolean;
   docker_installed: boolean;
   docker_running: boolean;
+  compose_installed: boolean;
   wsl2_needed: boolean;
   wsl2_installed: boolean;
   all_met: boolean;

--- a/installer/src/pages/Prerequisites.tsx
+++ b/installer/src/pages/Prerequisites.tsx
@@ -106,6 +106,21 @@ export default function Prerequisites({ onNext, onError }: Props) {
     setPrereqs(updated);
   };
 
+  // These are the same conditions check_prerequisites folds into all_met, and
+  // they have to stay that way: the page only renders this branch when all_met
+  // is false, so a Continue that disagrees walks the user straight past
+  // whatever is missing. It used to ignore Compose and WSL2 both, which meant
+  // the button was live on a Windows box with no WSL2, and live on any host
+  // with Docker but no Compose — an install that fails minutes later in
+  // 05-docker.sh rather than here.
+  const blockers = [
+    !prereqs.git_installed && "Git",
+    !prereqs.docker_installed && "Docker",
+    prereqs.docker_installed && !prereqs.docker_running && "Docker to be running",
+    !prereqs.compose_installed && "Docker Compose",
+    prereqs.wsl2_needed && !prereqs.wsl2_installed && "WSL2",
+  ].filter((blocker): blocker is string => typeof blocker === "string");
+
   return (
     <div className="flex flex-col items-center justify-center h-full px-8">
       <h2 className="text-2xl font-bold mb-2">Prerequisites Needed</h2>
@@ -177,11 +192,33 @@ export default function Prerequisites({ onNext, onError }: Props) {
             </Button>
           )}
         </div>
+
+        {/* Docker Compose */}
+        <div className="flex items-center justify-between bg-gray-900 rounded-lg px-4 py-3">
+          <div className="flex items-center gap-3">
+            <StatusIcon status={prereqs.compose_installed ? "pass" : "fail"} />
+            <div>
+              <p className="text-sm text-white">Docker Compose</p>
+              {!prereqs.compose_installed && (
+                <p className="text-xs text-yellow-500">
+                  Ships with Docker Desktop. On Linux, install the
+                  docker-compose-plugin package.
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
       </div>
 
       {message && (
         <p className="text-sm text-gray-400 mb-4 text-center max-w-md">
           {message}
+        </p>
+      )}
+
+      {blockers.length > 0 && (
+        <p className="text-sm text-gray-500 mb-4 text-center max-w-md">
+          Still waiting on {blockers.join(", ")}.
         </p>
       )}
 
@@ -200,14 +237,7 @@ export default function Prerequisites({ onNext, onError }: Props) {
           <Button variant="ghost" onClick={handleRecheck}>
             Re-check
           </Button>
-          <Button
-            onClick={onNext}
-            disabled={
-              !prereqs.git_installed ||
-              !prereqs.docker_installed ||
-              !prereqs.docker_running
-            }
-          >
+          <Button onClick={onNext} disabled={blockers.length > 0}>
             Continue
           </Button>
         </div>


### PR DESCRIPTION
The Continue button was disabled on git, docker_installed and
docker_running. check_prerequisites folds two more into all_met: Docker
Compose, and WSL2 on Windows. This screen only renders when all_met is
false, so every disagreement between the two showed the user a page
titled "Prerequisites Needed" with a live Continue button.

A host with Docker but no Compose could walk straight through, and the
install then failed several minutes later in 05-docker.sh instead of
here. A Windows box with no WSL2 could walk past the WSL2 row while it
was displaying a red cross.

compose_installed was not on PrerequisiteStatus at all, so the page could
not have drawn it even if the gate had been right — on a Compose-less
host every visible row was green and nothing explained the title. Add the
field, give it a row, and derive one blockers list that drives both the
gate and a line naming what is still missing, so a disabled button always
says why.