### PR TITLE
fix: propagate exit code from _check_version_compat in cmd_update

### DIFF
--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -80,17 +80,19 @@ except Exception:  # pragma: no cover - platform dependent
 # ── Config ──────────────────────────────────────────────────────────────────
 
 POLICY_FILE = Path(os.environ.get("APE_POLICY_FILE", "/config/policy.yaml"))
-AUDIT_LOG   = Path(os.environ.get("APE_AUDIT_LOG",   "/data/ape/audit.jsonl"))
-RATE_LIMIT  = int(os.environ.get("APE_RATE_LIMIT_RPM", "60"))
+AUDIT_LOG = Path(os.environ.get("APE_AUDIT_LOG", "/data/ape/audit.jsonl"))
+RATE_LIMIT = int(os.environ.get("APE_RATE_LIMIT_RPM", "60"))
 STRICT_MODE = os.environ.get("APE_STRICT_MODE", "false").lower() == "true"
 _API_KEY = os.environ.get("APE_API_KEY", "")
 
 # Persistent governance state lives next to the audit log on the /data/ape
 # volume so it survives container restarts.
-STATE_FILE = Path(os.environ.get(
-    "APE_STATE_FILE",
-    str(AUDIT_LOG.parent / "state.json"),
-))
+STATE_FILE = Path(
+    os.environ.get(
+        "APE_STATE_FILE",
+        str(AUDIT_LOG.parent / "state.json"),
+    )
+)
 
 # Warmup grace period (seconds) after process start during which windowed
 # limits and the circuit breaker are not enforced. 0 disables warmup.
@@ -102,10 +104,14 @@ logger = logging.getLogger("ape")
 API_KEY = _API_KEY or secrets.token_hex(32)
 
 if not _API_KEY:
-    logger.warning(f"APE_API_KEY not set - auto-generated key: {API_KEY[:16]}... (set APE_API_KEY env var to use a fixed key)")
+    logger.warning(
+        f"APE_API_KEY not set - auto-generated key: {API_KEY[:16]}... (set APE_API_KEY env var to use a fixed key)"
+    )
 
 if not STRICT_MODE:
-    logger.warning("WARNING: APE is running in advisory mode. Tool calls are logged but NOT blocked. Set APE_STRICT_MODE=true to enforce policies.")
+    logger.warning(
+        "WARNING: APE is running in advisory mode. Tool calls are logged but NOT blocked. Set APE_STRICT_MODE=true to enforce policies."
+    )
 
 # Named sliding-window tiers. Order matters only for readability; each window
 # is evaluated independently.
