### PR TITLE
feat(preview): publish and inspect named project text files

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelCodeBlock.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCodeBlock.jsx
@@ -1,10 +1,10 @@
 import { Children, isValidElement } from 'react'
 import ReactMarkdown from 'react-markdown'
 import rehypeHighlight from 'rehype-highlight'
+import { sourceLanguage } from '../lib/pixelSourceLanguage'
 import './pixel-file-changes.css'
 
-const LANGUAGES = {html:'html',htm:'html',css:'css',js:'javascript',mjs:'javascript',cjs:'javascript',jsx:'jsx',ts:'typescript',tsx:'tsx',py:'python',json:'json',svg:'xml',xml:'xml',md:'markdown',markdown:'markdown',sh:'bash',yml:'yaml',yaml:'yaml',txt:'text',map:'json',csv:'text',tsv:'text'}
-export const fileLanguage = path => LANGUAGES[String(path).split('.').pop().toLowerCase()] || 'text'
+export const fileLanguage = path => sourceLanguage(path) || 'text'
 export function PixelLanguageBadge({path}) {
   const language = fileLanguage(path)
   const extension = String(path).split('.').pop().toLowerCase()

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -3,15 +3,14 @@ import { loadArtifactBytes } from '../lib/pixelArtifacts'
 import { PixelCodeLines, PixelLanguageBadge } from './PixelCodeBlock'
 import PixelArtifactDownload from './PixelArtifactDownload'
 import PixelSourceFind from './PixelSourceFind'
+import { sourceLanguage } from '../lib/pixelSourceLanguage'
 
 
-const TEXT_LANGUAGES = {html:'html',htm:'html',css:'css',scss:'scss',js:'javascript',mjs:'javascript',cjs:'javascript',jsx:'javascript',ts:'typescript',tsx:'typescript',py:'python',sh:'bash',yml:'yaml',yaml:'yaml',toml:'ini',json:'json',svg:'xml',xml:'xml',md:'markdown',markdown:'markdown',txt:'text',map:'json',csv:'text',tsv:'text'}
 
 export default function PixelPreviewSource({ preview, file }) {
   const path = file?.path || 'index.html'
   const expectedDigest = file?.sha256 || preview.entrySha256
-  const extension = path.split('.').pop().toLowerCase()
-  const language = TEXT_LANGUAGES[extension]
+  const language = sourceLanguage(path)
   const [source, setSource] = useState(null)
   const [binarySize, setBinarySize] = useState(null)
   const [error, setError] = useState('')

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
@@ -61,3 +61,24 @@ it.each([
   await waitFor(() => expect(screen.getByRole('button',{name:'Copy code'})).toBeEnabled())
   expect(container.querySelector('pre code').textContent).toBe(text)
 })
+
+it.each(['Dockerfile', 'containers/Containerfile', 'Makefile', 'docs/README', 'LICENSE', 'NOTICE'])('inspects verified project text in %s', async path => {
+  const text = '# Project configuration\nkeep exact text\n'
+  const bytes = new TextEncoder().encode(text)
+  const file = {path,bytes:bytes.byteLength,sha256:createHash('sha256').update(bytes).digest('hex')}
+  vi.stubGlobal('fetch',vi.fn(async () => ({ok:true,arrayBuffer:async () => bytes.buffer})))
+  const view = render(<PixelPreviewSource preview={preview} file={file}/>)
+  await waitFor(() => expect(screen.queryByText('Verifying source…')).toBeNull())
+  expect(view.container.querySelector('pre code')).toHaveTextContent('keep exact text')
+  expect(view.container.querySelector('pre code').textContent).toBe(text)
+  expect(screen.getByRole('button',{name:'Copy code'})).toBeEnabled()
+})
+
+it('keeps unknown extensionless binary artifacts out of the text inspector', async () => {
+  const bytes = new Uint8Array([0,255,3])
+  const file = {path:'app',bytes:3,sha256:createHash('sha256').update(bytes).digest('hex')}
+  vi.stubGlobal('fetch',vi.fn(async () => ({ok:true,arrayBuffer:async () => bytes.buffer})))
+  const view = render(<PixelPreviewSource preview={preview} file={file}/>)
+  expect(await screen.findByText(/Binary asset/)).toBeVisible()
+  expect(view.container.querySelector('pre')).toBeNull()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.test.jsx
@@ -1,4 +1,5 @@
 import { webcrypto, createHash } from 'node:crypto'
+import { Buffer } from 'node:buffer'
 import { render, screen, waitFor } from '@testing-library/react'
 import PixelPreviewSource from './PixelPreviewSource'
 const source = '<!doctype html><button onclick="alert(1)">Click</button>\n```\n<script>bad()</script>'
@@ -75,7 +76,9 @@ it.each(['Dockerfile', 'containers/Containerfile', 'Makefile', 'docs/README', 'L
 })
 
 it('keeps unknown extensionless binary artifacts out of the text inspector', async () => {
-  const bytes = new Uint8Array([0,255,3])
+  // Node 20 WebCrypto expects the Node-realm buffer a real fetch supplies.
+  const bytes = Buffer.alloc(3)
+  bytes.set([0,255,3])
   const file = {path:'app',bytes:3,sha256:createHash('sha256').update(bytes).digest('hex')}
   vi.stubGlobal('fetch',vi.fn(async () => ({ok:true,arrayBuffer:async () => bytes.buffer})))
   const view = render(<PixelPreviewSource preview={preview} file={file}/>)

--- a/ods/extensions/services/dashboard/src/lib/pixelSourceLanguage.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelSourceLanguage.js
@@ -1,0 +1,16 @@
+const EXTENSIONS = {
+  html:'html', htm:'html', css:'css', scss:'scss', js:'javascript', mjs:'javascript', cjs:'javascript',
+  jsx:'jsx', ts:'typescript', tsx:'tsx', py:'python', sh:'bash', yml:'yaml', yaml:'yaml', toml:'ini',
+  json:'json', svg:'xml', xml:'xml', md:'markdown', markdown:'markdown', txt:'text', map:'json', csv:'text', tsv:'text',
+}
+const FILENAMES = {
+  makefile:'makefile', gnumakefile:'makefile', readme:'text', license:'text', notice:'text',
+  dockerfile:'dockerfile', containerfile:'dockerfile',
+}
+
+// Recognize documented project text names without treating unknown binaries as
+// text. Byte limits, SHA-256 verification and strict UTF-8 decoding stay upstream.
+export function sourceLanguage(path) {
+  const name = String(path).split('/').at(-1).toLowerCase()
+  return FILENAMES[name] || (name.includes('.') ? EXTENSIONS[name.split('.').at(-1)] : undefined)
+}

--- a/ods/extensions/services/pixel-agent/host/workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/host/workspace_preview.py
@@ -47,6 +47,7 @@ ALLOWED_SUFFIXES = frozenset(
     }
 )
 MAX_REQUEST_BYTES = 2048
+PROJECT_TEXT_NAMES = frozenset({'readme', 'license', 'notice', 'dockerfile', 'containerfile', 'makefile', 'gnumakefile'})
 MAX_RESPONSE_BYTES = 8192
 MAX_FILES = 128
 MAX_FILE_BYTES = 4 * 1024 * 1024
@@ -230,7 +231,8 @@ def _source_files(
                 or any(PATH_COMPONENT.fullmatch(part) is None for part in relative.split("/"))
             ):
                 raise PreviewError("unsafe preview file")
-            if pathlib.PurePosixPath(relative).suffix.lower() not in ALLOWED_SUFFIXES:
+            if (pathlib.PurePosixPath(relative).suffix.lower() not in ALLOWED_SUFFIXES
+                    and name.lower() not in PROJECT_TEXT_NAMES):
                 raise PreviewError("unsupported preview file type")
             files.append((relative, source, info))
             if len(files) > MAX_FILES:
@@ -506,7 +508,7 @@ def snapshot_changes(previews: pathlib.Path, site_id: str, before_id: str | None
 
 def _preview_content_type(target: pathlib.Path, body: bytes) -> str:
     content_type = mimetypes.guess_type(target.name)[0] or "application/octet-stream"
-    if target.suffix.lower() in {".md", ".markdown"}:
+    if target.suffix.lower() in {".md", ".markdown"} or target.name.lower() in PROJECT_TEXT_NAMES:
         content_type = "text/plain"
     if content_type.startswith("text/") or content_type == "application/javascript":
         try:

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview_documents.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview_documents.py
@@ -1,0 +1,64 @@
+import sys
+
+if sys.platform == 'win32':
+    from unittest import SkipTest
+    raise SkipTest('Preview broker requires POSIX; run this contract under Linux/WSL')
+
+import hashlib
+import http.client
+import json
+import os
+import threading
+
+import pytest
+from test_workspace_preview import MODULE
+
+
+def make_site(tmp_path, files):
+    workspace, previews = tmp_path / 'workspace', tmp_path / 'previews'
+    workspace.mkdir(mode=0o700)
+    previews.mkdir(mode=0o700)
+    site = workspace / 'demo'
+    site.mkdir(mode=0o700)
+    for name, data in {'index.html': b'<h1>Project</h1>', **files}.items():
+        path = site / name
+        path.write_bytes(data)
+        path.chmod(0o600)
+    return workspace, previews
+
+
+def test_publish_project_documents_and_serve_exact_inert_bytes(tmp_path):
+    names = ('README', 'LICENSE', 'NOTICE', 'Dockerfile', 'Containerfile', 'Makefile', 'GNUmakefile')
+    files = {name: f'# {name}\n<script>alert(1)</script>\n'.encode() for name in names}
+    workspace, previews = make_site(tmp_path, files)
+    receipt = MODULE.publish_snapshot(workspace, previews, 'demo', os.getuid())
+    manifest = json.loads(MODULE.snapshot_manifest(previews, receipt['siteId']))
+    assert {item['path'] for item in manifest['files']} == {'index.html', *names}
+    with MODULE.PreviewHTTPServer(('127.0.0.1', 0), previews) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            for name, data in files.items():
+                connection = http.client.HTTPConnection(*server.server_address, timeout=5)
+                try:
+                    connection.request('GET', f'/{receipt["siteId"]}/{name}',
+                                       headers={'Host':f'{receipt["siteId"]}.localhost:{server.server_port}'})
+                    response = connection.getresponse()
+                    assert response.status == 200
+                    assert response.headers.get_content_type() == 'text/plain'
+                    assert response.headers['X-Content-Type-Options'] == 'nosniff'
+                    assert response.headers['X-Preview-SHA256'] == hashlib.sha256(data).hexdigest()
+                    assert response.read() == data
+                finally:
+                    connection.close()
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+
+@pytest.mark.parametrize('name', ['program', 'secret.env', 'credentials', 'Dockerfile.exe'])
+def test_unknown_extensionless_or_executable_names_remain_rejected(tmp_path, name):
+    workspace, previews = make_site(tmp_path, {name:b'not public documentation'})
+    with pytest.raises(MODULE.PreviewError, match='unsupported preview file type'):
+        MODULE.publish_snapshot(workspace, previews, 'demo', os.getuid())
+    assert not list(previews.iterdir())


### PR DESCRIPTION
Static projects with an extensionless README or LICENSE currently fail publication with unsupported_file_type. Support the exact case-insensitive basenames README, LICENSE, NOTICE, Dockerfile, Containerfile, Makefile and GNUmakefile as inert project text, and make their verified source inspectable in Workbench.

## Why this matters
The production path is workspace project -> preview broker enumeration -> create-only content-addressed snapshot -> manifest/HTTP -> Workbench source inspector. A normal project document should not prevent its index.html from being published. Backend and frontend now recognize the same names; HTTP serves them as text/plain with nosniff, and Workbench still verifies SHA-256 and decodes UTF-8 before display.

## Overlap check
Searched open and closed PRs for extensionless source, preview README and preview Dockerfile, plus matches for workspace_preview.py, PixelPreviewSource.jsx and PixelCodeBlock.jsx among 2,000 recent PRs. #4216 adds actionable recovery for unsupported files; #4116 preserves exact highlighted source; #4085 supplies UTF-8 response metadata. None support these project document names. The pending source clipboard PR #4223 edits a different part of PixelPreviewSource; combined validation will include both.

## Contract and tradeoffs
- All ownership, symlink/hardlink, path, per-file, file-count and snapshot byte bounds remain enforced.
- This is publication of file bytes, not build or command execution. Dotfiles, credentials, arbitrary extensionless files and executable suffixes remain outside the added allowlist.
- Rollback: revert this commit. Existing immutable publications remain unchanged and readable; new publications resume the prior file-type restriction.
- Runtime is POSIX on Linux/macOS and Windows via WSL. No live fleet activation has been performed; a maintainer should review the explicit allowlist before merge.

## Validation
- Broker regression fails on beta f5f49b7d before the change; 34 broker tests pass under Linux/WSL, covering actual HTTP response bytes/headers, manifest membership, immutable snapshots, symlinks and rejected names.
- 33 frontend tests pass across source, clipboard, download, search and diff; six new text-inspector cases and an unknown-binary control exercise verified bytes.
- ESLint, scoped pre-commit and diff whitespace checks pass.
- Full make gate has an existing no-sudo Docker fixture failure; this is not claimed as a live install qualification.

No merge ordering dependency; test the combined source-inspector changes with #4223 before merging the batch.

## Final batch validation receipt

Candidate: `38b9b0b3eabba768a2d81df11b43129dd7cc9961`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Follow-up 38b9b0b3 uses Buffer.alloc for the Node 20 binary fixture to avoid a cross-realm request-body mismatch. All 34 broker tests pass in the combined Linux candidate; Chromium verifies exact extensionless README download/copy bytes.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
