### PR TITLE
fix(pixel): preserve evidence reports when replacement fails

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/evidence-artifact.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/evidence-artifact.mjs
@@ -3,11 +3,14 @@ import {
   closeSync,
   constants,
   fchmodSync,
-  ftruncateSync,
   fsyncSync,
   fstatSync,
   lstatSync,
   mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmdirSync,
+  unlinkSync,
   openSync,
   readSync,
   realpathSync,
@@ -21,6 +24,7 @@ const SAFE_COMPONENT = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
 const WRITE_FLAGS =
   constants.O_RDWR |
   constants.O_CREAT |
+  constants.O_EXCL |
   (constants.O_NOFOLLOW ?? 0) |
   (constants.O_CLOEXEC ?? 0);
 
@@ -34,6 +38,26 @@ function assertOwnedDirectory(value, owner) {
   ) {
     throw new Error("unsafe Pixel workspace directory");
   }
+}
+
+// Inspect without truncating or changing permissions on the existing report.
+function destinationState(destination, owner) {
+  let info;
+  try { info = lstatSync(destination); }
+  catch (error) { if (error?.code === "ENOENT") return null; throw error; }
+  if (!info.isFile() || info.isSymbolicLink() || info.nlink !== 1 ||
+      (owner !== undefined && info.uid !== owner)) {
+    throw new Error("unsafe Pixel evidence destination");
+  }
+  // Preserve the original writable-file requirement, including filesystem ACLs.
+  const handle = openSync(destination, constants.O_RDWR | (constants.O_NOFOLLOW ?? 0));
+  try {
+    const opened = fstatSync(handle);
+    if (opened.dev !== info.dev || opened.ino !== info.ino) {
+      throw new Error("Pixel evidence destination changed");
+    }
+  } finally { closeSync(handle); }
+  return info;
 }
 
 function safeParts(relativePath) {
@@ -94,9 +118,12 @@ export function createEvidenceArtifactWriter({
       throw new Error("Pixel evidence path escaped its workspace");
     }
 
+    const previous = destinationState(destination, owner);
+    const stage = mkdtempSync(path.join(parent, ".pixel-evidence-"));
+    const temporary = path.join(stage, "report");
     let handle;
     try {
-      handle = openSync(destination, WRITE_FLAGS, 0o600);
+      handle = openSync(temporary, WRITE_FLAGS, 0o600);
       const details = fstatSync(handle);
       if (
         !details.isFile() ||
@@ -106,10 +133,7 @@ export function createEvidenceArtifactWriter({
         throw new Error("unsafe Pixel evidence destination");
       }
       fchmodSync(handle, 0o600);
-      // Validate the opened inode before changing any bytes. In particular,
-      // O_TRUNC at open time would destroy a multiply-linked destination even
-      // though the guard subsequently rejects it.
-      ftruncateSync(handle, 0);
+      // The previous report remains untouched until staged bytes pass readback.
       let written = 0;
       while (written < bytes.length) {
         written += writeSync(handle, bytes, written, bytes.length - written, written);
@@ -125,8 +149,19 @@ export function createEvidenceArtifactWriter({
       if (read !== bytes.length || !observed.equals(bytes)) {
         throw new Error("Pixel evidence readback mismatch");
       }
+      closeSync(handle);
+      handle = undefined;
+      const current = destinationState(destination, owner);
+      if (previous === null ? current !== null : current === null ||
+          ["dev", "ino", "size", "mtimeMs", "ctimeMs"].some(key => previous[key] !== current[key])) {
+        throw new Error("Pixel evidence destination changed");
+      }
+      renameSync(temporary, destination);
     } finally {
       if (handle !== undefined) closeSync(handle);
+      try { unlinkSync(temporary); }
+      catch (error) { if (error?.code !== "ENOENT") throw error; }
+      rmdirSync(stage);
     }
 
     return {

--- a/ods/extensions/services/pixel-agent/tests/evidence_artifact_failure.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/evidence_artifact_failure.test.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { syncBuiltinESMExports } from 'node:module';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createEvidenceArtifactWriter } from '../plugin/evidence-artifact.mjs';
+
+test('a partial failed write preserves the previous verified report and cleans staging', () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'pixel-evidence-failure-'));
+  const destination = path.join(root, 'report.txt');
+  const original = 'Previous verified report\n';
+  const replacement = 'Replacement report that cannot finish\n';
+  fs.writeFileSync(destination, original, {mode:0o600});
+  const write = fs.writeSync;
+  try {
+    fs.writeSync = (fd, buffer, offset, length, position) => {
+      if (Buffer.isBuffer(buffer) && buffer.toString('utf8') === replacement) {
+        write(fd, buffer, offset, 3, position);
+        throw Object.assign(new Error('Simulated full filesystem'), {code:'ENOSPC'});
+      }
+      return write(fd, buffer, offset, length, position);
+    };
+    syncBuiltinESMExports();
+    assert.throws(() => createEvidenceArtifactWriter({workspaceRoot:root})({
+      relativePath:'report.txt', content:replacement,
+    }), {code:'ENOSPC'});
+  } finally {
+    fs.writeSync = write;
+    syncBuiltinESMExports();
+  }
+  try {
+    assert.equal(fs.readFileSync(destination, 'utf8'), original);
+    assert.deepEqual(fs.readdirSync(root), ['report.txt']);
+    const result = createEvidenceArtifactWriter({workspaceRoot:root})({
+      relativePath:'report.txt', content:replacement,
+    });
+    assert.equal(result.readbackVerified, true);
+    assert.equal(fs.readFileSync(destination, 'utf8'), replacement);
+    assert.deepEqual(fs.readdirSync(root), ['report.txt']);
+  } finally {
+    fs.rmSync(root, {recursive:true, force:true});
+  }
+});
+
+test('a readback mismatch never replaces an existing report', () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'pixel-evidence-readback-'));
+  const destination = path.join(root, 'report.txt');
+  fs.writeFileSync(destination, 'Keep this report', {mode:0o600});
+  const read = fs.readSync;
+  try {
+    fs.readSync = (fd, buffer, offset, length, position) => {
+      const count = read(fd, buffer, offset, length, position);
+      if (count && buffer.toString('utf8') === 'New verified report') buffer[0] ^= 1;
+      return count;
+    };
+    syncBuiltinESMExports();
+    assert.throws(() => createEvidenceArtifactWriter({workspaceRoot:root})({
+      relativePath:'report.txt', content:'New verified report',
+    }), /readback mismatch/);
+  } finally {
+    fs.readSync = read;
+    syncBuiltinESMExports();
+  }
+  try {
+    assert.equal(fs.readFileSync(destination, 'utf8'), 'Keep this report');
+    assert.deepEqual(fs.readdirSync(root), ['report.txt']);
+  } finally { fs.rmSync(root, {recursive:true, force:true}); }
+});
+
+test('destination symlinks cannot replace the linked report', t => {
+  if (process.platform === 'win32') return t.skip('Windows symlink creation needs additional privileges');
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'pixel-evidence-symlink-'));
+  try {
+    fs.writeFileSync(path.join(root, 'original.txt'), 'Keep', {mode:0o600});
+    fs.symlinkSync('original.txt', path.join(root, 'report.txt'));
+    assert.throws(() => createEvidenceArtifactWriter({workspaceRoot:root})({
+      relativePath:'report.txt', content:'Replace',
+    }), /unsafe Pixel evidence destination/);
+    assert.equal(fs.readFileSync(path.join(root, 'original.txt'), 'utf8'), 'Keep');
+    assert.equal(fs.lstatSync(path.join(root, 'report.txt')).isSymbolicLink(), true);
+  } finally { fs.rmSync(root, {recursive:true, force:true}); }
+});


