### PR TITLE
fix(pixel): bind source clipboard feedback to the current copy

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewClipboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewClipboard.test.jsx
@@ -1,5 +1,5 @@
 import {webcrypto, createHash} from 'node:crypto'
-import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
 import PixelPreviewSource from './PixelPreviewSource'
 
 const source = '<!doctype html><h1>Exact clipboard content</h1>'
@@ -36,4 +36,34 @@ it('does not retain Copied feedback when a later clipboard write fails', async (
   await screen.findByRole('alert')
   expect(copy).not.toHaveTextContent('Copied')
   expect(copy).toBeEnabled()
+})
+
+it('does not apply a clipboard receipt to a different publication', async () => {
+  let finish
+  vi.stubGlobal('navigator', {clipboard:{writeText:vi.fn(() => new Promise(resolve => {finish=resolve}))}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
+  const view = render(<PixelPreviewSource preview={preview}/>)
+  const copy = screen.getByRole('button',{name:'Copy code'})
+  await waitFor(() => expect(copy).toBeEnabled())
+  fireEvent.click(copy)
+  view.rerender(<PixelPreviewSource preview={{...preview,siteId:'site-'+'b'.repeat(24)}}/>)
+  await waitFor(() => expect(copy).toBeEnabled())
+  await act(async () => finish())
+  expect(copy).not.toHaveTextContent('Copied')
+})
+
+it('keeps the newest receipt when clipboard writes finish out of order', async () => {
+  let finish
+  const writeText = vi.fn().mockImplementationOnce(() => new Promise(resolve => {finish=resolve})).mockRejectedValueOnce(new Error('Denied'))
+  vi.stubGlobal('navigator', {clipboard:{writeText}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => new TextEncoder().encode(source).buffer})))
+  render(<PixelPreviewSource preview={preview}/>)
+  const copy = screen.getByRole('button',{name:'Copy code'})
+  await waitFor(() => expect(copy).toBeEnabled())
+  fireEvent.click(copy)
+  fireEvent.click(copy)
+  await screen.findByRole('alert')
+  await act(async () => finish())
+  expect(screen.getByRole('alert')).toHaveTextContent('Clipboard access failed')
+  expect(copy).not.toHaveTextContent('Copied')
 })

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -18,7 +18,9 @@ export default function PixelPreviewSource({ preview, file }) {
   const [copied, setCopied] = useState(false)
   const [attempt, setAttempt] = useState(0)
   const codeRef = useRef(null)
+  const copyRevision = useRef(0)
   useEffect(() => {
+    copyRevision.current++
     let current = true
     const controller = new AbortController()
     const timeout = setTimeout(() => controller.abort(), 12000)
@@ -34,11 +36,19 @@ export default function PixelPreviewSource({ preview, file }) {
       finally { clearTimeout(timeout) }
     }
     void load()
-    return () => { current = false; controller.abort(); clearTimeout(timeout) }
+    return () => { current = false; copyRevision.current++; controller.abort(); clearTimeout(timeout) }
   }, [preview.siteId, path, expectedDigest, file?.bytes, language, attempt])
   async function copy() {
-    try { await navigator.clipboard.writeText(source); setCopied(true); setError('') }
-    catch { setCopied(false); setError('Clipboard access failed. You can select and copy the code manually.') }
+    const revision = ++copyRevision.current
+    setCopied(false)
+    try {
+      await navigator.clipboard.writeText(source)
+      if (revision !== copyRevision.current) return
+      setCopied(true); setError('')
+    } catch {
+      if (revision !== copyRevision.current) return
+      setCopied(false); setError('Clipboard access failed. You can select and copy the code manually.')
+    }
   }
   return <section className="pixel-preview-source pixel-original-source" aria-label={path === 'index.html' ? 'Published HTML source' : `Source: ${path}`}>
     {source === null && binarySize === null && !error && <p role="status">Verifying source…</p>}

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -359,6 +359,9 @@ test('compact views keep the connection draft and never apply changes on navigat
   render(createElement(RemoteProvider, { compact: true }))
   await screen.findByRole('button', { name: 'Connection', exact: true })
   expect(screen.queryByRole('heading', { name: 'Egress' })).toBeNull()
+  // The tab exists before the status-to-form effect has hydrated the fields.
+  // Start this navigation test from a fully loaded connection draft.
+  await waitFor(() => expect(screen.getByLabelText('Base URL')).toHaveValue(statusPayload.routeState.provider.baseUrl))
   fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://draft.example/v1' } })
   fireEvent.click(screen.getByRole('button', { name: 'Diagnostics', exact: true }))
   expect(screen.getByRole('heading', { name: 'Egress' })).toBeVisible()


### PR DESCRIPTION
Copying verified source can complete after another copy or publication selection. A late success previously labeled the new source Copied and could erase a newer clipboard error. Bind feedback to a monotonically increasing copy revision, invalidated by source reload and unmount.

## Why this matters
Workbench source inspection exposes Copy code. Its receipt must describe the latest copy of the displayed source. Clipboard permission prompts and delayed browser writes make the race reachable without malformed inputs. This changes feedback only; it cannot cancel an OS clipboard write already accepted by the browser.

## Overlap check
Searched open/closed PRs for source clipboard and inspected production-file matches in 2,000 recent PRs. #4107 fixes sequential success/failure feedback and is already merged; #4139 and #4145 add download and search controls. This PR tests pending writes across source replacement and out-of-order completion, neither covered there. No dependency on other batch PRs.

## Validation
- Both new component regressions fail on public-beta f5f49b7d.
- All 19 tests across PixelPreviewClipboard, PixelPreviewSource, PixelSourceFind and PixelArtifactDownload pass after the fix.
- Scoped pre-commit hooks and git diff --check pass.
- Full-batch dashboard lint/build and integration validation are tracked separately. Linux make gate on the same beta base reaches an existing no-sudo Docker fallback failure (2 assertions in test-preflight-resolver-bug.sh); it is not reported as green.
- Frontend behavior is shared across Windows, macOS and Linux; no live clipboard permission dialog was tested.

No storage migration. Revert this commit to restore previous feedback ordering.

## Final batch validation receipt

Candidate: `aa2b37bb3c8325aaec0f384d93d6048446dbd55f`; target: `public-beta`. Latest observed checks: 31 success, 1 failure, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Follow-up aa2b37bb fixes the CI-exposed RemoteProvider test hydration race by awaiting the initial saved Base URL before editing; no provider production code changes. Actual Chromium clipboard copy and verified source download passed. CI still has an openSUSE repository metadata/key retrieval failure (rsync consequently unavailable); maintainer rerun is needed because upstream rerun authorization was rejected for missing admin rights.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
