### PR TITLE
feat(dashboard): download Pixel diagnostic check summaries

### DIFF
--- a/ods/extensions/services/dashboard/src/components/settings/PixelDiagnostics.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelDiagnostics.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Activity, Cpu, ShieldCheck, RefreshCw } from 'lucide-react'
 import MetalMetricIcon from '../MetalMetricIcon'
+import PixelDiagnosticsDownload from './PixelDiagnosticsDownload'
 
 const checks = [
   { id: 'agent', label: 'Agent connection', path: '/api/pixel/status', icon: Activity },
@@ -75,6 +76,7 @@ export default function PixelDiagnostics() {
       <button type="button" onClick={refresh} disabled={busy}><MetalMetricIcon icon={RefreshCw} size={14}/>{busy ? 'Checking…' : 'Refresh checks'}</button>
     </div>
     <p role="status" className="pixel-diagnostics-time">{busy ? 'Reading current host status…' : checkedAt ? `Checked ${checkedAt.toLocaleTimeString()}` : 'Not checked'}</p>
+    <PixelDiagnosticsDownload results={results} checkedAt={checkedAt} busy={busy}/>
     {checks.map(check => {
       const result = results[check.id]
       return <section key={check.id} aria-labelledby={`pixel-check-${check.id}`} className="pixel-diagnostic-check">

--- a/ods/extensions/services/dashboard/src/components/settings/PixelDiagnosticsDownload.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelDiagnosticsDownload.jsx
@@ -1,0 +1,22 @@
+import {useState} from 'react'
+import {diagnosticSummary} from '../../lib/pixelDiagnosticSummary'
+
+export default function PixelDiagnosticsDownload({results,checkedAt,busy}) {
+  const [error,setError]=useState('')
+  function download(){
+    setError('')
+    try {
+      const summary=diagnosticSummary(results,checkedAt)
+      const url=URL.createObjectURL(new Blob([JSON.stringify(summary,null,2)+'\n'],{type:'application/json'}))
+      const link=document.createElement('a')
+      link.href=url;link.download=`ods-pixel-diagnostics-${summary.checkedAt.slice(0,10)}.json`
+      document.body.append(link)
+      try{link.click()}finally{link.remove();setTimeout(()=>URL.revokeObjectURL(url),1000)}
+    } catch {setError('The diagnostic summary could not be downloaded. Refresh checks and try again.')}
+  }
+  return <div>
+    <button type="button" disabled={busy || !checkedAt} onClick={download}>Download check summary</button>
+    <p className="text-xs text-theme-text-muted">Includes check outcomes, context sizes and access modes. Model names and connection details are omitted.</p>
+    {error && <p role="alert">{error}</p>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/settings/PixelDiagnosticsDownload.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/PixelDiagnosticsDownload.test.jsx
@@ -1,0 +1,42 @@
+import {render,screen,fireEvent,waitFor} from '@testing-library/react'
+import {MemoryRouter} from 'react-router-dom'
+import PixelDiagnostics from './PixelDiagnostics'
+
+let blobs,clicks
+beforeEach(()=>{
+  blobs=[];clicks=[]
+  vi.spyOn(URL,'createObjectURL').mockImplementation(blob=>{blobs.push(blob);return 'blob:summary'})
+  vi.spyOn(URL,'revokeObjectURL').mockImplementation(()=>{})
+  vi.spyOn(HTMLAnchorElement.prototype,'click').mockImplementation(function(){clicks.push(this.download)})
+  vi.stubGlobal('fetch',vi.fn(async path=>({ok:true,json:async()=>path==='/api/status' ? {inference:{loadedModel:'private-model-name',contextSize:32768},secret:'never-export'} : path.endsWith('access-mode') ? {available:true,configured_mode:'full-access',effective_mode:'sandboxed',runtime_verified:true,privateKey:'never-export'} : {available:true,detail:'private-host/path token=never-export',runtime:{model:'private-model-name',contextLength:8192}}})))
+})
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
+const show=()=>render(<MemoryRouter><PixelDiagnostics/></MemoryRouter>)
+it('downloads only an explicit status allowlist from a completed diagnostic read',async()=>{
+  show()
+  const button=screen.getByRole('button',{name:'Download check summary'})
+  expect(button).toBeDisabled()
+  await waitFor(()=>expect(button).toBeEnabled())
+  fireEvent.click(button)
+  expect(fetch).toHaveBeenCalledTimes(3)
+  const text=await new Promise(resolve=>{const reader=new globalThis.FileReader();reader.onload=()=>resolve(reader.result);reader.readAsText(blobs[0])})
+  const report=JSON.parse(text)
+  expect(report.kind).toBe('ods-pixel-diagnostic-summary')
+  expect(report.checks.agent).toEqual({state:'Ready',ok:true,contextWindow:(8192).toLocaleString()+' tokens'})
+  expect(report.checks.access).toEqual({state:'Verified',ok:true,configuredMode:'Full Access',effectiveMode:'Safer mode'})
+  expect(text).not.toMatch(/private-model|private-host|never-export|privateKey|detail/)
+  expect(clicks[0]).toMatch(/^ods-pixel-diagnostics-\d{4}-\d{2}-\d{2}\.json$/)
+  expect(blobs[0].type).toBe('application/json')
+  expect(document.querySelector('a[download]')).toBeNull()
+  await waitFor(()=>expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:summary'),{timeout:2000})
+})
+it('disables stale report export during refresh and reports download failures',async()=>{
+  show();await waitFor(()=>expect(screen.getByRole('button',{name:'Download check summary'})).toBeEnabled())
+  URL.createObjectURL.mockImplementation(()=>{throw new Error('Unavailable')})
+  fireEvent.click(screen.getByRole('button',{name:'Download check summary'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be downloaded')
+  fetch.mockImplementation(()=>new Promise(()=>{}))
+  fireEvent.click(screen.getByRole('button',{name:'Refresh checks'}))
+  expect(screen.getByRole('button',{name:'Download check summary'})).toBeDisabled()
+  expect(clicks).toHaveLength(0)
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelDiagnosticSummary.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelDiagnosticSummary.js
@@ -1,0 +1,22 @@
+const states = new Set(['Ready','Unavailable','Reported by ODS','Not loaded','Verified','Not verified'])
+const accessModes = new Set(['Safer mode','Full Access','Not verified'])
+const row = (result,label) => result.rows?.find(item => item[0] === label)?.[1]
+
+export function diagnosticSummary(results, checkedAt) {
+  if (!(checkedAt instanceof Date) || !Number.isFinite(checkedAt.getTime()) || !['agent','model','access'].every(id => results[id])) throw new Error('Checks are incomplete')
+  const checks = Object.fromEntries(['agent','model','access'].map(id => {
+    const result = results[id]
+    const summary = {state:states.has(result.state) ? result.state : 'Unavailable', ok:result.ok === true}
+    if (id === 'access') {
+      for (const [label,key] of [['Configured','configuredMode'],['Effective','effectiveMode']]) {
+        const value=row(result,label)
+        summary[key]=accessModes.has(value) ? value : 'Not verified'
+      }
+    } else {
+      const value=row(result,'Context window')
+      summary.contextWindow=typeof value === 'string' && value.length <= 64 && /^[\p{N},.\s\u066B\u066C]+ tokens$/u.test(value) ? value : 'Not reported'
+    }
+    return [id,summary]
+  }))
+  return {schemaVersion:1,kind:'ods-pixel-diagnostic-summary',checkedAt:checkedAt.toISOString(),checks}
+}


### PR DESCRIPTION
﻿## Why this matters

Pixel diagnostic checks can now be downloaded for support and comparisons without copying arbitrary backend details. The existing Settings checks remain read-only; this exports the completed check timestamp, outcomes, context sizes and configured/effective access modes as versioned JSON. Model names, endpoints, errors and connection details are deliberately omitted by an explicit field allowlist.

## Overlap check

Searched all-state diagnostic summary/export PRs and the recent 1,500-PR changed-file inventory for PixelDiagnostics.jsx. #4103 improves loaded-model reporting; this consumes the existing displayed results and adds no health or inference claims. No equivalent summary download was found.

## Validation and risk

Node 20 diagnostic boundary suites: 6 passed. Tests run the real Settings diagnostics, assert the exact exported JSON and omission of private sentinel fields, verify download cleanup/error feedback, and disable export during refresh. Production build, focused ESLint (no errors), git diff --check and changed-file pre-commit hooks pass.

Base public-beta d7d76cdc. Combined validation is recorded below. Baseline full gate remains limited by existing literal unit-test-key fixtures and WSL phase03 no-sudo fixture failures. No installed hardware validation claimed. Revert removes only the local download control; no server or persisted state changes.

## AI assistance

Codex implemented and tested this change. Independent human review remains outstanding. No merge or deployment implied.


## Final batch receipt (2026-09-11)

Exact PR head: `6b2fdaebbe51c9e3d035e3f8b18df08ddab8962a`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
