### PR TITLE
feat(pixel): find and navigate messages in the current conversation

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationFind.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationFind.jsx
@@ -1,0 +1,53 @@
+import {useMemo, useRef, useState} from 'react'
+import {createPortal} from 'react-dom'
+
+const PAGE_SIZE = 25
+
+export default function PixelConversationFind({messages, onNavigate}) {
+  const dialog = useRef(null), trigger = useRef(null), input = useRef(null)
+  const [query,setQuery] = useState('')
+  const [page,setPage] = useState(0)
+  const matches = useMemo(() => {
+    const needle = query.trim().toLocaleLowerCase()
+    if (!needle) return []
+    return messages.flatMap((message,index) => {
+      if (!['user','assistant'].includes(message.role) || typeof message.content !== 'string') return []
+      const at = message.content.toLocaleLowerCase().indexOf(needle)
+      if (at < 0) return []
+      const start = Math.max(0,at - 48), end = Math.min(message.content.length,at + needle.length + 120)
+      return [{index,role:message.role === 'user' ? 'prompt' : 'reply',excerpt:`${start ? '…' : ''}${message.content.slice(start,end)}${end < message.content.length ? '…' : ''}`}]
+    })
+  },[messages,query])
+  const lastPage = Math.max(0,Math.ceil(matches.length / PAGE_SIZE) - 1)
+  const currentPage = Math.min(page,lastPage)
+  const shown = matches.slice(currentPage * PAGE_SIZE,(currentPage + 1) * PAGE_SIZE)
+  function close(restore = true) {
+    dialog.current.close()
+    const options = trigger.current.closest('details')
+    options?.removeAttribute('open')
+    if (restore) (options?.querySelector('summary') || trigger.current).focus()
+  }
+  function choose(match) {if (match) {close(false); onNavigate(match.index)}}
+  return <>
+    <button ref={trigger} type="button" className="block p-2 text-xs" disabled={!messages.length} onClick={() => {dialog.current.showModal(); input.current.focus()}}>Find in this conversation</button>
+    {createPortal(<dialog ref={dialog} className="chat-delete-dialog" style={{maxHeight:'calc(100dvh - 32px)',overflowY:'auto'}} aria-label="Find in this conversation" onCancel={event => {event.preventDefault();close()}}>
+      <h3>Find in this conversation</h3>
+      <input ref={input} type="search" aria-label="Search message text" placeholder="Find a word or phrase" maxLength={1000} value={query} className="my-2 w-full rounded border border-theme-border bg-theme-bg p-2 text-theme-text" onChange={event => {setQuery(event.target.value);setPage(0)}} onKeyDown={event => {
+        if (event.nativeEvent.isComposing) return
+        if (event.key === 'Enter') {event.preventDefault();choose(shown[0])}
+      }}/>
+      <p role="status">{!query.trim() ? 'Search prompts and replies in this conversation.' : !matches.length ? 'No matching messages.' : `${matches.length} matching message${matches.length === 1 ? '' : 's'} · Showing ${currentPage * PAGE_SIZE + 1}–${currentPage * PAGE_SIZE + shown.length}`}</p>
+      <ul>{shown.map(match => <li key={match.index} className="my-2">
+        <button type="button" aria-label={`Go to ${match.role} message ${match.index + 1}`} className="w-full rounded border border-theme-border p-2 text-left text-xs" onClick={() => choose(match)}>
+          <strong>{match.role === 'prompt' ? 'Prompt' : 'Reply'} · Message {match.index + 1}</strong>
+          <span className="mt-1 block whitespace-pre-wrap break-words">{match.excerpt}</span>
+        </button>
+      </li>)}</ul>
+      {lastPage > 0 && <div className="flex gap-3 text-xs">
+        <button type="button" disabled={!currentPage} onClick={() => setPage(currentPage - 1)}>Previous results</button>
+        <button type="button" disabled={currentPage === lastPage} onClick={() => setPage(currentPage + 1)}>Next results</button>
+      </div>}
+      <footer><button type="button" onClick={() => close()}>Close message search</button></footer>
+    </dialog>,document.body)}
+  </>
+}

--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -19,6 +19,7 @@ import PixelSelectionActions from '../components/PixelSelectionActions'
 import PixelTaskFiles from '../components/PixelTaskFiles'
 import PixelTaskActivity from '../components/PixelTaskActivity'
 import PixelTurnNavigation from '../components/PixelTurnNavigation'
+import PixelConversationFind from '../components/PixelConversationFind'
 import PixelSnapshotChanges from '../components/PixelSnapshotChanges'
 import PixelPreviewViewport from '../components/PixelPreviewViewport'
 import PixelPreviewHistory from '../components/PixelPreviewHistory'
