### PR TITLE
fix(pixel): reject corrupt research text before using it

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/perplexica-research.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/perplexica-research.mjs
@@ -36,7 +36,7 @@ async function readChunks(response, signal, consume) {
 }
 
 export async function readResearchStream(response, signal, onEvent) {
-  const decoder = new TextDecoder();
+  const decoder = new TextDecoder("utf-8", { fatal: true });
   let pending = "", complete = false;
   const line = (text) => {
     if (!text.trim()) return;
@@ -121,7 +121,7 @@ export function createPerplexicaResearchTool(deps = {}) {
         controller.signal.throwIfAborted();
         const configResponse = await request(`${base}/api/config`, { signal: controller.signal, redirect: "error" });
         if (!configResponse.ok) throw new Error("Research service configuration unavailable.");
-        const decoder = new TextDecoder();
+        const decoder = new TextDecoder("utf-8", { fatal: true });
         let configText = "";
         await readChunks(configResponse, controller.signal, (chunk) => { configText += decoder.decode(chunk, { stream: true }); });
         const preferences = JSON.parse(configText + decoder.decode()).values?.preferences;

--- a/ods/extensions/services/pixel-agent/tests/perplexica_research.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/perplexica_research.test.mjs
@@ -163,3 +163,34 @@ test("a completed request without sources is explicitly unverified", async () =>
   assert.match(result.content[0].text, /returned no source citations.*unverified/);
   assert.deepEqual(evidence(result).sources, []);
 });
+
+test("corrupt UTF-8 cannot become successful research or a different model identity", async () => {
+  for (const stage of ["config", "answer"]) {
+    const original = stage === "config" ? JSON.stringify(config) :
+      '{"type":"response","data":"Evidence MARKER."}\n{"type":"done"}';
+    const marked = stage === "config" ? original.replace("owner-chat", "MARKER") : original;
+    const offset = marked.indexOf("MARKER");
+    const bytes = new Uint8Array([
+      ...new TextEncoder().encode(marked.slice(0, offset)),
+      0xff,
+      ...new TextEncoder().encode(marked.slice(offset + 6)),
+    ]);
+    let calls = 0;
+    const tool = createPerplexicaResearchTool({env:{}, fetch:async () => {
+      calls++;
+      if (stage === "config" || calls === 2) return new Response(bytes);
+      return Response.json(config);
+    }});
+    const result = await tool.execute("corrupt-utf8", {query:"Research"}, signal());
+    assert.equal(result.details.status, "unavailable", stage);
+    assert.equal(result.isError, true);
+    if (stage === "config") assert.equal(calls, 1, "do not submit a changed model identity");
+    assert.doesNotMatch(JSON.stringify(result), /Evidence|\ufffd/);
+  }
+});
+
+test("rejects an incomplete UTF-8 sequence at the end of the stream", async () => {
+  const prefix = new TextEncoder().encode('{"type":"response","data":"OK"}\n{"type":"done"}\n');
+  await assert.rejects(readResearchStream(new Response(new Uint8Array([...prefix, 0xc3])),
+    signal(), () => {}));
+});


### PR DESCRIPTION
## Why this matters

Perplexica configuration and research streams currently replace malformed UTF-8 with U+FFFD before JSON parsing. A corrupted provider identifier can therefore be submitted as a different model selection, and corrupted answer text can be returned as completed evidence.

Decode both responses strictly. Malformed input now uses the existing unavailable-service result; invalid configuration never starts research. Split valid Unicode characters continue to decode across transport chunks.

## Overlap check

Searched open and closed upstream PRs for “Perplexica UTF-8” and `perplexica-research.mjs`, plus recent changed-file metadata. Returned router/installer PRs and the broader Portal proposal #3385 do not address this stream decoder.

## Validation

- `node --test ods/extensions/services/pixel-agent/tests/perplexica_research.test.mjs`: 12 passed.
- Added public-tool regressions for corrupt model identifiers and answer bytes, plus an incomplete final UTF-8 sequence. The regression fails before the change.
- Existing byte-by-byte Unicode and cancellation tests pass.
- `git diff --check`: passed.

## Risk and release lane

Public beta; medium risk, research response validation. Valid UTF-8 retains its existing behavior. Corrupt upstream output is rejected instead of silently repaired. Tests use injected local transport; no live Perplexica/model run was performed. No persisted state or migration; rollback is a commit revert.

## AI Assistance

Codex assisted with diagnosis, implementation, tests and this description. Independent human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
