### PR TITLE
fix(dashboard): preserve newer wallpaper selections during import

### DIFF
--- a/ods/extensions/services/dashboard/src/contexts/CustomTheme.test.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/CustomTheme.test.jsx
@@ -11,6 +11,20 @@ function Gallery() {
 }
 beforeEach(()=>{localStorage.clear();vi.resetAllMocks();readCustomWallpapers.mockResolvedValue([])})
 
+it.each(['preset', 'other tab'])('keeps a newer %s choice when an earlier import finishes',async choice=>{
+  let finishImport
+  addCustomWallpaper.mockReturnValue(new Promise(resolve=>{finishImport=resolve}))
+  render(<ThemeProvider><Gallery/></ThemeProvider>)
+  await act(async()=>{})
+  fireEvent.change(screen.getByLabelText('Choose local wallpaper'),{target:{files:[new File(['x'],'x.png',{type:'image/png'})]}})
+  if(choice === 'preset') fireEvent.click(screen.getByRole('button',{name:'Forest',exact:true}))
+  else act(()=>window.dispatchEvent(new StorageEvent('storage',{key:'ods-theme',newValue:'forest'})))
+  await act(async()=>finishImport(row))
+  expect(screen.getByRole('button',{name:'My forest'})).toBeVisible()
+  expect(localStorage.getItem('ods-theme')).toBe('forest')
+  expect(document.documentElement).toHaveAttribute('data-wallpaper','forest')
+})
+
 it('imports, selects, restores and removes a custom image while retaining the default palette',async()=>{
   addCustomWallpaper.mockResolvedValue(row)
   deleteCustomWallpaper.mockResolvedValue(undefined)

--- a/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
@@ -16,6 +16,7 @@ export function ThemeProvider({ children }) {
     try { return localStorage.getItem('ods-wallpaper-motion') !== 'paused' } catch { return true }
   })
   const galleryRevision = useRef(0)
+  const selectionRevision = useRef(0)
   const wallpapers = [...WALLPAPERS, ...custom]
   const [theme, setThemeState] = useState(() => {
     let stored
@@ -37,6 +38,7 @@ export function ThemeProvider({ children }) {
     const sync = event => {
       if (event.key === 'ods-wallpaper-motion') { setWallpaperMotionState(event.newValue !== 'paused'); return }
       if (event.key !== STORAGE_KEY) return
+      selectionRevision.current++
       setThemeState(THEMES.includes(event.newValue) || isCustomWallpaper(event.newValue) ? event.newValue : DEFAULT_THEME)
       void refresh()
     }
@@ -69,14 +71,18 @@ export function ThemeProvider({ children }) {
   }, [])
 
   const setTheme = useCallback((t) => {
-    if (THEMES.includes(t) || isCustomWallpaper(t)) setThemeState(t)
+    if (THEMES.includes(t) || isCustomWallpaper(t)) {
+      selectionRevision.current++
+      setThemeState(t)
+    }
   }, [])
 
   const addWallpaper = async file => {
+    const selection = ++selectionRevision.current
     const row = await addCustomWallpaper(file)
     galleryRevision.current++
     setCustom(previous => [...previous.filter(item => item.id !== row.id), row])
-    setThemeState(row.id)
+    if (selection === selectionRevision.current) setThemeState(row.id)
   }
   const removeWallpaper = async id => {
     await deleteCustomWallpaper(id)
@@ -86,6 +92,7 @@ export function ThemeProvider({ children }) {
   }
 
   const cycleTheme = useCallback(() => {
+    selectionRevision.current++
     setThemeState(prev => {
       const idx = THEMES.indexOf(prev)
       return THEMES[(idx + 1) % THEMES.length]


### PR DESCRIPTION
Keep a newer wallpaper choice when an earlier local import finishes. Import still stores the file and adds it to the gallery, but only selects it if no later selection has occurred.

## Why this matters
Preparing a video thumbnail or committing IndexedDB can take time. Choosing a preset during that work, or selecting a theme in another tab, previously appeared to work and then was silently overwritten. Track selection intent separately from gallery-read ordering, including preset cycling and incoming theme storage events.

## Overlap check
Searched open/closed wallpaper upload theme race and ThemeContext.jsx in 2,000 recent PR file lists. Merged #4216 protects older gallery reads and adds video playback; it does not order pending imports against newer selections. #4222 handles video.play interruption in a different component.

## Validation
- Two component regressions fail on public-beta f5f49b7d: local preset selection and cross-tab selection during deferred import.
- 20 theme, gallery, media and storage tests pass on Node 20.
- ESLint, scoped pre-commit and whitespace checks pass.
- Mocked import completion and storage events verify ordering; actual browser media decoding is not repeated. Shared UI behavior covers all host platforms.

No storage schema change, merge dependency or migration. Revert for rollback.

## Final batch validation receipt

Candidate: `3adcc5782ac62dee23425faad7a576708ebea47a`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual Chromium WebM import was left pending while Forest was selected; the second custom row was retained and Forest remained selected.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
