### PR TITLE
Make the Close buttons actually close the installer

### DIFF
--- a/installer/src-tauri/capabilities/default.json
+++ b/installer/src-tauri/capabilities/default.json
@@ -4,6 +4,7 @@
   "description": "Default capability for the installer",
   "windows": ["main"],
   "permissions": [
-    "core:default"
+    "core:default",
+    "core:window:allow-close"
   ]
 }

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWindow } from "@tauri-apps/api/window";
 
 // Types matching Rust structs
 
@@ -112,3 +113,10 @@ export const getInstallState = () =>
   invoke<InstallState>("get_install_state");
 
 export const openODSserver = () => invoke("open_ods");
+
+// Close the installer window.
+//
+// The DOM's window.close() is a no-op in an embedded webview — it only closes
+// windows that script opened — so the Close buttons need the Tauri window API,
+// which also means the capability has to grant core:window:allow-close.
+export const closeInstaller = () => getCurrentWindow().close();

--- a/installer/src/pages/Complete.tsx
+++ b/installer/src/pages/Complete.tsx
@@ -1,5 +1,5 @@
 import Button from "../components/Button";
-import { openODSserver } from "../hooks/useTauri";
+import { closeInstaller, openODSserver } from "../hooks/useTauri";
 
 export default function Complete() {
   return (
@@ -33,7 +33,7 @@ export default function Complete() {
       </div>
 
       <div className="flex gap-3">
-        <Button variant="secondary" onClick={() => window.close()}>
+        <Button variant="secondary" onClick={() => void closeInstaller()}>
           Close Installer
         </Button>
         <Button onClick={() => openODSserver()}>Open ODS</Button>

--- a/installer/src/pages/Prerequisites.tsx
+++ b/installer/src/pages/Prerequisites.tsx
@@ -3,6 +3,7 @@ import Button from "../components/Button";
 import StatusIcon from "../components/StatusIcon";
 import {
   checkPrerequisites,
+  closeInstaller,
   installPrerequisite,
   type PrerequisiteStatus,
 } from "../hooks/useTauri";
@@ -191,7 +192,7 @@ export default function Prerequisites({ onNext, onError }: Props) {
             A restart is needed to finish WSL2 setup. After restarting, run this
             installer again — it will pick up where it left off.
           </p>
-          <Button variant="secondary" onClick={() => window.close()}>
+          <Button variant="secondary" onClick={() => void closeInstaller()}>
             Close &amp; Restart Later
           </Button>
         </div>


### PR DESCRIPTION
window.close() only closes script-opened windows, so the Close buttons on Complete and on the WSL2 reboot prompt were dead. Adds closeInstaller() using getCurrentWindow().close(). core:default covers only read-only window queries, so the capability file gains core:window:allow-close.