### PR TITLE
fix(pixel): reveal and announce keyboard search results

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCommandSearch.jsx
@@ -45,6 +45,9 @@ export default function PixelCommandSearch({ onInsert, onNewTask }) {
     { title: 'Research with evidence', detail: 'Draft a research request with citations', icon: Globe2, run: () => onInsert('Research this question using current sources, inline citations, and explicit evidence-versus-inference labels.') },
     ...chats.map(chat => ({ title: conversationTitle(chat), detail: `${chat.messages.filter(item => item.role === 'user').length} turns · Saved locally`, excerpt:conversationExcerpt(chat, query), icon: MessageSquare, run: () => window.dispatchEvent(new CustomEvent(SELECT_EVENT, { detail: chat.chatId })) })),
   ].filter(item => item.excerpt || `${item.title} ${item.detail}`.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase()))
+  useEffect(() => {
+    if (dialog.current?.open) dialog.current.querySelector('.pixel-command-results .is-active')?.scrollIntoView?.({block:'nearest'})
+  }, [index, query, chats])
   function close() { dialog.current.close(); trigger.current?.focus?.() }
   function choose(entry) { if (entry) { close(); entry.run() } }
   return <dialog ref={dialog} className="pixel-command-dialog" aria-label="Search Pixel" onClick={event => { if (event.target === event.currentTarget) close() }} onCancel={() => trigger.current?.focus?.()}>
@@ -53,6 +56,7 @@ export default function PixelCommandSearch({ onInsert, onNewTask }) {
       if (event.key === 'ArrowDown' || event.key === 'ArrowUp') { event.preventDefault(); setIndex(value => entries.length ? (value + (event.key === 'ArrowDown' ? 1 : -1) + entries.length) % entries.length : 0) }
       if (event.key === 'Enter') { event.preventDefault(); choose(entries[index]) }
     }}/><button aria-label="Close search" onClick={close}><X size={16}/></button></div>
+    <p className="sr-only" role="status">{entries[index] ? `${index + 1} of ${entries.length}: ${entries[index].title}` : 'No results'}</p>
     <div className="pixel-command-results">{entries.length ? entries.map((entry, at) => <button className={at === index ? 'is-active' : ''} key={`${entry.title}-${at}`} onFocus={() => setIndex(at)} onClick={() => choose(entry)}><entry.icon size={17}/><span><strong>{entry.title}</strong><small>{entry.detail}</small>{entry.excerpt && <small className="break-words whitespace-normal">{entry.excerpt}</small>}</span></button>) : <p>No matching conversations or actions.</p>}</div>
   </dialog>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelCommandSearch.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCommandSearch.test.jsx
@@ -5,8 +5,8 @@ import { saveConversation, deleteConversation, SELECT_EVENT } from '../lib/pixel
 
 beforeEach(() => {
   localStorage.clear()
-  HTMLDialogglobalThis.Element.prototype.showModal = function () { this.open = true }
-  HTMLDialogglobalThis.Element.prototype.close = function () { this.open = false }
+  HTMLDialogElement.prototype.showModal = function () { this.open = true }
+  HTMLDialogElement.prototype.close = function () { this.open = false }
 })
 
 test('keeps keyboard-selected results visible and announces the selected action', () => {

--- a/ods/extensions/services/dashboard/src/components/PixelCommandSearch.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCommandSearch.test.jsx
@@ -5,8 +5,30 @@ import { saveConversation, deleteConversation, SELECT_EVENT } from '../lib/pixel
 
 beforeEach(() => {
   localStorage.clear()
-  HTMLDialogElement.prototype.showModal = function () { this.open = true }
-  HTMLDialogElement.prototype.close = function () { this.open = false }
+  HTMLDialogglobalThis.Element.prototype.showModal = function () { this.open = true }
+  HTMLDialogglobalThis.Element.prototype.close = function () { this.open = false }
+})
+
+test('keeps keyboard-selected results visible and announces the selected action', () => {
+  const scroll = vi.fn()
+  const previous = globalThis.Element.prototype.scrollIntoView
+  globalThis.Element.prototype.scrollIntoView = scroll
+  try {
+    render(<MemoryRouter><PixelCommandSearch onInsert={() => {}} onNewTask={() => {}}/></MemoryRouter>)
+    fireEvent(window, new Event(OPEN_PIXEL_SEARCH))
+    const input = screen.getByLabelText('Search conversations and actions')
+    fireEvent.keyDown(input, {key:'ArrowUp'})
+    const active = screen.getByRole('button', {name:/Research with evidence/})
+    expect(scroll).toHaveBeenLastCalledWith({block:'nearest'})
+    expect(scroll.mock.instances.at(-1)).toBe(active)
+    expect(screen.getByRole('status')).toHaveTextContent('4 of 4: Research with evidence')
+    expect(input).toHaveFocus()
+    fireEvent.change(input, {target:{value:'does not exist'}})
+    expect(screen.getByRole('status')).toHaveTextContent('No results')
+  } finally {
+    if (previous) globalThis.Element.prototype.scrollIntoView = previous
+    else delete globalThis.Element.prototype.scrollIntoView
+  }
 })
 test('Ctrl K searches real saved conversations and selects the exact identity', () => {
   saveConversation({schema:1,chatId:'saved-one',messages:[{role:'user',content:'Build a clock'}]})


### PR DESCRIPTION
Arrow navigation in Pixel search now scrolls the highlighted result into view and announces its position and title. Focus stays in the search field so typing and IME input continue to work.

## Why this matters
Saved conversations share a scrollable result list with search actions. Previously keyboard selection could move below the visible list with no announcement; Enter then ran an unseen action. This makes the selected result visible and available through a polite status announcement, including empty results.

## Overlap check
Searched open/closed PRs for search keyboard and all PixelCommandSearch file matches in 2,000 recent PRs. #4105 preserves IME, #4112 preserves repeated-search state, #4081 refreshes history, and #4142 searches message text. None reveal or announce arrow-selected results. This is independent of those merged scopes and of other batch PRs.

## Validation
- New keyboard regression fails before the fix; all 14 tests across PixelCommandSearch, PixelCommandSearchComposition and PixelConversationContentSearch pass afterward.
- ESLint passes; scoped pre-commit and diff whitespace checks pass.
- Full dashboard suite and combined batch build are being checked separately. Native screen-reader output has not been manually tested; DOM tests prove the live status and exact scroll target.

No schema or stored-data change. Shared browser behavior covers Linux, Windows and macOS. Revert the commit to restore prior navigation. No batch merge dependency.

## Final batch validation receipt

Candidate: `4c80df7bd52c5af004318b8fb5c95ecf0701126c`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
