### PR TITLE
fix(extensions): reject redirected data directories during purge

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -2506,9 +2506,12 @@ def purge_extension_data(
             if (check_dir / "compose.yaml").exists():
                 raise HTTPException(status_code=400, detail=f"{service_id} is still enabled. Disable it first.")
 
-        data_path = (Path(DATA_DIR) / service_id).resolve()
-        if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
+        data_root = Path(DATA_DIR).resolve()
+        data_path = (data_root / service_id).resolve()
+        if not data_path.is_relative_to(data_root):
             raise HTTPException(status_code=400, detail="Invalid data path")
+        if data_path != data_root / service_id:
+            raise HTTPException(status_code=400, detail="Service data directory redirects to another location")
 
         if not data_path.is_dir():
             raise HTTPException(status_code=404, detail=f"No data directory found for {service_id}")

--- a/ods/extensions/services/dashboard-api/tests/test_purge_data_alias.py
+++ b/ods/extensions/services/dashboard-api/tests/test_purge_data_alias.py
@@ -1,0 +1,55 @@
+"""Purge must not follow an extension's data alias into another directory."""
+import os
+
+import pytest
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Directory symlink creation requires Windows privileges")
+def test_purge_refuses_sibling_data_alias(test_client, monkeypatch, tmp_path):
+    import routers.extensions as extensions
+
+    monkeypatch.setattr(extensions, "DATA_DIR", str(tmp_path))
+    monkeypatch.setattr(extensions, "EXTENSIONS_DIR", tmp_path / "builtin")
+    monkeypatch.setattr(extensions, "USER_EXTENSIONS_DIR", tmp_path / "user")
+    sibling = tmp_path / "another-service"
+    sibling.mkdir()
+    evidence = sibling / "keep.db"
+    evidence.write_text("other service data")
+    alias = tmp_path / "my-ext"
+    alias.symlink_to(sibling, target_is_directory=True)
+
+    response = test_client.request(
+        "DELETE", "/api/extensions/my-ext/data",
+        headers=test_client.auth_headers, json={"confirm": True},
+    )
+
+    assert response.status_code == 400
+    assert "redirect" in response.json()["detail"].lower()
+    assert evidence.read_text() == "other service data"
+    assert alias.is_symlink()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Directory symlink creation requires Windows privileges")
+def test_purge_supports_a_configured_data_root_alias(test_client, monkeypatch, tmp_path):
+    import routers.extensions as extensions
+
+    root = tmp_path / "actual-data"
+    root.mkdir()
+    configured = tmp_path / "configured-data"
+    configured.symlink_to(root, target_is_directory=True)
+    target = root / "my-ext"
+    target.mkdir()
+    (target / "old.db").write_text("purge this")
+    monkeypatch.setattr(extensions, "DATA_DIR", str(configured))
+    monkeypatch.setattr(extensions, "EXTENSIONS_DIR", tmp_path / "builtin")
+    monkeypatch.setattr(extensions, "USER_EXTENSIONS_DIR", tmp_path / "user")
+
+    response = test_client.request(
+        "DELETE", "/api/extensions/my-ext/data",
+        headers=test_client.auth_headers, json={"confirm": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["action"] == "purged"
+    assert not target.exists()
+    assert configured.is_symlink()


### PR DESCRIPTION
Purging disabled service my-ext currently resolves data/my-ext before deletion. If it is a symlink to data/another-service, the request deletes the sibling service directory and returns purged. Refuse a service directory that resolves anywhere other than its named child beneath the resolved configured data root.

## Why this matters
The authenticated DELETE /api/extensions/{id}/data route is destructive and confirmation identifies one service. That confirmation must not authorize deletion of another service's data through an alias. Preserve configured DATA_DIR symlinks (whole-root storage relocation), existing auth/confirmation/disabled-service checks, and per-service mutation locking.

## Overlap check
Searched every open/closed extensions.py PR and purge/symlink/partial-deletion keywords. #4169/#3986 address extension code reinstall staging; #892 cleans progress receipts; #2903 adds lifecycle plans. None constrains the resolved purge target to its named data child. Issue #4183's example is inaccurate on this base: a post-rmtree existence check already rejects partial deletion. The confirmed counterexample here is a sibling data alias, exercised through HTTP with a real filesystem link.

## Validation
- Regression fails on f5f49b7d with HTTP 200 and sibling data removed.
- Native WSL Linux: `python -m pytest tests/test_purge_data_alias.py tests/test_extensions.py -q`: 265 passed.
- Tests preserve the sibling's exact file content and symlink, and prove a configured data-root symlink still supports an ordinary confirmed purge.
- Scoped pre-commit and diff checks passed.
- Full baseline make test stops at the known optional host-agent restart defect covered by existing #3159; remaining BATS/smoke/simulation run separately. No duplicate PR created for that defect.

## Risk, review and rollback
Keep draft for independent maintainer review: this changes a destructive filesystem boundary. Tests use isolated temporary directories only. Symlink cases run on Linux; Windows junctions and physical deployments remain unverified. This is a guard against pre-existing redirection, not a claim of race-free hostile-filesystem protection. Operators intentionally using a per-service symlink must manage that target explicitly rather than purging through the dashboard. Reverting restores the unsafe alias behavior; no migration or data rewrite is performed.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
