### PR TITLE
fix(preview): verify artifact hashes on HTTP LAN origins

### DIFF
--- a/ods/extensions/services/dashboard/package-lock.json
+++ b/ods/extensions/services/dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ods-dashboard",
       "version": "0.1.0",
       "dependencies": {
+        "@noble/hashes": "2.4.0",
         "@paper-design/shaders-react": "^0.0.80",
         "gsap": "^3.12.7",
         "lucide-react": "^0.441.0",
@@ -1263,6 +1264,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/ods/extensions/services/dashboard/package.json
+++ b/ods/extensions/services/dashboard/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@noble/hashes": "2.4.0",
     "@paper-design/shaders-react": "^0.0.80",
     "gsap": "^3.12.7",
     "lucide-react": "^0.441.0",

--- a/ods/extensions/services/dashboard/src/components/PixelArtifactHttp.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelArtifactHttp.test.jsx
@@ -1,0 +1,40 @@
+import {createHash} from 'node:crypto'
+import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+import {loadArtifactBytes} from '../lib/pixelArtifacts'
+
+const source = '<h1>Verified over LAN</h1>\n'
+const bytes = new TextEncoder().encode(source)
+const digest = value => createHash('sha256').update(value).digest('hex')
+const preview = {siteId:'site-'+'a'.repeat(24), entrySha256:digest(bytes)}
+beforeEach(() => {
+  // HTTP LAN exposes crypto.getRandomValues, but no SubtleCrypto.
+  vi.stubGlobal('crypto', {})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true, arrayBuffer:async () => bytes.buffer})))
+})
+afterEach(() => {vi.restoreAllMocks(); vi.unstubAllGlobals()})
+
+it('verifies source and downloads the original bytes without SubtleCrypto', async () => {
+  vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:verified')
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  render(<PixelPreviewSource preview={preview}/> )
+  expect(await screen.findByLabelText('Code for index.html')).toHaveTextContent('Verified over LAN')
+  fireEvent.click(screen.getByRole('button', {name:'Download index.html'}))
+  await screen.findByText('Verified download started')
+  expect(click).toHaveBeenCalledOnce()
+  await waitFor(() => expect(URL.revokeObjectURL).toHaveBeenCalled(), {timeout:2000})
+})
+
+it('still rejects tampered bytes without SubtleCrypto', async () => {
+  render(<PixelPreviewSource preview={{...preview, entrySha256:'0'.repeat(64)}}/> )
+  expect(await screen.findByRole('alert')).toHaveTextContent('could not be verified')
+  expect(screen.queryByLabelText('Code for index.html')).toBeNull()
+})
+
+it.each([0, 1, 55, 56, 63, 64, 65, 1024, 4 * 1024 * 1024])('matches independently hashed artifact bytes at length %i', async length => {
+  const data = Uint8Array.from({length}, (_, index) => index % 251)
+  fetch.mockResolvedValue({ok:true, arrayBuffer:async () => data.buffer})
+  const file = {path:'asset.bin', bytes:length, sha256:digest(data)}
+  expect(await loadArtifactBytes(preview, file)).toBe(data.buffer)
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
@@ -1,3 +1,5 @@
+import { sha256 as hashSha256 } from '@noble/hashes/sha2.js'
+
 const DIGEST = /^[a-f0-9]{64}$/
 export const isSnapshotId = value => typeof value === 'string' && /^site-[a-f0-9]{24}$/.test(value)
 export const isArtifactPath = value => typeof value === 'string' && value.length <= 1664
@@ -34,7 +36,8 @@ export async function readBoundedBytes(response, maximum) {
 }
 
 export async function sha256(bytes) {
-  return Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', bytes)), byte => byte.toString(16).padStart(2, '0')).join('')
+  // LAN HTTP has no SubtleCrypto. Verify the same digest on every origin.
+  return Array.from(hashSha256(new Uint8Array(bytes)), byte => byte.toString(16).padStart(2, '0')).join('')
 }
 
 export async function loadSnapshotFiles(preview, signal) {


### PR DESCRIPTION
Opening Workbench source or downloading a published artifact from an HTTP LAN URL currently fails even for valid files: these operations call crypto.subtle.digest, which is unavailable outside secure contexts. Use the pinned @noble/hashes SHA-256 implementation on every origin, preserving digest/length checks and the existing bounded fetch path.

## Why this matters
Public-beta supports browser access from other LAN devices. PixelPreviewSource and PixelArtifactDownload both call loadArtifactBytes, so the current dependency blocks source inspection and verified downloads on that supported entry point.

## Overlap check
Searched open/closed upstream PR file lists for pixelArtifacts.js and semantic queries for SHA-256, WebCrypto, insecure origins and HTTP LAN. #4228 fixes UUID consumers; its changed files do not include artifact hashing. #4092 handles response cancellation. This change addresses neither UUID generation nor transport authentication.

## Validation
- HTTP-origin regression: 10 failures on base f5f49b7d, including source/download and independent binary digest comparisons.
- `npm test -- src/components/PixelArtifactHttp.test.jsx src/components/PixelArtifactDownload.test.jsx src/components/PixelPreviewSource.test.jsx src/components/PixelTaskFiles.test.jsx`: 31 passed.
- Covers tampered content, SHA block/padding boundaries, and the 4 MiB artifact limit, using Node crypto as an independent reference.
- `npm run build`: passed; Pixel chunk gzip increases from 100.02 to 102.87 kB.
- Focused ESLint: zero errors; scoped pre-commit secret/private-key/large-file checks and diff check passed.

## Design and limitations
Use the documented SHA-256 submodule, pinned to 2.4.0 with lockfile integrity and no transitive dependencies (https://github.com/paulmillr/noble-hashes). No bespoke crypto or digest bypass. This is artifact consistency verification; it does not authenticate HTTP transport. Hashing runs synchronously inside the existing async interface, bounded to 4 MiB. Tests simulate unavailable SubtleCrypto; a physical LAN browser has not been exercised. Revert the commit and dependency entry together to roll back.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
