### PR TITLE
feat(pixel): inspect custom preview breakpoints

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.jsx
@@ -5,11 +5,19 @@ const sizes = {phone:[375,667], tablet:[768,1024], desktop:[1280,800]}
 export default function PixelPreviewViewport({access, title, hidden}) {
   const [size, setSize] = useState('fit')
   const [rotated, setRotated] = useState(false)
-  const dimensions = sizes[size]
+  const [custom, setCustom] = useState([1024,768])
+  const [draft, setDraft] = useState(['1024','768'])
+  const valid = draft.every(value => /^\d+$/.test(value) && Number(value) >= 240 && Number(value) <= 4096)
+  const dimensions = size === 'custom' ? custom : sizes[size]
   const [width, height] = dimensions ? (rotated ? [...dimensions].reverse() : dimensions) : ['100%', '100%']
   return <section className="pixel-preview-viewport" hidden={hidden} aria-label="Preview viewport">
     <div className="pixel-viewport-controls">
-      <label>Viewport <select aria-label="Preview viewport size" value={size} onChange={event => {setSize(event.target.value); setRotated(false)}}><option value="fit">Fit panel</option><option value="phone">Phone · 375 × 667</option><option value="tablet">Tablet · 768 × 1024</option><option value="desktop">Desktop · 1280 × 800</option></select></label>
+      <label>Viewport <select aria-label="Preview viewport size" value={size} onChange={event => {setSize(event.target.value); setRotated(false)}}><option value="fit">Fit panel</option><option value="phone">Phone · 375 × 667</option><option value="tablet">Tablet · 768 × 1024</option><option value="desktop">Desktop · 1280 × 800</option><option value="custom">Custom dimensions</option></select></label>
+      {size === 'custom' && <form onSubmit={event => {event.preventDefault(); if (valid) {setCustom(draft.map(Number)); setRotated(false)}}}>
+        {['width','height'].map((label,index) => <label key={label}>Viewport {label} <input aria-label={`Viewport ${label}`} type="number" min="240" max="4096" step="1" value={draft[index]} onChange={event => setDraft(previous => previous.map((value,at) => at === index ? event.target.value : value))}/></label>)}
+        <button type="submit" disabled={!valid}>Apply viewport</button>
+        <span>240–4096 CSS pixels per side</span>
+      </form>}
       <button type="button" disabled={!dimensions} aria-pressed={rotated} onClick={() => setRotated(value => !value)}>Rotate viewport</button>
       {dimensions && <span role="status">{width} × {height} CSS pixels</span>}
     </div>

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewViewport.test.jsx
@@ -2,6 +2,29 @@ import {render, screen, fireEvent} from '@testing-library/react'
 import PixelPreviewViewport from './PixelPreviewViewport'
 
 const access = {frameUrl:'/pixel-preview/site-'+'a'.repeat(24)+'/__ods_view__.html',sandbox:'allow-scripts allow-forms allow-downloads',route:'dashboard-relay'}
+it('applies exact custom breakpoints atomically without reloading the verified frame', () => {
+  render(<PixelPreviewViewport access={access} title="Interactive preview" hidden={false}/>)
+  const frame = screen.getByTitle('Interactive preview')
+  fireEvent.change(screen.getByLabelText('Preview viewport size'),{target:{value:'custom'}})
+  const width = screen.getByLabelText('Viewport width'), height = screen.getByLabelText('Viewport height')
+  fireEvent.change(width,{target:{value:'1023'}})
+  fireEvent.change(height,{target:{value:'900'}})
+  expect(frame.style.width).toBe('1024px')
+  fireEvent.click(screen.getByRole('button',{name:'Apply viewport'}))
+  expect(frame.style.width).toBe('1023px')
+  expect(frame.style.height).toBe('900px')
+  for(const value of ['', '0', '4097', '300.5']) {
+    fireEvent.change(width,{target:{value}})
+    expect(screen.getByRole('button',{name:'Apply viewport'})).toBeDisabled()
+    expect(frame.style.width).toBe('1023px')
+  }
+  fireEvent.click(screen.getByRole('button',{name:'Rotate viewport'}))
+  expect(frame.style.width).toBe('900px')
+  expect(frame.style.height).toBe('1023px')
+  expect(screen.getByTitle('Interactive preview')).toBe(frame)
+  expect(frame).toHaveAttribute('sandbox',access.sandbox)
+  expect(frame).toHaveAttribute('src',access.frameUrl)
+})
 it('changes actual frame dimensions without remounting or changing its authenticated route', () => {
   render(<PixelPreviewViewport access={access} title="Interactive preview" hidden={false}/>)
   const frame = screen.getByTitle('Interactive preview')

--- a/ods/extensions/services/dashboard/src/components/pixel-preview-viewport.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-preview-viewport.css
@@ -3,6 +3,8 @@
 .pixel-viewport-controls { display:flex; flex-wrap:wrap; align-items:center; gap:8px; padding:8px; color:rgb(var(--theme-text-secondary)); font-size:11px; }
 .pixel-viewport-controls select,.pixel-viewport-controls button { padding:5px; border:1px solid rgb(var(--theme-border)); border-radius:5px; background:rgb(var(--theme-bg)); color:inherit; }
 .pixel-viewport-controls button:disabled { opacity:.4; }
+.pixel-viewport-controls form { display:flex; flex-wrap:wrap; align-items:center; gap:8px; }
+.pixel-viewport-controls input { width:78px; padding:5px; border:1px solid rgb(var(--theme-border)); border-radius:5px; background:rgb(var(--theme-bg)); color:inherit; }
 .pixel-viewport-stage { flex:1; min-height:0; min-width:0; overflow:auto; background:rgb(var(--theme-bg)); }
 .pixel-viewport-stage iframe { display:block; max-width:none; border:0; background:#fff; }
 .pixel-viewport-note { margin:0; padding:6px 8px; font-size:10px; color:rgb(var(--theme-text-muted)); }

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -359,6 +359,9 @@ test('compact views keep the connection draft and never apply changes on navigat
   render(createElement(RemoteProvider, { compact: true }))
   await screen.findByRole('button', { name: 'Connection', exact: true })
   expect(screen.queryByRole('heading', { name: 'Egress' })).toBeNull()
+  // The tab exists before the status-to-form effect has hydrated the fields.
+  // Start this navigation test from a fully loaded connection draft.
+  await waitFor(() => expect(screen.getByLabelText('Base URL')).toHaveValue(statusPayload.routeState.provider.baseUrl))
   fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://draft.example/v1' } })
   fireEvent.click(screen.getByRole('button', { name: 'Diagnostics', exact: true }))
   expect(screen.getByRole('heading', { name: 'Egress' })).toBeVisible()


### PR DESCRIPTION
Add custom preview dimensions with explicit Apply, rotation and bounded integer inputs. Keep the current iframe alive while changing its CSS viewport.

## Why this matters
Fixed phone/tablet/desktop presets cannot inspect a layout immediately below a specific CSS breakpoint. Operators can now use exact dimensions from 240 to 4096 CSS pixels per side. Editing incomplete input does not resize the running page; Apply commits both dimensions together. This does not emulate device/browser/touch behavior, as the existing UI explains.

## Overlap check
Searched open/closed preview custom viewport dimensions and PixelPreviewViewport files. #4148 introduced fixed responsive presets; it has no custom input. No other matching PR found. Changed files are the existing viewport component, stylesheet and public component test.

## Validation
- Custom-breakpoint regression fails on public-beta f5f49b7d.
- 79 viewport and Pixel page tests pass on Node 20, covering atomic Apply, invalid input, rotation, iframe identity, unchanged authenticated route and sandbox.
- ESLint, whitespace and scoped pre-commit pass.
- DOM tests verify dimensions and identity, not browser rendering at each breakpoint. Shared dashboard implementation covers all host platforms.

No persistence, migration or required merge order. Revert removes custom controls; preview routing is unchanged.

## Final batch validation receipt

Candidate: `5148dc0c8fc833b7165bb59649aefa60d13b3426`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Follow-up 5148dc0c carries the same awaited RemoteProvider test hydration fix as #4223; retain one identical assertion when merging both. Actual Chromium iframe measured 1023x900 CSS pixels, then 900x1023 after rotation, with unchanged script execution marker. Invalid input could not apply.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
