### PR TITLE
feat(pixel): inspect actual next-request context selection

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelRequestContext.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelRequestContext.jsx
@@ -1,0 +1,28 @@
+import {useMemo, useState} from 'react'
+import {boundedHistory} from '../lib/pixelRequestContext'
+
+export default function PixelRequestContext({messages, contextStart, draft, busy}) {
+  const [open, setOpen] = useState(false)
+  const summary = useMemo(() => {
+    if (!open || busy) return null
+    const prompt = draft.trim()
+    const history = boundedHistory(messages.slice(contextStart), prompt)
+    const original = messages.slice(messages.length - history.length)
+    const shortened = history.filter((message, index) => message.content !== original[index]?.content).length
+    const encoder = new TextEncoder()
+    const bytes = [...history.map(message => message.content), prompt].reduce((sum, text) => sum + encoder.encode(text).byteLength, 0)
+    return {history:history.length, omitted:messages.length - history.length, shortened, bytes}
+  }, [open, busy, draft, messages, contextStart])
+  return <div className="p-2 text-xs">
+    <button type="button" aria-expanded={open} onClick={() => setOpen(value => !value)}>Request context</button>
+    {open && <section aria-label="Next request context" className="mt-2 space-y-2">
+      {busy ? <p>Available after the active request finishes.</p> : <>
+        <p>{summary.history} earlier messages included; {summary.omitted} omitted; {summary.shortened} shortened.</p>
+        <p>{summary.bytes.toLocaleString()} UTF-8 text bytes including the trimmed draft.</p>
+        {!draft.trim() && <p>Enter a draft to preview a sendable request.</p>}
+        {draft.trim().length > 16384 && <p>This draft exceeds the message limit and cannot be sent.</p>}
+        <p>Earlier visible history stays saved. This describes the dashboard request, not model tokens or additional agent instructions.</p>
+      </>}
+    </section>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/lib/pixelRequestContext.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelRequestContext.js
@@ -1,0 +1,25 @@
+const MAX_INPUT_LEN = 16 * 1024
+const MAX_REQUEST_MESSAGES = 50
+const MAX_TOTAL_MESSAGE_BYTES = 256 * 1024
+
+export function boundedHistory(messages, nextUserContent) {
+  const encoder = new TextEncoder()
+  const budget = MAX_TOTAL_MESSAGE_BYTES - encoder.encode(nextUserContent).byteLength
+  const selected = []
+  let bytes = 0
+  for (let index = messages.length - 1; index >= 0 && selected.length < MAX_REQUEST_MESSAGES - 2; index -= 1) {
+    const { role } = messages[index]
+    // The transport's per-message cap is not a transcript storage limit.
+    // Bound only the copy sent to the model; keep the complete reply in chat.
+    const omission = '\n[Earlier response shortened for model context.]'
+    const original = messages[index].content
+    const content = original.length > MAX_INPUT_LEN
+      ? original.slice(0, MAX_INPUT_LEN - omission.length) + omission : original
+    const size = encoder.encode(content).byteLength
+    if (bytes + size > budget) break
+    selected.unshift({ role, content })
+    bytes += size
+  }
+  while (selected[0]?.role === 'assistant') selected.shift()
+  return selected
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { readConversations, saveConversation, SELECT_EVENT, DELETE_EVENT, deleteConversation, isConversationDeleted } from '../lib/pixelConversations'
 import ReactMarkdown from 'react-markdown'
+import {boundedHistory} from '../lib/pixelRequestContext'
+import PixelRequestContext from '../components/PixelRequestContext'
 import remarkGfm from 'remark-gfm'
 import rehypeHighlight from 'rehype-highlight'
 import { Link } from 'react-router-dom'
@@ -82,8 +84,6 @@ const MARKDOWN_COMPONENTS = {
 }
 
 const MAX_INPUT_LEN = 16 * 1024
-const MAX_REQUEST_MESSAGES = 50
-const MAX_TOTAL_MESSAGE_BYTES = 256 * 1024
 // Visible history is independent of the model's per-request context budget.
 const MAX_STORED_MESSAGES = 2000
 const MAX_STORED_MESSAGE_BYTES = 4 * 1024 * 1024
@@ -487,27 +487,6 @@ function loadStoredChat(selected) {
   }
 }
 
-function boundedHistory(messages, nextUserContent) {
-  const encoder = new TextEncoder()
-  const budget = MAX_TOTAL_MESSAGE_BYTES - encoder.encode(nextUserContent).byteLength
-  const selected = []
-  let bytes = 0
-  for (let index = messages.length - 1; index >= 0 && selected.length < MAX_REQUEST_MESSAGES - 2; index -= 1) {
-    const { role } = messages[index]
-    // The transport's per-message cap is not a transcript storage limit.
-    // Bound only the copy sent to the model; keep the complete reply in chat.
-    const omission = '\n[Earlier response shortened for model context.]'
-    const original = messages[index].content
-    const content = original.length > MAX_INPUT_LEN
-      ? original.slice(0, MAX_INPUT_LEN - omission.length) + omission : original
-    const size = encoder.encode(content).byteLength
-    if (bytes + size > budget) break
-    selected.unshift({ role, content })
-    bytes += size
-  }
-  while (selected[0]?.role === 'assistant') selected.shift()
-  return selected
-}
 
 export default function Pixel({ systemStatus = null }) {
   const profile = useLocalProfile()
@@ -1218,6 +1197,7 @@ export default function Pixel({ systemStatus = null }) {
             <label className="block p-2 text-xs">Send shortcut<select className="mt-1 block w-full rounded border border-theme-border bg-theme-bg p-2" aria-label="Send shortcut" value={sendKey.mode} onChange={event => sendKey.change(event.target.value)}><option value="enter">Enter to send</option><option value="mod-enter">Ctrl/⌘+Enter to send</option></select></label>
             {sendKey.error && <p role="alert" className="p-2 text-xs">{sendKey.error}</p>}
 
+            <PixelRequestContext messages={messages} contextStart={contextStartRef.current} draft={input} busy={sending || restoredActive || restoredChecking || stopping}/>
             <PixelTurnNavigation messages={messages} onNavigate={index => {
               const row = scrollRef.current?.parentElement?.querySelector(`[data-pixel-message-index="${index}"]`)
               row?.scrollIntoView?.({block:'start', behavior:'auto'})

--- a/ods/extensions/services/dashboard/src/pages/PixelRequestContext.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelRequestContext.test.jsx
@@ -1,0 +1,38 @@
+import {render} from '../test/test-utils'
+import {screen, fireEvent, waitFor} from '@testing-library/react'
+import Pixel from './Pixel'
+import {saveConversation} from '../lib/pixelConversations'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubGlobal('fetch',vi.fn(async url => url === '/api/pixel/chat/stream'
+    ? {ok:true,headers:new Map([['content-type','text/event-stream']]),body:{getReader:() => ({read:async()=>({done:true}),releaseLock(){}})}}
+    : {ok:true,json:async()=>({available:true,model:'pixel/default'})}))
+})
+afterEach(() => {vi.unstubAllGlobals();vi.restoreAllMocks()})
+
+it('reports the exact bounded payload, including Unicode bytes and shortened replies', async () => {
+  const messages = Array.from({length:60},(_,i)=>({role:i%2?'assistant':'user',content:i === 59 ? 'Long '.repeat(4000) : `Message ${i}`}))
+  saveConversation({schema:1,chatId:'context',messages,draft:' Việt '})
+  render(<Pixel/>);await screen.findByText('Available')
+  fireEvent.click(screen.getByRole('button',{name:'Request context',hidden:true}))
+  expect(screen.getByText('48 earlier messages included; 12 omitted; 1 shortened.')).toBeInTheDocument()
+  const byteText=screen.getByText(/UTF-8 text bytes including/).textContent
+  fireEvent.keyDown(screen.getByPlaceholderText('Message Portal...'),{key:'Enter'})
+  await waitFor(()=>expect(fetch.mock.calls.some(([url])=>url === '/api/pixel/chat/stream')).toBe(true))
+  const body=JSON.parse(fetch.mock.calls.find(([url])=>url === '/api/pixel/chat/stream')[1].body)
+  expect(body.messages).toHaveLength(49)
+  const bytes=body.messages.reduce((sum,message)=>sum+new TextEncoder().encode(message.content).byteLength,0)
+  expect(byteText).toBe(`${bytes.toLocaleString()} UTF-8 text bytes including the trimmed draft.`)
+  expect(body.messages.at(-1).content).toBe('Việt')
+})
+
+it('honors a retained clean-context boundary and updates when the draft changes', async () => {
+  saveConversation({schema:1,chatId:'clean',contextStart:2,messages:[{role:'user',content:'Old'},{role:'assistant',content:'Old reply'},{role:'user',content:'New'}]})
+  render(<Pixel/>);await screen.findByText('Available')
+  fireEvent.click(screen.getByRole('button',{name:'Request context',hidden:true}))
+  expect(screen.getByText('1 earlier messages included; 2 omitted; 0 shortened.')).toBeInTheDocument()
+  expect(screen.getByText('Enter a draft to preview a sendable request.')).toBeInTheDocument()
+  fireEvent.change(screen.getByPlaceholderText('Message Portal...'),{target:{value:'😊'}})
+  expect(screen.getByText('7 UTF-8 text bytes including the trimmed draft.')).toBeInTheDocument()
+})

--- a/ods/extensions/services/dashboard/src/pixel-workspace.css
+++ b/ods/extensions/services/dashboard/src/pixel-workspace.css
@@ -85,7 +85,7 @@ select option, select optgroup { background-color:rgb(var(--theme-card)); color:
 .pixel-workspace::before,.pixel-workspace::after { display:none; }
 .pixel-chat { height:calc(100dvh - 16px); }
 .pixel-chat-column { container-type:inline-size; container-name:pixel-chat-column; }
-.pixel-chat-header { display:flex; flex-wrap:wrap; align-items:center; flex-shrink:0; gap:12px; min-height:58px; padding:12px 20px; background:var(--pixel-canvas); }
+.pixel-chat-header { position:relative; display:flex; flex-wrap:wrap; align-items:center; flex-shrink:0; gap:12px; min-height:58px; padding:12px 20px; background:var(--pixel-canvas); }
 .pixel-chat-identity { display:flex; align-items:center; gap:12px; min-width:0; }
 .pixel-chat-header-actions { display:flex; flex:1; min-width:0; flex-wrap:wrap; align-items:center; justify-content:flex-end; gap:4px; }
 .pixel-chat-header-actions > * { flex-shrink:0; }
@@ -243,6 +243,11 @@ select option, select optgroup { background-color:rgb(var(--theme-card)); color:
 .pixel-chat-options > summary:hover { background:#232426; color:#ddd; }
 .pixel-chat-options-menu { position:absolute; right:0; top:100%; width:220px; padding:8px; display:flex; flex-direction:column; gap:6px; border:1px solid #323438; border-radius:10px; background:#1b1c1e; z-index:40; box-shadow:0 10px 30px #0004; }
 .pixel-chat-options-menu > button { text-align:left; width:100%; border:0; }
+.pixel-chat-options-menu { max-height:calc(100dvh - 160px); overflow-y:auto; }
+@container pixel-chat-column (max-width:720px) {
+  .pixel-chat-options { position:static; }
+  .pixel-chat-options-menu { left:16px; right:16px; width:auto; max-height:min(60dvh,480px); }
+}
 .pixel-welcome { width:min(100%,740px); padding:64px 16px 24px; }
 .pixel-welcome h2 { font-size:28px; color:#dedfe3; letter-spacing:-.04em; margin:12px 0 8px; }
 .pixel-welcome-character,.pixel-pet-button > .pixel-welcome-character { width:60px; height:60px; flex-basis:60px; }


### PR DESCRIPTION
﻿## Why this matters

Long visible Pixel history is not necessarily sent to the model: the dashboard bounds message count, total UTF-8 text and each earlier reply, and honors retained recovery boundaries. Add an optional Request context inspector under Chat options showing included/omitted/shortened earlier-message counts and text bytes including the trimmed draft. It uses the same existing bounded-history function as the actual request instead of approximating tokens.

## Overlap check

Searched all-state context inspector/budget PRs and the recent Pixel.jsx file inventory. #1190 changes Hermes context configuration; existing clean-context recovery controls request boundaries. Neither exposes the actual frontend selection to an owner. This preserves selection semantics while extracting that function for both consumers.

## Validation and risk

Node 20 inspector + Pixel boundary suites: 78 passed. Tests compare displayed bytes/counts directly with the outgoing streaming POST, including Unicode, 60-message history, a shortened long reply and a retained context boundary. Existing recovery and request-limit tests pass. Production build, focused lint, whitespace and changed-file hooks pass. Combined validation is recorded below.

Base public-beta d8f8c89b. Calculation only runs while the inspector is open and no request is active. The receipt describes dashboard text, not model token use, server-added instructions or hardware capacity. No persistence changes. Revert restores inline history selection and removes the inspector. Existing unrelated baseline full-gate limitations remain.

## AI assistance

Codex investigated, implemented and tested this change. Independent human review remains outstanding. No merge/deployment implied.


## Final batch receipt (2026-09-11)

Exact PR head: `8128245356208496d1bac3679d86a3b010067e30`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.

Browser follow-up `81282453`: contain the expanded options menu on narrow chat columns and cap its vertical height. The 78 focused/affected tests, build, final 898-test suite and actual 390px menu bounds pass. This also covers the shared menu CSS needed to make the inspector reachable.