@@ -122,11 +128,22 @@ DEFAULT_POLICY = {
     "intents": {
         "ExecuteCommand": {
             "mode": "allowlist",
-            "allowed": ["ls", "cat", "grep", "find", "head", "tail", "wc",
-                        "echo", "pwd", "env", "which"],
+            "allowed": [
+                "ls",
+                "cat",
+                "grep",
+                "find",
+                "head",
+                "tail",
+                "wc",
+                "echo",
+                "pwd",
+                "env",
+                "which",
+            ],
             "deny_patterns": [
-                r"rm\s+-rf",      # recursive delete
-                r">\s*/dev/sd",   # disk writes
+                r"rm\s+-rf",  # recursive delete
+                r">\s*/dev/sd",  # disk writes
                 r"curl.*\|.*sh",  # curl pipe to shell
                 r"wget.*\|.*sh",  # wget pipe to shell
                 r"chmod\s+[0-7]*7[0-7]*\s+/",  # chmod 777 /...
@@ -139,10 +156,10 @@ DEFAULT_POLICY = {
                 "/tmp",
             ],
         },
-        "ReadFile":     {"mode": "allow"},
+        "ReadFile": {"mode": "allow"},
         "NetworkFetch": {"mode": "allow"},
-        "SpawnAgent":   {"mode": "allow"},
-        "Other":        {"mode": "allow"},
+        "SpawnAgent": {"mode": "allow"},
+        "Other": {"mode": "allow"},
     },
     "rate_limit": {"requests_per_minute": RATE_LIMIT},
     # Per-intent sliding-window caps. Each entry maps a tier name (see
@@ -260,6 +277,7 @@ _MAX_SAMPLES_PER_WINDOW = 20000
 _MAX_BREAKER_SAMPLES = 5000
 _MAX_PENDING_APPROVALS = 1000
 _MAX_PENDING_GRANTS = 1000
+_APPROVAL_TTL = 3600  # 1 hour
 
 
 def _empty_state() -> dict[str, Any]:
@@ -276,15 +294,17 @@ def _args_hash(args: dict) -> str:
     """Stable short hash of the call args so a grant is tied to the exact
     invocation that was approved, not just any call to the same tool."""
     try:
-        canon = json.dumps(args or {}, sort_keys=True, separators=(",", ":"),
-                           default=str)
+        canon = json.dumps(
+            args or {}, sort_keys=True, separators=(",", ":"), default=str
+        )
     except Exception:  # pragma: no cover - non-serialisable args
         canon = repr(args)
     return hashlib.sha256(canon.encode("utf-8")).hexdigest()[:16]
 
 
-def _grant_key(session_id: Optional[str], tool_name: str, intent: str,
-               args_hash: str) -> str:
+def _grant_key(
+    session_id: Optional[str], tool_name: str, intent: str, args_hash: str
+) -> str:
     """Tight one-shot-grant key: scope + tool + intent + args fingerprint."""
     scope = session_id or "_global"
     return f"{scope}|{tool_name}|{intent}|{args_hash}"
@@ -304,8 +324,7 @@ def _coerce_state(raw: Any) -> dict[str, Any]:
             for tier, samples in tiers.items():
                 if isinstance(samples, list):
                     clean[str(tier)] = [
-                        float(s) for s in samples
-                        if isinstance(s, (int, float))
+                        float(s) for s in samples if isinstance(s, (int, float))
                     ]
             if clean:
                 state["windows"][str(key)] = clean
@@ -316,7 +335,8 @@ def _coerce_state(raw: Any) -> dict[str, Any]:
             state["breaker"]["decisions"] = [
                 [float(d[0]), bool(d[1])]
                 for d in decisions
-                if isinstance(d, (list, tuple)) and len(d) == 2
+                if isinstance(d, (list, tuple))
+                and len(d) == 2
                 and isinstance(d[0], (int, float))
             ]
         tu = breaker.get("tripped_until")
@@ -361,11 +381,20 @@ def _prune_state(now: float) -> None:
 
     cb = _state["breaker"]
     cb_cut = min(cutoff_default, now - 24 * 60 * 60)
-    cb["decisions"] = [
-        d for d in cb["decisions"] if d[0] >= cb_cut
-    ][-_MAX_BREAKER_SAMPLES:]
+    cb["decisions"] = [d for d in cb["decisions"] if d[0] >= cb_cut][
+        -_MAX_BREAKER_SAMPLES:
+    ]
     if cb.get("tripped_until", 0.0) and cb["tripped_until"] < now:
         cb["tripped_until"] = 0.0
+
+    now = time.time()
+    expired = [
+        tok
+        for tok, rec in _state["approvals"].items()
+        if rec.get("expires_at", 0) < now
+    ]
+    for tok in expired:
+        _state["approvals"].pop(tok, None)
 
     if len(_state["approvals"]) > _MAX_PENDING_APPROVALS:
         # Drop the oldest pending approvals by issued timestamp.
@@ -473,14 +502,21 @@ def _intent_window_config(policy: dict, intent: str) -> dict[str, Any]:
     if not isinstance(wl, dict) or not wl.get("enabled", True):
         return {}
     intents = wl.get("intents", {})
-    if isinstance(intents, dict) and intent in intents and isinstance(intents[intent], dict):
+    if (
+        isinstance(intents, dict)
+        and intent in intents
+        and isinstance(intents[intent], dict)
+    ):
         return intents[intent]
     default = wl.get("default", {})
     return default if isinstance(default, dict) else {}
 
 
 def check_windowed_limits(
-    policy: dict, session_id: Optional[str], intent: str, now: float,
+    policy: dict,
+    session_id: Optional[str],
+    intent: str,
+    now: float,
 ) -> tuple[str, str]:
     """Evaluate sliding-window caps for (scope, intent).
 
@@ -514,8 +550,7 @@ def check_windowed_limits(
             tiers[tier_name] = samples
             if len(samples) >= limit:
                 reason = (
-                    f"{intent} exceeded {tier_name} window "
-                    f"({len(samples)}/{limit})"
+                    f"{intent} exceeded {tier_name} window ({len(samples)}/{limit})"
                 )
                 if action == "deny":
                     # Hard deny always wins over an approval escalation.
@@ -534,7 +569,10 @@ def check_windowed_limits(
 
 
 def consume_grant(
-    session_id: Optional[str], tool_name: str, intent: str, args: dict,
+    session_id: Optional[str],
+    tool_name: str,
+    intent: str,
+    args: dict,
 ) -> Optional[dict[str, Any]]:
     """Atomically consume a one-shot approval grant for this exact action.
 
@@ -550,7 +588,10 @@ def consume_grant(
 
 
 def record_window_sample(
-    policy: dict, session_id: Optional[str], intent: str, now: float,
+    policy: dict,
+    session_id: Optional[str],
+    intent: str,
+    now: float,
 ) -> None:
     """Record one window sample for (scope, intent) without re-evaluating the
     caps. Used after a one-shot grant is consumed so the approved retry is
@@ -571,6 +612,7 @@ def record_window_sample(
 
 # ── Circuit breaker ─────────────────────────────────────────────────────────
 
+
 def circuit_breaker_blocked(policy: dict, now: float) -> tuple[bool, str]:
     """Return (blocked, reason). Caller-independent; takes the state lock."""
     cb = policy.get("circuit_breaker", {})
@@ -579,8 +621,11 @@ def circuit_breaker_blocked(policy: dict, now: float) -> tuple[bool, str]:
     with _STATE_LOCK:
         tripped_until = _state["breaker"].get("tripped_until", 0.0)
         if tripped_until and now < tripped_until:
-            return (True, f"circuit breaker open (cooldown until "
-                          f"{datetime.fromtimestamp(tripped_until, timezone.utc).isoformat()})")
+            return (
+                True,
+                f"circuit breaker open (cooldown until "
+                f"{datetime.fromtimestamp(tripped_until, timezone.utc).isoformat()})",
+            )
         if tripped_until and now >= tripped_until:
             _state["breaker"]["tripped_until"] = 0.0
     return (False, "")
@@ -607,7 +652,9 @@ def record_breaker_decision(policy: dict, allowed: bool, now: float) -> None:
                 _state["breaker"]["tripped_until"] = now + cooldown
                 logger.warning(
                     "Circuit breaker TRIPPED: %d/%d denied over %.0fs window",
-                    denied, len(decisions), window,
+                    denied,
+                    len(decisions),
+                    window,
                 )
 
 
@@ -626,9 +673,9 @@ def in_warmup(now: float) -> bool:
 # ── Intent classification ─────────────────────────────────────────────────────
 
 _EXEC_VERBS = {"exec", "run", "execute", "shell", "bash", "sh", "cmd"}
-_READ_VERBS  = {"read", "cat", "head", "tail", "get_file", "read_file", "view"}
+_READ_VERBS = {"read", "cat", "head", "tail", "get_file", "read_file", "view"}
 _WRITE_VERBS = {"write", "create", "append", "write_file", "save", "put"}
-_NET_VERBS   = {"fetch", "curl", "wget", "web_fetch", "http_get", "request"}
+_NET_VERBS = {"fetch", "curl", "wget", "web_fetch", "http_get", "request"}
 _SPAWN_VERBS = {"spawn", "agent", "sub_agent", "subagent", "delegate"}
 
 
@@ -655,6 +702,7 @@ def classify_intent(tool_name: str, args: dict) -> str:
 
 
 # ── Policy evaluation ─────────────────────────────────────────────────────────
+
 
 def evaluate(intent: str, tool_name: str, args: dict, policy: dict) -> tuple[bool, str]:
     """Return (allowed, reason)."""
@@ -688,7 +736,9 @@ def evaluate(intent: str, tool_name: str, args: dict, policy: dict) -> tuple[boo
             return True, "no path specified"
         real = os.path.realpath(path)
         allowed_paths = intent_policy.get("allowed_paths", [])
-        if any(real == p or real.startswith(p.rstrip("/") + "/") for p in allowed_paths):
+        if any(
+            real == p or real.startswith(p.rstrip("/") + "/") for p in allowed_paths
+        ):
             return True, "path is within allowed zone"
         return False, f"write to '{real}' is outside allowed paths"
 
@@ -696,6 +746,7 @@ def evaluate(intent: str, tool_name: str, args: dict, policy: dict) -> tuple[boo
 
 
 # ── Audit log ─────────────────────────────────────────────────────────────────
+
 
 def write_audit(entry: dict) -> None:
     try:
@@ -721,6 +772,7 @@ _decision_counts = {
 
 # ── App ───────────────────────────────────────────────────────────────────────
 
+
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
     load_state()
@@ -736,8 +788,12 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3001", "http://localhost:3000",
-                   "http://127.0.0.1:3001", "http://127.0.0.1:3000"],
+    allow_origins=[
+        "http://localhost:3001",
+        "http://localhost:3000",
+        "http://127.0.0.1:3001",
+        "http://127.0.0.1:3000",
+    ],
     allow_methods=["GET", "POST"],
     allow_headers=["Content-Type", "Authorization", "X-API-Key"],
 )
@@ -786,12 +842,17 @@ class ApproveResponse(BaseModel):
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "strict_mode": STRICT_MODE,
-            "timestamp": datetime.now(timezone.utc).isoformat()}
+    return {
+        "status": "ok",
+        "strict_mode": STRICT_MODE,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
 
 
 @app.post("/verify", response_model=VerifyResponse)
-async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(verify_api_key)):
+async def verify(
+    req: VerifyRequest, request: Request, api_key: str = Depends(verify_api_key)
+):
     policy = load_policy()
     decision_id = f"{int(time.time() * 1000)}-{secrets.token_hex(8)}"
     now = time.time()
@@ -819,9 +880,13 @@ async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(ve
             write_audit(entry)
             if STRICT_MODE:
                 raise HTTPException(status_code=429, detail=cb_reason)
-            return VerifyResponse(allowed=False, reason=cb_reason,
-                                  intent="unknown", decision_id=decision_id,
-                                  decision="deny")
+            return VerifyResponse(
+                allowed=False,
+                reason=cb_reason,
+                intent="unknown",
+                decision_id=decision_id,
+                decision="deny",
+            )
 
     # 2) Legacy per-minute rate limit — preserved verbatim.
     if not check_rate_limit(policy, req.session_id):
@@ -841,9 +906,13 @@ async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(ve
         write_audit(entry)
         if STRICT_MODE:
             raise HTTPException(status_code=429, detail="Rate limit exceeded")
-        return VerifyResponse(allowed=False, reason="rate limit exceeded",
-                              intent="unknown", decision_id=decision_id,
-                              decision="deny")
+        return VerifyResponse(
+            allowed=False,
+            reason="rate limit exceeded",
+            intent="unknown",
+            decision_id=decision_id,
+            decision="deny",
+        )
 
     intent = classify_intent(req.tool_name, req.args)
 
@@ -857,15 +926,15 @@ async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(ve
     grant_used: Optional[dict[str, Any]] = None
     if allowed and not warming:
         w_decision, w_reason = check_windowed_limits(
-            policy, req.session_id, intent, now)
+            policy, req.session_id, intent, now
+        )
         if w_decision != "allow":
             # The window is exhausted. Before escalating again, check for a
             # one-shot bypass grant minted by a prior /approve for THIS exact
             # {session, tool, intent, args}. If present, consume it (strictly
             # one-shot) and allow this single retry past the window. A second
             # retry finds no grant and re-escalates — no broad cap lift.
-            grant_used = consume_grant(
-                req.session_id, req.tool_name, intent, req.args)
+            grant_used = consume_grant(req.session_id, req.tool_name, intent, req.args)
         if grant_used is not None:
             allowed = True
             decision = "allow"
@@ -903,6 +972,7 @@ async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(ve
                 "agent": req.agent_id,
                 "reason": reason,
                 "issued_at": now,
+                "expires_at": now + _APPROVAL_TTL,
                 "decision_id": decision_id,
             }
         _decision_counts["require_approval"] += 1
@@ -937,8 +1007,15 @@ async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(ve
         entry["approver"] = grant_used.get("approver")
     write_audit(entry)
     save_state()
-    logger.info("%s tool=%s intent=%s decision=%s allowed=%s reason=%s",
-                decision_id, req.tool_name, intent, decision, allowed, reason)
+    logger.info(
+        "%s tool=%s intent=%s decision=%s allowed=%s reason=%s",
+        decision_id,
+        req.tool_name,
+        intent,
+        decision,
+        allowed,
+        reason,
+    )
 
     # STRICT_MODE: hard policy denials still raise 403. require_approval is an
     # advisory escalation and intentionally returns 200 so the agent framework
@@ -946,14 +1023,20 @@ async def verify(req: VerifyRequest, request: Request, api_key: str = Depends(ve
     if decision == "deny" and not allowed and STRICT_MODE:
         raise HTTPException(status_code=403, detail=reason)
 
-    return VerifyResponse(allowed=allowed, reason=reason,
-                          intent=intent, decision_id=decision_id,
-                          decision=decision, approval_token=approval_token)
+    return VerifyResponse(
+        allowed=allowed,
+        reason=reason,
+        intent=intent,
+        decision_id=decision_id,
+        decision=decision,
+        approval_token=approval_token,
+    )
 
 
 @app.post("/approve", response_model=ApproveResponse)
-async def approve(req: ApproveRequest, request: Request,
-                  api_key: str = Depends(verify_api_key)):
+async def approve(
+    req: ApproveRequest, request: Request, api_key: str = Depends(verify_api_key)
+):
     """Grant a pending human-approval decision issued by /verify.
 
     Consumes the one-shot approval token AND mints a one-shot windowed-limit
@@ -968,8 +1051,10 @@ async def approve(req: ApproveRequest, request: Request,
         rec = _state["approvals"].pop(req.approval_token, None)
         if rec is None:
             return ApproveResponse(
-                granted=False,
-                reason="unknown or already-consumed approval token")
+                granted=False, reason="unknown or already-consumed approval token"
+            )
+        if rec.get("expires_at", 0) < time.time():
+            return ApproveResponse(granted=False, reason="approval token has expired")
         # Persist a one-shot bypass tightly keyed to the approved action.
         gkey = _grant_key(
             rec.get("session"),
@@ -1002,13 +1087,18 @@ async def approve(req: ApproveRequest, request: Request,
     }
     write_audit(entry)
     save_state()
-    logger.info("approval granted token=%s tool=%s approver=%s "
-                "(one-shot grant minted)",
-                req.approval_token[:12] + "...", rec.get("tool_name"),
-                req.approver)
-    return ApproveResponse(granted=True, reason="approval granted",
-                           tool_name=rec.get("tool_name"),
-                           intent=rec.get("intent"))
+    logger.info(
+        "approval granted token=%s tool=%s approver=%s (one-shot grant minted)",
+        req.approval_token[:12] + "...",
+        rec.get("tool_name"),
+        req.approver,
+    )
+    return ApproveResponse(
+        granted=True,
+        reason="approval granted",
+        tool_name=rec.get("tool_name"),
+        intent=rec.get("intent"),
+    )
 
 
 @app.get("/audit")
@@ -1031,7 +1121,7 @@ async def audit(last_n: int = 50, api_key: str = Depends(verify_api_key)):
                 chunk_start = max(0, position - chunk_size)
                 f.seek(chunk_start)
                 chunk = f.read(position - chunk_start)
-                lines_found += chunk.count(b'\n')
+                lines_found += chunk.count(b"\n")
                 position = chunk_start
             f.seek(position)
             for line in f:
@@ -1049,12 +1139,14 @@ async def audit(last_n: int = 50, api_key: str = Depends(verify_api_key)):
 async def policy(api_key: str = Depends(verify_api_key)):
     """Return the active policy (args not shown for security)."""
     p = load_policy()
-    return {"version": p.get("version", 1),
-            "intents": list(p.get("intents", {}).keys()),
-            "rate_limit": p.get("rate_limit", {}),
-            "windowed_limits": p.get("windowed_limits", {}),
-            "circuit_breaker": p.get("circuit_breaker", {}),
-            "strict_mode": STRICT_MODE}
+    return {
+        "version": p.get("version", 1),
+        "intents": list(p.get("intents", {}).keys()),
+        "rate_limit": p.get("rate_limit", {}),
+        "windowed_limits": p.get("windowed_limits", {}),
+        "circuit_breaker": p.get("circuit_breaker", {}),
+        "strict_mode": STRICT_MODE,
+    }
 
 
 @app.get("/metrics")
@@ -1062,17 +1154,18 @@ async def metrics(api_key: str = Depends(verify_api_key)):
     with _STATE_LOCK:
         pending = len(_state["approvals"])
         pending_grants = len(_state.get("grants", {}))
-        breaker_open = bool(
-            _state["breaker"].get("tripped_until", 0.0) > time.time()
-        )
-    return {"decisions": _decision_counts,
-            "total": sum(_decision_counts.values()),
-            "pending_approvals": pending,
-            "pending_grants": pending_grants,
-            "circuit_breaker_open": breaker_open}
+        breaker_open = bool(_state["breaker"].get("tripped_until", 0.0) > time.time())
+    return {
+        "decisions": _decision_counts,
+        "total": sum(_decision_counts.values()),
+        "pending_approvals": pending,
+        "pending_grants": pending_grants,
+        "circuit_breaker_open": breaker_open,
+    }
 
 
 if __name__ == "__main__":
     import uvicorn
+
     port = int(os.environ.get("APE_PORT", "7890"))
     uvicorn.run(app, host="0.0.0.0", port=port)

--- a/ods/extensions/services/ape/tests/test_main.py
+++ b/ods/extensions/services/ape/tests/test_main.py
@@ -212,6 +212,31 @@ def test_approve_unknown_token(make_client):
     assert g.json()["granted"] is False
 
 
+def test_approve_token_expires(make_client):
+    """Approval token returns 403 when expired."""
+    client, _ = make_client()
+    with patch("main._APPROVAL_TTL", 0):
+        r = _verify(client, tool="web_fetch", args={"url": "http://x"}, session="ap-exp")
+        token = r.json()["approval_token"]
+
+    g = client.post("/approve", json={"approval_token": token, "approver": "alice"})
+    assert g.status_code == 200
+    assert g.json()["granted"] is False
+    assert "expired" in g.json().get("reason", "").lower()
+
+
+def test_approve_token_not_expired(make_client):
+    """Approval token is accepted before TTL expires."""
+    client, _ = make_client()
+    with patch("main._APPROVAL_TTL", 9999):
+        r = _verify(client, tool="web_fetch", args={"url": "http://x"}, session="ap-valid")
+        token = r.json()["approval_token"]
+
+    g = client.post("/approve", json={"approval_token": token, "approver": "alice"})
+    assert g.status_code == 200
+    assert g.json()["granted"] is True
+
+
 # ── Approval is a REAL one-shot retry bypass (issue #1269 remediation) ───────
 
 

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -22,9 +22,14 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from config import (
-    ALWAYS_ON_SERVICES, CORE_SERVICE_IDS, DATA_DIR,
-    EXTENSION_CATALOG, EXTENSIONS_DIR,
-    EXTENSIONS_LIBRARY_DIR, GPU_BACKEND, SERVICES,
+    ALWAYS_ON_SERVICES,
+    CORE_SERVICE_IDS,
+    DATA_DIR,
+    EXTENSION_CATALOG,
+    EXTENSIONS_DIR,
+    EXTENSIONS_LIBRARY_DIR,
+    GPU_BACKEND,
+    SERVICES,
     USER_EXTENSIONS_DIR,
 )
 from host_agent_client import (
@@ -76,16 +81,26 @@ def _extension_tree_digest(root: Path) -> str:
             entries.append(("L", canonical, os.readlink(path)))
         elif path.is_dir():
             stat_result = path.stat()
-            entries.append((
-                "D", canonical, stat_result.st_mtime_ns, stat_result.st_ctime_ns,
-            ))
+            entries.append(
+                (
+                    "D",
+                    canonical,
+                    stat_result.st_mtime_ns,
+                    stat_result.st_ctime_ns,
+                )
+            )
         elif path.is_file():
             stat_result = path.stat()
-            entries.append((
-                "F", canonical, stat_result.st_size, stat_result.st_mtime_ns,
-                stat_result.st_ctime_ns,
-                bool(stat_result.st_mode & 0o111),
-            ))
+            entries.append(
+                (
+                    "F",
+                    canonical,
+                    stat_result.st_size,
+                    stat_result.st_mtime_ns,
+                    stat_result.st_ctime_ns,
+                    bool(stat_result.st_mode & 0o111),
+                )
+            )
     signature = tuple(entries)
     cache_key = str(root.resolve())
     with _extension_digest_cache_lock:
@@ -125,7 +140,10 @@ def _read_library_receipt(extension_dir: Path) -> dict | None:
         data = json.loads(receipt_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return None
-    if not isinstance(data, dict) or data.get("schema_version") != _LIBRARY_RECEIPT_SCHEMA:
+    if (
+        not isinstance(data, dict)
+        or data.get("schema_version") != _LIBRARY_RECEIPT_SCHEMA
+    ):
         return None
     required = ("source_digest", "installed_digest")
     if any(not isinstance(data.get(key), str) or not data[key] for key in required):
@@ -162,7 +180,11 @@ def _library_update_state(service_id: str) -> dict:
         "locally_modified": False,
         "rollback_available": backup.is_dir() and not backup.is_symlink(),
     }
-    if not installed.is_dir() or not source.is_dir() or not (source / "compose.yaml").is_file():
+    if (
+        not installed.is_dir()
+        or not source.is_dir()
+        or not (source / "compose.yaml").is_file()
+    ):
         return state
     receipt = _read_library_receipt(installed)
     if receipt is None:
@@ -239,7 +261,9 @@ def _cleanup_stale_progress() -> None:
     for f in progress_dir.glob("*.json"):
         try:
             data = json.loads(f.read_text(encoding="utf-8"))
-            if data.get("status") == "started" and _is_stale(data.get("updated_at", ""), 900):
+            if data.get("status") == "started" and _is_stale(
+                data.get("updated_at", ""), 900
+            ):
                 f.unlink(missing_ok=True)
             elif _is_stale(data.get("updated_at", ""), 3600):
                 f.unlink(missing_ok=True)
@@ -268,8 +292,14 @@ def _write_error_progress(service_id: str, error_msg: str) -> None:
     """Update progress file to error state so the UI stops spinning."""
     progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
     now = datetime.now(timezone.utc).isoformat()
-    data = {"service_id": service_id, "status": "pulling", "error": None,
-            "phase_label": "", "started_at": now, "updated_at": now}
+    data = {
+        "service_id": service_id,
+        "status": "pulling",
+        "error": None,
+        "phase_label": "",
+        "started_at": now,
+        "updated_at": now,
+    }
     try:
         if progress_file.exists():
             data = json.loads(progress_file.read_text(encoding="utf-8"))
@@ -438,8 +468,10 @@ def _assert_not_core(service_id: str) -> None:
     """
     if service_id in ALWAYS_ON_SERVICES:
         raise HTTPException(
-            status_code=403, detail=f"Cannot modify always-on service: {service_id}",
+            status_code=403,
+            detail=f"Cannot modify always-on service: {service_id}",
         )
+
 
 def _resolve_extension_dir(service_id: str) -> Path:
     """Resolve an extension's directory, checking user-extensions first, then built-in.
@@ -455,7 +487,8 @@ def _resolve_extension_dir(service_id: str) -> Path:
         return builtin_dir
 
     raise HTTPException(
-        status_code=404, detail=f"Extension not found: {service_id}",
+        status_code=404,
+        detail=f"Extension not found: {service_id}",
     )
 
 
@@ -497,7 +530,7 @@ def _split_port_host(port_str: str) -> tuple[Optional[str], str]:
         if end == -1 or end + 1 >= len(port_str) or port_str[end + 1] != ":":
             # Malformed expansion or no host:port separator after it.
             return port_str, ""
-        return port_str[: end + 1], port_str[end + 2:]
+        return port_str[: end + 1], port_str[end + 2 :]
     if ":" not in port_str:
         return None, port_str
     host, _, rest = port_str.partition(":")
@@ -525,7 +558,8 @@ def _scan_compose_content(
 
     if not isinstance(data, dict):
         raise HTTPException(
-            status_code=400, detail="Compose file must be a YAML mapping",
+            status_code=400,
+            detail="Compose file must be a YAML mapping",
         )
 
     services = data.get("services", {})
@@ -552,7 +586,9 @@ def _scan_compose_content(
         if isinstance(labels, dict):
             label_keys = labels.keys()
         elif isinstance(labels, list):
-            label_keys = [lbl.split("=", 1)[0] for lbl in labels if isinstance(lbl, str)]
+            label_keys = [
+                lbl.split("=", 1)[0] for lbl in labels if isinstance(lbl, str)
+            ]
         else:
             label_keys = []
         for lk in label_keys:
@@ -593,9 +629,16 @@ def _scan_compose_content(
             for cap in cap_add:
                 cap_str = str(cap).upper().removeprefix("CAP_")
                 if cap_str in {
-                    "SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "NET_RAW",
-                    "DAC_OVERRIDE", "SETUID", "SETGID", "SYS_MODULE",
-                    "SYS_RAWIO", "ALL",
+                    "SYS_ADMIN",
+                    "NET_ADMIN",
+                    "SYS_PTRACE",
+                    "NET_RAW",
+                    "DAC_OVERRIDE",
+                    "SETUID",
+                    "SETGID",
+                    "SYS_MODULE",
+                    "SYS_RAWIO",
+                    "ALL",
                 }:
                     raise HTTPException(
                         status_code=400,
@@ -646,7 +689,10 @@ def _scan_compose_content(
                     detail=f"Extension rejected: unsupported extra_hosts in {svc_name}",
                 )
             for entry in extra_hosts:
-                if not isinstance(entry, str) or entry.strip() not in allowed_trusted_extra_hosts:
+                if (
+                    not isinstance(entry, str)
+                    or entry.strip() not in allowed_trusted_extra_hosts
+                ):
                     raise HTTPException(
                         status_code=400,
                         detail=f"Extension rejected: unsupported extra_hosts in {svc_name}",
@@ -660,7 +706,11 @@ def _scan_compose_content(
         if isinstance(security_opt, list):
             for opt in security_opt:
                 opt_str = str(opt).lower().replace("=", ":")
-                if opt_str in ("seccomp:unconfined", "apparmor:unconfined", "label:disable"):
+                if opt_str in (
+                    "seccomp:unconfined",
+                    "apparmor:unconfined",
+                    "label:disable",
+                ):
                     raise HTTPException(
                         status_code=400,
                         detail=f"Extension rejected: dangerous security_opt '{opt}' in {svc_name}",
@@ -765,9 +815,13 @@ def _ignore_special(directory: str, files: list[str]) -> list[str]:
         full = os.path.join(directory, f)
         try:
             st = os.lstat(full)
-            if (stat.S_ISLNK(st.st_mode) or stat.S_ISFIFO(st.st_mode)
-                    or stat.S_ISBLK(st.st_mode) or stat.S_ISCHR(st.st_mode)
-                    or stat.S_ISSOCK(st.st_mode)):
+            if (
+                stat.S_ISLNK(st.st_mode)
+                or stat.S_ISFIFO(st.st_mode)
+                or stat.S_ISBLK(st.st_mode)
+                or stat.S_ISCHR(st.st_mode)
+                or stat.S_ISSOCK(st.st_mode)
+            ):
                 ignored.append(f)
         except OSError:
             ignored.append(f)
@@ -782,6 +836,7 @@ def _copytree_safe(src: Path, dst: Path) -> None:
 def _get_service_data_info(service_id: str) -> dict | None:
     """Return data directory info for a service, or None if no data dir exists."""
     from helpers import dir_size_gb  # noqa: PLC0415 — deferred to avoid circular import at module level
+
     data_path = (Path(DATA_DIR) / service_id).resolve()
     if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
         return None
@@ -834,7 +889,8 @@ def _call_agent(action: str, service_id: str) -> bool:
     except AgentClientError as exc:
         logger.warning(
             "Host agent unreachable at %s — fallback to restart_required: %s",
-            "shared transport", exc,
+            "shared transport",
+            exc,
         )
         return False
 
@@ -851,7 +907,8 @@ def _call_agent_invalidate_compose_cache() -> None:
     except AgentClientError as exc:
         logger.warning(
             "Host agent unreachable for compose-flags invalidation at %s: %s",
-            "shared transport", exc,
+            "shared transport",
+            exc,
         )
 
 
@@ -907,7 +964,9 @@ def _call_agent_install(service_id: str) -> bool:
         return False
 
 
-def _call_agent_sync_config(service_id: str, *, preserve_existing: bool = False) -> bool:
+def _call_agent_sync_config(
+    service_id: str, *, preserve_existing: bool = False
+) -> bool:
     """Ask host agent to copy <ext>/config/* into INSTALL_DIR/config/.
 
     The dashboard-api container has /ods/config bind-mounted
@@ -945,7 +1004,9 @@ def _call_agent_sync_config(service_id: str, *, preserve_existing: bool = False)
         return True
     except AgentHTTPError as exc:
         logger.warning(
-            "sync_config failed for %s (HTTP %d)", service_id, exc.status_code,
+            "sync_config failed for %s (HTTP %d)",
+            service_id,
+            exc.status_code,
         )
         return False
     except AgentClientError:
@@ -969,7 +1030,8 @@ def _call_agent_compose_rename(action: str, service_id: str) -> bool:
         return True
     except AgentClientError as exc:
         logger.warning(
-            "Host agent unreachable for compose rename: %s", exc,
+            "Host agent unreachable for compose rename: %s",
+            exc,
         )
         return False
 
@@ -1045,6 +1107,7 @@ def _extension_operation_lock(service_id: str):
 
 def _serialize_extension_operation(func):
     """Keep same-service portal mutations serialized through runtime proof."""
+
     @wraps(func)
     def wrapped(service_id: str, *args, **kwargs):
         if not _SERVICE_ID_RE.match(service_id):
@@ -1095,7 +1158,8 @@ async def extensions_catalog(
 ):
     """Get the extensions catalog with computed status."""
     _cleanup_future = asyncio.get_running_loop().run_in_executor(
-        None, _cleanup_stale_progress,
+        None,
+        _cleanup_stale_progress,
     )
 
     def _log_cleanup_error(f: asyncio.Future) -> None:
@@ -1117,7 +1181,9 @@ async def extensions_catalog(
     from helpers import _CATALOG_HEALTH_TIMEOUT, check_service_health
     from user_extensions import get_user_services_cached
 
-    user_svc_configs = await asyncio.to_thread(get_user_services_cached, USER_EXTENSIONS_DIR)
+    user_svc_configs = await asyncio.to_thread(
+        get_user_services_cached, USER_EXTENSIONS_DIR
+    )
 
     # Only health-check extensions that declare a health endpoint.  Use a
     # short per-probe timeout so one slow extension cannot stall the catalog
@@ -1135,23 +1201,29 @@ async def extensions_catalog(
     # Extensions without health endpoints — assume running if scanned
     # (presence in user_svc_configs means compose.yaml + manifest exist)
     from models import ServiceStatus
+
     for sid, cfg in user_svc_configs.items():
         if not cfg.get("health") and sid not in services_by_id:
             services_by_id[sid] = ServiceStatus(
-                id=sid, name=cfg.get("name", sid),
+                id=sid,
+                name=cfg.get("name", sid),
                 port=cfg.get("port", 0),
                 external_port=cfg.get("external_port", cfg.get("port", 0)),
-                status="healthy", response_time_ms=None,
+                status="healthy",
+                response_time_ms=None,
             )
 
     user_extension_ids = [
-        entry["id"] for entry in EXTENSION_CATALOG
+        entry["id"]
+        for entry in EXTENSION_CATALOG
         if (USER_EXTENSIONS_DIR / entry["id"]).is_dir()
     ]
-    update_results = await asyncio.gather(*[
-        asyncio.to_thread(_library_update_state, service_id)
-        for service_id in user_extension_ids
-    ])
+    update_results = await asyncio.gather(
+        *[
+            asyncio.to_thread(_library_update_state, service_id)
+            for service_id in user_extension_ids
+        ]
+    )
     update_states = dict(zip(user_extension_ids, update_results))
 
     extensions = []
@@ -1160,14 +1232,21 @@ async def extensions_catalog(
         installable = _is_installable(ext["id"])
         ext_id = ext["id"]
         user_dir = USER_EXTENSIONS_DIR / ext_id
-        source = "user" if user_dir.is_dir() else ("core" if ext_id in SERVICES else "library")
+        source = (
+            "user"
+            if user_dir.is_dir()
+            else ("core" if ext_id in SERVICES else "library")
+        )
         has_data = (Path(DATA_DIR) / ext_id).is_dir()
-        update_state = update_states.get(ext_id, {
-            "update_status": "unavailable",
-            "update_available": False,
-            "locally_modified": False,
-            "rollback_available": False,
-        })
+        update_state = update_states.get(
+            ext_id,
+            {
+                "update_status": "unavailable",
+                "update_available": False,
+                "locally_modified": False,
+                "rollback_available": False,
+            },
+        )
         enriched = {
             **ext,
             "status": status,
@@ -1218,14 +1297,21 @@ async def extensions_catalog(
                 dep_status[dep] = dep_ext["status"]
             elif dep in SERVICES:
                 svc = services_by_id.get(dep)
-                dep_status[dep] = "enabled" if (svc and svc.status == "healthy") else "disabled"
+                dep_status[dep] = (
+                    "enabled" if (svc and svc.status == "healthy") else "disabled"
+                )
             else:
                 dep_status[dep] = "unknown"
         e["dependency_status"] = dep_status
 
     summary = {
         "total": len(extensions),
-        "installed": sum(1 for e in extensions if e["status"] in ("enabled", "cli_installed", "disabled", "stopped", "unhealthy")),
+        "installed": sum(
+            1
+            for e in extensions
+            if e["status"]
+            in ("enabled", "cli_installed", "disabled", "stopped", "unhealthy")
+        ),
         "enabled": sum(1 for e in extensions if e["status"] == "enabled"),
         "cli_installed": sum(1 for e in extensions if e["status"] == "cli_installed"),
         "disabled": sum(1 for e in extensions if e["status"] == "disabled"),
@@ -1240,9 +1326,8 @@ async def extensions_catalog(
     }
 
     try:
-        lib_available = (
-            EXTENSIONS_LIBRARY_DIR.is_dir()
-            and any(EXTENSIONS_LIBRARY_DIR.iterdir())
+        lib_available = EXTENSIONS_LIBRARY_DIR.is_dir() and any(
+            EXTENSIONS_LIBRARY_DIR.iterdir()
         )
     except OSError:
         lib_available = False
@@ -1286,7 +1371,9 @@ async def extension_detail(
 
     ext = next((e for e in EXTENSION_CATALOG if e["id"] == service_id), None)
     if not ext:
-        raise HTTPException(status_code=404, detail=f"Extension not found: {service_id}")
+        raise HTTPException(
+            status_code=404, detail=f"Extension not found: {service_id}"
+        )
 
     from helpers import _CATALOG_HEALTH_TIMEOUT, check_service_health, get_all_services
     from user_extensions import get_user_services_cached
@@ -1294,7 +1381,9 @@ async def extension_detail(
     service_list = await get_all_services()
     services_by_id = {s.id: s for s in service_list}
 
-    user_svc_configs = await asyncio.to_thread(get_user_services_cached, USER_EXTENSIONS_DIR)
+    user_svc_configs = await asyncio.to_thread(
+        get_user_services_cached, USER_EXTENSIONS_DIR
+    )
 
     # Same short per-probe timeout as the catalog fan-out — one slow user
     # extension must not block the detail view.
@@ -1309,13 +1398,16 @@ async def extension_detail(
             services_by_id[sid] = result
 
     from models import ServiceStatus
+
     for sid, cfg in user_svc_configs.items():
         if not cfg.get("health") and sid not in services_by_id:
             services_by_id[sid] = ServiceStatus(
-                id=sid, name=cfg.get("name", sid),
+                id=sid,
+                name=cfg.get("name", sid),
                 port=cfg.get("port", 0),
                 external_port=cfg.get("external_port", cfg.get("port", 0)),
-                status="healthy", response_time_ms=None,
+                status="healthy",
+                response_time_ms=None,
             )
 
     status = _compute_extension_status(ext, services_by_id)
@@ -1326,13 +1418,21 @@ async def extension_detail(
     manifest = {**ext, **({"llm": llm_contract} if llm_contract is not None else {})}
 
     user_dir = USER_EXTENSIONS_DIR / service_id
-    source = "user" if user_dir.is_dir() else ("core" if service_id in SERVICES else "library")
-    update_state = await asyncio.to_thread(_library_update_state, service_id) if source == "user" else {
-        "update_status": "unavailable",
-        "update_available": False,
-        "locally_modified": False,
-        "rollback_available": False,
-    }
+    source = (
+        "user"
+        if user_dir.is_dir()
+        else ("core" if service_id in SERVICES else "library")
+    )
+    update_state = (
+        await asyncio.to_thread(_library_update_state, service_id)
+        if source == "user"
+        else {
+            "update_status": "unavailable",
+            "update_available": False,
+            "locally_modified": False,
+            "rollback_available": False,
+        }
+    )
 
     # See extensions_catalog: same rationale for inlining the install error.
     error_message: Optional[str] = None
@@ -1380,7 +1480,9 @@ async def extension_logs(
 
     try:
         body = await asyncio.to_thread(
-            _fetch_agent_logs, service_id, _AGENT_LOG_TIMEOUT,
+            _fetch_agent_logs,
+            service_id,
+            _AGENT_LOG_TIMEOUT,
         )
         return json.loads(body)
     except AgentHTTPError as exc:
@@ -1391,7 +1493,9 @@ async def extension_logs(
             detail=f"Host agent unavailable. Use 'docker logs ods-{service_id}' in terminal.",
         ) from exc
     except (AgentProtocolError, json.JSONDecodeError) as exc:
-        raise HTTPException(status_code=502, detail=f"Invalid host agent response: {exc}") from exc
+        raise HTTPException(
+            status_code=502, detail=f"Invalid host agent response: {exc}"
+        ) from exc
 
 
 @contextlib.contextmanager
@@ -1403,17 +1507,20 @@ def _staged_library_extension(service_id: str, dest: Path):
         lib_available = False
     if not lib_available:
         raise HTTPException(
-            status_code=503, detail="Extensions library is unavailable",
+            status_code=503,
+            detail="Extensions library is unavailable",
         )
 
     source = (EXTENSIONS_LIBRARY_DIR / service_id).resolve()
     if not source.is_relative_to(EXTENSIONS_LIBRARY_DIR.resolve()):
         raise HTTPException(
-            status_code=404, detail=f"Extension not found: {service_id}",
+            status_code=404,
+            detail=f"Extension not found: {service_id}",
         )
     if not source.is_dir():
         raise HTTPException(
-            status_code=404, detail=f"Extension not found: {service_id}",
+            status_code=404,
+            detail=f"Extension not found: {service_id}",
         )
 
     # Server-side install gate: refuse entries that have no deployable
@@ -1447,7 +1554,9 @@ def _staged_library_extension(service_id: str, dest: Path):
     USER_EXTENSIONS_DIR.mkdir(parents=True, exist_ok=True)
     tmp_parent = USER_EXTENSIONS_DIR / ".tmp"
     if tmp_parent.is_symlink():
-        raise HTTPException(status_code=409, detail="Extension temporary path is a symlink")
+        raise HTTPException(
+            status_code=409, detail="Extension temporary path is a symlink"
+        )
     tmp_parent.mkdir(parents=True, exist_ok=True)
     tmpdir = tempfile.mkdtemp(prefix=f".{service_id}-", dir=str(tmp_parent))
     staged: Path | None = None
@@ -1501,7 +1610,9 @@ def _install_from_library(service_id: str) -> None:
                 status_code=409,
                 detail=f"Extension already installed: {service_id}",
             )
-        logger.warning("Cleaning up extension directory under lock before retry: %s", dest)
+        logger.warning(
+            "Cleaning up extension directory under lock before retry: %s", dest
+        )
         shutil.rmtree(dest)
         _clear_progress(service_id)
 
@@ -1572,7 +1683,9 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
             service["build"] = {"context": rewritten_context}
             logger.info(
                 "Rewrote build context for service '%s' from '%s' to '%s'",
-                service_name, build, rewritten_context,
+                service_name,
+                build,
+                rewritten_context,
             )
             changed = True
             continue
@@ -1584,7 +1697,8 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
                 build["context"] = str(final_dir)
                 logger.info(
                     "Set build context for service '%s' to '%s' (was implicit)",
-                    service_name, final_dir,
+                    service_name,
+                    final_dir,
                 )
                 changed = True
                 continue
@@ -1593,7 +1707,9 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
                 build["context"] = rewritten_context
                 logger.info(
                     "Rewrote build context for service '%s' from '%s' to '%s'",
-                    service_name, context, rewritten_context,
+                    service_name,
+                    context,
+                    rewritten_context,
                 )
                 changed = True
 
@@ -1617,7 +1733,8 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
         has_disabled = (dest / "compose.yaml.disabled").exists()
         if (has_compose or has_disabled) and not _has_error_progress(service_id):
             raise HTTPException(
-                status_code=409, detail=f"Extension already installed: {service_id}",
+                status_code=409,
+                detail=f"Extension already installed: {service_id}",
             )
         # Broken or failed directory — clean up before reinstall.
         logger.warning("Cleaning up extension directory before retry: %s", dest)
@@ -1663,7 +1780,8 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
         "restart_required": not agent_ok,
         "progress_endpoint": f"/api/extensions/{service_id}/progress",
         "message": (
-            "Extension installed and starting." if agent_ok
+            "Extension installed and starting."
+            if agent_ok
             else "Extension installed. Run 'ods restart' to start."
         ),
     }
@@ -1697,14 +1815,20 @@ def _restore_extension_backup(service_id: str) -> bool:
     backup = _extension_backup_dir(service_id)
     if backup.parent.is_symlink():
         return False
-    if (not dest.is_dir() or dest.is_symlink()
-            or not backup.is_dir() or backup.is_symlink()):
+    if (
+        not dest.is_dir()
+        or dest.is_symlink()
+        or not backup.is_dir()
+        or backup.is_symlink()
+    ):
         return False
     swap_parent = USER_EXTENSIONS_DIR / ".tmp"
     if swap_parent.is_symlink():
         return False
     swap_parent.mkdir(parents=True, exist_ok=True)
-    swap_root = Path(tempfile.mkdtemp(prefix=f".{service_id}-rollback-", dir=swap_parent))
+    swap_root = Path(
+        tempfile.mkdtemp(prefix=f".{service_id}-rollback-", dir=swap_parent)
+    )
     current = swap_root / service_id
     parked = False
     try:
@@ -1721,7 +1845,8 @@ def _restore_extension_backup(service_id: str) -> bool:
                 logger.error(
                     "Rollback failed for %s and the live definition could "
                     "not be re-seated; parked at %s",
-                    service_id, current,
+                    service_id,
+                    current,
                 )
             raise
         backup.parent.mkdir(parents=True, exist_ok=True)
@@ -1735,7 +1860,8 @@ def _restore_extension_backup(service_id: str) -> bool:
             logger.warning(
                 "Rollback restored %s but could not retain the replaced "
                 "definition; parked at %s",
-                service_id, current,
+                service_id,
+                current,
             )
         _invalidate_extension_digest_cache(dest, backup, current)
         return True
@@ -1788,7 +1914,9 @@ def _recover_extension_swap(
         try:
             start_ok, hook_warnings = _start_extension_lifecycle(service_id)
         except Exception as exc:  # pragma: no cover - defensive boundary
-            logger.error("Extension runtime recovery failed for %s: %s", service_id, exc)
+            logger.error(
+                "Extension runtime recovery failed for %s: %s", service_id, exc
+            )
             start_ok, hook_warnings = False, []
         for warning in hook_warnings:
             logger.warning("Recovered %s with warning: %s", service_id, warning)
@@ -1807,10 +1935,7 @@ def _transaction_failure(
     if recovery_failures:
         return HTTPException(
             status_code=500,
-            detail=(
-                f"{message}; recovery incomplete: "
-                + ", ".join(recovery_failures)
-            ),
+            detail=(f"{message}; recovery incomplete: " + ", ".join(recovery_failures)),
         )
     return HTTPException(status_code=502, detail=f"{message}; {recovered_label}")
 
@@ -1826,17 +1951,26 @@ def update_extension(
     _validate_service_id(service_id)
     _assert_not_core(service_id)
     dest = USER_EXTENSIONS_DIR / service_id
-    if (dest.is_symlink() or not dest.resolve().is_relative_to(USER_EXTENSIONS_DIR.resolve())
-            or not dest.is_dir()):
-        raise HTTPException(status_code=404, detail=f"Extension not installed: {service_id}")
+    if (
+        dest.is_symlink()
+        or not dest.resolve().is_relative_to(USER_EXTENSIONS_DIR.resolve())
+        or not dest.is_dir()
+    ):
+        raise HTTPException(
+            status_code=404, detail=f"Extension not installed: {service_id}"
+        )
     if not _is_installable(service_id):
-        raise HTTPException(status_code=409, detail="No deployable library update is available")
+        raise HTTPException(
+            status_code=409, detail="No deployable library update is available"
+        )
 
     backup = _extension_backup_dir(service_id)
     with _extensions_lock():
         progress = _read_progress(service_id)
         if _progress_blocks_mutation(progress):
-            raise HTTPException(status_code=409, detail="Extension operation is still in progress")
+            raise HTTPException(
+                status_code=409, detail="Extension operation is still in progress"
+            )
         state = _library_update_state(service_id)
         if state["update_status"] == "current" and not force:
             raise HTTPException(status_code=409, detail="Extension is already current")
@@ -1889,9 +2023,13 @@ def update_extension(
                 installed_digest=installed_digest,
             )
             if backup.parent.is_symlink() or backup.is_symlink():
-                raise HTTPException(status_code=409, detail="Extension backup path is a symlink")
+                raise HTTPException(
+                    status_code=409, detail="Extension backup path is a symlink"
+                )
             if backup.exists() and not backup.is_dir():
-                raise HTTPException(status_code=409, detail="Extension backup path is not a directory")
+                raise HTTPException(
+                    status_code=409, detail="Extension backup path is not a directory"
+                )
             # Retire the prior rollback point aside instead of deleting it
             # before the new update has committed: a failure between here
             # and the staged->dest swap must leave the old backup intact.
@@ -1899,11 +2037,19 @@ def update_extension(
             if backup.exists():
                 retire_parent = USER_EXTENSIONS_DIR / ".tmp"
                 if retire_parent.is_symlink():
-                    raise HTTPException(status_code=409, detail="Extension tmp path is a symlink")
+                    raise HTTPException(
+                        status_code=409, detail="Extension tmp path is a symlink"
+                    )
                 retire_parent.mkdir(parents=True, exist_ok=True)
-                retired = Path(tempfile.mkdtemp(
-                    prefix=f".{service_id}-retired-backup-", dir=retire_parent,
-                )) / service_id
+                retired = (
+                    Path(
+                        tempfile.mkdtemp(
+                            prefix=f".{service_id}-retired-backup-",
+                            dir=retire_parent,
+                        )
+                    )
+                    / service_id
+                )
                 os.replace(backup, retired)
             backup.parent.mkdir(parents=True, exist_ok=True)
             os.replace(dest, backup)
@@ -1919,7 +2065,8 @@ def update_extension(
                         logger.error(
                             "Update failed for %s and the prior backup could "
                             "not be re-seated; parked at %s",
-                            service_id, retired,
+                            service_id,
+                            retired,
                         )
                 raise
             _invalidate_extension_digest_cache(dest, backup, staged)
@@ -1927,11 +2074,15 @@ def update_extension(
             if retired is not None:
                 shutil.rmtree(retired.parent, ignore_errors=True)
 
-    ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
+    ext = next(
+        (entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {}
+    )
     one_shot = _is_one_shot_extension(ext)
     if not _sync_extension_config(service_id, preserve_existing=True):
         recovery_failures = _recover_extension_swap(
-            service_id, enabled=enabled, one_shot=one_shot,
+            service_id,
+            enabled=enabled,
+            one_shot=one_shot,
         )
         raise _transaction_failure(
             "Extension update config sync failed",
@@ -1944,7 +2095,9 @@ def update_extension(
         start_ok, start_warnings = _start_extension_lifecycle(service_id)
         if not start_ok:
             recovery_failures = _recover_extension_swap(
-                service_id, enabled=enabled, one_shot=one_shot,
+                service_id,
+                enabled=enabled,
+                one_shot=one_shot,
             )
             raise _transaction_failure(
                 "Extension update failed to start",
@@ -1963,10 +2116,10 @@ def update_extension(
         "warnings": warnings,
         "message": (
             "Extension definition updated; disabled state preserved."
-            if disabled else
-            "Extension updated and started."
-            if not one_shot else
-            "CLI extension updated."
+            if disabled
+            else "Extension updated and started."
+            if not one_shot
+            else "CLI extension updated."
         ),
     }
 
@@ -1985,10 +2138,18 @@ def rollback_extension_update(
     with _extensions_lock():
         progress = _read_progress(service_id)
         if _progress_blocks_mutation(progress):
-            raise HTTPException(status_code=409, detail="Extension operation is still in progress")
-        if (not dest.is_dir() or dest.is_symlink()
-                or not backup.is_dir() or backup.is_symlink()):
-            raise HTTPException(status_code=404, detail="No extension update backup is available")
+            raise HTTPException(
+                status_code=409, detail="Extension operation is still in progress"
+            )
+        if (
+            not dest.is_dir()
+            or dest.is_symlink()
+            or not backup.is_dir()
+            or backup.is_symlink()
+        ):
+            raise HTTPException(
+                status_code=404, detail="No extension update backup is available"
+            )
         enabled = (dest / "compose.yaml").is_file()
         if not _set_extension_compose_state(dest, enabled=enabled):
             raise HTTPException(
@@ -2004,14 +2165,20 @@ def rollback_extension_update(
                 detail="Extension update backup has an invalid compose state",
             )
         if not _restore_extension_backup(service_id):
-            raise HTTPException(status_code=500, detail="Could not restore extension backup")
+            raise HTTPException(
+                status_code=500, detail="Could not restore extension backup"
+            )
         _call_agent_invalidate_compose_cache()
 
-    ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
+    ext = next(
+        (entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {}
+    )
     one_shot = _is_one_shot_extension(ext)
     if not _sync_extension_config(service_id, preserve_existing=True):
         recovery_failures = _recover_extension_swap(
-            service_id, enabled=enabled, one_shot=one_shot,
+            service_id,
+            enabled=enabled,
+            one_shot=one_shot,
         )
         raise _transaction_failure(
             "Rollback config sync failed",
@@ -2024,7 +2191,9 @@ def rollback_extension_update(
         start_ok, start_warnings = _start_extension_lifecycle(service_id)
         if not start_ok:
             recovery_failures = _recover_extension_swap(
-                service_id, enabled=enabled, one_shot=one_shot,
+                service_id,
+                enabled=enabled,
+                one_shot=one_shot,
             )
             raise _transaction_failure(
                 "Rollback failed to start",
@@ -2091,7 +2260,10 @@ def _is_dep_satisfied(dep: str) -> bool:
 
 
 def _get_missing_deps_transitive(
-    service_id: str, *, _visiting: set | None = None, _order: list | None = None,
+    service_id: str,
+    *,
+    _visiting: set | None = None,
+    _order: list | None = None,
 ) -> list[str]:
     """Return all transitive missing deps in dependency order (leaves first).
 
@@ -2141,7 +2313,8 @@ def _activate_service(service_id: str) -> dict:
 
     if not disabled_compose.exists():
         raise HTTPException(
-            status_code=404, detail=f"Extension has no compose file: {service_id}",
+            status_code=404,
+            detail=f"Extension has no compose file: {service_id}",
         )
 
     # Re-scan compose content (TOCTOU prevention). Built-in extensions
@@ -2165,7 +2338,8 @@ def _activate_service(service_id: str) -> dict:
     st = os.lstat(disabled_compose)
     if stat.S_ISLNK(st.st_mode):
         raise HTTPException(
-            status_code=400, detail="Compose file is a symlink",
+            status_code=400,
+            detail="Compose file is a symlink",
         )
 
     # Built-in extensions live on a :ro mount — delegate rename to host agent
@@ -2203,7 +2377,8 @@ def enable_extension(
             st = os.lstat(enabled_compose)
             if stat.S_ISLNK(st.st_mode):
                 raise HTTPException(
-                    status_code=400, detail="Compose file is a symlink",
+                    status_code=400,
+                    detail="Compose file is a symlink",
                 )
             # Built-in extensions legitimately use their own service name which
             # appears in CORE_SERVICE_IDS — skip the name-collision check for
@@ -2232,14 +2407,16 @@ def enable_extension(
             "action": "enabled",
             "restart_required": not agent_ok,
             "message": (
-                "Extension started." if agent_ok
+                "Extension started."
+                if agent_ok
                 else "Extension is enabled. Run 'ods restart' to start."
             ),
         }
 
     if not disabled_compose.exists():
         raise HTTPException(
-            status_code=404, detail=f"Extension has no compose file: {service_id}",
+            status_code=404,
+            detail=f"Extension has no compose file: {service_id}",
         )
 
     # Check dependencies (transitive — gathers full tree, detects cycles)
@@ -2295,8 +2472,11 @@ def enable_extension(
                 f"{svc_id}: post_start hook failed — manual configuration may be needed",
             )
 
-    logger.info("Enabled extension: %s (deps: %s)", service_id,
-                enabled_services[:-1] if len(enabled_services) > 1 else "none")
+    logger.info(
+        "Enabled extension: %s (deps: %s)",
+        service_id,
+        enabled_services[:-1] if len(enabled_services) > 1 else "none",
+    )
     return {
         "id": service_id,
         "action": "enabled",
@@ -2304,7 +2484,8 @@ def enable_extension(
         "restart_required": not agent_ok,
         "warnings": warnings,
         "message": (
-            "Extension enabled and started." if agent_ok
+            "Extension enabled and started."
+            if agent_ok
             else "Extension enabled. Run 'ods restart' to start."
         ),
     }
@@ -2312,7 +2493,11 @@ def enable_extension(
 
 @router.post("/api/extensions/{service_id}/disable")
 @_serialize_extension_operation
-def disable_extension(service_id: str, include_data_info: bool = Query(True), api_key: str = Depends(verify_api_key)):
+def disable_extension(
+    service_id: str,
+    include_data_info: bool = Query(True),
+    api_key: str = Depends(verify_api_key),
+):
     """Disable an enabled extension."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
@@ -2324,7 +2509,8 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
 
     if not enabled_compose.exists():
         raise HTTPException(
-            status_code=409, detail=f"Extension already disabled: {service_id}",
+            status_code=409,
+            detail=f"Extension already disabled: {service_id}",
         )
 
     # Check reverse dependents (warn, don't block). Scan user and built-in
@@ -2341,8 +2527,11 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
         except OSError:
             continue
         for peer_dir in peer_dirs:
-            if (not peer_dir.is_dir() or peer_dir.name == service_id
-                    or peer_dir.name in seen_peers):
+            if (
+                not peer_dir.is_dir()
+                or peer_dir.name == service_id
+                or peer_dir.name in seen_peers
+            ):
                 continue
             seen_peers.add(peer_dir.name)
             if not (peer_dir / "compose.yaml").exists():
@@ -2353,14 +2542,17 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
     # Call agent to stop BEFORE renaming (prevents zombie containers)
     agent_ok = _call_agent("stop", service_id)
     if not agent_ok:
-        logger.warning("Could not stop %s via agent — container may still be running", service_id)
+        logger.warning(
+            "Could not stop %s via agent — container may still be running", service_id
+        )
 
     with _extensions_lock():
         # lstat check inside lock (TOCTOU prevention)
         st = os.lstat(enabled_compose)
         if stat.S_ISLNK(st.st_mode):
             raise HTTPException(
-                status_code=400, detail="Compose file is a symlink",
+                status_code=400,
+                detail="Compose file is a symlink",
             )
 
         # Built-in extensions live on a :ro mount — delegate rename to host agent
@@ -2381,7 +2573,8 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
     logger.info("Disabled extension: %s", service_id)
 
     message = (
-        "Extension disabled and stopped." if agent_ok
+        "Extension disabled and stopped."
+        if agent_ok
         else "Extension disabled. Run 'ods restart' to apply changes."
     )
     if dependents_warning:
@@ -2402,7 +2595,11 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
 
 @router.delete("/api/extensions/{service_id}")
 @_serialize_extension_operation
-def uninstall_extension(service_id: str, include_data_info: bool = Query(True), api_key: str = Depends(verify_api_key)):
+def uninstall_extension(
+    service_id: str,
+    include_data_info: bool = Query(True),
+    api_key: str = Depends(verify_api_key),
+):
     """Uninstall a disabled extension."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
@@ -2413,11 +2610,13 @@ def uninstall_extension(service_id: str, include_data_info: bool = Query(True), 
     ext_dir = ext_candidate.resolve()
     if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
         raise HTTPException(
-            status_code=404, detail=f"Extension not found: {service_id}",
+            status_code=404,
+            detail=f"Extension not found: {service_id}",
         )
     if not ext_dir.is_dir():
         raise HTTPException(
-            status_code=404, detail=f"Extension not installed: {service_id}",
+            status_code=404,
+            detail=f"Extension not installed: {service_id}",
         )
 
     # Must be disabled before uninstall
@@ -2432,19 +2631,24 @@ def uninstall_extension(service_id: str, include_data_info: bool = Query(True), 
         st = os.lstat(ext_dir)
         if stat.S_ISLNK(st.st_mode):
             raise HTTPException(
-                status_code=400, detail="Extension directory is a symlink",
+                status_code=400,
+                detail="Extension directory is a symlink",
             )
 
         try:
             shutil.rmtree(ext_dir)
         except OSError as e:
             logger.error("Failed to remove extension %s: %s", service_id, e)
-            raise HTTPException(status_code=500, detail=f"Failed to remove extension files: {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Failed to remove extension files: {e}"
+            )
         _call_agent_invalidate_compose_cache()
 
         backup = _extension_backup_dir(service_id)
         if backup.parent.is_symlink():
-            logger.warning("Refusing to clean extension backup through symlink: %s", backup.parent)
+            logger.warning(
+                "Refusing to clean extension backup through symlink: %s", backup.parent
+            )
         elif backup.is_symlink():
             backup.unlink(missing_ok=True)
         elif backup.is_dir():
@@ -2480,32 +2684,48 @@ def purge_extension_data(
         raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
 
     if service_id in ALWAYS_ON_SERVICES:
-        raise HTTPException(status_code=403, detail="Cannot purge always-on service data")
+        raise HTTPException(
+            status_code=403, detail="Cannot purge always-on service data"
+        )
 
     with _extensions_lock():
         # Check if service is still enabled (built-in or user extension)
-        for check_dir in [Path(EXTENSIONS_DIR) / service_id, USER_EXTENSIONS_DIR / service_id]:
+        for check_dir in [
+            Path(EXTENSIONS_DIR) / service_id,
+            USER_EXTENSIONS_DIR / service_id,
+        ]:
             if (check_dir / "compose.yaml").exists():
-                raise HTTPException(status_code=400, detail=f"{service_id} is still enabled. Disable it first.")
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"{service_id} is still enabled. Disable it first.",
+                )
 
         data_path = (Path(DATA_DIR) / service_id).resolve()
         if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
             raise HTTPException(status_code=400, detail="Invalid data path")
 
         if not data_path.is_dir():
-            raise HTTPException(status_code=404, detail=f"No data directory found for {service_id}")
+            raise HTTPException(
+                status_code=404, detail=f"No data directory found for {service_id}"
+            )
 
         if not body.confirm:
-            raise HTTPException(status_code=400, detail="Confirmation required: set confirm=true")
+            raise HTTPException(
+                status_code=400, detail="Confirmation required: set confirm=true"
+            )
 
         from helpers import dir_size_gb, invalidate_dir_size_cache  # noqa: PLC0415
+
         size_gb = dir_size_gb(data_path)
 
-        shutil.rmtree(data_path, ignore_errors=True)
+        shutil.rmtree(data_path)
         invalidate_dir_size_cache(data_path)
 
         if data_path.exists():
-            raise HTTPException(status_code=500, detail=f"Could not fully remove data/{service_id}. Some files may be owned by root.")
+            raise HTTPException(
+                status_code=500,
+                detail=f"Could not fully remove data/{service_id}. Some files may be owned by root.",
+            )
 
         # Also clean up the per-service install-progress file so
         # _compute_extension_status does not keep showing a stale "installing"
@@ -2529,8 +2749,12 @@ def orphaned_storage(api_key: str = Depends(verify_api_key)):
     # state created outside the installer: extension-progress (this router)
     # and config-backups (host agent's .env backup writer).
     system_dirs = {
-        "models", "config", "user-extensions", "extensions-library",
-        "extension-progress", "config-backups",
+        "models",
+        "config",
+        "user-extensions",
+        "extensions-library",
+        "extension-progress",
+        "config-backups",
     }
     known_ids = set(SERVICES.keys()) | system_dirs
 
@@ -2542,7 +2766,9 @@ def orphaned_storage(api_key: str = Depends(verify_api_key)):
         if child.name in known_ids:
             continue
         size = dir_size_gb(child)
-        orphaned.append({"name": child.name, "size_gb": size, "path": f"data/{child.name}"})
+        orphaned.append(
+            {"name": child.name, "size_gb": size, "path": f"data/{child.name}"}
+        )
         total += size
 
     return {"orphaned": orphaned, "total_gb": round(total, 2)}

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -16,8 +16,14 @@ from routers.extensions import _assert_not_core
 # --- Helpers ---
 
 
-def _make_catalog_ext(ext_id, name="Test", category="optional",
-                      gpu_backends=None, env_vars=None, features=None):
+def _make_catalog_ext(
+    ext_id,
+    name="Test",
+    category="optional",
+    gpu_backends=None,
+    env_vars=None,
+    features=None,
+):
     return {
         "id": ext_id,
         "name": name,
@@ -37,7 +43,11 @@ def _make_catalog_ext(ext_id, name="Test", category="optional",
 
 def _make_service_status(sid, status="healthy"):
     return ServiceStatus(
-        id=sid, name=sid, port=8080, external_port=8080, status=status,
+        id=sid,
+        name=sid,
+        port=8080,
+        external_port=8080,
+        status=status,
     )
 
 
@@ -52,8 +62,9 @@ def can_create_symlinks(tmp_path: Path) -> bool:
     return link.is_symlink()
 
 
-def _patch_extensions_config(monkeypatch, catalog, services=None,
-                             gpu_backend="nvidia", tmp_path=None):
+def _patch_extensions_config(
+    monkeypatch, catalog, services=None, gpu_backend="nvidia", tmp_path=None
+):
     """Apply standard patches for extensions router tests."""
     monkeypatch.setattr("routers.extensions.EXTENSION_CATALOG", catalog)
     monkeypatch.setattr("routers.extensions.SERVICES", services or {})
@@ -62,24 +73,27 @@ def _patch_extensions_config(monkeypatch, catalog, services=None,
     user_dir = (tmp_path / "user") if tmp_path else Path("/tmp/nonexistent-user")
     monkeypatch.setattr("routers.extensions.EXTENSIONS_LIBRARY_DIR", lib_dir)
     monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
-    monkeypatch.setattr("routers.extensions.DATA_DIR",
-                        str(tmp_path or "/tmp/nonexistent"))
+    monkeypatch.setattr(
+        "routers.extensions.DATA_DIR", str(tmp_path or "/tmp/nonexistent")
+    )
 
 
 # --- Catalog endpoint ---
 
 
 class TestExtensionsCatalog:
-
-    def test_catalog_returns_enriched_extensions(self, test_client, monkeypatch, tmp_path):
+    def test_catalog_returns_enriched_extensions(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Catalog endpoint returns extensions with status enrichment."""
         catalog = [_make_catalog_ext("test-svc", "Test Service")]
         services = {"test-svc": {"host": "localhost", "port": 8080, "name": "Test"}}
         _patch_extensions_config(monkeypatch, catalog, services, tmp_path=tmp_path)
 
         mock_svc = _make_service_status("test-svc", "healthy")
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[mock_svc]):
+        with patch(
+            "helpers.get_all_services", new_callable=AsyncMock, return_value=[mock_svc]
+        ):
             resp = test_client.get(
                 "/api/extensions/catalog",
                 headers=test_client.auth_headers,
@@ -93,7 +107,9 @@ class TestExtensionsCatalog:
         assert "summary" in data
         assert data["gpu_backend"] == "nvidia"
 
-    def test_catalog_merges_manifest_llm_contract(self, test_client, monkeypatch, tmp_path):
+    def test_catalog_merges_manifest_llm_contract(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Catalog rows expose the runtime manifest LLM contract."""
         catalog = [_make_catalog_ext("llm-app", "LLM App")]
         services = {
@@ -113,8 +129,9 @@ class TestExtensionsCatalog:
         _patch_extensions_config(monkeypatch, catalog, services, tmp_path=tmp_path)
 
         mock_svc = _make_service_status("llm-app", "healthy")
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[mock_svc]):
+        with patch(
+            "helpers.get_all_services", new_callable=AsyncMock, return_value=[mock_svc]
+        ):
             resp = test_client.get(
                 "/api/extensions/catalog",
                 headers=test_client.auth_headers,
@@ -134,8 +151,7 @@ class TestExtensionsCatalog:
         ]
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
 
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[]):
+        with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
             resp = test_client.get(
                 "/api/extensions/catalog?category=ai",
                 headers=test_client.auth_headers,
@@ -152,11 +168,11 @@ class TestExtensionsCatalog:
             _make_catalog_ext("compat", "Compatible", gpu_backends=["nvidia"]),
             _make_catalog_ext("incompat", "Incompatible", gpu_backends=["amd"]),
         ]
-        _patch_extensions_config(monkeypatch, catalog, gpu_backend="nvidia",
-                                 tmp_path=tmp_path)
+        _patch_extensions_config(
+            monkeypatch, catalog, gpu_backend="nvidia", tmp_path=tmp_path
+        )
 
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[]):
+        with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
             resp = test_client.get(
                 "/api/extensions/catalog?gpu_compatible=true",
                 headers=test_client.auth_headers,
@@ -180,15 +196,17 @@ class TestExtensionsCatalog:
             "enabled-svc": {"host": "localhost", "port": 8080, "name": "Enabled"},
             "disabled-svc": {"host": "localhost", "port": 8081, "name": "Disabled"},
         }
-        _patch_extensions_config(monkeypatch, catalog, services,
-                                 gpu_backend="nvidia", tmp_path=tmp_path)
+        _patch_extensions_config(
+            monkeypatch, catalog, services, gpu_backend="nvidia", tmp_path=tmp_path
+        )
 
         mock_svcs = [
             _make_service_status("enabled-svc", "healthy"),
             _make_service_status("disabled-svc", "down"),
         ]
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=mock_svcs):
+        with patch(
+            "helpers.get_all_services", new_callable=AsyncMock, return_value=mock_svcs
+        ):
             resp = test_client.get(
                 "/api/extensions/catalog",
                 headers=test_client.auth_headers,
@@ -207,8 +225,7 @@ class TestExtensionsCatalog:
         """Missing catalog file results in empty extensions list."""
         _patch_extensions_config(monkeypatch, [], tmp_path=tmp_path)
 
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[]):
+        with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
             resp = test_client.get(
                 "/api/extensions/catalog",
                 headers=test_client.auth_headers,
@@ -229,14 +246,12 @@ class TestExtensionsCatalog:
 
 
 class TestExtensionDetail:
-
     def test_detail_returns_extension(self, test_client, monkeypatch, tmp_path):
         """Detail endpoint returns correct extension with setup instructions."""
         catalog = [_make_catalog_ext("test-svc", "Test Service")]
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
 
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[]):
+        with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
             resp = test_client.get(
                 "/api/extensions/test-svc",
                 headers=test_client.auth_headers,
@@ -252,7 +267,9 @@ class TestExtensionDetail:
         assert data["setup_instructions"]["cli_enable"] == "ods enable test-svc"
         assert data["setup_instructions"]["cli_disable"] == "ods disable test-svc"
 
-    def test_detail_returns_configured_public_url(self, test_client, monkeypatch, tmp_path):
+    def test_detail_returns_configured_public_url(
+        self, test_client, monkeypatch, tmp_path
+    ):
         catalog = [_make_catalog_ext("test-svc", "Test Service")]
         services = {
             "test-svc": {
@@ -319,7 +336,6 @@ class TestExtensionDetail:
 
 
 class TestUserExtensionStatus:
-
     def test_user_ext_compose_yaml_healthy(self, test_client, monkeypatch, tmp_path):
         """User extension with compose.yaml + healthy service → enabled."""
         user_dir = tmp_path / "user"
@@ -332,8 +348,9 @@ class TestUserExtensionStatus:
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
         mock_svc = _make_service_status("my-ext", "healthy")
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[mock_svc]):
+        with patch(
+            "helpers.get_all_services", new_callable=AsyncMock, return_value=[mock_svc]
+        ):
             resp = test_client.get(
                 "/api/extensions/catalog",
                 headers=test_client.auth_headers,
@@ -356,10 +373,10 @@ class TestUserExtensionStatus:
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
         # No service in health results — svc is None → stopped
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
+        with patch("user_extensions.get_user_services_cached", return_value={}):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
                 resp = test_client.get(
                     "/api/extensions/catalog",
                     headers=test_client.auth_headers,
@@ -381,8 +398,7 @@ class TestUserExtensionStatus:
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
-        with patch("helpers.get_all_services", new_callable=AsyncMock,
-                   return_value=[]):
+        with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
             resp = test_client.get(
                 "/api/extensions/catalog",
                 headers=test_client.auth_headers,
@@ -407,10 +423,14 @@ def _setup_library_ext(tmp_path, service_id, compose_content=None):
     ext_dir = lib_dir / service_id
     ext_dir.mkdir(exist_ok=True)
     (ext_dir / "compose.yaml").write_text(compose_content or _SAFE_COMPOSE)
-    (ext_dir / "manifest.yaml").write_text(yaml.dump({
-        "schema_version": "ods.services.v1",
-        "service": {"id": service_id, "name": service_id},
-    }))
+    (ext_dir / "manifest.yaml").write_text(
+        yaml.dump(
+            {
+                "schema_version": "ods.services.v1",
+                "service": {"id": service_id, "name": service_id},
+            }
+        )
+    )
     return lib_dir
 
 
@@ -438,17 +458,17 @@ def _patch_mutation_config(monkeypatch, tmp_path, lib_dir=None, user_dir=None):
     monkeypatch.setattr("routers.extensions.EXTENSIONS_LIBRARY_DIR", lib_dir)
     monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
     monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
-    monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
-                        tmp_path / "builtin")
-    monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS",
-                        frozenset({"dashboard-api", "open-webui", "hermes", "hermes-proxy"}))
+    monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", tmp_path / "builtin")
+    monkeypatch.setattr(
+        "routers.extensions.CORE_SERVICE_IDS",
+        frozenset({"dashboard-api", "open-webui", "hermes", "hermes-proxy"}),
+    )
 
 
 # --- Install endpoint ---
 
 
 class TestInstallExtension:
-
     def test_install_copies_and_enables(self, test_client, monkeypatch, tmp_path):
         """Install copies from library and keeps compose.yaml enabled."""
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
@@ -478,8 +498,9 @@ class TestInstallExtension:
         broken_dir = user_dir / "my-ext"
         broken_dir.mkdir(exist_ok=True)
         (broken_dir / "manifest.yaml").write_text("leftover: true\n")
-        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
-                               user_dir=user_dir)
+        _patch_mutation_config(
+            monkeypatch, tmp_path, lib_dir=lib_dir, user_dir=user_dir
+        )
 
         resp = test_client.post(
             "/api/extensions/my-ext/install",
@@ -492,15 +513,19 @@ class TestInstallExtension:
         assert (user_dir / "my-ext" / "compose.yaml").exists()
 
     def test_install_stages_tmp_under_user_extensions_dir(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Library installs must not require write access to the /data mount root."""
         import tempfile
 
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
         user_dir = tmp_path / "user"
-        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
-                               user_dir=user_dir)
+        _patch_mutation_config(
+            monkeypatch, tmp_path, lib_dir=lib_dir, user_dir=user_dir
+        )
 
         captured = {}
         real_mkdtemp = tempfile.mkdtemp
@@ -524,8 +549,9 @@ class TestInstallExtension:
         """409 when extension is already installed."""
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
-        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
-                               user_dir=user_dir)
+        _patch_mutation_config(
+            monkeypatch, tmp_path, lib_dir=lib_dir, user_dir=user_dir
+        )
 
         resp = test_client.post(
             "/api/extensions/my-ext/install",
@@ -533,22 +559,29 @@ class TestInstallExtension:
         )
         assert resp.status_code == 409
 
-    def test_install_retries_after_error_progress(self, test_client, monkeypatch, tmp_path):
+    def test_install_retries_after_error_progress(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """A terminal install error should allow retrying the library install."""
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
         progress_dir = tmp_path / "extension-progress"
         progress_dir.mkdir()
-        (progress_dir / "my-ext.json").write_text(json.dumps({
-            "service_id": "my-ext",
-            "status": "error",
-            "error": "previous compose resolve failed",
-            "started_at": "2026-01-01T00:00:00+00:00",
-            "updated_at": "2026-01-01T00:00:00+00:00",
-        }))
+        (progress_dir / "my-ext.json").write_text(
+            json.dumps(
+                {
+                    "service_id": "my-ext",
+                    "status": "error",
+                    "error": "previous compose resolve failed",
+                    "started_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:00+00:00",
+                }
+            )
+        )
         (user_dir / "my-ext" / "stale.txt").write_text("left over")
-        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
-                               user_dir=user_dir)
+        _patch_mutation_config(
+            monkeypatch, tmp_path, lib_dir=lib_dir, user_dir=user_dir
+        )
 
         resp = test_client.post(
             "/api/extensions/my-ext/install",
@@ -571,7 +604,10 @@ class TestInstallExtension:
         assert resp.status_code == 404
 
     def test_install_rejects_library_entry_without_compose(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when the library entry exists but ships no deployable compose.yaml.
 
@@ -588,10 +624,14 @@ class TestInstallExtension:
         ext_dir.mkdir(exist_ok=True)
         # Only .disabled — no deployable compose.yaml
         (ext_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
-        (ext_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "reference-only", "name": "reference-only"},
-        }))
+        (ext_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {"id": "reference-only", "name": "reference-only"},
+                }
+            )
+        )
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -605,7 +645,10 @@ class TestInstallExtension:
         assert not (tmp_path / "user" / "reference-only").exists()
 
     def test_install_rejects_library_entry_with_only_reference_compose(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Same shape, .reference suffix variant (mirrors fooocus).
 
@@ -618,10 +661,14 @@ class TestInstallExtension:
         ext_dir = lib_dir / "reference-only"
         ext_dir.mkdir(exist_ok=True)
         (ext_dir / "compose.yaml.reference").write_text(_SAFE_COMPOSE)
-        (ext_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "reference-only", "name": "reference-only"},
-        }))
+        (ext_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {"id": "reference-only", "name": "reference-only"},
+                }
+            )
+        )
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -644,8 +691,7 @@ class TestInstallExtension:
     def test_install_rejects_privileged(self, test_client, monkeypatch, tmp_path):
         """400 when compose uses privileged mode."""
         bad_compose = "services:\n  svc:\n    image: test\n    privileged: true\n"
-        lib_dir = _setup_library_ext(tmp_path, "bad-ext",
-                                     compose_content=bad_compose)
+        lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=bad_compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -661,8 +707,7 @@ class TestInstallExtension:
             "services:\n  svc:\n    image: test\n"
             "    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n"
         )
-        lib_dir = _setup_library_ext(tmp_path, "bad-ext",
-                                     compose_content=bad_compose)
+        lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=bad_compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -672,11 +717,12 @@ class TestInstallExtension:
         assert resp.status_code == 400
         assert "Docker socket mount" in resp.json()["detail"]
 
-    def test_install_allows_library_build_context(self, test_client, monkeypatch, tmp_path):
+    def test_install_allows_library_build_context(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Library extensions with build: context are allowed (trusted)."""
         bad_compose = "services:\n  svc:\n    build: .\n"
-        lib_dir = _setup_library_ext(tmp_path, "bad-ext",
-                                     compose_content=bad_compose)
+        lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=bad_compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -693,9 +739,11 @@ class TestInstallExtension:
 
     # test_install_writes_pending_change removed — v3 uses host agent, no pending changes file
 
-
     def test_install_allows_library_host_gateway_extra_host(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Bundled library extensions may use the host-gateway bridge."""
         compose = (
@@ -705,8 +753,9 @@ class TestInstallExtension:
             "    extra_hosts:\n"
             "      - host.docker.internal:host-gateway\n"
         )
-        lib_dir = _setup_library_ext(tmp_path, "host-gateway-ext",
-                                     compose_content=compose)
+        lib_dir = _setup_library_ext(
+            tmp_path, "host-gateway-ext", compose_content=compose
+        )
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -718,7 +767,10 @@ class TestInstallExtension:
         assert resp.json()["action"] == "installed"
 
     def test_install_rejects_untrusted_extra_hosts(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """User-installed extension compose files cannot add host aliases."""
         compose = (
@@ -732,10 +784,14 @@ class TestInstallExtension:
         ext_dir = user_dir / "host-gateway-ext"
         ext_dir.mkdir(parents=True)
         (ext_dir / "compose.yaml.disabled").write_text(compose)
-        (ext_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "host-gateway-ext", "name": "host-gateway-ext"},
-        }))
+        (ext_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {"id": "host-gateway-ext", "name": "host-gateway-ext"},
+                }
+            )
+        )
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         resp = test_client.post(
@@ -747,7 +803,10 @@ class TestInstallExtension:
         assert "extra_hosts" in resp.json()["detail"]
 
     def test_install_rejects_unapproved_library_extra_hosts(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Trusted library status only permits the known host-gateway mapping."""
         compose = (
@@ -757,8 +816,7 @@ class TestInstallExtension:
             "    extra_hosts:\n"
             "      - metadata.google.internal:169.254.169.254\n"
         )
-        lib_dir = _setup_library_ext(tmp_path, "bad-host-ext",
-                                     compose_content=compose)
+        lib_dir = _setup_library_ext(tmp_path, "bad-host-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
         resp = test_client.post(
@@ -774,7 +832,6 @@ class TestInstallExtension:
 
 
 class TestEnableExtension:
-
     def test_enable_renames_to_compose_yaml(self, test_client, monkeypatch, tmp_path):
         """Enable renames compose.yaml.disabled → compose.yaml."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
@@ -792,7 +849,9 @@ class TestEnableExtension:
         assert (user_dir / "my-ext" / "compose.yaml").exists()
         assert not (user_dir / "my-ext" / "compose.yaml.disabled").exists()
 
-    def test_enable_stopped_starts_without_rename(self, test_client, monkeypatch, tmp_path):
+    def test_enable_stopped_starts_without_rename(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Enable when compose.yaml exists (stopped) → starts without rename."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
@@ -807,11 +866,12 @@ class TestEnableExtension:
         # compose.yaml still exists (no rename happened)
         assert (user_dir / "my-ext" / "compose.yaml").exists()
 
-    def test_enable_allows_core_service_dependency(self, test_client, monkeypatch, tmp_path):
+    def test_enable_allows_core_service_dependency(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Enable succeeds when depends_on includes a core service."""
         manifest = {"service": {"depends_on": ["open-webui"]}}
-        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False,
-                                   manifest=manifest)
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False, manifest=manifest)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         resp = test_client.post(
@@ -825,8 +885,7 @@ class TestEnableExtension:
     def test_enable_missing_dependency_400(self, test_client, monkeypatch, tmp_path):
         """400 when a dependency is not enabled."""
         manifest = {"service": {"depends_on": ["missing-dep"]}}
-        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False,
-                                   manifest=manifest)
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False, manifest=manifest)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         resp = test_client.post(
@@ -861,7 +920,9 @@ class TestEnableExtension:
         ext_dir = user_dir / "bad-ext"
         ext_dir.mkdir(exist_ok=True)
         (ext_dir / "compose.yaml.disabled").write_text(bad_compose)
-        (ext_dir / "manifest.yaml").write_text("schema_version: ods.services.v1\nservice:\n  id: bad-ext\n  name: bad-ext\n")
+        (ext_dir / "manifest.yaml").write_text(
+            "schema_version: ods.services.v1\nservice:\n  id: bad-ext\n  name: bad-ext\n"
+        )
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         resp = test_client.post(
@@ -876,7 +937,10 @@ class TestEnableExtensionHookReturnHandling:
     """pre_start failures must block start; post_start failures surface as warnings."""
 
     def test_enable_pre_start_failure_blocks_start(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """pre_start False → start NOT called, error progress written, agent_ok=False."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
@@ -916,7 +980,10 @@ class TestEnableExtensionHookReturnHandling:
         assert "pre_start hook failed" in progress["error"]
 
     def test_enable_post_start_failure_returns_warning(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """post_start False → start IS called, response carries a warning, success path."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
@@ -952,17 +1019,22 @@ class TestEnableExtensionHookReturnHandling:
         assert "post_start hook failed" in data["warnings"][0]
 
     def test_enable_both_hooks_succeed_no_warnings(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Baseline: pre_start + post_start True → no warnings, agent_ok True."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         monkeypatch.setattr(
-            "routers.extensions._call_agent", lambda action, sid: True,
+            "routers.extensions._call_agent",
+            lambda action, sid: True,
         )
         monkeypatch.setattr(
-            "routers.extensions._call_agent_hook", lambda sid, hook: True,
+            "routers.extensions._call_agent_hook",
+            lambda sid, hook: True,
         )
 
         resp = test_client.post(
@@ -977,7 +1049,10 @@ class TestEnableExtensionHookReturnHandling:
         assert data["message"] == "Extension enabled and started."
 
     def test_multi_svc_pre_start_failure_on_dep_does_not_warn(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Multi-svc mixed-outcome: dep pre_start fails, main proceeds.
 
@@ -996,23 +1071,35 @@ class TestEnableExtensionHookReturnHandling:
         dep_dir = user_dir / "dep"
         dep_dir.mkdir()
         (dep_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
-        (dep_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "dep", "name": "dep"},
-        }))
+        (dep_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {"id": "dep", "name": "dep"},
+                }
+            )
+        )
         # Main ext, depends_on dep.
         main_dir = user_dir / "main-ext"
         main_dir.mkdir()
         (main_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
-        (main_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "main-ext", "name": "main-ext",
-                         "depends_on": ["dep"]},
-        }))
+        (main_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {
+                        "id": "main-ext",
+                        "name": "main-ext",
+                        "depends_on": ["dep"],
+                    },
+                }
+            )
+        )
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         monkeypatch.setattr(
-            "routers.extensions._call_agent", lambda action, sid: True,
+            "routers.extensions._call_agent",
+            lambda action, sid: True,
         )
         # pre_start fails for dep; everything else succeeds.
         monkeypatch.setattr(
@@ -1048,7 +1135,10 @@ class TestEnableExtensionHookReturnHandling:
         assert "pre_start hook failed" in progress["error"]
 
     def test_multi_svc_post_start_failure_on_main_only_warns_main(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Multi-svc mixed-outcome: dep all-pass, main post_start fails.
 
@@ -1063,22 +1153,34 @@ class TestEnableExtensionHookReturnHandling:
         dep_dir = user_dir / "dep"
         dep_dir.mkdir()
         (dep_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
-        (dep_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "dep", "name": "dep"},
-        }))
+        (dep_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {"id": "dep", "name": "dep"},
+                }
+            )
+        )
         main_dir = user_dir / "main-ext"
         main_dir.mkdir()
         (main_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
-        (main_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "main-ext", "name": "main-ext",
-                         "depends_on": ["dep"]},
-        }))
+        (main_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {
+                        "id": "main-ext",
+                        "name": "main-ext",
+                        "depends_on": ["dep"],
+                    },
+                }
+            )
+        )
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
         monkeypatch.setattr(
-            "routers.extensions._call_agent", lambda action, sid: True,
+            "routers.extensions._call_agent",
+            lambda action, sid: True,
         )
         # post_start fails ONLY for main-ext.
         monkeypatch.setattr(
@@ -1114,7 +1216,6 @@ class TestEnableExtensionHookReturnHandling:
 
 
 class TestDisableExtension:
-
     def test_disable_renames_to_disabled(self, test_client, monkeypatch, tmp_path):
         """Disable renames compose.yaml → compose.yaml.disabled."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
@@ -1133,7 +1234,10 @@ class TestDisableExtension:
         assert not (user_dir / "my-ext" / "compose.yaml").exists()
 
     def test_disable_builtin_delegates_to_host_agent(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         builtin_root = tmp_path / "builtin"
         ext_dir = builtin_root / "my-ext"
@@ -1172,7 +1276,9 @@ class TestDisableExtension:
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
         progress_file = tmp_path / "extension-progress" / "my-ext.json"
         progress_file.parent.mkdir(parents=True, exist_ok=True)
-        progress_file.write_text('{"status": "started", "updated_at": "2026-04-10T00:00:00"}')
+        progress_file.write_text(
+            '{"status": "started", "updated_at": "2026-04-10T00:00:00"}'
+        )
 
         resp = test_client.post(
             "/api/extensions/my-ext/disable",
@@ -1230,7 +1336,10 @@ class TestDisableExtension:
         assert "dependent-ext" in data["dependents_warning"]
 
     def test_disable_warns_about_builtin_dependents(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Disable warns when an enabled built-in extension depends on the target.
 
@@ -1269,7 +1378,10 @@ class TestDisableExtension:
         assert "dependent-ext" in resp.json()["dependents_warning"]
 
     def test_disable_skips_disabled_dependents(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """A dependent that is itself disabled does not trigger the warning."""
         user_dir = tmp_path / "user"
@@ -1315,7 +1427,6 @@ class TestDisableExtension:
 
 
 class TestUninstallExtension:
-
     def test_uninstall_removes_dir(self, test_client, monkeypatch, tmp_path):
         """Uninstall removes the extension directory."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
@@ -1337,7 +1448,9 @@ class TestUninstallExtension:
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
         progress_file = tmp_path / "extension-progress" / "my-ext.json"
         progress_file.parent.mkdir(parents=True, exist_ok=True)
-        progress_file.write_text('{"status": "started", "updated_at": "2026-04-10T00:00:00"}')
+        progress_file.write_text(
+            '{"status": "started", "updated_at": "2026-04-10T00:00:00"}'
+        )
 
         resp = test_client.delete(
             "/api/extensions/my-ext",
@@ -1467,7 +1580,6 @@ class TestComposeCacheInvalidation:
 
 
 class TestMutationPathTraversal:
-
     def test_path_traversal_all_mutations(self, test_client, monkeypatch, tmp_path):
         """Path traversal IDs are rejected on all mutation endpoints."""
         _patch_mutation_config(monkeypatch, tmp_path)
@@ -1486,17 +1598,21 @@ class TestMutationPathTraversal:
                 url = pattern.format(bad_id)
                 if method == "POST":
                     resp = test_client.post(
-                        url, headers=test_client.auth_headers,
+                        url,
+                        headers=test_client.auth_headers,
                     )
                 elif "/data" in pattern:
                     # Purge endpoint requires a JSON body (PurgeRequest)
                     resp = test_client.request(
-                        "DELETE", url, headers=test_client.auth_headers,
+                        "DELETE",
+                        url,
+                        headers=test_client.auth_headers,
                         json={"confirm": False},
                     )
                 else:
                     resp = test_client.delete(
-                        url, headers=test_client.auth_headers,
+                        url,
+                        headers=test_client.auth_headers,
                     )
                 assert resp.status_code == 404, (
                     f"Expected 404 for {method} {url}, got {resp.status_code}"
@@ -1507,10 +1623,11 @@ class TestMutationPathTraversal:
 
 
 class TestComposeScanEdgeCases:
-
     def test_scan_rejects_cap_add_sys_admin(self, test_client, monkeypatch, tmp_path):
         """400 when compose adds SYS_ADMIN capability."""
-        compose = "services:\n  svc:\n    image: test\n    cap_add:\n      - SYS_ADMIN\n"
+        compose = (
+            "services:\n  svc:\n    image: test\n    cap_add:\n      - SYS_ADMIN\n"
+        )
         lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
@@ -1574,7 +1691,10 @@ class TestComposeScanEdgeCases:
         assert "root" in resp.json()["detail"]
 
     def test_scan_rejects_absolute_host_path_mount(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose mounts an absolute host path."""
         compose = (
@@ -1608,13 +1728,13 @@ class TestComposeScanEdgeCases:
         assert "Docker socket mount" in resp.json()["detail"]
 
     def test_scan_rejects_bare_port_binding(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose uses bare host:container port binding."""
-        compose = (
-            "services:\n  svc:\n    image: test\n"
-            "    ports:\n      - '8080:80'\n"
-        )
+        compose = "services:\n  svc:\n    image: test\n    ports:\n      - '8080:80'\n"
         lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
@@ -1626,7 +1746,10 @@ class TestComposeScanEdgeCases:
         assert "127.0.0.1" in resp.json()["detail"]
 
     def test_scan_allows_localhost_port_binding(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Safe compose with 127.0.0.1 port binding passes scan."""
         compose = (
@@ -1643,7 +1766,10 @@ class TestComposeScanEdgeCases:
         assert resp.status_code == 200
 
     def test_scan_rejects_0000_port_binding(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose binds to 0.0.0.0 explicitly."""
         compose = (
@@ -1661,7 +1787,10 @@ class TestComposeScanEdgeCases:
         assert "127.0.0.1" in resp.json()["detail"]
 
     def test_scan_allows_bind_address_var_with_loopback_default(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """${BIND_ADDRESS:-127.0.0.1} is the sanctioned LAN-toggle pattern (PR #964)."""
         compose = (
@@ -1678,7 +1807,10 @@ class TestComposeScanEdgeCases:
         assert resp.status_code == 200
 
     def test_scan_allows_arbitrary_var_name_with_loopback_default(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Any ${VAR:-127.0.0.1} form is accepted, not just BIND_ADDRESS."""
         compose = (
@@ -1695,7 +1827,10 @@ class TestComposeScanEdgeCases:
         assert resp.status_code == 200
 
     def test_scan_rejects_var_with_non_loopback_default(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """A variable defaulting to 0.0.0.0 must NOT be accepted."""
         compose = (
@@ -1713,7 +1848,10 @@ class TestComposeScanEdgeCases:
         assert "127.0.0.1" in resp.json()["detail"]
 
     def test_scan_rejects_var_without_default(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """A bare ${VAR} (no default) is unsafe — it binds 0.0.0.0 when unset."""
         compose = (
@@ -1731,7 +1869,10 @@ class TestComposeScanEdgeCases:
         assert "127.0.0.1" in resp.json()["detail"]
 
     def test_scan_allows_dict_port_with_bind_address_default(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Dict-form port with host_ip: ${VAR:-127.0.0.1} is also accepted."""
         compose = (
@@ -1750,7 +1891,10 @@ class TestComposeScanEdgeCases:
         assert resp.status_code == 200
 
     def test_scan_rejects_core_service_name(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose service name collides with a core service."""
         compose = "services:\n  open-webui:\n    image: test:latest\n"
@@ -1766,7 +1910,11 @@ class TestComposeScanEdgeCases:
 
     @pytest.mark.parametrize("service_name", ["hermes", "hermes-proxy"])
     def test_scan_rejects_hermes_core_service_name(
-        self, test_client, monkeypatch, tmp_path, service_name,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
+        service_name,
     ):
         """Hermes built-ins must be protected from user extension shadowing."""
         compose = f"services:\n  {service_name}:\n    image: test:latest\n"
@@ -1782,10 +1930,15 @@ class TestComposeScanEdgeCases:
         assert "conflicts with core service" in resp.json()["detail"]
 
     def test_scan_rejects_cap_add_sys_ptrace(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose adds SYS_PTRACE (expanded blocklist)."""
-        compose = "services:\n  svc:\n    image: test\n    cap_add:\n      - SYS_PTRACE\n"
+        compose = (
+            "services:\n  svc:\n    image: test\n    cap_add:\n      - SYS_PTRACE\n"
+        )
         lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
@@ -1797,10 +1950,15 @@ class TestComposeScanEdgeCases:
         assert "SYS_PTRACE" in resp.json()["detail"]
 
     def test_scan_rejects_lowercase_cap(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose adds lowercase capability (case-insensitive check)."""
-        compose = "services:\n  svc:\n    image: test\n    cap_add:\n      - sys_admin\n"
+        compose = (
+            "services:\n  svc:\n    image: test\n    cap_add:\n      - sys_admin\n"
+        )
         lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
@@ -1812,7 +1970,10 @@ class TestComposeScanEdgeCases:
         assert "dangerous capability" in resp.json()["detail"]
 
     def test_scan_rejects_ipc_host(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose uses ipc: host."""
         compose = "services:\n  svc:\n    image: test\n    ipc: host\n"
@@ -1827,7 +1988,10 @@ class TestComposeScanEdgeCases:
         assert "host IPC" in resp.json()["detail"]
 
     def test_scan_rejects_userns_mode_host(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose uses userns_mode: host."""
         compose = "services:\n  svc:\n    image: test\n    userns_mode: host\n"
@@ -1842,7 +2006,10 @@ class TestComposeScanEdgeCases:
         assert "host user namespace" in resp.json()["detail"]
 
     def test_scan_rejects_named_volume_bind_mount(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when top-level volume uses driver_opts to bind-mount host path."""
         compose = (
@@ -1862,7 +2029,10 @@ class TestComposeScanEdgeCases:
         assert "bind-mount host path" in resp.json()["detail"]
 
     def test_scan_rejects_dict_port_without_localhost(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose uses dict-form port binding without 127.0.0.1."""
         compose = (
@@ -1880,13 +2050,13 @@ class TestComposeScanEdgeCases:
         assert "127.0.0.1" in resp.json()["detail"]
 
     def test_scan_rejects_bare_port_no_colon(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose uses bare port without colon (e.g. '8080')."""
-        compose = (
-            "services:\n  svc:\n    image: test\n"
-            "    ports:\n      - '8080'\n"
-        )
+        compose = "services:\n  svc:\n    image: test\n    ports:\n      - '8080'\n"
         lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
 
@@ -1898,7 +2068,10 @@ class TestComposeScanEdgeCases:
         assert "bare port" in resp.json()["detail"]
 
     def test_scan_rejects_security_opt_equals_separator(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose uses security_opt with '=' separator."""
         compose = (
@@ -1916,7 +2089,10 @@ class TestComposeScanEdgeCases:
         assert "dangerous security_opt" in resp.json()["detail"]
 
     def test_scan_rejects_deploy_resources_devices(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when compose requests GPU passthrough via
         deploy.resources.reservations.devices (Compose v2 GPU syntax).
@@ -1953,19 +2129,23 @@ class TestHostPartIsLoopback:
 
     def test_literal_loopback(self):
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("127.0.0.1") is True
 
     def test_var_with_loopback_default(self):
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("${BIND_ADDRESS:-127.0.0.1}") is True
         assert _host_part_is_loopback("${MY_HOST:-127.0.0.1}") is True
 
     def test_rejects_var_without_default(self):
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("${BIND_ADDRESS}") is False
 
     def test_rejects_non_loopback_default(self):
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("${BIND_ADDRESS:-0.0.0.0}") is False
         assert _host_part_is_loopback("${BIND_ADDRESS:-localhost}") is False
 
@@ -1973,33 +2153,39 @@ class TestHostPartIsLoopback:
         """Compose's ${VAR:=default} (assignment) is not the same as
         ${VAR:-default} (substitution); reject defensively."""
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("${BIND_ADDRESS:=127.0.0.1}") is False
 
     def test_rejects_dash_only_default_form(self):
         """${VAR-default} (only-if-unset) differs from ${VAR:-default}
         (only-if-unset-or-empty). Strictly require the colon form."""
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("${BIND_ADDRESS-127.0.0.1}") is False
 
     def test_rejects_zero_padded_loopback(self):
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("127.000.000.001") is False
         assert _host_part_is_loopback("${BIND_ADDRESS:-127.000.000.001}") is False
 
     def test_rejects_ipv6_loopback(self):
         """IPv6 binds aren't in scope for the LAN toggle."""
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("::1") is False
         assert _host_part_is_loopback("[::1]") is False
 
     def test_rejects_trailing_newline(self):
         """fullmatch must defend against `$` matching before \\n."""
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("127.0.0.1\n") is False
         assert _host_part_is_loopback("${BIND_ADDRESS:-127.0.0.1}\n") is False
 
     def test_rejects_empty_and_whitespace(self):
         from routers.extensions import _host_part_is_loopback
+
         assert _host_part_is_loopback("") is False
         assert _host_part_is_loopback(" 127.0.0.1") is False
         assert _host_part_is_loopback("127.0.0.1 ") is False
@@ -2012,43 +2198,53 @@ class TestSplitPortHost:
 
     def test_literal_host_three_parts(self):
         from routers.extensions import _split_port_host
+
         assert _split_port_host("127.0.0.1:8080:80") == ("127.0.0.1", "8080:80")
 
     def test_var_with_default(self):
         from routers.extensions import _split_port_host
+
         assert _split_port_host("${BIND_ADDRESS:-127.0.0.1}:8080:80") == (
-            "${BIND_ADDRESS:-127.0.0.1}", "8080:80",
+            "${BIND_ADDRESS:-127.0.0.1}",
+            "8080:80",
         )
 
     def test_var_with_default_and_proto(self):
         from routers.extensions import _split_port_host
+
         assert _split_port_host("${BIND_ADDRESS:-127.0.0.1}:8554:8554/udp") == (
-            "${BIND_ADDRESS:-127.0.0.1}", "8554:8554/udp",
+            "${BIND_ADDRESS:-127.0.0.1}",
+            "8554:8554/udp",
         )
 
     def test_var_no_default(self):
         """`${VAR}:8080:80` — no `:-` default, but still has the brace."""
         from routers.extensions import _split_port_host
+
         assert _split_port_host("${BIND_ADDRESS}:8080:80") == (
-            "${BIND_ADDRESS}", "8080:80",
+            "${BIND_ADDRESS}",
+            "8080:80",
         )
 
     def test_var_with_default_alone(self):
         """`${VAR:-127.0.0.1}` with NO host:container suffix — must
         return rest='' so the caller's `':' not in core` check kicks in."""
         from routers.extensions import _split_port_host
+
         host, rest = _split_port_host("${BIND_ADDRESS:-127.0.0.1}")
         assert rest == ""
 
     def test_malformed_no_closing_brace(self):
         """`${VAR:-127.0.0.1` (missing `}`) — fail closed."""
         from routers.extensions import _split_port_host
+
         host, rest = _split_port_host("${BIND_ADDRESS:-127.0.0.1")
         assert rest == ""
 
     def test_malformed_no_separator_after_brace(self):
         """`${VAR:-127.0.0.1}8080:80` (no `:` between `}` and host port)."""
         from routers.extensions import _split_port_host
+
         host, rest = _split_port_host("${BIND_ADDRESS:-127.0.0.1}8080:80")
         assert rest == ""
 
@@ -2056,14 +2252,17 @@ class TestSplitPortHost:
         """`8080:80` — host position is a port number, no host_ip; treat
         as no-host so caller rejects (binds 0.0.0.0)."""
         from routers.extensions import _split_port_host
+
         assert _split_port_host("8080:80") == (None, "8080:80")
 
     def test_bare_port_returns_no_host(self):
         from routers.extensions import _split_port_host
+
         assert _split_port_host("8080") == (None, "8080")
 
     def test_empty_string(self):
         from routers.extensions import _split_port_host
+
         assert _split_port_host("") == (None, "")
 
 
@@ -2072,12 +2271,14 @@ class TestScanComposePortBindingRegressionLocks:
     they vaguely look like loopback bindings."""
 
     def test_ipv6_loopback_bracketed_rejected(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """`[::1]:8080:80` is not in the policy; must be rejected."""
         compose = (
-            "services:\n  svc:\n    image: test\n"
-            "    ports:\n      - '[::1]:8080:80'\n"
+            "services:\n  svc:\n    image: test\n    ports:\n      - '[::1]:8080:80'\n"
         )
         lib_dir = _setup_library_ext(tmp_path, "ipv6-ext", compose_content=compose)
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
@@ -2090,7 +2291,10 @@ class TestScanComposePortBindingRegressionLocks:
         assert "127.0.0.1" in resp.json()["detail"]
 
     def test_var_with_proto_suffix_accepted(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """`${VAR:-127.0.0.1}:8554:8554/udp` is the sanctioned pattern
         with an explicit /proto suffix (e.g. frigate's WebRTC port)."""
@@ -2108,7 +2312,10 @@ class TestScanComposePortBindingRegressionLocks:
         assert resp.status_code == 200
 
     def test_hostname_in_host_position_rejected(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """A hostname like `localhost` is not loopback under the regex —
         the runtime resolution might not even resolve to 127.0.0.1
@@ -2136,6 +2343,7 @@ class TestScanComposeSkipNameCollision:
 
     def test_rejects_core_name_by_default(self, tmp_path):
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text("services:\n  open-webui:\n    image: test\n")
         with pytest.raises(HTTPException) as exc:
@@ -2145,12 +2353,14 @@ class TestScanComposeSkipNameCollision:
 
     def test_allows_core_name_when_skipped(self, tmp_path):
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text("services:\n  open-webui:\n    image: test\n")
         _scan_compose_content(compose, skip_name_collision=True)
 
     def test_privileged_still_blocked_when_skipped(self, tmp_path):
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text("services:\n  svc:\n    image: test\n    privileged: true\n")
         with pytest.raises(HTTPException) as exc:
@@ -2159,8 +2369,11 @@ class TestScanComposeSkipNameCollision:
 
     def test_docker_socket_still_blocked_when_skipped(self, tmp_path):
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
-        compose.write_text("services:\n  svc:\n    image: test\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n")
+        compose.write_text(
+            "services:\n  svc:\n    image: test\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n"
+        )
         with pytest.raises(HTTPException) as exc:
             _scan_compose_content(compose, skip_name_collision=True)
         assert "Docker socket" in exc.value.detail
@@ -2173,6 +2386,7 @@ class TestScanComposeVolumeBypass:
 
     def _scan(self, tmp_path, compose_text):
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(compose_text)
         _scan_compose_content(compose)
@@ -2219,8 +2433,7 @@ class TestScanComposeVolumeBypass:
         # A ./subdir bind stays inside the extension's own directory.
         self._scan(
             tmp_path,
-            "services:\n  svc:\n    image: test\n"
-            "    volumes:\n      - ./data:/data\n",
+            "services:\n  svc:\n    image: test\n    volumes:\n      - ./data:/data\n",
         )
 
 
@@ -2245,6 +2458,7 @@ class TestScanComposeSkipGpuPassthroughCheck:
 
     def test_rejects_deploy_devices_by_default(self, tmp_path):
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(self._GPU_COMPOSE)
         with pytest.raises(HTTPException) as exc:
@@ -2258,6 +2472,7 @@ class TestScanComposeSkipGpuPassthroughCheck:
         get rejected when the dashboard-api re-scans during activate/enable.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(self._GPU_COMPOSE)
         # Should not raise
@@ -2274,11 +2489,10 @@ class TestScanComposeSkipGpuPassthroughCheck:
         because no GPU passthrough request can be expressed via null resources.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(
-            "services:\n  svc:\n    image: test\n"
-            "    deploy:\n"
-            "      resources: null\n"
+            "services:\n  svc:\n    image: test\n    deploy:\n      resources: null\n"
         )
         # Should not raise — no GPU request can be expressed via null resources.
         _scan_compose_content(compose)
@@ -2293,6 +2507,7 @@ class TestScanComposeSkipGpuPassthroughCheck:
         only on the new outer guards) cannot reintroduce a 500 here.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(
             "services:\n  svc:\n    image: test\n"
@@ -2314,11 +2529,9 @@ class TestScanComposeSkipGpuPassthroughCheck:
         reintroduce a 500 here.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
-        compose.write_text(
-            "services:\n  svc:\n    image: test\n"
-            "    deploy: null\n"
-        )
+        compose.write_text("services:\n  svc:\n    image: test\n    deploy: null\n")
         # Should not raise.
         _scan_compose_content(compose)
 
@@ -2333,9 +2546,7 @@ class TestScanComposeSkipRootUserCheck:
     root user, while user/library extensions cannot. Regression guard for
     the openclaw init-time chown + setpriv pattern."""
 
-    _ROOT_COMPOSE = (
-        'services:\n  svc:\n    image: test\n    user: "0:0"\n'
-    )
+    _ROOT_COMPOSE = 'services:\n  svc:\n    image: test\n    user: "0:0"\n'
 
     def test_builtin_with_root_user_accepted(self, tmp_path):
         """A built-in extension with user: 0:0 (init-time chown + setpriv
@@ -2344,6 +2555,7 @@ class TestScanComposeSkipRootUserCheck:
         `user: '0:0'` must be accepted when skip_root_user_check=True.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(self._ROOT_COMPOSE)
         # Should not raise
@@ -2355,6 +2567,7 @@ class TestScanComposeSkipRootUserCheck:
         new parameter doesn't accidentally weaken security for non-built-ins.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(self._ROOT_COMPOSE)
         with pytest.raises(HTTPException) as exc:
@@ -2368,6 +2581,7 @@ class TestScanComposeSkipRootUserCheck:
         exemption.
         """
         from routers.extensions import _scan_compose_content
+
         compose = tmp_path / "compose.yaml"
         compose.write_text(
             'services:\n  svc:\n    image: test\n    user: "0:0"\n'
@@ -2382,9 +2596,11 @@ class TestScanComposeSkipRootUserCheck:
 
 
 class TestInstallSizeQuota:
-
     def test_install_rejects_oversized_extension(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """400 when extension exceeds 50MB size limit."""
         lib_dir = _setup_library_ext(tmp_path, "huge-ext")
@@ -2405,31 +2621,52 @@ class TestInstallSizeQuota:
 
 
 class TestExtensionLifecycleStatus:
-
-    def test_user_extension_enabled_and_healthy(self, test_client, monkeypatch, tmp_path):
+    def test_user_extension_enabled_and_healthy(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """User extension with compose.yaml + healthy container → enabled."""
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)
         (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
-        (ext_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "my-ext", "name": "My Ext", "port": 8080,
-                         "health": "/health"},
-        }))
+        (ext_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {
+                        "id": "my-ext",
+                        "name": "My Ext",
+                        "port": 8080,
+                        "health": "/health",
+                    },
+                }
+            )
+        )
 
         catalog = [_make_catalog_ext("my-ext", "My Extension")]
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
         mock_svc = _make_service_status("my-ext", "healthy")
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={"my-ext": {"host": "my-ext", "port": 8080,
-                                             "health": "/health", "name": "My Ext"}}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
-                with patch("helpers.check_service_health", new_callable=AsyncMock,
-                           return_value=mock_svc):
+        with patch(
+            "user_extensions.get_user_services_cached",
+            return_value={
+                "my-ext": {
+                    "host": "my-ext",
+                    "port": 8080,
+                    "health": "/health",
+                    "name": "My Ext",
+                }
+            },
+        ):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
+                with patch(
+                    "helpers.check_service_health",
+                    new_callable=AsyncMock,
+                    return_value=mock_svc,
+                ):
                     resp = test_client.get(
                         "/api/extensions/catalog",
                         headers=test_client.auth_headers,
@@ -2439,30 +2676,52 @@ class TestExtensionLifecycleStatus:
         ext = resp.json()["extensions"][0]
         assert ext["status"] == "enabled"
 
-    def test_user_extension_enabled_but_unhealthy(self, test_client, monkeypatch, tmp_path):
+    def test_user_extension_enabled_but_unhealthy(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """User extension with compose.yaml + unhealthy container → stopped."""
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)
         (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
-        (ext_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "my-ext", "name": "My Ext", "port": 8080,
-                         "health": "/health"},
-        }))
+        (ext_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {
+                        "id": "my-ext",
+                        "name": "My Ext",
+                        "port": 8080,
+                        "health": "/health",
+                    },
+                }
+            )
+        )
 
         catalog = [_make_catalog_ext("my-ext", "My Extension")]
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
         mock_svc = _make_service_status("my-ext", "down")
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={"my-ext": {"host": "my-ext", "port": 8080,
-                                             "health": "/health", "name": "My Ext"}}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
-                with patch("helpers.check_service_health", new_callable=AsyncMock,
-                           return_value=mock_svc):
+        with patch(
+            "user_extensions.get_user_services_cached",
+            return_value={
+                "my-ext": {
+                    "host": "my-ext",
+                    "port": 8080,
+                    "health": "/health",
+                    "name": "My Ext",
+                }
+            },
+        ):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
+                with patch(
+                    "helpers.check_service_health",
+                    new_callable=AsyncMock,
+                    return_value=mock_svc,
+                ):
                     resp = test_client.get(
                         "/api/extensions/catalog",
                         headers=test_client.auth_headers,
@@ -2472,30 +2731,52 @@ class TestExtensionLifecycleStatus:
         ext = resp.json()["extensions"][0]
         assert ext["status"] == "stopped"
 
-    def test_user_extension_http_unhealthy_returns_unhealthy(self, test_client, monkeypatch, tmp_path):
+    def test_user_extension_http_unhealthy_returns_unhealthy(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """User extension with compose.yaml + HTTP 4xx/5xx health → unhealthy."""
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)
         (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
-        (ext_dir / "manifest.yaml").write_text(yaml.dump({
-            "schema_version": "ods.services.v1",
-            "service": {"id": "my-ext", "name": "My Ext", "port": 8080,
-                         "health": "/health"},
-        }))
+        (ext_dir / "manifest.yaml").write_text(
+            yaml.dump(
+                {
+                    "schema_version": "ods.services.v1",
+                    "service": {
+                        "id": "my-ext",
+                        "name": "My Ext",
+                        "port": 8080,
+                        "health": "/health",
+                    },
+                }
+            )
+        )
 
         catalog = [_make_catalog_ext("my-ext", "My Extension")]
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
         mock_svc = _make_service_status("my-ext", "unhealthy")
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={"my-ext": {"host": "my-ext", "port": 8080,
-                                             "health": "/health", "name": "My Ext"}}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
-                with patch("helpers.check_service_health", new_callable=AsyncMock,
-                           return_value=mock_svc):
+        with patch(
+            "user_extensions.get_user_services_cached",
+            return_value={
+                "my-ext": {
+                    "host": "my-ext",
+                    "port": 8080,
+                    "health": "/health",
+                    "name": "My Ext",
+                }
+            },
+        ):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
+                with patch(
+                    "helpers.check_service_health",
+                    new_callable=AsyncMock,
+                    return_value=mock_svc,
+                ):
                     resp = test_client.get(
                         "/api/extensions/catalog",
                         headers=test_client.auth_headers,
@@ -2510,7 +2791,9 @@ class TestExtensionLifecycleStatus:
         assert data["summary"]["installed"] == 1
         assert data["summary"]["stopped"] == 0
 
-    def test_user_extension_disabled_unchanged(self, test_client, monkeypatch, tmp_path):
+    def test_user_extension_disabled_unchanged(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """User extension with compose.yaml.disabled → disabled (unchanged)."""
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
@@ -2521,10 +2804,10 @@ class TestExtensionLifecycleStatus:
         _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
+        with patch("user_extensions.get_user_services_cached", return_value={}):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
                 resp = test_client.get(
                     "/api/extensions/catalog",
                     headers=test_client.auth_headers,
@@ -2541,10 +2824,12 @@ class TestExtensionLifecycleStatus:
         _patch_extensions_config(monkeypatch, catalog, services, tmp_path=tmp_path)
 
         mock_svc = _make_service_status("core-svc", "healthy")
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[mock_svc]):
+        with patch("user_extensions.get_user_services_cached", return_value={}):
+            with patch(
+                "helpers.get_all_services",
+                new_callable=AsyncMock,
+                return_value=[mock_svc],
+            ):
                 resp = test_client.get(
                     "/api/extensions/catalog",
                     headers=test_client.auth_headers,
@@ -2554,7 +2839,9 @@ class TestExtensionLifecycleStatus:
         ext = resp.json()["extensions"][0]
         assert ext["status"] == "enabled"
 
-    def test_catalog_includes_user_extension_health(self, test_client, monkeypatch, tmp_path):
+    def test_catalog_includes_user_extension_health(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Catalog response includes 'stopped' in summary counts."""
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
@@ -2566,10 +2853,10 @@ class TestExtensionLifecycleStatus:
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
 
         # No health data → stopped
-        with patch("user_extensions.get_user_services_cached",
-                   return_value={}):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
+        with patch("user_extensions.get_user_services_cached", return_value={}):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
                 resp = test_client.get(
                     "/api/extensions/catalog",
                     headers=test_client.auth_headers,
@@ -2597,13 +2884,15 @@ class TestExtensionLifecycleStatus:
         assert (user_dir / "my-ext" / "compose.yaml").exists()
 
     def test_enable_stopped_writes_error_progress_on_agent_failure(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Enable-stopped path writes error progress with restart guidance on agent failure."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
-        monkeypatch.setattr("routers.extensions._call_agent",
-                            lambda action, sid: False)
+        monkeypatch.setattr("routers.extensions._call_agent", lambda action, sid: False)
 
         resp = test_client.post(
             "/api/extensions/my-ext/enable",
@@ -2614,19 +2903,23 @@ class TestExtensionLifecycleStatus:
         assert resp.json()["restart_required"] is True
 
         progress_file = Path(tmp_path) / "extension-progress" / "my-ext.json"
-        assert progress_file.exists(), "enable-stopped path must write progress on agent failure"
+        assert progress_file.exists(), (
+            "enable-stopped path must write progress on agent failure"
+        )
         data = json.loads(progress_file.read_text())
         assert data["status"] == "error"
         assert "ods restart" in data["error"]
 
     def test_install_error_progress_includes_restart_guidance(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Install failure-path error message contains 'ods restart' actionable guidance."""
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
-        monkeypatch.setattr("routers.extensions._call_agent_install",
-                            lambda sid: False)
+        monkeypatch.setattr("routers.extensions._call_agent_install", lambda sid: False)
 
         resp = test_client.post(
             "/api/extensions/my-ext/install",
@@ -2640,7 +2933,9 @@ class TestExtensionLifecycleStatus:
         assert data["status"] == "error"
         assert "ods restart" in data["error"]
 
-    def test_enable_stopped_rejects_malicious_compose(self, test_client, monkeypatch, tmp_path):
+    def test_enable_stopped_rejects_malicious_compose(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Enable stopped ext with malicious compose.yaml → 400."""
         bad_compose = "services:\n  svc:\n    image: test\n    privileged: true\n"
         user_dir = tmp_path / "user"
@@ -2714,11 +3009,12 @@ class TestExtensionLifecycleStatus:
 
 
 class TestSymlinkHandling:
-
     def test_copytree_safe_skips_symlinks(self, tmp_path):
         """_copytree_safe skips symlinks in source directory."""
         if os.name == "nt" and not can_create_symlinks(tmp_path):
-            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
+            pytest.skip(
+                "Windows symlink creation requires Developer Mode or administrator privileges"
+            )
         from routers.extensions import _copytree_safe
 
         src = tmp_path / "src"
@@ -2733,11 +3029,16 @@ class TestSymlinkHandling:
         assert not (dst / "link.txt").exists()
 
     def test_enable_stopped_rejects_symlinked_compose(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Enable stopped ext rejects a compose.yaml that is a symlink."""
         if os.name == "nt" and not can_create_symlinks(tmp_path):
-            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
+            pytest.skip(
+                "Windows symlink creation requires Developer Mode or administrator privileges"
+            )
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)
@@ -2755,11 +3056,16 @@ class TestSymlinkHandling:
         assert "symlink" in resp.json()["detail"]
 
     def test_enable_rejects_symlinked_compose(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         """Enable rejects a compose.yaml.disabled that is a symlink."""
         if os.name == "nt" and not can_create_symlinks(tmp_path):
-            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
+            pytest.skip(
+                "Windows symlink creation requires Developer Mode or administrator privileges"
+            )
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)
@@ -2781,7 +3087,6 @@ class TestSymlinkHandling:
 
 
 class TestPurgeExtensionData:
-
     def test_purge_happy_path(self, test_client, monkeypatch, tmp_path):
         """Purge succeeds for disabled extension with existing data dir."""
         _patch_mutation_config(monkeypatch, tmp_path)
@@ -2789,10 +3094,16 @@ class TestPurgeExtensionData:
         data_dir.mkdir()
         (data_dir / "some-file.db").write_text("data")
 
-        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()), \
-             patch("helpers.dir_size_gb", return_value=1.5):
+        with (
+            patch(
+                "routers.extensions._extensions_lock",
+                return_value=contextlib.nullcontext(),
+            ),
+            patch("helpers.dir_size_gb", return_value=1.5),
+        ):
             resp = test_client.request(
-                "DELETE", "/api/extensions/my-ext/data",
+                "DELETE",
+                "/api/extensions/my-ext/data",
                 headers=test_client.auth_headers,
                 json={"confirm": True},
             )
@@ -2821,10 +3132,16 @@ class TestPurgeExtensionData:
             ' "updated_at": "2026-04-10T00:00:00+00:00"}'
         )
 
-        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()), \
-             patch("helpers.dir_size_gb", return_value=0.1):
+        with (
+            patch(
+                "routers.extensions._extensions_lock",
+                return_value=contextlib.nullcontext(),
+            ),
+            patch("helpers.dir_size_gb", return_value=0.1),
+        ):
             resp = test_client.request(
-                "DELETE", "/api/extensions/my-ext/data",
+                "DELETE",
+                "/api/extensions/my-ext/data",
                 headers=test_client.auth_headers,
                 json={"confirm": True},
             )
@@ -2843,9 +3160,12 @@ class TestPurgeExtensionData:
         data_dir = tmp_path / "my-ext"
         data_dir.mkdir()
 
-        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+        with patch(
+            "routers.extensions._extensions_lock", return_value=contextlib.nullcontext()
+        ):
             resp = test_client.request(
-                "DELETE", "/api/extensions/my-ext/data",
+                "DELETE",
+                "/api/extensions/my-ext/data",
                 headers=test_client.auth_headers,
                 json={"confirm": True},
             )
@@ -2858,9 +3178,12 @@ class TestPurgeExtensionData:
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
 
-        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+        with patch(
+            "routers.extensions._extensions_lock", return_value=contextlib.nullcontext()
+        ):
             resp = test_client.request(
-                "DELETE", "/api/extensions/my-ext/data",
+                "DELETE",
+                "/api/extensions/my-ext/data",
                 headers=test_client.auth_headers,
                 json={"confirm": True},
             )
@@ -2873,7 +3196,8 @@ class TestPurgeExtensionData:
         _patch_mutation_config(monkeypatch, tmp_path)
 
         resp = test_client.request(
-            "DELETE", "/api/extensions/open-webui/data",
+            "DELETE",
+            "/api/extensions/open-webui/data",
             headers=test_client.auth_headers,
             json={"confirm": True},
         )
@@ -2887,7 +3211,8 @@ class TestPurgeExtensionData:
 
         for bad_id in ["..etc", ".hidden", "UPPERCASE", "-starts-dash"]:
             resp = test_client.request(
-                "DELETE", f"/api/extensions/{bad_id}/data",
+                "DELETE",
+                f"/api/extensions/{bad_id}/data",
                 headers=test_client.auth_headers,
                 json={"confirm": True},
             )
@@ -2897,9 +3222,12 @@ class TestPurgeExtensionData:
         """404 when valid ID but no data directory exists."""
         _patch_mutation_config(monkeypatch, tmp_path)
 
-        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+        with patch(
+            "routers.extensions._extensions_lock", return_value=contextlib.nullcontext()
+        ):
             resp = test_client.request(
-                "DELETE", "/api/extensions/my-ext/data",
+                "DELETE",
+                "/api/extensions/my-ext/data",
                 headers=test_client.auth_headers,
                 json={"confirm": True},
             )
@@ -2913,9 +3241,12 @@ class TestPurgeExtensionData:
         data_dir = tmp_path / "my-ext"
         data_dir.mkdir()
 
-        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+        with patch(
+            "routers.extensions._extensions_lock", return_value=contextlib.nullcontext()
+        ):
             resp = test_client.request(
-                "DELETE", "/api/extensions/my-ext/data",
+                "DELETE",
+                "/api/extensions/my-ext/data",
                 headers=test_client.auth_headers,
                 json={"confirm": False},
             )
@@ -2930,7 +3261,8 @@ class TestPurgeExtensionData:
         _patch_mutation_config(monkeypatch, tmp_path)
 
         resp = test_client.request(
-            "DELETE", "/api/extensions/..%2fetc/data",
+            "DELETE",
+            "/api/extensions/..%2fetc/data",
             headers=test_client.auth_headers,
             json={"confirm": True},
         )
@@ -2940,17 +3272,76 @@ class TestPurgeExtensionData:
     def test_purge_requires_auth(self, test_client):
         """DELETE /api/extensions/{id}/data without auth → 401."""
         resp = test_client.request(
-            "DELETE", "/api/extensions/my-ext/data",
+            "DELETE",
+            "/api/extensions/my-ext/data",
             json={"confirm": True},
         )
         assert resp.status_code == 401
+
+    def test_purge_500_when_rmtree_fails(self, test_client, monkeypatch, tmp_path):
+        """Purge returns 500 when shutil.rmtree raises an error."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+        data_dir = tmp_path / "my-ext"
+        data_dir.mkdir()
+        (data_dir / "some-file.db").write_text("data")
+
+        with (
+            patch(
+                "routers.extensions._extensions_lock",
+                return_value=contextlib.nullcontext(),
+            ),
+            patch("helpers.dir_size_gb", return_value=1.5),
+            patch(
+                "routers.extensions.shutil.rmtree",
+                side_effect=PermissionError("permission denied"),
+            ),
+        ):
+            resp = test_client.request(
+                "DELETE",
+                "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+
+        assert resp.status_code == 500
+        data = resp.json()
+        assert "Could not fully remove" in data.get("detail", "")
+
+    def test_purge_500_when_partial_delete(self, test_client, monkeypatch, tmp_path):
+        """Purge returns 500 when rmtree succeeds partially but dir still exists."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+        data_dir = tmp_path / "my-ext"
+        data_dir.mkdir()
+        (data_dir / "some-file.db").write_text("data")
+
+        def _fake_rmtree(path, *args, **kwargs):
+            # Remove some files but leave the directory
+            (path / "some-file.db").unlink(missing_ok=True)
+
+        with (
+            patch(
+                "routers.extensions._extensions_lock",
+                return_value=contextlib.nullcontext(),
+            ),
+            patch("helpers.dir_size_gb", return_value=1.5),
+            patch("routers.extensions.shutil.rmtree", side_effect=_fake_rmtree),
+        ):
+            resp = test_client.request(
+                "DELETE",
+                "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+
+        assert resp.status_code == 500
+        data = resp.json()
+        assert "Could not fully remove" in data.get("detail", "")
 
 
 # --- Orphaned storage ---
 
 
 class TestOrphanedStorage:
-
     def test_orphaned_requires_auth(self, test_client):
         """GET /api/storage/orphaned without auth → 401."""
         resp = test_client.get("/api/storage/orphaned")
@@ -2975,8 +3366,9 @@ class TestOrphanedStorage:
 
     def test_orphaned_nonexistent_data_dir(self, test_client, monkeypatch, tmp_path):
         """Non-existent data dir returns empty orphaned list."""
-        monkeypatch.setattr("routers.extensions.DATA_DIR",
-                            str(tmp_path / "nonexistent"))
+        monkeypatch.setattr(
+            "routers.extensions.DATA_DIR", str(tmp_path / "nonexistent")
+        )
         monkeypatch.setattr("routers.extensions.SERVICES", {})
 
         resp = test_client.get(
@@ -2995,8 +3387,10 @@ class TestOrphanedStorage:
         data_dir.mkdir()
         (data_dir / "known-svc").mkdir()
         monkeypatch.setattr("routers.extensions.DATA_DIR", str(data_dir))
-        monkeypatch.setattr("routers.extensions.SERVICES",
-                            {"known-svc": {"host": "localhost", "port": 8080}})
+        monkeypatch.setattr(
+            "routers.extensions.SERVICES",
+            {"known-svc": {"host": "localhost", "port": 8080}},
+        )
 
         with patch("helpers.dir_size_gb", return_value=2.0):
             resp = test_client.get(
@@ -3074,11 +3468,11 @@ class TestOrphanedStorage:
         assert data["orphaned"][0]["name"] == "orphan-dir"
         assert data["total_gb"] == 0.5
 
+
 # --- Install progress tracking ---
 
 
 class TestInstallProgress:
-
     def test_progress_endpoint_no_progress(self, test_client, monkeypatch, tmp_path):
         """GET progress when no file exists → idle."""
         _patch_mutation_config(monkeypatch, tmp_path)
@@ -3131,6 +3525,7 @@ class TestInstallProgress:
         progress_dir = tmp_path / "extension-progress"
         progress_dir.mkdir()
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc).isoformat()
         progress_data = {
             "service_id": "my-ext",
@@ -3158,6 +3553,7 @@ class TestInstallProgress:
         progress_dir = tmp_path / "extension-progress"
         progress_dir.mkdir()
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc).isoformat()
         progress_data = {
             "service_id": "my-ext",
@@ -3185,6 +3581,7 @@ class TestInstallProgress:
         progress_dir = tmp_path / "extension-progress"
         progress_dir.mkdir()
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc).isoformat()
         progress_data = {
             "service_id": "my-ext",
@@ -3212,6 +3609,7 @@ class TestInstallProgress:
         progress_dir = tmp_path / "extension-progress"
         progress_dir.mkdir()
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc).isoformat()
         progress_data = {
             "service_id": "my-ext",
@@ -3227,7 +3625,9 @@ class TestInstallProgress:
         status = _compute_extension_status(ext, {})
         assert status == "error"
 
-    def test_status_cli_installed_for_oneshot_started_recent(self, monkeypatch, tmp_path):
+    def test_status_cli_installed_for_oneshot_started_recent(
+        self, monkeypatch, tmp_path
+    ):
         """One-shot extension (port=0) with recent 'started' progress →
         'cli_installed'. Regression: previously the install toast cycled
         through 'installing' / 'stopped' because there is no healthcheck
@@ -3242,6 +3642,7 @@ class TestInstallProgress:
         progress_dir = tmp_path / "extension-progress"
         progress_dir.mkdir()
         from datetime import datetime, timezone
+
         now = datetime.now(timezone.utc).isoformat()
         progress_data = {
             "service_id": "aider",
@@ -3259,7 +3660,9 @@ class TestInstallProgress:
         status = _compute_extension_status(ext, {})
         assert status == "cli_installed"
 
-    def test_status_cli_installed_for_oneshot_user_dir_compose(self, monkeypatch, tmp_path):
+    def test_status_cli_installed_for_oneshot_user_dir_compose(
+        self, monkeypatch, tmp_path
+    ):
         """Steady-state: a one-shot extension (port=0) installed under
         USER_EXTENSIONS_DIR with compose.yaml present should remain
         'cli_installed' even when no recent progress file exists."""
@@ -3350,7 +3753,9 @@ class TestInstallProgress:
 
         assert not (progress_dir / "my-ext.json").exists()
 
-    def test_install_returns_progress_endpoint(self, test_client, monkeypatch, tmp_path):
+    def test_install_returns_progress_endpoint(
+        self, test_client, monkeypatch, tmp_path
+    ):
         """Install response includes progress_endpoint field."""
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
         _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
@@ -3395,7 +3800,8 @@ class TestSyncExtensionConfig:
         from routers import extensions as ext_mod
 
         monkeypatch.setattr(
-            ext_mod, "_call_agent_sync_config",
+            ext_mod,
+            "_call_agent_sync_config",
             lambda _sid, *, preserve_existing=False: False,
         )
         assert ext_mod._sync_extension_config("my-ext") is False
@@ -3433,16 +3839,30 @@ class TestUpdateExtension:
         lib_dir = _setup_library_ext(tmp_path, "my-ext")
         user_dir = tmp_path / "user"
         _patch_mutation_config(
-            monkeypatch, tmp_path, lib_dir=lib_dir, user_dir=user_dir,
-        )
-        monkeypatch.setattr(ext_mod, "EXTENSION_CATALOG", [{
-            "id": "my-ext", "name": "My Ext", "port": 8080,
-        }])
-        monkeypatch.setattr(
-            ext_mod, "_call_agent_invalidate_compose_cache", lambda: None,
+            monkeypatch,
+            tmp_path,
+            lib_dir=lib_dir,
+            user_dir=user_dir,
         )
         monkeypatch.setattr(
-            ext_mod, "_sync_extension_config",
+            ext_mod,
+            "EXTENSION_CATALOG",
+            [
+                {
+                    "id": "my-ext",
+                    "name": "My Ext",
+                    "port": 8080,
+                }
+            ],
+        )
+        monkeypatch.setattr(
+            ext_mod,
+            "_call_agent_invalidate_compose_cache",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            ext_mod,
+            "_sync_extension_config",
             lambda _sid, *, preserve_existing=False: True,
         )
         monkeypatch.setattr(ext_mod, "_call_agent_hook", lambda _sid, _hook: True)
@@ -3455,7 +3875,9 @@ class TestUpdateExtension:
         return ext_mod, lib_dir, user_dir, installed
 
     def test_invalid_id_is_rejected_before_operation_lock(
-        self, test_client, monkeypatch,
+        self,
+        test_client,
+        monkeypatch,
     ):
         from routers import extensions as ext_mod
 
@@ -3467,16 +3889,21 @@ class TestUpdateExtension:
         monkeypatch.setattr(ext_mod, "_extension_operation_lock", unexpected_lock)
 
         response = test_client.post(
-            "/api/extensions/INVALID/update", headers=test_client.auth_headers,
+            "/api/extensions/INVALID/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 404
 
     def test_enable_disable_rename_is_not_a_local_modification(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, _lib, _user, _installed = self._prepare(
-            monkeypatch, tmp_path, enabled=False,
+            monkeypatch,
+            tmp_path,
+            enabled=False,
         )
         state = ext_mod._library_update_state("my-ext")
         assert state["update_status"] == "current"
@@ -3490,7 +3917,10 @@ class TestUpdateExtension:
         assert ext_mod._library_update_state("my-ext")["update_status"] == "current"
 
     def test_staging_rejects_library_change_during_copy(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
@@ -3505,7 +3935,8 @@ class TestUpdateExtension:
         monkeypatch.setattr(ext_mod, "_copytree_safe", copy_then_change)
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 409
@@ -3513,13 +3944,17 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == original
 
     def test_update_replaces_definition_and_keeps_backup(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 200
@@ -3529,14 +3964,18 @@ class TestUpdateExtension:
         assert ext_mod._library_update_state("my-ext")["update_status"] == "current"
 
     def test_update_blocks_local_changes_without_force(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         _ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         (installed / "local.txt").write_text("keep me")
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
 
         blocked = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
         assert blocked.status_code == 409
         assert blocked.json()["detail"]["code"] == "locally_modified"
@@ -3549,39 +3988,51 @@ class TestUpdateExtension:
         assert (user_dir / ".backups" / "my-ext" / "local.txt").read_text() == "keep me"
 
     def test_update_start_failure_restores_previous_definition(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
         start_results = iter([False, True])
         monkeypatch.setattr(
-            ext_mod, "_call_agent",
+            ext_mod,
+            "_call_agent",
             lambda action, _sid: next(start_results) if action == "start" else True,
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 502
         assert "previous definition restored" in response.json()["detail"]
         assert (installed / "manifest.yaml").read_text() == original
-        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
+        assert (
+            user_dir / ".backups" / "my-ext" / "manifest.yaml"
+        ).read_text() == "release: broken\n"
 
     def test_update_start_failure_reports_incomplete_runtime_recovery(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
         monkeypatch.setattr(
-            ext_mod, "_call_agent",
+            ext_mod,
+            "_call_agent",
             lambda action, _sid: False if action == "start" else True,
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 500
@@ -3590,28 +4041,38 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == original
 
     def test_update_config_failure_restores_previous_definition(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
         sync_results = iter([False, True])
         monkeypatch.setattr(
-            ext_mod, "_sync_extension_config",
+            ext_mod,
+            "_sync_extension_config",
             lambda _sid, *, preserve_existing=False: next(sync_results),
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 502
         assert "previous definition restored" in response.json()["detail"]
         assert (installed / "manifest.yaml").read_text() == original
-        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
+        assert (
+            user_dir / ".backups" / "my-ext" / "manifest.yaml"
+        ).read_text() == "release: broken\n"
 
     def test_update_config_failure_reports_incomplete_config_recovery(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
@@ -3623,7 +4084,8 @@ class TestUpdateExtension:
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 500
@@ -3632,34 +4094,45 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == original
 
     def test_update_reports_definition_restore_failure(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, _installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
         start_results = iter([False])
         monkeypatch.setattr(
-            ext_mod, "_call_agent",
+            ext_mod,
+            "_call_agent",
             lambda action, _sid: next(start_results) if action == "start" else True,
         )
         monkeypatch.setattr(ext_mod, "_restore_extension_backup", lambda _sid: False)
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 500
         assert "definition restore failed" in response.json()["detail"]
 
     def test_update_rejects_concurrent_extension_operation(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        monkeypatch.setattr(ext_mod, "_read_progress", lambda _sid: {"status": "pulling"})
+        monkeypatch.setattr(
+            ext_mod, "_read_progress", lambda _sid: {"status": "pulling"}
+        )
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 409
@@ -3667,10 +4140,15 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == original
 
     def test_update_rejects_symlinked_install_directory(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         if os.name == "nt" and not can_create_symlinks(tmp_path):
-            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
+            pytest.skip(
+                "Windows symlink creation requires Developer Mode or administrator privileges"
+            )
         _ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         outside = tmp_path / "outside-install"
         installed.rename(outside)
@@ -3678,26 +4156,35 @@ class TestUpdateExtension:
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 404
         assert (outside / "manifest.yaml").is_file()
 
     def test_update_preserves_disabled_state_without_start(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(
-            monkeypatch, tmp_path, enabled=False,
+            monkeypatch,
+            tmp_path,
+            enabled=False,
         )
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
         starts = []
         monkeypatch.setattr(
-            ext_mod, "_call_agent", lambda action, sid: starts.append((action, sid)),
+            ext_mod,
+            "_call_agent",
+            lambda action, sid: starts.append((action, sid)),
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 200
@@ -3706,7 +4193,10 @@ class TestUpdateExtension:
         assert starts == []
 
     def test_update_rejects_ambiguous_compose_state(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         _ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
@@ -3723,7 +4213,10 @@ class TestUpdateExtension:
         assert "invalid compose state" in response.json()["detail"]
 
     def test_update_holds_service_operation_lock_through_runtime_proof(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, _installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
@@ -3752,24 +4245,33 @@ class TestUpdateExtension:
         monkeypatch.setattr(ext_mod, "_call_agent", assert_locked_agent)
 
         response = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 200
         assert lock_state["active"] is False
 
     def test_rollback_restores_previous_definition(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         _ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
 
         response = test_client.post(
-            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/rollback",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 200
@@ -3777,7 +4279,10 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == original
 
     def test_rollback_preserves_disabled_state_after_update(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
@@ -3789,16 +4294,25 @@ class TestUpdateExtension:
             lambda action, sid: agent_calls.append((action, sid)) or True,
         )
 
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
-        assert test_client.post(
-            "/api/extensions/my-ext/disable", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/disable",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
         agent_calls.clear()
 
         response = test_client.post(
-            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/rollback",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 200
@@ -3808,44 +4322,64 @@ class TestUpdateExtension:
         assert agent_calls == []
 
     def test_rollback_start_failure_restores_updated_definition(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
         start_results = iter([False, True])
         monkeypatch.setattr(
-            ext_mod, "_call_agent",
+            ext_mod,
+            "_call_agent",
             lambda action, _sid: next(start_results) if action == "start" else True,
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/rollback",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 502
         assert "updated definition restored" in response.json()["detail"]
         assert (installed / "manifest.yaml").read_text() == "release: two\n"
-        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == original
+        assert (
+            user_dir / ".backups" / "my-ext" / "manifest.yaml"
+        ).read_text() == original
 
     def test_rollback_start_failure_reports_incomplete_runtime_recovery(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
         monkeypatch.setattr(
-            ext_mod, "_call_agent",
+            ext_mod,
+            "_call_agent",
             lambda action, _sid: False if action == "start" else True,
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/rollback",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 500
@@ -3854,13 +4388,20 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == "release: two\n"
 
     def test_rollback_config_failure_restores_updated_definition(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
         sync_results = iter([False, True])
         monkeypatch.setattr(
             ext_mod,
@@ -3869,7 +4410,8 @@ class TestUpdateExtension:
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/rollback",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 502
@@ -3877,13 +4419,20 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == "release: two\n"
 
     def test_rollback_config_failure_reports_incomplete_recovery(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
         monkeypatch.setattr(
             ext_mod,
             "_sync_extension_config",
@@ -3891,7 +4440,8 @@ class TestUpdateExtension:
         )
 
         response = test_client.post(
-            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/rollback",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 500
@@ -3900,18 +4450,28 @@ class TestUpdateExtension:
         assert (installed / "manifest.yaml").read_text() == "release: two\n"
 
     def test_uninstall_removes_definition_backup(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         _ext_mod, lib_dir, user_dir, _installed = self._prepare(
-            monkeypatch, tmp_path, enabled=False,
+            monkeypatch,
+            tmp_path,
+            enabled=False,
         )
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
-        assert test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
-        ).status_code == 200
+        assert (
+            test_client.post(
+                "/api/extensions/my-ext/update",
+                headers=test_client.auth_headers,
+            ).status_code
+            == 200
+        )
 
         response = test_client.delete(
-            "/api/extensions/my-ext", headers=test_client.auth_headers,
+            "/api/extensions/my-ext",
+            headers=test_client.auth_headers,
         )
 
         assert response.status_code == 200
@@ -3923,7 +4483,6 @@ class TestUpdateExtension:
 
 
 class TestWriteErrorProgress:
-
     def test_sets_error_status_on_existing_progress(self, monkeypatch, tmp_path):
         """Error progress overwrites status but preserves started_at."""
         from routers.extensions import _write_initial_progress, _write_error_progress
@@ -3954,6 +4513,7 @@ class TestWriteErrorProgress:
         assert data["error"] == "Agent unreachable"
         assert "phase_label" in data
 
+
 # --- _activate_service: built-in (EXTENSIONS_DIR) branch ---
 
 
@@ -3963,7 +4523,9 @@ class TestActivateServiceBuiltinBranch:
     enable built-in extensions like n8n, tts, etc."""
 
     def test_activate_service_resolves_builtin_with_disabled_compose(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """Built-in extension with compose.yaml.disabled is renamed to compose.yaml."""
         from routers.extensions import _activate_service
@@ -3998,7 +4560,9 @@ class TestActivateServiceBuiltinBranch:
         assert not (ext_dir / "compose.yaml.disabled").exists()
 
     def test_activate_service_resolves_builtin_already_enabled(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """Built-in extension already enabled returns idempotent action without mutation."""
         from routers.extensions import _activate_service
@@ -4022,7 +4586,9 @@ class TestActivateServiceBuiltinBranch:
         assert not (ext_dir / "compose.yaml.disabled").exists()
 
     def test_activate_service_user_dir_takes_precedence_over_builtin(
-        self, monkeypatch, tmp_path,
+        self,
+        monkeypatch,
+        tmp_path,
     ):
         """When the same id exists in both, the user-installed copy wins."""
         from routers.extensions import _activate_service
@@ -4058,18 +4624,41 @@ class TestActivateServiceBuiltinBranch:
 class TestAssertNotCoreAllowsBuiltins:
     """_assert_not_core blocks only the 4 always-on base-compose services."""
 
-    @pytest.mark.parametrize("service_id", [
-        "n8n", "tts", "whisper", "comfyui", "litellm", "openclaw",
-        "perplexica", "searxng", "privacy-shield", "token-spy", "qdrant",
-        "embeddings", "ape", "langfuse", "opencode", "hermes", "hermes-proxy",
-    ])
+    @pytest.mark.parametrize(
+        "service_id",
+        [
+            "n8n",
+            "tts",
+            "whisper",
+            "comfyui",
+            "litellm",
+            "openclaw",
+            "perplexica",
+            "searxng",
+            "privacy-shield",
+            "token-spy",
+            "qdrant",
+            "embeddings",
+            "ape",
+            "langfuse",
+            "opencode",
+            "hermes",
+            "hermes-proxy",
+        ],
+    )
     def test_assert_not_core_allows_builtin_extension(self, service_id):
         """Built-in extensions are toggleable and must not be blocked."""
         _assert_not_core(service_id)
 
-    @pytest.mark.parametrize("service_id", [
-        "llama-server", "open-webui", "dashboard", "dashboard-api",
-    ])
+    @pytest.mark.parametrize(
+        "service_id",
+        [
+            "llama-server",
+            "open-webui",
+            "dashboard",
+            "dashboard-api",
+        ],
+    )
     def test_assert_not_core_blocks_always_on(self, service_id):
         """Always-on base-compose services must raise 403."""
         with pytest.raises(HTTPException) as exc_info:
@@ -4079,7 +4668,9 @@ class TestAssertNotCoreAllowsBuiltins:
 
 def test_production_core_service_ids_include_hermes_services():
     """The production anti-shadowing allowlist must cover Hermes built-ins."""
-    core_ids_path = Path(__file__).resolve().parents[4] / "config" / "core-service-ids.json"
+    core_ids_path = (
+        Path(__file__).resolve().parents[4] / "config" / "core-service-ids.json"
+    )
     core_ids = set(json.loads(core_ids_path.read_text(encoding="utf-8")))
 
     assert {"hermes", "hermes-proxy"} <= core_ids
@@ -4116,7 +4707,11 @@ class TestCallAgentErrorNarrowing:
             ext_module._call_agent("start", "svc-x")
 
     def test_catalog_logs_when_cleanup_future_fails(
-        self, test_client, monkeypatch, tmp_path, caplog,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
+        caplog,
     ):
         """Stale-progress cleanup failures are logged, not lost to fire-and-forget."""
         import logging
@@ -4128,25 +4723,26 @@ class TestCallAgentErrorNarrowing:
             raise RuntimeError("cleanup exploded")
 
         monkeypatch.setattr(
-            "routers.extensions._cleanup_stale_progress", _boom,
+            "routers.extensions._cleanup_stale_progress",
+            _boom,
         )
 
         with caplog.at_level(logging.ERROR, logger="routers.extensions"):
-            with patch("helpers.get_all_services", new_callable=AsyncMock,
-                       return_value=[]):
+            with patch(
+                "helpers.get_all_services", new_callable=AsyncMock, return_value=[]
+            ):
                 resp = test_client.get(
                     "/api/extensions/catalog",
                     headers=test_client.auth_headers,
                 )
 
         assert resp.status_code == 200
-        assert any(
-            "stale-progress cleanup failed" in r.message for r in caplog.records
-        )
+        assert any("stale-progress cleanup failed" in r.message for r in caplog.records)
 
 
 def test_extensions_lock_falls_back_when_data_root_is_unwritable(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ):
     """Extension installs should still lock when /data itself is not writable."""
     from routers import extensions as ext_module
@@ -4165,7 +4761,8 @@ def test_extensions_lock_falls_back_when_data_root_is_unwritable(
 
 
 def test_extension_operation_lock_falls_back_when_primary_lock_parent_cannot_create(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ):
     """A stale root lock must not select a parent that cannot hold service locks."""
     from routers import extensions as ext_module
@@ -4210,27 +4807,43 @@ class TestUpdateHardening(TestUpdateExtension):
         old = "2020-01-01T00:00:00+00:00"
         now = datetime.now(timezone.utc).isoformat()
         assert ext_mod._progress_blocks_mutation(None) is False
-        assert ext_mod._progress_blocks_mutation(
-            {"status": "error", "started_at": old, "updated_at": old},
-        ) is False
+        assert (
+            ext_mod._progress_blocks_mutation(
+                {"status": "error", "started_at": old, "updated_at": old},
+            )
+            is False
+        )
         # Never advanced by the agent and past the grace period: abandoned.
-        assert ext_mod._progress_blocks_mutation(
-            {"status": "pulling", "started_at": old, "updated_at": old},
-        ) is False
+        assert (
+            ext_mod._progress_blocks_mutation(
+                {"status": "pulling", "started_at": old, "updated_at": old},
+            )
+            is False
+        )
         # Fresh initial record still blocks.
-        assert ext_mod._progress_blocks_mutation(
-            {"status": "pulling", "started_at": now, "updated_at": now},
-        ) is True
+        assert (
+            ext_mod._progress_blocks_mutation(
+                {"status": "pulling", "started_at": now, "updated_at": now},
+            )
+            is True
+        )
         # Advancing record blocks regardless of age.
-        assert ext_mod._progress_blocks_mutation(
-            {"status": "pulling", "started_at": old, "updated_at": now},
-        ) is True
+        assert (
+            ext_mod._progress_blocks_mutation(
+                {"status": "pulling", "started_at": old, "updated_at": now},
+            )
+            is True
+        )
 
     def test_update_blocks_unknown_state_without_force(
-        self, test_client, monkeypatch, tmp_path,
+        self,
+        test_client,
+        monkeypatch,
+        tmp_path,
     ):
         ext_mod, lib_dir, _user_dir, _installed = self._prepare(
-            monkeypatch, tmp_path,
+            monkeypatch,
+            tmp_path,
         )
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
 
@@ -4239,7 +4852,8 @@ class TestUpdateHardening(TestUpdateExtension):
 
         monkeypatch.setattr(ext_mod, "_extension_tree_digest", unreadable)
         blocked = test_client.post(
-            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+            "/api/extensions/my-ext/update",
+            headers=test_client.auth_headers,
         )
         assert blocked.status_code == 409
         assert blocked.json()["detail"]["code"] == "update_state_unknown"
@@ -4249,18 +4863,28 @@ class TestUpdateHardening(TestUpdateExtension):
         from routers import extensions as ext_mod
 
         monkeypatch.setattr(
-            ext_mod, "request_agent_json",
+            ext_mod,
+            "request_agent_json",
             lambda *a, **k: {"status": "ok"},
         )
-        assert ext_mod._call_agent_sync_config(
-            "my-ext", preserve_existing=True,
-        ) is False
+        assert (
+            ext_mod._call_agent_sync_config(
+                "my-ext",
+                preserve_existing=True,
+            )
+            is False
+        )
         assert ext_mod._call_agent_sync_config("my-ext") is True
 
         monkeypatch.setattr(
-            ext_mod, "request_agent_json",
+            ext_mod,
+            "request_agent_json",
             lambda *a, **k: {"status": "ok", "preserve_existing": True},
         )
-        assert ext_mod._call_agent_sync_config(
-            "my-ext", preserve_existing=True,
-        ) is True
+        assert (
+            ext_mod._call_agent_sync_config(
+                "my-ext",
+                preserve_existing=True,
+            )
+            is True
+        )

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -2006,9 +2006,7 @@ cmd_update() {
     read -ra flags <<< "$flags_str"
 
     # Version compatibility check — warn on major version jumps before touching anything
-    if ! _check_version_compat "$force_flag"; then
-        exit 0
-    fi
+    _check_version_compat "$force_flag" || exit $?
 
     # Show what we're updating from/to (if versions were resolved)
     if [[ -n "${_COMPAT_INSTALLED_VER:-}" && -n "${_COMPAT_TARGET_VER:-}" \

--- a/ods/tests/test-ods-cli-update-verification.sh
+++ b/ods/tests/test-ods-cli-update-verification.sh
@@ -224,3 +224,36 @@ token_after="$(awk -F= '/^HERMES_DASHBOARD_SESSION_TOKEN=/{print $2}' "$install_
 }
 
 printf '[PASS] ods update verifies active compose services under set -e\n'
+
+# Test that _check_version_compat exit code is propagated from cmd_update.
+# When _check_version_compat returns non-zero (e.g., user cancels or hard block),
+# cmd_update must exit with that code, not exit 0.
+printf '[TEST] ods update propagates _check_version_compat exit code\n'
+cat > "$install_dir/.env" <<'ENV'
+ODS_VERSION=1.0.0
+ODS_MODE=local
+GPU_BACKEND=cpu
+GPU_COUNT=1
+TIER=1
+SHIELD_API_KEY=test-shield-key
+LLAMA_CPU_LIMIT=8.0
+LLAMA_CPU_RESERVATION=2.0
+ENV
+
+cat > "$install_dir/manifest.json" <<'MANIFEST'
+{"ods_version":"2.0.0","min_compatible_ods_version":"2.0.0"}
+MANIFEST
+
+# ods-cli returns non-zero when installed version is below minimum.
+# Previously it would exit 0 (bug). Now it must exit non-zero.
+"$BASH" "$ods_cli" update > "$tmp_dir/compat.out" 2>&1 && {
+    cat "$tmp_dir/compat.out" >&2
+    printf '[FAIL] ods update should have exited non-zero when compat check fails\n' >&2
+    exit 1
+}
+grep -q 'Upgrade blocked\|compat\|minimum' "$tmp_dir/compat.out" || {
+    cat "$tmp_dir/compat.out" >&2
+    printf '[FAIL] compat check did not produce expected error output\n' >&2
+    exit 1
+}
+printf '[PASS] ods update propagates _check_version_compat exit code\n'


### PR DESCRIPTION
## Summary
Fixes #4179: When user blocks/cancels compat check, _check_version_compat returns 1 which was being swallowed as exit 0 in cmd_update. Now correctly exits with the failure code.

## Changes
- Changed `if ! _check_version_compat "$force_flag"; then exit 0; fi` to `_check_version_compat "$force_flag" || exit $?` in ods/ods-cli

Closes #4179