### PR TITLE
feat(dashboard): search saved prompt names and full text

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.jsx
@@ -8,6 +8,9 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
   const [editing, setEditing] = useState(null)
   const [removing, setRemoving] = useState(null)
   const [error, setError] = useState('')
+  const [query, setQuery] = useState('')
+  const needle = query.trim().toLocaleLowerCase()
+  const shown = items.filter(item => `${item.title}\n${item.text}`.toLocaleLowerCase().includes(needle))
   function refresh() {
     try {setItems(readSavedPrompts()); setError('')}
     catch {setError('Saved prompts could not be read. Existing browser data has been preserved.')}
@@ -45,7 +48,13 @@ export default function PixelPromptLibrary({input, disabled, onInsert}) {
       </div> : <>
         <button className={buttonClass} type="button" onClick={() => edit(null)}>Save a new prompt</button>
         {!items.length && <p>No saved prompts yet. Start with your current draft or write a new one.</p>}
-        <ul>{items.map(item => {
+        {!!items.length && <div role="search" aria-label="Search prompt library">
+          <input className={fieldClass} type="search" aria-label="Search saved prompts" placeholder="Search names and full prompt text" value={query} onChange={event => setQuery(event.target.value)}/>
+          {query && <button className={buttonClass} type="button" onClick={() => setQuery('')}>Clear prompt search</button>}
+          <p role="status">{shown.length} of {items.length} prompts</p>
+          {!shown.length && <p>No prompts match your search.</p>}
+        </div>}
+        <ul>{shown.map(item => {
           const fits = input.length + item.text.length + 1 <= 16384
           return <li key={item.id} className="my-3 rounded border border-theme-border p-2">
             <strong>{item.title}</strong><p className="whitespace-pre-wrap break-words">{item.text.slice(0, 160)}{item.text.length > 160 ? '…' : ''}</p>

--- a/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPromptLibrary.test.jsx
@@ -20,6 +20,36 @@ function create() {
   fireEvent.change(screen.getByLabelText('Prompt name'), {target:{value:'Review'}})
   fireEvent.click(screen.getByRole('button', {name:'Save prompt'}))
 }
+it('searches full prompt text and names without changing stored prompts or inserting automatically', () => {
+  const items = [{id:'a', title:'Review', text:'x'.repeat(170)+'Narrow regression'}, {id:'b', title:'Deployment', text:'Inspect logs'}]
+  const saved = JSON.stringify(items)
+  localStorage.setItem(SAVED_PROMPTS_KEY, saved)
+  const insert = mount()
+  fireEvent.change(screen.getByLabelText('Search saved prompts'), {target:{value:'REGRESSION'}})
+  expect(screen.getByRole('button',{name:'Insert prompt: Review'})).toBeVisible()
+  expect(screen.queryByRole('button',{name:'Insert prompt: Deployment'})).toBeNull()
+  expect(screen.getByRole('status')).toHaveTextContent('1 of 2 prompts')
+  fireEvent.change(screen.getByLabelText('Search saved prompts'), {target:{value:'missing'}})
+  expect(screen.getByText('No prompts match your search.')).toBeVisible()
+  fireEvent.click(screen.getByRole('button',{name:'Clear prompt search'}))
+  expect(screen.getByRole('button',{name:'Insert prompt: Deployment'})).toBeVisible()
+  expect(insert).not.toHaveBeenCalled()
+  expect(localStorage.getItem(SAVED_PROMPTS_KEY)).toBe(saved)
+})
+
+it('reapplies search after an edit and a cross-tab update while preserving the filter', () => {
+  localStorage.setItem(SAVED_PROMPTS_KEY, JSON.stringify([{id:'a', title:'Review', text:'Evidence'}]))
+  mount()
+  fireEvent.change(screen.getByLabelText('Search saved prompts'), {target:{value:'review'}})
+  fireEvent.click(screen.getByRole('button',{name:'Edit prompt: Review'}))
+  fireEvent.change(screen.getByLabelText('Prompt name'),{target:{value:'Inspect'}})
+  fireEvent.click(screen.getByRole('button',{name:'Save prompt'}))
+  expect(screen.getByText('No prompts match your search.')).toBeVisible()
+  localStorage.setItem(SAVED_PROMPTS_KEY, JSON.stringify([{id:'a',title:'Review again',text:'Evidence'}]))
+  fireEvent(window, new StorageEvent('storage',{key:SAVED_PROMPTS_KEY}))
+  expect(screen.getByRole('button',{name:'Insert prompt: Review again'})).toBeVisible()
+  expect(screen.getByLabelText('Search saved prompts')).toHaveValue('review')
+})
 it('saves the current draft, edits it, then explicitly inserts reusable text', () => {
   const insert = mount()
   create()


### PR DESCRIPTION
Search saved prompts by name and full text inside the existing composer library. Show the matching count, a distinct no-results state and an explicit clear control. Retain the query while editing and when another tab updates storage.

## Why this matters
The library allows 30 prompts of up to 16,000 characters, but list previews show only 160 characters. Operators can now find an instruction buried beyond that preview without opening every prompt. Filtering is read-only; insertion remains explicit and draft-limit checks remain in place.

## Overlap check
Searched open/closed prompt library search/filter and PixelPromptLibrary.jsx. #4143 introduced CRUD; #4221 adds backup/import, not retrieval. #3385 is the earlier Portal experience. This feature is independent of transfer and was included in combined compatibility validation with #4221 (receipt below).

## Validation
- Two public composer/library regressions demonstrate missing functionality on public-beta f5f49b7d.
- 12 library/composer tests pass on Node 20, including full-text matching, case folding, no results/clear, edit and storage refresh, byte-identical storage and no automatic insertion.
- ESLint, whitespace and scoped pre-commit pass.
- Shared dashboard implementation for all host platforms; no remote service or storage schema change. Chromium browser receipt is recorded below.

Revert removes the filter only. No merge dependency; #4221 touches the same dialog and needs combined validation.

## Final batch validation receipt

Candidate: `3063bef34c570adbaff2ba988143db35c0215a68`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual mobile Chromium native dialog found prompt text beyond the preview without inserting it. Compatibility with #4221 was tested on 89cbb507: retain both query/filter state and isOpen/transfer state at the textual conflict; both prompt suites passed (11 tests).

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
