### PR TITLE
feat(dashboard-api): add workspace snapshot export endpoint

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/pixel_settings.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_settings.py
@@ -97,3 +97,37 @@ async def change_runtime(request: Request, _key: str = Depends(verify_api_key)):
     if response["outcome"] == "applied" and response["appliedRevision"] != payload["settingsRevision"]:
         raise HTTPException(502, "Settings runtime revision mismatch")
     return _no_store_response(response)
+
+
+@router.get("/api/pixel/settings/export")
+async def export_workspace_snapshot(_key: str = Depends(verify_api_key)):
+    try:
+        settings_raw = await request_agent_json("GET", "/v1/pixel/settings", timeout=10)
+        settings = normalize_response(settings_raw)
+        
+        providers_raw = await request_agent_json("GET", "/v1/pixel/providers", timeout=10)
+        from pixel_provider_public import normalize_public
+        providers = normalize_public(providers_raw)
+        
+        content = {
+            "schemaVersion": 1,
+            "type": "ods-workspace-snapshot",
+            "settings": settings["configuration"],
+            "providers": providers
+        }
+        return JSONResponse(
+            content=content,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Disposition": 'attachment; filename="ods-workspace-snapshot.json"'
+            }
+        )
+    except AgentHTTPError as exc:
+        code = exc.status_code if exc.status_code in (400, 409, 413, 503) else 502
+        raise HTTPException(code, "Snapshot export failed") from None
+    except AgentUnavailable:
+        raise HTTPException(503, "Settings are unavailable for export") from None
+    except (AgentProtocolError, ValueError, TypeError, RecursionError):
+        raise HTTPException(502, "Invalid response during export") from None
+
+

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_settings.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_settings.py
@@ -267,3 +267,56 @@ def test_invalid_host_envelope_is_never_exposed(client, mock_request_agent, muta
     response = client.get("/api/pixel/settings", headers={"Authorization": "Bearer test-key-12345"})
     assert response.status_code == 502
     assert "do-not-echo" not in response.text
+
+def test_export_workspace_snapshot(client, mock_request_agent):
+    def mock_agent_response(method, path, **kwargs):
+        if path == "/v1/pixel/settings":
+            return copy.deepcopy(VALID_GET)
+        if path == "/v1/pixel/providers":
+            return {
+                "schemaVersion": 1,
+                "revision": 2,
+                "enabled": True,
+                "providers": [
+                    {
+                        "id": "my-local-ai",
+                        "label": "Local AI",
+                        "kind": "local",
+                        "baseUrl": "http://127.0.0.1:8080/v1",
+                        "model": "llama3",
+                        "contextTokens": 4096,
+                        "maxOutputTokens": 2048,
+                        "supportsTools": False,
+                        "supportsVision": False,
+                        "reasoning": False,
+                        "enabled": True,
+                        "hasCredential": False
+                    }
+                ],
+                "roles": {
+                    "leader": "my-local-ai",
+                    "backups": [],
+                    "advisor": None,
+                    "handoff": None
+                },
+                "policy": {
+                    "deadlineSeconds": 60,
+                    "allowCloud": True,
+                    "maxAttempts": 3
+                }
+            }
+        return {}
+    mock_request_agent.side_effect = mock_agent_response
+
+    resp = client.get(
+        "/api/pixel/settings/export",
+        headers={"Authorization": "Bearer test-key-12345"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("Content-Disposition") == 'attachment; filename="ods-workspace-snapshot.json"'
+    data = resp.json()
+    assert data["schemaVersion"] == 1
+    assert data["type"] == "ods-workspace-snapshot"
+    assert "settings" in data
+    assert "providers" in data
+    assert data["providers"]["providers"][0]["id"] == "my-local-ai"


### PR DESCRIPTION
## Description

Recent commits to the `public-beta` branch introduced several new test modules containing top-level imports of POSIX-only packages such as `fcntl` and `pwd`, as well as calls to POSIX-only APIs such as `os.getuid()`.

When running the test suite on Windows, pytest fails during test collection, causing the entire local test run to crash before any tests can execute.

Additionally, two newly added test files shared the same filename (`test_store.py`), causing pytest to raise an import file mismatch during collection.

### Errors

```text
ModuleNotFoundError: No module named 'fcntl'
AttributeError: module 'os' has no attribute 'getuid'. Did you mean: 'getpid'?
import file mismatch: imported module 'test_store' has this __file__ attribute...
```

### Environment / Device

* **OS:** Windows (Docker Desktop with WSL2 backend)
* **Python:** 3.10.x
* **Hardware:** Local desktop development environment

### Fix

This PR ensures the test suite can initialize and run successfully on Windows, building on the DX improvements from PR #4062.

#### 1. Module Skips

Added `sys.platform == "win32"` checks and:

```python
pytest.skip("POSIX only", allow_module_level=True)
```

to 7 newly introduced POSIX-dependent test files, including:

* `test_service.py`
* `test_pixel_extension_catalog.py`
* `test_provider_coordinator.py`
* and other affected test modules.

This prevents Windows-incompatible dependencies from being imported during test collection and allows the affected modules to be reported as skipped.

#### 2. Namespace Collision Fix

Renamed:

```text
ods/tests/pixel_settings/test_store.py
```

to:

```text
ods/tests/pixel_settings/test_pixel_settings_store.py
```

This prevents pytest from confusing it with:

```text
ods/tests/pixel_inference/test_store.py
```

and eliminates the resulting import file mismatch.

### How to Test

1. Pull the branch locally on a Windows machine.
2. Run:

   ```bash
   pytest ods/tests/ --ignore=ods/tests/bats
   ```
3. Verify that pytest initializes without collection errors.
4. Confirm that the POSIX-dependent test modules are gracefully reported as skipped.

### Expected Behavior

The test suite should successfully begin collection on Windows, with POSIX-only test modules being skipped rather than causing collection failures.

### Actual Behavior

Pytest encounters POSIX-only imports and APIs during collection, resulting in `ModuleNotFoundError`, `AttributeError`, and import file mismatch errors before any tests can execute.
