### PR TITLE
fix(beta): deliver visual projects in Workbench and simplify stopped responses

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -1346,12 +1346,12 @@ export default function Pixel({ systemStatus = null }) {
                 : message.status === 'error'
                   ? 'border border-red-500/25 bg-red-500/10 text-red-200'
                   : message.status === 'stopped'
-                    ? 'border border-amber-500/30 bg-amber-500/10 text-theme-text-secondary'
+                    ? 'pixel-stopped-response bg-transparent text-theme-text-secondary'
                   : 'bg-transparent text-theme-text-secondary'
             }`}>
               {message.status === 'stopped' && (
-                <div role="status" className="mb-2 inline-flex items-center gap-1.5 text-xs font-medium text-amber-300">
-                  <Square className="h-3 w-3 fill-current" />
+                <div role="status" className="mb-2 inline-flex items-center gap-2 text-xs font-medium text-theme-text-muted">
+                  <Square className="h-3 w-3" />
                   Response stopped
                 </div>
               )}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.test.jsx
@@ -1700,7 +1700,8 @@ describe('Pixel', () => {
     expect(globalThis.fetch).toHaveBeenCalledWith('/api/pixel/chat/cancel', expect.objectContaining({
       method: 'POST',
     }))
-    expect(stopped.parentElement).toHaveClass('bg-amber-500/10')
+    expect(stopped.parentElement).toHaveClass('pixel-stopped-response', 'bg-transparent')
+    expect(stopped.parentElement).not.toHaveClass('bg-amber-500/10', 'border-amber-500/30')
     expect(stopped.parentElement).not.toHaveClass('bg-red-500/10')
     expect(screen.getByText('Stopped by you. Workspace changes completed before cancellation were preserved.')).toBeInTheDocument()
     expect(screen.getByText('Available')).toBeInTheDocument()

--- a/ods/extensions/services/pixel-agent/plugin/tool-loop-guard.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/tool-loop-guard.mjs
@@ -5047,7 +5047,7 @@ function ownerForbidsWorkspacePreview(messages, prompt) {
   // Preserve explicit owner constraints without requiring a positive visual
   // vocabulary to use the local snapshot tool. These are delivery actions,
   // not filenames, quoted examples, or another clause's edit restriction.
-  return portuguesePreviewForbidden(text) || /\b(?:do\s+not|don['’]t|never|must\s+not|should\s+not|avoid|skip|without)\s+(?:(?:create|build|edit|write|run|execute)\s*(?:,\s*|and\s+|or\s+))*(?:show(?:ing)?|preview(?:ing)?|view(?:ing)?|open(?:ing)?|serv(?:e|ing)|publish(?:ing)?|republish(?:ing)?|display(?:ing)?)\b/i.test(text);
+  return portuguesePreviewForbidden(text) || /\b(?:only|just)\s+(?:the\s+)?(?:code|source(?:\s+code)?)\b/i.test(text) || /\b(?:do\s+not|don['’]t|never|must\s+not|should\s+not|avoid|skip|without)\s+(?:(?:create|build|edit|write|run|execute)\s*(?:,\s*|and\s+|or\s+))*(?:show(?:ing)?|preview(?:ing)?|view(?:ing)?|open(?:ing)?|serv(?:e|ing)|publish(?:ing)?|republish(?:ing)?|display(?:ing)?)\b/i.test(text);
 }
 
 function portuguesePreviewForbidden(text) {
@@ -5064,10 +5064,21 @@ function portugueseWorkspaceBuildRequest(text) {
     .replace(/^\s*>[^\n]*/gm, ' ').replace(/"[^"\n]*"|`[^`\n]*`/g, ' ')
     .normalize('NFD').replace(/[\u0300-\u036f]/g, '');
   if (portuguesePreviewForbidden(prose)) return false;
