### PR TITLE
fix(pixel): preserve oversized unsent drafts on restoration

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Pixel.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Pixel.jsx
@@ -478,7 +478,9 @@ function loadStoredChat(selected) {
       chatId: stored.chatId, messages, preview,
       contextStart: Number.isInteger(stored.contextStart) && stored.contextStart >= 0 && stored.contextStart <= messages.length ? stored.contextStart : 0,
       workspaceOpen: stored.workspaceOpen !== false && (stored.workspaceOpen === true || Boolean(preview)),
-      draft: typeof stored.draft === 'string' ? stored.draft.slice(0, MAX_INPUT_LEN) : '',
+      // The send limit must not truncate unsent text when restoring a draft.
+      // The composer keeps sending disabled until the user shortens it.
+      draft: typeof stored.draft === 'string' ? stored.draft : '',
       requestId: SAFE_CHAT_ID.test(stored.requestId || '') ? stored.requestId : null,
       interrupted: stored.inFlight === true || stored.interrupted === true,
     }

--- a/ods/extensions/services/dashboard/src/pages/PixelOversizedDraft.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelOversizedDraft.test.jsx
@@ -1,0 +1,39 @@
+import {act, fireEvent, screen, waitFor} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import Pixel from './Pixel'
+import {CHAT_KEY, saveConversation, SELECT_EVENT} from '../lib/pixelConversations'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,json:async () => ({available:true,model:'pixel/default'})})))
+})
+afterEach(() => {vi.unstubAllGlobals(); vi.restoreAllMocks()})
+
+it('retains an oversized unsent draft across reload and permits editing it back under the send limit', async () => {
+  const text = 'x'.repeat(16384) + '\nDo not lose this ending.'
+  const first = render(<Pixel/> )
+  await screen.findByText('Available')
+  fireEvent.change(screen.getByPlaceholderText('Message Portal...'), {target:{value:text}})
+  await waitFor(() => expect(JSON.parse(localStorage.getItem(CHAT_KEY)).draft).toBe(text))
+  expect(screen.getByTitle('Send')).toBeDisabled()
+  first.unmount()
+  render(<Pixel/> )
+  await screen.findByText('Available')
+  expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue(text)
+  expect(JSON.parse(localStorage.getItem(CHAT_KEY)).draft).toBe(text)
+  expect(screen.getByTitle('Send')).toBeDisabled()
+  fireEvent.change(screen.getByPlaceholderText('Message Portal...'), {target:{value:'Edited draft'}})
+  expect(screen.getByTitle('Send')).toBeEnabled()
+  expect(fetch.mock.calls.some(([url]) => url === '/api/pixel/chat')).toBe(false)
+})
+
+it('retains the complete oversized draft when selecting an existing conversation', async () => {
+  const text = 'a'.repeat(16384) + 'END'
+  saveConversation({schema:1, chatId:'large', messages:[], draft:text})
+  saveConversation({schema:1, chatId:'current', messages:[], draft:'Current'})
+  render(<Pixel/> )
+  await screen.findByText('Available')
+  act(() => window.dispatchEvent(new CustomEvent(SELECT_EVENT, {detail:'large'})))
+  expect(screen.getByPlaceholderText('Message Portal...')).toHaveValue(text)
+  expect(screen.getByTitle('Send')).toBeDisabled()
+})


### PR DESCRIPTION
A user can paste a draft longer than the 16,384-character send limit and edit it before sending. The draft is saved in full, but reopening Pixel or selecting the conversation silently truncates it, and the persistence effect then saves the shortened version. Restore the complete draft and let the existing send-limit UI require an explicit edit.

## Why this matters
The production path is composer paste -> saveConversation -> loadStoredChat during reload or sidebar selection -> persistence. The send limit must never become a destructive storage transformation. No oversized message is sent: existing inputOver validation and the disabled Send button remain authoritative.

## Overlap check
Searched open/closed upstream PRs by draft/truncation keywords and all Pixel.jsx file changes. #4078 concerns cleared drafts, #4149 imports bounded JSON exports, #4150 previews drafts, #4236 reviews files, and #4230 handles assistant identity. #4220/#4219/#4255 extend context/scroll/search behavior. None preserves over-limit composer text on restoration.

## Validation
- Both full-page regression tests fail on base f5f49b7d, showing the missing draft suffix after reload and conversation selection.
- `npm test -- src/pages/PixelOversizedDraft.test.jsx src/pages/PixelComposerIntegration.test.jsx src/pages/PixelSendKey.test.jsx src/components/PixelConversationImport.test.jsx`: 20 passed.
- Tests verify exact persisted text, disabled sending, successful shortening, and no chat request.
- Scoped pre-commit checks and `git diff --check`: passed.
- Dashboard baseline lint/build passed. Hardware inference is not exercised by this browser-only fix.

## Risk and rollback
The retained draft was already stored and rendered before reload; restoration now preserves it. Stored message limits, request limits and import validation are unchanged. Shared browser behavior applies to Linux, Windows and macOS clients. No migration is needed; revert this commit to roll back, although the old restore path would again truncate oversized drafts.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
