### PR TITLE
feat(dashboard-api): add active provider health monitor endpoint

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/pixel_providers.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_providers.py
@@ -228,3 +228,16 @@ async def get_provider_runtime(_key: str = Depends(verify_api_key)):
 @router.post("/api/pixel/providers/runtime")
 async def change_provider_runtime(request: Request, _key: str = Depends(verify_api_key)):
     return await _runtime_request("POST", await _body(request, runtime=True))
+
+@router.get("/api/pixel/providers/health")
+async def get_active_provider_health(_key: str = Depends(verify_api_key)):
+    """Background or on-demand probe of the active provider's health."""
+    try:
+        raw = await request_agent_json("GET", "/v1/models", timeout=10)
+        return JSONResponse(
+            content={"status": "online", "models": len(raw.get("data", [])) if isinstance(raw, dict) else 0},
+            headers=NO_STORE
+        )
+    except (AgentHTTPError, AgentUnavailable, AgentProtocolError):
+        return JSONResponse(content={"status": "offline"}, headers=NO_STORE)
+

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_providers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_providers.py
@@ -1,3 +1,4 @@
+from host_agent_client import AgentUnavailable, AgentHTTPError, AgentProtocolError
 import copy
 import json
 from unittest.mock import AsyncMock, patch
@@ -253,3 +254,18 @@ def test_host_credential_url_never_reflected(client, mock_request):
     response = client.get("/api/pixel/providers", headers={"Authorization": "Bearer test-key-12345"})
     assert response.status_code == 502
     assert "private-sentinel" not in response.text
+
+
+def test_active_provider_health_online(client, mock_request):
+    mock_request.return_value = {"data": [{"id": "model-1"}, {"id": "model-2"}]}
+    resp = client.get("/api/pixel/providers/health", headers={"Authorization": "Bearer test-key-12345"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "online", "models": 2}
+    mock_request.assert_called_once_with("GET", "/v1/models", timeout=10)
+
+def test_active_provider_health_offline(client, mock_request):
+    mock_request.side_effect = AgentUnavailable()
+    resp = client.get("/api/pixel/providers/health", headers={"Authorization": "Bearer test-key-12345"})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "offline"}
+


### PR DESCRIPTION
## Description

Currently, there is no passive way for the system or UI to determine whether an active external AI provider—such as a custom cloud endpoint or local inference server—has gone offline until the user attempts a chat request and it fails.

This PR introduces a lightweight `/api/pixel/providers/health` endpoint to the Dashboard API, providing the foundation for visual provider health indicators and future auto-failover logic.

### How It Works

The new health endpoint:

* Performs a fast, timeout-bounded **10-second probe** against the active provider.
* Requests `/v1/models` through the local `ods-host-agent`.
* Returns the number of available models when the provider responds successfully:

  ```json
  {
    "status": "online",
    "models": 3
  }
  ```
* Gracefully handles provider/agent failures by returning:

  ```json
  {
    "status": "offline"
  }
  ```
* Catches boundary exceptions such as:

  * `AgentUnavailable`
  * `AgentHTTPError`
  * `AgentProtocolError`

This prevents expected provider connectivity issues from surfacing as `500`/`502` errors to the frontend.

### Environment / Device

* **OS:** Windows (Docker Desktop with WSL2 backend)
* **Python:** 3.10.x
* **Hardware:** Local desktop development environment

### How to Test

1. Pull the branch locally and start the development server.
2. Ensure a working provider is connected.
3. Call the health endpoint with a valid bearer token:

   ```bash
   curl http://localhost:PORT/api/pixel/providers/health
   ```
4. Verify that an available provider returns:

   ```json
   {
     "status": "online",
     "models": <count>
   }
   ```
5. Kill or disconnect the active provider.
6. Call the endpoint again and verify that it returns:

   ```json
   {
     "status": "offline"
   }
   ```

   rather than throwing a `500` or `502` error.
7. Run the targeted unit tests:

   ```bash
   pytest ods/extensions/services/dashboard-api/tests/test_pixel_providers.py -k test_active_provider_health
   ```
8. Verify that the new mock health-check tests pass.

### Expected Behavior

The Dashboard API should be able to passively determine the health of the active AI provider and return a simple `online` or `offline` status without propagating expected provider connectivity failures to the frontend.

### Future Use

This endpoint provides a foundation for:

* Visual provider health indicators in the UI.
* Detecting unavailable providers before a chat request is attempted.
* Future automatic provider failover and recovery logic.