-  return prose.split(/[!?;\n]+|\.(?=\s|$)/).some(clause =>
-    /^\s*(?:por\s+favor[, ]+)?(?:(?:voce|vc)\s+)?(?:pode\s+)?(?:crie|criar|faca|fazer|construa|construir|desenvolva|desenvolver|implemente|implementar)\s+/i.test(clause)
-    && /\b(?:html|site|website|pagina\s+web|app\s+web|aplicativo\s+web)\b/i.test(clause)
-    && !/\b(?:nao|nunca|sem)\s+(?:criar|crie|fazer|faca|public\w*)\b/i.test(clause));
+  return prose.split(/[!?;\n]+|\.(?=\s|$)/).some(clause => {
+    const request = clause.trim().replace(/^(?:(?:ok|ta|agora|entao)[,\s]+)+/i, '')
+      .replace(/^por\s+favor[,\s]+/i, '');
+    const command = /^(?:(?:voce|vc)\s+)?(?:pode\s+)?(?:crie|cria|criar|faca|faz|fazer|construa|construir|desenvolva|desenvolver|implemente|implementar)\s+/i.test(request);
+    const desired = /^(?:eu\s+)?(?:quero|queria|gostaria\s+de)\s+(?:(?:que\s+(?:voce|vc)\s+)?(?:crie|faca|faz|criar|fazer)\s+)?(?:um|uma|outro|outra)\b/i.test(request);
+    // Conversational task requests often omit "create": "agora um site em
+    // html ...". Require a task prefix and a new visual object, not any mention
+    // of HTML in a question, diagnosis, quotation, or already-existing page.
+    const elliptical = /^\s*(?:(?:ok|ta)[,\s]+)*(?:agora|entao)[,\s]+/i.test(clause)
+      && /^(?:mais\s+)?(?:um|uma|outro|outra)\s+(?:novo\s+|nova\s+)?(?:site|website|pagina\s+web|app\s+web|aplicativo\s+web|jogo|calculadora)\b/i.test(request)
+      && !/\b(?:explique|explica|como|por\s+que|porque|significa|existe|existente|esta|ficou|parou|falhou|mostra|abre|carrega|funciona)\b/i.test(request);
+    return (command || desired || elliptical)
+      && /\b(?:html|site|website|pagina\s+web|app\s+web|aplicativo\s+web|interface|dashboard|landing\s+page|visualizacao|svg)\b/i.test(request)
+      && !/\b(?:nao|nunca|sem)\s+(?:criar|crie|fazer|faca|faz|public\w*)\b/i.test(request);
+  });
 }
 
 function withoutWorkspaceHtmlTargets(text) {
@@ -8029,7 +8040,7 @@ export function createToolLoopGuard({
         // With no verified previous preview, ordinary tools must remain usable
         // to locate the requested files. Only a real preview binds its scope.
         state.workspacePreviewRequired = !state.workspacePreviewForbidden && (
-          Boolean(trustedSessionPreview) ||
+          Boolean(trustedSessionPreview) || state.workspaceVisualArtifactProduced ||
           ((!visualContinuationRequested || explicitDelivery) && previewRequested)
         );
         state.workspacePreviewAuthorshipRequired = Boolean(
@@ -8368,6 +8379,21 @@ export function createToolLoopGuard({
       : [];
     if (completedEditPath) state.successfulEditPaths.add(completedEditPath);
     const completedVisualMutationPath = completedEditPath ?? completedWritePath;
+    const previousVisualDirectory = sessionPreviews.get(state.currentSessionId)?.relativeDirectory;
+    const updatesPublishedProject = previousVisualDirectory && completedVisualMutationPath?.startsWith(`${previousVisualDirectory}/`);
+    if (state.ownerIntentObserved && !state.workspacePreviewForbidden &&
+        !state.operationsRequired && !state.exactDownloadRequested &&
+        completedVisualMutationPath && (updatesPublishedProject || /\.(?:html?|svg|jsx|tsx|vue|svelte)$/i.test(completedVisualMutationPath)) &&
+        !/(?:^|\/)(?:node_modules|vendor|__tests__|tests?|fixtures?)(?:\/|$)/i.test(completedVisualMutationPath)) {
+      // Actual successful workspace mutations are a stronger delivery signal
+      // than a fixed vocabulary of request verbs or languages. Reads, failed
+      // tools, quoted model claims and text-only files never activate this.
+      state.workspaceVisualArtifactProduced = true;
+      state.workspacePreviewRequired = true;
+      state.workspaceTaskRequested = true;
+      state.workspaceMutationRequested = true;
+      if (updatesPublishedProject) state.workspacePreviewDirectory = previousVisualDirectory;
+    }
     if (
       completedVisualMutationPath &&
       state.workspaceVisualContinuationRequested &&
@@ -9042,7 +9068,7 @@ export function createToolLoopGuard({
       return {
         stage: "workspace-preview-files",
         instruction:
-          "Do not reply yet. Create or inspect the requested static website in one workspace-relative directory with index.html and any local CSS or JavaScript assets. Do not start a server. After index.html has been written or read in this response, call pixel_ods_workspace_preview with that relative directory.",
+          "Do not reply yet. Deliver the visual project in Workbench: prepare a browser-ready version in one workspace-relative directory with index.html and its local CSS, JavaScript, SVG and image assets. Preserve the project source files. Raw JSX/TSX/Vue/Svelte source is not a browser preview: prepare the runnable output first and inspect its entry point. For a standalone visual asset, create an index.html that displays it. Do not start a server or claim an unverified preview. After index.html has been written or read in this response, call pixel_ods_workspace_preview with that relative directory.",
       };
     }
     state.workspacePreviewDirectory = directory;
@@ -9123,6 +9149,15 @@ export function createToolLoopGuard({
       return undefined;
     })();
     const previewStageInstruction = (() => {
+      if (state?.workspacePreviewRequired && !state.workspacePreview && !state.workspacePreviewVerifiedDirectory &&
+          !state.workspacePreviewForbidden && !state.operationsRequired && !state.exactDownloadRequested) {
+        const directory = workspacePreviewDirectoryFromState(state);
+        return "[ODS Pixel next step] This visual project must be delivered in Workbench. " +
+          "Finish all requested files, edits and checks first, then publish BEFORE your final answer. " +
+          (directory ? `Call tool_call with id ${WORKSPACE_PREVIEW_TOOL} and args ${JSON.stringify({relativeDirectory:directory})}. ` :
+            "Prepare a browser-ready directory with index.html and local assets, preserve the source files, then call pixel_ods_workspace_preview with that relativeDirectory. ") +
+          "Do not start a server. A saved file or a previous snapshot is not a verified current preview.";
+      }
       if (state?.workspacePreviewVerifiedDirectory && !state.workspacePreview &&
           state.workspacePreviewRequired && !state.workspacePreviewForbidden &&
           !state.operationsRequired && !state.exactDownloadRequested) {

--- a/ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs
@@ -207,6 +207,113 @@ test("Portuguese HTML creation requests require a preview without overriding neg
   ]) assert.equal(userMessageRequestsWorkspacePreview([], prompt), false, prompt);
 });
 
+test("conversational Portuguese HTML requests cannot finish with an unverified prose claim", () => {
+  for (const prompt of [
+    "agora um site em html de uma calculadora minimalista em preto e branco e bonita.",
+    "ok, agora uma calculadora em HTML preta e branca",
+    "Então, outro site em html para um portfolio",
+    "quero uma calculadora em html",
+    "agora faça um site de portfolio",
+    "faz um jogo em html",
+  ]) {
+    assert.equal(userMessageRequestsWorkspacePreview([], prompt), true, prompt);
+    const guard = createToolLoopGuard();
+    const context = { agentId: 'pixel', runId: 'run-1', sessionId: 'session-1' };
+    guard.observeRun(context, 'pixel', { prompt });
+    const retry = guard.beforeAgentFinalize({lastAssistantMessage: 'Criei a calculadora e salvei index.html.'}, context);
+    assert.ok(retry?.retry, prompt);
+    assert.notEqual(guard.verificationForRun('run-1').status, 'passed');
+  }
+  for (const prompt of [
+    'explique agora um site em html de calculadora',
+    'agora um site em html ficou indisponível, explique por quê',
+    'agora um site em html não carrega',
+    'Traduza: agora um site em html de calculadora',
+    'Traduza: "agora um site em html de calculadora"',
+    '> agora um site em html de calculadora',
+    '```\nagora um site em html de calculadora\n```',
+    'agora um site em html, mas não publique',
+    'agora um site em html, apenas o código',
+    'agora não crie um site em html',
+    'agora um script python para uma calculadora',
+  ]) assert.equal(userMessageRequestsWorkspacePreview([], prompt), false, prompt);
+});
+
+test("conversational calculator delivery emits the verified snapshot consumed by Workbench", () => {
+  const guard = createToolLoopGuard();
+  guard.observeRun({agentId:'pixel',runId:'run-1',sessionId:'session-1'}, 'pixel', {
+    prompt: 'agora um site em html de uma calculadora minimalista em preto e branco e bonita.',
+  });
+  const writes = [
+    {path:'calculator/index.html',content:'<!doctype html><title>Calculator</title><link rel="stylesheet" href="styles.css"><button>1</button><script src="app.js"></script>'},
+    {path:'calculator/styles.css',content:'body{background:#111;color:#eee}'},
+    {path:'calculator/app.js',content:'document.querySelector("button").onclick=()=>{}'},
+  ];
+  for (const write of writes) {
+    call(guard, 'write', {event:{params:write}});
+    afterCall(guard, 'write', {event:{params:write,result:{details:{status:'completed'}}}});
+    const persisted = persistToolResult(guard, 'write', `write-${write.path}`);
+    assert.match(JSON.stringify(persisted), /publish BEFORE your final answer/);
+  }
+  const params = {relativeDirectory:'calculator'};
+  const snapshot = workspacePreviewSnapshot('calculator',writes);
+  const details = {schemaVersion:1,kind:'ods-pixel-workspace-preview',status:'succeeded',relativeDirectory:'calculator',...snapshot,port:9437,
+    url:`http://${snapshot.siteId}.localhost:9437/${snapshot.siteId}/`,httpStatus:200,readbackVerified:true,executable:false,overwritten:false};
+  assert.notEqual(call(guard, 'pixel_ods_workspace_preview', {event:{params}})?.block, true);
+  // A written file alone is not a delivered preview.
+  assert.notEqual(guard.verificationForRun('run-1').status, 'passed');
+  afterCall(guard, 'pixel_ods_workspace_preview', {event:{params,result:{details}}});
+  const verification = guard.verificationForRun('run-1');
+  assert.equal(verification.status, 'passed');
+  assert.equal(verification.preview.sha256, snapshot.sha256);
+  assert.equal(verification.preview.files, 3);
+  assert.match(verification.text, /Open preview/);
+});
+
+test("actual visual files request Workbench delivery independent of prompt wording", () => {
+  for (const path of ['project/index.html','project/chart.svg','project/src/App.tsx','project/src/App.vue','project/src/App.svelte']) {
+    const guard = createToolLoopGuard();
+    const context = {agentId:'pixel',runId:'run-1',sessionId:'session-1'};
+    guard.observeRun(context,'pixel',{prompt:'Um projeto bonito para mim.'});
+    const params = {path,content:'visual project source'};
+    call(guard,'write',{event:{params}});
+    afterCall(guard,'write',{event:{params,result:{details:{status:'completed'}}}});
+    // Subsequent run observations must not lose the production signal.
+    guard.observeRun(context,'pixel',{prompt:'Um projeto bonito para mim.'});
+    assert.ok(guard.beforeAgentFinalize({},context)?.retry, path);
+  }
+  for (const scenario of [
+    {path:'project/notes.txt'}, {path:'project/tests/fixture.html'},
+    {path:'project/index.html',failed:true}, {path:'project/index.html',read:true},
+    {path:'project/index.html',prompt:'Crie o site, mas não publique'},
+    {path:'project/index.html',prompt:'Create the source code only. Do not show a preview.'},
+    {path:'project/index.html',prompt:'Only the code for a site'},
+  ]) {
+    const guard = createToolLoopGuard();
+    const context = {agentId:'pixel',runId:'run-1',sessionId:'session-1'};
+    guard.observeRun(context,'pixel',{prompt:scenario.prompt || 'Um projeto bonito para mim.'});
+    const params = {path:scenario.path,content:'source'};
+    const tool = scenario.read ? 'read' : 'write';
+    call(guard,tool,{event:{params}});
+    afterCall(guard,tool,{event:{params,result:scenario.failed ? {isError:true} : {details:{status:'completed'}}}});
+    assert.equal(guard.beforeAgentFinalize({},context)?.retry, undefined, JSON.stringify(scenario));
+  }
+});
+
+test("asset-only edits refresh a previously verified project in the same session", () => {
+  const guard = createToolLoopGuard();
+  seedNamedPreview(guard);
+  const context = {agentId:'pixel',runId:'run-2',sessionId:'session-1'};
+  guard.observeRun(context,'pixel',{prompt:'mude a cor do botão para azul'});
+  const params = {path:'log-viewer-lab/styles.css',content:'button{color:blue}'};
+  call(guard,'write',{event:{params},context});
+  afterCall(guard,'write',{event:{params,result:{details:{status:'completed'}}},context});
+  const continuation = guard.beforeAgentFinalize({},context);
+  assert.ok(continuation?.retry);
+  assert.match(continuation.retry.instruction, /log-viewer-lab/);
+  assert.notEqual(guard.verificationForRun('run-2').status,'passed');
+});
+
 test("Portuguese publication commands require verified delivery, not a prose promise", () => {
   for (const prompt of [
     "Corrija o contador e publique essa pasta no preview.",
@@ -10020,9 +10127,11 @@ test("tracks and drains only the active hashed ODS OpenAI user", async () => {
   assert.equal(guard.trackedUserCount(), 0);
 });
 
-test("client cancellation signals the exact run and blocks any later tool", async () => {
+test("client cancellation signals the exact run and blocks any later tool", {timeout:5000}, async () => {
   const signals = [];
   const clears = [];
+  let cleanupDone;
+  const cleaned = new Promise(resolve => { cleanupDone = resolve; });
   const guard = createToolLoopGuard({
     abortRunAndDrain: async () => ({ aborted: true, drained: true }),
     execMarkerCleanupDelayMs: 0,
@@ -10032,7 +10141,7 @@ test("client cancellation signals the exact run and blocks any later tool", asyn
         signals.push(runId);
         return true;
       },
-      clear: (runId) => clears.push(runId),
+      clear: (runId) => { clears.push(runId); cleanupDone(); },
     },
   });
   const user = `ods-${"e".repeat(64)}`;
@@ -10043,7 +10152,8 @@ test("client cancellation signals the exact run and blocks any later tool", asyn
     runId: "run-live",
   });
   assert.equal(await guard.abortUserRun(user), true);
-  await new Promise((resolve) => setImmediate(resolve));
+  // Cleanup is a timer; setImmediate is not ordered after it on every Node/OS.
+  await cleaned;
   assert.deepEqual(signals, ["run-live"]);
   assert.deepEqual(clears, ["run-live"]);
   assert.deepEqual(
@@ -10815,7 +10925,7 @@ test("publishes an existing app without treating keep-unchanged instructions as 
   }), { params: previewParams }, "displaying an unchanged app must not require a fresh write");
 });
 
-test("SVG output alone does not require HTML publication or replace a verified file result", () => {
+test("an authored SVG requests visual delivery while preserving the original file", () => {
   const prompt = "Write a tiny valid SVG of a yellow sun on a blue background to release-2654/sun.svg, read the file back to check it, and tell me the saved path.";
   for (const request of [prompt, "Make an intricate animated SVG illustration.", "Make a detailed SVG illustration of a floating greenhouse.", "Save an animated SVG to artwork/orbit.svg."]) {
     assert.equal(userMessageRequestsWorkspacePreview([], request), false, request);
@@ -10840,8 +10950,10 @@ test("SVG output alone does not require HTML publication or replace a verified f
   const readParams = { path: params.path };
   call(guard, "read", { event: { params: readParams } });
   afterCall(guard, "read", { event: { params: readParams, result: { content: [{ type: "text", text: params.content }] } } });
-  assert.equal(guard.beforeAgentFinalize({}, { agentId: "pixel", runId: "run-1" }), undefined);
-  assert.notEqual(guard.deliveryVerificationForRun("run-1")?.status, "failed");
+  const continuation = guard.beforeAgentFinalize({}, { agentId: "pixel", runId: "run-1" });
+  assert.match(continuation.retry.instruction, /Preserve the project source files/);
+  assert.match(continuation.retry.instruction, /standalone visual asset/);
+  assert.notEqual(guard.deliveryVerificationForRun("run-1")?.status, "passed");
 });
 
 test("keeps every visual category on the model-authored write path", () => {

--- a/ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs
@@ -10152,8 +10152,19 @@ test("client cancellation signals the exact run and blocks any later tool", {tim
     runId: "run-live",
   });
   assert.equal(await guard.abortUserRun(user), true);
-  // Cleanup is a timer; setImmediate is not ordered after it on every Node/OS.
-  await cleaned;
+  // Production cleanup is deliberately unref'd. Keep this test alive until
+  // its callback runs, with a bounded deadline rather than timer ordering.
+  let cleanupDeadline;
+  try {
+    await Promise.race([
+      cleaned,
+      new Promise((_, reject) => {
+        cleanupDeadline = setTimeout(() => reject(new Error('Cancellation marker cleanup did not run')), 2000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(cleanupDeadline);
+  }
   assert.deepEqual(signals, ["run-live"]);
   assert.deepEqual(clears, ["run-live"]);
   assert.deepEqual(


### PR DESCRIPTION
## Summary

- Make the stopped-response notice neutral and transparent without changing cancellation behavior or preserved workspace changes.
- Recognize conversational Portuguese visual-project requests, including omitted creation verbs such as "agora um site em html...".
- Require verified Workbench delivery after successful visual source writes/edits and asset changes within a previously published project.
- Remind the agent to publish through the existing preview capability during tool results, before finalization. This addresses gateways that cannot retry finalization after side effects.
- Preserve project sources and direct framework/standalone visual output toward a browser-ready entry point with its assets.

## Scope and safeguards

Targets `public-beta` only, following the already merged UI/UX work in #4207 and #4210. No installation settings, credentials, local QA artifacts, wallpapers or machine-specific runtime configuration are included.

Existing receipt, authorship and snapshot verification remain required. Explicit code-only/no-preview requests, failed tools, read-only actions and fixture/test paths do not activate the new mutation-based delivery signal. This does not add backend hosting or guarantee arbitrary framework builds. Verified publication is distinct from correctness of model-generated application logic.

## Validation

- Agent guard and workspace preview: 504 tests passed (rerun before publication).
- Pixel page: 76 tests passed (rerun before publication).
- Full dashboard suite previously passed on these changes: 101 files / 885 tests; ESLint passed.
- `git diff --check` passed.
- Live local browser: multi-file HTML/CSS/JS creation automatically opened a verified preview; subsequent HTML and JavaScript-only changes published fresh versions and file diffs; Files opened verified source; reload retained all three publications and their change summaries.
- Live cancellation: stopped response has transparent background and zero border; earlier published changes remain in history.
- Regression coverage includes colloquial requests, negative/quoted requests, successful visual mutations, asset-only refreshes and early publication hints. Cancellation cleanup test now waits for actual cleanup instead of relying on timer/immediate ordering across platforms.

## CI follow-up

The initial GitHub integration run exposed a test-lifetime issue: production cleanup correctly uses an unreferenced timer, so merely awaiting its callback could allow Node's event loop to exit and cancel subsequent tests. The follow-up commit adds a referenced, bounded test deadline and clears it afterward; production behavior is unchanged. The complete agent JavaScript suite passes in the Linux Node 20 container, and the isolated cancellation regression also passes on Windows Node 22. The full native-Windows agent suite still has an unrelated existing POSIX private-marker permission test incompatibility; Pixel's host integration runs on Linux/WSL, and the cross-platform dashboard checks passed.
