### PR TITLE
feat(pixel): export reply tables as CSV

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelReplyTable.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelReplyTable.jsx
@@ -1,0 +1,38 @@
+import {useRef, useState} from 'react'
+
+function csvCell(cell) {
+  const text = cell.textContent || ''
+  // Spreadsheet programs can interpret formula prefixes even inside quoted CSV.
+  const value = /^[\s]*[=+@-]/u.test(text) ? `'${text}` : text
+  return `"${value.replaceAll('"', '""')}"`
+}
+
+export default function PixelReplyTable({children}) {
+  const table = useRef(null)
+  const [error, setError] = useState('')
+  function download() {
+    setError('')
+    try {
+      const rows = Array.from(table.current.rows, row => Array.from(row.cells, csvCell).join(','))
+      const url = URL.createObjectURL(new Blob(['\uFEFF', rows.join('\r\n'), '\r\n'], {type:'text/csv;charset=utf-8'}))
+      const link = document.createElement('a')
+      link.href = url
+      link.download = 'pixel-reply-table.csv'
+      document.body.append(link)
+      try { link.click() } finally {
+        link.remove()
+        setTimeout(() => URL.revokeObjectURL(url), 1000)
+      }
+    } catch {
+      setError('This table could not be downloaded. Try again or copy its text.')
+    }
+  }
+  return <div className="my-3 max-w-full">
+    <div role="region" aria-label="Scrollable table" tabIndex={0} className="overflow-x-auto rounded border border-theme-border">
+      <table ref={table} className="w-full border-collapse text-left text-sm">{children}</table>
+    </div>
+    <button type="button" onClick={download} className="mt-2 rounded border border-theme-border px-2 py-1 text-xs">Download table CSV</button>
+    <p className="mt-1 text-xs text-theme-text-muted">Exports displayed text. Formula-like cells are prefixed with an apostrophe for spreadsheet safety.</p>
+    {error && <p role="alert">{error}</p>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelReplyTable.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelReplyTable.test.jsx
@@ -1,0 +1,36 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import PixelReplyTable from './PixelReplyTable'
+
+afterEach(() => {vi.restoreAllMocks(); vi.useRealTimers()})
+
+it('exports rendered GFM cells with CSV escaping and neutralized formulas', async () => {
+  let blob
+  vi.spyOn(URL, 'createObjectURL').mockImplementation(value => {blob = value; return 'blob:table'})
+  const revoke = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  let filename
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {filename = this.download})
+  render(<ReactMarkdown remarkPlugins={[remarkGfm]} components={{table:PixelReplyTable}}>{'| Name | Value |\n|---|---|\n| **Việt**, "hello" | `=SUM(A1)` |\n| [Docs](https://example.com) | @cmd |\n| +start | -end |'}</ReactMarkdown>)
+  expect(screen.getAllByRole('row')).toHaveLength(4)
+  fireEvent.click(screen.getByRole('button', {name:'Download table CSV'}))
+  const content = await new Promise((resolve, reject) => {
+    const reader = new globalThis.FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = reject
+    reader.readAsText(blob)
+  })
+  expect(content).toBe('"Name","Value"\r\n"Việt, ""hello""","\'=SUM(A1)"\r\n"Docs","\'@cmd"\r\n"\'+start","\'-end"\r\n')
+  expect(filename).toBe('pixel-reply-table.csv')
+  expect(blob.type).toBe('text/csv;charset=utf-8')
+  expect(document.querySelector('a[download]')).toBeNull()
+  await vi.waitFor(() => expect(revoke).toHaveBeenCalledWith('blob:table'), {timeout:1500})
+})
+
+it('shows a recoverable download failure without removing the table', () => {
+  vi.spyOn(URL, 'createObjectURL').mockImplementation(() => {throw new Error('unavailable')})
+  render(<PixelReplyTable><tbody><tr><td>Retained</td></tr></tbody></PixelReplyTable>)
+  fireEvent.click(screen.getByRole('button', {name:'Download table CSV'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be downloaded')
+  expect(screen.getByRole('cell')).toHaveTextContent('Retained')
+})

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { readConversations, saveConversation, SELECT_EVENT, DELETE_EVENT, deleteConversation, isConversationDeleted } from '../lib/pixelConversations'
 import ReactMarkdown from 'react-markdown'
+import PixelReplyTable from '../components/PixelReplyTable'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { Link } from 'react-router-dom'
@@ -59,11 +60,7 @@ const MARKDOWN_COMPONENTS = {
   em: ({ children }) => <em className="italic">{children}</em>,
   code: ({ children, className = '' }) => <code className={`rounded bg-theme-bg/70 px-1 py-0.5 font-mono text-[13px] text-theme-text ${className}`}>{children}</code>,
   pre: ({ children }) => <pre className="my-2 overflow-x-auto rounded border border-theme-border bg-theme-bg/70 [&>code]:block [&>code]:p-2">{children}</pre>,
-  table: ({ children }) => (
-    <div role="region" aria-label="Scrollable table" tabIndex={0} className="my-3 max-w-full overflow-x-auto rounded border border-theme-border">
-      <table className="w-full border-collapse text-left text-sm">{children}</table>
-    </div>
-  ),
+  table: PixelReplyTable,
   th: ({ children, style }) => <th scope="col" style={style} className="border-b border-theme-border bg-theme-bg/70 px-3 py-2 font-semibold">{children}</th>,
   td: ({ children, style }) => <td style={style} className="border-b border-theme-border px-3 py-2 align-top [overflow-wrap:anywhere]">{children}</td>,
   a: ({ href, children }) => {


### PR DESCRIPTION
﻿## Why this matters

Owners can export a reply's Markdown table directly to CSV instead of manually reconstructing rows in a spreadsheet. The real Pixel Markdown renderer preserves its accessible scrollable table and adds a local download of displayed cell text. CSV quotes, Unicode, commas and line endings are handled; formula-like cells receive an explicit apostrophe prefix, explained beside the control. Links export their displayed labels, not hidden URLs.

## Overlap check

Searched all-state table/csv PRs and recent changed Pixel.jsx files, including #4207/#4210 workspace polish and #4214 delivery. No reply-table export exists; usage CSV and conversation exports have different production consumers. Based on current public-beta d8f8c89b, which includes the earlier batch integrations.

## Validation and risk

Node 20 real Markdown renderer + Pixel page suites: 78 passed. Covers CSV bytes, quoted commas/Unicode, formula prefixes, table semantics, download cleanup and recoverable browser failure. Production build and focused lint pass; changed-file hooks and whitespace pass. Combined validation is recorded below.

This is local browser export only; no remote request, persisted state or execution capability changes. Spreadsheet formula-like values intentionally gain an apostrophe; do not treat this as byte-for-byte source export. Revert removes the control. No installed inference/hardware claim; existing unrelated WSL full-gate limitations remain.

## AI assistance

Codex investigated, implemented and tested this change. Independent human review remains outstanding. No merge/deployment implied.


## Final batch receipt (2026-09-11)

Exact PR head: `a13b99edcf2f4d94af2a63c5c0e9eac7059f9257`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.

**Ready for review / not merge-ready:** `pixel-inference-contracts (3.11)` has 783 passes and one `ProcessLookupError` in the pre-existing `/proc` process-cleanup fixture. Dashboard checks pass. GitHub rejected the attempted failed-job rerun because it requires repository admin rights. A maintainer must rerun or resolve that canonical fixture before merge. No unrelated Python change or empty commit was added to this CSV PR.


## Review status update — 2026-09-15

Ready for review at the author's request. **Not merge-ready.** The existing pixel-inference-contracts (3.11) check fails with ProcessLookupError; the author cannot rerun the upstream workflow. All other completed checks succeeded or were conditionally skipped. This is not a clean CI receipt.

Reviewed head: a13b99edcf2f4d94af2a63c5c0e9eac7059f9257. Changing draft status does not bypass these gates or authorize a merge.
