### PR TITLE
Carry the installer phase id through to the progress dots

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -206,7 +206,11 @@ pub fn get_install_progress() -> ProgressInfo {
     if let Ok(data) = std::fs::read_to_string(&state_path) {
         if let Ok(state) = serde_json::from_str::<InstallState>(&data) {
             return ProgressInfo {
-                phase: format!("{:?}", state.phase),
+                // The installer's phase id, not the wizard phase. The front
+                // end keys its labels and dots off this field, and the wizard
+                // phase only ever debug-printed as "Installing" — which is not
+                // one of those keys, so nothing ever matched.
+                phase: state.progress_phase,
                 percent: state.progress_pct,
                 message: state.progress_message,
                 error: state.error,

--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -38,11 +38,11 @@ pub fn run_install(
     features: Vec<String>,
 ) -> Result<(), String> {
     // Phase 1: Clone the repo
-    update_progress(&state, "Downloading ODS", 5);
+    update_progress(&state, "setup", "Downloading ODS", 5);
 
     ensure_checkout(&install_dir)?;
 
-    update_progress(&state, "Configuring installation", 15);
+    update_progress(&state, "setup", "Configuring installation", 15);
 
     // Phase 2: Build installer arguments
     let ods_dir = install_dir.join("ods");
@@ -65,7 +65,7 @@ pub fn run_install(
     }
 
     // Phase 3: Run the installer with progress parsing
-    update_progress(&state, "Running installer", 20);
+    update_progress(&state, "setup", "Running installer", 20);
 
     let install_script = ods_dir.join("install.sh");
     let install_ps1 = install_dir.join("install.ps1");
@@ -136,7 +136,7 @@ pub fn run_install(
         for line in reader.lines() {
             if let Ok(line) = line {
                 if let Some(progress) = parse_progress_line(&line) {
-                    update_progress(&state, &progress.message, progress.percent);
+                    update_progress(&state, &progress.phase, &progress.message, progress.percent);
                 }
             }
         }
@@ -150,7 +150,7 @@ pub fn run_install(
         .unwrap_or_default();
 
     if output.success() {
-        update_progress(&state, "Installation complete!", 100);
+        update_progress(&state, "complete", "Installation complete!", 100);
         let mut s = state.lock().unwrap();
         s.phase = InstallPhase::Complete;
         let _ = s.save();
@@ -338,13 +338,29 @@ fn parse_progress_line(line: &str) -> Option<ProgressEvent> {
     })
 }
 
-fn update_progress(state: &Arc<Mutex<InstallState>>, message: &str, percent: u8) {
+fn update_progress(state: &Arc<Mutex<InstallState>>, phase: &str, message: &str, percent: u8) {
     if let Ok(mut s) = state.lock() {
-        s.progress_pct = percent;
-        s.progress_message = message.to_string();
-        s.phase = InstallPhase::Installing;
+        set_progress(&mut s, phase, message, percent);
         let _ = s.save();
     }
+}
+
+/// Record one progress event on the state.
+///
+/// `phase` is the installer's own phase id from the ODS_PROGRESS line, which
+/// the front end keys its phase labels and dots off. parse_progress_line has
+/// always read it and update_progress always threw it away, so the id never
+/// reached the state file and the dots never lit.
+///
+/// An empty id means the line carried no phase — the two-field ODS_PROGRESS
+/// form — so the last known one is kept rather than blanking the dots.
+fn set_progress(state: &mut InstallState, phase: &str, message: &str, percent: u8) {
+    state.progress_pct = percent;
+    state.progress_message = message.to_string();
+    if !phase.is_empty() {
+        state.progress_phase = phase.to_string();
+    }
+    state.phase = InstallPhase::Installing;
 }
 
 /// Default install directory per platform.
@@ -369,6 +385,110 @@ pub fn default_install_dir() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn progressed(events: &[(&str, &str, u8)]) -> InstallState {
+        let mut state = InstallState::default();
+        for (phase, message, percent) in events {
+            set_progress(&mut state, phase, message, *percent);
+        }
+        state
+    }
+
+    #[test]
+    fn a_progress_event_records_the_installer_phase_id() {
+        let state = progressed(&[("docker", "Setting up Docker", 30)]);
+        assert_eq!(state.progress_phase, "docker");
+        assert_eq!(state.progress_message, "Setting up Docker");
+        assert_eq!(state.progress_pct, 30);
+    }
+
+    #[test]
+    fn a_blank_phase_keeps_the_one_before_it() {
+        // The two-field ODS_PROGRESS form parses to an empty phase; it should
+        // still move the bar without dropping the dots back to nothing.
+        let state = progressed(&[("images", "Downloading", 48), ("", "Pulling 3/9", 52)]);
+        assert_eq!(state.progress_phase, "images");
+        assert_eq!(state.progress_pct, 52);
+    }
+
+    #[test]
+    fn the_parsed_phase_survives_all_the_way_onto_the_state() {
+        let event = parse_progress_line("ODS_PROGRESS:85:health:Checking service health")
+            .expect("the three-field form should parse");
+        let state = progressed(&[(event.phase.as_str(), event.message.as_str(), event.percent)]);
+        assert_eq!(state.progress_phase, "health");
+    }
+
+    /// Every id the PHASES ladder in installer/src/pages/Installing.tsx draws a
+    /// dot for. Any phase id that reaches the front end has to be in here, or
+    /// the label lookup misses and the dots go dark mid-install.
+    const LADDER_IDS: &[&str] = &[
+        "setup",
+        "preflight",
+        "detection",
+        "features",
+        "requirements",
+        "docker",
+        "directories",
+        "devtools",
+        "images",
+        "offline",
+        "amd-tuning",
+        "services",
+        "health",
+        "summary",
+        "complete",
+    ];
+
+    #[test]
+    fn every_phase_the_installer_emits_has_a_dot() {
+        // One real ODS_PROGRESS line per phase, as emitted by the ods_progress
+        // calls in ods/installers/phases/01-preflight .. 13-summary.
+        for line in [
+            "ODS_PROGRESS:5:preflight:Running preflight checks",
+            "ODS_PROGRESS:12:detection:Detecting GPU hardware",
+            "ODS_PROGRESS:18:features:Selecting features",
+            "ODS_PROGRESS:25:requirements:Checking system requirements",
+            "ODS_PROGRESS:30:docker:Setting up Docker",
+            "ODS_PROGRESS:38:directories:Preparing installation directory",
+            "ODS_PROGRESS:42:devtools:Installing developer tools",
+            "ODS_PROGRESS:48:images:Downloading container images",
+            "ODS_PROGRESS:65:offline:Configuring offline mode",
+            "ODS_PROGRESS:70:amd-tuning:Tuning AMD GPU settings",
+            "ODS_PROGRESS:75:services:Starting services",
+            "ODS_PROGRESS:85:health:Checking service health",
+            "ODS_PROGRESS:98:summary:Finishing up",
+        ] {
+            let event = parse_progress_line(line).expect(line);
+            assert!(
+                LADDER_IDS.contains(&event.phase.as_str()),
+                "{line} carries phase {} which the ladder has no dot for",
+                event.phase
+            );
+        }
+    }
+
+    #[test]
+    fn the_keyword_fallback_stays_on_the_ladder_too() {
+        // Plain installer output with no ODS_PROGRESS prefix falls through to
+        // keyword matching, which makes up phase ids of its own.
+        for line in [
+            "Running preflight checks",
+            "Detecting GPU hardware",
+            "Installing Docker engine",
+            "Pulling image 3/9",
+            "Starting services",
+            "Running health check",
+            "Stack is ready",
+        ] {
+            let event = parse_progress_line(line).expect(line);
+            assert!(
+                LADDER_IDS.contains(&event.phase.as_str()),
+                "{line} was read as phase {} which the ladder has no dot for",
+                event.phase
+            );
+        }
+    }
 
     fn fnv1a64(bytes: &[u8]) -> u64 {
         bytes.iter().fold(0xcbf29ce484222325, |hash, byte| {

--- a/installer/src-tauri/src/state.rs
+++ b/installer/src-tauri/src/state.rs
@@ -11,6 +11,12 @@ pub struct InstallState {
     pub selected_tier: Option<u8>,
     pub selected_features: Vec<String>,
     pub error: Option<String>,
+    /// The installer script's own phase id — "preflight", "docker", "health",
+    /// as emitted by ods_progress. Distinct from `phase` above, which tracks
+    /// the wizard page. Defaulted so a state file written before this field
+    /// existed still loads.
+    #[serde(default)]
+    pub progress_phase: String,
     pub progress_pct: u8,
     pub progress_message: String,
     pub reboot_pending: bool,
@@ -56,6 +62,7 @@ impl Default for InstallState {
             selected_tier: None,
             selected_features: vec![],
             error: None,
+            progress_phase: String::new(),
             progress_pct: 0,
             progress_message: String::new(),
             reboot_pending: false,

--- a/installer/src/pages/Installing.tsx
+++ b/installer/src/pages/Installing.tsx
@@ -9,15 +9,33 @@ interface Props {
   onError: (msg: string) => void;
 }
 
-const PHASE_LABELS: Record<string, string> = {
-  preflight: "Running preflight checks",
-  detection: "Detecting hardware",
-  docker: "Setting up Docker",
-  images: "Downloading container images",
-  services: "Starting services",
-  health: "Checking service health",
-  complete: "Finishing up",
-};
+// The phase ids ods_progress emits, in the order install-core.sh sources the
+// phases (ods/installers/phases/01-preflight .. 13-summary). "setup" is the
+// Tauri side's own clone-and-configure step before the script starts, and
+// "complete" is the success write it makes afterwards.
+//
+// The old list was keyed on ids the installer never emits — it was missing
+// features, requirements, directories, devtools, offline, amd-tuning and
+// summary, and carried a "complete" that only the backend sends. That was
+// moot while get_install_progress reported the wizard phase here, but it
+// would have left half the ladder dark once it stopped.
+const PHASES: { id: string; label: string }[] = [
+  { id: "setup", label: "Preparing" },
+  { id: "preflight", label: "Running preflight checks" },
+  { id: "detection", label: "Detecting hardware" },
+  { id: "features", label: "Selecting features" },
+  { id: "requirements", label: "Checking system requirements" },
+  { id: "docker", label: "Setting up Docker" },
+  { id: "directories", label: "Preparing installation directory" },
+  { id: "devtools", label: "Installing developer tools" },
+  { id: "images", label: "Downloading container images" },
+  { id: "offline", label: "Configuring offline mode" },
+  { id: "amd-tuning", label: "Tuning AMD GPU settings" },
+  { id: "services", label: "Starting services" },
+  { id: "health", label: "Checking service health" },
+  { id: "summary", label: "Finishing up" },
+  { id: "complete", label: "Done" },
+];
 
 export default function Installing({
   tier,
@@ -65,8 +83,12 @@ export default function Installing({
     return () => clearInterval(interval);
   }, [tier, features, installDir, onComplete, onError]);
 
+  // -1 for a phase the installer skipped past or one this build does not know;
+  // the dots then stay dark and the label falls through to whatever the
+  // installer last said, which is the same as the old unknown-phase behaviour.
+  const currentIdx = PHASES.findIndex((p) => p.id === progress.phase);
   const phaseLabel =
-    PHASE_LABELS[progress.phase] || progress.message || "Working...";
+    PHASES[currentIdx]?.label || progress.message || "Working...";
 
   return (
     <div className="flex flex-col items-center justify-center h-full px-8">
@@ -93,25 +115,22 @@ export default function Installing({
 
       {/* Phase dots */}
       <div className="flex gap-2">
-        {Object.keys(PHASE_LABELS).map((phase) => {
-          const currentIdx = Object.keys(PHASE_LABELS).indexOf(progress.phase);
-          const thisIdx = Object.keys(PHASE_LABELS).indexOf(phase);
-          const done = thisIdx < currentIdx;
-          const active = phase === progress.phase;
-          return (
-            <div
-              key={phase}
-              className={`w-2 h-2 rounded-full transition-colors ${
-                done
-                  ? "bg-ods-500"
-                  : active
-                    ? "bg-ods-400 animate-pulse"
-                    : "bg-gray-700"
-              }`}
-              title={PHASE_LABELS[phase]}
-            />
-          );
-        })}
+        {PHASES.map((phase, idx) => (
+          <div
+            key={phase.id}
+            // Index order, not equality, so a phase the run skips — offline
+            // and amd-tuning do not fire on every host — still reads as done
+            // once the install is past it.
+            className={`w-2 h-2 rounded-full transition-colors ${
+              idx < currentIdx
+                ? "bg-ods-500"
+                : idx === currentIdx
+                  ? "bg-ods-400 animate-pulse"
+                  : "bg-gray-700"
+            }`}
+            title={phase.label}
+          />
+        ))}
       </div>
 
       <p className="mt-10 text-xs text-gray-600 text-center max-w-sm">


### PR DESCRIPTION
The GUI installer's phase dots never lit. Three separate breaks on one path:

update_progress dropped the phase id that parse_progress_line had already parsed — InstallState had no field for it. Adds progress_phase (#[serde(default)], since the state file is read back to resume after a reboot).
get_install_progress returned format!("{:?}", state.phase) — the wizard enum, always "Installing". That is not a label key, so the front-end lookup missed on every poll. Now returns the installer's own id.
PHASE_LABELS was keyed on a stale set: seven of the thirteen emitted ids were missing and it carried a complete no phase sends. Replaced with an ordered PHASES array mirroring ods/installers/phases/01..13.
Five tests, including two that pin the Rust-side ids against the front-end ladder — one per real ODS_PROGRESS line, plus the keyword-fallback branch. Not compiled or built locally; no Rust or Node toolchain on this machine.

Note: conflicts with fix/installer-progress-polling-teardown in Installing.tsx.