### PR TITLE
fix: Extension reinstall deletes tree before staged copy succeeds

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1501,9 +1501,10 @@ def _install_from_library(service_id: str) -> None:
                 status_code=409,
                 detail=f"Extension already installed: {service_id}",
             )
-        logger.warning("Cleaning up extension directory under lock before retry: %s", dest)
-        shutil.rmtree(dest)
-        _clear_progress(service_id)
+        logger.warning(
+            "Replacing extension directory under lock after failed/partial install: %s",
+            dest,
+        )
 
     with _staged_library_extension(service_id, dest) as (staged, source_digest):
         installed_digest = _extension_tree_digest(staged)
@@ -1512,8 +1513,26 @@ def _install_from_library(service_id: str) -> None:
             source_digest=source_digest,
             installed_digest=installed_digest,
         )
-        os.rename(str(staged), str(dest))
+        prior: Path | None = None
+        if dest.exists():
+            swap_parent = USER_EXTENSIONS_DIR / ".tmp"
+            if swap_parent.is_symlink():
+                raise HTTPException(status_code=409, detail="Extension tmp path is a symlink")
+            swap_parent.mkdir(parents=True, exist_ok=True)
+            prior = Path(tempfile.mkdtemp(
+                prefix=f".{service_id}-prior-", dir=swap_parent,
+            )) / service_id
+            os.replace(dest, prior)
+        try:
+            os.replace(staged, dest)
+        except OSError:
+            if prior is not None:
+                os.replace(prior, dest)
+            raise
         _invalidate_extension_digest_cache(dest)
+        if prior is not None:
+            _clear_progress(service_id)
+            shutil.rmtree(prior.parent, ignore_errors=True)
 
 
 def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
@@ -1619,10 +1638,6 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
             raise HTTPException(
                 status_code=409, detail=f"Extension already installed: {service_id}",
             )
-        # Broken or failed directory — clean up before reinstall.
-        logger.warning("Cleaning up extension directory before retry: %s", dest)
-        shutil.rmtree(dest)
-        _clear_progress(service_id)
 
     # NOTE: pre_install hook is deferred to a future version. On fresh library
     # installs, the extension directory doesn't exist yet, so the host agent

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -560,6 +560,78 @@ class TestInstallExtension:
         assert (user_dir / "my-ext" / "compose.yaml").exists()
         assert resp.json()["action"] == "installed"
 
+    def test_install_preserves_tree_when_staging_fails(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Reinstall must not delete dest until the staged copy commits."""
+        from routers import extensions as ext_mod
+
+        lib_dir = _setup_library_ext(tmp_path, "my-ext")
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        progress_dir = tmp_path / "extension-progress"
+        progress_dir.mkdir()
+        (progress_dir / "my-ext.json").write_text(json.dumps({
+            "service_id": "my-ext",
+            "status": "error",
+            "error": "previous compose resolve failed",
+            "started_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        }))
+        original_compose = (user_dir / "my-ext" / "compose.yaml").read_text()
+        (user_dir / "my-ext" / "stale.txt").write_text("keep me")
+        source_manifest = lib_dir / "my-ext" / "manifest.yaml"
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
+                               user_dir=user_dir)
+        real_copy = ext_mod._copytree_safe
+
+        def copy_then_change(source, staged):
+            real_copy(source, staged)
+            source_manifest.write_text("release: changed-during-copy\n")
+
+        monkeypatch.setattr(ext_mod, "_copytree_safe", copy_then_change)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 409
+        assert "changed while" in resp.json()["detail"]
+        assert (user_dir / "my-ext" / "compose.yaml").read_text() == original_compose
+        assert (user_dir / "my-ext" / "stale.txt").read_text() == "keep me"
+
+    def test_install_preserves_broken_tree_when_staging_fails(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Broken partial installs must survive a failed staging attempt."""
+        from routers import extensions as ext_mod
+
+        lib_dir = _setup_library_ext(tmp_path, "my-ext")
+        user_dir = tmp_path / "user"
+        user_dir.mkdir(exist_ok=True)
+        broken_dir = user_dir / "my-ext"
+        broken_dir.mkdir(exist_ok=True)
+        (broken_dir / "manifest.yaml").write_text("leftover: true\n")
+        source_manifest = lib_dir / "my-ext" / "manifest.yaml"
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
+                               user_dir=user_dir)
+        real_copy = ext_mod._copytree_safe
+
+        def copy_then_change(source, staged):
+            real_copy(source, staged)
+            source_manifest.write_text("release: changed-during-copy\n")
+
+        monkeypatch.setattr(ext_mod, "_copytree_safe", copy_then_change)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 409
+        assert "changed while" in resp.json()["detail"]
+        assert (broken_dir / "manifest.yaml").read_text() == "leftover: true\n"
+
     def test_install_unknown_extension_404(self, test_client, monkeypatch, tmp_path):
         """404 when extension is not in the library."""
         _patch_mutation_config(monkeypatch, tmp_path)

