### PR TITLE
fix(beta): resume video wallpapers after interrupted playback

### DIFF
--- a/ods/extensions/services/dashboard/src/components/WallpaperVideo.jsx
+++ b/ods/extensions/services/dashboard/src/components/WallpaperVideo.jsx
@@ -29,7 +29,11 @@ export default function WallpaperVideo() {
       else {
         const playing = video.play()
         playing?.then(() => { if (!disposed && (document.hidden || reduced?.matches)) video.pause() })
-          .catch(() => { if (!disposed) setFailed(true) })
+          .catch(error => {
+            // pause() can interrupt a pending play when visibility or motion
+            // changes. That cancellation must not disable later playback.
+            if (!disposed && error.name !== 'AbortError') setFailed(true)
+          })
       }
     }
     sync()

--- a/ods/extensions/services/dashboard/src/components/WallpaperVideo.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/WallpaperVideo.test.jsx
@@ -53,3 +53,17 @@ it('falls back to the theme poster when decoding or autoplay fails', async () =>
   await act(async () => {})
   expect(retry.container.querySelector('video')).toBeNull()
 })
+
+it('resumes video after hiding the tab interrupts a pending play', async () => {
+  let rejectPlay
+  HTMLMediaElement.prototype.play.mockImplementationOnce(() => new Promise((_, reject) => { rejectPlay = reject }))
+  const hidden = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false)
+  const view = render(<WallpaperVideo/>)
+  hidden.mockReturnValue(true)
+  fireEvent(document, new Event('visibilitychange'))
+  await act(async () => { rejectPlay(new DOMException('Playback interrupted by pause', 'AbortError')) })
+  expect(view.container.querySelector('video')).not.toBeNull()
+  hidden.mockReturnValue(false)
+  fireEvent(document, new Event('visibilitychange'))
+  expect(HTMLMediaElement.prototype.play).toHaveBeenCalledTimes(2)
+})

--- a/ods/extensions/services/dashboard/src/components/WallpaperVideo.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/WallpaperVideo.test.jsx
@@ -61,7 +61,7 @@ it('resumes video after hiding the tab interrupts a pending play', async () => {
   const view = render(<WallpaperVideo/>)
   hidden.mockReturnValue(true)
   fireEvent(document, new Event('visibilitychange'))
-  await act(async () => { rejectPlay(new DOMException('Playback interrupted by pause', 'AbortError')) })
+  await act(async () => { rejectPlay(new globalThis.DOMException('Playback interrupted by pause', 'AbortError')) })
   expect(view.container.querySelector('video')).not.toBeNull()
   hidden.mockReturnValue(false)
   fireEvent(document, new Event('visibilitychange'))


### PR DESCRIPTION
Hiding the dashboard while a video wallpaper is starting can interrupt `play()` with `AbortError`. The component treated this normal pause cancellation as a permanent playback failure and removed the video. Ignore that specific cancellation so the visibility handler can resume it; decoding and autoplay failures still use the poster.

## Why this matters
App renders WallpaperVideo for custom video themes. Switching tabs during initial playback previously required changing themes or reloading to recover animation. The invariant is that an intentional pause must not mark the wallpaper unusable.

## Overlap check
Searched open and closed Osmantic/ODS PRs for wallpaper playback and inspected changed-file matches across 2,000 recent PRs. #4216 introduced WallpaperVideo; #4027 is the older broad UI branch. Neither handles interrupted play promises. Only WallpaperVideo.jsx and its component regression test change.

## Validation
- Regression reproduced on public-beta f5f49b7d (1 failure), then all 4 WallpaperVideo tests passed.
- Dashboard lint passed with existing warnings; Vite production build passed.
- Full make gate under WSL initially stopped because Windows worktree paths are not Linux Git paths; a Linux checkout is being validated separately.
- All-file pre-commit: gitleaks and both ShellCheck passes passed; existing private-key fixtures were flagged and the Windows environment lacks awk. These are not claimed as passing checks.
- No live browser video decoder or native hardware validation performed. This is browser frontend behavior shared by Linux, macOS and Windows; CI provides the platform test matrix.

No persisted format changes or migration. Reverting this commit restores previous playback handling. No merge dependency on other batch PRs.

## Final batch validation receipt

Candidate: `7923cca04bcdd2fb30f663cd8cfe2f51a5eda1a0`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Chromium decoded a real WebM, played it, and passed explicit pause/resume. The interrupted-play regression is covered by the focused component test. Follow-up 7923cca0 qualifies DOMException through globalThis for ESLint.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