@@ -1218,6 +1219,11 @@ export default function Pixel({ systemStatus = null }) {
             <label className="block p-2 text-xs">Send shortcut<select className="mt-1 block w-full rounded border border-theme-border bg-theme-bg p-2" aria-label="Send shortcut" value={sendKey.mode} onChange={event => sendKey.change(event.target.value)}><option value="enter">Enter to send</option><option value="mod-enter">Ctrl/⌘+Enter to send</option></select></label>
             {sendKey.error && <p role="alert" className="p-2 text-xs">{sendKey.error}</p>}
 
+            <PixelConversationFind key={chatIdRef.current} messages={messages} onNavigate={index => {
+              const row = scrollRef.current?.parentElement?.querySelector(`[data-pixel-message-index="${index}"]`)
+              row?.scrollIntoView?.({block:'start', behavior:'auto'})
+              row?.focus?.({preventScroll:true})
+            }}/>
             <PixelTurnNavigation messages={messages} onNavigate={index => {
               const row = scrollRef.current?.parentElement?.querySelector(`[data-pixel-message-index="${index}"]`)
               row?.scrollIntoView?.({block:'start', behavior:'auto'})

--- a/ods/extensions/services/dashboard/src/pages/PixelConversationFind.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelConversationFind.test.jsx
@@ -1,0 +1,70 @@
+import {render} from '../test/test-utils'
+import {screen,fireEvent,within,act} from '@testing-library/react'
+import Pixel from './Pixel'
+import {saveConversation,SELECT_EVENT} from '../lib/pixelConversations'
+
+beforeEach(()=>{
+  localStorage.clear()
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>({available:true,model:'pixel/default'})})))
+  globalThis.HTMLElement.prototype.scrollIntoView=vi.fn()
+  globalThis.HTMLDialogElement.prototype.showModal=function(){this.open=true}
+  globalThis.HTMLDialogElement.prototype.close=function(){this.open=false}
+})
+afterEach(()=>{
+  vi.unstubAllGlobals();vi.restoreAllMocks()
+  delete globalThis.HTMLElement.prototype.scrollIntoView
+  delete globalThis.HTMLDialogElement.prototype.showModal
+  delete globalThis.HTMLDialogElement.prototype.close
+})
+
+it('finds a retained reply and focuses its actual message without editing or sending the draft',async()=>{
+  saveConversation({schema:1,chatId:'find',messages:[{role:'user',content:'First prompt'},{role:'assistant',content:'Earlier [a.*] evidence'},{role:'user',content:'Latest prompt'},{role:'assistant',content:'Latest answer'}],draft:'Keep my draft'})
+  const {container}=render(<Pixel/>);await screen.findByText('Available')
+  fireEvent.click(screen.getByLabelText('Chat options'))
+  fireEvent.click(screen.getByRole('button',{name:'Find in this conversation'}))
+  const dialog=screen.getByRole('dialog',{name:'Find in this conversation'})
+  const input=within(dialog).getByLabelText('Search message text')
+  fireEvent.change(input,{target:{value:'[A.*]'}})
+  expect(within(dialog).getByRole('status')).toHaveTextContent('1 matching message')
+  fireEvent.keyDown(input,{key:'Enter',isComposing:true})
+  expect(dialog).toHaveAttribute('open')
+  fireEvent.click(within(dialog).getByRole('button',{name:'Go to reply message 2'}))
+  const target=container.querySelector('[data-pixel-message-index="1"]')
+  expect(target).toHaveFocus()
+  expect(target.scrollIntoView).toHaveBeenCalledWith({block:'start',behavior:'auto'})
+  expect(screen.queryByRole('dialog')).toBeNull()
+  expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue('Keep my draft')
+  expect(fetch.mock.calls.some(([url])=>url==='/api/pixel/chat/stream')).toBe(false)
+})
+
+it('pages through duplicate matches, reports no results, and restores focus on cancel',async()=>{
+  saveConversation({schema:1,chatId:'many',messages:Array.from({length:60},(_,index)=>({role:index%2?'assistant':'user',content:'Repeated evidence '+index}))})
+  render(<Pixel/>);await screen.findByText('Available')
+  const options=screen.getByLabelText('Chat options')
+  fireEvent.click(options)
+  fireEvent.click(screen.getByRole('button',{name:'Find in this conversation'}))
+  const dialog=screen.getByRole('dialog',{name:'Find in this conversation'})
+  fireEvent.change(within(dialog).getByLabelText('Search message text'),{target:{value:'evidence'}})
+  expect(within(dialog).getAllByRole('button',{name:/Go to .* message/})).toHaveLength(25)
+  fireEvent.click(within(dialog).getByRole('button',{name:'Next results'}))
+  expect(within(dialog).getByRole('button',{name:'Go to reply message 26'})).toBeVisible()
+  fireEvent.change(within(dialog).getByLabelText('Search message text'),{target:{value:'not present'}})
+  expect(within(dialog).getByRole('status')).toHaveTextContent('No matching messages')
+  fireEvent.click(within(dialog).getByRole('button',{name:'Close message search'}))
+  expect(options).toHaveFocus()
+})
+
+it('closes and clears message search when switching conversations',async()=>{
+  saveConversation({schema:1,chatId:'other',messages:[{role:'user',content:'Other conversation'}]})
+  saveConversation({schema:1,chatId:'current',messages:[{role:'user',content:'Current conversation'}]})
+  render(<Pixel/>);await screen.findByText('Available')
+  fireEvent.click(screen.getByLabelText('Chat options'))
+  fireEvent.click(screen.getByRole('button',{name:'Find in this conversation'}))
+  fireEvent.change(screen.getByLabelText('Search message text'),{target:{value:'Current'}})
+  act(()=>window.dispatchEvent(new CustomEvent(SELECT_EVENT,{detail:'other'})))
+  expect(screen.queryByRole('dialog',{name:'Find in this conversation'})).toBeNull()
+  const options=screen.getByLabelText('Chat options')
+  if (!options.closest('details').open) fireEvent.click(options)
+  fireEvent.click(screen.getByRole('button',{name:'Find in this conversation'}))
+  expect(screen.getByLabelText('Search message text')).toHaveValue('')
+})

