### PR TITLE
fix(pixel): normalize progress fingerprint argument order

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/run-progress-budget.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/run-progress-budget.mjs
@@ -54,7 +54,10 @@ export function createRunProgressBudget() {
       // An actual running-process receipt is a verified wait, not a failure.
       // Plain text saying "running" must never be supplied as this signal.
       if (pending) { rounds = 0; return; }
-      const fingerprint = createHash('sha256').update(JSON.stringify([tool, params])).digest('hex');
+      const fingerprint = createHash('sha256').update(JSON.stringify([tool, params], (_key, value) =>
+        value && typeof value === 'object' && !Array.isArray(value)
+          ? Object.fromEntries(Object.keys(value).sort().map(key => [key, value[key]]))
+          : value)).digest('hex');
       const count = (successes.get(fingerprint) ?? 0) + 1;
       successes.set(fingerprint, count);
       if (successes.size > 128) successes.delete(successes.keys().next().value);

--- a/ods/extensions/services/pixel-agent/tests/run_progress_argument_order.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/run_progress_argument_order.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createRunProgressBudget } from '../plugin/run-progress-budget.mjs';
+import { createToolLoopGuard } from '../plugin/tool-loop-guard.mjs';
+
+const variants = [
+  {query:'read', options:{limit:5, scope:'core', format:'json'}},
+  {options:{format:'json', scope:'core', limit:5}, query:'read'},
+  {query:'read', options:{scope:'core', format:'json', limit:5}},
+  {options:{limit:5, format:'json', scope:'core'}, query:'read'},
+];
+
+test('key reordering cannot keep identical successful tool descriptions alive', () => {
+  const guard = createToolLoopGuard();
+  const context = {agentId:'pixel', runId:'argument-order', sessionId:'session-order'};
+  guard.observeRun(context, 'pixel', {prompt:'Describe the read tool.'});
+  for (let i=0; i<12; i++) {
+    guard.observeModelCall({runId:context.runId}, context);
+    guard.afterToolCall({toolName:'tool_describe', toolCallId:`call-${i}`,
+      params:variants[i % variants.length], result:{content:[{type:'text', text:'Read a file.'}]}}, context);
+  }
+  assert.equal(guard.deliveryVerificationForRun(context.runId).status, 'failed');
+  assert.match(guard.deliveryVerificationForRun(context.runId).text, /without progress/);
+});
+
+test('ordered arguments and changed values remain distinct progress', () => {
+  const budget = createRunProgressBudget();
+  for (let i=0; i<20; i++) {
+    assert.equal(budget.beginModelRound(), false);
+    budget.observeResult({callId:`read-${i}`, tool:'read', params:{paths:[String(i), 'common']}, failed:false});
+  }
+  assert.equal(budget.exhausted, false);
+});


### PR DESCRIPTION
## Why this matters

Repeated successful tool calls receive a limited progress allowance. Reordering the keys of identical JSON arguments currently creates new fingerprints, extending that allowance without doing different work. This also affects nested Tool Search arguments.

Canonicalize object keys when hashing arguments. Array order and argument values retain their meaning. A hook-level regression sends four object-order variants through model-round and after-tool callbacks: before the fix the run exceeds the intended repetition allowance; after it the existing no-progress receipt terminates the run.

## Overlap check

Searched open and closed PR titles across the upstream history for tool loops and progress budgets, queried “progress budget parameter order” and `run-progress-budget.mjs`, and checked recent changed-file metadata. #4216 introduced the current budget; #3385 is a broader Portal proposal. Neither returned scope addresses argument-order fingerprints.

## Validation

- `node --test ods/extensions/services/pixel-agent/tests/run_progress_argument_order.test.mjs ods/extensions/services/pixel-agent/tests/run_progress_budget.test.mjs`: 10 passed; the hook regression fails on public-beta before this fix.
- `node --test ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs`: passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; medium risk, agent progress accounting. Calls that differ only by object key order now share the same allowance; genuinely different values and ordered arrays still count separately. No host mutation or persisted schema changes. No live inference/hardware run was performed. Revert this commit to restore earlier accounting.

## AI Assistance

Codex assisted with diagnosis, implementation, regression tests and this description. Independent human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
