### PR TITLE
fix(pixel): bind diff clipboard receipts to the displayed patch

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelDiffClipboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDiffClipboard.test.jsx
@@ -1,0 +1,51 @@
+import {act, fireEvent, render, screen, waitFor} from '@testing-library/react'
+import PixelFileChanges from './PixelFileChanges'
+
+const change = text => ({path:'main.js', change:'modified', additions:1, deletions:0,
+  diff:[{type:'add', oldLine:null, newLine:1, text}]})
+const copyButton = () => screen.getByRole('button', {name:'Copy changes to main.js'})
+async function open() {
+  fireEvent.click(screen.getByText('Edited main.js').closest('summary'))
+  await screen.findByRole('region', {name:'Changes to main.js'})
+}
+afterEach(() => {vi.unstubAllGlobals(); vi.useRealTimers()})
+
+it('allows only one clipboard write and rejects its receipt after the diff changes', async () => {
+  let finish
+  const writeText = vi.fn(() => new Promise(resolve => {finish = resolve}))
+  vi.stubGlobal('navigator', {clipboard:{writeText}})
+  const {rerender} = render(<PixelFileChanges changes={[change('old')]}/> )
+  await open()
+  fireEvent.click(copyButton()); fireEvent.click(copyButton())
+  expect(writeText).toHaveBeenCalledTimes(1)
+  expect(copyButton()).toBeDisabled()
+  rerender(<PixelFileChanges changes={[change('new')]}/> )
+  expect(copyButton()).toBeEnabled()
+  await act(async () => finish())
+  expect(copyButton()).toHaveTextContent('Copy')
+  expect(copyButton()).not.toHaveTextContent('Copied')
+  writeText.mockResolvedValue(undefined)
+  fireEvent.click(copyButton())
+  await waitFor(() => expect(copyButton()).toHaveTextContent('Copied'))
+  expect(writeText).toHaveBeenLastCalledWith('+new')
+})
+
+it('ends a stalled clipboard write with a recoverable error and ignores its late success', async () => {
+  let finish
+  const writeText = vi.fn(() => new Promise(resolve => {finish = resolve}))
+  vi.stubGlobal('navigator', {clipboard:{writeText}})
+  render(<PixelFileChanges changes={[change('content')]}/> )
+  await open()
+  vi.useFakeTimers()
+  fireEvent.click(copyButton())
+  await act(async () => {await vi.advanceTimersByTimeAsync(5000)})
+  expect(screen.getByRole('alert')).toHaveTextContent('Clipboard access failed')
+  expect(copyButton()).toBeEnabled()
+  await act(async () => finish())
+  expect(copyButton()).toHaveTextContent('Copy failed')
+  writeText.mockResolvedValue(undefined)
+  fireEvent.click(copyButton())
+  await act(async () => {})
+  expect(copyButton()).toHaveTextContent('Copied')
+  expect(screen.queryByRole('alert')).toBeNull()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelFileChanges.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelFileChanges.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Pencil } from 'lucide-react'
 import { fileLanguage, PixelCodeLines, PixelLanguageBadge } from './PixelCodeBlock'
 import './pixel-file-changes.css'
@@ -50,22 +50,40 @@ function FileChange({file, onPreview, expansion}) {
   useEffect(() => {if (expansion) setOpen(expansion.open)}, [expansion])
   const [copyState, setCopyState] = useState('Copy')
   const rows = Array.isArray(file.diff) ? file.diff : []
+  const copyRequest = useRef(null)
+  // Receipts belong to the displayed patch, not merely its filename.
+  const patch = rows.map(row => `${row?.type === 'add' ? '+' : row?.type === 'remove' ? '-' : ' '}${row?.text}${row?.noFinalNewline ? '\n\\ No newline at end of file' : ''}`).join('\n')
+  useEffect(() => {
+    setCopyState('Copy')
+    return () => { clearTimeout(copyRequest.current?.timer); copyRequest.current = null }
+  }, [patch])
   const hasCounts = count(file.additions) && count(file.deletions)
   const validRows = rows.every(row => row && ['context','add','remove'].includes(row.type) && typeof row.text === 'string' && !row.text.includes('\n') &&
     (row.oldLine === null || Number.isSafeInteger(row.oldLine) && row.oldLine > 0) &&
     (row.newLine === null || Number.isSafeInteger(row.newLine) && row.newLine > 0))
   const copy = async () => {
+    if (copyRequest.current) return
+    const request = {timer:null}
+    copyRequest.current = request
+    setCopyState('Copying…')
     try {
-      await navigator.clipboard.writeText(rows.map(row => `${row.type === 'add' ? '+' : row.type === 'remove' ? '-' : ' '}${row.text}${row.noFinalNewline ? '\n\\ No newline at end of file' : ''}`).join('\n'))
-      setCopyState('Copied')
-    } catch { setCopyState('Copy failed') }
+      await Promise.race([
+        navigator.clipboard.writeText(patch),
+        new Promise((_, reject) => { request.timer = setTimeout(() => reject(new Error('Clipboard timed out')), 5000) }),
+      ])
+      if (copyRequest.current === request) setCopyState('Copied')
+    } catch { if (copyRequest.current === request) setCopyState('Copy failed') }
+    finally {
+      clearTimeout(request.timer)
+      if (copyRequest.current === request) copyRequest.current = null
+    }
   }
   return <details className="chat-file-change" open={open} onToggle={event => setOpen(event.currentTarget.open)}>
     <summary><Pencil size={16} strokeWidth={1.25} aria-hidden="true"/><span className="file-change-name">{LABELS[file.change] || 'Changed'} {file.path}</span><PixelChangeCounts additions={file.additions} deletions={file.deletions}/></summary>
     {open && <div className="inline-artifact-content">
       {file.change === 'published' && <p className="pixel-publication-baseline">First published version. No earlier snapshot was available for comparison.</p>}
       {!validRows || !hasCounts && (file.additions !== null || file.deletions !== null) ? <p role="status">Changes could not be verified.</p> : !hasCounts ? <p role="status">Line comparison unavailable for this file.</p> : !rows.length ? <p role="status">{file.additions || file.deletions ? 'Line changes are unavailable for this file.' : 'No line changes.'}</p> : <section className="pixel-code-block artifact-diff" aria-label={`Changes to ${file.path}`}>
-        <header className="code-block-header"><PixelLanguageBadge path={file.path}/><span title={file.path}>{file.path}</span><PixelChangeCounts additions={file.additions} deletions={file.deletions}/>{onPreview && file.change !== 'deleted' && <button type="button" onClick={() => onPreview(file)} aria-label={`Preview ${file.path}`}>Preview</button>}<button type="button" onClick={copy} aria-label={`Copy changes to ${file.path}`}>{copyState}</button></header>
+        <header className="code-block-header"><PixelLanguageBadge path={file.path}/><span title={file.path}>{file.path}</span><PixelChangeCounts additions={file.additions} deletions={file.deletions}/>{onPreview && file.change !== 'deleted' && <button type="button" onClick={() => onPreview(file)} aria-label={`Preview ${file.path}`}>Preview</button>}<button type="button" onClick={copy} disabled={copyState === 'Copying…'} aria-label={`Copy changes to ${file.path}`}>{copyState}</button></header>
         <pre tabIndex={0} aria-label={`Diff for ${file.path}`}><DiffLines rows={rows} path={file.path}/></pre>
         {file.truncated && <p className="pixel-diff-notice" role="status">Only part of this diff is displayed. Counts cover the verified file change.</p>}
         {copyState === 'Copy failed' && <p className="pixel-diff-notice" role="alert">Clipboard access failed. Select the changes to copy them manually.</p>}


### PR DESCRIPTION
When an operator copies a Workbench diff twice, both clipboard writes currently run. A delayed write can also report success after the displayed patch changes. Serialize writes, bind feedback to the exact patch, and end a stalled write after five seconds with the existing manual-copy guidance.

## Why this matters
Pixel Workbench renders published snapshot comparisons through PixelSnapshotChanges -> PixelFileChanges. A Copy receipt must describe the patch currently displayed. This also makes the button usable again after a clipboard operation stalls.

## Overlap check
Searched all open/closed upstream PR file lists and semantic queries for diff/clipboard and PixelFileChanges. #4147 adds filtering/expansion; #4027 is the original workspace implementation. #4223 concerns PixelPreviewSource, #4107 concerns source-copy recovery, and #4116/#4083 concern source fidelity/newlines. None implements diff clipboard operation ownership or a deadline.

## Validation
- Regression tests fail on public-beta f5f49b7d: duplicate writes and missing timeout recovery.
- `npm test -- src/components/PixelDiffClipboard.test.jsx src/components/PixelFileChanges.test.jsx src/components/PixelChangeReview.test.jsx src/components/PixelSnapshotChanges.test.jsx`: 17 passed.
- Dashboard baseline lint/build passed (559 pre-existing lint warnings).
- `git diff --check`: passed.
- Full-tree gitleaks and large-file hooks passed; private-key hook flags existing test fixtures in test-remote-provider-egress-policy.py and test_host_agent.py. This change contains no credentials.

## Risk and rollback
Browser-only behavior shared by Linux/macOS/Windows clients. Tests simulate clipboard ordering; no real-browser clipboard permission dialog was exercised. Clipboard writes cannot be cancelled by the browser API: obsolete completion is ignored, but an already-started system clipboard write may still finish. Revert this commit to restore previous behavior. No persisted data or backend mutation changes.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
