### PR TITLE
fix(preview): preserve UTF-8 BOM in verified source text

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -27,7 +27,7 @@ export default function PixelPreviewSource({ preview, file }) {
       try {
         const bytes = await loadArtifactBytes(preview, {path, sha256:expectedDigest, bytes:file?.bytes}, controller.signal)
         if (language) {
-          const value = new TextDecoder('utf-8', {fatal:true}).decode(bytes)
+          const value = new TextDecoder('utf-8', {fatal:true, ignoreBOM:true}).decode(bytes)
           if (current) setSource(value)
         } else if (current) setBinarySize(bytes.byteLength)
       } catch { if (current) setError('The published source could not be verified. No unverified code is displayed.') }

--- a/ods/extensions/services/dashboard/src/components/PixelSourceBom.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSourceBom.test.jsx
@@ -1,0 +1,23 @@
+import {webcrypto, createHash} from 'node:crypto'
+import {render, screen, fireEvent, waitFor} from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+
+afterEach(() => {vi.unstubAllGlobals(); vi.restoreAllMocks()})
+
+it.each(['index.html','notes.txt'])('preserves the verified UTF-8 BOM in displayed and copied %s source', async path => {
+  const source = '\uFEFFfirst\r\nlast\n'
+  const bytes = new TextEncoder().encode(source)
+  const sha256 = createHash('sha256').update(bytes).digest('hex')
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal('crypto', webcrypto)
+  vi.stubGlobal('navigator', {clipboard:{writeText}})
+  vi.stubGlobal('fetch', vi.fn(async () => ({ok:true,arrayBuffer:async () => bytes.buffer})))
+  const {container} = render(<PixelPreviewSource preview={{siteId:'site-'+'a'.repeat(24),entrySha256:sha256}} file={{path,sha256,bytes:bytes.length}}/> )
+  await waitFor(() => expect(screen.getByRole('button',{name:'Copy code'})).toBeEnabled())
+  const shown = container.querySelector('pre code').textContent
+  expect(shown.charCodeAt(0)).toBe(0xFEFF)
+  expect(shown).toBe(source)
+  fireEvent.click(screen.getByRole('button',{name:'Copy code'}))
+  await waitFor(() => expect(writeText).toHaveBeenCalledWith(source))
+  expect([...new TextEncoder().encode(writeText.mock.calls[0][0])]).toEqual([...bytes])
+})


### PR DESCRIPTION
A verified UTF-8 source file beginning with a byte-order mark loses that character when decoded for display. Copy code therefore returns different bytes despite successful SHA-256 verification. Preserve the BOM as source text with TextDecoder ignoreBOM while retaining fatal UTF-8 validation.

## Why this matters
The source pane promises original verified source for inspection and reuse. BOM-bearing files are common in Windows-created projects. The reachable path is loadArtifactBytes -> PixelPreviewSource TextDecoder -> displayed code/clipboard. Source display and copy must reproduce the validated file; this does not change JSON import decoding.

## Overlap check
Searched open/closed PRs for BOM, byte-order mark, ignoreBOM and all PixelPreviewSource changes. #4116 addresses Markdown whitespace normalization after decoding; it cannot restore a BOM discarded earlier. #4223 concerns clipboard ownership, #4226 file types, #4321 hash availability, and #4325 bounded rendering. None changes decoder BOM semantics.

## Validation
- Both source-control regressions fail on f5f49b7d: first displayed character is f rather than U+FEFF.
- `npm test -- src/components/PixelSourceBom.test.jsx src/components/PixelPreviewSource.test.jsx src/components/PixelPreviewClipboard.test.jsx src/components/PixelSourceFind.test.jsx`: 16 passed.
- Tests cover highlighted HTML and plain text, exact CRLF/final newlines, and re-encoded clipboard bytes matching the original file.
- Scoped pre-commit and diff checks passed. 

## Risk and rollback
No backend, permission or stored-state changes. One decoding option changes for source inspection only, across all browser clients. Existing code-line fidelity handling preserves this character if the highlighter normalizes it. Revert this commit to restore old decoding. Real browser clipboard permission prompts were not exercised.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
