### PR TITLE
fix(preview): resolve nested directory links through the relay

### DIFF
--- a/ods/extensions/services/pixel-edge/pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/pixel_edge.py
@@ -1097,6 +1097,9 @@ def _preview_upstream_path(site_id: str, tail: str) -> str | None:
         return f"/{site_id}/{tail}"
     if re.fullmatch(r"__ods_changes__/(?:initial|site-[a-f0-9]{24})\.json", tail):
         return f"/{site_id}/{tail}"
+    # Match the host static server: a directory URL selects its index file.
+    if tail.endswith("/"):
+        tail += "index.html"
     parts = tail.split("/")
     if any(_PREVIEW_PATH_COMPONENT.fullmatch(part) is None for part in parts):
         return None

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -146,6 +146,7 @@ async def _upstream_cancel(request):
 
 async def _upstream_preview(request):
     request.app["preview_hosts"].append(request.headers.get("Host"))
+    request.app["preview_paths"].append(request.path)
     site_id = "site-" + "a" * 24
     if request.match_info.get("site_id") != site_id:
         return web.Response(status=404)
@@ -194,6 +195,7 @@ async def _start_upstream():
     app["release_stream"] = asyncio.Event()
     app["release_on_cancel"] = False
     app["preview_hosts"] = []
+    app["preview_paths"] = []
     app.router.add_post("/v1/chat/completions", _upstream_chat)
     app.router.add_post("/v1/chat/cancel", _upstream_cancel)
     app.router.add_get("/v1/models", _upstream_models)
@@ -431,6 +433,30 @@ class TestAuth(BaseEdgeTest):
 
 
 class TestPreviewRelay(BaseEdgeTest):
+
+    async def test_nested_directory_links_resolve_to_published_index(self):
+        site = "site-" + "a" * 24
+        for method in ["GET", "HEAD"]:
+            async with self.client.request(
+                method, f"http://localhost/preview/{site}/guide/chapter/",
+                headers=self.auth(),
+            ) as response:
+                self.assertEqual(response.status, 200)
+                self.assertEqual(await response.read(),
+                                 b"<button id=launch>Remote preview</button>" if method == "GET" else b"")
+        self.assertEqual(self.up_runner.app["preview_paths"],
+                         [f"/{site}/guide/chapter/index.html"] * 2)
+        async with self.client.get(f"http://localhost/preview/{site}/guide/") as response:
+            self.assertEqual(response.status, 401)
+        self.assertEqual(len(self.up_runner.app["preview_paths"]), 2)
+
+    async def test_directory_alias_does_not_admit_unsafe_or_reserved_paths(self):
+        from pixel_edge import _preview_upstream_path
+        site = "site-" + "a" * 24
+        for tail in ["guide//", "../", "/guide/", "__ods_manifest__.json/",
+                     "guide/../", "guide/%2e%2e/", "guide/?file=private"]:
+            self.assertIsNone(_preview_upstream_path(site, tail), tail)
+
     async def test_manifest_route_is_exact_and_keeps_authentication(self):
         from pixel_edge import _preview_upstream_path
         site = "site-" + "a" * 24


### PR DESCRIPTION
## Why this matters

A published site can contain `guide/chapter/index.html` and link to `guide/chapter/`. The host static server supports that URL, but the authenticated Dashboard relay rejects its trailing empty path component with 404.

Resolve the trailing slash to `index.html` before the existing component validation. Authentication, reserved metadata routes, digest verification and the opaque preview sandbox remain enforced.

## Overlap check

Searched open and closed PRs for “preview directory index query” and “pixel_edge.py trailing slash”, and inspected recent changed-file metadata. The only broad result was #3385. This fixes the existing relay's nested directory URL handling.

## Validation

- HTTP regression against the real edge app and a Unix-socket upstream reproduces the 404 before the fix. GET and HEAD now reach the exact nested index path; unauthenticated requests never reach the upstream.
- `python -m pytest -q ods/extensions/services/pixel-edge/tests/test_pixel_edge.py -k PreviewRelay`: 11 passed.
- Full edge suite: 89 passed, 2 failures in existing socket teardown under Python 3.13. Both also fail on unmodified public-beta (87 passed); they concern unlinking Unix sockets already removed by asyncio.
- `git diff --check`: passed.

## Risk and release lane

Public beta; proxy path handling. Draft for independent review of this request-boundary change. Tested locally with Python 3.13 and the pinned aiohttp 3.11.12; no deployed browser/fleet validation was performed. Revert restores the prior trailing-slash rejection; no state migration.

## AI Assistance

Codex assisted with diagnosis, code, HTTP regression tests and this description. Automated results do not replace human review.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
