### PR TITLE
fix: APE ships with `STRICT_MODE=false` by default

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -466,7 +466,7 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # APE audits and can enforce policy decisions for agent tool usage.
 # APE_PORT=7890
 # APE_RATE_LIMIT_RPM=60
-# APE_STRICT_MODE=false
+# APE_STRICT_MODE=true
 
 # ═══════════════════════════════════════════════════════════════════
 # AMD-specific (only needed with GPU_BACKEND=amd)

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -1204,7 +1204,7 @@
       "type": "string",
       "description": "When true, APE blocks policy violations instead of only logging advisory decisions.",
       "enum": ["true", "false"],
-      "default": "false"
+      "default": "true"
     },
     "OPENCLAW_API_KEY": {
       "type": "string",

--- a/ods/extensions/services/ape/compose.yaml
+++ b/ods/extensions/services/ape/compose.yaml
@@ -11,7 +11,7 @@ services:
       - APE_POLICY_FILE=/config/policy.yaml
       - APE_AUDIT_LOG=/data/ape/audit.jsonl
       - APE_RATE_LIMIT_RPM=${APE_RATE_LIMIT_RPM:-60}
-      - APE_STRICT_MODE=${APE_STRICT_MODE:-false}
+      - APE_STRICT_MODE=${APE_STRICT_MODE:-true}
       - APE_API_KEY=${APE_API_KEY:-}
     volumes:
       - ./config/ape:/config:ro,z

--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -82,7 +82,7 @@ except Exception:  # pragma: no cover - platform dependent
 POLICY_FILE = Path(os.environ.get("APE_POLICY_FILE", "/config/policy.yaml"))
 AUDIT_LOG   = Path(os.environ.get("APE_AUDIT_LOG",   "/data/ape/audit.jsonl"))
 RATE_LIMIT  = int(os.environ.get("APE_RATE_LIMIT_RPM", "60"))
-STRICT_MODE = os.environ.get("APE_STRICT_MODE", "false").lower() == "true"
+STRICT_MODE = os.environ.get("APE_STRICT_MODE", "true").lower() == "true"
 _API_KEY = os.environ.get("APE_API_KEY", "")
 
 # Persistent governance state lives next to the audit log on the /data/ape

--- a/ods/extensions/services/ape/tests/test_strict_mode_default.py
+++ b/ods/extensions/services/ape/tests/test_strict_mode_default.py
@@ -1,0 +1,37 @@
+"""Regression tests for issue #4170 — APE ships with STRICT_MODE enabled."""
+
+import importlib
+import sys
+
+from fastapi.testclient import TestClient
+
+
+def _reload_main(monkeypatch, *, strict_env: str | None = "__unset__"):
+    if strict_env == "__unset__":
+        monkeypatch.delenv("APE_STRICT_MODE", raising=False)
+    else:
+        monkeypatch.setenv("APE_STRICT_MODE", strict_env)
+    if "main" in sys.modules:
+        del sys.modules["main"]
+    return importlib.import_module("main")
+
+
+def test_strict_mode_defaults_true_when_env_unset(ape_env, monkeypatch):
+    main = _reload_main(monkeypatch)
+    assert main.STRICT_MODE is True
+
+
+def test_health_reports_strict_mode_true_by_default(ape_env, monkeypatch):
+    main = _reload_main(monkeypatch)
+    main.load_state()
+    client = TestClient(main.app)
+    client.headers.update({"X-API-Key": ape_env.api_key})
+    try:
+        assert client.get("/health").json()["strict_mode"] is True
+    finally:
+        client.close()
+
+
+def test_explicit_false_enables_advisory_mode(ape_env, monkeypatch):
+    main = _reload_main(monkeypatch, strict_env="false")
+    assert main.STRICT_MODE is False

--- a/ods/tests/contracts/test-ape-strict-mode-default.sh
+++ b/ods/tests/contracts/test-ape-strict-mode-default.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression contract for issue #4170: APE must ship with STRICT_MODE=true by default.
+# Fails when compose/.env.example/.env.schema/main.py default to advisory-only mode.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pass() { echo "[PASS] $*"; }
+fail() { echo "[FAIL] $*" >&2; exit 1; }
+
+COMPOSE="extensions/services/ape/compose.yaml"
+MAIN="extensions/services/ape/main.py"
+ENV_EXAMPLE=".env.example"
+ENV_SCHEMA=".env.schema.json"
+
+echo "[contract] APE compose default for APE_STRICT_MODE"
+if grep -q 'APE_STRICT_MODE=${APE_STRICT_MODE:-true}' "$COMPOSE"; then
+    pass "compose.yaml: APE_STRICT_MODE defaults to true"
+else
+    fail "compose.yaml: expected APE_STRICT_MODE=\${APE_STRICT_MODE:-true}"
+fi
+
+if grep -q 'APE_STRICT_MODE=${APE_STRICT_MODE:-false}' "$COMPOSE"; then
+    fail "compose.yaml: must not default APE_STRICT_MODE to false"
+fi
+
+echo "[contract] main.py import-time default"
+if grep -q 'os.environ.get("APE_STRICT_MODE", "true")' "$MAIN"; then
+    pass "main.py: APE_STRICT_MODE defaults to true at import"
+else
+    fail 'main.py: expected os.environ.get("APE_STRICT_MODE", "true")'
+fi
+
+if grep -q 'os.environ.get("APE_STRICT_MODE", "false")' "$MAIN"; then
+    fail "main.py: must not default APE_STRICT_MODE to false"
+fi
+
+echo "[contract] .env.example documents secure default"
+if grep -qE '# APE_STRICT_MODE=true' "$ENV_EXAMPLE"; then
+    pass ".env.example: documents APE_STRICT_MODE=true"
+else
+    fail ".env.example: expected commented APE_STRICT_MODE=true"
+fi
+
+if grep -qE '# APE_STRICT_MODE=false' "$ENV_EXAMPLE"; then
+    fail ".env.example: must not document APE_STRICT_MODE=false as default"
+fi
+
+echo "[contract] .env.schema.json default"
+schema_default="$(python3 -c "
+import json
+from pathlib import Path
+schema = json.loads(Path('$ENV_SCHEMA').read_text(encoding='utf-8'))
+print(schema['properties']['APE_STRICT_MODE']['default'])
+")"
+if [[ "$schema_default" == "true" ]]; then
+    pass ".env.schema.json: APE_STRICT_MODE default is true"
+else
+    fail ".env.schema.json: APE_STRICT_MODE default must be true (got: $schema_default)"
+fi
+
+echo ""
+echo "ALL APE STRICT MODE DEFAULT CONTRACT TESTS PASSED"


### PR DESCRIPTION
## Summary
Live-scouted fix for: APE ships with `STRICT_MODE=false` by default

Closes #4170

## Changes
- See diff (one-click scout pipeline, staged n8n run)

## Testing
- Developer stage ran scoped tests

## Related
- Desktop issues.md entry #4
- Classification: medium