### PR TITLE
Point the Tauri config schema at this project's generated schema

### DIFF
--- a/installer/src-tauri/tauri.conf.json
+++ b/installer/src-tauri/tauri.conf.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/nicegui/tauri-v2/main/src-tauri/gen/schemas/desktop-schema.json",
+  "$schema": "gen/schemas/desktop-schema.json",
   "productName": "ODS Installer",
   "version": "0.1.0",
   "identifier": "ai.ods.installer",


### PR DESCRIPTION
$schema referenced raw.githubusercontent.com/nicegui/tauri-v2/..., so editor validation depended on a third party's file and on network access. Points it at the local gen/schemas/desktop-schema.json that Tauri generates for this project.