--- a/ods/tests/contracts/test-extension-reinstall-atomicity.sh
+++ b/ods/tests/contracts/test-extension-reinstall-atomicity.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Contract: extension library reinstall must not delete the live tree before
+# staging succeeds. Regression for issue #4162 — early shutil.rmtree(dest)
+# left operators with no extension when staging failed mid-copy.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXT_PY="$ROOT/extensions/services/dashboard-api/routers/extensions.py"
+
+if [[ ! -f "$EXT_PY" ]]; then
+    echo "[FAIL] missing extensions router: $EXT_PY"
+    exit 1
+fi
+
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+
+echo "[contract] extension reinstall keeps dest until staged copy commits"
+
+# install_extension must not pre-delete a broken/partial tree before the lock.
+if grep -q 'Cleaning up extension directory before retry' "$EXT_PY"; then
+    fail "install_extension still deletes dest before locked reinstall"
+fi
+if awk '/^def install_extension\(/,/^def _rewrite_build_context\(/' "$EXT_PY" | grep -q 'shutil\.rmtree(dest)'; then
+    fail "install_extension still calls shutil.rmtree(dest)"
+fi
+pass "install_extension does not pre-delete dest"
+
+# _install_from_library must stage first, then swap with os.replace (not early rmtree).
+install_fn="$(awk '/^def _install_from_library\(/,/^def _rewrite_build_context\(/' "$EXT_PY")"
+if printf '%s\n' "$install_fn" | grep -q 'shutil\.rmtree(dest)'; then
+    fail "_install_from_library still calls shutil.rmtree(dest)"
+fi
+if ! printf '%s\n' "$install_fn" | grep -q 'with _staged_library_extension'; then
+    fail "_install_from_library lost staged library copy path"
+fi
+if ! printf '%s\n' "$install_fn" | grep -q 'os\.replace(staged, dest)'; then
+    fail "_install_from_library must commit staged copy with os.replace(staged, dest)"
+fi
+if ! printf '%s\n' "$install_fn" | grep -q 'os\.replace(dest, prior)'; then
+    fail "_install_from_library must move prior tree aside with os.replace(dest, prior)"
+fi
+if ! printf '%s\n' "$install_fn" | grep -q 'os\.replace(prior, dest)'; then
+    fail "_install_from_library must restore prior tree when staged commit fails"
+fi
+pass "_install_from_library uses stage-then-replace swap"
+
+echo "[contract] extension reinstall atomicity — all checks passed"


### PR DESCRIPTION
## Summary

Extension reinstall/update deleted the destination tree with `shutil.rmtree(dest)` before the staged copy was successfully committed. A staging failure left the extension gone.

## Changes

- Atomic stage-then-`os.replace` swap in `_install_from_library` / `install_extension` (park prior tree, restore on failure)
- Pytest regressions for staging-failure preserve behavior
- Shell contract: `ods/tests/contracts/test-extension-reinstall-atomicity.sh`

Closes #4162

## Testing

- `py -3 -m pytest` targeted preserves_tree / preserves_broken tests (2 passed)
- `bash ods/tests/contracts/test-extension-reinstall-atomicity.sh` (pass)
