### PR TITLE
fix(pixel): preserve reading position during streaming

### DIFF
--- a/ods/extensions/services/dashboard/src/lib/usePixelAutoScroll.js
+++ b/ods/extensions/services/dashboard/src/lib/usePixelAutoScroll.js
@@ -1,0 +1,34 @@
+import {useLayoutEffect, useRef, useState} from 'react'
+
+export function usePixelAutoScroll(messages, conversationId, endRef) {
+  const following = useRef(true)
+  const previousChat = useRef(conversationId)
+  const [showLatest, setShowLatest] = useState(false)
+
+  function jumpToLatest() {
+    const container = endRef.current?.parentElement
+    if (!container) return
+    following.current = true
+    container.scrollTop = container.scrollHeight
+    container.focus({preventScroll:true})
+    setShowLatest(false)
+  }
+
+  function onScroll(event) {
+    const container = event.currentTarget
+    following.current = container.scrollHeight - container.clientHeight - container.scrollTop <= 64
+    setShowLatest(!following.current)
+  }
+
+  useLayoutEffect(() => {
+    if (previousChat.current !== conversationId) {
+      previousChat.current = conversationId
+      following.current = true
+      setShowLatest(false)
+    }
+    const container = endRef.current?.parentElement
+    if (following.current && container) container.scrollTop = container.scrollHeight
+  }, [messages, conversationId, endRef])
+
+  return {onScroll, jumpToLatest, showLatest}
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { readConversations, saveConversation, SELECT_EVENT, DELETE_EVENT, deleteConversation, isConversationDeleted } from '../lib/pixelConversations'
 import ReactMarkdown from 'react-markdown'
+import {usePixelAutoScroll} from '../lib/usePixelAutoScroll'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { Link } from 'react-router-dom'
@@ -545,6 +546,7 @@ export default function Pixel({ systemStatus = null }) {
   const requestIdRef = useRef(initialChat?.requestId || null)
   const inputRef = useRef(null)
   const scrollRef = useRef(null)
+  const chatScroll = usePixelAutoScroll(messages, chatIdRef.current, scrollRef)
 
   const activeModel = agentRuntime?.model || systemStatus?.inference?.loadedModel || systemStatus?.model?.name || ''
   const activeContext = formatContext(
@@ -723,10 +725,6 @@ export default function Pixel({ systemStatus = null }) {
     const timer = globalThis.setInterval(updateElapsed, 1000)
     return () => globalThis.clearInterval(timer)
   }, [sending])
-
-  useEffect(() => {
-    scrollRef.current?.scrollIntoView?.({ behavior: 'smooth' })
-  }, [messages])
 
   useEffect(() => {
     const field = inputRef.current
@@ -1279,7 +1277,7 @@ export default function Pixel({ systemStatus = null }) {
           </span>
         </div>
       </header>
-      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-5 sm:px-6">
+      <div role="region" aria-label="Conversation messages" tabIndex={-1} onScroll={chatScroll.onScroll} className="min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-5 sm:px-6">
         {interrupted && !sending && (
           <div role="status" className="mx-auto w-full max-w-5xl rounded-xl border border-amber-500/25 bg-amber-500/10 px-4 py-3 text-sm text-amber-300">
             {restoredActivity === 'active'
@@ -1388,6 +1386,7 @@ export default function Pixel({ systemStatus = null }) {
       </div>
 
       <div className="pixel-composer px-4 py-3 sm:px-6">
+        {chatScroll.showLatest && <div className="mb-2 text-center"><button type="button" onClick={chatScroll.jumpToLatest} className="rounded border border-theme-border px-3 py-1 text-xs">Jump to latest</button></div>}
         <div className="mx-auto max-w-5xl">
           <div className="pixel-composer-row">
           <textarea

--- a/ods/extensions/services/dashboard/src/pages/PixelReadingPosition.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelReadingPosition.test.jsx
@@ -1,0 +1,54 @@
+import {render} from '../test/test-utils'
+import {screen, fireEvent, waitFor} from '@testing-library/react'
+import Pixel from './Pixel'
+import {saveConversation, SELECT_EVENT} from '../lib/pixelConversations'
+
+beforeEach(() => {
+  localStorage.clear()
+  saveConversation({schema:1,chatId:'reading',messages:[{role:'user',content:'Earlier prompt'},{role:'assistant',content:'Earlier response'}]})
+  vi.stubGlobal('fetch', vi.fn(async url => {
+    if (url === '/api/pixel/chat/stream') {
+      const frames = ['data: {"choices":[{"delta":{"content":"New reply"}}]}\n\n', 'data: [DONE]\n\n']
+      return {ok:true, headers:new Map([['content-type','text/event-stream']]), body:{getReader:() => ({read:async() => frames.length ? {done:false,value:new TextEncoder().encode(frames.shift())} : {done:true},releaseLock(){}})}}
+    }
+    return {ok:true,json:async() => ({available:true,model:'pixel/default'})}
+  }))
+})
+afterEach(() => {vi.unstubAllGlobals();vi.restoreAllMocks()})
+
+async function setup(top) {
+  render(<Pixel/>); await screen.findByText('Available')
+  const region = screen.getByRole('region',{name:'Conversation messages'})
+  Object.defineProperties(region,{scrollHeight:{configurable:true,value:2000},clientHeight:{configurable:true,value:500}})
+  region.scrollTop = top
+  fireEvent.scroll(region)
+  return region
+}
+async function send() {
+  fireEvent.change(screen.getByPlaceholderText('Message Portal...'),{target:{value:'Continue'}})
+  fireEvent.keyDown(screen.getByPlaceholderText('Message Portal...'),{key:'Enter'})
+  await screen.findByText('New reply')
+}
+it('keeps an older reading position through stream updates and resumes on explicit jump', async () => {
+  const region = await setup(300)
+  await send()
+  expect(region.scrollTop).toBe(300)
+  fireEvent.click(screen.getByRole('button',{name:'Jump to latest'}))
+  expect(region.scrollTop).toBe(2000)
+  expect(region).toHaveFocus()
+  expect(screen.queryByRole('button',{name:'Jump to latest'})).toBeNull()
+})
+it('continues following when the owner is near the bottom', async () => {
+  const region = await setup(1480)
+  await send()
+  expect(region.scrollTop).toBe(2000)
+  expect(screen.queryByRole('button',{name:'Jump to latest'})).toBeNull()
+})
+it('resets following when selecting another retained conversation', async () => {
+  const region = await setup(300)
+  saveConversation({schema:1,chatId:'other',messages:[{role:'user',content:'Other history'}]})
+  fireEvent(window,new CustomEvent(SELECT_EVENT,{detail:'other'}))
+  await screen.findByText('Other history')
+  await waitFor(() => expect(region.scrollTop).toBe(2000))
+  expect(screen.queryByRole('button',{name:'Jump to latest'})).toBeNull()
+})


### PR DESCRIPTION
﻿## Why this matters

Pixel previously scrolled to the bottom on every message update, pulling owners away from earlier replies while a response streamed. Preserve their reading position until they scroll within 64 pixels of the bottom or choose Jump to latest. New/selected conversations start at the bottom; explicit jumping returns keyboard focus to the conversation region. The existing turn outline still navigates exact message rows.

## Overlap check

Searched all-state scroll/reading and jump-conversation PRs plus changed Pixel.jsx inventory. #4154 adds explicit turn navigation, while this fixes unconditional scrolling during updates. Current workspace polish #4207/#4210 does not implement reading-position tracking. Independent of request, cancellation and retained-history logic.

## Validation and risk

Node 20 Pixel boundary, reading-position and turn-navigation suites: 81 passed. Tests submit through the real streaming route, preserve a scrolled-up position, follow near the bottom, restore focus after jumping and reset on conversation selection. Focused lint and production build pass; whitespace and changed-file hooks pass. Combined validation is recorded below.

Base public-beta d8f8c89b. No persistence/API changes. Auto-follow uses immediate container scrolling rather than repeatedly animated document scrolling; reverting restores prior behavior. No installed runtime/hardware claim. Existing unrelated baseline full-gate limitations remain.

## AI assistance

Codex implemented and tested the change. Independent human review remains outstanding. No merge or deployment implied.


## Final batch receipt (2026-09-11)

Exact PR head: `474479ba90c6ee275ce9fd04996bfceea6e8d8ab`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
