### PR TITLE
Drop the unused sys-info dependency

### DIFF
--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -656,7 +656,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "sys-info",
  "tauri",
  "tauri-build",
  "tokio",
@@ -3245,16 +3244,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -10,7 +10,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 which = "7"
-sys-info = "0.9"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
sys-info has zero references in src/. Removing it drops a cc-building dependency from cold builds. cc itself is still pulled in by four other packages, so the lockfile keeps it.