### PR TITLE
feat(pixel): navigate verified source by line and match case

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelSourceFind.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSourceFind.jsx
@@ -4,12 +4,18 @@ import './pixel-source-find.css'
 export default function PixelSourceFind({source, codeRef}) {
   const [query, setQuery] = useState('')
   const [index, setIndex] = useState(0)
+  const [matchCase, setMatchCase] = useState(false)
+  const [requestedLine, setRequestedLine] = useState('')
+  const [jumpedLine, setJumpedLine] = useState(null)
+  const lineCount = source.replace(/\n$/u, '').split('\n').length
+  const target = Number(requestedLine)
+  const canJump = /^\d+$/.test(requestedLine) && Number.isSafeInteger(target) && target >= 1 && target <= lineCount
   const matches = useMemo(() => {
     if (!query) return []
-    const needle = query.toLocaleLowerCase()
-    return source.split('\n').flatMap((line, at) => line.toLocaleLowerCase().includes(needle) ? [at + 1] : [])
-  }, [source, query])
-  const line = matches[index] ?? matches[0]
+    const needle = matchCase ? query : query.toLocaleLowerCase()
+    return source.split('\n').flatMap((line, at) => (matchCase ? line : line.toLocaleLowerCase()).includes(needle) ? [at + 1] : [])
+  }, [source, query, matchCase])
+  const line = jumpedLine ?? matches[index] ?? matches[0]
   useEffect(() => {
     if (!line) return
     const row = codeRef.current?.querySelector(`[data-line="${line}"]`)
@@ -19,13 +25,19 @@ export default function PixelSourceFind({source, codeRef}) {
   }, [line, codeRef, source])
   function move(direction) {setIndex(value => matches.length ? (value + direction + matches.length) % matches.length : 0)}
   return <div className="pixel-source-find" role="search" aria-label="Search verified source">
-    <input type="search" aria-label="Find in source" placeholder="Find in source…" value={query} onChange={event => {setQuery(event.target.value); setIndex(0)}} onKeyDown={event => {
+    <input type="search" aria-label="Find in source" placeholder="Find in source…" value={query} onChange={event => {setQuery(event.target.value); setIndex(0); setJumpedLine(null)}} onKeyDown={event => {
       if (event.nativeEvent?.isComposing) return
       if (event.key === 'Enter') {event.preventDefault(); move(event.shiftKey ? -1 : 1)}
-      if (event.key === 'Escape') {setQuery(''); setIndex(0)}
+      if (event.key === 'Escape') {setQuery(''); setIndex(0); setJumpedLine(null)}
     }}/>
+    <label><input type="checkbox" checked={matchCase} onChange={event => {setMatchCase(event.target.checked); setIndex(0); setJumpedLine(null)}}/> Match case</label>
     <button type="button" disabled={!matches.length} aria-label="Previous matching line" onClick={() => move(-1)}>Previous</button>
     <button type="button" disabled={!matches.length} aria-label="Next matching line" onClick={() => move(1)}>Next</button>
+    <form onSubmit={event => {event.preventDefault(); if (canJump) {setJumpedLine(target); setQuery(''); setIndex(0)}}}>
+      <input type="number" aria-label="Go to source line" min="1" max={lineCount} step="1" value={requestedLine} onChange={event => setRequestedLine(event.target.value)}/>
+      <button type="submit" disabled={!canJump}>Go to line</button>
+    </form>
+    {jumpedLine && <span role="status">Line {jumpedLine} of {lineCount}</span>}
     {query && <span role="status">{matches.length ? `${Math.min(index, matches.length - 1) + 1} of ${matches.length} matching lines · Line ${line}` : 'No matching lines'}</span>}
   </div>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelSourceFind.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSourceFind.test.jsx
@@ -12,6 +12,34 @@ beforeEach(() => {
 })
 afterEach(() => {vi.unstubAllGlobals(); vi.restoreAllMocks(); delete globalThis.Element.prototype.scrollIntoView})
 
+it('jumps to a verified line, bounds line numbers, and gives search control back explicitly', async () => {
+  const {container} = render(<PixelPreviewSource preview={preview}/>)
+  const input = await screen.findByRole('searchbox', {name:'Find in source'})
+  const text = container.querySelector('pre').textContent
+  const line = screen.getByRole('spinbutton',{name:'Go to source line'})
+  fireEvent.change(line,{target:{value:'2'}})
+  fireEvent.click(screen.getByRole('button',{name:'Go to line'}))
+  expect(container.querySelector('[data-source-find-current]')).toHaveAttribute('data-line','2')
+  expect(screen.getByRole('status')).toHaveTextContent('Line 2 of 3')
+  fireEvent.change(line,{target:{value:'999'}})
+  expect(screen.getByRole('button',{name:'Go to line'})).toBeDisabled()
+  expect(container.querySelector('[data-source-find-current]')).toHaveAttribute('data-line','2')
+  fireEvent.change(input,{target:{value:'LAST'}})
+  expect(container.querySelector('[data-source-find-current]')).toHaveAttribute('data-line','3')
+  expect(container.querySelector('pre').textContent).toBe(text)
+})
+
+it('supports case-sensitive literal search and resets the active matching line when toggled', async () => {
+  const {container} = render(<PixelPreviewSource preview={preview}/>)
+  const input = await screen.findByRole('searchbox', {name:'Find in source'})
+  fireEvent.change(input,{target:{value:'last'}})
+  expect(container.querySelector('[data-source-find-current]')).toHaveAttribute('data-line','3')
+  fireEvent.click(screen.getByRole('checkbox',{name:'Match case'}))
+  expect(screen.getByText('No matching lines')).toBeVisible()
+  fireEvent.change(input,{target:{value:'LAST'}})
+  expect(container.querySelector('[data-source-find-current]')).toHaveAttribute('data-line','3')
+})
+
 it('finds literal matching lines in verified source without altering its text', async () => {
   const {container} = render(<PixelPreviewSource preview={preview}/>)
   const input = await screen.findByRole('searchbox', {name:'Find in source'})

--- a/ods/extensions/services/dashboard/src/components/pixel-source-find.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-source-find.css
@@ -2,5 +2,8 @@
 .pixel-source-find input { min-width:100px; flex:1; padding:6px 8px; color:inherit; background:transparent; border:1px solid #69717a; border-radius:5px; }
 .pixel-source-find button { padding:6px; border:1px solid #69717a; border-radius:5px; }
 .pixel-source-find button:disabled { opacity:.4; }
+.pixel-source-find input[type=checkbox] { min-width:0; flex:none; }
+.pixel-source-find form { display:flex; gap:8px; }
+.pixel-source-find input[type=number] { width:80px; min-width:60px; flex:none; }
 .pixel-source-find [role=status] { flex-basis:100%; padding:0; }
 .pixel-preview-source [data-source-find-current] { background:#e9ac3328; outline:1px solid #b78c40; outline-offset:-1px; }


### PR DESCRIPTION
Navigate verified source by exact line number and optionally match case in literal searches. Direct jumps and searches share one highlighted line; editing the search returns control to matches. Line bounds match the rendered code rows, including a trailing newline.

## Why this matters
Workbench users investigating an error with a file/line reference previously had to scroll or guess a text query. The inspector now reaches that line directly, and case-sensitive search distinguishes identifiers without executing source or changing verified text.

## Overlap check
Searched open/closed source go-line/navigation/case-sensitive and PixelSourceFind files in the recent PR inventory. #4145 introduced case-insensitive line search, not direct jumps or match-case. #4223 and #4226 change source copying/classification and will be checked together; this PR changes only the search component, styling and public source-inspector tests.

## Validation
- Two new inspector tests fail on public-beta f5f49b7d.
- 17 source/find/download tests pass on Node 20: bounded navigation, unchanged code text, case matching, failed-verification exclusion and publication reset.
- ESLint, whitespace and scoped pre-commit pass.
- Browser scrolling is asserted through the rendered line target; no live layout claim yet. Shared dashboard path for Linux, macOS and Windows.

No storage changes or migration. Revert removes the controls. No required merge order.

## Final batch validation receipt

Candidate: `dc9ca83733b6df9e7bb510024ad385d1d9c16e7b`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual Chromium exercised case-sensitive literal source matching and selected the correct logical source line while wrap was enabled. Copy/download bytes remained unchanged.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
