### PR TITLE
feat(dashboard): duplicate/fork conversation history

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationNavigation.jsx
@@ -5,6 +5,7 @@ import { conversationLabels } from '../lib/pixelConversationLabels'
 import PixelConversationRow, {ConversationTitle} from './PixelConversationRow'
 
 import { exportConversation } from '../lib/pixelConversationExport'
+import { forkConversation } from '../lib/pixelConversationFork'
 
 export default function PixelConversationNavigation({ collapsed }) {
   const [chats, setChats] = useState(readConversations)
@@ -42,7 +43,7 @@ export default function PixelConversationNavigation({ collapsed }) {
   const regular = visible.filter(item => !item.labels.pinned).map(item => item.chat)
   const chevron = <svg className="rail-chevron" viewBox="0 0 16 16" aria-hidden="true"><path d="m5 6 3 3 3-3"/></svg>
   function rows(items, empty) {
-    return <div className="rail-conversations">{items.length ? items.map(chat => <PixelConversationRow key={chat.chatId} chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()} onDelete={event => {trigger.current=event.currentTarget;setDeleteError('');setPending(chat)}} onExport={() => {
+    return <div className="rail-conversations">{items.length ? items.map(chat => <PixelConversationRow key={chat.chatId} chat={chat} title={conversationTitle(chat)} onSaved={() => archiveToggle.current?.focus()} onDelete={event => {trigger.current=event.currentTarget;setDeleteError('');setPending(chat)}} onFork={() => { try { forkConversation(chat.chatId) } catch { setExportError('Failed to duplicate chat.') } }} onExport={() => {
       try { exportConversation(chat.chatId); setExportError('') }
       catch { setExportError('This conversation could not be exported. Your saved history is unchanged.') }
     }}><button className={`conversation-link ${chat.chatId === active ? 'active' : ''}`} title={conversationTitle(chat)} aria-current={chat.chatId === active ? 'page' : undefined} onClick={() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId }))}><ConversationTitle title={conversationTitle(chat)}/>{chat.inFlight && <span className="rail-task-running" role="status" aria-label="Working"/>}</button></PixelConversationRow>) : <span className="rail-empty">{empty}</span>}</div>

--- a/ods/extensions/services/dashboard/src/components/PixelConversationRow.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationRow.jsx
@@ -19,7 +19,7 @@ export function ConversationTitle({title}) {
   return <strong ref={viewport} className="conversation-title" data-overflow={overflow>0} style={{'--title-travel':`${-overflow}px`,'--title-duration':`${Math.max(4,overflow/28+2)}s`}}><span ref={text}>{title}</span></strong>
 }
 
-export default function PixelConversationRow({chat,title,onDelete,onExport,onSaved,children}) {
+export default function PixelConversationRow({chat,title,onDelete,onExport,onFork,onSaved,children}) {
   const row=useRef(null), menu=useRef(null), returnFocus=useRef(null)
   const [position,setPosition]=useState(null)
   const [error,setError]=useState('')
@@ -71,6 +71,8 @@ export default function PixelConversationRow({chat,title,onDelete,onExport,onSav
       <button role="menuitem" onClick={()=>{close(false);row.current.querySelector('.conversation-organize')?.click()}}><Pencil size={15}/>Rename</button>
       <button role="menuitem" onClick={()=>toggle('pinned')}><Pin size={15}/>{labels.pinned?'Unpin':'Pin'}</button>
       <button role="menuitem" onClick={()=>toggle('archived')}><Archive size={15}/>{labels.archived?'Unarchive':'Archive'}</button>
+      <div role="separator"/>
+      <button role="menuitem" onClick={()=>{close();if(onFork)onFork()}}><Pencil size={15}/>Duplicate / Fork</button>
       <div role="separator"/>
       <button role="menuitem" onClick={()=>{close();onExport()}}><Download size={15}/>Export conversation</button>
       <button role="menuitem" onClick={()=>{close(false);row.current.querySelector('.conversation-delete')?.click()}}><X size={15}/>Delete chat</button>

--- a/ods/extensions/services/dashboard/src/components/PixelConversationRow.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationRow.test.jsx
@@ -19,7 +19,7 @@ it('opens only supported actions on right click, supports keyboard navigation an
   const button=screen.getByRole('button',{name:'My chat',exact:true})
   fireEvent.contextMenu(button,{clientX:900,clientY:700})
   const menu=screen.getByRole('menu')
-  expect(within(menu).getAllByRole('menuitem').map(item=>item.textContent)).toEqual(['Rename','Pin','Archive','Export conversation','Delete chat'])
+  expect(within(menu).getAllByRole('menuitem').map(item=>item.textContent)).toEqual(['Rename','Pin','Archive','Duplicate / Fork','Export conversation','Delete chat'])
   expect(screen.getByRole('menuitem',{name:'Rename'})).toHaveFocus()
   fireEvent.keyDown(menu,{key:'ArrowDown'})
   expect(screen.getByRole('menuitem',{name:'Pin'})).toHaveFocus()

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationFork.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationFork.js
@@ -1,0 +1,16 @@
+import { readConversations, saveConversation, SELECT_EVENT } from './pixelConversations'
+
+export function forkConversation(chatId) {
+  const conversation = readConversations().find(chat => chat.chatId === chatId)
+  if (!conversation) throw new Error('Conversation unavailable')
+
+  const newChatId = 'ods-pixel-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6)
+  const forkedChat = {
+    ...conversation,
+    chatId: newChatId,
+    messages: JSON.parse(JSON.stringify(conversation.messages))
+  }
+  
+  saveConversation(forkedChat)
+  window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: newChatId }))
+}


### PR DESCRIPTION
## Description

In complex conversations, users may want to try a completely different approach, experiment with a risky prompt, or rewrite their last message without losing the original, successful conversation trajectory.

This PR introduces a **Duplicate / Fork** feature to the conversation sidebar, allowing users to seamlessly branch an existing conversation while keeping the original intact.

### How It Works

The new fork functionality:

* Adds `pixelConversationFork.js` to handle conversation duplication.
* Performs a deep copy of the target conversation's message history.
* Generates a new collision-free conversation ID using the format:

  ```text
  ods-pixel-[timestamp]-[random]
  ```
* Saves the duplicated conversation to `localStorage` using the existing `saveConversation` utility.
* Automatically dispatches a `SELECT_EVENT` after creating the fork, immediately navigating the user to the new conversation without requiring a page refresh.
* Adds a new **Duplicate / Fork** menu item with a `<Pencil>` icon to `PixelConversationRow.jsx`.
* Updates the Vitest assertions to explicitly cover the new sidebar menu action.

### Environment / Device

* **OS:** Windows (Docker Desktop with WSL2 backend)
* **Frontend Runtime:** Node.js / React (Vitest)
* **Hardware:** Local desktop development environment

### How to Test

1. Pull the branch locally and start the Dashboard development server.
2. Open an existing conversation containing several messages.
3. Right-click the conversation in the left sidebar.
4. Select **Duplicate / Fork**.
5. Verify that:

   * A cloned conversation appears at the top of the sidebar as the most recent chat.
   * The UI automatically switches to the newly forked conversation.
   * The original conversation remains available.
6. Send a new message in the cloned conversation.
7. Verify that changes to the fork do not modify the original conversation.
8. Run the Dashboard frontend test suite:

   ```bash
   npm test run
   ```

   from:

   ```text
   ods/extensions/services/dashboard
   ```
9. Verify that the frontend test suite passes.

### Expected Behavior

Users should be able to duplicate any existing conversation into an independent branch. The fork should contain the complete original message history while allowing users to continue experimenting without affecting the original conversation.
