### PR TITLE
feat(pixel): back up and restore saved prompt libraries

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef, useState} from 'react'
 import { Bookmark } from 'lucide-react'
+import PixelPromptTransfer from './PixelPromptTransfer'
 import {readSavedPrompts, writeSavedPrompt} from '../lib/pixelSavedPrompts'
 
 export default function PixelPromptLibrary({input, disabled, onInsert}) {
@@ -8,6 +9,7 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
   const [editing, setEditing] = useState(null)
   const [removing, setRemoving] = useState(null)
   const [error, setError] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
   function refresh() {
     try {setItems(readSavedPrompts()); setError('')}
     catch {setError('Saved prompts could not be read. Existing browser data has been preserved.')}
@@ -17,7 +19,7 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
     window.addEventListener('storage', update)
     return () => window.removeEventListener('storage', update)
   }, [])
-  function close() {dialog.current?.close(); setEditing(null); setRemoving(null); trigger.current?.focus()}
+  function close() {dialog.current?.close(); setIsOpen(false); setEditing(null); setRemoving(null); trigger.current?.focus()}
   function edit(item) {previous.current = item; setEditing(item || {id:'prompt-'+Date.now().toString(36)+'-'+Math.random().toString(36).slice(2, 10), title:'', text:input}); setError('')}
   function save(event) {
     event.preventDefault()
@@ -31,7 +33,7 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
   const fieldClass = 'my-2 block w-full rounded border border-theme-border bg-theme-bg p-2 text-theme-text'
   const buttonClass = 'rounded border border-theme-border px-3 py-2 text-xs hover:bg-theme-surface-hover disabled:opacity-40'
   return <>
-    <button ref={trigger} type="button" disabled={disabled} aria-label="Saved prompts" title="Saved prompts" onClick={() => {refresh(); dialog.current.showModal()}}><Bookmark size={16}/></button>
+    <button ref={trigger} type="button" disabled={disabled} aria-label="Saved prompts" title="Saved prompts" onClick={() => {refresh(); setIsOpen(true); dialog.current.showModal()}}><Bookmark size={16}/></button>
     <dialog ref={dialog} className="chat-delete-dialog" style={{maxHeight:'calc(100dvh - 32px)', overflowY:'auto'}} aria-label="Saved prompts" onCancel={event => {event.preventDefault(); close()}}>
       <h3>Saved prompts</h3><p>Reusable text stored in this browser. Insert a prompt into your draft, then review it before sending.</p>
       {error && <p role="alert">{error}</p>}
@@ -44,6 +46,7 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
         <footer><button type="button" autoFocus onClick={() => setRemoving(null)}>Keep prompt</button><button type="button" onClick={remove}>Delete prompt</button></footer>
       </div> : <>
         <button className={buttonClass} type="button" onClick={() => edit(null)}>Save a new prompt</button>
+        {isOpen && <PixelPromptTransfer onImported={setItems}/>}
         {!items.length && <p>No saved prompts yet. Start with your current draft or write a new one.</p>}
         <ul>{items.map(item => {
           const fits = input.length + item.text.length + 1 <= 16384

--- a/ods/extensions/services/dashboard/src/components/PixelPromptTransfer.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptTransfer.jsx
@@ -1,0 +1,56 @@
+import {useEffect, useRef, useState} from 'react'
+import {mergePromptBackup, parsePromptBackup, promptBackupText} from '../lib/pixelPromptTransfer'
+
+export default function PixelPromptTransfer({onImported}) {
+  const reader = useRef(null)
+  const [pending, setPending] = useState(null)
+  const [reading, setReading] = useState(false)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+  useEffect(() => () => { if (reader.current) {reader.current.onload = null;reader.current.onerror = null;reader.current.abort()} }, [])
+  function select(event) {
+    const file = event.target.files?.[0]
+    event.target.value = ''
+    if (!file) return
+    setPending(null);setError('');setNotice('')
+    if (file.size > 4 * 1024 * 1024) {setError('Choose a JSON backup no larger than 4 MB.');return}
+    setReading(true)
+    const current = new globalThis.FileReader()
+    reader.current = current
+    current.onload = () => {
+      setReading(false)
+      try {setPending(parsePromptBackup(current.result))}
+      catch (failure) {setError(failure instanceof SyntaxError ? 'This file is not valid JSON.' : failure.message)}
+    }
+    current.onerror = () => {setReading(false);setError('This backup could not be read. Try selecting it again.')}
+    current.readAsText(file)
+  }
+  function restore() {
+    try {
+      const items = mergePromptBackup(pending)
+      onImported(items)
+      setPending(null);setError('');setNotice('Backup imported. Existing prompts were kept; exact duplicates were skipped.')
+    } catch (failure) {setError(failure.message)}
+  }
+  function download() {
+    setError('')
+    try {
+      const url = URL.createObjectURL(new Blob([promptBackupText()],{type:'application/json'}))
+      const link = document.createElement('a')
+      link.href=url;link.download='pixel-saved-prompts.json';document.body.append(link)
+      try {link.click()} finally {link.remove();setTimeout(()=>URL.revokeObjectURL(url),1000)}
+    } catch {setError('The prompt backup could not be downloaded. Existing browser data was preserved.')}
+  }
+  return <div className="my-3 space-y-2 rounded border border-theme-border p-2 text-xs">
+    <button type="button" onClick={download}>Download prompt backup</button>
+    <label className="block">Import prompt backup<input className="mt-1 block max-w-full" type="file" accept=".json,application/json" disabled={reading} onChange={select}/></label>
+    {reading && <p role="status">Reading backup…</p>}
+    {pending && <div>
+      <p>Review {pending.length} prompts before adding them. Matching names with different text are kept as separate prompts.</p>
+      <ul className="max-h-32 overflow-y-auto">{pending.map((item,index)=><li key={index}>{item.title}</li>)}</ul>
+      <div className="mt-2 flex gap-3"><button type="button" onClick={()=>{setPending(null);setError('')}}>Cancel import</button><button type="button" onClick={restore}>Confirm prompt import</button></div>
+    </div>}
+    {error && <p role="alert">{error}</p>}
+    {notice && <p role="status">{notice}</p>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelPromptTransfer.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptTransfer.test.jsx
@@ -1,0 +1,66 @@
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
+import PixelPromptLibrary from './PixelPromptLibrary'
+import {SAVED_PROMPTS_KEY} from '../lib/pixelSavedPrompts'
+
+const existing = {id:'prompt-existing',title:'Review',text:'Original text'}
+const backup = prompts => JSON.stringify({schemaVersion:1,kind:'ods-pixel-prompts',prompts})
+beforeEach(()=>{
+  localStorage.setItem(SAVED_PROMPTS_KEY,JSON.stringify([existing]))
+  HTMLDialogElement.prototype.showModal=function(){this.open=true}
+  HTMLDialogElement.prototype.close=function(){this.open=false}
+})
+afterEach(()=>{vi.restoreAllMocks();delete HTMLDialogElement.prototype.showModal;delete HTMLDialogElement.prototype.close})
+function open() {
+  const insert=vi.fn()
+  render(<PixelPromptLibrary input="Retained draft" disabled={false} onInsert={insert}/>)
+  fireEvent.click(screen.getByRole('button',{name:'Saved prompts'}))
+  return insert
+}
+async function select(text) {
+  fireEvent.change(screen.getByLabelText('Import prompt backup'),{target:{files:[new File([text],'backup.json',{type:'application/json'})]}})
+  await screen.findByRole('button',{name:'Confirm prompt import'})
+}
+it('stages then merges exact text while preserving concurrent edits and skipping duplicates',async()=>{
+  const insert=open()
+  await select(backup([existing,{title:'Review',text:'Việt\r\n```js\n1\n```'}]))
+  expect(JSON.parse(localStorage.getItem(SAVED_PROMPTS_KEY))).toEqual([existing])
+  const concurrent={id:'prompt-other',title:'Other',text:'Concurrent edit'}
+  localStorage.setItem(SAVED_PROMPTS_KEY,JSON.stringify([existing,concurrent]))
+  fireEvent.click(screen.getByRole('button',{name:'Confirm prompt import'}))
+  const saved=JSON.parse(localStorage.getItem(SAVED_PROMPTS_KEY))
+  expect(saved).toHaveLength(3)
+  expect(saved.slice(0,2)).toEqual([existing,concurrent])
+  expect(saved[2]).toMatchObject({title:'Review',text:'Việt\r\n```js\n1\n```'})
+  expect(saved[2].id).toMatch(/^prompt-[a-f0-9-]+$/)
+  expect(insert).not.toHaveBeenCalled()
+})
+it('rejects overflow atomically and clears staged imports when the dialog closes',async()=>{
+  open()
+  await select(backup(Array.from({length:30},(_,i)=>({title:`Prompt ${i}`,text:'Text'}))))
+  fireEvent.click(screen.getByRole('button',{name:'Confirm prompt import'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('exceed 30')
+  expect(JSON.parse(localStorage.getItem(SAVED_PROMPTS_KEY))).toEqual([existing])
+  fireEvent.click(screen.getByRole('button',{name:'Close prompts'}))
+  fireEvent.click(screen.getByRole('button',{name:'Saved prompts'}))
+  expect(screen.queryByRole('button',{name:'Confirm prompt import'})).toBeNull()
+})
+it('exports only versioned prompt text and names from current storage',async()=>{
+  let blob
+  vi.spyOn(URL,'createObjectURL').mockImplementation(value=>{blob=value;return 'blob:backup'})
+  vi.spyOn(URL,'revokeObjectURL').mockImplementation(()=>{})
+  vi.spyOn(HTMLAnchorElement.prototype,'click').mockImplementation(()=>{})
+  open()
+  fireEvent.click(screen.getByRole('button',{name:'Download prompt backup'}))
+  const text=await new Promise(resolve=>{const reader=new globalThis.FileReader();reader.onload=()=>resolve(reader.result);reader.readAsText(blob)})
+  expect(JSON.parse(text)).toEqual({schemaVersion:1,kind:'ods-pixel-prompts',prompts:[{title:'Review',text:'Original text'}]})
+})
+it('preserves unreadable local storage and rejects malformed imported records',async()=>{
+  open()
+  fireEvent.change(screen.getByLabelText('Import prompt backup'),{target:{files:[new File([backup([{title:'Bad',text:''}])],'bad.json')]}})
+  await waitFor(()=>expect(screen.getByRole('alert')).toHaveTextContent('Each prompt needs'))
+  await select(backup([{title:'Good',text:'Useful'}]))
+  localStorage.setItem(SAVED_PROMPTS_KEY,'broken')
+  fireEvent.click(screen.getByRole('button',{name:'Confirm prompt import'}))
+  expect(screen.getByRole('alert')).toBeInTheDocument()
+  expect(localStorage.getItem(SAVED_PROMPTS_KEY)).toBe('broken')
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelPromptTransfer.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelPromptTransfer.js
@@ -1,0 +1,25 @@
+import {readSavedPrompts, SAVED_PROMPTS_KEY} from './pixelSavedPrompts'
+
+export function parsePromptBackup(text) {
+  const backup = JSON.parse(text)
+  if (backup?.schemaVersion !== 1 || backup.kind !== 'ods-pixel-prompts' || !Array.isArray(backup.prompts) || backup.prompts.length > 30) throw new Error('Choose a version 1 Pixel prompt backup containing at most 30 prompts.')
+  return backup.prompts.map(item => {
+    if (!item || typeof item.title !== 'string' || !item.title.trim() || item.title.length > 80 || typeof item.text !== 'string' || !item.text.trim() || item.text.length > 16000) throw new Error('Each prompt needs a name of at most 80 characters and text of at most 16,000 characters.')
+    return {title:item.title, text:item.text}
+  })
+}
+
+export function mergePromptBackup(prompts) {
+  // Re-read at confirmation so concurrent edits are retained, not overwritten.
+  const next = [...readSavedPrompts()]
+  for (const item of prompts) {
+    if (!next.some(saved => saved.title === item.title && saved.text === item.text)) next.push({...item,id:`prompt-${crypto.randomUUID()}`})
+  }
+  if (next.length > 30) throw new Error('Import would exceed 30 saved prompts. Remove some prompts or choose a smaller backup.')
+  localStorage.setItem(SAVED_PROMPTS_KEY, JSON.stringify(next))
+  return next
+}
+
+export function promptBackupText() {
+  return JSON.stringify({schemaVersion:1,kind:'ods-pixel-prompts',prompts:readSavedPrompts().map(({title,text}) => ({title,text}))},null,2) + '\n'
+}


### PR DESCRIPTION
﻿## Why this matters

Saved personal prompts otherwise remain trapped in one browser. Add a versioned local JSON backup and a staged import inside the existing Saved prompts dialog. Import preserves current prompts, skips exact title/text duplicates, keeps differing text under matching names, generates fresh local identities, and checks the 30-prompt cap before a single storage write. Nothing is inserted into a draft or sent automatically.

## Overlap check

Searched all-state prompt import/export and the recent changed-file inventory for PixelPromptLibrary.jsx/pixelSavedPrompts.js. #4143 introduced local CRUD/insert; this is an independent complete portability flow. Conversation JSON import/export targets a different schema and library. No equivalent prompt transfer exists.

## Validation and risk

Node 20 transfer + existing prompt-library/composer suites: 14 passed. Tests exercise the actual Saved prompts dialog, staged confirmation, exact Unicode/line-ending preservation, concurrent storage edits, duplicate handling, atomic over-cap rejection, malformed records, corrupt local storage, close/reopen cleanup and exported schema. Production build, focused lint, whitespace and changed-file hooks pass. Combined validation is recorded below.

Base public-beta d8f8c89b. File reads are bounded to 4 MB; at most 30 records with existing 80-character names and 16,000-character text limits. Closing/editing unmounts the staged reader and cancels pending reads. Restore re-reads current storage at confirmation; failures remain visible and do not use a fallback empty library. Revert removes transfer controls; existing prompt storage remains readable. No remote upload, server mutation or installed runtime claim. Existing unrelated baseline full-gate limitations remain.

## AI assistance

Codex investigated, implemented and tested this change. Independent human review remains outstanding. No merge or deployment implied.


## Final batch receipt (2026-09-11)

Exact PR head: `3546a7f364d22d843659d3e9b3d612092af45914`. [Integration evidence, merge order, all 20 heads, browser fixtures and screenshots](https://github.com/tang-vu/DreamServer/blob/5227c42e31f19c14cf2bdb86e480a008b393452a/docs/validation/beta-feature-batch-20260911.md). Combined code head `25339b15`: **898 tests / 106 files pass**, production build and lint pass. Browser checks cover desktop/mobile, actual downloads and storage/stream interactions.

Limits remain explicit: the WSL/root installer and BATS gates are not fully green; simulation reports a failed Linux NVIDIA path despite exit code 0. No installed inference, hardware fleet or deployment qualification is claimed. The receipt records the unrelated failed Python CI check on #4218 and the maintainer-only rerun requirement.
