### PR TITLE
fix(pixel): retain extraction matches in long paragraphs

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/web-extract.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/web-extract.mjs
@@ -99,8 +99,9 @@ function queryKeywords(query) {
 
 function evidenceBounds(text, index) {
   let start = Math.max(0, index - BEFORE_MATCH_CHARS);
-  const priorBreak = text.lastIndexOf("\n", start);
-  if (priorBreak >= 0) start = priorBreak + 1;
+  // Prefer a nearby line boundary without moving the match out of the window.
+  const priorBreak = text.lastIndexOf("\n", index);
+  if (priorBreak >= start) start = priorBreak + 1;
   let end = Math.min(text.length, start + MAX_EVIDENCE_CHARS);
   const finalBreak = text.lastIndexOf("\n", end);
   if (end < text.length && finalBreak > index) end = finalBreak;

--- a/ods/extensions/services/pixel-agent/tests/web_extract.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/web_extract.test.mjs
@@ -238,3 +238,33 @@ test("requires every security dependency", () => {
     /dependencies are unavailable/
   );
 });
+
+test("extraction includes a late match on a long paragraph after a heading", async () => {
+  const body = "Heading\n" + "background ".repeat(3000) + "Path.exists returns true for existing files." + " tail".repeat(3000);
+  const harness = fixture({ body });
+  const result = await harness.tool.execute("late-match", {
+    url: "https://docs.example.org/reference", query: "Path.exists",
+  });
+  assert.equal(result.details.matched, true);
+  assert.match(result.content[0].text, /Path.exists returns true/);
+  assert.equal(result.details.evidence_truncated_before, true);
+  assert.equal(result.details.evidence_truncated_after, true);
+  assert.ok(selectEvidenceWindow(body, "Path.exists").text.length <= 6000);
+});
+
+test("a line break inside a multi-word match does not truncate the match", async () => {
+  const body = "intro ".repeat(400) + "needle one\nneedle two" + " tail".repeat(2000);
+  const selected = selectEvidenceWindow(body, "needle one");
+  assert.match(selected.text, /needle one/);
+  assert.ok(selected.text.length <= 6000);
+});
+
+test("keyword extraction finds terms deep inside a long paragraph", async () => {
+  const body = "Heading\n" + "background ".repeat(3000) + "Follow symlinks to existing targets." + " tail".repeat(3000);
+  const harness = fixture({ body });
+  const result = await harness.tool.execute("keywords", {
+    url: "https://docs.example.org/reference", query: "symlinks existing targets",
+  });
+  assert.equal(result.details.matched, true);
+  assert.match(result.content[0].text, /Follow symlinks to existing targets/);
+});


### PR DESCRIPTION
## Why this matters

Pixel can report a successful targeted web match while returning unrelated text. A heading followed by a 30 KB paragraph with `Path.exists` near its end reproduces this through `pixel_ods_web_extract.execute()`. Keyword extraction can also incorrectly report no match for the same layout.

The start of the excerpt was moved back to an arbitrarily distant newline, pushing the matched text outside the 6,000-character window. Prefer a newline only inside the allowed preceding context. Exact and keyword matches now retain the relevant paragraph without increasing the output limit.

## Overlap check

Searched open and closed upstream PRs for “web extract evidence window” and `web-extract.mjs`, and checked changed-file metadata in the latest 400 PRs. #3385 is the broader Portal proposal; no returned PR fixes long-paragraph evidence selection. This change targets the implementation already present on public-beta.

## Validation

- Regression tests call the public extraction tool with a late exact match and co-occurring keywords after a long paragraph; both fail before the fix.
- `node --test ods/extensions/services/pixel-agent/tests/web_extract.test.mjs`: 15 passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; medium risk, Pixel read-only evidence selection. URL admission, transport, response-byte bounds and trust markers retain their existing behavior. Tests use injected public-page transport; no live website or model run was performed. Reverting this commit restores the earlier excerpt selection without a data migration.

## AI Assistance

Codex assisted with diagnosis, code, regression tests and this description. Automated validation is recorded above; independent human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
