### PR TITLE
feat(pixel): wrap long verified source lines for reading

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -17,6 +17,7 @@ export default function PixelPreviewSource({ preview, file }) {
   const [error, setError] = useState('')
   const [copied, setCopied] = useState(false)
   const [attempt, setAttempt] = useState(0)
+  const [wrapLines, setWrapLines] = useState(false)
   const codeRef = useRef(null)
   useEffect(() => {
     let current = true
@@ -40,13 +41,13 @@ export default function PixelPreviewSource({ preview, file }) {
     try { await navigator.clipboard.writeText(source); setCopied(true); setError('') }
     catch { setCopied(false); setError('Clipboard access failed. You can select and copy the code manually.') }
   }
-  return <section className="pixel-preview-source pixel-original-source" aria-label={path === 'index.html' ? 'Published HTML source' : `Source: ${path}`}>
+  return <section className="pixel-preview-source pixel-original-source" data-wrap-lines={wrapLines} aria-label={path === 'index.html' ? 'Published HTML source' : `Source: ${path}`}>
     {source === null && binarySize === null && !error && <p role="status">Verifying source…</p>}
     {binarySize !== null && <p role="status">Binary asset. Its bytes are verified; no text source is available.</p>}
     {error && <div role="alert"><p>{error}</p><button type="button" onClick={() => setAttempt(value => value + 1)}>Retry source</button></div>}
     <div className="pixel-code-block">
       <header className="code-block-header"><PixelLanguageBadge path={path}/><span title={path}>{path}</span><PixelArtifactDownload key={`${preview.siteId}/${path}/${expectedDigest}`} preview={preview} file={{path, sha256:expectedDigest, bytes:file?.bytes}}/>{language && <button type="button" aria-label="Copy code" onClick={copy} disabled={source === null}>{copied ? 'Copied' : 'Copy'}</button>}</header>
-      {source !== null && <><PixelSourceFind key={`${preview.siteId}/${path}/${expectedDigest}`} source={source} codeRef={codeRef}/><pre ref={codeRef} tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre></>}
+      {source !== null && <><div className="p-2 text-xs"><button type="button" aria-pressed={wrapLines} onClick={() => setWrapLines(value => !value)}>Wrap lines</button></div><PixelSourceFind key={`${preview.siteId}/${path}/${expectedDigest}`} source={source} codeRef={codeRef}/><pre ref={codeRef} tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre></>}
 
     </div>
     {(source !== null || binarySize !== null) && <p className="pixel-source-verification">Published snapshot · SHA-256 verified{binarySize !== null ? ` · ${binarySize.toLocaleString()} bytes` : ''}</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelSourceWrap.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSourceWrap.test.jsx
@@ -1,0 +1,31 @@
+import {webcrypto, createHash} from 'node:crypto'
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+
+const source = '<div>'+ 'long-unbroken-content'.repeat(80) + '</div>\r\nsecond line\r\n'
+const digest = createHash('sha256').update(source).digest('hex')
+const preview = {siteId:'site-'+'a'.repeat(24),entrySha256:digest}
+beforeEach(()=>{
+  vi.stubGlobal('crypto',webcrypto)
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,arrayBuffer:async()=>new TextEncoder().encode(source).buffer})))
+  Object.defineProperty(navigator,'clipboard',{configurable:true,value:{writeText:vi.fn().mockResolvedValue(undefined)}})
+})
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks();delete navigator.clipboard})
+
+it('wraps verified source for reading without changing logical lines, copying or refetching',async()=>{
+  const {container}=render(<PixelPreviewSource preview={preview}/>)
+  const toggle=await screen.findByRole('button',{name:'Wrap lines'})
+  const code=screen.getByLabelText('Code for index.html')
+  expect(toggle).toHaveAttribute('aria-pressed','false')
+  fireEvent.click(toggle)
+  expect(toggle).toHaveAttribute('aria-pressed','true')
+  expect(code.closest('section')).toHaveAttribute('data-wrap-lines','true')
+  expect(code.textContent).toBe(source)
+  expect(container.querySelectorAll('[data-line]')).toHaveLength(2)
+  fireEvent.click(screen.getByRole('button',{name:'Copy code'}))
+  await waitFor(()=>expect(navigator.clipboard.writeText).toHaveBeenCalledWith(source))
+  fireEvent.click(toggle)
+  expect(code.closest('section')).toHaveAttribute('data-wrap-lines','false')
+  expect(code.textContent).toBe(source)
+  expect(fetch).toHaveBeenCalledTimes(1)
+})

--- a/ods/extensions/services/dashboard/src/components/pixel-source-find.css
+++ b/ods/extensions/services/dashboard/src/components/pixel-source-find.css
@@ -4,3 +4,6 @@
 .pixel-source-find button:disabled { opacity:.4; }
 .pixel-source-find [role=status] { flex-basis:100%; padding:0; }
 .pixel-preview-source [data-source-find-current] { background:#e9ac3328; outline:1px solid #b78c40; outline-offset:-1px; }
+.pixel-preview-source[data-wrap-lines=true] pre > code { min-width:0; }
+.pixel-preview-source[data-wrap-lines=true] .code-line { min-width:0; grid-template-columns:44px minmax(0,1fr); }
+.pixel-preview-source[data-wrap-lines=true] .code-line-content { white-space:pre-wrap; overflow-wrap:anywhere; }


### PR DESCRIPTION
Add an explicit Wrap lines reading mode to the verified source inspector. Long unbroken lines can fit the panel while retaining one gutter number per original source line.

## Why this matters
Published HTML, CSS and JSON can contain very long lines. The current max-content grid forces horizontal navigation even in narrow Workbench panels. Wrapping changes only layout: SHA-256 verification, original text, logical line numbers, search and copy continue using the exact source.

## Overlap check
Searched open/closed source wrap lines and the source-inspector file inventory. #4145 adds search; #4233 adds line navigation and case matching; neither wraps long source lines. #4223/#4226 affect copying and source classification. All shared-file combinations are part of final batch validation.

## Validation
- The public inspector regression fails on public-beta f5f49b7d.
- 15 source/find/clipboard tests pass on Node 20. The regression preserves exact CRLF text and logical line count, copies original bytes as text, and does not refetch when toggling layout.
- ESLint, scoped pre-commit and whitespace checks pass.
- DOM assertions prove controls and source integrity; final browser QA is needed to measure wrapping in the actual CSS grid. Shared dashboard code covers all host platforms.

The preference is session-local to the inspector. No persistence, migration or required merge order; revert restores the previous single layout mode.

## Final batch validation receipt

Candidate: `9e6a0049c44ac225310934a12263f2315981d38b`; target: `public-beta`. Latest observed checks: 32 success, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual Chromium at 390px and 1280px wrapped a 13,395px source line into the available code width, kept logical line navigation correct, and copied/downloaded identical 2,043-byte CRLF content.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
