### PR TITLE
feat(pixel): review local file contents before draft insertion

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelTextFileInput.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTextFileInput.jsx
@@ -33,7 +33,7 @@ export default function PixelTextFileInput({ input, disabled, limit, onInsert })
       try {
         const text = new TextDecoder('utf-8', {fatal:true}).decode(next.result)
         if (text.includes('\0')) throw new Error('Binary content')
-        setFile({name:selected.name, text:quotedFile(selected.name, text)})
+        setFile({name:selected.name, content:text, bytes:selected.size, text:quotedFile(selected.name, text)})
       } catch { setError('The file must contain valid UTF-8 text, without binary bytes.') }
     }
     next.onerror = () => { setReading(false); setError('The file could not be read. Choose it again.') }
@@ -47,6 +47,10 @@ export default function PixelTextFileInput({ input, disabled, limit, onInsert })
     {error && <p role="alert">{error}</p>}
     {file && <div role="group" aria-label="Review text file">
       <p>{file.name} · Text will be inserted into your draft. It is sent to the selected model only when you send the message.</p>
+      <p>Bytes: {file.bytes.toLocaleString()} · Lines: {file.content.replace(/\n$/u, '').split('\n').length.toLocaleString()}</p>
+      <details open><summary>Review file contents</summary>
+        <pre role="region" aria-label="Local file contents" tabIndex={0} className="my-2 max-h-48 overflow-auto whitespace-pre rounded border border-theme-border bg-theme-bg p-2 text-theme-text">{file.content}</pre>
+      </details>
       {!fits && <p role="alert">The file and draft exceed the message limit. Shorten the draft or choose a smaller file.</p>}
       <button type="button" disabled={disabled || !fits} onClick={() => { onInsert(file.text); setFile(null) }}>Insert file text</button>
       <button type="button" onClick={() => setFile(null)}>Discard file</button>

--- a/ods/extensions/services/dashboard/src/components/PixelTextFileInput.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTextFileInput.test.jsx
@@ -3,6 +3,22 @@ import PixelTextFileInput from './PixelTextFileInput'
 
 const upload = file => fireEvent.change(screen.getByLabelText('Choose text file'), {target:{files:[file]}})
 const props = {input:'Analyze this', limit:16384, disabled:false}
+it('shows exact file contents as inert text before explicit insertion and clears discarded content', async () => {
+  const insert = vi.fn()
+  const {container} = render(<PixelTextFileInput {...props} onInsert={insert}/>)
+  const text = '<script>doNotRun()</script>\r\nUnicode: Việt\r\n'
+  upload(new File([text], 'review.html', {type:'text/html'}))
+  const review = await screen.findByLabelText('Local file contents')
+  expect(review.textContent).toBe(text)
+  expect(container.querySelector('script')).toBeNull()
+  expect(screen.getByText(/Lines: 2/)).toBeVisible()
+  expect(insert).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button',{name:'Discard file'}))
+  expect(screen.queryByLabelText('Local file contents')).toBeNull()
+  upload(new File(['Replacement'], 'replacement.txt'))
+  expect((await screen.findByLabelText('Local file contents')).textContent).toBe('Replacement')
+  expect(screen.queryByText(/doNotRun/)).toBeNull()
+})
 it('stages exact Unicode/CRLF text without sending and inserts only on confirmation', async () => {
   const insert = vi.fn()
   render(<PixelTextFileInput {...props} onInsert={insert}/>)
@@ -33,7 +49,7 @@ it('rechecks the current draft budget and working state before insertion', async
   const insert = vi.fn()
   const {rerender} = render(<PixelTextFileInput {...props} onInsert={insert}/>)
   upload(new File(['hello'], 'a.txt'))
-  await screen.findByRole('group')
+  await screen.findByRole('group', {name:'Review text file'})
   rerender(<PixelTextFileInput {...props} input={'x'.repeat(16380)} onInsert={insert}/>)
   expect(screen.getByRole('button', {name:'Insert file text'})).toBeDisabled()
   rerender(<PixelTextFileInput {...props} disabled onInsert={insert}/>)


### PR DESCRIPTION
Show local text-file contents before inserting them into the Pixel draft. The staged review includes byte and line counts and a bounded, keyboard-scrollable plain-text region that can be collapsed.

## Why this matters
The existing review displayed only the filename. Operators can now inspect the actual content they selected, including long lines and code, before changing their draft. Source is rendered as inert text; insertion and sending retain their existing separate explicit actions.

## Overlap check
Searched open/closed text file preview/review contents and PixelTextFileInput.jsx file history. #4140 introduced bounded staging/insertion; #4207 changed workspace presentation. Neither provides content review. No matching open PR found.

## Validation
- Public upload/review regression fails on public-beta f5f49b7d.
- 14 file/composer tests pass on Node 20: exact Unicode and CRLF review, no executable markup, discard/replacement cleanup, explicit insertion, size/type/UTF-8 rejection, draft-budget recheck and reader cleanup.
- ESLint, whitespace and scoped pre-commit pass.
- No network calls or persistent storage added. File reads remain capped at 16 KB. Shared browser code covers Linux, macOS and Windows; actual file-dialog/browser layout QA remains separate.

No migration or merge dependency. Revert removes the review region only.

## Final batch validation receipt

Candidate: `317ebd49c05145f6854f2f5a77ab2f019c842fcc`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Mobile Chromium displayed the full decoded file as inert text and preserved the draft until explicit Insert file text. The browser probe includes literal script markup and Unicode.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
