### PR TITLE
Handle rejected promises in the installer wizard pages

### DIFF
--- a/installer/src/App.tsx
+++ b/installer/src/App.tsx
@@ -89,6 +89,10 @@ export default function App() {
               update({ tier });
               goTo("features");
             }}
+            onError={(msg) => {
+              update({ error: msg });
+              goTo("error");
+            }}
           />
         )}
         {step === "features" && (

--- a/installer/src/pages/Complete.tsx
+++ b/installer/src/pages/Complete.tsx
@@ -1,7 +1,17 @@
+import { useState } from "react";
 import Button from "../components/Button";
 import { openODSserver } from "../hooks/useTauri";
 
 export default function Complete() {
+  const [openError, setOpenError] = useState<string | null>(null);
+
+  // The click handler dropped this promise, so a failure to open the browser
+  // was silent — the button did nothing and said nothing.
+  const handleOpen = () => {
+    setOpenError(null);
+    openODSserver().catch((e) => setOpenError(String(e)));
+  };
+
   return (
     <div className="flex flex-col items-center justify-center h-full px-8 text-center">
       <div className="text-6xl mb-6">&#10024;</div>
@@ -36,8 +46,15 @@ export default function Complete() {
         <Button variant="secondary" onClick={() => window.close()}>
           Close Installer
         </Button>
-        <Button onClick={() => openODSserver()}>Open ODS</Button>
+        <Button onClick={handleOpen}>Open ODS</Button>
       </div>
+
+      {openError && (
+        <p className="mt-4 text-sm text-yellow-500 text-center max-w-md">
+          Could not open the browser ({openError}). ODS is still running — go to
+          localhost:3000.
+        </p>
+      )}
 
       <p className="mt-8 text-xs text-gray-600 max-w-sm">
         To manage ODS later, use the Dashboard at localhost:3001 or run

--- a/installer/src/pages/GpuDetected.tsx
+++ b/installer/src/pages/GpuDetected.tsx
@@ -5,6 +5,7 @@ import { detectGpu, type GpuResult } from "../hooks/useTauri";
 
 interface Props {
   onNext: (tier: number) => void;
+  onError: (msg: string) => void;
 }
 
 const VENDOR_LABELS: Record<string, string> = {
@@ -15,18 +16,26 @@ const VENDOR_LABELS: Record<string, string> = {
   none: "No dedicated GPU",
 };
 
-export default function GpuDetected({ onNext }: Props) {
+export default function GpuDetected({ onNext, onError }: Props) {
   const [loading, setLoading] = useState(true);
   const [result, setResult] = useState<GpuResult | null>(null);
   const [selectedTier, setSelectedTier] = useState<number>(1);
 
   useEffect(() => {
-    detectGpu().then((r) => {
-      setResult(r);
-      setSelectedTier(r.recommended_tier);
-      setLoading(false);
-    });
-  }, []);
+    detectGpu()
+      .then((r) => {
+        setResult(r);
+        setSelectedTier(r.recommended_tier);
+        setLoading(false);
+      })
+      .catch((e) => {
+        // Nothing cleared loading on the rejected path, so the page spun
+        // forever: no error, no Continue, and the wizard could not be left
+        // except by closing the window.
+        setLoading(false);
+        onError(String(e));
+      });
+  }, [onError]);
 
   if (loading) {
     return (

--- a/installer/src/pages/Prerequisites.tsx
+++ b/installer/src/pages/Prerequisites.tsx
@@ -102,8 +102,14 @@ export default function Prerequisites({ onNext, onError }: Props) {
   };
 
   const handleRecheck = async () => {
-    const updated = await checkPrerequisites();
-    setPrereqs(updated);
+    try {
+      const updated = await checkPrerequisites();
+      setPrereqs(updated);
+    } catch (e) {
+      // Re-check is a button the user can press again, so this reports in
+      // place instead of tearing the wizard down to the error page.
+      setMessage(`Could not re-check prerequisites: ${String(e)}`);
+    }
   };
 
   return (


### PR DESCRIPTION
Three unhandled rejections in the Tauri installer front end.

- GpuDetected — detectGpu().then(…) with no .catch. On rejection loading was never cleared, so the page spun forever with no error and no way forward. Adds an onError prop (the only loader page missing one) wired in App.tsx to match 

- SystemCheck and Prerequisites.
Prerequisites.handleRecheck — unguarded await. Reports via the page's existing message line instead of the error page, since Re-check is retryable.

- Complete — the Open ODS button discarded its invoke promise; a failed browser launch was completely silent. Now surfaces the error and points at localhost:3000.
- No behaviour change on the success paths. Not type-checked or built locally — no Node toolchain on this machine.

Note: the Prerequisites.tsx hunk overlaps fix/installer-prereq-continue-gate; whichever lands second needs a one-hunk rebase.