### PR TITLE
feat(beta): workspace UX, Portal mascot and Settings refinement

### DIFF
--- a/ods/extensions/services/dashboard/index.html
+++ b/ods/extensions/services/dashboard/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="ODS Dashboard - Control your local AI" />
     <title>ODS</title>
-    <script src="/pixel-mascot.js"></script>
+    <script src="/pixel-mascot.js?v=portal-motion-20260910"></script>
     <link rel="icon" type="image/svg+xml" sizes="any" href="/ods-metal-favicon.svg?v=20260908" />
 
     <!-- PWA manifest — makes the dashboard installable as "ODS" on phone home screens -->

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -152,6 +152,12 @@ server {
         proxy_send_timeout 1800s;
     }
 
+    # This public script has a stable filename, unlike Vite's hashed chunks.
+    # Revalidate it so mascot behavior updates together with the React UI.
+    location = /pixel-mascot.js {
+        expires -1;
+    }
+
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;

--- a/ods/extensions/services/dashboard/public/pixel-mascot.js
+++ b/ods/extensions/services/dashboard/public/pixel-mascot.js
@@ -1,14 +1,59 @@
-/* Pixel's own soft-square character. Local SVG, no image service or animation dependency. */
+/* Portal's soft-square character. The PixelMascot API stays compatible with saved integrations. */
 "use strict";
 
 (() => {
-  const STATES = Object.freeze(["idle", "working", "waiting", "blocked", "thinking", "done"]);
+  const STATES = Object.freeze(["idle", "working", "waiting", "blocked", "thinking", "done", "sleeping"]);
   const TAU = Math.PI * 2;
   const clamp = (value, low, high) => Math.min(high, Math.max(low, value));
   const wave = (time, period) => Math.sin(time * TAU / period);
+  const GESTURES = Object.freeze({hello:1.8, 'hop-left':1.45, 'hop-right':1.45, squish:1.65, wink:1.7, twirl:2.1, stretch:2.2, perk:1.1, nod:1.2, starstruck:2.5});
+  const PLAY_SEQUENCE = ['hop-left', 'hop-right', 'squish', 'wink', 'twirl'];
+
+  // Gestures decorate a pose, never replace an actual task state.
+  function sampleGesture(name, seconds = 0, direction = 1) {
+    const duration = GESTURES[name] || 0;
+    const g = {x:0,y:0,rotate:0,sx:1,sy:1,lookX:0,lookY:0,eyeOpen:1,leftOpen:1,rightOpen:1,happy:0,blush:0,sparkle:0};
+    if (!duration || !Number.isFinite(seconds) || seconds <= 0 || seconds >= duration) return g;
+    const u = seconds / duration;
+    const e = Math.sin(Math.PI * u) ** 2;
+    const bounce = Math.sin(Math.PI * clamp((u - .12) / .7, 0, 1));
+    if (name === 'hello') {
+      g.rotate = 12 * e * Math.sin(u * TAU * 1.5); g.y = -5 * e;
+      g.eyeOpen = 1 + .18 * e; g.happy = .4 * e;
+    } else if (name.startsWith('hop-')) {
+      const side = name === 'hop-left' ? -1 : 1;
+      g.x = side * 9 * e; g.y = -15 * bounce;
+      g.rotate = side * 13 * e; g.sx = 1 - .075 * bounce; g.sy = 1 + .09 * bounce;
+      g.blush = .25 * e;
+    } else if (name === 'squish') {
+      g.sx = 1 + .17 * e; g.sy = 1 - .18 * e; g.y = 6 * e;
+      g.eyeOpen = 1 - .5 * e; g.happy = .8 * e; g.blush = .35 * e;
+    } else if (name === 'wink') {
+      g.rotate = -9 * e; g.leftOpen = 1 - .96 * Math.sin(Math.PI * u) ** 6;
+      g.lookX = 2 * e; g.blush = .3 * e;
+    } else if (name === 'twirl') {
+      // A tiny side-to-side dance, not a full screen-spinning rotation.
+      g.rotate = direction * 24 * e * Math.sin(u * TAU * 1.5);
+      g.x = direction * 7 * e * Math.sin(u * TAU); g.y = -6 * e;
+      g.sx = 1 - .06 * e; g.sy = 1 + .06 * e; g.happy = .8 * e;
+    } else if (name === 'stretch') {
+      g.sy = 1 + .16 * e; g.sx = 1 - .09 * e; g.y = -5 * e;
+      g.eyeOpen = 1 - .7 * Math.sin(Math.PI * clamp(u / .65, 0, 1)) ** 2;
+      g.rotate = -8 * e;
+    } else if (name === 'perk') {
+      g.y = -3 * e; g.rotate = -5 * e; g.eyeOpen = 1 + .18 * e;
+    } else if (name === 'nod') {
+      g.y = 3 * e * Math.sin(u * TAU); g.rotate = 5 * e;
+    } else if (name === 'starstruck') {
+      g.y = -12 * e; g.rotate = 12 * e * Math.sin(u * TAU * 2);
+      g.happy = e; g.blush = .5 * e; g.sparkle = e;
+      g.sx = 1 + .06 * e; g.sy = 1 - .04 * e;
+    }
+    return g;
+  }
   const PALETTE = Object.freeze({
     idle: [229, 229, 228], thinking: [226, 220, 240], working: [205, 217, 238],
-    waiting: [236, 219, 193], blocked: [237, 184, 174], done: [236, 229, 221],
+    waiting: [236, 219, 193], blocked: [230, 204, 193], done: [236, 229, 221], sleeping: [216, 218, 221],
   });
 
   // Pure, deterministic poses make motion inspectable without a running agent.
@@ -18,26 +63,44 @@
     const t = Math.max(0, Number.isFinite(seconds) ? seconds : 0);
     const still = reduced || settled;
     const [red, green, blue] = PALETTE[state];
-    const p = { x: 0, y: 0, rotate: -3, sx: 1, sy: 1, round: 19, lookX: 0, lookY: 0, eyeOpen: 1, eyeTilt: 0, happy: 0, red, green, blue, blush: 0 };
-    if (state === "idle") {
+    const p = { x: 0, y: 0, rotate: -3, sx: 1, sy: 1, round: 19, lookX: 0, lookY: 0, eyeOpen: 1, leftOpen:1, rightOpen:1, eyeTilt: 0, happy: 0, red, green, blue, blush: 0, sparkle:0, question:0, lens:0, propX:0, propY:0, propRotate:0, gear:0, gearRotate:0, hourglass:0, waitRotate:0, grainY:0, attention:0, sleepX:0, sleepY:0, sleepOpacity:.7 };
+    if (state === "sleeping") {
+      const breath = still ? 0 : wave(t, 4.6);
+      p.eyeOpen = .08; p.rotate = 12 + 1.8 * breath; p.y = 4 - 1.2 * breath;
+      p.sx = 1 + .025 * breath; p.sy = .94 - .03 * breath;
+      p.sleepX = still ? 0 : 2.5 * wave(t, 5.4);
+      p.sleepY = still ? 0 : -3 - 3 * wave(t, 4.6);
+      p.sleepOpacity = still ? .7 : .65 + .22 * wave(t, 4.6);
+    } else if (state === "idle") {
       p.y = still ? 0 : -1.2 * wave(t, 4.8);
       p.sx = 1 + (still ? 0 : .012 * wave(t, 4.8));
       p.sy = 1 - (still ? 0 : .014 * wave(t, 4.8));
       p.lookX = still ? 0 : 1.7 * wave(t, 9.6);
+      const curiosity = still ? 0 : Math.sin(Math.PI * clamp(((t + 7) % 23 - 18) / 3, 0, 1)) ** 2;
+      p.rotate -= 6 * curiosity; p.lookY = -2 * curiosity; p.eyeOpen += .1 * curiosity;
     } else if (state === "thinking") {
-      p.rotate = -10 + (still ? 0 : 3 * wave(t, 4.4));
-      p.y = -2 + (still ? 0 : 2.2 * wave(t, 4.4));
+      p.rotate = -10 + (still ? 0 : 8 * wave(t, 3.2));
+      p.y = -2 + (still ? 0 : 3.5 * wave(t, 3.2));
       p.x = still ? 0 : 1.6 * wave(t, 8.8);
       p.sx = .97 + (still ? 0 : .015 * wave(t, 4.4)); p.sy = 1.035 - (still ? 0 : .02 * wave(t, 4.4)); p.round = 22;
-      p.lookX = 3 + (still ? 0 : 1.5 * wave(t, 4.4));
+      p.lookX = 3 + (still ? 0 : 2.5 * wave(t, 6.8));
       p.lookY = -5; p.eyeOpen = .92;
+      // Visual thinking metaphors, not claims of web/search tool execution.
+      const phase = t % 8;
+      p.question = still ? 1 : Math.sin(Math.PI * clamp((phase + .2) / 3.4, 0, 1)) ** 2;
+      p.lens = still ? 0 : Math.sin(Math.PI * clamp((phase - 3.4) / 4.4, 0, 1)) ** 2;
+      p.propX = -13 * (1 - p.lens);
+      p.propY = still ? 0 : -3 * wave(t, 2.2);
+      p.propRotate = still ? 0 : -18 + 12 * wave(t, 2.6);
+      p.lookX += 3 * p.lens;
     } else if (state === "working") {
       const beat = still ? 0 : wave(t, .92);
       p.x = still ? 0 : 1.2 * wave(t, 1.84);
       p.y = -1.5 - 3 * beat;
       p.rotate = 7 + (still ? 0 : 3 * wave(t, 1.84));
       p.sx = 1 - .035 * beat; p.sy = 1 + .045 * beat;
-      p.round = 17; p.lookX = 4; p.lookY = 2; p.eyeOpen = .7; p.eyeTilt = -5;
+      p.round = 17; p.lookX = still ? 3 : 4 * wave(t, 2.8); p.lookY = 2; p.eyeOpen = .84; p.eyeTilt = -5;
+      p.gear = 1; p.gearRotate = still ? 0 : t * 80;
     } else if (state === "waiting") {
       const patience = still ? 0 : clamp((t - 12) / 35, 0, 1);
       const sway = still ? 0 : wave(t, 3.6);
@@ -49,12 +112,17 @@
       p.lookX = still ? -3 : -5 * wave(t, 3.6);
       p.lookY = 1 + .6 * fidget; p.eyeOpen = .88;
       p.green -= 12 * patience; p.blue -= 15 * patience;
+      p.hourglass = 1;
+      const flip = clamp((t % 5 - 4) / 1, 0, 1);
+      p.waitRotate = still ? 0 : Math.floor(t / 5) * 180 + 180 * flip * flip * (3 - 2 * flip);
+      p.grainY = still ? 0 : 3 * wave(t, 1.2);
     } else if (state === "blocked") {
       // A brief head shake followed by a quiet, concerned pose. No alarm loop.
-      p.x = still ? 0 : 3.2 * Math.exp(-2.8 * t) * Math.sin(18 * t);
-      p.rotate = -5 + (still ? 0 : 5 * Math.exp(-2.8 * t) * Math.sin(18 * t));
-      p.y = 3; p.sx = 1.045; p.sy = .925; p.round = 17;
-      p.lookY = -1; p.eyeOpen = .56; p.eyeTilt = 18;
+      p.x = still ? 0 : 1.8 * Math.exp(-2.8 * t) * Math.sin(12 * t);
+      p.rotate = -7 + (still ? 0 : 3 * Math.exp(-2.8 * t) * Math.sin(12 * t));
+      p.y = 2; p.sx = .985; p.sy = .99; p.round = 22;
+      p.lookX = -1; p.lookY = 1; p.eyeOpen = .9; p.leftOpen = .84;
+      p.attention = 1;
     } else if (state === "done") {
       // One springy acknowledgement, then smiling eyes at rest. Never loop success.
       const bounce = still ? 0 : Math.exp(-3.4 * t) * Math.sin(8 * t);
@@ -62,9 +130,10 @@
       p.sx = 1 - .09 * bounce; p.sy = 1 + .11 * bounce;
       p.round = 21; p.eyeOpen = 1; p.happy = 1;
     }
-    if (!still && state !== "done" && state !== "blocked") {
+    if (!still && !["done", "blocked", "sleeping"].includes(state)) {
       // Smooth periodic blink: no hard reset at a loop boundary.
-      const blink = Math.pow(Math.max(0, Math.cos((t - 3.1) * TAU / 5.8)), 90);
+      const phase = t % 12.6;
+      const blink = Math.max(Math.exp(-(((phase - 3.1) / .085) ** 2)), Math.exp(-(((phase - 9.1) / .085) ** 2)), .85 * Math.exp(-(((phase - 9.38) / .07) ** 2)));
       p.eyeOpen *= 1 - .93 * blink;
     }
     return p;
@@ -91,6 +160,20 @@
   }
 
   function draw(record, p) {
+    record.sleepMark.setAttribute('opacity', record.state === 'sleeping' ? rounded(p.sleepOpacity) : '0');
+    record.sleepMark.setAttribute('transform', `translate(${rounded(p.sleepX)} ${rounded(p.sleepY)})`);
+    record.sparkles.setAttribute('opacity', rounded(p.sparkle));
+    record.sparkles.setAttribute('transform', `translate(0 ${rounded(-4 * p.sparkle)})`);
+    record.question.setAttribute('opacity', rounded(p.question));
+    record.question.setAttribute('transform', `translate(0 ${rounded(-3 * p.question)}) rotate(${rounded(8 * p.question)} 84 18)`);
+    record.lens.setAttribute('opacity', rounded(p.lens));
+    record.lens.setAttribute('transform', `translate(${rounded(87 + p.propX)} ${rounded(43 + p.propY)}) rotate(${rounded(p.propRotate)})`);
+    record.gear.setAttribute('opacity', rounded(p.gear));
+    record.gear.setAttribute('transform', `translate(87 65) rotate(${rounded(p.gearRotate)})`);
+    record.hourglass.setAttribute('opacity', rounded(p.hourglass));
+    record.hourglass.setAttribute('transform', `translate(88 36) rotate(${rounded(p.waitRotate)})`);
+    record.grain.setAttribute('cy', rounded(p.grainY));
+    record.attention.setAttribute('opacity', rounded(p.attention));
     const r = p.round;
     // A rounded pixel, not an oval or a framed robot badge. Slight asymmetry keeps it soft.
     record.body.setAttribute("d", `M ${19 + r} 20 H ${81 - r} Q 81 20 81 ${20 + r} V ${80 - r} Q 81 80 ${81 - r} 80 H ${19 + r} Q 19 80 19 ${80 - r} V ${20 + r} Q 19 20 ${19 + r} 20 Z`);
@@ -101,10 +184,14 @@
     record.eyes.forEach((eye, index) => {
       const x = index === 0 ? -10 : 10;
       const happy = p.happy;
-      const startY = -5.5 * (1 - happy) + happy;
-      const endY = 5.5 * (1 - happy) + happy;
-      eye.setAttribute("d", `M ${x - happy * 4} ${rounded(startY)} Q ${x} ${rounded(-7 * happy)} ${x + happy * 4} ${rounded(endY)}`);
-      eye.setAttribute("transform", `translate(${x} 0) rotate(${rounded((index ? -1 : 1) * p.eyeTilt)}) scale(1 ${rounded(Math.max(.04, p.eyeOpen))}) translate(${-x} 0)`);
+      // Wider rounded eyes; shorter centerline preserves the overall height.
+      const startY = -7.25 * (1 - happy) + happy;
+      const endY = 7.25 * (1 - happy) + happy;
+      const asleep = record.state === 'sleeping';
+      eye.style.setProperty('--portal-eye-stroke', asleep ? '3.5' : '9');
+      eye.setAttribute('stroke-width', asleep ? '3.5' : '9');
+      eye.setAttribute("d", asleep ? `M ${x-5} 0 Q ${x} 4 ${x+5} 0` : `M ${x - happy * 4} ${rounded(startY)} Q ${x} ${rounded(-7 * happy)} ${x + happy * 4} ${rounded(endY)}`);
+      eye.setAttribute("transform", `translate(${x} 0) rotate(${rounded((index ? -1 : 1) * p.eyeTilt)}) scale(1 ${asleep ? 1 : rounded(Math.max(.04, p.eyeOpen * (index ? p.rightOpen : p.leftOpen)))}) translate(${-x} 0)`);
     });
   }
 
@@ -120,16 +207,17 @@
       p.lookX = reducedMotion?.matches ? 0 : record.gazeX;
       p.lookY = reducedMotion?.matches ? 0 : record.gazeY;
     }
-    if (record.hovered && !record.static && !reducedMotion?.matches) {
-      const elapsed = (now - record.hoverStarted) / 1000;
-      const delight = Math.exp(-3 * elapsed) * Math.sin(10 * elapsed);
-      p.blush = .5;
-      p.eyeOpen = record.brand ? 1.12 : 1;
-      if (!record.brand) {
-        p.y -= 7 * delight;
-        p.rotate += 5 * delight;
-        p.happy = .8;
-      }
+    if (record.interactive && record.state === 'idle' && !reducedMotion?.matches && now - record.lastGaze < 2400) {
+      p.lookX = record.gazeX; p.lookY = record.gazeY;
+    }
+    if (record.gesture && !reducedMotion?.matches && !record.static && !record.settled) {
+      const g = sampleGesture(record.gesture, (now - record.gestureStarted) / 1000, record.playDirection);
+      for (const key of ['x','y','rotate','lookX','lookY']) p[key] += g[key];
+      for (const key of ['sx','sy','eyeOpen','leftOpen','rightOpen']) p[key] *= g[key];
+      for (const key of ['happy','blush','sparkle']) p[key] = Math.max(p[key], g[key]);
+    }
+    if (record.hovered && (record.interactive || record.brand) && record.state === 'idle' && !record.static && !reducedMotion?.matches) {
+      p.blush = Math.max(p.blush, .16); // Warm attention, not permanently smiling/closed eyes.
     }
     return p;
   }
@@ -150,6 +238,10 @@
   }
 
   function settleInteraction(record, now = clock()) {
+    if (record.gesture && now >= record.gestureStarted + GESTURES[record.gesture] * 1000) {
+      record.gesture = null;
+      delete record.element.dataset.portalGesture;
+    }
     if (!record.interactionUntil || now < record.interactionUntil) return;
     record.interactionUntil = 0;
     record.pose = target(record, now);
@@ -194,6 +286,11 @@
     element.removeEventListener("pointerenter", record.onEnter);
     element.removeEventListener("pointerleave", record.onLeave);
     if (record.key && keyed.get(record.key) === element) keyed.delete(record.key);
+    if (!records.size && frame !== null) {
+      globalThis.cancelAnimationFrame(frame);
+      frame = null;
+      previousFrame = 0;
+    }
   }
 
   function prune() {
@@ -231,7 +328,7 @@
         if (pruneQueued) return;
         pruneQueued = true;
         // renderChat removes and reattaches keyed nodes synchronously every poll.
-        queueMicrotask(() => { pruneQueued = false; prune(); requestFrame(); });
+        globalThis.queueMicrotask(() => { pruneQueued = false; prune(); requestFrame(); });
       });
       mutations.observe(doc.documentElement, { childList: true, subtree: true });
     }
@@ -245,7 +342,7 @@
     doc.addEventListener("pointermove", (event) => {
       if (event.pointerType === "touch" || doc.hidden || reducedMotion?.matches) return;
       for (const record of records.values()) {
-        if (!record.brand || !record.visible || !record.element.isConnected) continue;
+        if ((!record.brand && !record.interactive) || record.static || record.settled || !record.visible || !record.element.isConnected || record.state !== 'idle') continue;
         const box = record.element.getBoundingClientRect();
         if (!box.width || !box.height) continue;
         const dx = event.clientX - box.left - box.width / 2;
@@ -253,14 +350,15 @@
         const distance = Math.max(90, Math.hypot(dx, dy));
         record.gazeX = clamp(dx / distance * 6, -6, 6);
         record.gazeY = clamp(dy / distance * 5, -5, 5);
-        record.interactionUntil = clock() + 1200;
+        record.lastGaze = clock();
+        record.interactionUntil = Math.max(record.interactionUntil, clock() + 1200);
       }
       requestFrame();
     }, { passive: true });
     doc.addEventListener("pointerleave", () => {
-      for (const record of records.values()) if (record.brand) {
+      for (const record of records.values()) if (record.brand || record.interactive) {
         record.gazeX = 0; record.gazeY = 0; record.hovered = false;
-        record.interactionUntil = clock() + 1200;
+        record.interactionUntil = Math.max(record.interactionUntil, clock() + 1200);
       }
       requestFrame();
     });
@@ -271,12 +369,17 @@
     if (!record) return mount(element, { state, settled });
     const next = STATES.includes(state) ? state : "idle";
     if (record.state === next && record.settled === settled) return element;
+    const previous = record.state;
+    record.gesture = null;
+    delete element.dataset.portalGesture;
     record.state = next;
     record.settled = settled;
     record.started = clock();
     record.interactionUntil = clock() + 1200;
+    if (record.interactive && next === 'idle' && previous === 'sleeping') gesture(record, 'stretch');
+    else if (record.interactive && next === 'idle' && ['thinking','working'].includes(previous)) gesture(record, 'nod');
     element.dataset.mascotState = next;
-    element.title = `Pixel · ${next}`;
+    element.title = `${element.dataset.pixelName || 'Portal'} · ${next}`;
     if (record.static || settled || reducedMotion?.matches) {
       record.pose = target(record, clock());
       draw(record, record.pose);
@@ -294,23 +397,42 @@
     const body = svg("path", { class: "pixel-mascot-body" });
     const face = svg("g");
     const cheeks = [-18, 18].map((x) => svg("ellipse", { cx: x, cy: 9, rx: 5, ry: 2.8, fill: "#dc8f83", opacity: 0 }));
-    const eyes = [svg("path", { class: "pixel-mascot-eye" }), svg("path", { class: "pixel-mascot-eye" })];
-    face.append(...cheeks, ...eyes); motion.append(body, face); canvas.append(motion);
+    const eyes = [0,1].map(() => svg('path', {class:'pixel-mascot-eye', fill:'none',stroke:'#18191b','stroke-width':9,'stroke-linecap':'round','stroke-linejoin':'round'}));
+    const sparkles = svg('g', {class:'portal-sparkles',opacity:0, fill:'none',stroke:'#d7e3e8','stroke-width':1.8,'stroke-linecap':'round'});
+    [[13,24,3],[85,19,4],[85,65,2.5]].forEach(([x,y,r]) => sparkles.append(svg('path',{d:`M ${x} ${y-r} Q ${x} ${y} ${x+r} ${y} Q ${x} ${y} ${x} ${y+r} Q ${x} ${y} ${x-r} ${y} Q ${x} ${y} ${x} ${y-r} Z`})));
+    const sleepMark = svg('text', {x:73, y:18, fill:'currentColor', 'font-size':16, opacity:0});
+    sleepMark.textContent = 'zzz';
+    const question = svg('text', {class:'portal-thinking-question',x:82,y:24,fill:'#d7e3e8','font-size':30,'font-weight':600,'font-family':'system-ui, sans-serif',opacity:0});
+    question.textContent = '?';
+    const lens = svg('g',{class:'portal-thinking-lens',opacity:0,stroke:'#c0d0dc','stroke-width':3.5,'stroke-linecap':'round',fill:'none'});
+    lens.append(svg('path',{d:'M 6 6 L 15 15'}),svg('circle',{cx:0,cy:0,r:10,fill:'#151c22','fill-opacity':.8}),svg('path',{d:'M -5 -1 Q -5 -5 -1 -5','stroke-width':1.5,opacity:.65}));
+    const gear = svg('g',{class:'portal-working-gear',opacity:0,stroke:'#c0d0dc','stroke-width':3,'stroke-linecap':'round',fill:'none'});
+    gear.append(svg('circle',{r:8,fill:'#151c22','fill-opacity':.85}),svg('circle',{r:2.5,'stroke-width':2}));
+    for (let tooth=0;tooth<8;tooth++) gear.append(svg('path',{d:'M 0 -8 L 0 -12',transform:`rotate(${tooth*45})`}));
+    const hourglass = svg('g',{class:'portal-waiting-hourglass',opacity:0,stroke:'#dbcbad','stroke-width':2.5,'stroke-linecap':'round','stroke-linejoin':'round',fill:'none'});
+    const grain=svg('circle',{r:1.2,cy:0,fill:'#dbcbad',stroke:'none'});
+    hourglass.append(svg('path',{d:'M -8 -12 H 8 M -8 12 H 8 M -6 -12 V -7 L 4 5 V 12 M 6 -12 V -7 L -4 5 V 12',fill:'#1d1b18','fill-opacity':.65}),svg('path',{d:'M -4 -8 H 4 L 0 -3 Z M -3 9 H 3 L 0 5 Z',fill:'#dbcbad',stroke:'none'}),grain);
+    const attention=svg('g',{class:'portal-attention-mark',opacity:0,transform:'translate(86 23)',stroke:'#d7bcae','stroke-width':2.3,'stroke-linecap':'round',fill:'none'});
+    attention.append(svg('circle',{r:10,fill:'#28231f','fill-opacity':.9,'stroke-width':1.5}),svg('path',{d:'M 0 -5 V 1'}),svg('circle',{cy:5,r:1.1,fill:'#d7bcae',stroke:'none'}));
+    face.append(...cheeks, ...eyes); motion.append(body, face); canvas.append(motion, sleepMark, sparkles, question, lens, gear, hourglass, attention);
     element.replaceChildren(canvas);
     element.classList.add("pixel-mascot");
     element.setAttribute("aria-hidden", "true");
     element.dataset.mascotState = next;
-    element.title = `Pixel · ${next}`;
-    const record = { element, motion, body, face, eyes, cheeks, key, state: next, static: isStatic, settled,
+    element.title = `${element.dataset.pixelName || 'Portal'} · ${next}`;
+    const record = { element, motion, body, face, eyes, cheeks, sleepMark, sparkles, question, lens, gear, hourglass, grain, attention, key, state: next, static: isStatic, settled,
+      interactive: element.hasAttribute('data-pixel-interactive'), gesture:null, gestureStarted:0, playDirection:1, playCount:0, clickTimes:[], lastPlay:-Infinity, lastGaze:-Infinity,
       brand: element.hasAttribute("data-pixel-brand"), gazeX: 0, gazeY: 0,
       hovered: false, hoverStarted: 0, interactionUntil: 0, started: clock(), visible: !intersection };
     record.onEnter = (event) => {
-      if (event.pointerType === "touch" || record.static || reducedMotion?.matches) return;
-      record.hovered = true; record.hoverStarted = clock(); record.interactionUntil = clock() + 1800;
+      if (event.pointerType === "touch" || record.static || record.settled || (!record.interactive && !record.brand) || reducedMotion?.matches) return;
+      record.hovered = true; record.hoverStarted = clock(); record.interactionUntil = Math.max(record.interactionUntil, clock() + 1800);
+      if (record.interactive && record.state === 'idle' && !record.gesture) gesture(record, 'perk');
       requestFrame();
     };
     record.onLeave = () => {
-      record.hovered = false; record.interactionUntil = clock() + 1200;
+      if (record.static || record.settled || (!record.interactive && !record.brand)) return;
+      record.hovered = false; record.interactionUntil = Math.max(record.interactionUntil, clock() + 1200);
       requestFrame();
     };
     element.addEventListener("pointerenter", record.onEnter);
@@ -318,6 +440,7 @@
     record.pose = target(record, clock());
     record.velocity = Object.fromEntries(Object.keys(record.pose).map((name) => [name, 0]));
     records.set(element, record);
+    if (record.interactive && next === 'idle' && !settled) gesture(record, 'hello');
     if (key) keyed.set(key, element);
     draw(record, record.pose);
     intersection?.observe(element);
@@ -352,6 +475,7 @@
     blocked: "A brief head shake and a soft coral tint. Something needs attention.",
     thinking: "An upward glance and a gentle sway while the agent thinks.",
     done: "One small bounce, smiling eyes, then back to rest.",
+    sleeping: "A quiet nap after the configured idle time. Activity wakes Portal with a stretch.",
   };
 
   function init(root = doc) {
@@ -378,6 +502,25 @@
     });
   }
 
-  globalThis.PixelMascot = Object.freeze({ STATES, samplePose, create, mount, setState, destroy, init });
+  function gesture(record, name) {
+    if (reducedMotion?.matches || record.static || record.settled || !GESTURES[name]) return;
+    record.gesture = name; record.gestureStarted = clock();
+    record.element.dataset.portalGesture = name;
+    record.interactionUntil = Math.max(record.interactionUntil, clock() + GESTURES[name] * 1000 + 500);
+    requestFrame();
+  }
+
+  function play(element) {
+    const record = records.get(element);
+    if (!record || record.static || record.settled || !record.interactive || reducedMotion?.matches || clock()-record.lastPlay<100) return;
+    record.lastPlay = clock();
+    if (record.state === 'sleeping') {setState(element, 'idle');return;}
+    if (record.state !== 'idle') {gesture(record,'nod');return;}
+    record.playDirection *= -1;
+    record.clickTimes = [...record.clickTimes.filter(time => clock()-time<900),clock()];
+    if (record.clickTimes.length >= 3) {record.clickTimes=[];gesture(record,'starstruck');}
+    else gesture(record, PLAY_SEQUENCE[record.playCount++ % PLAY_SEQUENCE.length]);
+  }
+  globalThis.PixelMascot = Object.freeze({ STATES, GESTURES, samplePose, sampleGesture, create, mount, setState, destroy, play, init });
   if (doc) init();
 })();

