### PR TITLE
fix(preview): bound source viewer DOM expansion

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelCodeBlock.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelCodeBlock.jsx
@@ -30,7 +30,11 @@ function highlightedLines(children) {
   return lines
 }
 
+export const needsPlainSource = source => source.length > 128 * 1024 || source.split('\n', 2001).length > 2000
+
 export function PixelCodeLines({source, language = 'text', renderLine}) {
+  // Diff rows have their own bounded contract and must retain annotations.
+  if (!renderLine && needsPlainSource(String(source))) return <code>{String(source)}</code>
   const text = String(source).replace(/\n$/u, '')
   const rows = text.split('\n')
   const render = tokens => rows.map((row, index) => {

--- a/ods/extensions/services/dashboard/src/components/PixelLargeSource.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelLargeSource.test.jsx
@@ -1,0 +1,25 @@
+import {webcrypto, createHash} from 'node:crypto'
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+
+afterEach(() => {vi.unstubAllGlobals(); vi.restoreAllMocks()})
+
+it.each(['x'.repeat(128 * 1024), 'line\n'.repeat(2001), '\n'.repeat(140000)])('renders large verified source as exact plain text with bounded DOM and truthful controls (%#)', async prefix => {
+  const source = prefix + '\n<script>not executable</script>\r\n\n'
+  const bytes = new TextEncoder().encode(source)
+  const sha256 = createHash('sha256').update(bytes).digest('hex')
+  vi.stubGlobal('crypto', webcrypto)
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal('navigator', {clipboard:{writeText}})
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,arrayBuffer:async()=>bytes.buffer})))
+  const {container} = render(<PixelPreviewSource preview={{siteId:'site-'+'a'.repeat(24),entrySha256:sha256}}/> )
+  await waitFor(() => expect(screen.getByRole('button',{name:'Copy code'})).toBeEnabled())
+  expect(container.querySelector('pre code').textContent === source).toBe(true)
+  expect(container.querySelector('pre code').childElementCount).toBe(0)
+  expect(screen.queryByRole('searchbox',{name:'Find in source'})).toBeNull()
+  expect(screen.getByText(/Large source is shown as plain text/)).toBeVisible()
+  expect(container.querySelector('script')).toBeNull()
+  fireEvent.click(screen.getByRole('button',{name:'Copy code'}))
+  await waitFor(() => expect(writeText).toHaveBeenCalledWith(source))
+  expect(screen.getByRole('button',{name:'Download index.html'})).toBeEnabled()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { loadArtifactBytes } from '../lib/pixelArtifacts'
-import { PixelCodeLines, PixelLanguageBadge } from './PixelCodeBlock'
+import { PixelCodeLines, PixelLanguageBadge, needsPlainSource } from './PixelCodeBlock'
 import PixelArtifactDownload from './PixelArtifactDownload'
 import PixelSourceFind from './PixelSourceFind'
 
@@ -18,6 +18,7 @@ export default function PixelPreviewSource({ preview, file }) {
   const [copied, setCopied] = useState(false)
   const [attempt, setAttempt] = useState(0)
   const codeRef = useRef(null)
+  const plain = source !== null && needsPlainSource(source)
   useEffect(() => {
     let current = true
     const controller = new AbortController()
@@ -46,7 +47,7 @@ export default function PixelPreviewSource({ preview, file }) {
     {error && <div role="alert"><p>{error}</p><button type="button" onClick={() => setAttempt(value => value + 1)}>Retry source</button></div>}
     <div className="pixel-code-block">
       <header className="code-block-header"><PixelLanguageBadge path={path}/><span title={path}>{path}</span><PixelArtifactDownload key={`${preview.siteId}/${path}/${expectedDigest}`} preview={preview} file={{path, sha256:expectedDigest, bytes:file?.bytes}}/>{language && <button type="button" aria-label="Copy code" onClick={copy} disabled={source === null}>{copied ? 'Copied' : 'Copy'}</button>}</header>
-      {source !== null && <><PixelSourceFind key={`${preview.siteId}/${path}/${expectedDigest}`} source={source} codeRef={codeRef}/><pre ref={codeRef} tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre></>}
+      {source !== null && <>{plain ? <p role="status">Large source is shown as plain text. Use browser find or download the file; line search and highlighting are disabled.</p> : <PixelSourceFind key={`${preview.siteId}/${path}/${expectedDigest}`} source={source} codeRef={codeRef}/>}<pre ref={codeRef} tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre></>}
 
     </div>
     {(source !== null || binarySize !== null) && <p className="pixel-source-verification">Published snapshot · SHA-256 verified{binarySize !== null ? ` · ${binarySize.toLocaleString()} bytes` : ''}</p>}


### PR DESCRIPTION
A verified artifact may contain up to 4 MiB, but the source viewer currently allocates two spans for every line. A valid 140,000-newline file expands into roughly 280,000 DOM elements. Above 128 Ki characters or 2,000 lines, render one inert text node and hide line-based search with an explicit explanation. Full text, clipboard copy and verified download remain available.

## Why this matters
Workspace publication permits these file sizes; opening the Files/source pane calls PixelCodeLines for every verified source byte. Disabling syntax highlighting alone did not limit DOM expansion. The invariant is that large source rendering stays bounded without dropping original text or claiming that unavailable line navigation works.

## Overlap check
Searched open/closed PR files for PixelCodeBlock.jsx/PixelPreviewSource.jsx and source/render-limit keywords. #4116 preserves source fidelity, #4223 owns clipboard receipts, #4226 adds extensionless sources, #4251 wraps source, and #4233 extends line navigation. None bounds source DOM growth. Those controls continue for structured-size sources; large files explicitly use plain text. Diff annotations retain their separate bounded row contract.

## Validation
- The public source-control regression fails on f5f49b7d because code still contains per-line elements.
- `npm test -- src/components/PixelLargeSource.test.jsx src/components/PixelPreviewSource.test.jsx src/components/PixelSourceFind.test.jsx src/components/PixelFileChanges.test.jsx`: 24 passed.
- Includes 140,000 newlines, size/line thresholds, exact CRLF/final-newline text, inert HTML, full clipboard content, download availability, ordinary source search, and diff rendering.
- Focused ESLint: zero errors. Scoped pre-commit and diff checks passed.
- No physical-browser performance benchmark; tests prove a constant element count for large source, not a frame-rate claim. 

## Tradeoff and rollback
Large files temporarily lose highlighted line search/line numbers, with browser find and download available. Source text is complete. Browser-only, all host platforms; no persisted-state migration. Revert the commit to restore the old renderer.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
