### PR TITLE
fix(advice): reject obsolete provider inspection results

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
@@ -7,6 +7,7 @@ const jobPattern = /^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f
 const terminal = new Set(['completed', 'failed', 'cancelled', 'interrupted'])
 const button = 'rounded border border-theme-border px-3 py-2 text-xs disabled:opacity-40'
 const field = 'w-full rounded border border-theme-border bg-theme-bg p-2 text-sm'
+const PROVIDER_LOAD_ERROR = 'Provider settings unavailable. Reload before submitting.'
 
 function trackedJob() {
   try {
@@ -30,6 +31,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
   const inFlight = useRef(false)
   const polling = useRef(false)
   const jobVersion = useRef(0)
+  const providerVersion = useRef(0)
   const controllers = useRef(new Set())
   const panel = useRef(null)
   const trigger = useRef(null)
@@ -53,16 +55,19 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
 
   useEffect(() => {
     const pending = controllers.current
-    return () => { for (const controller of pending) controller.abort() }
+    return () => { providerVersion.current++; for (const controller of pending) controller.abort() }
   }, [])
 
   const load = useCallback(async () => {
+    const version = ++providerVersion.current
     setConfig(null); setCloud(false); setCost(false)
     try {
       const response = await request('/api/pixel/providers')
       if (configurationError(response.configuration)) throw new Error('Invalid settings')
+      if (version !== providerVersion.current) return
       setConfig(response.configuration)
-    } catch { setError('Provider settings unavailable. Reload before submitting.') }
+      setError(current => current === PROVIDER_LOAD_ERROR ? '' : current)
+    } catch { if (version === providerVersion.current) setError(PROVIDER_LOAD_ERROR) }
   }, [request])
 
   useEffect(() => { if (open) void load() }, [open, load])
@@ -70,7 +75,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
     if (open) panel.current?.querySelector('button')?.focus()
   }, [open])
 
-  function close() { setOpen(false); setRuntimeReady(false); trigger.current?.focus() }
+  function close() { providerVersion.current++; setOpen(false); setRuntimeReady(false); trigger.current?.focus() }
   function dialogKey(event) {
     if (event.key === 'Escape') { event.stopPropagation(); close(); return }
     if (event.key !== 'Tab') return

--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
@@ -34,6 +34,33 @@ async function setup({ kind, post, onInsert = vi.fn() } = {}) {
 beforeEach(() => localStorage.clear())
 afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); localStorage.clear() })
 
+it('keeps the newest provider inspection when reloads finish out of order', async () => {
+  const {fetchMock} = await setup()
+  let finishOld
+  const latest = {...config(),revision:4}
+  fetchMock.mockImplementationOnce(() => new Promise(resolve => {finishOld=resolve}))
+    .mockResolvedValueOnce(response({configuration:latest}))
+  const reload = screen.getByRole('button',{name:'Reload saved providers'})
+  fireEvent.click(reload)
+  fireEvent.click(reload)
+  await screen.findByText(/saved revision 4/)
+  await act(async () => finishOld(response({configuration:config()})))
+  expect(screen.getByText(/saved revision 4/)).toBeVisible()
+  expect(fetchMock.mock.calls.some(([url]) => url.endsWith('/start'))).toBe(false)
+})
+
+it('ignores a provider inspection failure from a closed advice panel', async () => {
+  const {fetchMock} = await setup()
+  let failOld
+  fetchMock.mockImplementationOnce(() => new Promise((_,reject) => {failOld=reject}))
+  fireEvent.click(screen.getByRole('button',{name:'Reload saved providers'}))
+  fireEvent.click(screen.getByRole('button',{name:'Close advice'}))
+  fireEvent.click(screen.getByRole('button',{name:/^Ask for advice/}))
+  await screen.findByText(/saved revision 3/)
+  await act(async () => failOld(new Error('Old inspection failed')))
+  expect(screen.queryByText('Provider settings unavailable. Reload before submitting.')).toBeNull()
+})
+
 it('sends only reviewed capsule and fixed selected revision once, stores only job ID', async () => {
   const { fetchMock, onInsert } = await setup()
   const baselineKeys = Object.keys(localStorage)


### PR DESCRIPTION
Ignore obsolete provider inspections in the advice panel. Repeated Reload saved providers and close/reopen can overlap GET requests. An older response previously replaced a newer provider revision, and a failure from the closed panel could add an error to a successful new inspection.

## Why this matters
Advice displays the exact configured recipient and revision used for explicit capsule review. That display must reflect the latest requested inspection. Version each provider read and invalidate it on close/unmount; clear only the provider-load error on successful recovery, preserving unrelated job errors. No provider mutation or advice submission is added.

## Overlap check
Searched open/closed PRs for advice provider stale and PixelAdvice.jsx matches in 2,000 recent PRs. #4102 protects job status/stop receipts, not provider configuration reads. #4228 adds HTTP UUID support in submission; it changes a separate part of this component and is included in combined validation.

## Validation
- Both public component races fail on public-beta f5f49b7d.
- 22 advice/advisory-runtime tests pass on Node 20, including explicit consent, submission tracking, cancellation and stale terminal receipts.
- ESLint, scoped pre-commit and whitespace checks pass.
- Tests use deferred HTTP responses, not live paid advice calls. The backend still owns revision validation and job execution; frontend read ordering is shared across Windows, macOS and Linux.

No persisted-format change or migration. Revert for rollback. No merge dependency; combine with #4228 when validating the batch.

## Final batch validation receipt

Candidate: `1da53d3beaeb90890f816afe87e7bf3d80309bd1`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

The batch merge retains both this PR's provider read-order regressions and #4228's UUID failure regressions in PixelAdvice.test.jsx; both were included in the 934-test run.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