### PR DESCRIPTION
## Why this matters

A failed evidence rewrite destroys the previous report: the writer truncates the destination before writing replacement bytes. A simulated ENOSPC after three bytes reproduces that loss through `createEvidenceArtifactWriter()`.

Write, fsync and verify a private staged file first, then rename it over the destination. Existing destination ownership, regular-file, hard-link and writable-file checks run before staging. Recheck its identity and modification metadata before replacement so an intervening edit is rejected. Failed staging leaves the old report intact and removes the temporary files.

## Overlap check

Searched open and closed upstream PRs for “evidence artifact atomic” and `evidence-artifact.mjs`, plus recent changed-file metadata. Returned installer/configuration backup proposals and #3385/#3951 do not fix this existing evidence writer's truncate-before-write behavior.

## Validation

- Partial-write ENOSPC regression fails before the fix and preserves the previous report after it.
- Readback-corruption regression preserves the existing report; successful replacement returns a verified receipt.
- Destination symlink, hard-link and parent traversal protections pass.
- `node --test ods/extensions/services/pixel-agent/tests/evidence_artifact*.test.mjs ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs`: 507 passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; host file replacement. Draft pending independent human review. Atomic replacement changes the destination inode; readers holding the old descriptor continue to see the old report. This provides process-level atomic publication, not a claim of power-loss durability or protection against an actively malicious workspace owner. Tested on Linux/WSL; macOS and Windows behavior was not executed locally. No migration; revert the commit to restore the previous writer.

## AI Assistance

Codex assisted with diagnosis, implementation, fault-injection tests and this description. Human review and platform validation remain necessary.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