--- a/ods/tests/pixel_inference/test_advice_setup_process.py
+++ b/ods/tests/pixel_inference/test_advice_setup_process.py
@@ -19,7 +19,8 @@ pytestmark=pytest.mark.skipif(sys.platform!='linux',reason='Linux process-state 
 
 def live(pid):
     try: return Path(f'/proc/{pid}/stat').read_text().split(') ',1)[1].split()[0]!='Z'
-    except FileNotFoundError: return False
+    # A process can disappear after procfs opens stat but before read completes.
+    except (FileNotFoundError, ProcessLookupError): return False
 
 
 def until(check,seconds=5):


### PR DESCRIPTION
Find a specific prompt or reply within the current Pixel conversation. Search literal text case-insensitively, show excerpts around matches in pages of 25, and navigate directly to the selected message's existing focus/scroll target.

## Why this matters
Global search can locate a conversation containing an old reply, but opening that chat does not locate the matching message. The new Chat options action lets users choose the exact retained message, including repeated text, without changing the draft or sending a request. Search is reset when the conversation changes.

## Overlap check
Searched open/closed search within conversation and find current conversation plus Pixel navigation/search file history. #4142 searches across conversations; #4154 jumps by user-turn outline; #4219 preserves reading position while streaming. None offers a searchable prompt/reply index inside the current conversation. This complements those paths and reuses the existing message navigation boundary.

## Validation
- Two page-level regressions fail on public-beta f5f49b7d.
- Final 10 message-find/turn-navigation/global-content-search tests pass on Node 20: exact selected message focus, repeated-match pagination, no results, IME Enter, cancel focus, conversation-switch cleanup, unchanged draft and no inference POST.
- ESLint, scoped pre-commit and whitespace checks pass.
- Native dialog layout and message focus passed final Chromium QA. Shared dashboard behavior covers Linux, macOS and Windows.

Only retained prompt/reply text is indexed; metadata is excluded, and no remote search or persisted index is created. Revert removes this local navigation control. No required merge order.

## Final batch validation receipt

Candidate: `aa661cea31f5d27fd4f48987ab5384413105fe2f`; target: `public-beta`. Latest observed checks: 29 success, 3 in_progress, 4 skipped.

The synthetic 20-PR production candidate `14137c9a` passed **934 dashboard tests, 2,709 API tests (1 skipped), 34 preview broker tests, dashboard lint and build**. Final batch head `62d00a61` adds only the procfs test follow-up, verified with six actual process scenarios. [Evidence, browser screenshots, merge resolutions and release-gate limitations](https://github.com/tang-vu/DreamServer/blob/integration/beta-quality-20260911/docs/validation/beta-quality-batch-20260911.md).

Actual mobile Chromium exercised native dialog search, 60-match pagination, exact selected-message focus, and unchanged draft. Follow-up aa661cea fixes an existing CI process-observation race: ProcessLookupError during an opened /proc/<pid>/stat read also means the process exited. Six actual parent-loss scenarios pass after the fix. The original Ubuntu distro job separately failed to download prerequisites from archive.ubuntu.com; the latest exact-head checks are recorded below.

The full local release gate is not green: unchanged root/WSL/disk-sensitive shell fixtures and the Linux simulation receipt remain unsuccessful. No hardware installation or live inference claim is made. See the linked report for exact failing gates, tested merge order and rollback limits.