--- a/ods/extensions/services/dashboard/src/components/CustomWallpaperPicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/CustomWallpaperPicker.jsx
@@ -1,0 +1,23 @@
+import {useRef, useState} from 'react'
+import {useTheme} from '../contexts/ThemeContext'
+import {isCustomWallpaper} from '../lib/customWallpapers'
+
+export default function CustomWallpaperPicker() {
+  const {theme, addWallpaper, removeWallpaper, wallpaperError} = useTheme()
+  const input = useRef(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState('')
+  async function run(action) {
+    setBusy(true); setError('')
+    try { await action() } catch (failure) { setError(failure.message || 'Could not update wallpaper.') }
+    finally { setBusy(false) }
+  }
+  return <div className="custom-wallpaper-actions">
+    <input ref={input} type="file" accept="image/jpeg,image/png,image/webp" hidden aria-label="Choose local wallpaper" disabled={busy}
+      onChange={event => { const file = event.target.files?.[0]; event.target.value = ''; if (file) void run(() => addWallpaper(file)) }}/>
+    <button type="button" className="btn-secondary" disabled={busy} onClick={() => input.current?.click()}>{busy ? 'Saving wallpaper…' : 'Add wallpaper'}</button>
+    {isCustomWallpaper(theme) && <button type="button" className="btn-secondary" disabled={busy} onClick={() => void run(() => removeWallpaper(theme))}>Remove selected wallpaper</button>}
+    <p className="wallpaper-note">JPG, PNG or WebP · up to 20 MB. Your images stay in this browser and are never uploaded.</p>
+    {(error || wallpaperError) && <p role="alert">{error || wallpaperError}</p>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/FittedLibraryPage.jsx
+++ b/ods/extensions/services/dashboard/src/components/FittedLibraryPage.jsx
@@ -15,7 +15,7 @@ export function fittedPageNumbers(current, pages) {
 
 // Pagination uses the utility panel's remaining height, not the whole window.
 // Expanded errors/progress can grow naturally; content is never clipped.
-export default function FittedLibraryPage({items, label, children}) {
+export default function FittedLibraryPage({items, label, children, minimumItems = 1}) {
   const root = useRef(null)
   const measured = useRef({width: 0, row: 0})
   const [capacity, setCapacity] = useState(4)
@@ -41,7 +41,7 @@ export default function FittedLibraryPage({items, label, children}) {
         : window.innerHeight - bounds.top - 24
       if (height <= 0) return
       setAvailableHeight(height)
-      setCapacity(fittedPageSize(height, measured.current.row))
+      setCapacity(Math.max(minimumItems, fittedPageSize(height, measured.current.row)))
     }
     measure()
     const observer = typeof ResizeObserver === 'function' ? new ResizeObserver(measure) : null
@@ -49,7 +49,7 @@ export default function FittedLibraryPage({items, label, children}) {
     if (panel) observer?.observe(panel)
     window.addEventListener('resize', measure)
     return () => {observer?.disconnect(); window.removeEventListener('resize', measure)}
-  }, [items.length])
+  }, [items.length, minimumItems])
   return <section ref={root} className="fitted-library-page" style={{minHeight: availableHeight || undefined}} aria-label={label}>
     {children(items.slice((current - 1) * capacity, current * capacity))}
     {items.length > 0 && <footer className="extensions-page-footer">

--- a/ods/extensions/services/dashboard/src/components/FittedLibraryPage.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/FittedLibraryPage.test.jsx
@@ -13,6 +13,16 @@ it('reserves the footer and keeps at least one item in a short panel', () => {
   expect(fittedPageSize(624, 144)).toBe(4)
   expect(fittedPageSize(50, 144)).toBe(1)
 })
+
+it('keeps a browsable group of models even when the panel is short',()=>{
+  vi.stubGlobal('ResizeObserver',class {observe(){} disconnect(){}})
+  vi.spyOn(HTMLElement.prototype,'getBoundingClientRect').mockReturnValue({top:0,width:440,height:200})
+  vi.spyOn(HTMLElement.prototype,'clientHeight','get').mockReturnValue(200)
+  render(<div className="portal-panel-content"><FittedLibraryPage minimumItems={6} label="Models" items={Array.from({length:12},(_,i)=>i)}>{items=>items.map(i=><article className="model-entry" key={i}>Model {i}</article>)}</FittedLibraryPage></div>)
+  expect(screen.getAllByRole('article')).toHaveLength(6)
+  fireEvent.click(screen.getByRole('button',{name:'Page 2'}))
+  expect(screen.getByText('Model 11')).toBeVisible()
+})
 it('fits the actual utility panel and paginates without dropping entries', () => {
   vi.stubGlobal('ResizeObserver', class {observe(){} disconnect(){}})
   vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {

--- a/ods/extensions/services/dashboard/src/components/ODSLogo.jsx
+++ b/ods/extensions/services/dashboard/src/components/ODSLogo.jsx
@@ -3,17 +3,21 @@ import { LiquidMetal } from '@paper-design/shaders-react'
 
 const source = '/osmantic-isolated-os.png'
 
-export default function ODSLogo({ active = true }) {
+export default function ODSLogo() {
   const [mask, setMask] = useState(null)
-  const [still, setStill] = useState(false)
+  const [hovered, setHovered] = useState(false)
+  const [reduced, setReduced] = useState(false)
+  useEffect(() => {
+    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+    const update = () => setReduced(Boolean(media?.matches))
+    update()
+    media?.addEventListener?.('change', update)
+    return () => media?.removeEventListener?.('change', update)
+  }, [])
   useEffect(() => {
     // Keep the original image in embedded/limited renderers without browser APIs.
     if (typeof window.matchMedia !== 'function') return
     let disposed = false
-    const preference = window.matchMedia('(prefers-reduced-motion: reduce)')
-    const update = () => setStill(preference.matches)
-    update()
-    preference.addEventListener('change', update)
     const canvas = document.createElement('canvas')
     let supported = null
     try {
@@ -47,9 +51,9 @@ export default function ODSLogo({ active = true }) {
       }
       img.src = source
     }
-    return () => { disposed = true; preference.removeEventListener('change', update) }
+    return () => { disposed = true }
   }, [])
-  return <div className="ods-metal-logo" aria-hidden="true">
-    {mask ? <LiquidMetal image={mask} width="100%" height="100%" colorBack="#00000000" colorTint="#ffffff" repetition={2} softness={0.1} shiftRed={0.3} shiftBlue={0.3} distortion={0.07} contour={0.4} angle={70} speed={still || !active ? 0 : 1} scale={0.9} fit="contain" /> : <img src={source} alt="" style={{filter:'grayscale(1)',mixBlendMode:'screen'}} />}
+  return <div className="ods-metal-logo" aria-hidden="true" onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+    {mask ? <LiquidMetal image={mask} width="100%" height="100%" colorBack="#00000000" colorTint="#ffffff" repetition={2} softness={0.1} shiftRed={0.3} shiftBlue={0.3} distortion={0.07} contour={0.4} angle={70} speed={hovered && !reduced ? 0.35 : 0} scale={0.9} fit="contain" /> : <img src={source} alt="" style={{filter:'grayscale(1)',mixBlendMode:'screen'}} />}
   </div>
 }

--- a/ods/extensions/services/dashboard/src/components/ODSLogo.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/ODSLogo.test.jsx
@@ -1,8 +1,8 @@
 import { afterEach, expect, it, vi } from 'vitest'
-import { cleanup, render } from '@testing-library/react'
+import { cleanup, render, fireEvent } from '@testing-library/react'
 import ODSLogo from './ODSLogo'
 
-vi.mock('@paper-design/shaders-react', () => ({ LiquidMetal: () => <canvas /> }))
+vi.mock('@paper-design/shaders-react', () => ({ LiquidMetal: ({speed}) => <canvas data-speed={speed}/> }))
 afterEach(() => { cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals() })
 
 it('keeps the supplied logo visible when WebGL is unavailable', () => {
@@ -38,4 +38,17 @@ it('falls back to the static logo when canvas readback is denied', () => {
   const {container} = render(<ODSLogo />)
   expect(container.querySelector('img')).toHaveAttribute('src', '/osmantic-isolated-os.png')
   expect(container.querySelector('canvas')).toBeNull()
+})
+
+it.each([false,true])('animates only on hover and honors reduced motion: %s', reduced => {
+  vi.stubGlobal('matchMedia', () => ({matches:reduced}))
+  vi.stubGlobal('Image', class { naturalWidth=1; naturalHeight=1; set src(_value) {this.onload()} })
+  vi.spyOn(HTMLCanvasElement.prototype,'getContext').mockImplementation(type => type === 'webgl2' ? {getExtension:()=>null} : {drawImage:vi.fn(),getImageData:()=>({data:new Uint8ClampedArray([255,0,0,255])}),putImageData:vi.fn()})
+  vi.spyOn(HTMLCanvasElement.prototype,'toDataURL').mockReturnValue('data:image/png;base64,YQ==')
+  const {container}=render(<ODSLogo active/>)
+  expect(container.querySelector('canvas')).toHaveAttribute('data-speed','0')
+  fireEvent.mouseEnter(container.firstChild)
+  expect(container.querySelector('canvas')).toHaveAttribute('data-speed',reduced ? '0' : '0.35')
+  fireEvent.mouseLeave(container.firstChild)
+  expect(container.querySelector('canvas')).toHaveAttribute('data-speed','0')
 })

--- a/ods/extensions/services/dashboard/src/components/PixelComposerTools.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelComposerTools.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { AtSign, Slash, ShieldCheck, ListChecks, Globe2, CheckCheck } from 'lucide-react'
 import PixelMascot from './PixelMascot'
 import PixelPromptLibrary from './PixelPromptLibrary'
+import { usePortalIdentity } from '../contexts/PortalIdentityContext'
 
 const commands = [
   { title: 'Plan', detail: 'Milestones and completion checks', icon: ListChecks, text: 'Plan this outcome with milestones and exact completion criteria: ' },
@@ -13,7 +14,8 @@ const sources = [
   { title: 'Current task', detail: 'Reference the current conversation', icon: AtSign, text: '@current-task ' },
   { title: 'Retained evidence', detail: 'Request evidence; no files are attached automatically', icon: AtSign, text: '@retained-evidence ' },
 ]
-export default function PixelComposerTools({ disabled, input, onInsert }) {
+export default function PixelComposerTools({ disabled, input, onInsert, children }) {
+  const {displayName} = usePortalIdentity()
   const [menu, setMenu] = useState(null)
   const root = useRef(null)
   const lastTrigger = useRef(null)
@@ -42,10 +44,12 @@ export default function PixelComposerTools({ disabled, input, onInsert }) {
     }} aria-label={menu === 'sources' ? 'Mention a source' : 'Prompt commands'}>
       {(menu === 'sources' ? sources : commands).map(item => <button type="button" key={item.title} aria-label={`${item.title} ${item.detail}`} onClick={() => { setMenu(null); onInsert(item.text) }}><item.icon size={17}/><span><strong>{item.title}</strong><small>{item.detail}</small></span></button>)}
     </div>}
-    <button type="button" disabled={disabled} aria-label="Mention source" aria-expanded={menu === 'sources'} onClick={event => toggle('sources', event)}><AtSign size={16}/></button>
+    {children}
+    <button type="button" disabled={disabled} title="Mention source" aria-label="Mention source" aria-expanded={menu === 'sources'} onClick={event => toggle('sources', event)}><AtSign size={16}/></button>
     <PixelPromptLibrary input={input} disabled={disabled} onInsert={onInsert}/>
-    <button type="button" disabled={disabled} aria-label="Open prompt commands" aria-expanded={menu === 'commands'} onClick={event => toggle('commands', event)}><Slash size={16}/></button>
-    <Link to="/models" className="pixel-composer-agent"><PixelMascot/><span>Pixel agent</span></Link>
+    <button type="button" disabled={disabled} title="Prompt commands" aria-label="Open prompt commands" aria-expanded={menu === 'commands'} onClick={event => toggle('commands', event)}><Slash size={16}/></button>
+    <span className="pixel-tool-divider" aria-hidden="true"/>
+    <Link to="/models" className="pixel-composer-agent" title="Choose the agent model"><PixelMascot name={displayName}/><span>{displayName} agent</span></Link>
     <Link to="/pixel/settings?section=access" title="Pixel access settings"><ShieldCheck size={15}/><span>Permissions</span></Link>
   </div>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelConversationExport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationExport.test.jsx
@@ -20,7 +20,8 @@ test('exports complete retained history and metadata without selecting or trunca
   window.addEventListener(SELECT_EVENT,select)
   try {
     render(<PixelConversationNavigation collapsed={false}/>)
-    fireEvent.click(screen.getByRole('button',{name:'Export chat: Turn 0'}))
+    fireEvent.contextMenu(screen.getByRole('button',{name:/^Turn 0/}))
+    fireEvent.click(screen.getByRole('menuitem',{name:'Export conversation'}))
     expect(URL.createObjectURL).toHaveBeenCalledOnce()
     const blob=URL.createObjectURL.mock.calls[0][0]
     expect(blob.type).toBe('application/json')
@@ -43,7 +44,8 @@ test('reports download failure while preserving the conversation', () => {
   saveConversation({schema:1,chatId:'export-test',messages:[{role:'user',content:'Keep me'}]})
   URL.createObjectURL.mockImplementation(() => {throw new Error('Unavailable')})
   render(<PixelConversationNavigation collapsed={false}/>)
-  fireEvent.click(screen.getByRole('button',{name:'Export chat: Keep me'}))
+  fireEvent.contextMenu(screen.getByRole('button',{name:'Keep me',exact:true}))
+  fireEvent.click(screen.getByRole('menuitem',{name:'Export conversation'}))
   expect(screen.getByRole('alert')).toHaveTextContent('could not be exported')
   expect(readConversations()).toHaveLength(1)
   expect(window.HTMLAnchorElement.prototype.click).not.toHaveBeenCalled()

--- a/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import { Download, Plus, X } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { CHAT_KEY, LIBRARY_EVENT, SELECT_EVENT, DELETE_EVENT, readConversations, conversationTitle } from '../lib/pixelConversations'
 import { conversationLabels } from '../lib/pixelConversationLabels'
-import PixelConversationOrganizer from './PixelConversationOrganizer'
+import PixelConversationRow, {ConversationTitle} from './PixelConversationRow'
 
 import { exportConversation } from '../lib/pixelConversationExport'
 
@@ -42,10 +42,10 @@ export default function PixelConversationNavigation({ collapsed }) {
   const regular = visible.filter(item => !item.labels.pinned).map(item => item.chat)
   const chevron = <svg className="rail-chevron" viewBox="0 0 16 16" aria-hidden="true"><path d="m5 6 3 3 3-3"/></svg>
   function rows(items, empty) {
-    return <div className="rail-conversations">{items.length ? items.map(chat => <div className="conversation-row" key={chat.chatId}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={`${conversationTitle(chat)} · ${chat.messages.filter(item => item.role === 'user').length} turns`} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><strong>{conversationTitle(chat)}</strong>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button><PixelConversationOrganizer chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()}/><button className="conversation-delete" aria-label={`Delete chat: ${conversationTitle(chat)}`} title="Delete chat" onClick={event => { trigger.current = event.currentTarget; setDeleteError(''); setPending(chat) }}><X size={13}/></button><button type="button" className="conversation-export" aria-label={'Export chat: ' + conversationTitle(chat)} title="Export this conversation as JSON" onClick={() => {
+    return <div className="rail-conversations">{items.length ? items.map(chat => <PixelConversationRow key={chat.chatId} chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()} onDelete={event => {trigger.current=event.currentTarget;setDeleteError('');setPending(chat)}} onExport={() => {
       try { exportConversation(chat.chatId); setExportError('') }
       catch { setExportError('This conversation could not be exported. Your saved history is unchanged.') }
-    }}><Download size={13}/></button></div>) : <span className="rail-empty">{empty}</span>}</div>
+    }}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={conversationTitle(chat)} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><ConversationTitle title={conversationTitle(chat)}/>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button></PixelConversationRow>) : <span className="rail-empty">{empty}</span>}</div>
 
   }
   return <div className="pixel-conversation-navigation">

--- a/ods/extensions/services/dashboard/src/components/PixelConversationRow.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationRow.jsx
@@ -1,0 +1,80 @@
+import {useEffect, useLayoutEffect, useRef, useState} from 'react'
+import {createPortal} from 'react-dom'
+import {Archive, Download, Pencil, Pin, X} from 'lucide-react'
+import PixelConversationOrganizer from './PixelConversationOrganizer'
+import {conversationLabels, saveConversationLabels} from '../lib/pixelConversationLabels'
+
+export function ConversationTitle({title}) {
+  const viewport=useRef(null), text=useRef(null)
+  const [overflow,setOverflow]=useState(0)
+  useLayoutEffect(()=>{
+    const measure=()=>setOverflow(Math.max(0,(text.current?.scrollWidth || 0)-(viewport.current?.clientWidth || 0)))
+    measure()
+    const observer=typeof ResizeObserver === 'function' ? new ResizeObserver(measure) : null
+    observer?.observe(viewport.current)
+    observer?.observe(text.current)
+    window.addEventListener('resize',measure)
+    return ()=>{observer?.disconnect();window.removeEventListener('resize',measure)}
+  },[title])
+  return <strong ref={viewport} className="conversation-title" data-overflow={overflow>0} style={{'--title-travel':`${-overflow}px`,'--title-duration':`${Math.max(4,overflow/28+2)}s`}}><span ref={text}>{title}</span></strong>
+}
+
+export default function PixelConversationRow({chat,title,onDelete,onExport,onSaved,children}) {
+  const row=useRef(null), menu=useRef(null), returnFocus=useRef(null)
+  const [position,setPosition]=useState(null)
+  const [error,setError]=useState('')
+  const labels=conversationLabels(chat.chatId)
+  function close(restore=true) {setPosition(null);setError('');if(restore) returnFocus.current?.focus()}
+  function open(event) {
+    if(event.target.closest('dialog')) return
+    event.preventDefault()
+    returnFocus.current=row.current.querySelector('.conversation-link')
+    const box=row.current.getBoundingClientRect()
+    setPosition({x:event.clientX || box.left+24,y:event.clientY || box.bottom})
+  }
+  useLayoutEffect(()=>{
+    if(!position || !menu.current) return
+    const box=menu.current.getBoundingClientRect()
+    menu.current.style.left=`${Math.max(8,Math.min(position.x,window.innerWidth-box.width-8))}px`
+    menu.current.style.top=`${Math.max(8,Math.min(position.y,window.innerHeight-box.height-8))}px`
+    menu.current.querySelector('[role="menuitem"]')?.focus()
+  },[position])
+  useEffect(()=>{
+    if(!position) return
+    const outside=event=>{if(!menu.current?.contains(event.target)) close(false)}
+    const dismiss=()=>close(false)
+    document.addEventListener('pointerdown',outside)
+    window.addEventListener('resize',dismiss)
+    window.addEventListener('scroll',dismiss,true)
+    return ()=>{document.removeEventListener('pointerdown',outside);window.removeEventListener('resize',dismiss);window.removeEventListener('scroll',dismiss,true)}
+  },[position])
+  function toggle(field) {
+    try {saveConversationLabels(chat.chatId,{...labels,[field]:!labels[field]},labels);close();onSaved?.()}
+    catch(failure) {setError(failure.message)}
+  }
+  return <div ref={row} className="conversation-row" onContextMenu={open} onKeyDown={event=>{
+    if(event.key==='ContextMenu' || (event.shiftKey && event.key==='F10')) open(event)
+  }}>
+    {children}
+    <PixelConversationOrganizer chat={chat} title={title} onSaved={onSaved}/>
+    <button className="conversation-delete" aria-label={`Delete chat: ${title}`} title="Delete chat" onClick={onDelete}><X size={13}/></button>
+    {position && createPortal(<div ref={menu} role="menu" aria-label={`Chat actions: ${title}`} className="conversation-context-menu" style={{left:position.x,top:position.y}} onContextMenu={event=>event.preventDefault()} onKeyDown={event=>{
+      if(event.key==='Escape') {event.preventDefault();close();return}
+      if(event.key==='Tab') {close();return}
+      if(!['ArrowDown','ArrowUp','Home','End'].includes(event.key)) return
+      event.preventDefault()
+      const items=[...event.currentTarget.querySelectorAll('[role="menuitem"]')]
+      const index=items.indexOf(document.activeElement)
+      const next=event.key==='Home'?0:event.key==='End'?items.length-1:(index+(event.key==='ArrowDown'?1:-1)+items.length)%items.length
+      items[next]?.focus()
+    }}>
+      <button role="menuitem" onClick={()=>{close(false);row.current.querySelector('.conversation-organize')?.click()}}><Pencil size={15}/>Rename</button>
+      <button role="menuitem" onClick={()=>toggle('pinned')}><Pin size={15}/>{labels.pinned?'Unpin':'Pin'}</button>
+      <button role="menuitem" onClick={()=>toggle('archived')}><Archive size={15}/>{labels.archived?'Unarchive':'Archive'}</button>
+      <div role="separator"/>
+      <button role="menuitem" onClick={()=>{close();onExport()}}><Download size={15}/>Export conversation</button>
+      <button role="menuitem" onClick={()=>{close(false);row.current.querySelector('.conversation-delete')?.click()}}><X size={15}/>Delete chat</button>
+      {error && <p role="alert">{error}</p>}
+    </div>,document.body)}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelConversationRow.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationRow.test.jsx
@@ -1,0 +1,54 @@
+import {render,screen,fireEvent,within} from '@testing-library/react'
+import PixelConversationNavigation from './PixelConversationNavigation'
+import {ConversationTitle} from './PixelConversationRow'
+import {saveConversation,readConversations,SELECT_EVENT} from '../lib/pixelConversations'
+import {conversationLabels} from '../lib/pixelConversationLabels'
+
+beforeEach(()=>{
+  localStorage.clear()
+  saveConversation({schema:1,chatId:'row-test',messages:[{role:'user',content:'My chat'}]})
+  HTMLDialogElement.prototype.showModal=function(){this.open=true}
+  HTMLDialogElement.prototype.close=function(){this.open=false}
+})
+afterEach(()=>{vi.restoreAllMocks();vi.unstubAllGlobals();delete HTMLDialogElement.prototype.showModal;delete HTMLDialogElement.prototype.close})
+
+it('opens only supported actions on right click, supports keyboard navigation and restores focus',()=>{
+  const selected=vi.fn()
+  window.addEventListener(SELECT_EVENT,selected)
+  render(<PixelConversationNavigation/> )
+  const button=screen.getByRole('button',{name:'My chat',exact:true})
+  fireEvent.contextMenu(button,{clientX:900,clientY:700})
+  const menu=screen.getByRole('menu')
+  expect(within(menu).getAllByRole('menuitem').map(item=>item.textContent)).toEqual(['Rename','Pin','Archive','Export conversation','Delete chat'])
+  expect(screen.getByRole('menuitem',{name:'Rename'})).toHaveFocus()
+  fireEvent.keyDown(menu,{key:'ArrowDown'})
+  expect(screen.getByRole('menuitem',{name:'Pin'})).toHaveFocus()
+  fireEvent.keyDown(menu,{key:'Escape'})
+  expect(screen.queryByRole('menu')).toBeNull()
+  expect(button).toHaveFocus()
+  expect(selected).not.toHaveBeenCalled()
+  window.removeEventListener(SELECT_EVENT,selected)
+})
+
+it('pins from the context menu without changing messages and keeps deletion confirmation',()=>{
+  render(<PixelConversationNavigation/> )
+  fireEvent.keyDown(screen.getByRole('button',{name:'My chat',exact:true}),{key:'F10',shiftKey:true})
+  fireEvent.click(screen.getByRole('menuitem',{name:'Pin'}))
+  expect(conversationLabels('row-test').pinned).toBe(true)
+  expect(readConversations()[0].messages[0].content).toBe('My chat')
+  fireEvent.contextMenu(screen.getByRole('button',{name:'My chat',exact:true}))
+  expect(screen.getByRole('menuitem',{name:'Unpin'})).toBeVisible()
+  fireEvent.click(screen.getByRole('menuitem',{name:'Delete chat'}))
+  expect(screen.getByRole('dialog',{name:'Delete this chat?'})).toBeVisible()
+  expect(readConversations()).toHaveLength(1)
+})
+
+it('measures only overflowing titles for the hover animation',()=>{
+  vi.spyOn(HTMLElement.prototype,'clientWidth','get').mockReturnValue(120)
+  vi.spyOn(HTMLElement.prototype,'scrollWidth','get').mockImplementation(function(){return this.textContent==='Long title'?300:60})
+  const view=render(<ConversationTitle title="Long title"/>)
+  expect(view.container.firstChild).toHaveAttribute('data-overflow','true')
+  expect(view.container.firstChild.style.getPropertyValue('--title-travel')).toBe('-180px')
+  view.rerender(<ConversationTitle title="Short"/>)
+  expect(view.container.firstChild).toHaveAttribute('data-overflow','false')
+})

--- a/ods/extensions/services/dashboard/src/components/PixelDraftPreview.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDraftPreview.jsx
@@ -1,4 +1,5 @@
 import {useState} from 'react'
+import { ScanEye } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import './pixel-draft-preview.css'
@@ -11,7 +12,7 @@ const components = {
 export default function PixelDraftPreview({input}) {
   const [open,setOpen]=useState(false)
   return <div className="pixel-draft-preview">
-    <button type="button" disabled={!input.trim() && !open} aria-expanded={open} onClick={()=>setOpen(value=>!value)}>{open?'Hide draft preview':'Preview draft'}</button>
+    <button type="button" title={open?'Hide draft preview':'Preview draft'} aria-label={open?'Hide draft preview':'Preview draft'} disabled={!input.trim() && !open} aria-expanded={open} onClick={()=>setOpen(value=>!value)}><ScanEye size={16}/></button>
     {open && <section aria-label="Draft Markdown preview">
       <p className="pixel-draft-note">Preview only. Links and external images stay inactive.</p>
       {input.trim() ? <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>{input}</ReactMarkdown> : <p>Your draft is empty.</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelLiveActivity.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelLiveActivity.jsx
@@ -1,0 +1,14 @@
+import {parseTaskActivity} from '../lib/pixelTaskActivity'
+
+const labels = {read:'Reading', run:'Commands / checks', edit:'File edits', browser:'Web / browser', preview:'Preview publication', action:'Operations', agent:'Agent coordination', unknown:'Other tools'}
+
+export default function PixelLiveActivity({task: raw, active = false}) {
+  const task = parseTaskActivity(raw, raw?.runId)
+  if (!task) return null
+  return <details className="pixel-live-activity">
+    <summary>{active ? 'Live activity' : 'Recorded activity'} · {task.calls} tool {task.calls === 1 ? 'call' : 'calls'}</summary>
+    <ul>{task.activities.map(item => <li key={item.kind}><span>{labels[item.kind]}</span><span>{item.calls}{item.failures ? ` · ${item.failures} failed` : ''}</span></li>)}</ul>
+    {task.calls === 0 && <p>{active ? 'The runtime started this turn. No tool calls observed yet.' : 'No tool calls were recorded.'}</p>}
+    <p>Runtime observations, not private reasoning or proof of completion.{task.truncated ? ' Limited to the first 512 calls.' : ''}</p>
+  </details>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelMascot.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelMascot.jsx
@@ -1,17 +1,33 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import {useMascotPreferences} from '../lib/portalMascotPreferences'
 
 // Reuse the original Pixel renderer, including gaze and reduced-motion handling.
-export default function PixelMascot({ state = 'idle', settled = false, brand = false, className = '' }) {
+export default function PixelMascot({ state = 'idle', settled = false, brand = false, interactive = false, name = 'Portal', className = '', preview = false }) {
+  const preferences = useMascotPreferences()
+  const visible = preview || preferences.enabled
   const element = useRef(null)
   const animation = useRef(null)
+  const [sleeping, setSleeping] = useState(false)
+  useEffect(() => {
+    if (!visible || preview || !interactive || state !== 'idle' || !preferences.sleepAfterSeconds) { setSleeping(false); return }
+    let timer
+    const wake = () => { setSleeping(false); clearTimeout(timer); timer = setTimeout(() => setSleeping(true), preferences.sleepAfterSeconds * 1000) }
+    wake()
+    const events = ['pointermove', 'pointerdown', 'keydown', 'focus']
+    events.forEach(event => window.addEventListener(event, wake, {passive:true}))
+    return () => { clearTimeout(timer); events.forEach(event => window.removeEventListener(event, wake)) }
+  }, [interactive, state, visible, preview, preferences.sleepAfterSeconds])
   useEffect(() => {
     const node = element.current
+    if (!node || !visible) return
     const renderer = globalThis.PixelMascot
     animation.current = renderer
-    renderer?.mount(node, { state, settled })
+    renderer?.mount(node, { state, settled, static: !preferences.animated })
     return () => {renderer?.destroy(node); animation.current = null}
     // Mount once: state changes must retain the renderer's spring/pose.
-  }, [])
-  useEffect(() => {animation.current?.setState(element.current, state, { settled })}, [state, settled])
-  return <span ref={element} data-pixel-brand={brand ? '' : undefined} className={`pixel-character ${className}`} aria-hidden="true"><svg viewBox="0 0 64 64"><rect x="8" y="9" width="48" height="46" rx="15" fill="#e5e5e4"/><path d="M24 26v9m16-9v9" stroke="#18191b" strokeWidth="5" strokeLinecap="round"/></svg></span>
+  }, [visible, preferences.animated])
+  useEffect(() => {animation.current?.setState(element.current, sleeping && state === 'idle' ? 'sleeping' : state, { settled }); if (element.current) element.current.title = `${name} · ${sleeping && state === 'idle' ? 'sleeping' : state}`}, [state, settled, sleeping, name, visible, preferences.animated])
+  if (!visible) return null
+  const character = <span ref={element} data-pixel-name={name} data-pixel-brand={brand ? '' : undefined} data-pixel-interactive={interactive ? '' : undefined} className={`pixel-character ${className}`} aria-hidden="true"><svg viewBox="0 0 100 100"><rect x="19" y="20" width="62" height="60" rx="19" fill="#e5e5e4"/><path d="M40 41.75v14.5m20-14.5v14.5" stroke="#18191b" strokeWidth="9" strokeLinecap="round"/></svg></span>
+  return interactive ? <button type="button" className="pixel-pet-button" aria-label={`Play with ${name}`} title={sleeping ? `${name} is resting` : `Play with ${name}`} onClick={() => { setSleeping(false); animation.current?.play?.(element.current) }}>{character}</button> : character
 }

--- a/ods/extensions/services/dashboard/src/components/PixelMascot.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelMascot.test.jsx
@@ -1,11 +1,12 @@
-import {render, cleanup} from '@testing-library/react'
+import {render, cleanup, fireEvent, act, screen} from '@testing-library/react'
 import {afterEach, expect, it, vi} from 'vitest'
 import mascotSource from '../../public/pixel-mascot.js?raw'
 import vm from 'node:vm'
 import PixelMascot from './PixelMascot'
 import {pixelHeaderPose, pixelReplyPose} from '../lib/pixelMascotState'
+import {PORTAL_MASCOT_KEY,saveMascotPreferences} from '../lib/portalMascotPreferences'
 
-afterEach(() => {cleanup(); vi.unstubAllGlobals()})
+afterEach(() => {cleanup(); localStorage.removeItem(PORTAL_MASCOT_KEY); vi.unstubAllGlobals(); vi.useRealTimers()})
 
 it('updates state without remounting the SVG and destroys the renderer on unmount', () => {
   const renderer = {mount:vi.fn(), setState:vi.fn(), destroy:vi.fn()}
@@ -23,12 +24,15 @@ it('updates state without remounting the SVG and destroys the renderer on unmoun
 it('maps waiting, actual work, errors and historical replies coherently', () => {
   expect(pixelHeaderPose({status:'available'})).toBe('idle')
   expect(pixelHeaderPose({status:'available',sending:true})).toBe('thinking')
+  expect(pixelHeaderPose({status:'available',sending:true,task:{state:'running',tools:{started:1}}})).toBe('working')
+  expect(pixelHeaderPose({status:'available',sending:true,task:{state:'completed',tools:{started:1}}})).toBe('thinking')
   expect(pixelHeaderPose({status:'available',stopping:true,sending:true})).toBe('waiting')
   expect(pixelHeaderPose({status:'available',restoredActive:true})).toBe('working')
   expect(pixelHeaderPose({status:'unavailable'})).toBe('blocked')
   expect(pixelHeaderPose({status:'available',interrupted:true,restoredActivity:'unknown'})).toBe('blocked')
   expect(pixelReplyPose({status:'streaming'},false)).toBe('waiting')
   expect(pixelReplyPose({status:'streaming'},true)).toBe('thinking')
+  expect(pixelReplyPose({status:'streaming',task:{state:'running',tools:{started:1}}},true)).toBe('working')
   expect(pixelReplyPose({content:'Done'})).toBe('done')
   expect(pixelReplyPose({content:'Error',task:{state:'failed'}})).toBe('blocked')
   expect(pixelReplyPose({status:'stopped'})).toBe('idle')
@@ -36,10 +40,174 @@ it('maps waiting, actual work, errors and historical replies coherently', () => 
 
 function loadRenderer(reduced = false) {
   let frame
-  const runtime = {document, performance:{now:() => 0}, requestAnimationFrame:vi.fn(callback => {frame=callback; return 1}), cancelAnimationFrame:vi.fn(), matchMedia:() => ({matches:reduced,addEventListener(){}})}
+  let now=0
+  const runtime = {document, performance:{now:() => now}, requestAnimationFrame:vi.fn(callback => {frame=callback; return 1}), cancelAnimationFrame:vi.fn(() => {frame=undefined}), matchMedia:() => ({matches:reduced,addEventListener(){}})}
   vm.runInNewContext(mascotSource,runtime)
-  return {renderer:runtime.PixelMascot, runtime, advance:time => frame?.(time)}
+  return {renderer:runtime.PixelMascot, runtime, advance:time => {now=time;const pending=frame;frame=undefined;pending?.(time)}}
 }
+
+it('alternates thinking props, preserves the real state and clears props after thinking',()=>{
+  const {renderer,advance}=loadRenderer()
+  const question=renderer.samplePose('thinking',1.5)
+  const lens=renderer.samplePose('thinking',5.6)
+  expect(question.question).toBeGreaterThan(.95)
+  expect(question.lens).toBe(0)
+  expect(lens.lens).toBeGreaterThan(.95)
+  expect(lens.question).toBeLessThan(.001)
+  const element=document.createElement('span')
+  document.body.append(element)
+  renderer.mount(element,{state:'thinking'})
+  for(let t=16;t<=1600;t+=16) advance(t)
+  expect(Number(element.querySelector('.portal-thinking-question').getAttribute('opacity'))).toBeGreaterThan(.5)
+  for(let t=1616;t<=5600;t+=16) advance(t)
+  expect(Number(element.querySelector('.portal-thinking-lens').getAttribute('opacity'))).toBeGreaterThan(.5)
+  expect(element.dataset.mascotState).toBe('thinking')
+  renderer.setState(element,'done',{settled:true})
+  expect(element.querySelector('.portal-thinking-lens').getAttribute('opacity')).toBe('0')
+  expect(element.querySelector('.portal-thinking-question').getAttribute('opacity')).toBe('0')
+  renderer.destroy(element);element.remove()
+})
+
+it('applies visibility, motion and sleep preferences live, while keeping an isolated settings preview',()=>{
+  vi.useFakeTimers()
+  const renderer={mount:vi.fn(),setState:vi.fn(),destroy:vi.fn(),play:vi.fn()}
+  vi.stubGlobal('PixelMascot',renderer)
+  const view=render(<PixelMascot interactive/>)
+  act(()=>saveMascotPreferences({sleepAfterSeconds:15}))
+  act(()=>vi.advanceTimersByTime(15000))
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'sleeping',{settled:false})
+  act(()=>saveMascotPreferences({sleepAfterSeconds:0,animated:false}))
+  expect(renderer.mount).toHaveBeenLastCalledWith(expect.anything(),expect.objectContaining({static:true}))
+  act(()=>vi.advanceTimersByTime(600000))
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'idle',{settled:false})
+  act(()=>saveMascotPreferences({enabled:false}))
+  expect(screen.queryByRole('button',{name:'Play with Portal'})).toBeNull()
+  expect(renderer.destroy).toHaveBeenCalled()
+  const callsWhileHidden=renderer.setState.mock.calls.length
+  act(()=>vi.advanceTimersByTime(600000))
+  expect(renderer.setState).toHaveBeenCalledTimes(callsWhileHidden)
+  view.rerender(<PixelMascot interactive preview/>)
+  expect(screen.getByRole('button',{name:'Play with Portal'})).toBeVisible()
+  act(()=>vi.advanceTimersByTime(600000))
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'idle',{settled:false})
+})
+
+it('keeps every gesture bounded, finite, distinct, and returns gently to its base pose',()=>{
+  const {renderer}=loadRenderer()
+  const neutral=renderer.sampleGesture('unknown')
+  expect(Object.keys(renderer.GESTURES)).toHaveLength(10)
+  for(const [name,duration] of Object.entries(renderer.GESTURES)) {
+    expect(renderer.sampleGesture(name,-1)).toEqual(neutral)
+    expect(renderer.sampleGesture(name,duration)).toEqual(neutral)
+    expect(renderer.sampleGesture(name,Infinity)).toEqual(neutral)
+    expect(renderer.sampleGesture(name,duration/2)).not.toEqual(neutral)
+    for(let t=0;t<duration;t+=.02) {
+      const pose=renderer.sampleGesture(name,t)
+      expect(Object.values(pose).every(Number.isFinite)).toBe(true)
+      expect(Math.abs(pose.x)).toBeLessThanOrEqual(10)
+      expect(Math.abs(pose.y)).toBeLessThanOrEqual(16)
+      expect(Math.abs(pose.rotate)).toBeLessThanOrEqual(25)
+      expect(pose.sy).toBeGreaterThan(.8)
+      expect(pose.sy).toBeLessThan(1.2)
+    }
+  }
+  expect(renderer.sampleGesture('hop-left',.7).x).toBeLessThan(0)
+  expect(renderer.sampleGesture('hop-right',.7).x).toBeGreaterThan(0)
+  const wink=renderer.sampleGesture('wink',.85)
+  expect(wink.leftOpen).toBeLessThan(.1)
+  expect(wink.rightOpen).toBe(1)
+})
+
+it('greets, cycles five click reactions, and reveals a finite triple-click surprise',()=>{
+  const {renderer,advance,runtime}=loadRenderer()
+  const element=document.createElement('span')
+  element.dataset.pixelInteractive=''
+  document.body.append(element)
+  renderer.mount(element)
+  expect(element.dataset.portalGesture).toBe('hello')
+  expect(element.querySelector('.pixel-mascot-eye').getAttribute('d')).toContain('-7.25')
+  expect(element.querySelector('.pixel-mascot-eye').getAttribute('stroke-width')).toBe('9')
+  for(const [index,name] of ['hop-left','hop-right','squish','wink','twirl'].entries()) {
+    advance(3000+index*3000)
+    renderer.play(element)
+    expect(element.dataset.portalGesture).toBe(name)
+  }
+  advance(18000);renderer.play(element)
+  advance(18180);renderer.play(element)
+  advance(18360);renderer.play(element)
+  expect(element.dataset.portalGesture).toBe('starstruck')
+  for(let t=18376;t<19700;t+=16) advance(t)
+  expect(Number(element.querySelector('.portal-sparkles').getAttribute('opacity'))).toBeGreaterThan(.5)
+  advance(22000)
+  expect(element.dataset.portalGesture).toBeUndefined()
+  expect(element.querySelector('.portal-sparkles').getAttribute('opacity')).toBe('0')
+  renderer.destroy(element)
+  expect(runtime.cancelAnimationFrame).toHaveBeenCalled()
+  element.remove()
+})
+
+it('never replaces real task states with play, interrupts gestures on state changes, and stretches on waking',()=>{
+  const {renderer,advance}=loadRenderer()
+  const element=document.createElement('span')
+  element.dataset.pixelInteractive=''
+  document.body.append(element)
+  renderer.mount(element)
+  renderer.setState(element,'working')
+  expect(element.dataset.portalGesture).toBeUndefined()
+  renderer.play(element)
+  expect(element.dataset.portalGesture).toBe('nod')
+  expect(element.dataset.mascotState).toBe('working')
+  renderer.setState(element,'blocked')
+  expect(element.dataset.portalGesture).toBeUndefined()
+  renderer.setState(element,'sleeping')
+  advance(2000)
+  renderer.play(element)
+  expect(element.dataset.mascotState).toBe('idle')
+  expect(element.dataset.portalGesture).toBe('stretch')
+  renderer.setState(element,'done',{settled:true})
+  const still=element.innerHTML
+  renderer.play(element)
+  fireEvent.pointerEnter(element)
+  advance(5000)
+  expect(element.innerHTML).toBe(still)
+  renderer.destroy(element);element.remove()
+})
+
+it('suppresses optional gestures and RAFs with reduced motion while retaining readable states',()=>{
+  const {renderer,runtime,advance}=loadRenderer(true)
+  const element=document.createElement('span')
+  element.dataset.pixelInteractive=''
+  document.body.append(element)
+  renderer.mount(element)
+  renderer.play(element)
+  fireEvent.pointerEnter(element)
+  advance(2000)
+  expect(element.dataset.portalGesture).toBeUndefined()
+  renderer.setState(element,'sleeping')
+  expect(element.querySelector('text').getAttribute('opacity')).toBe('0.7')
+  renderer.setState(element,'idle')
+  expect(element.dataset.portalGesture).toBeUndefined()
+  expect(runtime.requestAnimationFrame).not.toHaveBeenCalled()
+  renderer.destroy(element);element.remove()
+})
+
+it('rests after one idle minute by default, wakes on activity, never sleeps during a task, and supports keyboard play',()=>{
+  vi.useFakeTimers()
+  const renderer={mount:vi.fn(),setState:vi.fn(),destroy:vi.fn(),play:vi.fn()}
+  vi.stubGlobal('PixelMascot',renderer)
+  const view=render(<PixelMascot interactive name="Nova"/>)
+  act(()=>vi.advanceTimersByTime(59999))
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'idle',{settled:false})
+  act(()=>vi.advanceTimersByTime(1))
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'sleeping',{settled:false})
+  fireEvent.keyDown(window,{key:'a'})
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'idle',{settled:false})
+  fireEvent.click(screen.getByRole('button',{name:'Play with Nova'}))
+  expect(renderer.play).toHaveBeenCalledOnce()
+  view.rerender(<PixelMascot interactive name="Nova" state="thinking"/>)
+  act(()=>vi.advanceTimersByTime(600000))
+  expect(renderer.setState).toHaveBeenLastCalledWith(expect.anything(),'thinking',{settled:false})
+})
 
 it('the original renderer moves a live pose, keeps settled replies still and honors reduced motion', () => {
   const {renderer,runtime,advance} = loadRenderer()
@@ -67,4 +235,63 @@ it('the original renderer moves a live pose, keeps settled replies still and hon
   expect(reduced.renderer.samplePose('thinking',0,{reduced:true})).toEqual(reduced.renderer.samplePose('thinking',10,{reduced:true}))
   reduced.renderer.destroy(quiet)
   quiet.remove()
+})
+
+it('tracks the pointer, alternates play, and gently animates sleep until the mascot is removed', () => {
+  const {renderer,runtime,advance}=loadRenderer()
+  const element=document.createElement('span')
+  element.dataset.pixelInteractive=''
+  element.dataset.pixelName='Nova'
+  element.getBoundingClientRect=()=>({left:0,top:0,width:64,height:64})
+  document.body.append(element)
+  renderer.mount(element,{state:'idle'})
+  const motion=element.querySelector('svg > g')
+  const rest=motion.getAttribute('transform')
+  renderer.play(element)
+  for(let t=16;t<=192;t+=16) advance(t)
+  const first=motion.getAttribute('transform')
+  expect(first).not.toBe(rest)
+  for(let t=208;t<=2016;t+=16) advance(t)
+  renderer.play(element)
+  for(let t=2032;t<=2208;t+=16) advance(t)
+  expect(motion.getAttribute('transform')).not.toBe(first)
+  for(let t=2224;t<=4000;t+=16) advance(t)
+  const beforeGaze=element.innerHTML
+  fireEvent(document,new MouseEvent('pointermove',{clientX:600,clientY:100,bubbles:true}))
+  for(let t=4016;t<=4208;t+=16) advance(t)
+  expect(element.innerHTML).not.toBe(beforeGaze)
+  renderer.setState(element,'sleeping')
+  advance(7000)
+  expect(element.title).toBe('Nova · sleeping')
+  expect(element.querySelector('text')).toHaveTextContent('zz')
+  runtime.requestAnimationFrame.mockClear()
+  const sleepPose=motion.getAttribute('transform')
+  advance(8000)
+  expect(runtime.requestAnimationFrame).toHaveBeenCalled()
+  expect(motion.getAttribute('transform')).not.toBe(sleepPose)
+  renderer.destroy(element)
+  runtime.requestAnimationFrame.mockClear()
+  advance(9000)
+  expect(runtime.requestAnimationFrame).not.toHaveBeenCalled()
+  element.remove()
+})
+
+it('gives sleep, work and waiting distinct motion, and attention a gentle finite pose',()=>{
+  const {renderer}=loadRenderer()
+  const sleep=renderer.samplePose('sleeping',1)
+  expect(sleep.sleepY).not.toBe(renderer.samplePose('sleeping',3).sleepY)
+  expect(sleep.sy).not.toBe(renderer.samplePose('sleeping',3).sy)
+  expect(renderer.samplePose('working',2).gear).toBe(1)
+  expect(renderer.samplePose('working',2).gearRotate).toBeGreaterThan(renderer.samplePose('working',1).gearRotate)
+  expect(renderer.samplePose('waiting',4.5).hourglass).toBe(1)
+  expect(renderer.samplePose('waiting',4.5).waitRotate).toBeGreaterThan(0)
+  const attention=renderer.samplePose('blocked',5,{settled:true})
+  expect(attention.attention).toBe(1)
+  expect(attention.eyeTilt).toBe(0)
+  expect(attention.eyeOpen).toBeGreaterThan(.8)
+  expect(attention.sy).toBeGreaterThan(.98)
+  for(const state of ['sleeping','working','waiting','blocked']) {
+    expect(renderer.samplePose(state,0,{reduced:true})).toEqual(renderer.samplePose(state,8,{reduced:true}))
+    expect(renderer.samplePose(state,0,{settled:true})).toEqual(renderer.samplePose(state,8,{settled:true}))
+  }
 })

--- a/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
@@ -1,4 +1,5 @@
 import {useEffect, useRef, useState} from 'react'
+import { Bookmark } from 'lucide-react'
 import {readSavedPrompts, writeSavedPrompt} from '../lib/pixelSavedPrompts'
 
 export default function PixelPromptLibrary({input, disabled, onInsert}) {
@@ -30,7 +31,7 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
   const fieldClass = 'my-2 block w-full rounded border border-theme-border bg-theme-bg p-2 text-theme-text'
   const buttonClass = 'rounded border border-theme-border px-3 py-2 text-xs hover:bg-theme-surface-hover disabled:opacity-40'
   return <>
-    <button ref={trigger} type="button" disabled={disabled} aria-label="Saved prompts" onClick={() => {refresh(); dialog.current.showModal()}}>Saved prompts</button>
+    <button ref={trigger} type="button" disabled={disabled} aria-label="Saved prompts" title="Saved prompts" onClick={() => {refresh(); dialog.current.showModal()}}><Bookmark size={16}/></button>
     <dialog ref={dialog} className="chat-delete-dialog" style={{maxHeight:'calc(100dvh - 32px)', overflowY:'auto'}} aria-label="Saved prompts" onCancel={event => {event.preventDefault(); close()}}>
       <h3>Saved prompts</h3><p>Reusable text stored in this browser. Insert a prompt into your draft, then review it before sending.</p>
       {error && <p role="alert">{error}</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelTaskActivity.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTaskActivity.jsx
@@ -37,7 +37,7 @@ export default function PixelTaskActivity({messages, sending, elapsed}) {
       <h2>{turn?.prompt || 'Ready for your next task'}</h2>
       <p role="status">{active ? `Working · ${elapsed} elapsed` : task ? `${task.state === 'failed' ? 'Turn ended with an error' : task.state === 'running' ? 'Completion not observed' : 'Turn ended'}${duration !== null ? ` · ${duration}s` : ''}` : 'No recorded tool activity for this turn'}</p>
     </header>
-    {active ? <p className="pixel-activity-note">The tool summary will appear when the runtime finishes this turn.</p> : task ? <>
+    {task ? <>
       <div className="pixel-activity-heading"><h3>Tools</h3><span>{task.calls} calls</span></div>
       <ul>
         {task.activities.map(item => {
@@ -51,9 +51,9 @@ export default function PixelTaskActivity({messages, sending, elapsed}) {
           </li>
         })}
       </ul>
-      {task.calls === 0 && <p className="pixel-activity-note">No tool calls were observed. This turn used the model only.</p>}
+      {task.calls === 0 && <p className="pixel-activity-note">{active ? 'The runtime started this turn. No tool calls observed yet.' : 'No tool calls were observed. This turn used the model only.'}</p>}
       {task.truncated && <p className="pixel-activity-warning">Only the first 512 calls are included.</p>}
       <p className="pixel-activity-note">Recorded by the Pixel runtime. Tool calls show attempts, not proof that the requested result works. Saved with this conversation in this browser.</p>
-    </> : <p className="pixel-activity-note">Older replies do not contain runtime observations. They are not reconstructed from the assistant’s claims.</p>}
+    </> : <p className="pixel-activity-note">{active ? 'Waiting for runtime observations. This runtime may not provide live activity.' : 'Older replies do not contain runtime observations. They are not reconstructed from the assistant’s claims.'}</p>}
   </section>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelTaskActivity.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTaskActivity.test.jsx
@@ -30,3 +30,14 @@ it('shares strict schema behavior with the host and rejects nonterminal/cross-ru
   expect(parseTaskActivityFrame({id:'other',pixel_task:task,choices:[{finish_reason:'stop'}]})).toBeNull()
   expect(parseTaskActivityFrame({id:task.runId,pixel_task:task,choices:[{finish_reason:null}]})).toBeNull()
 })
+
+it('accepts only explicit live observation packets and renders tools during the turn',()=>{
+  const live={...task,state:'running',finishedAt:null}
+  const packet={object:'ods.task.activity',id:task.runId,pixel_task:live}
+  expect(parseTaskActivityFrame(packet)).toEqual(live)
+  expect(parseTaskActivityFrame({...packet,prompt:'secret'})).toBeNull()
+  expect(parseTaskActivityFrame({...packet,pixel_task:task})).toBeNull()
+  render(<PixelTaskActivity sending elapsed="0:05" messages={[{role:'assistant',task:live}]}/> )
+  expect(screen.getByText('Read')).toBeVisible()
+  expect(screen.getByRole('status')).toHaveTextContent('Working · 0:05')
+})

--- a/ods/extensions/services/dashboard/src/components/PixelTextFileInput.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTextFileInput.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Paperclip } from 'lucide-react'
 
 const EXTENSIONS = /\.(txt|md|markdown|csv|tsv|json|jsonl|yaml|yml|toml|xml|html|css|js|jsx|ts|tsx|py|sh|log)$/i
 const MAX_BYTES = 16 * 1024
@@ -41,7 +42,7 @@ export default function PixelTextFileInput({ input, disabled, limit, onInsert })
   const fits = file && input.length + file.text.length + 1 <= limit
   return <div className="pixel-text-file-input text-xs text-theme-text-secondary">
     <input ref={field} type="file" aria-label="Choose text file" accept=".txt,.md,.csv,.tsv,.json,.jsonl,.yaml,.yml,.toml,.xml,.html,.css,.js,.jsx,.ts,.tsx,.py,.sh,.log" hidden disabled={disabled} onChange={choose}/>
-    <button type="button" className="pixel-metal-control rounded px-2 py-1" disabled={disabled || reading} onClick={() => field.current?.click()}>Add text file</button>
+    <button type="button" aria-label="Add text file" title="Add text file" disabled={disabled || reading} onClick={() => field.current?.click()}><Paperclip size={16}/></button>
     {reading && <span role="status">Reading local file…</span>}
     {error && <p role="alert">{error}</p>}
     {file && <div role="group" aria-label="Review text file">

--- a/ods/extensions/services/dashboard/src/components/SettingsModal.jsx
+++ b/ods/extensions/services/dashboard/src/components/SettingsModal.jsx
@@ -4,13 +4,17 @@ import { Search, Settings as Gear, Palette, Activity, Network, HardDrive, Refres
 import Settings from '../pages/Settings'
 import MetalMetricIcon from './MetalMetricIcon'
 import ProfileSettings from './settings/ProfileSettings'
+import AssistantIdentitySettings from './settings/AssistantIdentitySettings'
+import PortalMascotSettings from './settings/PortalMascotSettings'
 import '../settings-refinement.css'
+import '../settings-workspace.css'
 const Integrations = lazy(() => import('../pages/ServiceMap'))
 const RemoteGPU = lazy(() => import('../pages/RemoteProvider'))
 const PixelDiagnostics = lazy(() => import('./settings/PixelDiagnostics'))
 
 const sections = [
   ['general', 'General', Gear], ['profile', 'Profile', UserRound], ['appearance', 'Appearance', Palette],
+  ['portal-mascot', 'Portal mascot', Bot],
   ['usage', 'Usage', Activity], ['owner', 'Setup / Owner', UserRound],
   ['connections', 'Pixel connections', Bot], ['access', 'Pixel access', ShieldCheck],
   ['sharing', 'Model sharing', Share2], ['services', 'Services', Network],
@@ -41,8 +45,9 @@ export default function SettingsModal() {
         {!sections.some(([,label]) => label.toLowerCase().includes(query.toLowerCase())) && <p>No settings found.</p>}
       </nav>
     </aside>
-    <div ref={content} className="ods-settings-content" aria-label={sections.find(([id]) => id === section)[1]}><div hidden={section === 'profile'}><Settings activeSection={section} /></div>
-      {visited.has('profile') && <div hidden={section !== 'profile'}><ProfileSettings/></div>}
+    <div ref={content} className="ods-settings-content" aria-label={sections.find(([id]) => id === section)[1]}><div hidden={['profile','portal-mascot','pixel-diagnostics','integrations','remote'].includes(section)}><Settings activeSection={section} /></div>
+      {visited.has('profile') && <div hidden={section !== 'profile'} className="space-y-6"><ProfileSettings/><AssistantIdentitySettings/></div>}
+      {section === 'portal-mascot' && <PortalMascotSettings/>}
       <Suspense fallback={<p>Loading settings…</p>}>
         {section === 'pixel-diagnostics' && <PixelDiagnostics />}
         {visited.has('integrations') && <div hidden={section !== 'integrations'}><Integrations compact /></div>}

--- a/ods/extensions/services/dashboard/src/components/SettingsModal.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/SettingsModal.test.jsx
@@ -36,11 +36,21 @@ it('leaves closing and collapsing to the workspace panel header', () => {
   expect(close).not.toHaveBeenCalled()
 })
 
+it('provides mascot controls in their own settings section',()=>{
+  render(<SettingsModal/>)
+  fireEvent.click(screen.getByRole('button',{name:'Portal mascot',exact:true}))
+  expect(screen.getByRole('heading',{name:'Portal mascot'})).toBeVisible()
+  expect(screen.getByLabelText('Sleep after inactivity')).toBeVisible()
+  expect(screen.getByRole('button',{name:'Thinking',exact:true})).toHaveAttribute('aria-pressed','true')
+})
+
 it('opens the editable profile section without losing another settings draft',()=>{
   render(<SettingsModal/>)
   fireEvent.change(screen.getByLabelText('Draft'),{target:{value:'Unsaved'}})
   fireEvent.click(screen.getByRole('button',{name:'Profile',exact:true}))
   expect(screen.getByRole('textbox',{name:'Display name'})).toBeVisible()
+  expect(screen.getByRole('textbox',{name:'Assistant display name'})).toBeVisible()
+  expect(screen.getByRole('button',{name:'Save name'})).toBeVisible()
   fireEvent.click(screen.getByRole('button',{name:'General',exact:true}))
   expect(screen.getByLabelText('Draft')).toHaveValue('Unsaved')
 })

--- a/ods/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/ods/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { NavLink, useLocation } from 'react-router-dom'
+import { NavLink, useLocation, useNavigate } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { ArrowLeft, ChevronLeft, ChevronRight, Plus, Search, Sparkles, Settings } from 'lucide-react'
 import { getSidebarExternalLinks, getSidebarNavItems } from '../plugins/registry'
@@ -15,6 +15,7 @@ import UserAvatar from './UserAvatar'
 export default function Sidebar({ status, collapsed, onToggle }) {
   const profile = useLocalProfile()
   const { pathname } = useLocation()
+  const navigate = useNavigate()
   const pixelMode = pathname.startsWith('/pixel')
   const [query, setQuery] = useState('')
   const [searchOpen, setSearchOpen] = useState(false)
@@ -41,6 +42,14 @@ export default function Sidebar({ status, collapsed, onToggle }) {
     { path: '/pixel/settings', label: 'Settings', icon: Settings },
   ] : getSidebarNavItems({ status }).map(item => item.id === 'pixel' ? { ...item, label: displayName } : item)
   function closeSearch() { setSearchOpen(false); setQuery('') }
+  function navigatePanel(event, path) {
+    closeSearch()
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return
+    if (path !== '/' && path !== '/pixel' && pathname === path) {
+      event.preventDefault()
+      navigate('/')
+    }
+  }
   function toggleSearch() {
     if (searchOpen) { closeSearch(); return }
     if (collapsed) onToggle()
@@ -60,7 +69,7 @@ export default function Sidebar({ status, collapsed, onToggle }) {
       </>}
       <button className="pixel-nav-item" title="Search navigation" aria-label="Search" onClick={toggleSearch} aria-expanded={searchOpen}><Search size={16} /><span>Search</span></button>
       {searchOpen && !collapsed && <input autoFocus aria-label="Search navigation" placeholder="Find a page…" value={query} onChange={event => setQuery(event.target.value)} onKeyDown={event => { if (event.key === 'Escape') { closeSearch(); event.currentTarget.previousElementSibling?.focus() } }} className="pixel-nav-search" />}
-      {links.filter(item => item.label.toLowerCase().includes(query.toLowerCase())).map(({ path, label, icon: Icon }) => <NavLink key={path} to={path} end title={label} aria-label={label} onClick={closeSearch} className={({ isActive }) => `pixel-nav-item ${isActive ? 'is-active' : ''}`}><Icon size={16} /><span>{label}</span></NavLink>)}
+      {links.filter(item => item.label.toLowerCase().includes(query.toLowerCase())).map(({ path, label, icon: Icon }) => <NavLink key={path} to={path} end title={label} aria-label={label} onClick={event => navigatePanel(event, path)} className={({ isActive }) => `pixel-nav-item ${isActive ? 'is-active' : ''}`}><Icon size={16} /><span>{label}</span></NavLink>)}
       {!pixelMode && applications.length > 0 && <details className="pixel-applications" open={query ? true : undefined}>
         <summary aria-label="Applications"><span>{collapsed ? '•••' : 'Applications'}</span><svg className="rail-chevron" viewBox="0 0 16 16" aria-hidden="true"><path d="m5 6 3 3 3-3"/></svg></summary>
         {applications.filter(link => link.label.toLowerCase().includes(query.toLowerCase())).map(({ key, label, icon: Icon, healthy, url }) => {

--- a/ods/extensions/services/dashboard/src/components/SidebarToggle.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/SidebarToggle.test.jsx
@@ -1,0 +1,24 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import {MemoryRouter, useLocation} from 'react-router-dom'
+import Sidebar from './Sidebar'
+vi.mock('./ODSLogo',()=>({default:()=>null}))
+vi.mock('./PixelConversationNavigation',()=>({default:()=>null}))
+vi.mock('../plugins/registry',()=>({getSidebarExternalLinks:()=>[],getSidebarNavItems:()=>['Dashboard','Models','Extensions','Settings'].map(label=>({label,path:`/${label.toLowerCase()}`,icon:()=>null}))}))
+function Location(){return <output data-testid="location">{useLocation().pathname}</output>}
+beforeEach(()=>vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>[]}))))
+afterEach(()=>vi.unstubAllGlobals())
+it.each(['Dashboard','Models','Extensions','Settings'])('toggles %s open and closed from the navigation',label=>{
+  render(<MemoryRouter><Sidebar status={{}}/><Location/></MemoryRouter>)
+  const link=screen.getByRole('link',{name:label,exact:true})
+  fireEvent.click(link)
+  expect(screen.getByTestId('location')).toHaveTextContent(`/${label.toLowerCase()}`)
+  fireEvent.click(link)
+  expect(screen.getByTestId('location').textContent).toBe('/')
+})
+it('switches panels directly and leaves modified clicks to the browser',()=>{
+  render(<MemoryRouter initialEntries={['/models']}><Sidebar status={{}}/><Location/></MemoryRouter>)
+  fireEvent.click(screen.getByRole('link',{name:'Models'}),{ctrlKey:true})
+  expect(screen.getByTestId('location')).toHaveTextContent('/models')
+  fireEvent.click(screen.getByRole('link',{name:'Extensions'}))
+  expect(screen.getByTestId('location')).toHaveTextContent('/extensions')
+})

--- a/ods/extensions/services/dashboard/src/components/__tests__/EnvEditor.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/EnvEditor.test.jsx
@@ -56,6 +56,15 @@ const renderEditor = (overrides = {}) =>
   )
 
 describe('EnvEditor', () => {
+  test('offers compact category navigation and search without behavior cards', () => {
+    const onSearchChange = vi.fn(), onSectionChange = vi.fn()
+    renderEditor({ onSearchChange, onSectionChange, sections: [...baseSections, { id: 'ports', title: 'Ports', keys: [] }] })
+    fireEvent.change(screen.getByRole('combobox', { name: 'Configuration category' }), { target: { value: 'ports' } })
+    expect(onSectionChange).toHaveBeenCalledWith('ports')
+    fireEvent.change(screen.getByRole('textbox', { name: 'Filter configuration fields' }), { target: { value: 'model' } })
+    expect(onSearchChange).toHaveBeenCalledWith('model')
+    expect(screen.queryByText(/Save Behavior|Restart Behavior|Apply Behavior/)).toBeNull()
+  })
   test('renders stored secrets as masked placeholders instead of exposing values', () => {
     renderEditor()
 
@@ -195,7 +204,7 @@ describe('EnvEditor', () => {
       values: { ODS_MODE: 'local' },
     })
 
-    expect(screen.getByRole('combobox')).toBeDisabled()
+    expect(screen.getByRole('combobox', { name: /ODS Mode/i })).toBeDisabled()
     expect(screen.getByText('read only')).toBeInTheDocument()
     expect(screen.getByText(/selected by the installer/i)).toBeInTheDocument()
   })

--- a/ods/extensions/services/dashboard/src/components/pixel-conversation-organizer.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-conversation-organizer.css
@@ -1,5 +1,16 @@
-.pixel-conversation-navigation .pixel-original-sections .conversation-row .conversation-link { padding-left:64px; }
-.conversation-organize { position:absolute; left:32px; top:50%; transform:translateY(-50%); width:26px; height:26px; display:grid; place-items:center; opacity:0; color:#aeb5be; border:0; border-radius:5px; background:transparent; pointer-events:none; }
+.pixel-conversation-navigation .pixel-original-sections .conversation-row .conversation-link { padding-left:34px; padding-right:32px; }
+.conversation-organize { position:absolute; right:3px; top:50%; transform:translateY(-50%); width:26px; height:26px; display:grid; place-items:center; opacity:0; color:#aeb5be; border:0; border-radius:5px; background:transparent; pointer-events:none; }
 .conversation-row:hover .conversation-organize,.conversation-row:focus-within .conversation-organize { opacity:1; pointer-events:auto; }
 .conversation-organize:hover { color:#fff; background:#ffffff12; }
 @media(hover:none) { .conversation-organize { opacity:1; pointer-events:auto; } }
+.conversation-title > span { display:block; width:max-content; min-width:100%; max-width:100%; overflow:hidden; text-overflow:ellipsis; }
+.conversation-row:is(:hover,:focus-within) .conversation-title[data-overflow='true'] { text-overflow:clip; }
+.conversation-row:is(:hover,:focus-within) .conversation-title[data-overflow='true'] > span { max-width:none; overflow:visible; animation:conversation-title-scroll var(--title-duration,5s) ease-in-out infinite alternate; }
+@keyframes conversation-title-scroll { 0%,18% { transform:translateX(0); } 82%,100% { transform:translateX(var(--title-travel)); } }
+@media(prefers-reduced-motion:reduce) { .conversation-row .conversation-title > span { animation:none!important; } }
+.conversation-context-menu { position:fixed; z-index:1000; width:224px; max-width:calc(100vw - 16px); max-height:calc(100dvh - 16px); overflow:auto; padding:5px; border:1px solid #ffffff16; border-radius:10px; background:#202223; color:#e1e4e7; box-shadow:0 12px 36px #0006; font:12px/1.4 Inter,ui-sans-serif,system-ui,sans-serif; }
+.conversation-context-menu > button { display:flex; align-items:center; gap:11px; width:100%; padding:9px 10px; border-radius:6px; text-align:left; background:transparent; }
+.conversation-context-menu > button:is(:hover,:focus-visible) { background:#ffffff0d; outline:none; }
+.conversation-context-menu > button svg { color:#adb4bc; }
+.conversation-context-menu > [role='separator'] { margin:4px 5px; border-top:1px solid #ffffff14; }
+.conversation-context-menu > p { padding:8px; color:#f1b4a9; }

--- a/ods/extensions/services/dashboard/src/components/settings/AssistantIdentitySettings.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/AssistantIdentitySettings.jsx
@@ -5,16 +5,15 @@ export default function AssistantIdentitySettings() {
   const { document, ready, busy, error, notice, reload, save } = usePortalIdentity()
   const [draft, setDraft] = useState('')
   useEffect(() => { if (document) setDraft(document.displayName) }, [document])
-  return <section className="rounded border border-theme-border p-4 space-y-3" aria-labelledby="assistant-identity-title">
-    <h2 id="assistant-identity-title" className="font-medium">Assistant identity</h2>
-    <p className="text-sm text-theme-text-muted">Applies to this ODS installation across browsers. Changes display text only; no model restart or permission changes. Your own profile is separate.</p>
+  return <section className="profile-settings assistant-identity-settings" aria-labelledby="assistant-identity-title">
+    <h2 id="assistant-identity-title">Assistant identity</h2>
+    <p>The assistant’s name across this ODS installation.</p>
     <form onSubmit={event => { event.preventDefault(); void save(draft) }} className="space-y-3">
-      <label className="block">Assistant display name
-        <input className="block w-full rounded border border-theme-border bg-theme-bg p-2" autoComplete="off" maxLength={240}
-          placeholder="Portal" value={draft} onChange={event => setDraft(event.target.value)} disabled={busy || !ready}/>
+      <label className="profile-name-label">Assistant display name
+        <input autoComplete="off" maxLength={60}
+          placeholder="Assistant name" value={draft} onChange={event => setDraft(event.target.value)} disabled={busy || !ready}/>
       </label>
-      <p className="text-xs text-theme-text-muted">Up to 60 characters. An empty name resets to Portal.</p>
-      <div className="flex flex-wrap gap-3">
+      <div className="profile-settings-actions assistant-identity-actions">
         <button type="submit" disabled={busy || !ready}>Save name</button>
         <button type="button" disabled={busy || !ready} onClick={() => setDraft('Portal')}>Reset to Portal</button>
         <button type="button" disabled={busy} onClick={() => { void reload() }}>Refresh saved name</button>

--- a/ods/extensions/services/dashboard/src/components/settings/EnvEditor.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/EnvEditor.jsx
@@ -1,14 +1,10 @@
 import {
   AlertTriangle,
-  BookOpen,
   CheckCircle2,
   Database,
   Download,
-  ExternalLink,
   Eye,
   EyeOff,
-  FileText,
-  Folder,
   Lock,
   RefreshCw,
   RotateCcw,
@@ -43,18 +39,6 @@ const groupSections = (sections = []) => {
   return grouped.filter(group => group.sections.length > 0)
 }
 
-const sectionDescription = (section) => {
-  const title = String(section?.title || '').toLowerCase()
-  if (title.includes('required')) return 'Required values read from the active .env schema.'
-  if (title.includes('network') || title.includes('port')) return 'Network bindings and port overrides read from the active .env schema.'
-  if (title.includes('llm') || title.includes('cloud')) return 'Model backend, hosted LLM, and provider settings from the active .env schema.'
-  if (title.includes('langfuse')) return 'LLM observability settings from the active .env schema.'
-  if (title.includes('gpu')) return 'GPU and runtime allocation settings from the active .env schema.'
-  if (title.includes('security')) return 'Security-related environment values from the active .env schema.'
-  if (title.includes('proxy')) return 'LAN proxy settings from the active .env schema.'
-  return 'Fields and descriptions are generated from .env.schema.json and the current .env file.'
-}
-
 export default function EnvEditor({
   editor,
   search,
@@ -74,6 +58,7 @@ export default function EnvEditor({
   onRefresh,
   onReload,
   onSave,
+  onExport,
   onApply = () => {},
   dirty,
   saving,
@@ -92,6 +77,7 @@ export default function EnvEditor({
         onRefresh={onRefresh || onReload}
         onReload={onReload}
         onSave={onSave}
+        onExport={onExport}
         onApply={onApply}
         saving={saving}
         applying={applying}
@@ -105,12 +91,6 @@ export default function EnvEditor({
           fieldCount={Object.keys(fields || {}).length}
           issueCount={issues.length}
           issueSectionCount={issueSectionCount}
-        />
-
-        <EnvironmentBehaviorCards
-          editor={editor}
-          canApply={canApply}
-          applyPlan={applyPlan}
         />
 
         {applyPlan?.status && applyPlan.status !== 'none' ? (
@@ -159,7 +139,7 @@ export default function EnvEditor({
           </div>
         ) : null}
 
-        <div className="grid gap-5 xl:grid-cols-[320px_1fr]">
+        <div className="environment-editor-layout">
           <EnvironmentCategorySidebar
             search={search}
             onSearchChange={onSearchChange}
@@ -176,7 +156,6 @@ export default function EnvEditor({
                     <SlidersHorizontal size={20} className="mt-1 shrink-0 text-theme-accent-light" />
                     <div>
                       <h3 className="text-xl font-semibold text-theme-text">{activeSection.title}</h3>
-                      <p className="mt-1 text-sm leading-6 text-theme-text-muted">{sectionDescription(activeSection)}</p>
                     </div>
                   </div>
                   <div className="flex flex-wrap items-center gap-4 text-xs">
@@ -188,7 +167,7 @@ export default function EnvEditor({
                   </div>
                 </div>
 
-                <div className="max-h-[58rem] space-y-4 overflow-y-auto pr-1">
+                <div className="environment-field-list">
                   {activeKeys.map((key) => (
                     <EnvironmentFieldCard
                       key={key}
@@ -202,7 +181,6 @@ export default function EnvEditor({
                       onChange={(value) => onFieldChange(key, value)}
                     />
                   ))}
-                  <EnvironmentHelpCard />
                 </div>
               </>
             ) : (
@@ -217,16 +195,14 @@ export default function EnvEditor({
   )
 }
 
-function EnvironmentEditorHeader({ onRefresh, onReload, onSave, onApply, saving, applying, dirty, canApply }) {
+function EnvironmentEditorHeader({ onRefresh, onReload, onSave, onExport, onApply, saving, applying, dirty, canApply }) {
   return (
     <header className="settings-environment-header flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
       <div className="flex items-start gap-3.5">
         <Database size={22} strokeWidth={1.7} className="mt-1 shrink-0 text-theme-accent-light" />
         <div>
           <h2 className="text-2xl font-semibold text-theme-text">Environment Editor</h2>
-          <p className="mt-1 max-w-3xl text-sm leading-6 text-theme-text-muted">
-            Edit the ODS .env file directly from the dashboard. Changes are validated and applied securely.
-          </p>
+          <p className="mt-1 text-sm text-theme-text-muted">{dirty ? 'Unsaved changes' : 'Local .env configuration'}</p>
         </div>
       </div>
       <div className="flex flex-wrap items-center gap-3 lg:justify-end">
@@ -237,101 +213,41 @@ function EnvironmentEditorHeader({ onRefresh, onReload, onSave, onApply, saving,
         <ToolbarButton icon={RotateCcw} label="Reload" onClick={onReload} />
         <ToolbarButton icon={Save} label={saving ? 'Saving...' : 'Save .env'} onClick={onSave} disabled={!dirty || saving} />
         <ToolbarButton icon={Zap} label={applying ? 'Applying...' : 'Apply changes'} onClick={onApply} primary disabled={!canApply || applying || saving} />
+        {onExport && <button type="button" onClick={onExport} aria-label="Export configuration" title="Export configuration" className="environment-export"><Download size={16} /></button>}
       </div>
     </header>
   )
 }
 
 function EnvironmentStatusStrip({ editor, fieldCount, issueCount, issueSectionCount }) {
-  return (
-    <div className="env-status-strip grid gap-4 rounded-lg border border-theme-border bg-theme-bg/30 px-5 py-4 md:grid-cols-[1.2fr_1fr_1fr_1fr] md:items-center">
-      <div className="flex items-center gap-3">
-        <Folder size={19} className="shrink-0 text-theme-accent-light" />
-        <div>
-          <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-theme-text-muted">Local Configuration</p>
-          <div className="mt-1 flex flex-wrap items-center gap-3">
-            <p className="text-sm font-semibold text-theme-text">Editing ODS .env</p>
-            <span className={`inline-flex items-center gap-1.5 text-xs font-medium ${editor?.agentAvailable === false ? 'text-yellow-200' : 'text-emerald-300'}`}>
-              <span className={`h-1.5 w-1.5 rounded-full ${editor?.agentAvailable === false ? 'bg-yellow-300' : 'bg-emerald-400'}`} />
-              {editor?.agentAvailable === false ? 'Agent offline' : 'Connected'}
-            </span>
-          </div>
-        </div>
-      </div>
-      <StatusMetric icon={FileText} value={fieldCount} label="Fields" />
-      <StatusMetric icon={AlertTriangle} value={issueCount} label="Validation Issues" />
-      <StatusMetric icon={Folder} value={issueSectionCount} label="Sections with Issues" />
-    </div>
-  )
-}
-
-function EnvironmentBehaviorCards({ editor, canApply, applyPlan }) {
-  const applyText = editor?.agentAvailable === false
-    ? 'ODS host agent is offline. Start it first, then use Apply Changes to recreate affected services.'
-    : canApply
-      ? `Apply changes will recreate: ${applyPlan.services.join(', ')}.`
-      : 'Apply Changes becomes available after saving keys that affect running services. You will see affected services before applying.'
-
-  return (
-    <div className="settings-environment-behavior">
-      <BehaviorCard icon={Download} title="Save Behavior" text={editor.saveHint || 'Saving writes the .env file directly, preserves blank secrets, and stores a backup first.'} />
-      <BehaviorCard icon={RefreshCw} title="Restart Behavior" text={editor.restartHint || 'Some ODS services need a container recreate before changes take effect.'} />
-      <BehaviorCard icon={Zap} title="Apply Behavior" text={applyText} />
-    </div>
-  )
+  return <div className="environment-status-line">
+    <span>{fieldCount} fields</span>
+    <span>{issueCount ? `${issueCount} issues in ${issueSectionCount} sections` : 'No validation issues'}</span>
+    {editor?.agentAvailable === false && <span className="text-amber-300">Host agent offline · applying unavailable</span>}
+  </div>
 }
 
 function EnvironmentCategorySidebar({ search, onSearchChange, sections, activeSection, onSectionChange }) {
   const grouped = groupSections(sections)
   return (
-    <aside className="env-category-nav self-start rounded-lg border border-theme-border bg-theme-card p-3 xl:sticky xl:top-6">
+    <div className="environment-navigation">
       <label className="flex items-center gap-2 rounded-md border border-theme-border bg-theme-bg/35 px-3 py-2.5">
         <span className="sr-only">Filter configuration fields</span>
         <Search size={15} className="text-theme-text-muted" />
         <input
           value={search}
           onChange={(event) => onSearchChange(event.target.value)}
-          placeholder="Filter categories..."
+          placeholder="Search fields or categories…"
           aria-label="Filter configuration fields"
           className="min-w-0 flex-1 bg-transparent text-sm text-theme-text outline-none placeholder:text-theme-text-muted/55"
         />
       </label>
 
-      <div className="mt-3 max-h-[60rem] overflow-y-auto pr-1">
-        {grouped.map(group => (
-          <div key={group.id} className="mb-4 last:mb-0">
-            <div className="mb-2 flex items-center gap-2 px-2">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-theme-text-muted">{group.title}</p>
-              <span className="h-px flex-1 bg-theme-border" />
-            </div>
-            <div className="space-y-1">
-              {group.sections.map(section => (
-                <button
-                  key={section.id}
-                  type="button"
-                  onClick={() => onSectionChange(section.id)}
-                  aria-pressed={activeSection?.id === section.id}
-                  className={`group relative flex w-full items-center justify-between gap-3 rounded-md px-3 py-2.5 text-left transition-colors ${
-                    activeSection?.id === section.id
-                      ? 'bg-theme-accent/24 text-theme-text shadow-[inset_3px_0_0_rgba(215,164,255,0.95)]'
-                      : 'text-theme-text-muted hover:bg-theme-surface-hover hover:text-theme-text'
-                  }`}
-                >
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-semibold">{section.title}</span>
-                  </span>
-                  <span className={`shrink-0 rounded-full px-2 py-0.5 text-xs font-medium ${
-                    activeSection?.id === section.id ? 'bg-theme-accent/35 text-theme-accent-light' : 'text-theme-text-muted/65'
-                  }`}>
-                    {section.keys.length}
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        ))}
-      </div>
-    </aside>
+      <label className="environment-category-picker"><span className="sr-only">Configuration category</span><select aria-label="Configuration category" value={activeSection?.id || ''} onChange={event=>onSectionChange(event.target.value)}>
+        {!activeSection && <option value="">No matching categories</option>}
+        {grouped.map(group=><optgroup key={group.id} label={group.title}>{group.sections.map(section=><option key={section.id} value={section.id}>{section.title} · {section.keys.length}</option>)}</optgroup>)}
+      </select></label>
+    </div>
   )
 }
 
@@ -342,8 +258,6 @@ function EnvironmentFieldCard({ field, value, issues, revealed, cleared, onToggl
   const isInteger = field?.type === 'integer'
   const isReadOnly = Boolean(field?.readOnly)
   const secretPlaceholder = field?.secret ? (field?.hasValue ? 'Stored locally' : 'Not set') : (field?.default !== undefined && field?.default !== null ? String(field.default) : '')
-  const looksValid = !hasIssues && value !== ''
-  const versionLike = /version/i.test(field?.key || '')
 
   return (
     <div className={`settings-environment-field ${hasIssues ? 'settings-environment-field--issue' : ''}`}>
@@ -353,10 +267,10 @@ function EnvironmentFieldCard({ field, value, issues, revealed, cleared, onToggl
             <label htmlFor={`env-field-${field?.key}`} className="text-base font-semibold text-theme-text">{field?.label}</label>
             <Badge muted>{fieldKeyLabel(field?.key)}</Badge>
             {field?.secret ? <Badge accent>Secret</Badge> : null}
-            {field?.required ? <Badge>Required</Badge> : <Badge muted>Optional</Badge>}
+            {field?.required && <Badge>Required</Badge>}
             {isReadOnly ? <Badge muted>read only</Badge> : null}
           </div>
-          <p className="mt-2 text-sm leading-6 text-theme-text-muted">{field?.description || 'No description available.'}</p>
+          {field?.description && <p className="mt-2 text-sm leading-6 text-theme-text-muted">{field.description}</p>}
         </div>
       </div>
 
@@ -441,12 +355,7 @@ function EnvironmentFieldCard({ field, value, issues, revealed, cleared, onToggl
             />
           ) : null}
         </div>
-      ) : looksValid ? (
-        <p className="mt-3 flex items-center gap-2 text-xs text-emerald-300">
-          <CheckCircle2 size={14} />
-          {versionLike ? 'Valid version format' : 'Value looks valid'}
-        </p>
-      ) : field?.default !== undefined && field?.default !== null ? (
+      ) : value === '' && field?.default !== undefined && field?.default !== null ? (
         <p className="mt-3 text-xs text-theme-text-muted">
           Default: <span className="font-mono text-theme-text">{String(field.default)}</span>
         </p>
@@ -458,50 +367,6 @@ function EnvironmentFieldCard({ field, value, issues, revealed, cleared, onToggl
           {issue}
         </p>
       ))}
-    </div>
-  )
-}
-
-function EnvironmentHelpCard() {
-  return (
-    <div className="flex flex-col gap-4 border-t border-theme-border px-1 pt-5 lg:flex-row lg:items-center lg:justify-between">
-      <div className="flex items-start gap-3">
-        <BookOpen size={18} className="mt-0.5 shrink-0 text-theme-text-muted" />
-        <div>
-          <p className="text-sm font-semibold text-theme-text">Environment reference</p>
-          <p className="mt-1 text-sm text-theme-text-muted">Field labels, helper text, defaults, and validation come from the active ODS environment schema.</p>
-        </div>
-      </div>
-      <a href="https://github.com/Osmantic/ODS/tree/main/ods/docs" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-sm font-medium text-theme-accent-light hover:text-theme-text">
-        Open documentation
-        <ExternalLink size={15} />
-      </a>
-    </div>
-  )
-}
-
-function StatusMetric({ icon: Icon, value, label }) {
-  return (
-    <div className="flex items-center gap-3 border-theme-border md:justify-center md:border-l">
-      <Icon size={18} className="text-theme-text-muted" strokeWidth={1.6} />
-      <div>
-        <p className="text-lg font-semibold text-theme-text">{value}</p>
-        <p className="text-xs text-theme-text-muted">{label}</p>
-      </div>
-    </div>
-  )
-}
-
-function BehaviorCard({ icon: Icon, title, text }) {
-  return (
-    <div className="p-4">
-      <div className="flex items-start gap-3">
-        <Icon size={17} className="mt-0.5 shrink-0 text-theme-accent-light" />
-        <div>
-          <p className="text-sm font-semibold text-theme-text">{title}</p>
-          <p className="mt-1 text-xs leading-5 text-theme-text-muted">{text}</p>
-        </div>
-      </div>
     </div>
   )
 }

--- a/ods/extensions/services/dashboard/src/components/settings/PixelProviderRuntime.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelProviderRuntime.jsx
@@ -34,7 +34,7 @@ function ProviderConfirmation({ confirmation, onCancel, onConfirm }) {
   </div>
 }
 
-export default function PixelProviderRuntime({ savedRevision, saving, blocked, routingEnabled, allowCloud, onBusyChange }) {
+export default function PixelProviderRuntime({ savedRevision, saving, blocked, routingEnabled, allowCloud, onBusyChange, compact = false }) {
   const { runtime, running, stale, error, notice, stage, inspect, change } = usePixelProviderRuntime({ savedRevision, saving, blocked, onBusyChange })
   const [confirmation, setConfirmation] = useState(null)
   const [workerReady, setWorkerReady] = useState(false)
@@ -76,9 +76,7 @@ export default function PixelProviderRuntime({ savedRevision, saving, blocked, r
   }
   return <section aria-labelledby="pixel-provider-runtime-title" className="space-y-3 min-w-0 rounded-lg border border-theme-border p-4">
     <h3 id="pixel-provider-runtime-title" className="font-medium">Provider runtime</h3>
-    <p className="text-sm text-theme-text-muted">Save keeps your desired configuration. Apply changes the current agent’s inference routing, not its tool permissions.</p>
-    <PixelAdviceRuntime title="Provider worker runtime" onReadyChange={setWorkerReady} disabled={Boolean(running) || saving} />
-    {!workerReady && <p className="text-sm">Prepare or repair the private worker runtime before Apply. Deactivate and recovery do not require it.</p>}
+    <p className="text-sm text-theme-text-muted">Inference routing only. Tool permissions stay unchanged.</p>
     <div aria-live="polite" className="space-y-2 text-sm break-words">
       {stage && <p role="status">{stage}</p>}
       {!running && stale && <p>Provider runtime status is unknown or stale. Refresh before changing it.</p>}
@@ -90,7 +88,7 @@ export default function PixelProviderRuntime({ savedRevision, saving, blocked, r
       {!stale && runtime && !['unavailable', 'pending'].includes(runtime.status) && savedRevision !== null && !matched &&
         <p>Saved providers and runtime inspection differ. Reload providers and refresh runtime status.</p>}
       {blocked && <p>Save or cancel edits and reload stale settings before Apply or Deactivate. Recovery does not discard your edits.</p>}
-      {!routingEnabled && <p>Enable desired routing and save before Apply. Deactivate restores the original inference configuration.</p>}
+      {!routingEnabled && runtime?.status !== 'unavailable' && <p>Enable desired routing and save before Apply. Deactivate restores the original inference configuration.</p>}
       {error && <p role="alert" className="text-red-600">{error}</p>}
       {notice && <p role="status">{notice}</p>}
     </div>
@@ -99,6 +97,11 @@ export default function PixelProviderRuntime({ savedRevision, saving, blocked, r
       {Object.entries(labels).map(([operation, label]) => <button type="button" key={operation} className={button}
         disabled={!eligible[operation]} onClick={event => open(operation, event.currentTarget)}>{label}</button>)}
     </div>
+    <details className="settings-worker-setup" open={!compact || undefined}>
+      <summary>Worker setup · {workerReady ? 'Ready' : 'Not ready'}</summary>
+      <PixelAdviceRuntime title="Provider worker runtime" onReadyChange={setWorkerReady} disabled={Boolean(running) || saving} />
+      {!workerReady && <p className="text-xs text-theme-text-muted">Required for Apply, not for deactivation or recovery.</p>}
+    </details>
     {valid && <ProviderConfirmation confirmation={confirmation} onCancel={close} onConfirm={submit} />}
   </section>
 }

--- a/ods/extensions/services/dashboard/src/components/settings/PixelProviderSettings.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelProviderSettings.jsx
@@ -15,6 +15,7 @@ function Toggle({ label, ...props }) {
 }
 
 export default function PixelProviderSettings({ showHeading = true }) {
+  const [view, setView] = useState('providers')
   const [snapshot, setSnapshot] = useState(null)
   const [draft, setDraft] = useState(null)
   const [secrets, setSecrets] = useState({})
@@ -149,6 +150,7 @@ export default function PixelProviderSettings({ showHeading = true }) {
     if (writePending.current || runtimeBusyRef.current || connectionBusyRef.current || stale || !draft
       || draft.providers.length >= 32 || draft.providers.some(p => p.id === provider.id)) return false
     edit(next => { next.providers.push(copy(provider)) })
+    setView('providers')
     setSecrets(values => ({ ...values, [provider.id]: apiKey }))
     setNotice('Connection added as a disabled provider draft. Review roles, Save, and separately Apply when ready.')
     return true
@@ -171,10 +173,10 @@ export default function PixelProviderSettings({ showHeading = true }) {
     if (removed) setNotice('The new leader was removed from the backup list.')
   }
 
-  return <section aria-labelledby="pixel-connections-title" className="settings-premium-card rounded-lg border border-theme-border p-5 space-y-5 text-theme-text">
+  return <section aria-labelledby="pixel-connections-title" className="settings-premium-card pixel-connections-settings rounded-lg border border-theme-border p-5 space-y-5 text-theme-text">
     <div className="flex flex-wrap items-start justify-between gap-3">
       <div><h2 id="pixel-connections-title" className={showHeading ? 'text-lg font-semibold' : 'sr-only'}>Pixel connections</h2>
-        <p className="text-sm text-theme-text-muted">Choose inference providers without changing other ODS apps.</p></div>
+        <p className="text-sm text-theme-text-muted">{dirty ? 'Unsaved provider changes' : 'Inference providers and routing'}</p></div>
       <div className="flex flex-wrap gap-2">
         <button className={buttonStyle} disabled={loading || saving || runtimeBusy || connectionBusy} onClick={reload}>Reload providers</button>
         <button className={buttonStyle} disabled={!dirty || loading || saving || runtimeBusy || connectionBusy} onClick={() => {
@@ -185,18 +187,22 @@ export default function PixelProviderSettings({ showHeading = true }) {
         <button className={buttonStyle + ' bg-blue-600 text-white'} disabled={!dirty || stale || saving || loading || runtimeBusy || connectionBusy} onClick={save}>{saving ? 'Saving providers…' : 'Save providers'}</button>
       </div>
     </div>
-    <p className="rounded border border-amber-500/40 bg-amber-500/10 p-3 text-sm">Saving providers does not apply them. Inspect the current runtime below before making a change.</p>
-    <p className="text-sm text-theme-text-muted">Choosing Tower2 inference does not move this device’s tools there. Full Access is not available through these controls.</p>
+    {!showHeading && <nav className="settings-view-tabs" aria-label="Connection views">
+      {[['providers', 'Providers'], ['runtime', 'Runtime'], ['import', 'Import connection']].map(([id, label]) => <button key={id} type="button" aria-pressed={view === id} onClick={() => setView(id)}>{label}</button>)}
+    </nav>}
+    <p className="text-xs text-theme-text-muted">Save stores your configuration. Apply it separately from Runtime.</p>
     {error && <p role="alert" className="text-sm text-red-400">{error}</p>}
     {notice && <p role="status" className="text-sm text-emerald-400">{notice}</p>}
     {stale && <p className="text-sm text-amber-400">Reload the stored configuration before another save.</p>}
     {loading && <p role="status">Loading provider settings…</p>}
-    <PixelProviderRuntime savedRevision={snapshot?.revision ?? null} saving={loading || saving || connectionBusy} blocked={dirty || stale || connectionBusy}
-      routingEnabled={snapshot?.enabled === true} allowCloud={snapshot?.policy.allowCloud === true} onBusyChange={runtimeBusyChanged} />
-    {draft && <PixelConnectionImport key={`${snapshot?.revision}:${importReset}`} providers={draft.providers}
-      disabled={loading || saving || runtimeBusy || stale} onBusyChange={connectionBusyChanged} onImport={importConnection} />}
-    {draft && <fieldset disabled={loading || saving || runtimeBusy || connectionBusy} className="min-w-0 space-y-5">
+    <div hidden={!showHeading && view !== 'runtime'}><PixelProviderRuntime compact={!showHeading} savedRevision={snapshot?.revision ?? null} saving={loading || saving || connectionBusy} blocked={dirty || stale || connectionBusy}
+      routingEnabled={snapshot?.enabled === true} allowCloud={snapshot?.policy.allowCloud === true} onBusyChange={runtimeBusyChanged} /></div>
+    <div hidden={!showHeading && view !== 'import'}>{draft && <PixelConnectionImport key={`${snapshot?.revision}:${importReset}`} providers={draft.providers}
+      disabled={loading || saving || runtimeBusy || stale} onBusyChange={connectionBusyChanged} onImport={importConnection} />}</div>
+    {draft && <fieldset hidden={!showHeading && view !== 'providers'} disabled={loading || saving || runtimeBusy || connectionBusy} className="min-w-0 space-y-5">
       <legend className="sr-only">Pixel provider configuration</legend>
+      <details className="settings-routing-options" open={showHeading || undefined}>
+      <summary>Routing &amp; fallback rules</summary>
       <div className="flex flex-wrap gap-5">
         <Toggle label="Enable desired Pixel routing" checked={draft.enabled} onChange={e => edit(next => { next.enabled = e.target.checked })} />
         <Toggle label="Allow cloud inference" checked={draft.policy.allowCloud} onChange={e => edit(next => { next.policy.allowCloud = e.target.checked })} />
@@ -228,13 +234,14 @@ export default function PixelProviderSettings({ showHeading = true }) {
         {!draft.roles.backups.length && <p className="text-sm text-theme-text-muted">No backups selected.</p>}
         <div className="flex flex-wrap gap-3">{draft.providers.filter(p => eligible(p, draft.policy) && p.id !== draft.roles.leader && !draft.roles.backups.includes(p.id)).map(p => <button key={p.id} className={buttonStyle} disabled={draft.roles.backups.length >= 8} onClick={() => edit(next => { next.roles.backups.push(p.id) })}>Add backup {p.label}</button>)}</div>
       </fieldset>
+      </details>
       <div className="grid items-end gap-3 sm:grid-cols-[1fr_1fr_auto]">
         <Field label="New provider ID"><input className={inputStyle} value={newId} maxLength={64} onChange={e => setNewId(e.target.value)} /></Field>
         <Field label="New provider label"><input className={inputStyle} value={newLabel} maxLength={256} onChange={e => setNewLabel(e.target.value)} /></Field>
         <button className={buttonStyle} disabled={draft.providers.length >= 32} onClick={add}>Add provider</button>
       </div>
       {!draft.providers.length && <p className="text-sm text-theme-text-muted">No providers configured.</p>}
-      {draft.providers.map(p => <fieldset key={p.id} className="min-w-0 rounded border border-theme-border p-4 space-y-4">
+      {draft.providers.map(p => <fieldset key={p.id} className="provider-editor min-w-0 space-y-4">
         <legend className="px-2 font-medium">{p.label} ({p.id})</legend>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <Toggle label="Provider enabled" checked={p.enabled} onChange={e => providerEdit(p.id, 'enabled', e.target.checked)} />

--- a/ods/extensions/services/dashboard/src/components/settings/PixelProviderSettings.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelProviderSettings.test.jsx
@@ -13,7 +13,7 @@ const response = (configuration, status = 200) => ({ ok: status === 200, status,
   json: async () => ({ configuration, runtime: { status: 'not-applied' } }) })
 const adviceReadiness = () => ({ status: 'not-configured', revision: 0, host: 'canary',
   sourceSha256: null, runtimeId: null, candidates: [], job: null })
-function setup(doc, post = async () => response({ ...doc, revision: doc.revision + 1 }), probe = null) {
+function setup(doc, post = async () => response({ ...doc, revision: doc.revision + 1 }), probe = null, props = {}) {
   const fetchMock = vi.fn(async (url, options) => {
     if (url === '/api/pixel/providers/runtime') return { ok: true, status: 200, json: async () => runtimeDoc('unavailable') }
     if (url === '/api/pixel/providers/save') return post(options)
@@ -23,10 +23,25 @@ function setup(doc, post = async () => response({ ...doc, revision: doc.revision
     throw new Error(`Unexpected fetch: ${url}`)
   })
   vi.stubGlobal('fetch', fetchMock)
-  render(<PixelProviderSettings />)
+  render(<PixelProviderSettings {...props} />)
   return fetchMock
 }
 const loaded = () => screen.findByLabelText('Model')
+
+it('organizes embedded connections without losing drafts or applying runtime changes', async () => {
+  const fetchMock = setup(tower(), undefined, null, { showHeading: false })
+  await loaded()
+  expect(screen.queryByRole('button', { name: 'Refresh provider runtime' })).toBeNull()
+  fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'unsaved-model' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Runtime', exact: true }))
+  expect(screen.queryByRole('textbox', { name: 'Model', exact: true })).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Import connection', exact: true }))
+  expect(screen.getByLabelText('Connection bundle (private)')).toBeVisible()
+  fireEvent.click(screen.getByRole('button', { name: 'Providers', exact: true }))
+  expect(screen.getByLabelText('Model')).toHaveValue('unsaved-model')
+  expect(screen.getByRole('button', { name: 'Save providers' })).toBeEnabled()
+  expect(fetchMock.mock.calls.some(([, options]) => options?.method === 'POST')).toBe(false)
+})
 
 it('imports a disabled peer without changing old keys or roles and requires a separate Save', async () => {
   const doc = tower(); doc.roles.leader = 'tower'
@@ -78,7 +93,7 @@ it('renders a pristine install without claiming runtime activation', async () =>
   setup(empty())
   expect(await screen.findByText('No providers configured.')).toBeInTheDocument()
   expect(screen.getByRole('button', { name: 'Save providers' })).toBeDisabled()
-  expect(screen.getByText('Saving providers does not apply them. Inspect the current runtime below before making a change.')).toBeInTheDocument()
+  expect(screen.getByText('Save stores your configuration. Apply it separately from Runtime.')).toBeInTheDocument()
 })
 
 it('shows unavailable for failed or malformed GET instead of fabricated defaults', async () => {

--- a/ods/extensions/services/dashboard/src/components/settings/PortalMascotSettings.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PortalMascotSettings.jsx
@@ -1,0 +1,38 @@
+import {useState} from 'react'
+import PixelMascot from '../PixelMascot'
+import {PORTAL_MASCOT_DEFAULTS, saveMascotPreferences, useMascotPreferences} from '../../lib/portalMascotPreferences'
+import './portal-mascot-settings.css'
+
+const states = [
+  ['idle','Idle','Breathing, curious glances and blinks. Move the pointer or click Portal to interact.'],
+  ['thinking','Thinking','A question mark and a small magnifying glass alternate as visual thinking expressions.'],
+  ['working','Working','A focused bounce and a turning gear while the runtime reports tool activity.'],
+  ['waiting','Waiting','A turning hourglass with a moving grain of sand. A waiting expression, not a progress estimate.'],
+  ['blocked','Attention','A small head tilt, a soft concerned expression and a discreet attention mark. No angry face or flashing alarm.'],
+  ['done','Done','One happy bounce, then smiling eyes at rest.'],
+  ['sleeping','Sleeping','Soft breathing, curved closed eyes and floating zzz. Activity wakes the chat mascot with a stretch.'],
+]
+export default function PortalMascotSettings() {
+  const preferences = useMascotPreferences()
+  const [state,setState] = useState('thinking')
+  const [replay,setReplay] = useState(0)
+  const [error,setError] = useState('')
+  function update(patch) {setError(saveMascotPreferences(patch) ? '' : 'Could not save preferences in this browser.')}
+  return <section className="portal-mascot-settings" aria-labelledby="portal-mascot-title">
+    <h2 id="portal-mascot-title">Portal mascot</h2>
+    <p>Customize the little character without changing the assistant or its permissions. Saved in this browser.</p>
+    <label className="portal-mascot-setting"><span><strong>Show mascot</strong><small>Hide or restore Portal’s character across the interface.</small></span><input type="checkbox" checked={preferences.enabled} onChange={event=>update({enabled:event.target.checked})}/></label>
+    <label className="portal-mascot-setting"><span><strong>Animate mascot</strong><small>Turn motion off and keep static expressions. System reduced-motion preferences are always respected.</small></span><input type="checkbox" checked={preferences.animated} onChange={event=>update({animated:event.target.checked})}/></label>
+    <label className="portal-mascot-setting"><span><strong>Sleep after inactivity</strong><small>Only when idle. Pointer or keyboard activity wakes Portal; running tasks never sleep.</small></span><select aria-label="Sleep after inactivity" value={preferences.sleepAfterSeconds} onChange={event=>update({sleepAfterSeconds:Number(event.target.value)})}>
+      <option value="15">15 seconds</option><option value="30">30 seconds</option><option value="60">1 minute</option><option value="120">2 minutes</option><option value="300">5 minutes</option><option value="0">Never</option>
+    </select></label>
+    <div className="portal-mascot-demo">
+      <PixelMascot key={replay} preview interactive state={state} className="portal-settings-character"/>
+      <div><h3>Try the expressions</h3><p>{states.find(([id])=>id===state)[2]}</p><small>Demo only — not live task activity. The preview remains visible when the chat mascot is hidden.</small></div>
+    </div>
+    <div className="portal-mascot-states" aria-label="Preview mascot state">{states.map(([id,label])=><button key={id} type="button" aria-pressed={state===id} onClick={()=>{setState(id);setReplay(value=>value+1)}}>{label}</button>)}</div>
+    <p>In Idle, clicks cycle through left/right hops, a squish, a wink and a little dance. Three quick clicks reveal a sparkle surprise. Waking brings a stretch.</p>
+    <button className="portal-mascot-reset" type="button" onClick={()=>update(PORTAL_MASCOT_DEFAULTS)}>Reset mascot preferences</button>
+    {error && <p role="alert">{error}</p>}
+  </section>
+}

--- a/ods/extensions/services/dashboard/src/components/settings/PortalMascotSettings.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PortalMascotSettings.test.jsx
@@ -1,0 +1,33 @@
+import {render,screen,fireEvent,cleanup} from '@testing-library/react'
+import {afterEach,expect,it,vi} from 'vitest'
+import PortalMascotSettings from './PortalMascotSettings'
+import {PORTAL_MASCOT_KEY,normalizeMascotPreferences} from '../../lib/portalMascotPreferences'
+
+afterEach(()=>{cleanup();localStorage.removeItem(PORTAL_MASCOT_KEY);vi.restoreAllMocks()})
+it('saves preferences, restores them on remount, previews every state and resets defaults',()=>{
+  const view=render(<PortalMascotSettings/>)
+  expect(screen.getByLabelText('Sleep after inactivity')).toHaveValue('60')
+  fireEvent.change(screen.getByLabelText('Sleep after inactivity'),{target:{value:'15'}})
+  fireEvent.click(screen.getByRole('checkbox',{name:/Show mascot/}))
+  expect(JSON.parse(localStorage.getItem(PORTAL_MASCOT_KEY))).toEqual({enabled:false,animated:true,sleepAfterSeconds:15})
+  for(const label of ['Idle','Thinking','Working','Waiting','Attention','Done','Sleeping']) {
+    fireEvent.click(screen.getByRole('button',{name:label,exact:true}))
+    expect(screen.getByRole('button',{name:label,exact:true})).toHaveAttribute('aria-pressed','true')
+  }
+  expect(screen.getByRole('button',{name:'Play with Portal'})).toBeVisible()
+  view.unmount();render(<PortalMascotSettings/>)
+  expect(screen.getByRole('checkbox',{name:/Show mascot/})).not.toBeChecked()
+  expect(screen.getByLabelText('Sleep after inactivity')).toHaveValue('15')
+  fireEvent.click(screen.getByRole('button',{name:'Reset mascot preferences'}))
+  expect(screen.getByRole('checkbox',{name:/Show mascot/})).toBeChecked()
+  expect(screen.getByLabelText('Sleep after inactivity')).toHaveValue('60')
+})
+it('normalizes malformed settings and reports blocked storage instead of claiming a save',()=>{
+  expect(normalizeMascotPreferences({enabled:'no',animated:null,sleepAfterSeconds:-1})).toEqual({enabled:true,animated:true,sleepAfterSeconds:60})
+  localStorage.setItem(PORTAL_MASCOT_KEY,'not json')
+  render(<PortalMascotSettings/>)
+  vi.spyOn(Storage.prototype,'setItem').mockImplementation(()=>{throw new Error('blocked')})
+  fireEvent.click(screen.getByRole('checkbox',{name:/Show mascot/}))
+  expect(screen.getByRole('alert')).toHaveTextContent('Could not save')
+  expect(screen.getByRole('checkbox',{name:/Show mascot/})).toBeChecked()
+})

--- a/ods/extensions/services/dashboard/src/components/settings/portal-mascot-settings.css
+++ b/ods/extensions/services/dashboard/src/components/settings/portal-mascot-settings.css
@@ -1,0 +1,16 @@
+.portal-mascot-settings{max-width:760px;color:rgb(var(--theme-text));font-size:13px}
+.portal-mascot-settings h2{font-size:18px;font-weight:600;margin:0 0 8px}
+.portal-mascot-settings p{color:rgb(var(--theme-text-muted));line-height:1.6;margin:8px 0 20px}
+.portal-mascot-setting{display:flex;align-items:center;justify-content:space-between;gap:24px;padding:20px 0;border-bottom:1px solid rgb(var(--theme-border))}
+.portal-mascot-setting strong{display:block;font-weight:500}.portal-mascot-setting small{display:block;color:rgb(var(--theme-text-muted));line-height:1.5;margin-top:5px;max-width:440px}
+.portal-mascot-setting input{width:17px;height:17px;flex-shrink:0;accent-color:#b7c5cf}
+.portal-mascot-setting select{background:rgb(var(--theme-bg));color:inherit;border:1px solid rgb(var(--theme-border));border-radius:8px;padding:8px;max-width:135px}
+.portal-mascot-demo{display:flex;gap:20px;align-items:center;padding:26px 0 18px;min-height:150px}
+.portal-mascot-demo .pixel-pet-button>.portal-settings-character{width:100px;height:100px;flex-basis:100px}
+.portal-mascot-demo h3{font-weight:500}.portal-mascot-demo p{margin:6px 0}.portal-mascot-demo small{color:rgb(var(--theme-text-muted));line-height:1.5}
+.portal-mascot-states{display:flex;gap:6px;flex-wrap:wrap;margin-bottom:18px}
+.portal-mascot-states button,.portal-mascot-reset{border:0;border-radius:7px;background:transparent;color:rgb(var(--theme-text-muted));padding:8px 10px}
+.portal-mascot-states button:hover,.portal-mascot-states button[aria-pressed=true]{background:rgb(var(--theme-card));color:rgb(var(--theme-text))}
+.portal-mascot-reset{padding-left:0;text-decoration:underline;text-underline-offset:4px}
+.portal-mascot-settings :focus-visible{outline:2px solid rgb(var(--theme-text-muted));outline-offset:3px}
+@media(max-width:500px){.portal-mascot-setting{gap:12px}.portal-mascot-demo{gap:8px}.portal-mascot-demo .pixel-pet-button>.portal-settings-character{width:80px;height:80px;flex-basis:80px}}

--- a/ods/extensions/services/dashboard/src/contexts/CustomTheme.test.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/CustomTheme.test.jsx
@@ -1,0 +1,69 @@
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react'
+import {ThemeProvider, useTheme} from './ThemeContext'
+import CustomWallpaperPicker from '../components/CustomWallpaperPicker'
+import {readCustomWallpapers, addCustomWallpaper, deleteCustomWallpaper} from '../lib/customWallpapers'
+
+vi.mock('../lib/customWallpapers', async importOriginal => ({...await importOriginal(), readCustomWallpapers:vi.fn(), addCustomWallpaper:vi.fn(), deleteCustomWallpaper:vi.fn()}))
+const row = {id:'custom-11111111-2222-4333-8444-555555555555',name:'My forest',image:'data:image/webp;base64,YQ=='}
+function Gallery() {
+  const {wallpapers,theme,setTheme} = useTheme()
+  return <><output>{theme}</output>{wallpapers.map(item => <button key={item.id} onClick={()=>setTheme(item.id)}>{item.name}</button>)}<CustomWallpaperPicker/></>
+}
+beforeEach(()=>{localStorage.clear();vi.resetAllMocks();readCustomWallpapers.mockResolvedValue([])})
+
+it('imports, selects, restores and removes a custom image while retaining the default palette',async()=>{
+  addCustomWallpaper.mockResolvedValue(row)
+  deleteCustomWallpaper.mockResolvedValue(undefined)
+  const view=render(<ThemeProvider><Gallery/></ThemeProvider>)
+  await act(async()=>{})
+  const file=new File(['image'],'forest.jpg',{type:'image/jpeg'})
+  fireEvent.change(screen.getByLabelText('Choose local wallpaper'),{target:{files:[file]}})
+  expect(await screen.findByRole('button',{name:'My forest'})).toBeVisible()
+  expect(addCustomWallpaper).toHaveBeenCalledWith(file)
+  expect(document.documentElement).toHaveAttribute('data-theme','ods')
+  expect(document.documentElement).toHaveAttribute('data-wallpaper',row.id)
+  expect(localStorage.getItem('ods-theme')).toBe(row.id)
+  view.unmount()
+  readCustomWallpapers.mockResolvedValue([row])
+  render(<ThemeProvider><Gallery/></ThemeProvider>)
+  await screen.findByRole('button',{name:'My forest'})
+  expect(document.documentElement.style.getPropertyValue('--workspace-wallpaper')).toContain(row.image)
+  fireEvent.click(screen.getByRole('button',{name:'Remove selected wallpaper'}))
+  await waitFor(()=>expect(screen.queryByRole('button',{name:'My forest'})).toBeNull())
+  expect(deleteCustomWallpaper).toHaveBeenCalledWith(row.id)
+  expect(localStorage.getItem('ods-theme')).toBe('ods')
+})
+
+it('keeps the selected preset when storage rejects an import, and allows another attempt',async()=>{
+  localStorage.setItem('ods-theme','forest')
+  addCustomWallpaper.mockRejectedValue(new Error('Storage full'))
+  render(<ThemeProvider><Gallery/></ThemeProvider>)
+  await act(async()=>{})
+  fireEvent.change(screen.getByLabelText('Choose local wallpaper'),{target:{files:[new File(['x'],'x.png',{type:'image/png'})]}})
+  expect(await screen.findByRole('alert')).toHaveTextContent('Storage full')
+  expect(document.documentElement).toHaveAttribute('data-wallpaper','forest')
+  expect(screen.getByRole('button',{name:'Add wallpaper'})).toBeEnabled()
+})
+
+it('falls back if a saved custom image was removed elsewhere',async()=>{
+  localStorage.setItem('ods-theme',row.id)
+  readCustomWallpapers.mockResolvedValue([row])
+  render(<ThemeProvider><Gallery/></ThemeProvider>)
+  await screen.findByRole('button',{name:'My forest'})
+  readCustomWallpapers.mockResolvedValue([])
+  act(()=>window.dispatchEvent(new Event('focus')))
+  await waitFor(()=>expect(document.documentElement).not.toHaveAttribute('data-wallpaper'))
+  expect(localStorage.getItem('ods-theme')).toBe('ods')
+})
+
+it('ignores an older gallery read that completes after a successful import',async()=>{
+  let finishRead
+  readCustomWallpapers.mockReturnValue(new Promise(resolve=>{finishRead=resolve}))
+  addCustomWallpaper.mockResolvedValue(row)
+  render(<ThemeProvider><Gallery/></ThemeProvider>)
+  fireEvent.change(screen.getByLabelText('Choose local wallpaper'),{target:{files:[new File(['x'],'x.png',{type:'image/png'})]}})
+  await screen.findByRole('button',{name:'My forest'})
+  await act(async()=>finishRead([]))
+  expect(screen.getByRole('button',{name:'My forest'})).toBeVisible()
+  expect(document.documentElement).toHaveAttribute('data-wallpaper',row.id)
+})

--- a/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
@@ -1,5 +1,6 @@
-import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import { createContext, useContext, useState, useEffect, useCallback, useRef } from 'react'
 import { WALLPAPERS } from '../lib/wallpapers'
+import { readCustomWallpapers, addCustomWallpaper, deleteCustomWallpaper, isCustomWallpaper, CUSTOM_WALLPAPER_EVENT } from '../lib/customWallpapers'
 
 const STORAGE_KEY = 'ods-theme'
 const THEMES = WALLPAPERS.map(item => item.id)
@@ -9,16 +10,43 @@ const DEFAULT_THEME = 'ods'
 const ThemeContext = createContext(null)
 
 export function ThemeProvider({ children }) {
+  const [custom, setCustom] = useState([])
+  const [wallpaperError, setWallpaperError] = useState('')
+  const galleryRevision = useRef(0)
+  const wallpapers = [...WALLPAPERS, ...custom]
   const [theme, setThemeState] = useState(() => {
     let stored
     try { stored = localStorage.getItem(STORAGE_KEY) } catch { /* Use Pixel when storage is unavailable. */ }
-    return THEMES.includes(stored) ? stored : DEFAULT_THEME
+    return THEMES.includes(stored) || isCustomWallpaper(stored) ? stored : DEFAULT_THEME
   })
+
+  useEffect(() => {
+    let active = true
+    const refresh = () => {
+      const revision = ++galleryRevision.current
+      return readCustomWallpapers().then(rows => {
+        if (!active || revision !== galleryRevision.current) return
+        setCustom(rows)
+        setWallpaperError('')
+        setThemeState(previous => isCustomWallpaper(previous) && !rows.some(row => row.id === previous) ? DEFAULT_THEME : previous)
+      }).catch(error => { if (active && revision === galleryRevision.current) setWallpaperError(error.message) })
+    }
+    const sync = event => {
+      if (event.key !== STORAGE_KEY) return
+      setThemeState(THEMES.includes(event.newValue) || isCustomWallpaper(event.newValue) ? event.newValue : DEFAULT_THEME)
+      void refresh()
+    }
+    void refresh()
+    window.addEventListener(CUSTOM_WALLPAPER_EVENT, refresh)
+    window.addEventListener('focus', refresh)
+    window.addEventListener('storage', sync)
+    return () => { active = false; window.removeEventListener(CUSTOM_WALLPAPER_EVENT, refresh); window.removeEventListener('focus', refresh); window.removeEventListener('storage', sync) }
+  }, [])
 
   useEffect(() => {
     const root = document.documentElement
     root.setAttribute('data-theme', 'ods')
-    const wallpaper = WALLPAPERS.find(item => item.id === theme)
+    const wallpaper = [...WALLPAPERS, ...custom].find(item => item.id === theme)
     if (wallpaper?.image) {
       root.setAttribute('data-wallpaper', theme)
       root.style.setProperty('--workspace-wallpaper', `url("${wallpaper.image}")`)
@@ -27,17 +55,24 @@ export function ThemeProvider({ children }) {
       root.style.removeProperty('--workspace-wallpaper')
     }
     try { localStorage.setItem(STORAGE_KEY, theme) } catch { /* Session-only theme. */ }
-  }, [theme])
-
-  useEffect(() => {
-    const sync = event => { if (event.key === STORAGE_KEY) setThemeState(THEMES.includes(event.newValue) ? event.newValue : DEFAULT_THEME) }
-    window.addEventListener('storage', sync)
-    return () => window.removeEventListener('storage', sync)
-  }, [])
+  }, [theme, custom])
 
   const setTheme = useCallback((t) => {
-    if (THEMES.includes(t)) setThemeState(t)
+    if (THEMES.includes(t) || isCustomWallpaper(t)) setThemeState(t)
   }, [])
+
+  const addWallpaper = async file => {
+    const row = await addCustomWallpaper(file)
+    galleryRevision.current++
+    setCustom(previous => [...previous.filter(item => item.id !== row.id), row])
+    setThemeState(row.id)
+  }
+  const removeWallpaper = async id => {
+    await deleteCustomWallpaper(id)
+    galleryRevision.current++
+    setCustom(previous => previous.filter(item => item.id !== id))
+    setThemeState(previous => previous === id ? DEFAULT_THEME : previous)
+  }
 
   const cycleTheme = useCallback(() => {
     setThemeState(prev => {
@@ -47,7 +82,7 @@ export function ThemeProvider({ children }) {
   }, [])
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme, cycleTheme, themes: THEMES, labels: THEME_LABELS }}>
+    <ThemeContext.Provider value={{ theme, setTheme, cycleTheme, themes: wallpapers.map(item => item.id), labels: {...THEME_LABELS, ...Object.fromEntries(custom.map(item => [item.id, item.name]))}, wallpapers, addWallpaper, removeWallpaper, wallpaperError }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/ods/extensions/services/dashboard/src/lib/customWallpapers.js
+++ b/ods/extensions/services/dashboard/src/lib/customWallpapers.js
@@ -1,0 +1,64 @@
+const DATABASE = 'ods-wallpapers-v1'
+const STORE = 'images'
+export const CUSTOM_WALLPAPER_EVENT = 'ods:wallpapers-changed'
+export const isCustomWallpaper = id => typeof id === 'string' && /^custom-[a-f0-9-]{36}$/.test(id)
+
+async function transact(mode, action) {
+  if (!globalThis.indexedDB) throw new Error('Wallpaper storage is unavailable in this browser.')
+  const db = await new Promise((resolve, reject) => {
+    const request = globalThis.indexedDB.open(DATABASE, 1)
+    let blocked = false
+    request.onblocked = () => { blocked = true; reject(new Error('Close other ODS tabs and try adding the wallpaper again.')) }
+    request.onupgradeneeded = () => request.result.createObjectStore(STORE, {keyPath:'id'})
+    request.onsuccess = () => { if (blocked) request.result.close(); else resolve(request.result) }
+    request.onerror = () => reject(new Error('Wallpaper storage is unavailable in this browser.'))
+  })
+  try {
+    return await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE, mode)
+      const request = action(tx.objectStore(STORE))
+      tx.oncomplete = () => resolve(request.result)
+      tx.onerror = tx.onabort = () => reject(new Error('Could not save wallpapers. Check available browser storage.'))
+    })
+  } finally { db.close() }
+}
+
+export async function readCustomWallpapers() {
+  const rows = await transact('readonly', store => store.getAll())
+  return rows.filter(row => isCustomWallpaper(row.id) && typeof row.name === 'string' &&
+    row.image?.length <= 6 * 1024 * 1024 && /^data:image\/(jpeg|png|webp);base64,[A-Za-z0-9+/]+=*$/.test(row.image))
+}
+
+export async function prepareWallpaper(file) {
+  if (!file || !['image/jpeg', 'image/png', 'image/webp'].includes(file.type)) throw new Error('Choose a JPG, PNG or WebP image.')
+  if (file.size > 20 * 1024 * 1024) throw new Error('Choose an image smaller than 20 MB.')
+  let bitmap
+  try { bitmap = await createImageBitmap(file, {imageOrientation:'from-image'}) }
+  catch { throw new Error('This image could not be opened. Try another wallpaper.') }
+  try {
+    if (!bitmap.width || !bitmap.height || bitmap.width * bitmap.height > 80000000) throw new Error('This image is too large. Choose a smaller wallpaper.')
+    const scale = Math.min(1, 2560 / Math.max(bitmap.width, bitmap.height))
+    const canvas = document.createElement('canvas')
+    canvas.width = Math.max(1, Math.round(bitmap.width * scale))
+    canvas.height = Math.max(1, Math.round(bitmap.height * scale))
+    const context = canvas.getContext('2d')
+    if (!context) throw new Error('Image processing is unavailable in this browser.')
+    context.drawImage(bitmap, 0, 0, canvas.width, canvas.height)
+    const image = canvas.toDataURL('image/webp', .86)
+    if (image.length > 6 * 1024 * 1024 || !/^data:image\/(webp|png);base64,/.test(image)) throw new Error('The wallpaper could not be resized. Try another image.')
+    return {id:`custom-${crypto.randomUUID()}`, name:file.name.replace(/\.[^.]+$/, '').slice(0, 80) || 'My wallpaper', image}
+  } finally { bitmap.close() }
+}
+
+export async function addCustomWallpaper(file) {
+  const row = await prepareWallpaper(file)
+  await transact('readwrite', store => store.put(row))
+  window.dispatchEvent(new Event(CUSTOM_WALLPAPER_EVENT))
+  return row
+}
+
+export async function deleteCustomWallpaper(id) {
+  if (!isCustomWallpaper(id)) throw new Error('Invalid wallpaper')
+  await transact('readwrite', store => store.delete(id))
+  window.dispatchEvent(new Event(CUSTOM_WALLPAPER_EVENT))
+}

--- a/ods/extensions/services/dashboard/src/lib/customWallpapers.test.js
+++ b/ods/extensions/services/dashboard/src/lib/customWallpapers.test.js
@@ -1,0 +1,22 @@
+import {prepareWallpaper, isCustomWallpaper} from './customWallpapers'
+afterEach(()=>{vi.restoreAllMocks();vi.unstubAllGlobals()})
+it('accepts only opaque custom IDs, not URLs or CSS',()=>{
+  expect(isCustomWallpaper('custom-11111111-2222-4333-8444-555555555555')).toBe(true)
+  for(const value of ['custom-evil','https://remote/image','url(test)',null]) expect(isCustomWallpaper(value)).toBe(false)
+})
+it('rejects unsupported formats and oversized images before decoding',async()=>{
+  const decode=vi.fn();vi.stubGlobal('createImageBitmap',decode)
+  await expect(prepareWallpaper({type:'image/svg+xml',size:20})).rejects.toThrow('JPG')
+  await expect(prepareWallpaper({type:'image/png',size:21*1024*1024})).rejects.toThrow('20 MB')
+  expect(decode).not.toHaveBeenCalled()
+})
+it('resizes without cropping, strips source metadata, and releases decoded resources',async()=>{
+  const bitmap={width:4000,height:2000,close:vi.fn()},drawImage=vi.fn()
+  vi.stubGlobal('createImageBitmap',vi.fn(async()=>bitmap))
+  vi.spyOn(HTMLCanvasElement.prototype,'getContext').mockReturnValue({drawImage})
+  vi.spyOn(HTMLCanvasElement.prototype,'toDataURL').mockReturnValue('data:image/webp;base64,YQ==')
+  const row=await prepareWallpaper({name:'Forest.jpg',type:'image/jpeg',size:2048})
+  expect(row.name).toBe('Forest');expect(isCustomWallpaper(row.id)).toBe(true)
+  expect(drawImage).toHaveBeenCalledWith(bitmap,0,0,2560,1280)
+  expect(bitmap.close).toHaveBeenCalledOnce()
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelMascotState.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelMascotState.js
@@ -1,7 +1,7 @@
-export function pixelHeaderPose({sending, stopping, restoredActive, restoredChecking, interrupted, restoredActivity, status}) {
+export function pixelHeaderPose({sending, stopping, restoredActive, restoredChecking, interrupted, restoredActivity, status, task}) {
   if (stopping || restoredChecking || status === 'loading' || status === 'switching') return 'waiting'
   if (restoredActive) return 'working'
-  if (sending) return 'thinking'
+  if (sending) return task?.state === 'running' && task?.tools?.started > 0 ? 'working' : 'thinking'
   if (status !== 'available' || (interrupted && restoredActivity === 'unknown')) return 'blocked'
   return 'idle'
 }
@@ -10,6 +10,6 @@ export function pixelReplyPose(message, active) {
   if (message.status === 'error' || message.task?.state === 'failed') return 'blocked'
   if (message.status === 'stopped') return 'idle'
   // A restored/abandoned streaming placeholder is not proof of ongoing work.
-  if (message.status === 'streaming') return active ? 'thinking' : 'waiting'
+  if (message.status === 'streaming') return active ? (message.task?.state === 'running' && message.task?.tools?.started > 0 ? 'working' : 'thinking') : 'waiting'
   return message.content ? 'done' : 'idle'
 }

--- a/ods/extensions/services/dashboard/src/lib/pixelTaskActivity.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelTaskActivity.js
@@ -24,6 +24,10 @@ export function parseTaskActivity(value, runId) {
 }
 
 export function parseTaskActivityFrame(frame) {
+  if (frame?.object === 'ods.task.activity' && Object.keys(frame).sort().join(',') === 'id,object,pixel_task') {
+    const task = parseTaskActivity(frame.pixel_task, frame.id);
+    return task?.state === 'running' ? task : null;
+  }
   if (frame?.choices?.[0]?.finish_reason !== 'stop') return null;
   return parseTaskActivity(frame.pixel_task, frame.id);
 }

--- a/ods/extensions/services/dashboard/src/lib/portalMascotPreferences.js
+++ b/ods/extensions/services/dashboard/src/lib/portalMascotPreferences.js
@@ -1,0 +1,32 @@
+import {useMemo, useSyncExternalStore} from 'react'
+
+export const PORTAL_MASCOT_KEY = 'ods.portal.mascot.v1'
+export const PORTAL_MASCOT_DEFAULTS = Object.freeze({enabled:true, animated:true, sleepAfterSeconds:60})
+const eventName = 'ods-portal-mascot-preferences'
+const delays = [0,15,30,60,120,300]
+export function normalizeMascotPreferences(value) {
+  return {
+    enabled: typeof value?.enabled === 'boolean' ? value.enabled : true,
+    animated: typeof value?.animated === 'boolean' ? value.animated : true,
+    sleepAfterSeconds: delays.includes(value?.sleepAfterSeconds) ? value.sleepAfterSeconds : 60,
+  }
+}
+function read() { try {return localStorage.getItem(PORTAL_MASCOT_KEY)} catch {return null} }
+function parse(raw) { try {return normalizeMascotPreferences(JSON.parse(raw))} catch {return PORTAL_MASCOT_DEFAULTS} }
+function subscribe(notify) {
+  const storage = event => {if (!event.key || event.key === PORTAL_MASCOT_KEY) notify()}
+  window.addEventListener('storage',storage)
+  window.addEventListener(eventName,notify)
+  return () => {window.removeEventListener('storage',storage);window.removeEventListener(eventName,notify)}
+}
+export function saveMascotPreferences(patch) {
+  try {
+    localStorage.setItem(PORTAL_MASCOT_KEY,JSON.stringify(normalizeMascotPreferences({...parse(read()),...patch})))
+    window.dispatchEvent(new Event(eventName))
+    return true
+  } catch {return false}
+}
+export function useMascotPreferences() {
+  const raw = useSyncExternalStore(subscribe,read,()=>null)
+  return useMemo(()=>parse(raw),[raw])
+}

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -779,6 +779,12 @@ export default function Dashboard({ status, loading, compact = false }) {
 
   systemMetrics.push(
     {
+      icon: Zap,
+      label: 'Tokens / second',
+      value: Number.isFinite(status?.inference?.tokensPerSecond) ? `${status.inference.tokensPerSecond.toFixed(1)} tok/s` : '—',
+      subvalue: Number.isFinite(status?.inference?.tokensPerSecond) ? 'runtime reading' : 'telemetry unavailable',
+    },
+    {
       icon: Brackets,
       label: 'Context',
       value: status?.inference?.contextSize ? `${(status.inference.contextSize / 1024).toFixed(0)}k` : '—',

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -125,6 +125,14 @@ describe('Dashboard system overview', () => {
     expect(screen.getByText('Accumulated Output')).toBeInTheDocument()
   })
 
+  it.each([[8.25, '8.3 tok/s'], [0, '0.0 tok/s'], [null, '—'], [undefined, '—']])('shows a real compact throughput reading for %s', async (tokensPerSecond, expected) => {
+    render(<Dashboard compact status={{...baseStatus, inference:{...baseStatus.inference, tokensPerSecond}}} loading={false}/>)
+    const row = screen.getByText('Tokens / second').closest('.dashboard-metric-row')
+    expect(within(row).getByText(expected)).toBeVisible()
+    expect(within(row).getByText(tokensPerSecond == null ? 'telemetry unavailable' : 'runtime reading')).toBeVisible()
+    await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/features'))
+  })
+
   it('uses theme-responsive surfaces instead of fixed dark dashboard panels', async () => {
     await renderDashboard()
 

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -329,8 +329,13 @@ export default function Extensions({ compact = false }) {
     )
   }
 
-  const extensions = catalog?.extensions || []
-  const summary = catalog?.summary || {}
+  const allExtensions = catalog?.extensions || []
+  const extensions = allExtensions.filter(ext => !['incompatible', 'unsupported'].includes(ext.status) && ext.compatible !== false)
+  const unsupportedIds = new Set(allExtensions.filter(ext => !extensions.includes(ext)).map(ext => ext.id))
+  const summary = {
+    not_installed: extensions.filter(ext => ext.status === 'not_installed').length,
+    updates_available: extensions.filter(ext => ext.update_available).length,
+  }
 
   // Derive unique categories from features
   const categories = ['all', ...new Set(
@@ -339,7 +344,7 @@ export default function Extensions({ compact = false }) {
       .filter(Boolean)
   )]
 
-  const STATUS_FILTERS = ['all', 'enabled', 'cli_installed', 'stopped', 'unhealthy', 'disabled', 'installing', 'setting_up', 'error', 'not_installed', 'incompatible']
+  const STATUS_FILTERS = ['all', 'enabled', 'cli_installed', 'stopped', 'unhealthy', 'disabled', 'installing', 'setting_up', 'error', 'not_installed']
   const STATUS_LABELS = { all: 'All', enabled: 'Enabled', cli_installed: 'CLI Installed', stopped: 'Stopped', unhealthy: 'Unhealthy', disabled: 'Disabled', installing: 'Installing', setting_up: 'Setting Up', error: 'Error', not_installed: 'Not Installed', incompatible: 'Incompatible' }
 
   // Filter extensions
@@ -353,7 +358,10 @@ export default function Extensions({ compact = false }) {
     if (query && !ext.name.toLowerCase().includes(query) && !ext.description?.toLowerCase().includes(query)) return false
     return true
   })
-  const collections = templates.map(template => ({...template, _status: getTemplateStatus(template, extensions)})).filter(template => template._status !== 'applied')
+  const collections = templates
+    .filter(template => !(template.services || []).some(id => unsupportedIds.has(id)))
+    .map(template => ({...template, _status: getTemplateStatus(template, extensions)}))
+    .filter(template => template._status !== 'applied')
   const filteredCollections = collections.filter(template => !query || `${template.name} ${template.description || ''}`.toLowerCase().includes(query))
   const showingCollections = libraryView === 'collections'
 

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -36,16 +36,44 @@ const baseSummary = (overrides = {}) => ({
 
 const baseFeature = { category: 'tools', icon: 'Box' }
 
-const installFetchMock = (catalogFixture) => {
+const installFetchMock = (catalogFixture, templates = []) => {
   const fetchMock = vi.fn(async (url) => {
     const u = String(url)
     if (u.includes('/api/extensions/catalog')) return makeJsonResponse(catalogFixture)
-    if (u.includes('/api/templates')) return makeJsonResponse({ templates: [] })
+    if (u.includes('/api/templates')) return makeJsonResponse({ templates })
     throw new Error(`Unmocked fetch: ${u}`)
   })
   vi.stubGlobal('fetch', fetchMock)
   return fetchMock
 }
+
+it('hides unsupported extensions from results, categories and counts without hiding unhealthy services',async()=>{
+  installFetchMock({agent_available:true,extensions:[
+    {id:'supported',name:'Supported',status:'unhealthy',source:'user',features:[baseFeature]},
+    {id:'unsupported',name:'Unsupported device',status:'incompatible',features:[{category:'hidden-category'}]},
+    {id:'unsupported-flag',name:'Unsupported flag',status:'not_installed',compatible:false,features:[]},
+  ],summary:baseSummary({total:3})})
+  render(<Extensions compact/> )
+  expect(await screen.findByText('Supported')).toBeVisible()
+  expect(screen.queryByText('Unsupported device')).toBeNull()
+  expect(screen.queryByText('Unsupported flag')).toBeNull()
+  expect(screen.queryByRole('option',{name:'hidden-category'})).toBeNull()
+  expect(screen.getByRole('button',{name:'All 1'})).toBeVisible()
+})
+
+it('hides collections that require unsupported services while retaining usable collections', async () => {
+  installFetchMock({agent_available:true,extensions:[
+    {id:'unsupported',name:'GPU unavailable',status:'incompatible',features:[]},
+    {id:'supported',name:'Ready to install',status:'not_installed',features:[]},
+  ]}, [
+    {id:'blocked',name:'Blocked collection',services:['unsupported']},
+    {id:'available',name:'Available collection',services:['supported']},
+  ])
+  render(<Extensions compact/>)
+  fireEvent.click(await screen.findByRole('button',{name:'Starter collections 1'}))
+  expect(screen.getByText('Available collection')).toBeVisible()
+  expect(screen.queryByText('Blocked collection')).toBeNull()
+})
 
 // Find the per-extension toggle <button> by its uniquely-shaped width class.
 // L680 uses Tailwind arbitrary values: `inline-flex h-[18px] w-[32px] ...`

--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -411,7 +411,7 @@ export default function Models({ compact = false }) {
 
         {compact ? <>
           <div className="models-results"><span>{libraryScope === 'installed' ? 'On this device' : 'ODS recommended'}</span><span>{filteredModels.length} {filteredModels.length === 1 ? 'model' : 'models'}</span></div>
-          {filteredModels.length ? <FittedLibraryPage key={`${libraryScope}:${query}:${categoryFilter}:${compatibilityFilter}:${speedFilter}:${contextFloor}`} items={filteredModels} label="Model library">{items => <div className="models-list">{items.map(renderModel)}</div>}</FittedLibraryPage> : <p className="models-empty">No models match the current filters.</p>}
+          {filteredModels.length ? <FittedLibraryPage key={`${libraryScope}:${query}:${categoryFilter}:${compatibilityFilter}:${speedFilter}:${contextFloor}`} items={filteredModels} label="Model library" minimumItems={6}>{items => <div className="models-list">{items.map(renderModel)}</div>}</FittedLibraryPage> : <p className="models-empty">No models match the current filters.</p>}
         </> : <section
           ref={libraryRef}
           className="overflow-hidden rounded-xl border"

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -16,7 +16,6 @@ import PixelDictation from '../components/PixelDictation'
 import PixelCommandSearch, { OPEN_PIXEL_SEARCH } from '../components/PixelCommandSearch'
 import PixelConversationImport from '../components/PixelConversationImport'
 import PixelSelectionActions from '../components/PixelSelectionActions'
-import PixelMessageActions from '../components/PixelMessageActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
 import PixelTurnNavigation from '../components/PixelTurnNavigation'
@@ -36,7 +35,6 @@ import {
   CheckCircle2,
   Code2,
   Copy,
-  Globe2,
   ExternalLink,
   Loader2,
   Plus,
@@ -49,7 +47,6 @@ import {
   Sparkles,
   Square,
   Terminal,
-  Wrench,
   X,
 } from 'lucide-react'
 
@@ -103,33 +100,6 @@ const OPS_TERMINAL_STATUSES = new Set(['succeeded', 'failed', 'cancelled', 'reje
 const OPS_APPROVAL_RECEIPT = /^Pixel prepared the exact (ods\.extensions\.(?:install|enable|disable|remove)) plan for extension ([a-z0-9](?:[a-z0-9_-]|\.(?=[a-z0-9])){0,63}), but external approval is required\. No lifecycle change was executed\. Job: (ops-[0-9]{13}-[a-f0-9]{12})\. Plan SHA-256: ([a-f0-9]{64})\.$/
 const OPS_HOST_COMMAND_APPROVAL_RECEIPT = /^Pixel prepared a protected ODS host command plan, but external approval is required\. No command was executed\. Job: (ops-[0-9]{13}-[a-f0-9]{12})\. Plan SHA-256: ([a-f0-9]{64})\.$/
 let fallbackChatSequence = 0
-
-const SUGGESTED_TASKS = [
-  {
-    icon: ShieldCheck,
-    label: 'Check ODS health',
-    description: 'Inspect the live stack and explain anything that needs attention.',
-    prompt: 'Check the current ODS status. Summarize what is healthy, identify anything degraded or stopped, and suggest the safest next action.',
-  },
-  {
-    icon: Code2,
-    label: 'Build in my workspace',
-    description: 'Create, edit, run, and verify code instead of only suggesting it.',
-    prompt: 'Help me build and verify something useful in your writable workspace. Start by asking what outcome I want if it is not clear.',
-  },
-  {
-    icon: Globe2,
-    label: 'Research with sources',
-    description: 'Use public web evidence and keep citations exact.',
-    prompt: 'Research a public topic for me using current sources. Ask what topic and decision I need to make, then return a concise evidence-backed answer with exact source URLs.',
-  },
-  {
-    icon: Wrench,
-    label: 'Plan a multi-step task',
-    description: 'Break down a larger job, use tools, and report verified progress.',
-    prompt: 'Help me complete a multi-step task safely. Ask for the objective, then make a short plan and carry out the steps you can verify.',
-  },
-]
 
 function formatContext(value) {
   const context = Number(value || 0)
@@ -924,7 +894,10 @@ export default function Pixel({ systemStatus = null }) {
               const candidatePreview = parseVerifiedPreviewFrame(frame)
               if (candidatePreview) verifiedPreview = candidatePreview
               const candidateTask = parseTaskActivityFrame(frame)
-              if (candidateTask) taskActivity = candidateTask
+              if (candidateTask) {
+                taskActivity = candidateTask
+                setMessages(previous => replaceLastAssistant(previous, {task:candidateTask}))
+              }
               const content = frame?.choices?.[0]?.delta?.content
               if (typeof content === 'string' && content.length > 0) {
                 assistantText += content
@@ -1138,11 +1111,6 @@ export default function Pixel({ systemStatus = null }) {
     inputRef.current?.focus?.()
   }, [sending, restoredActive, restoredChecking, stopping, updateRestoredActivity])
 
-  const selectSuggestion = useCallback((prompt) => {
-    setInput(prompt)
-    inputRef.current?.focus?.()
-  }, [])
-
   useEffect(() => {
     const remove = event => {
       const {chatId, complete} = event.detail
@@ -1228,7 +1196,7 @@ export default function Pixel({ systemStatus = null }) {
       <header className="pixel-chat-header">
         <div className="pixel-chat-identity">
         <div className="flex h-9 w-9 items-center justify-center text-theme-accent-light">
-          <PixelMascot state={pixelHeaderPose({sending, stopping, restoredActive, restoredChecking, interrupted, restoredActivity, status})} />
+          <PixelMascot interactive name={displayName} state={pixelHeaderPose({sending, stopping, restoredActive, restoredChecking, interrupted, restoredActivity, status, task:messages.at(-1)?.task})} />
         </div>
         <div className="min-w-0">
           <h1 className="text-base font-semibold leading-tight truncate max-w-[40vw]" title={displayName}>{displayName}</h1>
@@ -1361,29 +1329,11 @@ export default function Pixel({ systemStatus = null }) {
         {status === 'available' && messages.length === 0 && (
           <div className="pixel-welcome mx-auto text-theme-text-muted">
             <div>
-              <PixelMascot className="pixel-welcome-character" />
+              <PixelMascot interactive name={displayName} className="pixel-welcome-character" />
               <h2>What do you want to work on?</h2>
               <p className="pixel-welcome-description">Start a private task, explore an idea, or create something new.</p>
             </div>
 
-            <div className="pixel-suggestions">
-              {SUGGESTED_TASKS.map(({ icon: Icon, label, description, prompt }) => (
-                <button
-                  key={label}
-                  type="button"
-                  onClick={() => selectSuggestion(prompt)}
-                  className="pixel-suggestion"
-                >
-                  <span className="pixel-suggestion-icon">
-                    <Icon className="h-4 w-4" />
-                  </span>
-                  <span>
-                    <span className="block text-sm font-medium text-theme-text">{label}</span>
-                    <span className="mt-1 block text-xs leading-5 text-theme-text-muted">{description}</span>
-                  </span>
-                </button>
-              ))}
-            </div>
 
           </div>
         )}
@@ -1420,7 +1370,6 @@ export default function Pixel({ systemStatus = null }) {
               ) : (
                 <span className="break-words whitespace-pre-wrap">{message.content}</span>
               )}
-              {message.content && message.status !== 'streaming' && <PixelMessageActions key={`${chatIdRef.current}-${index}-${message.role}`} content={message.content} role={message.role} canReuse={!isDisabled && input.length + message.content.length + 1 <= MAX_INPUT_LEN} onReuse={insertComposerText}/>}
               {message.status === 'streaming' && !message.content && (
                 <span role="status" className="inline-flex items-start gap-2 text-theme-text-muted">
                   <span>
@@ -1486,10 +1435,11 @@ export default function Pixel({ systemStatus = null }) {
           </div>
           </div>
           {stopError && <p role="alert" className="mt-1.5 px-1 text-xs text-amber-300">{stopError}</p>}
-          <PixelTextFileInput key={`file-input-${chatIdRef.current}`} input={input} disabled={isDisabled} limit={MAX_INPUT_LEN} onInsert={insertComposerText}/>
-          <PixelDraftPreview key={`draft-preview-${chatIdRef.current}`} input={input}/>
           <div className="pixel-composer-secondary">
-            <PixelComposerTools input={input} disabled={isDisabled} onInsert={insertComposerText} />
+            <PixelComposerTools input={input} disabled={isDisabled} onInsert={insertComposerText}>
+              <PixelTextFileInput key={`file-input-${chatIdRef.current}`} input={input} disabled={isDisabled} limit={MAX_INPUT_LEN} onInsert={insertComposerText}/>
+              <PixelDraftPreview key={`draft-preview-${chatIdRef.current}`} input={input}/>
+            </PixelComposerTools>
             <div className="pixel-composer-limits">
               {activeContext && <span title="Model context window shared by instructions, conversation, tools, and reply">{activeContext}</span>}
               <span className={inputOver ? 'text-red-400' : ''} title="Characters in this message, not tokens or context usage">{input.length.toLocaleString()} / {MAX_INPUT_LEN.toLocaleString()} chars</span>

--- a/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
@@ -72,6 +72,22 @@ describe('Pixel', () => {
     expect(formatElapsed(3671)).toBe('1:01:11')
   })
 
+  it('keeps prompts clean without copy/reuse controls or inline tool-call summaries',async()=>{
+    localStorage.setItem('ods.pixel.chat.v1',JSON.stringify({schema:1,chatId:'clean-chat',messages:[
+      {role:'user',content:'A clean prompt'},
+      {role:'assistant',content:'A clean response',task:{schemaVersion:1,runId:'chatcmpl_12345678-1234-1234-1234-123456789012',startedAt:'2026-09-10T12:00:00.000Z',finishedAt:'2026-09-10T12:00:01.000Z',state:'completed',calls:2,failures:0,blocked:0,truncated:false,activities:[{kind:'read',calls:2,failures:0,blocked:0}]}},
+    ]}))
+    fetch.mockResolvedValue(response({available:true,model:'pixel/default'}))
+    render(<Pixel/>)
+    await waitFor(()=>expect(screen.getByText('Available')).toBeInTheDocument())
+    expect(screen.getByText('A clean prompt')).toBeVisible()
+    expect(screen.getByText('A clean response')).toBeVisible()
+    expect(screen.queryByRole('button',{name:'Copy message'})).toBeNull()
+    expect(screen.queryByRole('button',{name:'Reuse prompt'})).toBeNull()
+    expect(screen.queryByText(/(?:Live|Recorded) activity ·/)).toBeNull()
+    expect(screen.queryByRole('button',{name:'Copy Markdown'})).toBeNull()
+  })
+
   it('accepts only the fixed approval receipt grammar', () => {
     const jobId = 'ops-1788127319657-f3262c99a419'
     const planHash = 'e'.repeat(64)
@@ -861,7 +877,7 @@ describe('Pixel', () => {
     ])
   })
 
-  it('orients the owner with live runtime identity and editable starter tasks', async () => {
+  it('keeps new chats clear of sample tasks while preserving runtime identity', async () => {
     globalThis.fetch.mockResolvedValue(
       response({ available: true, model: 'pixel/default', detail: 'Owner agent ready' })
     )
@@ -878,10 +894,8 @@ describe('Pixel', () => {
     expect(screen.getByText('Qwen3.5-9B-Q4_K_M.gguf')).toBeInTheDocument()
     expect(screen.getByText('32K context')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: /Check ODS health/ }))
-    expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue(
-      'Check the current ODS status. Summarize what is healthy, identify anything degraded or stopped, and suggest the safest next action.'
-    )
+    for (const name of ['Check ODS health','Build in my workspace','Research with sources','Plan a multi-step task']) expect(screen.queryByRole('button',{name:new RegExp(name)})).toBeNull()
+    expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue('')
     expect(globalThis.fetch).toHaveBeenCalledTimes(1)
   })
 

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -193,9 +193,9 @@ function StatusPill({ status }) {
   )
 }
 
-function Panel({ icon: Icon, title, children, actions = null, className = '' }) {
+function Panel({ icon: Icon, title, children, actions = null, className = '', hidden = false }) {
   return (
-    <section className={`rounded-lg border border-theme-border bg-theme-card p-4 shadow-sm ${className}`}>
+    <section hidden={hidden} className={`remote-provider-panel rounded-lg border border-theme-border bg-theme-card p-4 shadow-sm ${className}`}>
       <div className="mb-4 flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Icon size={18} className="text-theme-accent" />
@@ -245,7 +245,7 @@ function TextInput({ label, value, onChange, type = 'text', autoComplete = 'off'
 
 function Field({ label, value, tone = 'text-theme-text' }) {
   return (
-    <div className="flex items-center justify-between gap-4 text-sm">
+    <div className="remote-field-row flex items-center justify-between gap-4 text-sm">
       <span className="text-theme-text-muted">{label}</span>
       <span className={`text-right font-medium ${tone}`}>{valueOrDash(value)}</span>
     </div>
@@ -312,6 +312,7 @@ function LoadingState() {
 }
 
 export default function RemoteProvider({ compact = false }) {
+  const [view, setView] = useState('connection')
   const [statusData, setStatusData] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -536,7 +537,7 @@ export default function RemoteProvider({ compact = false }) {
         <div>
           {!compact && <h1 className="text-2xl font-bold text-theme-text">Remote GPU</h1>}
           <p className="mt-1 text-sm text-theme-text-muted">
-            Switchboard route, egress health, and SSH tunnel proof.
+            {provider.model ? `Current model: ${provider.model}` : 'Remote inference connection'}
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
@@ -565,6 +566,9 @@ export default function RemoteProvider({ compact = false }) {
           </button>
         </div>
       </header>
+      {compact && <nav className="settings-view-tabs" aria-label="Remote GPU views">
+        {[['connection', 'Connection'], ['models', 'Peer models'], ['diagnostics', 'Diagnostics']].map(([id, label]) => <button key={id} type="button" aria-pressed={view === id} onClick={() => setView(id)}>{label}</button>)}
+      </nav>}
 
       {error && (
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-200">
@@ -605,7 +609,7 @@ export default function RemoteProvider({ compact = false }) {
       )}
 
       <div className="grid gap-4 lg:grid-cols-2">
-        <Panel icon={Route} title="Route">
+        <Panel hidden={compact && view !== 'diagnostics'} icon={Route} title="Route">
           <Field label="State" value={routeState.enabled ? 'Enabled' : 'Disabled'} tone={routeState.enabled ? 'text-emerald-300' : 'text-zinc-400'} />
           <Field label="Mode" value={routeState.mode} />
           <Field label="Transport" value={provider.transport} />
@@ -624,7 +628,7 @@ export default function RemoteProvider({ compact = false }) {
           )}
         </Panel>
 
-        <Panel icon={Cloud} title="Egress">
+        <Panel hidden={compact && view !== 'diagnostics'} icon={Cloud} title="Egress">
           <Field label="Status" value={titleize(egress.status)} tone={egress.ready ? 'text-emerald-300' : 'text-amber-300'} />
           <Field label="Ready" value={boolLabel(egress.ready)} />
           <Field label="Reachable" value={boolLabel(egress.reachable)} />
@@ -633,7 +637,7 @@ export default function RemoteProvider({ compact = false }) {
           <Field label="Reason" value={titleize(egress.reason)} />
         </Panel>
 
-        <Panel icon={Server} title="SSH Tunnel">
+        <Panel hidden={compact && view !== 'diagnostics'} icon={Server} title="SSH Tunnel">
           <Field label="Status" value={titleize(sshSupervisor.status)} tone={sshSupervisor.ready ? 'text-emerald-300' : 'text-amber-300'} />
           <Field label="Ready" value={boolLabel(sshSupervisor.ready)} />
           <Field label="Ready to start" value={boolLabel(sshSupervisor.readyToStart)} />
@@ -642,7 +646,7 @@ export default function RemoteProvider({ compact = false }) {
           <Field label="Missing secrets" value={(sshSupervisor.missingSecrets || []).length} />
         </Panel>
 
-        <Panel icon={ShieldCheck} title="Capabilities">
+        <Panel hidden={compact && view !== 'diagnostics'} icon={ShieldCheck} title="Capabilities">
           <Field label="Inference" value={boolLabel(statusData?.capabilities?.inference)} tone={statusData?.capabilities?.inference ? 'text-emerald-300' : 'text-zinc-400'} />
           <Field label="ODS peer lifecycle" value={boolLabel(statusData?.capabilities?.odsPeerLifecycle)} />
           <Field label="Available test" value={boolLabel(testEnabled)} />
@@ -656,6 +660,7 @@ export default function RemoteProvider({ compact = false }) {
         <Panel
           icon={Cloud}
           title="ODS Peer Models"
+          hidden={compact && view !== 'models'}
           className="lg:col-span-2"
           actions={(
             <ActionButton icon={RefreshCw} onClick={() => loadPeerModels()} disabled={!peerReady || peerBusy}>
@@ -773,7 +778,7 @@ export default function RemoteProvider({ compact = false }) {
           )}
         </Panel>
 
-        <Panel icon={KeyRound} title="Configure" className="lg:col-span-2">
+        <Panel hidden={compact && view !== 'connection'} icon={KeyRound} title="Configure" className="lg:col-span-2">
           <div className="grid gap-3 md:grid-cols-[1.2fr_1fr_1fr]">
             <TextInput
               label="Base URL"

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -354,6 +354,22 @@ test('renders remote provider status and proof receipt', async () => {
   expect(screen.getByRole('button', { name: /test route/i })).toBeEnabled()
 })
 
+test('compact views keep the connection draft and never apply changes on navigation', async () => {
+  globalThis.fetch.mockResolvedValue(response(statusPayload))
+  render(createElement(RemoteProvider, { compact: true }))
+  await screen.findByRole('button', { name: 'Connection', exact: true })
+  expect(screen.queryByRole('heading', { name: 'Egress' })).toBeNull()
+  fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://draft.example/v1' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Diagnostics', exact: true }))
+  expect(screen.getByRole('heading', { name: 'Egress' })).toBeVisible()
+  expect(screen.queryByRole('textbox', { name: 'Base URL' })).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Peer models', exact: true }))
+  expect(screen.getByRole('heading', { name: 'ODS Peer Models' })).toBeVisible()
+  fireEvent.click(screen.getByRole('button', { name: 'Connection', exact: true }))
+  expect(screen.getByLabelText('Base URL')).toHaveValue('https://draft.example/v1')
+  expect(globalThis.fetch.mock.calls.some(([, options]) => options?.method === 'POST')).toBe(false)
+})
+
 test('runs configured route probe and shows proof recording result', async () => {
   globalThis.fetch
     .mockResolvedValueOnce(response(statusPayload))

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -195,31 +195,33 @@ function edgePath(source, target) {
   return `M ${sx} ${sy} L ${sx} ${midY} L ${tx} ${midY} L ${tx} ${ty}`
 }
 
-function ServiceNode({ node, pos, selected, onSelect }) {
+function ServiceNode({ node, pos, selected, onSelect, compact = false }) {
   const meta = statusMeta(node.status)
+  const label = compact ? node.name.replace(/\s*\(.*\)$/, '') : node.name
   return (
     <g role="button" tabIndex={0} aria-label={`${node.name}: ${node.status}`} onClick={() => onSelect(node)} onKeyDown={event => {
       if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); onSelect(node) }
     }} className="cursor-pointer">
+      <title>{node.name}: {node.status}</title>
       {selected && (
         <rect x={pos.x - 4} y={pos.y - 4} width={NODE_W + 8} height={NODE_H + 8} rx={14} fill="none" stroke={meta.color} strokeWidth="2" />
       )}
       <rect x={pos.x} y={pos.y} width={NODE_W} height={NODE_H} rx={12} className="fill-zinc-900 stroke-zinc-700" />
       <circle cx={pos.x + 15} cy={pos.y + 25} r="4" fill={meta.color} />
-      <text x={pos.x + 27} y={pos.y + 29} className="fill-zinc-100" style={{ fontSize: 12, fontWeight: 700 }}>
-        {node.name.length > 18 ? `${node.name.slice(0, 17)}…` : node.name}
+      <text x={pos.x + 27} y={pos.y + 29} className="fill-zinc-100" style={{ fontSize: 12, fontWeight: compact ? 500 : 700 }}>
+        {label.length > 18 ? `${label.slice(0, 17)}…` : label}
       </text>
       <text x={pos.x + 15} y={pos.y + 47} className="fill-zinc-400" style={{ fontSize: 11 }}>
-        :{node.port}
+        {node.port ? `:${node.port}` : 'No port'}
       </text>
       <text x={pos.x + NODE_W - 10} y={pos.y + 47} textAnchor="end" style={{ fontSize: 9, fill: meta.color }}>
-        {node.status}
+        {node.status.replaceAll('_', ' ')}
       </text>
     </g>
   )
 }
 
-function DetailPanel({ node, edges, onClose }) {
+function DetailPanel({ node, edges, onClose, inline = false }) {
   if (!node) return null
   const meta = statusMeta(node.status)
   const upstream = edges.filter(edge => edge.target === node.id)
@@ -227,7 +229,7 @@ function DetailPanel({ node, edges, onClose }) {
   const url = serviceUrl(node)
 
   return (
-    <div className="absolute top-4 right-4 z-10 w-72 overflow-hidden rounded-xl border border-theme-border bg-theme-card shadow-2xl">
+    <div className={inline ? 'integration-detail' : 'absolute top-4 right-4 z-10 w-72 overflow-hidden rounded-xl border border-theme-border bg-theme-card shadow-2xl'}>
       <div className="flex items-center justify-between border-b border-theme-border px-4 py-3">
         <div className="flex items-center gap-2">
           <span className={`h-2.5 w-2.5 rounded-full ${meta.dot}`} />
@@ -264,8 +266,58 @@ function DependencyList({ label, edges, field }) {
   )
 }
 
+function CompactIntegrations({ nodes, edges, refresh, error }) {
+  const [view, setView] = useState('list')
+  const [search, setSearch] = useState('')
+  const [filter, setFilter] = useState('all')
+  const [selectedId, setSelectedId] = useState(null)
+  const detailRef = useRef(null)
+  useEffect(() => { if (selectedId) detailRef.current?.scrollIntoView?.({ block: 'nearest' }) }, [selectedId])
+  const selected = nodes.find(node => node.id === selectedId)
+  const visible = nodes.filter(node => `${node.name} ${node.id}`.toLowerCase().includes(search.toLowerCase()) && (filter === 'all' || (filter === 'healthy' ? node.status === 'healthy' : node.status !== 'healthy')))
+  const positions = {}
+  const labels = []
+  let height = 35
+  for (const layer of LAYERS) {
+    const members = visible.filter(node => node.category === layer).sort((a, b) => a.name.localeCompare(b.name))
+    if (!members.length) continue
+    labels.push({ layer, y: height })
+    height += 20
+    members.forEach((node, index) => { positions[node.id] = { x: 18 + (index % 2) * 212, y: height + Math.floor(index / 2) * 100 } })
+    height += Math.ceil(members.length / 2) * 100 + 25
+  }
+  return <section className="portal-integrations">
+    <header className="integrations-header"><div><h2>Integrations</h2><p>{nodes.length} services · {nodes.filter(node => node.status === 'healthy').length} healthy</p></div><button type="button" aria-label="Refresh integrations" onClick={refresh}><RefreshCw size={15} /></button></header>
+    <nav className="settings-view-tabs" aria-label="Integration views"><button type="button" aria-pressed={view === 'list'} onClick={() => setView('list')}>Service list</button><button type="button" aria-pressed={view === 'map'} onClick={() => setView('map')}>View map</button></nav>
+    {error && <p role="alert" className="text-red-400">Status could not be refreshed. {error}</p>}
+    <div className="integrations-filters"><input type="search" aria-label="Search integrations" placeholder="Search services…" value={search} onChange={event => setSearch(event.target.value)} /><select aria-label="Service status" value={filter} onChange={event => setFilter(event.target.value)}><option value="all">All statuses</option><option value="healthy">Healthy</option><option value="attention">Not healthy</option></select></div>
+    <div ref={detailRef}><DetailPanel inline node={selected} edges={edges} onClose={() => setSelectedId(null)} /></div>
+    {!visible.length ? <p className="integrations-empty">{nodes.length ? 'No matching services.' : 'No services reported.'}</p> : view === 'list' ? <div className="integrations-list">
+      {LAYERS.map(layer => {
+        const members = visible.filter(node => node.category === layer).sort((a, b) => a.name.localeCompare(b.name))
+        return members.length > 0 && <section key={layer}><h3>{LAYER_LABELS[layer].toLowerCase().replace('-', ' ')}</h3>{members.map(node => <button type="button" key={node.id} onClick={() => setSelectedId(node.id)} aria-pressed={selectedId === node.id}><span className="integration-name"><span className={`integration-dot ${statusMeta(node.status).dot}`} /><span>{node.name}</span></span><span className="integration-status">{node.status.replaceAll('_', ' ')}{node.port && <small>:{node.port}</small>}</span></button>)}</section>
+      })}
+    </div> : <div className="integrations-map" role="region" aria-label="Service topology" tabIndex={0}>
+      <p>Known dependencies · select a service to highlight its connections</p>
+      <svg width="100%" viewBox={`0 0 418 ${height}`} style={{ fontFamily: 'inherit' }}>
+        {labels.map(({ layer, y }) => <text key={layer} x="18" y={y} fill="currentColor" opacity=".55" fontSize="10">{LAYER_LABELS[layer]}</text>)}
+        {edges.map((edge, index) => {
+          const source = positions[edge.source], target = positions[edge.target]
+          if (!source || !target) return null
+          const highlighted = selectedId === edge.source || selectedId === edge.target
+          const sx = source.x < 200 ? source.x + NODE_W : source.x
+          const tx = target.x < 200 ? target.x + NODE_W : target.x
+          const gutter = 202 + (index % 5) * 3
+          const path = `M ${sx} ${source.y + NODE_H / 2} H ${gutter} V ${target.y + NODE_H / 2} H ${tx}`
+          return <path key={`${edge.source}-${edge.target}`} d={path} fill="none" stroke="currentColor" strokeWidth={highlighted ? 2 : 1} opacity={highlighted ? .85 : .13} />
+        })}
+        {visible.map(node => <ServiceNode compact key={node.id} node={node} pos={positions[node.id]} selected={selectedId === node.id} onSelect={value => setSelectedId(value.id)} />)}
+      </svg>
+    </div>}
+  </section>
+}
+
 export default function ServiceMap({ compact = false }) {
-  const [showMap, setShowMap] = useState(false)
   const [topology, setTopology] = useState({ nodes: [], edges: [] })
   const [selectedNode, setSelectedNode] = useState(null)
   const [loading, setLoading] = useState(true)
@@ -311,23 +363,17 @@ export default function ServiceMap({ compact = false }) {
   const edgeLabels = [...new Set(edges.map(edge => edge.label))]
 
   if (loading) {
-    return <div className="p-8 animate-pulse"><div className="mb-6 h-8 w-1/3 rounded bg-theme-card" /><div className="h-96 rounded-xl bg-theme-card" /></div>
+    return <p role="status" className="text-sm text-theme-text-muted">Loading integrations…</p>
   }
 
-  if (error) {
-    return <div className="p-8 text-sm text-red-400">Topology data unavailable: {error}</div>
+  if (error && !nodes.length) {
+    return <div role="alert" className="text-sm text-red-400">Topology data unavailable: {error}<button className="ml-3" onClick={fetchTopology}>Retry</button></div>
   }
 
-  if (compact && !showMap) return <section className="portal-integrations p-5">
-    <div className="mb-4 flex justify-between items-center gap-3"><p className="text-theme-text-muted">{nodes.length} services · {counts.healthy} healthy</p><button className="rounded border border-theme-border px-3 py-2" onClick={() => setShowMap(true)}>View map</button></div>
-    <p className="mb-4 text-xs text-theme-text-muted">Select a service to inspect its connections.</p>
-    {nodes.map(node => <button key={node.id} onClick={() => setSelectedNode(node)} aria-pressed={selectedNode?.id === node.id} className="flex w-full items-center justify-between gap-3 border-b border-theme-border py-3 text-left"><span>{node.name}</span><small className={node.status === 'healthy' ? 'text-emerald-300' : 'text-theme-text-muted'}>{node.status}</small></button>)}
-    <DetailPanel node={selectedNode} edges={edges} onClose={() => setSelectedNode(null)} />
-  </section>
+  if (compact) return <CompactIntegrations nodes={nodes} edges={edges} refresh={fetchTopology} error={error} />
 
   return (
     <div className="p-8">
-      {compact && <button className="mb-4 text-sm text-theme-text-muted" onClick={() => setShowMap(false)}>← Service list</button>}
       <div className="mb-6 flex items-start justify-between">
         <div>
           {!compact && <h1 className="flex items-center gap-2 text-2xl font-bold text-theme-text"><GitBranch size={22} className="text-theme-accent" />Integrations</h1>}

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.test.jsx
@@ -29,7 +29,7 @@ it('starts with readable service rows in a panel and keeps the full map accessib
   expect(screen.getByRole('button',{name:'Close service details'})).toBeVisible()
   fireEvent.click(screen.getByRole('button',{name:'View map'}))
   expect(screen.getByRole('region',{name:'Service topology'})).toBeVisible()
-  fireEvent.click(screen.getByRole('button',{name:'← Service list'}))
+  fireEvent.click(screen.getByRole('button',{name:'Service list'}))
   expect(screen.getByRole('button',{name:'View map'})).toBeVisible()
 })
 
@@ -56,6 +56,20 @@ const statusPayload = {
     { id: 'whisper', name: 'Whisper (STT)', status: 'healthy', port: 9000, uptime: 120 },
   ],
 }
+
+it('filters the compact list and renders a panel-sized map with inline details', async () => {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ok:true,json:async () => statusPayload}))
+  render(<ServiceMap compact />)
+  await screen.findByRole('searchbox', { name: 'Search integrations' })
+  fireEvent.change(screen.getByRole('searchbox'), { target: { value: 'llama' } })
+  expect(screen.queryByRole('button', { name: /APE/ })).toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: /llama-server/ }))
+  expect(screen.getByRole('button', { name: 'Close service details' }).closest('.integration-detail')).not.toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'View map' }))
+  expect(screen.getByRole('region', { name: 'Service topology' }).querySelector('svg').getAttribute('viewBox').split(' ')[2]).toBe('418')
+  fireEvent.change(screen.getByRole('combobox', { name: 'Service status' }), { target: { value: 'attention' } })
+  expect(screen.getByText('No matching services.')).toBeVisible()
+})
 
 const expectedIds = [
   'ape',

--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -1,7 +1,6 @@
 import MetalMetricIcon from '../components/MetalMetricIcon'
 import {
   Activity,
-  ArrowUpRight,
   Calendar,
   ChevronDown,
   ChevronRight,
@@ -17,7 +16,6 @@ import {
   RefreshCw,
   Route,
   Server,
-  Settings as SettingsIcon,
   UserPlus,
   WalletCards,
 } from 'lucide-react'
@@ -31,6 +29,7 @@ import PixelAccessCard from '../components/settings/PixelAccessCard'
 import AssistantIdentitySettings from '../components/settings/AssistantIdentitySettings'
 import { useTheme } from '../contexts/ThemeContext'
 import { WALLPAPERS } from '../lib/wallpapers'
+import CustomWallpaperPicker from '../components/CustomWallpaperPicker'
 import '../wallpaper-themes.css'
 import { dashboardHost, serviceUrl } from '../lib/serviceUrls'
 import {
@@ -392,7 +391,7 @@ export default function Settings({ activeSection = 'all' }) {
   if (loading && !initialized) return <SettingsSkeleton />
 
   return (
-    <div className="settings-refined min-h-full px-3 py-6 sm:px-4 lg:px-5 xl:px-6">
+    <div className={`settings-refined min-h-full ${activeSection === 'all' ? 'px-3 py-6 sm:px-4 lg:px-5 xl:px-6' : 'settings-single-section'}`}>
       <div hidden={activeSection !== 'all'}><SettingsPageHeader
         onRefresh={() => fetchSettings({ preserveEnvChanges: envDirty })}
         onCheckUpdates={() => {
@@ -412,9 +411,9 @@ export default function Settings({ activeSection = 'all' }) {
           <div hidden={!visible('usage')}><AccountUsageCard usageReport={usageReport} /></div>
           <div hidden={!visible('owner')}><RemoteSetupCard setupStatus={setupStatus} /></div>
         </div>
-        <div hidden={!visible('profile')}><AssistantIdentitySettings /></div>
+        {activeSection === 'all' && <AssistantIdentitySettings />}
         <div hidden={!visible('connections')}><PixelProviderSettings showHeading={activeSection === 'all'} /></div>
-        <div hidden={!visible('connections')}><PixelRuntimeSettings /></div>
+        <div hidden={!visible('connections')}><details className="settings-agent-behavior"><summary>Agent behavior</summary><PixelRuntimeSettings /></details></div>
         <div hidden={!visible('sharing')}><PixelSharingSettings /></div>
         <div hidden={!visible('access')}><PixelAccessCard showHeading={activeSection === 'all'} /></div>
         <div hidden={!visible('services')}><RoutingTableCard
@@ -426,16 +425,16 @@ export default function Settings({ activeSection = 'all' }) {
           onToggleExpanded={() => setRoutesExpanded(current => !current)}
         /></div>
 
-        <div hidden={!['all','storage','updates','advanced'].includes(activeSection)} className="grid items-stretch gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(22rem,0.85fr)]">
+        <div hidden={!['all','storage','updates'].includes(activeSection) && !(activeSection === 'advanced' && !envOpen)} className="grid items-stretch gap-4 xl:grid-cols-[minmax(0,1.65fr)_minmax(22rem,0.85fr)]">
           <div hidden={!visible('storage')}><StorageCard storage={storage} showHeading={activeSection === 'all'} /></div>
-          <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
+          <div hidden={!['all','updates','advanced'].includes(activeSection)} className="grid gap-4 sm:grid-cols-2 xl:grid-cols-1">
             <div hidden={!visible('updates')}><UpdatesCard version={version} showHeading={activeSection === 'all'} onCheckUpdates={() => fetchVersionInfo({ announce: true })} /></div>
-            <div hidden={!visible('advanced')}><CommandsCard onExportConfig={handleExportConfig} /><button className="mt-4 rounded border border-theme-border px-3 py-2" onClick={handleOpenEnvironmentEditor}>Environment editor</button></div>
+            <div hidden={!visible('advanced')} className="settings-advanced-tools"><CommandsCard onExportConfig={handleExportConfig} />{!envOpen && <button className="settings-open-editor" onClick={handleOpenEnvironmentEditor}>Open environment editor</button>}</div>
           </div>
         </div>
 
         {envOpen && envEditor ? (
-          <div hidden={!visible('advanced')} ref={envEditorRef} className="pt-4">
+          <div hidden={!visible('advanced')} ref={envEditorRef}>
             <EnvEditor
               editor={envEditor}
               search={envSearch}
@@ -459,6 +458,7 @@ export default function Settings({ activeSection = 'all' }) {
               onReload={() => fetchEnvEditor({ announce: true })}
               onSave={handleSaveEnv}
               onApply={handleApplyEnv}
+              onExport={handleExportConfig}
               dirty={envDirty}
               saving={envSaving}
               applyPlan={envApplyPlan}
@@ -515,6 +515,7 @@ function SystemIdentityCard({ version, className = '' }) {
 }
 
 function AppearanceCard({ theme, themes, labels, onThemeChange, className = '', showHeading = true }) {
+  const {wallpapers = WALLPAPERS} = useTheme()
   return (
     <PremiumCard className={`p-5 lg:p-6 ${className}`}>
       {showHeading && <CardIntro icon={Palette} title="Appearance" description="Pixel’s minimal interface is shared across ODS." />}
@@ -530,7 +531,7 @@ function AppearanceCard({ theme, themes, labels, onThemeChange, className = '', 
             className="wallpaper-choice"
           >
             <span className="wallpaper-thumbnail">
-              {WALLPAPERS.find(item => item.id === themeId)?.image && <img src={WALLPAPERS.find(item => item.id === themeId).image} alt="" loading="lazy"/>}
+              {wallpapers.find(item => item.id === themeId)?.image && <img src={wallpapers.find(item => item.id === themeId).image} alt="" loading="lazy"/>}
               <span className="wallpaper-mini-sidebar"><i/><i/><i/></span><span className="wallpaper-mini-chat"><i/><i/></span>
               {theme === themeId && <span className="wallpaper-check" aria-hidden="true">✓</span>}
             </span>
@@ -539,6 +540,7 @@ function AppearanceCard({ theme, themes, labels, onThemeChange, className = '', 
         ))}
       </div>
       <p className="wallpaper-note">Applied instantly · saved in this browser. Wallpapers add frosted glass without changing your layout.</p>
+      <CustomWallpaperPicker />
     </PremiumCard>
   )
 }
@@ -780,19 +782,9 @@ function UpdatesCard({ version, onCheckUpdates, showHeading = true }) {
 
 function CommandsCard({ onExportConfig }) {
   return (
-    <PremiumCard className="flex min-h-0 flex-col justify-between p-4">
-      <div className="flex items-start gap-3">
-        <SettingsIcon size={19} strokeWidth={1.8} className="mt-0.5 shrink-0 text-theme-accent-light" />
-        <div>
-          <h2 className="text-base font-semibold text-theme-text">Commands</h2>
-          <p className="mt-0.5 text-xs text-theme-text-muted">Portable operational metadata.</p>
-        </div>
-      </div>
-      <button type="button" onClick={onExportConfig} className="mt-4 flex w-full items-center justify-between border-t border-theme-border pt-3 text-left text-sm font-medium text-theme-text hover:text-theme-accent-light">
+      <button type="button" onClick={onExportConfig} className="settings-export-config">
         <span className="flex items-center gap-2"><Download size={16} />Export configuration</span>
-        <ArrowUpRight size={15} className="text-theme-text-muted" />
       </button>
-    </PremiumCard>
   )
 }
 

--- a/ods/extensions/services/dashboard/src/pages/models-refined.css
+++ b/ods/extensions/services/dashboard/src/pages/models-refined.css
@@ -34,7 +34,7 @@
 .models-refined .model-filter-disclosure input[type=range] { accent-color:#aeb8c0; }
 .models-results { display:flex; justify-content:space-between; gap:12px; padding:15px 0 4px; color:#828d96; font-size:10px; }
 .models-results > :first-child { color:#a8b1b8; }
-.model-entry { border-bottom:1px solid #292c2e; padding:17px 0; min-height:216px; }
+.model-entry { border-bottom:1px solid #292c2e; padding:12px 0; min-height:0; }
 .model-entry > header { display:flex; gap:11px; align-items:flex-start; }
 .model-entry > header > div { flex:1; min-width:0; }
 .model-entry h3 { font-size:13px; font-weight:550; line-height:1.6; overflow-wrap:anywhere; }
@@ -43,11 +43,11 @@
 .model-entry-symbol > div { width:22px; height:22px; min-width:0; padding:0; border:0; background:transparent; box-shadow:none; }
 .model-entry-symbol img { width:21px; height:21px; object-fit:contain; filter:grayscale(1); }
 .model-state { padding-top:5px; white-space:nowrap; color:#929ba3; font-size:9px; }
-.model-entry-metrics { display:grid; grid-template-columns:1fr 1fr; gap:9px 16px; margin:13px 0 10px 34px; }
+.model-entry-metrics { display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:8px; margin:10px 0 8px 34px; }
 .model-entry-metrics > div { min-width:0; }
 .model-entry-metrics dt { font-size:9px; color:#7f8b94; margin-bottom:4px; }
 .model-entry-metrics dd { color:#bdc6cd; font-size:11px; font-variant-numeric:tabular-nums; overflow-wrap:anywhere; }
-.model-speed-reading { grid-column:1/-1; }
+.model-speed-reading { grid-column:auto; }
 .model-fit { display:flex; flex-wrap:wrap; gap:5px 10px; margin-left:34px; font-size:9px; color:#8d99a3; }
 .model-fit > :first-child { color:#bbc4cb; }
 .model-entry > footer { display:flex; flex-wrap:wrap; gap:12px; align-items:center; justify-content:space-between; margin:13px 0 0 34px; }
@@ -75,7 +75,7 @@
 .models-hub .hf-repository-row img { filter:grayscale(1); }
 .models-hub :is(input,select) { background:#181a1b; border-color:#303437; font-size:11px; }
 @container (min-width:600px) {
-  .model-entry { min-height:176px; }
+  .model-entry { min-height:0; }
   .model-entry-metrics { grid-template-columns:minmax(0,.8fr) minmax(0,1fr) minmax(0,1.4fr); }
   .model-speed-reading { grid-column:auto; }
   .models-active dl { flex-direction:row; }

--- a/ods/extensions/services/dashboard/src/pixel-workspace.css
+++ b/ods/extensions/services/dashboard/src/pixel-workspace.css
@@ -95,11 +95,11 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 .pixel-chat textarea { background:#1e1f20; border-radius:12px; }
 .pixel-chat form { background:transparent; }
 .pixel-reply-character { width:24px; height:24px; flex-basis:24px; margin-top:13px; }
-.pixel-composer-tools { position:relative; display:flex; align-items:center; flex-wrap:wrap; gap:5px; padding:7px 0 1px; color:#989ea6; font-size:11px; }
+.pixel-composer-tools { position:relative; display:flex; align-items:center; flex-wrap:wrap; gap:3px; padding:0; color:#989ea6; font-size:11px; }
 .pixel-composer-tools > button,.pixel-composer-tools > a { display:inline-flex; align-items:center; gap:6px; min-height:30px; padding:5px 7px; border-radius:6px; }
 .pixel-composer-tools > button:hover,.pixel-composer-tools > a:hover { color:#e3e6e9; background:#25272a; }
 .pixel-composer-tools > button:disabled { opacity:.4; }
-.pixel-composer-agent .pixel-character { width:18px; height:18px; flex-basis:18px; }
+.pixel-composer-agent .pixel-character { width:22px; height:22px; flex-basis:22px; }
 .pixel-composer-popover { position:absolute; bottom:calc(100% + 8px); left:0; z-index:20; width:min(310px,calc(100vw - 100px)); max-height:240px; overflow:auto; border:1px solid #36393d; border-radius:12px; padding:5px; background:#1c1e20; box-shadow:0 12px 30px #0005; }
 .pixel-composer-popover button,.pixel-command-results button { display:flex; align-items:center; gap:12px; width:100%; text-align:left; padding:11px; border-radius:7px; }
 .pixel-composer-popover button:hover,.pixel-composer-popover button:focus-visible,.pixel-command-results button:hover,.pixel-command-results button.is-active { background:#2a2d30; color:#f1f2f3; }
@@ -177,12 +177,19 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 .pixel-preview-source header > span { min-width:0; overflow-wrap:anywhere; }
 .pixel-preview-source header button { flex-shrink:0; }
 .pixel-preview-source :is([role=status],[role=alert]) { padding:16px; color:#a4adb7; }
-.pixel-composer-secondary { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; column-gap:12px; row-gap:2px; }
+.pixel-composer-secondary { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:6px 16px; padding-top:7px; }
 .pixel-composer-row { display:flex; align-items:flex-end; gap:8px; min-width:0; }
 .pixel-composer-actions { display:flex; align-items:center; gap:8px; height:44px; flex:0 0 auto; }
 .pixel-composer-input { min-width:0; max-height:160px; overflow-y:auto; }
 .pixel-app .pixel-composer-input:focus,.pixel-app .pixel-composer-input:focus-visible { outline:none; box-shadow:none; }
-.pixel-composer-limits { display:flex; align-items:center; gap:12px; margin-left:auto; padding-top:6px; font-size:10px; color:#90969e; white-space:nowrap; font-variant-numeric:tabular-nums; }
+.pixel-composer-limits { display:flex; align-items:center; gap:12px; margin-left:auto; font-size:10px; color:#90969e; white-space:nowrap; font-variant-numeric:tabular-nums; }
+.pixel-tool-divider { width:1px; height:14px; margin:0 5px; background:#ffffff14; }
+.pixel-composer-tools .pixel-draft-preview,.pixel-composer-tools .pixel-text-file-input { margin:0; font:inherit; }
+.pixel-composer-tools :is(.pixel-draft-preview,.pixel-text-file-input) > button { display:flex; align-items:center; justify-content:center; width:30px; height:30px; padding:6px; border-radius:6px; color:inherit; }
+.pixel-composer-tools :is(.pixel-draft-preview,.pixel-text-file-input) > button:hover { background:#ffffff0a; color:#e3e6e9; }
+.pixel-composer-tools :is(.pixel-draft-preview,.pixel-text-file-input) > button:disabled { opacity:.4; }
+.pixel-composer-tools .pixel-draft-preview > section,.pixel-composer-tools .pixel-text-file-input > :is([role='group'],[role='alert']) { position:absolute; bottom:calc(100% + 12px); left:0; z-index:30; width:min(560px,calc(100vw - 100px)); max-height:260px; overflow:auto; margin:0; padding:14px; border:1px solid #36393d; border-radius:10px; background:#1c1e20; color:#d5dae0; box-shadow:0 12px 30px #0005; }
+.pixel-composer-tools .pixel-text-file-input [role='group'] > button { margin:8px 8px 0 0; padding:6px 9px; border:1px solid #ffffff20; border-radius:5px; }
 .pixel-dictation { display:flex; align-items:center; justify-content:center; align-self:flex-end; min-height:44px; flex-shrink:0; gap:6px; position:relative; }
 .pixel-dictation > [role=status]:not(.pixel-dictation-notice) { position:absolute; bottom:calc(100% + 8px); right:0; white-space:nowrap; font-size:11px; }
 .pixel-dictation > button { display:grid; place-items:center; min-height:30px; min-width:30px; border-radius:6px; }
@@ -212,9 +219,20 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 .pixel-app .uppercase { text-transform:none; letter-spacing:normal; }
 .pixel-app :focus-visible { outline:2px solid #999fa9; outline-offset:3px; }
 .ods-original-mark { width:28px; height:28px; object-fit:contain; }
-.pixel-character { display:inline-flex; width:32px; height:32px; flex:0 0 32px; }
+.pixel-character { display:inline-flex; width:38px; height:38px; flex:0 0 38px; }
+.pixel-character.pixel-reply-character { width:34px; height:34px; flex-basis:34px; }
+.pixel-pet-button > .pixel-character { width:42px; height:42px; flex-basis:42px; }
+.pixel-pet-button { display:inline-flex; align-items:center; justify-content:center; padding:0; border:0; background:transparent; color:inherit; cursor:pointer; border-radius:10px; }
+.pixel-pet-button:focus-visible { outline:2px solid var(--theme-text-muted,#939da5); outline-offset:3px; }
+.pixel-live-activity { margin-bottom:10px; color:var(--theme-text-muted,#939da5); font-size:11px; }
+.pixel-live-activity summary { cursor:pointer; }
+.pixel-live-activity ul { padding:8px 0; list-style:none; }
+.pixel-live-activity li { display:flex; justify-content:space-between; gap:20px; }
+.pixel-live-activity p { font-size:10px; max-width:42em; }
+.custom-wallpaper-actions { display:flex; flex-wrap:wrap; align-items:center; gap:10px; margin-top:16px; }
+.custom-wallpaper-actions p { flex-basis:100%; }
 .pixel-character > svg { display:block; width:100%; height:100%; overflow:visible; fill:none; stroke:none; }
-.pixel-character .pixel-mascot-eye { fill:none; stroke:#18191b; stroke-width:6; stroke-linecap:round; stroke-linejoin:round; }
+.pixel-character .pixel-mascot-eye { fill:none; stroke:#18191b; stroke-width:var(--portal-eye-stroke,9); stroke-linecap:round; stroke-linejoin:round; }
 .pixel-sidebar.is-collapsed .pixel-brand a .pixel-character { display:inline-flex; }
 .pixel-chat-header h1 { font-size:15px; }
 .pixel-chat-options { position:relative; }
@@ -224,7 +242,7 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 .pixel-chat-options-menu > button { text-align:left; width:100%; border:0; }
 .pixel-welcome { width:min(100%,740px); padding:64px 16px 24px; }
 .pixel-welcome h2 { font-size:28px; color:#dedfe3; letter-spacing:-.04em; margin:12px 0 8px; }
-.pixel-welcome-character { width:48px; height:48px; }
+.pixel-welcome-character,.pixel-pet-button > .pixel-welcome-character { width:60px; height:60px; flex-basis:60px; }
 .pixel-welcome-description { font-size:13px; line-height:1.7; }
 .pixel-suggestions { margin-top:32px; }
 .pixel-suggestion { display:flex; align-items:center; gap:14px; width:100%; padding:14px 8px; text-align:left; border-top:1px solid #2e3033; transition:background-color .15s; }
@@ -264,7 +282,7 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 .portal-side-panel { position:relative; width:var(--portal-panel-width,440px); max-width:75%; min-width:0; flex-shrink:0; display:flex; flex-direction:column; border-left:1px solid var(--pixel-border); background:var(--pixel-canvas); }
 .portal-panel-resizer { position:absolute; left:-4px; top:0; bottom:0; width:8px; cursor:col-resize; touch-action:none; z-index:20; }
 .portal-panel-resizer:hover,.portal-panel-resizer:focus-visible { background:#8f999955; outline:none; }
-@media(max-width:760px) { .portal-panel-resizer { display:none; } }
+@media(max-width:1100px) { .portal-panel-resizer { display:none; } }
 .portal-side-panel > header { display:flex; align-items:center; gap:8px; padding:14px; border-bottom:1px solid #303232; }
 .portal-side-panel > header strong { flex:1; font-weight:500; font-size:13px; }
 .portal-side-panel > header button { padding:6px; border-radius:6px; }
@@ -294,7 +312,7 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 .portal-side-panel.is-collapsed { width:48px; }
 .portal-side-panel.is-collapsed > header { flex-direction:column; padding:8px 4px; }
 .portal-side-panel.is-collapsed > header strong { display:none; }
-@media(max-width:760px) { .portal-workspace { position:relative; } .portal-side-panel:not(.is-collapsed) { position:absolute; inset:0 0 0 auto; width:100%; max-width:100%; z-index:15; background:#131415; } }
+@media(max-width:1100px) { .portal-workspace { position:relative; } .portal-side-panel:not(.is-collapsed) { position:absolute; inset:0 0 0 auto; width:100%; max-width:100%; z-index:15; background:var(--pixel-canvas); } }
 .ods-settings-modal { width:min(920px,calc(100vw - 40px)); height:min(720px,calc(100dvh - 48px)); max-width:none; max-height:none; margin:auto; padding:0; border:1px solid #303132; border-radius:16px; background:#202121; color:#e5e5e5; font:13px Inter, sans-serif; overflow:hidden; color-scheme:dark; }
 .ods-settings-modal[open] { display:grid; grid-template-columns:224px minmax(0,1fr); }
 .ods-settings-modal::backdrop { background:rgba(0,0,0,.72); backdrop-filter:blur(3px); }

--- a/ods/extensions/services/dashboard/src/settings-workspace.css
+++ b/ods/extensions/services/dashboard/src/settings-workspace.css
@@ -1,0 +1,91 @@
+/* Settings use the workspace's typography and surfaces, not a second card system. */
+.ods-settings-panel .ods-settings-content { container-type:inline-size; }
+.ods-settings-panel .ods-settings-content > div { padding:0; }
+.ods-settings-panel .settings-single-section { padding:0; min-height:0; }
+.ods-settings-panel .profile-settings { padding:0; }
+.ods-settings-panel .assistant-identity-settings { border:0; border-top:1px solid rgb(var(--theme-border)); padding-top:22px; border-radius:0; background:transparent; }
+.ods-settings-panel .assistant-identity-settings form { margin-top:18px; }
+.ods-settings-panel .assistant-identity-actions { flex-wrap:wrap; gap:8px; }
+.ods-settings-panel .pixel-diagnostics { padding:0; }
+.ods-settings-panel .settings-view-tabs { display:flex; flex-wrap:wrap; gap:4px; margin:16px 0; padding-bottom:12px; border-bottom:1px solid rgb(var(--theme-border)); }
+.settings-view-tabs button { border:0; border-radius:6px; padding:7px 11px; font:inherit; font-size:12px; color:rgb(var(--theme-text-muted)); background:transparent; }
+.settings-view-tabs button[aria-pressed=true] { color:rgb(var(--theme-text)); background:rgb(var(--theme-text) / .08); }
+.settings-view-tabs button:hover { color:rgb(var(--theme-text)); background:rgb(var(--theme-text) / .05); }
+.settings-view-tabs button:focus-visible { outline:1px solid rgb(var(--theme-text-muted)); outline-offset:2px; }
+.settings-routing-options, .settings-agent-behavior { border-block:1px solid rgb(var(--theme-border)); padding:14px 0; }
+.settings-routing-options summary, .settings-agent-behavior summary { cursor:pointer; font-size:13px; color:rgb(var(--theme-text)); }
+.settings-routing-options[open] > :not(summary) { margin-top:16px; }
+.settings-agent-behavior[open] > section { margin-top:18px; }
+.ods-settings-panel .provider-editor { border:0; border-top:1px solid rgb(var(--theme-border)); border-radius:0; padding:20px 0 0; }
+.ods-settings-panel .provider-editor legend { padding:0 10px 0 0; font-size:13px; }
+.ods-settings-panel .pixel-connections-settings > div:first-child { gap:12px; }
+.ods-settings-panel .pixel-connections-settings button { font-size:12px; }
+.ods-settings-panel .pixel-connections-settings section { border:0; border-radius:0; padding:0; background:transparent; }
+.settings-worker-setup { padding:14px 0; border-block:1px solid rgb(var(--theme-border)); }
+.settings-worker-setup summary { cursor:pointer; font-size:12px; color:rgb(var(--theme-text-muted)); }
+.settings-worker-setup[open] > :not(summary) { margin-top:16px; }
+.ods-settings-panel .remote-settings-content > header p { overflow-wrap:anywhere; }
+.ods-settings-panel .settings-environment .environment-navigation :is(input,select) { font-size:12px; }
+.ods-settings-panel .settings-environment .environment-navigation > label { padding-block:8px; }
+.ods-settings-panel .settings-environment .environment-navigation > .environment-category-picker { padding:0; }
+.ods-settings-panel .settings-advanced-tools { display:flex; justify-content:flex-end; gap:10px; }
+.settings-export-config, .settings-open-editor { padding:6px 0; font-size:12px; color:rgb(var(--theme-text-muted)); }
+.settings-export-config:hover, .settings-open-editor:hover { color:rgb(var(--theme-text)); }
+.ods-settings-panel .settings-environment-header h2 { font-size:15px; font-weight:550; }
+.ods-settings-panel .settings-environment-header > div:first-child > svg { display:none; }
+.ods-settings-panel .settings-environment-header button { padding:7px 10px; border-radius:6px; font-size:12px; box-shadow:none; }
+.ods-settings-panel .settings-environment > .mt-6 { margin-top:16px; }
+.environment-status-line { display:flex; flex-wrap:wrap; gap:6px 20px; padding-bottom:12px; border-bottom:1px solid rgb(var(--theme-border)); font-size:12px; color:rgb(var(--theme-text-muted)); }
+.environment-editor-layout { display:flex; flex-direction:column; gap:22px; min-width:0; }
+.environment-navigation { display:flex; flex-wrap:wrap; gap:10px; }
+.environment-navigation > label { flex:1 1 210px; min-width:0; }
+.environment-category-picker select { width:100%; height:100%; padding:10px 12px; border:1px solid rgb(var(--theme-border)); border-radius:6px; background:rgb(var(--theme-bg)); color:rgb(var(--theme-text)); font-size:12px; }
+.ods-settings-panel .settings-environment-fields h3 { font-size:14px; font-weight:500; }
+.ods-settings-panel .settings-environment-fields > div:first-child { flex-direction:row; align-items:center; gap:12px; }
+.ods-settings-panel .settings-environment-fields > div:first-child svg { display:none; }
+.ods-settings-panel .settings-environment-field { border-color:rgb(var(--theme-border)); }
+.ods-settings-panel .settings-environment-field label { font-weight:500; }
+.ods-settings-panel .remote-settings-content { font-family:inherit; font-size:13px; padding:0; }
+.ods-settings-panel .remote-settings-content > header { margin-bottom:12px; gap:12px; }
+.ods-settings-panel .remote-settings-content :is(button,input,select,p,.remote-field-row) { font-family:inherit; font-size:12px; }
+.ods-settings-panel .remote-settings-content .uppercase { text-transform:none; letter-spacing:normal; font-weight:500; }
+.ods-settings-panel .remote-settings-content button { font-weight:450; border-radius:6px; }
+.ods-settings-panel .remote-settings-content > .grid { gap:0; }
+.ods-settings-panel .remote-settings-content > .grid > .remote-provider-panel { min-width:0; padding:18px 0; background:transparent; border:0; border-bottom:1px solid rgb(var(--theme-border)); box-shadow:none; border-radius:0; }
+.remote-field-row { align-items:baseline; }
+.remote-field-row > :first-child { flex-shrink:0; }
+.remote-field-row > :last-child { min-width:0; overflow-wrap:anywhere; font-weight:400; }
+.ods-settings-panel .remote-provider-panel > div:first-child { flex-wrap:wrap; }
+.ods-settings-panel .remote-provider-panel > div:first-child svg { color:rgb(var(--theme-text-muted)); }
+.ods-settings-panel .remote-provider-panel [class*='grid-cols-[minmax'] { grid-template-columns:minmax(0,1fr) auto; }
+.ods-settings-panel .remote-provider-panel [class*='grid-cols-[minmax'] > .hidden { display:none; }
+.portal-integrations { color:rgb(var(--theme-text)); font-size:13px; min-width:0; }
+.integrations-header { display:flex; align-items:center; justify-content:space-between; gap:16px; }
+.integrations-header h2 { font-size:14px; font-weight:550; margin:0 0 6px; }
+.integrations-header p { color:rgb(var(--theme-text-muted)); font-size:12px; }
+.integrations-header > button { padding:8px; border-radius:6px; color:rgb(var(--theme-text-muted)); }
+.integrations-header > button:hover { background:rgb(var(--theme-text) / .06); }
+.integrations-filters { display:flex; flex-wrap:wrap; gap:8px; margin:16px 0; }
+.integrations-filters input { flex:1 1 170px; min-width:0; }
+.integrations-filters :is(input,select) { padding:9px 10px; border:1px solid rgb(var(--theme-border)); border-radius:6px; background:rgb(var(--theme-bg) / .5); font:inherit; font-size:12px; color:inherit; }
+.integrations-filters select { max-width:100%; }
+.integrations-list section { margin-top:22px; }
+.integrations-list h3 { margin-bottom:8px; font-size:11px; font-weight:500; color:rgb(var(--theme-text-muted)); text-transform:capitalize; }
+.integrations-list button { display:flex; align-items:center; justify-content:space-between; width:100%; gap:16px; border:0; border-bottom:1px solid rgb(var(--theme-border) / .65); padding:13px 6px; text-align:left; }
+.integrations-list button:hover, .integrations-list button[aria-pressed=true] { background:rgb(var(--theme-text) / .04); }
+.integration-name { display:flex; align-items:center; gap:10px; min-width:0; overflow-wrap:anywhere; }
+.integration-dot { width:6px; height:6px; flex-shrink:0; border-radius:50%; }
+.integration-status { display:flex; flex-direction:column; align-items:flex-end; gap:3px; flex-shrink:0; font-size:11px; color:rgb(var(--theme-text-muted)); }
+.integration-status small { opacity:.7; font-variant-numeric:tabular-nums; }
+.integration-detail { position:relative; margin:16px 0; border-block:1px solid rgb(var(--theme-border)); background:rgb(var(--theme-text) / .025); overflow-wrap:anywhere; }
+.integration-detail > div { padding:12px 6px; }
+.integration-detail .flex { min-width:0; gap:10px; }
+.integration-detail button { flex-shrink:0; padding:5px; }
+.integration-detail .font-mono { font-family:inherit; }
+.integrations-map { min-width:0; }
+.integrations-map > p, .integrations-empty { font-size:11px; color:rgb(var(--theme-text-muted)); margin:14px 0; }
+.integrations-map svg { display:block; max-width:100%; }
+@container (min-width:480px) {
+  .ods-settings-panel .pixel-connections-settings .grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
+  .ods-settings-panel .remote-provider-panel .grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
+}

--- a/ods/extensions/services/pixel-agent/host/pixel_ingress.mjs
+++ b/ods/extensions/services/pixel-agent/host/pixel_ingress.mjs
@@ -890,6 +890,41 @@ function completionSse(completion, verification) {
   );
 }
 
+// Side-channel observations only. Answer bytes still wait for final verification.
+export function streamTaskActivity(res, user, token, gatewayPort, signal, deps = defaultDeps) {
+  const since = new Date().toISOString();
+  let stopped = false, timer, inFlight, last = '', runId;
+  async function poll() {
+    if (stopped || signal.aborted || res.destroyed || res.writableEnded) return;
+    const controller = new AbortController();
+    inFlight = controller;
+    const abort = () => controller.abort();
+    signal.addEventListener('abort', abort, {once:true});
+    const deadline = deps.setTimeout(abort, 1800);
+    try {
+      const response = await deps.fetch(`http://127.0.0.1:${gatewayPort}/pixel-ods/activity`, {
+        method:'POST', headers:upstreamHeaders(false, token), body:JSON.stringify({user}), redirect:'error', signal:controller.signal,
+      });
+      if (response.status !== 200 || !String(response.headers.get('content-type')).startsWith('application/json')) { await drain(response.body); return; }
+      const value = JSON.parse((await readBounded(response.body, 4096)).toString('utf8'));
+      if (!value || Object.keys(value).join() !== 'task') return;
+      const task = parseTaskActivity(value.task, value.task?.runId);
+      if (!task || task.state !== 'running' || task.startedAt < since || (runId && task.runId !== runId)) return;
+      runId = task.runId;
+      const packet = JSON.stringify({object:'ods.task.activity', id:runId, pixel_task:task});
+      if (!stopped && !signal.aborted && !res.destroyed && !res.writableEnded && !res.writableNeedDrain && packet !== last) {
+        res.write(`data: ${packet}\n\n`); last = packet;
+      }
+    } catch { /* Optional telemetry must not fail or repeat the actual task. */ }
+    finally {
+      deps.clearTimeout(deadline); signal.removeEventListener('abort', abort); inFlight = null;
+      if (!stopped && !signal.aborted && !res.destroyed && !res.writableEnded) timer = deps.setTimeout(poll, 1500);
+    }
+  }
+  timer = deps.setTimeout(poll, 250);
+  return () => { stopped = true; deps.clearTimeout(timer); inFlight?.abort(); };
+}
+
 async function forwardChat(res, outgoing, token, gatewayPort, deps = defaultDeps) {
   const controller = new AbortController();
   const totalTimer = deps.setTimeout(() => controller.abort(), TOTAL_TIMEOUT_MS);
@@ -901,6 +936,7 @@ async function forwardChat(res, outgoing, token, gatewayPort, deps = defaultDeps
   // proxy can consume a close before it reaches this response object.
   res.once("close", abortOnDownstreamClose);
   const wantsStream = outgoing.stream === true;
+  let stopActivity;
   // OpenClaw's OpenAI-compatible streaming route concatenates assistant block
   // replies from every tool continuation. Its non-stream route returns only
   // the terminal assistant reply. This ingress already withholds response
@@ -919,6 +955,7 @@ async function forwardChat(res, outgoing, token, gatewayPort, deps = defaultDeps
       "X-Accel-Buffering": "no",
     });
     res.flushHeaders?.();
+    stopActivity = streamTaskActivity(res, outgoing.user, token, gatewayPort, controller.signal, deps);
   }
   try {
     const upstream = await deps.fetch(
@@ -1018,6 +1055,7 @@ async function forwardChat(res, outgoing, token, gatewayPort, deps = defaultDeps
       res.destroy();
     }
   } finally {
+    stopActivity?.();
     res.off("close", abortOnDownstreamClose);
     deps.clearTimeout(totalTimer);
   }

--- a/ods/extensions/services/pixel-agent/plugin/index.js
+++ b/ods/extensions/services/pixel-agent/plugin/index.js
@@ -341,6 +341,15 @@ export default definePluginEntry({
         return true;
       },
     });
+    api.registerHttpRoute({
+      path: '/pixel-ods/activity', auth: 'gateway', match: 'exact',
+      handler: async (req, res) => {
+        const parsed = await readAbortUser(req);
+        if (parsed.status !== 200) { sendJson(res, parsed.status, {error:'invalid activity request'}); return true; }
+        sendJson(res, 200, {task:taskActivity.activeForUser(parsed.user)});
+        return true;
+      },
+    });
     // The OpenAI-compatible gateway route does not dispatch channel delivery
     // hooks. Give the private host ingress a narrow, authenticated way to ask
     // for host-observed verification and source-evidence truth before it

--- a/ods/extensions/services/pixel-agent/plugin/task-activity.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/task-activity.mjs
@@ -48,7 +48,7 @@ export function createTaskActivity({now = () => new Date().toISOString(), maximu
       if (!settled) return;
       runs.delete(settled[0]);
     }
-    runs.set(id, {runId:id, startedAt:now(), finishedAt:null, state:'running', calls:new Map(), truncated:false});
+    runs.set(id, {runId:id, sessionKey:context?.sessionKey, startedAt:now(), finishedAt:null, state:'running', calls:new Map(), truncated:false});
   }
   function record(event, context, outcome) {
     const run = runs.get(identify(event, context));
@@ -76,6 +76,12 @@ export function createTaskActivity({now = () => new Date().toISOString(), maximu
   }
   return {
     begin,
+    activeForUser(user) {
+      if (typeof user !== 'string' || !/^ods-[a-f0-9]{64}$/.test(user)) return null;
+      const matches = [...runs.values()].filter(run => run.state === 'running' && run.sessionKey === `agent:pixel:openai-user:${user}`);
+      // Ambiguity is not evidence: never guess which run belongs to this turn.
+      return matches.length === 1 ? this.projection(matches[0].runId) : null;
+    },
     before(event, context, blocked = false) { record(event, context, blocked ? 'blocked' : 'running'); },
     after(event, context) { record(event, context, failedResult(event) ? 'failed' : 'completed'); },
     finish(event, context) {

--- a/ods/extensions/services/pixel-agent/tests/live_activity.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/live_activity.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {streamTaskActivity} from '../host/pixel_ingress.mjs';
+
+test('streams sanitized live observations before the answer and stops polling on teardown',async()=>{
+  const jobs=[]; const packets=[]; const calls=[];
+  const runId='chatcmpl_11111111-2222-4333-8444-555555555555';
+  let task;
+  const deps={setTimeout:fn=>{jobs.push(fn);return fn;},clearTimeout:fn=>{const i=jobs.indexOf(fn);if(i>=0)jobs.splice(i,1);},fetch:async(url,options)=>{
+    calls.push({url,body:JSON.parse(options.body)});
+    return new Response(JSON.stringify({task}),{headers:{'content-type':'application/json'}});
+  }};
+  const controller=new AbortController();
+  const stop=streamTaskActivity({write:text=>packets.push(text)},'ods-'+'a'.repeat(64),'private-token',18789,controller.signal,deps);
+  task={schemaVersion:1,runId,startedAt:new Date().toISOString(),finishedAt:null,state:'running',calls:1,failures:0,blocked:0,truncated:false,activities:[{kind:'read',calls:1,failures:0,blocked:0}]};
+  await jobs.shift()();
+  assert.equal(packets.length,1);assert.match(packets[0],/ods.task.activity/);assert.doesNotMatch(packets[0],/private-token|sessionKey/);
+  assert.deepEqual(calls[0].body,{user:'ods-'+'a'.repeat(64)});
+  await jobs.shift()(); assert.equal(packets.length,1); // no duplicates
+  task={...task,prompt:'secret'}; await jobs.shift()(); assert.equal(packets.length,1);
+  task={...task,runId:runId.replace('11111111','aaaaaaaa')};delete task.prompt;
+  await jobs.shift()();assert.equal(packets.length,1); // no cross-run replacement
+  stop(); assert.equal(jobs.length,0);
+});
+
+test('never replays stale observations from the previous request',async()=>{
+  const jobs=[], packets=[];
+  const task={schemaVersion:1,runId:'chatcmpl_11111111-2222-4333-8444-555555555555',startedAt:'2020-01-01T00:00:00.000Z',finishedAt:null,state:'running',calls:0,failures:0,blocked:0,truncated:false,activities:[]};
+  const deps={setTimeout:fn=>{jobs.push(fn);return fn},clearTimeout:()=>{},fetch:async()=>new Response(JSON.stringify({task}),{headers:{'content-type':'application/json'}})};
+  const stop=streamTaskActivity({write:text=>packets.push(text)},'ods-'+'a'.repeat(64),'token',18789,new AbortController().signal,deps);
+  await jobs.shift()();stop();assert.deepEqual(packets,[]);
+});

--- a/ods/extensions/services/pixel-agent/tests/task_activity.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/task_activity.test.mjs
@@ -6,6 +6,22 @@ const runId = 'chatcmpl_11111111-2222-4333-8444-555555555555';
 const ctx = {agentId:'pixel',runId};
 const now = () => '2026-09-08T20:00:00.000Z';
 
+test('live observations bind exactly one active run to its opaque user and exclude other sessions', () => {
+  const recorder=createTaskActivity({now});
+  const user='ods-'+ 'a'.repeat(64);
+  const context={...ctx,sessionKey:`agent:pixel:openai-user:${user}`};
+  recorder.begin({},context);
+  assert.equal(recorder.activeForUser(user).runId,runId);
+  assert.equal(recorder.activeForUser('ods-'+ 'b'.repeat(64)),null);
+  const second={...context,runId:runId.replace('11111111','aaaaaaaa')};
+  recorder.begin({},second);
+  assert.equal(recorder.activeForUser(user),null);
+  recorder.finish({success:true},second);
+  assert.equal(recorder.activeForUser(user).runId,runId);
+  recorder.finish({success:true},context);
+  assert.equal(recorder.activeForUser(user),null);
+});
+
 test('projects real attempts without arguments, outputs or unknown tool names', () => {
   const recorder = createTaskActivity({now});
   recorder.begin({prompt:'private prompt'},ctx);

--- a/ods/extensions/services/pixel-edge/pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/pixel_edge.py
@@ -19,10 +19,47 @@ import json
 import os
 import re
 import sys
+from datetime import datetime
 from urllib.parse import quote
 
 from aiohttp import web, ClientSession, UnixConnector, ClientTimeout
 from transition_gate import TransitionGate, GateError, strict_json, valid_binding
+
+
+def valid_live_task_event(event):
+    """Only bounded content-free observations may bypass the answer buffer."""
+    if not isinstance(event, dict) or set(event) != {"object", "id", "pixel_task"} or event["object"] != "ods.task.activity":
+        return False
+    task = event["pixel_task"]
+    if not isinstance(task, dict) or set(task) != {"schemaVersion", "runId", "startedAt", "finishedAt", "state", "calls", "failures", "blocked", "truncated", "activities"}:
+        return False
+    if type(task["schemaVersion"]) is not int or task["schemaVersion"] != 1 or task["state"] != "running" or task["finishedAt"] is not None or type(task["truncated"]) is not bool:
+        return False
+    if not isinstance(event["id"], str) or not re.fullmatch(r"chatcmpl_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", event["id"], re.I) or task["runId"] != event["id"]:
+        return False
+    stamp = task["startedAt"]
+    if not isinstance(stamp, str) or not re.fullmatch(r"\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{3}Z", stamp):
+        return False
+    try:
+        datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    count_keys = ("calls", "failures", "blocked")
+    if any(type(task[key]) is not int or not 0 <= task[key] <= 512 for key in count_keys):
+        return False
+    rows = task["activities"]
+    if not isinstance(rows, list) or len(rows) > 8:
+        return False
+    seen, sums = set(), dict.fromkeys(count_keys, 0)
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {"kind", *count_keys} or not isinstance(row["kind"], str) or row["kind"] not in {"read", "agent", "run", "edit", "browser", "preview", "action", "unknown"} or row["kind"] in seen:
+            return False
+        if any(type(row[key]) is not int for key in count_keys) or not 0 <= row["blocked"] <= row["failures"] <= row["calls"] <= 512 or row["calls"] == 0:
+            return False
+        seen.add(row["kind"])
+        for key in count_keys:
+            sums[key] += row[key]
+    return all(sums[key] == task[key] for key in count_keys)
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -967,6 +1004,10 @@ async def _stream_upstream(
                     continue
 
                 event, content, finish_reason = _sse_event(line)
+                if isinstance(event, dict) and event.get('object') == 'ods.task.activity':
+                    if valid_live_task_event(event):
+                        await response.write(line + b"\n\n")
+                    continue
                 if isinstance(event, dict) and "error" in event:
                     await flush_pending()
                     await response.write(line + b"\n")

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -43,6 +43,17 @@ async def _upstream_chat(request):
     request.app["chat_requests"].append(data)
     stream = data.get("stream", False)
 
+    if data.get('trigger_live'):
+        task = {"schemaVersion":1,"runId":"chatcmpl_11111111-2222-4333-8444-555555555555","startedAt":"2026-09-10T20:00:00.000Z","finishedAt":None,"state":"running","calls":1,"failures":0,"blocked":0,"truncated":False,"activities":[{"kind":"read","calls":1,"failures":0,"blocked":0}]}
+        packet = {"object":"ods.task.activity","id":task['runId'],"pixel_task":task}
+        resp = web.StreamResponse(headers={'Content-Type':'text/event-stream'})
+        await resp.prepare(request)
+        await resp.write(('data: ' + json.dumps({**packet,'prompt':'must-not-leak'}) + '\n\n').encode())
+        await resp.write(('data: ' + json.dumps(packet) + '\n\n').encode())
+        await request.app['release_stream'].wait()
+        await resp.write(b'data: {"choices":[{"delta":{"content":"Verified reply"},"finish_reason":"stop"}]}\n\ndata: [DONE]\n\n')
+        return resp
+
     if data.get("trigger_error"):
         return web.json_response({"error": "upstream-secret-path-/private/token"}, status=500)
 
@@ -1236,6 +1247,20 @@ class TestSyntheticModels(BaseEdgeTest):
 # ---------------------------------------------------------------------------
 
 class TestResponseRewrite(BaseEdgeTest):
+    async def test_live_activity_arrives_before_terminal_answer_without_leaking_extra_fields(self):
+        async with self.client.post('http://localhost/v1/chat/completions',headers=self.auth(),json={'model':'pixel/default','stream':True,'trigger_live':True,'messages':[{'role':'user','content':'observe'}]}) as resp:
+            try:
+                async with async_timeout(2):
+                    line = await resp.content.readline()
+                self.assertIn(b'ods.task.activity',line)
+                self.assertNotIn(b'must-not-leak',line)
+                self.assertFalse(self.up_runner.app['release_stream'].is_set())
+            finally:
+                self.up_runner.app['release_stream'].set()
+            remainder = await resp.text()
+            self.assertIn('Verified reply',remainder)
+            self.assertNotIn('must-not-leak',remainder)
+
     async def test_non_stream_model_rewritten(self):
         async with self.client.post(
             "http://localhost/v1/chat/completions",


### PR DESCRIPTION
## Summary

Publish the locally verified public-beta UI/UX follow-up requested by Mike and Gabriel. Targets **public-beta**, not main; no installer defaults, model configuration, credentials or access permissions are changed.

- Organize the chat composer and conversation sidebar, with hover title scrolling and supported context-menu actions; remove redundant message actions and inline activity summaries.
- Add local-only wallpaper imports and selectable thumbnails; preserve preset/default themes and glass styling. Keep ODS logo motion hover-only.
- Improve the Portal mascot's interactive gestures, thinking/working/waiting/sleep/error expressions and eye shape. Add settings for visibility, animation, sleep delay and state previews. Respect reduced motion and keep historical messages still; fix stable-script caching.
- Expose assistant display-name editing in Profile and standardize both identity forms.
- Reorganize Settings: eliminate empty wrapper spacing, simplify Connections and Advanced, retain explicit save/apply/credential safeguards, redesign Integrations list/map and split Remote GPU into focused views.
- Improve model browsing, dashboard tokens/s and unsupported-extension filtering.
- Add bounded, authenticated, content-free live task observations from the agent through ingress/edge. Final answer verification and permission boundaries remain intact; observations drive actual task state without exposing tool arguments or private reasoning.

## Validation

- Frontend: **100 files / 881 tests passed**; final export icon adjustment additionally reran all 9 EnvEditor tests.
- ESLint on src and public/pixel-mascot.js, git diff --check and production Docker build passed.
- Agent ingress/activity: **64 tests passed** in an isolated Linux Node container (Unix-socket/POSIX tests do not run correctly in native Windows).
- Pixel edge: **89 tests passed** in an isolated Linux Python container with the production transition-state environment unset, as expected by the test fixtures.
- Real local browser QA: identity input styles, settings spacing, category search/navigation, integration search/status filters/map/details, remote view navigation, chat history, mascot preferences and motion. Local frontend deployment is healthy.

## Scope and limitations

- Existing model/chat/configuration data was preserved. No live remote-GPU probe or provider Apply was run for this UI review.
- Native wallpaper file-picker upload has automated coverage but was not manually exercised through the in-app browser's native chooser.
- This is not a new Windows/macOS/Linux installer certification. The runtime changes use the existing platform adapters and retain unavailable states where an adapter is absent.
