### PR TITLE
feat(dashboard): export conversation history as Markdown

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
@@ -5,6 +5,7 @@ import { conversationLabels } from '../lib/pixelConversationLabels'
 import PixelConversationRow, {ConversationTitle} from './PixelConversationRow'
 
 import { exportConversation } from '../lib/pixelConversationExport'
+import { exportConversationMarkdown } from '../lib/pixelConversationExportMarkdown'
 
 export default function PixelConversationNavigation({ collapsed }) {
   const [chats, setChats] = useState(readConversations)
@@ -42,7 +43,7 @@ export default function PixelConversationNavigation({ collapsed }) {
   const regular = visible.filter(item => !item.labels.pinned).map(item => item.chat)
   const chevron = <svg className="rail-chevron" viewBox="0 0 16 16" aria-hidden="true"><path d="m5 6 3 3 3-3"/></svg>
   function rows(items, empty) {
-    return <div className="rail-conversations">{items.length ? items.map(chat => <PixelConversationRow key={chat.chatId} chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()} onDelete={event => {trigger.current=event.currentTarget;setDeleteError('');setPending(chat)}} onExport={() => {
+    return <div className="rail-conversations">{items.length ? items.map(chat => <PixelConversationRow key={chat.chatId} chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()} onDelete={event => {trigger.current=event.currentTarget;setDeleteError('');setPending(chat)}} onExportMarkdown={() => { try { exportConversationMarkdown(chat.chatId); setExportError('') } catch { setExportError('This conversation could not be exported as Markdown.') } }} onExport={() => {
       try { exportConversation(chat.chatId); setExportError('') }
       catch { setExportError('This conversation could not be exported. Your saved history is unchanged.') }
     }}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={conversationTitle(chat)} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><ConversationTitle title={conversationTitle(chat)}/>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button></PixelConversationRow>) : <span className="rail-empty">{empty}</span>}</div>

--- a/ods/extensions/services/dashboard/src/components/PixelConversationRow.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationRow.jsx
@@ -19,7 +19,7 @@ export function ConversationTitle({title}) {
   return <strong ref={viewport} className="conversation-title" data-overflow={overflow>0} style={{'--title-travel':`${-overflow}px`,'--title-duration':`${Math.max(4,overflow/28+2)}s`}}><span ref={text}>{title}</span></strong>
 }
 
-export default function PixelConversationRow({chat,title,onDelete,onExport,onSaved,children}) {
+export default function PixelConversationRow({chat,title,onDelete,onExport,onExportMarkdown,onSaved,children}) {
   const row=useRef(null), menu=useRef(null), returnFocus=useRef(null)
   const [position,setPosition]=useState(null)
   const [error,setError]=useState('')
@@ -73,6 +73,7 @@ export default function PixelConversationRow({chat,title,onDelete,onExport,onSav
       <button role="menuitem" onClick={()=>toggle('archived')}><Archive size={15}/>{labels.archived?'Unarchive':'Archive'}</button>
       <div role="separator"/>
       <button role="menuitem" onClick={()=>{close();onExport()}}><Download size={15}/>Export conversation</button>
+      <button role="menuitem" onClick={()=>{close();if(onExportMarkdown)onExportMarkdown()}}><Download size={15}/>Export Markdown</button>
       <button role="menuitem" onClick={()=>{close(false);row.current.querySelector('.conversation-delete')?.click()}}><X size={15}/>Delete chat</button>
       {error && <p role="alert">{error}</p>}
     </div>,document.body)}

--- a/ods/extensions/services/dashboard/src/components/PixelConversationRow.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationRow.test.jsx
@@ -19,7 +19,7 @@ it('opens only supported actions on right click, supports keyboard navigation an
   const button=screen.getByRole('button',{name:'My chat',exact:true})
   fireEvent.contextMenu(button,{clientX:900,clientY:700})
   const menu=screen.getByRole('menu')
-  expect(within(menu).getAllByRole('menuitem').map(item=>item.textContent)).toEqual(['Rename','Pin','Archive','Export conversation','Delete chat'])
+  expect(within(menu).getAllByRole('menuitem').map(item=>item.textContent)).toEqual(['Rename','Pin','Archive','Export conversation','Export Markdown','Delete chat'])
   expect(screen.getByRole('menuitem',{name:'Rename'})).toHaveFocus()
   fireEvent.keyDown(menu,{key:'ArrowDown'})
   expect(screen.getByRole('menuitem',{name:'Pin'})).toHaveFocus()

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationExportMarkdown.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationExportMarkdown.js
@@ -1,0 +1,33 @@
+import { readConversations } from './pixelConversations'
+
+export function exportConversationMarkdown(chatId) {
+  const conversation = readConversations().find(chat => chat.chatId === chatId)
+  if (!conversation) throw new Error('Conversation unavailable')
+  
+  let title = 'Untitled'
+  if (conversation.messages && conversation.messages.length > 0) {
+     const firstUserMsg = conversation.messages.find(m => m.role === 'user')
+     if (firstUserMsg && firstUserMsg.content) {
+         title = firstUserMsg.content.slice(0, 50).replace(/\n/g, ' ')
+     }
+  }
+
+  let markdown = `# Chat: ${title}\n\n`
+  for (const msg of conversation.messages || []) {
+    if (msg.role === 'system' || msg.role === 'developer') continue
+    const roleName = msg.role === 'user' ? '**You:**' : '**Pixel:**'
+    markdown += `${roleName}\n\n${msg.content || ''}\n\n---\n\n`
+  }
+  
+  const url = URL.createObjectURL(new Blob([markdown], {type:'text/markdown'}))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = 'ods-pixel-' + conversation.chatId + '.md'
+  try {
+    document.body.append(anchor)
+    anchor.click()
+  } finally {
+    anchor.remove()
+    setTimeout(() => URL.revokeObjectURL(url), 1000)
+  }
+}


### PR DESCRIPTION
## Description

Currently, users can only export their conversation history as a raw JSON file. While this is useful for backups and programmatic imports, JSON is difficult for humans to read, share with colleagues, or use in external documentation.

This PR introduces an **Export Markdown** option directly into the sidebar conversation context menu. It takes the entire conversation trajectory and formats it into a clean, readable `.md` file.

### How It Works

The new export functionality:

* Adds `pixelConversationExportMarkdown.js` to handle Markdown conversation exports.
* Reads the active conversation state and processes the complete chat trajectory.
* Filters out internal system and developer payloads to ensure only user-facing conversation content is exported.
* Formats messages using distinct Markdown headers:

  ```markdown
  **You:**

  ...

  **Pixel:**

  ...
  ```
* Dynamically generates the filename using the conversation ID:

  ```text
  ods-pixel-<id>.md
  ```
* Uses a temporary browser `Blob` URL to securely initiate the download locally without sending the conversation data to an external service.
* Updates `PixelConversationRow.test.jsx` to verify that the new context-menu option is present.

### Environment / Device

* **OS:** Windows (Docker Desktop with WSL2 backend)
* **Frontend Runtime:** Node.js / React (Vitest)
* **Hardware:** Local desktop development environment

### How to Test

1. Pull the branch locally and start the Dashboard development server.
2. In the left sidebar, right-click (or press `Shift+F10`) on an existing conversation.
3. Select **Export Markdown** from the context menu.
4. Verify that the browser downloads a `.md` file named:

   ```text
   ods-pixel-<id>.md
   ```
5. Open the exported file in a text editor or Markdown viewer.
6. Verify that:

   * User and Pixel messages are clearly distinguished.
   * Internal system/developer payloads are excluded.
   * Markdown formatting is readable.
   * Code blocks are preserved correctly.
7. Run the Dashboard frontend test suite:

   ```bash
   npm test run
   ```

   from:

   ```text
   ods/extensions/services/dashboard
   ```
8. Verify that the frontend test suite remains green.

### Expected Behavior

Users should be able to export any conversation directly from the sidebar as a human-readable Markdown file, making conversations easier to read, share, archive, and reuse in external documentation.
