### PR TITLE
fix(preview): order retained snapshots by last publication

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.jsx
@@ -1,5 +1,11 @@
 export default function PixelPreviewHistory({previews, selected, onSelect}) {
-  const versions = [...new Map(previews.map(preview => [preview.siteId,preview])).values()]
+  const retained = new Map()
+  for (const preview of previews) {
+    // Identical content reuses its site ID; order by its latest publication.
+    retained.delete(preview.siteId)
+    retained.set(preview.siteId, preview)
+  }
+  const versions = [...retained.values()]
   const currentListed = versions.some(preview => preview.siteId === selected.siteId)
   if (versions.length + (currentListed ? 0 : 1) < 2) return null
   const latest = versions.at(-1)

--- a/ods/extensions/services/dashboard/src/pages/PixelRepublishedPreview.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/PixelRepublishedPreview.test.jsx
@@ -1,0 +1,31 @@
+import {render} from '../test/test-utils'
+import {screen, fireEvent} from '@testing-library/react'
+import Pixel from './Pixel'
+import {saveConversation} from '../lib/pixelConversations'
+
+function publication(digit) {
+  const sha256 = digit.repeat(64), siteId = 'site-' + sha256.slice(0,24)
+  return {schemaVersion:1,kind:'ods-pixel-workspace-preview',relativeDirectory:'demo',siteId,sha256,
+    entrySha256:'f'.repeat(64),files:1,bytes:20,port:9437,url:`http://${siteId}.localhost:9437/${siteId}/`}
+}
+afterEach(() => {vi.unstubAllGlobals(); localStorage.clear()})
+
+it('treats a republished older snapshot as the latest retained publication', async () => {
+  localStorage.clear()
+  const a = publication('a'), b = publication('b')
+  saveConversation({schema:1,chatId:'republished',messages:[
+    {role:'user',content:'Build A'}, {role:'assistant',content:'A',publication:a},
+    {role:'user',content:'Change to B'}, {role:'assistant',content:'B',publication:b},
+    {role:'user',content:'Restore A'}, {role:'assistant',content:'A restored',publication:a},
+  ], preview:a, workspaceOpen:true})
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>({available:true,model:'pixel/default'})})))
+  render(<Pixel/> )
+  await screen.findByText('Available')
+  const selector = screen.getByLabelText('Published version')
+  expect([...selector.querySelectorAll('option')].map(option => option.value)).toEqual([b.siteId,a.siteId])
+  expect(screen.queryByRole('button',{name:'Show latest publication'})).toBeNull()
+  fireEvent.change(selector,{target:{value:b.siteId}})
+  fireEvent.click(screen.getByRole('button',{name:'Show latest publication'}))
+  expect(screen.getByTitle('Interactive Portal preview')).toHaveAttribute('src',`/pixel-preview/${a.siteId}/__ods_view__.html`)
+  expect(fetch.mock.calls.some(([url]) => url === '/api/pixel/chat/stream')).toBe(false)
+})


### PR DESCRIPTION
Publishing content A, changing it to B, and restoring A reuses A's content-addressed site ID. The history selector currently preserves the first Map insertion order, so it incorrectly labels B as latest and the latest-publication button navigates to B. Deduplicate by last occurrence instead.

## Why this matters
Pixel passes verified message publications to PixelPreviewHistory in turn order. Returning to an earlier design is a normal editing workflow; the latest retained publication must reflect the last successful publication, even when its bytes match an earlier version.

## Overlap check
Searched all upstream open/closed PR file lists and publication/preview-history keywords. #4152 introduced this history selector; no subsequent PR changes its ordering. This is independent of #4219 reading-position and #4255 conversation search.

## Validation
- Full-page A -> B -> A regression fails on f5f49b7d with A incorrectly ordered before B.
- `npm test -- src/pages/PixelRepublishedPreview.test.jsx src/pages/PixelPreviewHistory.test.jsx`: 3 passed.
- Tests verify selected iframe URL, latest action, unique entries and no chat submission.
- Focused ESLint: zero errors; scoped pre-commit and diff checks passed.

## Risk and rollback
Only the display order of repeated snapshot IDs changes. Publication receipts, iframe isolation, source verification and saved messages remain authoritative. No migration; revert this commit to roll back. Shared React code covers all host platforms.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
