### PR TITLE
fix(beta): keep UUID-dependent actions working over HTTP LAN

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { configurationError } from './settings/pixelProviderForm.js'
 import PixelAdviceRuntime from './PixelAdviceRuntime.jsx'
+import {browserUuid} from '../lib/browserUuid'
 
 const STORAGE = 'ods.pixel.advice.job.v1'
 const jobPattern = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/
@@ -111,7 +112,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
     jobVersion.current++
     let id
     try {
-      id = crypto.randomUUID()
+      id = browserUuid()
       // Only an opaque ID is persisted, before any possibly billable request.
       // A reload queries that ID; it never submits the capsule automatically.
       localStorage.setItem(STORAGE, id)

--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../test/test-utils'
 import PixelAdvice from './PixelAdvice.jsx'
+import {mockHttpCrypto} from '../test/httpCrypto'
 
 const id = '5c292c25-9368-4d9a-83cd-1e14d34cb128'
 const key = 'ods.pixel.advice.job.v1'
@@ -33,6 +34,27 @@ async function setup({ kind, post, onInsert = vi.fn() } = {}) {
 
 beforeEach(() => localStorage.clear())
 afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); localStorage.clear() })
+
+it('creates a trackable advisory request on an HTTP LAN origin', async () => {
+  const {fetchMock} = await setup()
+  mockHttpCrypto(id)
+  fireEvent.change(screen.getByLabelText('Capsule to send'), {target:{value:'Review this example'}})
+  fireEvent.click(screen.getByRole('button', {name:'Send reviewed capsule'}))
+  await screen.findByText('Advisory answer — untrusted model output')
+  expect(localStorage.getItem(key)).toBe(id)
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/start'))).toHaveLength(1)
+})
+
+it('does not submit advice if the browser has no secure random source', async () => {
+  const {fetchMock} = await setup()
+  vi.stubGlobal('crypto', {})
+  fireEvent.change(screen.getByLabelText('Capsule to send'), {target:{value:'Retain my capsule'}})
+  fireEvent.click(screen.getByRole('button', {name:'Send reviewed capsule'}))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Nothing was submitted')
+  expect(screen.getByLabelText('Capsule to send')).toHaveValue('Retain my capsule')
+  expect(localStorage.getItem(key)).toBeNull()
+  expect(fetchMock.mock.calls.some(([url]) => url.endsWith('/start'))).toBe(false)
+})
 
 it('sends only reviewed capsule and fixed selected revision once, stores only job ID', async () => {
   const { fetchMock, onInsert } = await setup()

--- a/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import {browserUuid} from '../lib/browserUuid'
 
 const key = 'ods.pixel.advice.setup.v1'
 const uuid = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/
@@ -103,7 +104,7 @@ export default function PixelAdviceRuntime({ onReadyChange, title = 'Advisory ru
     jobVersion.current++
     let id
     try {
-      id = globalThis.crypto.randomUUID(); localStorage.setItem(key, id)
+      id = browserUuid(); localStorage.setItem(key, id)
       tracked.current = id; setJobId(id); setJob(null)
       const result = await request('/prepare', { requestId: id, expectedRevision: readiness.revision,
         sourceSha256: readiness.sourceSha256, candidateId: selected, confirmed: true })

--- a/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdviceRuntime.test.jsx
@@ -2,6 +2,7 @@ import { fireEvent, screen, waitFor, act } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../test/test-utils'
 import PixelAdviceRuntime from './PixelAdviceRuntime.jsx'
+import {mockHttpCrypto} from '../test/httpCrypto'
 
 const id = 'c2ac7cba-198d-4cb6-b4ca-722eb29d778f'
 const storage = 'ods.pixel.advice.setup.v1'
@@ -24,6 +25,16 @@ async function setup(handler) {
 }
 beforeEach(() => localStorage.clear())
 afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); localStorage.clear() })
+
+it('tracks an explicitly approved runtime preparation on an HTTP LAN origin', async () => {
+  const {fetchMock} = await setup()
+  mockHttpCrypto(id)
+  fireEvent.click(screen.getByLabelText(consent))
+  fireEvent.click(screen.getByRole('button', {name:'Prepare private runtime'}))
+  await screen.findByText('Setup: running')
+  expect(localStorage.getItem(storage)).toBe(id)
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/prepare'))).toHaveLength(1)
+})
 
 it('requires explicit consent and submits only the server candidate ID once', async () => {
   const { fetchMock } = await setup()

--- a/ods/extensions/services/dashboard/src/components/PixelProviderScopes.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelProviderScopes.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import {browserUuid} from '../lib/browserUuid'
 
 const button = 'rounded border border-theme-border px-3 py-2 text-xs disabled:opacity-40'
 const scopes = ['task', 'conversation', 'default']
@@ -82,7 +83,7 @@ export default function PixelProviderScopes({ chatId, sending = false }) {
     const current = generation.current
     try {
       const body = { chatId, expectedRevision: state.revision, taskId: state.taskId }
-      if (action === 'begin') body.taskId = crypto.randomUUID()
+      if (action === 'begin') body.taskId = browserUuid()
       if (action === 'select' || action === 'return') body.scope = scope
       if (action === 'select') Object.assign(body, { providerId: target.id, providerRevision: configuration.revision,
         allowCloud: target.kind === 'cloud' && cloud, acceptUnknownCost: target.kind === 'cloud' && cost })

--- a/ods/extensions/services/dashboard/src/components/PixelProviderScopes.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelProviderScopes.test.jsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { render } from '../test/test-utils'
 import PixelProviderScopes from './PixelProviderScopes.jsx'
+import {mockHttpCrypto} from '../test/httpCrypto'
 
 const response = value => ({ ok: true, json: async () => value })
 const taskId = '8d23bf56-9f23-4afd-9cd6-c24e6e2931b8'
@@ -24,6 +25,15 @@ async function setup({ kind = 'local', mutate, state = initial(), sending = fals
   return { fetchMock, ...view }
 }
 afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+it('begins a new preference task on an HTTP LAN origin', async () => {
+  const {fetchMock} = await setup({state:{...initial(),taskId:null}})
+  mockHttpCrypto(taskId)
+  fireEvent.click(screen.getByRole('button', {name:'Begin task'}))
+  await waitFor(() => expect(fetchMock.mock.calls.some(([url]) => url.endsWith('/begin'))).toBe(true))
+  const call = fetchMock.mock.calls.find(([url]) => url.endsWith('/begin'))
+  expect(JSON.parse(call[1].body).taskId).toBe(taskId)
+})
 
 it('only reads on open and reload; never begins or approves work implicitly', async () => {
   const { fetchMock } = await setup()

--- a/ods/extensions/services/dashboard/src/lib/browserUuid.js
+++ b/ods/extensions/services/dashboard/src/lib/browserUuid.js
@@ -1,0 +1,12 @@
+export function browserUuid() {
+  const crypto = globalThis.crypto
+  if (typeof crypto?.randomUUID === 'function') return crypto.randomUUID()
+  if (typeof crypto?.getRandomValues !== 'function') throw new Error('Secure random identifiers are unavailable in this browser.')
+  // getRandomValues is also available on the supported HTTP LAN path. Keep
+  // RFC 4122 v4 version/variant bits; never substitute Math.random for job IDs.
+  const bytes = crypto.getRandomValues(new Uint8Array(16))
+  bytes[6] = (bytes[6] & 0x0f) | 0x40
+  bytes[8] = (bytes[8] & 0x3f) | 0x80
+  const hex = Array.from(bytes, value => value.toString(16).padStart(2,'0')).join('')
+  return `${hex.slice(0,8)}-${hex.slice(8,12)}-${hex.slice(12,16)}-${hex.slice(16,20)}-${hex.slice(20)}`
+}

--- a/ods/extensions/services/dashboard/src/lib/customWallpapers.js
+++ b/ods/extensions/services/dashboard/src/lib/customWallpapers.js
@@ -1,3 +1,5 @@
+import {browserUuid} from './browserUuid'
+
 const DATABASE = 'ods-wallpapers-v1'
 const STORE = 'images'
 export const MAX_WALLPAPER_VIDEO_BYTES = 100 * 1024 * 1024
@@ -64,7 +66,7 @@ async function prepareVideoWallpaper(file) {
     if (!context) throw new Error('Video thumbnails are unavailable in this browser.')
     context.drawImage(video, 0, 0, canvas.width, canvas.height)
     const image = canvas.toDataURL('image/webp', .8)
-    const row = {id:`custom-${crypto.randomUUID()}`, name:file.name.replace(/\.[^.]+$/, '').slice(0,80) || 'My video', kind:'video', image, video:file}
+    const row = {id:`custom-${browserUuid()}`, name:file.name.replace(/\.[^.]+$/, '').slice(0,80) || 'My video', kind:'video', image, video:file}
     if (!isStoredWallpaper(row)) throw new Error('Could not create a thumbnail for this video.')
     return row
   } finally {
@@ -95,7 +97,7 @@ export async function prepareWallpaper(file) {
     context.drawImage(bitmap, 0, 0, canvas.width, canvas.height)
     const image = canvas.toDataURL('image/webp', .86)
     if (image.length > 6 * 1024 * 1024 || !/^data:image\/(webp|png);base64,/.test(image)) throw new Error('The wallpaper could not be resized. Try another image.')
-    return {id:`custom-${crypto.randomUUID()}`, name:file.name.replace(/\.[^.]+$/, '').slice(0, 80) || 'My wallpaper', image}
+    return {id:`custom-${browserUuid()}`, name:file.name.replace(/\.[^.]+$/, '').slice(0, 80) || 'My wallpaper', image}
   } finally { bitmap.close() }
 }
 

--- a/ods/extensions/services/dashboard/src/lib/customWallpapers.test.js
+++ b/ods/extensions/services/dashboard/src/lib/customWallpapers.test.js
@@ -1,4 +1,5 @@
 import {prepareWallpaper, isCustomWallpaper, isStoredWallpaper, MAX_WALLPAPER_VIDEO_BYTES} from './customWallpapers'
+import {mockHttpCrypto} from '../test/httpCrypto'
 const {HTMLMediaElement, HTMLVideoElement} = window
 afterEach(()=>{vi.restoreAllMocks();vi.unstubAllGlobals()})
 it('accepts only opaque custom IDs, not URLs or CSS',()=>{
@@ -21,6 +22,15 @@ function mockVideo({error = false, width = 1920, duration = 3} = {}) {
   vi.spyOn(HTMLCanvasElement.prototype, 'toDataURL').mockReturnValue('data:image/webp;base64,YQ==')
   return {createObjectURL, revokeObjectURL, pause, drawImage}
 }
+
+it('prepares local video on an HTTP LAN origin without randomUUID', async () => {
+  const id = '11111111-2222-4333-8444-555555555555'
+  mockVideo()
+  mockHttpCrypto(id)
+  const row = await prepareWallpaper(new File(['video'],'local.mp4',{type:'video/mp4'}))
+  expect(row.id).toBe(`custom-${id}`)
+  expect(isStoredWallpaper(row)).toBe(true)
+})
 
 it.each(['video/mp4','video/webm'])('stores %s as a local blob with a static thumbnail', async type => {
   const mocks = mockVideo()

--- a/ods/extensions/services/dashboard/src/test/httpCrypto.js
+++ b/ods/extensions/services/dashboard/src/test/httpCrypto.js
@@ -1,0 +1,7 @@
+import {vi} from 'vitest'
+
+// HTTP LAN origins expose getRandomValues, but not secure-context randomUUID.
+export function mockHttpCrypto(uuid) {
+  const seed = Uint8Array.from(uuid.replaceAll('-', '').match(/../g), byte => Number.parseInt(byte,16))
+  vi.stubGlobal('crypto', {getRandomValues:vi.fn(bytes => {bytes.set(seed); return bytes})})
+}


### PR DESCRIPTION
Restore UUID-dependent beta actions on supported HTTP LAN origins. Those origins expose crypto.getRandomValues but not secure-context crypto.randomUUID. Advice submission, private-runtime preparation, Begin task and custom wallpaper preparation previously failed before completing their action.

## Why this matters
ODS documents normal HTTP LAN access (ods/docs/HERMES-SSO.md and TAILSCALE.md). Pixel chat already handles this browser capability difference, but these four new flows did not. A shared helper uses native randomUUID when present and otherwise formats cryptographically random bytes as UUID v4, preserving strict backend request/task ID validation. It never substitutes Math.random or timestamps for durable job identities.

## Overlap check
Searched open/closed PRs for randomUUID and UUID HTTP and inspected file matches across 2,000 recent PRs. #4216 introduces wallpapers, #4084 protects runtime receipts, #4102 protects advice terminal receipts, #4108 queues scope inspection and #3818 is the broad provider-feature branch. None handles absent randomUUID. One PR covers all four affected flows rather than splitting the same compatibility defect.

## Validation
- Four new public-boundary regressions fail on beta f5f49b7d with an HTTP-style crypto object exposing only getRandomValues.
- All 42 tests pass across advice, advice runtime, provider scopes and wallpaper preparation; an additional negative control proves no advisory request is sent when secure randomness is unavailable and the capsule stays editable.
- ESLint, scoped pre-commit and git diff --check pass.
- Browser capability tests cover shared frontend behavior on Windows, macOS and Linux. No claim that this enables microphone, clipboard or other APIs that independently require HTTPS; live LAN browser and runtime provisioning were not exercised.

Existing UUID formats, consent, pre-request tracking and backend lifecycle authorities are unchanged. No migration or merge-order dependency; reverting this commit restores the prior HTTP limitation.

## Final batch validation receipt

Candidate: `3373899ee011df9292142c5677069c5bb26a0809`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

The batch merge retains both this PR's UUID failure regressions and #4229's provider read-order regressions in PixelAdvice.test.jsx; both were included in the 934-test run.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
