### PR TITLE
fix(api): close pooled LLM client at application shutdown

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -139,6 +139,15 @@ async def _get_httpx_client() -> httpx.AsyncClient:
     return _httpx_client
 
 
+async def shutdown_llm_client() -> None:
+    """Close the pooled LLM client after application users have stopped."""
+    global _httpx_client, _httpx_client_lock
+    if _httpx_client is not None:
+        await _httpx_client.aclose()
+        _httpx_client = None
+    _httpx_client_lock = None
+
+
 def _service_status_from_config(service_id: str, config: dict, status: str) -> ServiceStatus:
     return ServiceStatus(
         id=service_id, name=config["name"], port=config["port"],

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -52,7 +52,7 @@ from helpers import (
     get_disk_usage, dir_size_gb, get_model_info, get_bootstrap_status,
     get_uptime, get_cpu_metrics, get_ram_metrics,
     get_llama_metrics, get_loaded_model, get_llama_context_size,
-    _get_httpx_client, shutdown_service_health_client,
+    _get_httpx_client, shutdown_service_health_client, shutdown_llm_client,
 )
 from context_policy import HERMES_MIN_CONTEXT, HERMES_TARGET_CONTEXT
 from host_agent_client import (
@@ -1064,7 +1064,10 @@ async def _lifespan(app: FastAPI):
         try:
             await shutdown_agent_clients()
         finally:
-            await shutdown_service_health_client()
+            try:
+                await shutdown_service_health_client()
+            finally:
+                await shutdown_llm_client()
 
 
 app = FastAPI(

--- a/ods/extensions/services/dashboard-api/tests/test_llm_client_lifespan.py
+++ b/ods/extensions/services/dashboard-api/tests/test_llm_client_lifespan.py
@@ -1,0 +1,40 @@
+"""The application lifetime owns the pooled LLM HTTP client."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import helpers
+import main
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("health_failure", [False, True])
+async def test_lifespan_closes_llm_pool_and_allows_a_fresh_lifetime(monkeypatch, health_failure):
+    monkeypatch.setattr(helpers, "_httpx_client", None)
+    monkeypatch.setattr(helpers, "_httpx_client_lock", None)
+    for name in ("collect_metrics", "_poll_service_health", "shutdown_agent_clients"):
+        monkeypatch.setattr(main, name, AsyncMock())
+    monkeypatch.setattr(main.gpu_router, "poll_gpu_history", AsyncMock())
+    health_close = AsyncMock(side_effect=RuntimeError("health cleanup failed") if health_failure else None)
+    monkeypatch.setattr(main, "shutdown_service_health_client", health_close)
+
+    context = main._lifespan(main.app)
+    await context.__aenter__()
+    client = await helpers._get_httpx_client()
+    assert not client.is_closed
+    if health_failure:
+        with pytest.raises(RuntimeError, match="health cleanup failed"):
+            await context.__aexit__(None, None, None)
+    else:
+        await context.__aexit__(None, None, None)
+    assert client.is_closed
+    assert helpers._httpx_client is None
+    assert helpers._httpx_client_lock is None
+
+    health_close.side_effect = None
+    async with main._lifespan(main.app):
+        fresh = await helpers._get_httpx_client()
+        assert fresh is not client
+        assert not fresh.is_closed
+    assert fresh.is_closed


### PR DESCRIPTION
Close the shared LLM httpx client at dashboard-api shutdown and reset its lazy client/lock state for a subsequent application lifetime. Run that cleanup even if the existing health-client cleanup raises.

## Why this matters
The pooled client is used by model information, model listing and performance probes. The app stopped its pollers but retained this client across shutdown, leaving its connection pool open and potentially reusing an old event-loop resource during a new lifespan.

Issue #4198 overstates the current defect: clients are created lazily, not at import, and aiohttp already has shutdown cleanup. This PR fixes only the confirmed missing httpx lifecycle. Fixes #4198.

## Overlap check
Searched open/closed httpx shutdown/client and helpers.py/main.py file history. #3740/#3992 concern remote-provider egress pools; #3499 concerns the LiteLLM Token Spy callback. None closes this dashboard LLM pool. The existing health/resolver and host-agent cleanup remain separate and run before LLM cleanup.

## Validation
- Both application-lifespan regressions fail on public-beta f5f49b7d.
- 130 lifespan/health/helper tests pass on Windows Python; 2 existing platform skips.
- Tests use real httpx client objects, verify close, cleared lock/client, fresh second lifetime, and propagated health cleanup failure. No live inference server or socket traffic is required.
- Scoped pre-commit and whitespace checks pass. Ruff reports 9 existing W293 blank-line warnings in unrelated helpers.py code; no new lint diagnostic.

Linux, macOS and Windows use this shared FastAPI lifetime. No config/storage migration; revert restores previous cleanup. In-flight foreground requests are drained by the ASGI server before lifespan teardown, and background pollers are cancelled and awaited first.

## Final batch validation receipt

Candidate: `b247e4e55fea3ecea4e2c39b053e9ff45b2c8aa6`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
