### PR TITLE
fix(history): preserve conversation data across partial storage writes

### DIFF
--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.js
@@ -29,9 +29,14 @@ function currentConversation() {
 
 function loadConversations(preserveInvalid = false) {
   const stored = storedArray(LIBRARY_KEY)
-  const entries = preserveInvalid ? stored : stored.filter(valid)
+  let entries = preserveInvalid ? stored : stored.filter(valid)
   const current = currentConversation()
-  if (valid(current) && current.messages.length && !entries.some(item => valid(item) && item.chatId === current.chatId)) entries.push(current)
+  if (valid(current) && (current.persistenceVersion === 2 || !entries.some(item => valid(item) && item.chatId === current.chatId))) {
+    // The active record is committed first. Reconcile a library write that
+    // failed afterward, including deletion of an emptied unsent draft.
+    entries = entries.filter(item => !valid(item) || item.chatId !== current.chatId)
+    if (current.messages.length || current.draft?.trim()) entries.push(current)
+  }
   const deleted = deletedIds()
   return entries.filter(item => !valid(item) || !deleted.includes(item.chatId))
     .sort((a, b) => (Number.isFinite(b?.updatedAt) ? b.updatedAt : 0) - (Number.isFinite(a?.updatedAt) ? a.updatedAt : 0))
@@ -50,18 +55,24 @@ export function saveConversation(chat) {
   // A read error is not an empty library. Never overwrite unreadable history.
   const entries = loadConversations(true)
   const previous = entries.find(item => valid(item) && item.chatId === chat.chatId)
-  const value = { ...previous, ...chat, updatedAt: Date.now() }
+  const value = { ...previous, ...chat, updatedAt: Date.now(), persistenceVersion: 2 }
   const remaining = entries.filter(item => !valid(item) || item.chatId !== value.chatId)
-  if (value.messages.length || value.draft?.trim()) {
-    const next = [value, ...remaining]
+  const next = value.messages.length || value.draft?.trim() ? [value, ...remaining] : remaining
+  const current = currentConversation()
+  if (valid(current) && current.chatId !== value.chatId) {
+    // Do not replace the only durable copy of a previous partial save when
+    // switching tasks. Flush its reconciled library before moving the pointer.
+    localStorage.setItem(LIBRARY_KEY, JSON.stringify(entries))
+  }
+  // Validate/read the library before either write. Commit the reload authority
+  // first so a failed second write cannot restore stale text over newer text.
+  localStorage.setItem(CHAT_KEY, JSON.stringify(value))
+  try {
     // Never silently evict an older conversation when browser storage fills up.
     localStorage.setItem(LIBRARY_KEY, JSON.stringify(next))
-  } else if (previous) {
-    // An erased unsent draft must not survive in the sidebar's saved library.
-    localStorage.setItem(LIBRARY_KEY, JSON.stringify(remaining))
+  } finally {
+    window.dispatchEvent(new Event(LIBRARY_EVENT))
   }
-  localStorage.setItem(CHAT_KEY, JSON.stringify(value))
-  window.dispatchEvent(new Event(LIBRARY_EVENT))
 }
 
 export function conversationTitle(chat) {

--- a/ods/extensions/services/dashboard/src/lib/pixelConversations.test.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversations.test.js
@@ -1,7 +1,54 @@
 import { CHAT_KEY, readConversations, saveConversation, conversationTitle, deleteConversation } from './pixelConversations'
 
 beforeEach(() => localStorage.clear())
+afterEach(() => vi.restoreAllMocks())
 const chat = (id, text) => ({ schema: 1, chatId: id, messages: [{ role: 'user', content: text }], preview: null })
+
+test('a failed library write preserves the newest current conversation for reload', () => {
+  saveConversation(chat('saved', 'Original message'))
+  const write = window.Storage.prototype.setItem
+  vi.spyOn(window.Storage.prototype, 'setItem').mockImplementation(function(key,value) {
+    if (key === 'ods.pixel.conversations.v1') throw new globalThis.DOMException('Quota', 'QuotaExceededError')
+    return write.call(this,key,value)
+  })
+  expect(() => saveConversation({...chat('saved','Newest message'),draft:'Retain this draft'})).toThrow('Quota')
+  expect(JSON.parse(localStorage.getItem(CHAT_KEY))).toMatchObject({draft:'Retain this draft',messages:[{role:'user',content:'Newest message'}]})
+  expect(readConversations()[0].draft).toBe('Retain this draft')
+  expect(() => saveConversation(chat('next','Another task'))).toThrow('Quota')
+  expect(JSON.parse(localStorage.getItem(CHAT_KEY)).draft).toBe('Retain this draft')
+})
+
+test('a failed current write cannot commit newer library text that an old pointer will overwrite', () => {
+  saveConversation(chat('saved', 'Original message'))
+  const originalLibrary = localStorage.getItem('ods.pixel.conversations.v1')
+  const write = window.Storage.prototype.setItem
+  vi.spyOn(window.Storage.prototype, 'setItem').mockImplementation(function(key,value) {
+    if (key === CHAT_KEY) throw new globalThis.DOMException('Quota', 'QuotaExceededError')
+    return write.call(this,key,value)
+  })
+  expect(() => saveConversation(chat('saved','New message'))).toThrow('Quota')
+  expect(localStorage.getItem('ods.pixel.conversations.v1')).toBe(originalLibrary)
+})
+
+test('keeps legacy library-first records authoritative until their next save', () => {
+  localStorage.setItem('ods.pixel.conversations.v1',JSON.stringify([chat('legacy','Latest library text')]))
+  localStorage.setItem(CHAT_KEY,JSON.stringify(chat('legacy','Older active text')))
+  expect(readConversations()[0].messages[0].content).toBe('Latest library text')
+})
+
+test('a partial cleared-draft save cannot resurrect the discarded draft on the next task', () => {
+  saveConversation({schema:1,chatId:'draft',messages:[],draft:'Remove this'})
+  const write = window.Storage.prototype.setItem
+  const mock = vi.spyOn(window.Storage.prototype, 'setItem').mockImplementation(function(key,value) {
+    if (key === 'ods.pixel.conversations.v1') throw new globalThis.DOMException('Quota', 'QuotaExceededError')
+    return write.call(this,key,value)
+  })
+  expect(() => saveConversation({schema:1,chatId:'draft',messages:[],draft:''})).toThrow('Quota')
+  expect(readConversations()).toEqual([])
+  mock.mockRestore()
+  saveConversation({schema:1,chatId:'next',messages:[],draft:''})
+  expect(readConversations()).toEqual([])
+})
 
 test('migrates the current conversation without deleting the original', () => {
   localStorage.setItem(CHAT_KEY, JSON.stringify(chat('legacy', 'Original task')))


### PR DESCRIPTION
Make interrupted two-key conversation saves recoverable. Previously the library was written before the active record; if the second write failed, reload restored the old active text, which could overwrite the newer library. Commit the active record first, reconcile it into library reads, and flush a previous partial save before switching to another conversation.

## Why this matters
Pixel calls saveConversation for drafts, turns and recovery identities. Browser quota/storage failures can occur between its writes. The invariant is that a partial save must neither replace newer text with an older active pointer nor lose the only durable copy when starting another task. An emptied draft must remain empty through recovery.

## Overlap check
Searched open/closed PRs for conversation partial save and all pixelConversations.js matches in 2,000 recent PRs. #4078 handles successful draft clearing; #4111/#4121 isolate malformed records; #4141 adds labels. None handles partial writes between the two storage keys. This changes the shared persistence boundary rather than adding per-component workarounds.

## Persistence contract and rollback
- Read and validate the library before any mutation; malformed retained records remain preserved and tombstones remain authoritative.
- New records carry persistenceVersion: 2 to identify current-first ordering. Legacy records keep their existing library precedence until saved; conversation schema remains 1.
- A failed library write still throws, so the UI reports the failure. Readers can recover the committed active record. Switching tasks first flushes that record to the library; if this fails, the old active record is not replaced.
- No claim of transactional cross-tab editing: localStorage is still not a compare-and-swap database.
- Before downgrading, complete a successful save and export important conversations so a pending new-format partial write has been reconciled. No bulk rewrite or deletion migration occurs.

## Validation
- Three quota regressions fail on public-beta f5f49b7d. They cover both failure positions, repeat failure during conversation switch and cleared-draft recovery; an additional compatibility test preserves legacy library precedence.
- 107 tests pass across persistence, Pixel page, conversation navigation, organizer and search, including pre-submit recovery identity and refusal to start orphaned work.
- ESLint, scoped pre-commit and diff whitespace checks pass.
- Shared browser code applies on Windows/macOS/Linux. Browser quota, reload, second-tab receipt and successful-save downgrade probes now pass as detailed below; this PR remains draft for independent human storage review.

No dependency on other batch branches. Validate with the complete batch before merging.

## Final batch validation receipt

Candidate: `bdd6f35727c2beb44f3952491cc57e7a07d3ded9`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual Chromium quota exhaustion reached current-write-success/library-write-failure. Reload and a second tab recovered newer text; after freeing space and saving successfully, the legacy public-beta reader saw it. Remains DRAFT pending independent human storage review. This is not a claim of atomic concurrent editing or safe downgrade before reconciling an interrupted partial write.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
