### PR TITLE
Render the feature checkmark instead of printing its entity

### DIFF
--- a/installer/src/pages/Features.tsx
+++ b/installer/src/pages/Features.tsx
@@ -107,7 +107,10 @@ export default function Features({ onNext }: Props) {
                       : "border-gray-600"
                   } ${isRequired ? "opacity-50" : ""}`}
                 >
-                  {isSelected && "&#10003;"}
+                  {/* An entity is only decoded as JSX text, so it needs the
+                      fragment — as a plain string React escapes the ampersand
+                      and the checkbox reads "&#10003;" literally. */}
+                  {isSelected && <>&#10003;</>}
                 </div>
                 <div className="flex-1">
                   <p className="text-sm font-medium text-white">


### PR DESCRIPTION
Render the feature checkmark instead of printing its entity

The selected-feature checkbox held {isSelected && "&#10003;"}. Entities
are decoded by the JSX parser, and a JavaScript string never passes
through it, so React escaped the ampersand and the box rendered the
literal text &#10003; — eight characters spilling out of a 20px square,
on every feature the user picks.

Wrap it in a fragment so it is parsed as JSX text. That keeps the numeric
reference the rest of the pages use rather than putting a bare ✓ in the
source.

This is the only entity in installer/src that sits inside an expression;
the seven in StatusIcon, Complete and Welcome are text children and were
always fine.