### PR TITLE
test(pixel-edge): tolerate asyncio-owned socket cleanup

### DIFF
--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -1194,12 +1194,12 @@ class TestHeaderStripping(BaseEdgeTest):
             self.assertFalse(seen.get("xforwarded"))
 
             await cap_runner.cleanup()
-            os.unlink(cap_sock)
+            Path(cap_sock).unlink(missing_ok=True)
         finally:
             os.environ["PIXEL_INGRESS_SOCKET"] = self.up_sock
             importlib.reload(pixel_edge)
             await runner.cleanup()
-            os.unlink(path)
+            Path(path).unlink(missing_ok=True)
 
 
 # ---------------------------------------------------------------------------
@@ -1535,7 +1535,7 @@ class TestSanitizedErrors(BaseEdgeTest):
                     self.assertNotIn("Traceback", json.dumps(data))
 
             await runner.cleanup()
-            os.unlink(sock)
+            Path(sock).unlink(missing_ok=True)
         finally:
             pixel_edge._SOCKET_PATH = old
 


### PR DESCRIPTION
## Why this matters

On Python 3.13, the edge header-stripping and upstream-unavailable tests fail during teardown after their HTTP assertions pass: asyncio has already removed the Unix socket when the runner is cleaned up.

Make the three post-runner unlink operations tolerate an already-absent socket. Setup-time unlink operations still require the placeholder file to exist; other filesystem errors still surface.

## Overlap check

Searched open and closed PRs for “socket cleanup Python 3.13” and “test_pixel_edge.py unlink”. #4329 reports this baseline failure while fixing directory links, but does not change teardown. This PR is independently useful on unmodified public-beta.

## Validation

With Python 3.13 and pinned aiohttp 3.11.12:
- Unmodified public-beta: 87 passed, 2 failed (FileNotFoundError at post-cleanup unlink).
- This branch: `python -m pytest -q --disable-warnings ods/extensions/services/pixel-edge/tests/test_pixel_edge.py`: 89 passed, 17 subtests passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; low risk, test fixtures only. No production behavior changes. Earlier Python versions may leave the socket behind, in which case it is still removed. That older-runtime path was not executed locally.

## AI Assistance

Codex assisted with failure diagnosis, the fixture edit and validation. Human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
