### PR TITLE
fix(dashboard): retain video resources across gallery refreshes

### DIFF
--- a/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/ThemeContext.jsx
@@ -29,7 +29,12 @@ export function ThemeProvider({ children }) {
       const revision = ++galleryRevision.current
       return readCustomWallpapers().then(rows => {
         if (!active || revision !== galleryRevision.current) return
-        setCustom(rows)
+        setCustom(previous => {
+          // Stored records are immutable: imports allocate new IDs. IndexedDB
+          // clones Blobs on reads; retain live resources for unchanged IDs.
+          const existing = new Map(previous.map(row => [row.id,row]))
+          return rows.map(row => existing.get(row.id) ?? row)
+        })
         setWallpaperError('')
         setThemeState(previous => isCustomWallpaper(previous) && !rows.some(row => row.id === previous) ? DEFAULT_THEME : previous)
       }).catch(error => { if (active && revision === galleryRevision.current) setWallpaperError(error.message) })

--- a/ods/extensions/services/dashboard/src/contexts/WallpaperContinuity.test.jsx
+++ b/ods/extensions/services/dashboard/src/contexts/WallpaperContinuity.test.jsx
@@ -1,0 +1,51 @@
+import {render, screen, fireEvent, act, cleanup} from '@testing-library/react'
+import {ThemeProvider, useTheme} from './ThemeContext'
+import WallpaperVideo from '../components/WallpaperVideo'
+import {readCustomWallpapers} from '../lib/customWallpapers'
+
+vi.mock('../lib/customWallpapers', async original => ({...await original(),readCustomWallpapers:vi.fn()}))
+const id = 'custom-11111111-2222-4333-8444-555555555555'
+const movie = () => ({id,name:'Movie',kind:'video',image:'data:image/webp;base64,YQ==',video:new Blob(['movie'],{type:'video/webm'})})
+function Stage() {
+  const {wallpapers,setTheme} = useTheme()
+  return <><WallpaperVideo/>{wallpapers.map(row => <button key={row.id} onClick={()=>setTheme(row.id)}>{row.name}</button>)}</>
+}
+beforeEach(()=>{
+  localStorage.clear()
+  localStorage.setItem('ods-theme',id)
+  readCustomWallpapers.mockReset().mockImplementation(async()=>[movie()])
+  vi.stubGlobal('matchMedia',()=>({matches:false,addEventListener:vi.fn(),removeEventListener:vi.fn()}))
+  vi.stubGlobal('URL',Object.assign(class extends URL {},{createObjectURL:vi.fn(()=>`blob:movie`),revokeObjectURL:vi.fn()}))
+  vi.spyOn(window.HTMLMediaElement.prototype,'play').mockResolvedValue(undefined)
+  vi.spyOn(window.HTMLMediaElement.prototype,'pause').mockImplementation(()=>{})
+})
+afterEach(()=>{cleanup();vi.restoreAllMocks();vi.unstubAllGlobals()})
+
+it('keeps the playing resource on focus refresh but releases it when storage removes the video',async()=>{
+  const {container}=render(<ThemeProvider><Stage/></ThemeProvider>)
+  await screen.findByRole('button',{name:'Movie'})
+  const video=container.querySelector('video')
+  video.currentTime=12
+  await act(async()=>window.dispatchEvent(new Event('focus')))
+  expect(readCustomWallpapers).toHaveBeenCalledTimes(2)
+  expect(URL.createObjectURL).toHaveBeenCalledTimes(1)
+  expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+  expect(container.querySelector('video')).toBe(video)
+  expect(video.currentTime).toBe(12)
+  readCustomWallpapers.mockResolvedValue([])
+  await act(async()=>window.dispatchEvent(new Event('focus')))
+  expect(container.querySelector('video')).toBeNull()
+  expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:movie')
+  expect(localStorage.getItem('ods-theme')).toBe('ods')
+})
+
+it('still discovers and selects newly added records after a refresh',async()=>{
+  render(<ThemeProvider><Stage/></ThemeProvider>)
+  await screen.findByRole('button',{name:'Movie'})
+  const image={id:'custom-aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee',name:'New image',image:'data:image/png;base64,Yg=='}
+  readCustomWallpapers.mockResolvedValue([movie(),image])
+  await act(async()=>window.dispatchEvent(new Event('focus')))
+  fireEvent.click(screen.getByRole('button',{name:'New image'}))
+  expect(document.documentElement).toHaveAttribute('data-wallpaper',image.id)
+  expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:movie')
+})


### PR DESCRIPTION
Preserve a playing wallpaper resource when the gallery refreshes on window focus. Reuse existing immutable wallpaper records by ID while still accepting newly added rows and removing deleted rows.

## Why this matters
IndexedDB getAll clones stored Blobs. Each focus refresh therefore replaced the video Blob identity, revoked its URL and loaded a new URL, restarting an unchanged background. The regression runs the real ThemeProvider and WallpaperVideo together and observes this resource replacement.

## Overlap check
Searched open/closed wallpaper focus restart and ThemeContext/WallpaperVideo file history. #4216 introduced video storage/playback. #4222 handles interrupted play promises; #4231 orders imports against newer user selections. Neither prevents unchanged IndexedDB reads from recreating media URLs. This scope has its own resource-lifetime invariant and integrates with both.

## Validation
- Focus-refresh regression fails on public-beta f5f49b7d: two object URLs for the same unchanged record.
- 20 theme/gallery/video/storage tests pass on Node 20, including unchanged resource identity, deletion cleanup and newly discovered image selection.
- ESLint, whitespace and scoped pre-commit pass.
- Media playback is mocked: tests prove URL lifecycle, not decoder behavior. Shared browser implementation covers all host platforms.

Imports always allocate new wallpaper IDs; the storage API has no in-place edit operation. Future in-place edits must add a revision before reusing this identity contract. No migration. Revert restores prior refresh behavior. No required merge order.

## Final batch validation receipt

Candidate: `15fa5a5c3a2358c69c31bbd413aade443dcaff9f`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual Chromium decoded and played an IndexedDB-backed WebM. Focus refresh retained the same Blob URL and caused zero new loadstart events. Pause/resume and a later pending import also passed.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
