### PR TITLE
fix(pixel): allow cancelling pending dictation finalization

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelDictation.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDictation.jsx
@@ -22,6 +22,7 @@ export default function PixelDictation({ disabled, conversationId, onInsert }) {
   }, [])
   useEffect(() => { stop() }, [disabled, conversationId])
   function start() {
+    if (finishing) { stop(); setNotice('Dictation cancelled. Text already received is kept; pending speech was discarded.'); return }
     if (listening) { recognition.current?.stop(); setFinishing(true); return }
     if (disabled) return
     const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition
@@ -46,7 +47,7 @@ export default function PixelDictation({ disabled, conversationId, onInsert }) {
     try { active.start(); setListening(true) } catch { recognition.current = null; setNotice('Dictation could not start in this browser.') }
   }
   return <div className="pixel-dictation">
-    <button type="button" disabled={disabled || finishing} aria-label={listening ? 'Stop dictation' : 'Dictate message'} aria-pressed={listening} title="Browser dictation may use your browser provider’s online speech service. Audio is not sent to the ODS model." onClick={start}>{listening ? <Square size={15}/> : <Mic size={16}/>}</button>
+    <button type="button" disabled={disabled} aria-label={finishing ? 'Cancel dictation' : listening ? 'Stop dictation' : 'Dictate message'} aria-pressed={listening} title="Browser dictation may use your browser provider’s online speech service. Audio is not sent to the ODS model." onClick={start}>{listening ? <Square size={15}/> : <Mic size={16}/>}</button>
     {listening && <span role="status">{finishing ? 'Finishing dictation…' : 'Listening…'}</span>}
     {notice && <span role="status" className="pixel-dictation-notice">{notice}</span>}
   </div>

--- a/ods/extensions/services/dashboard/src/components/PixelDictationCancel.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelDictationCancel.test.jsx
@@ -1,0 +1,29 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import PixelDictation from './PixelDictation'
+
+afterEach(() => { delete window.SpeechRecognition })
+
+test('cancels a pending speech finalization, preserves received text and rejects late results', () => {
+  const sessions = []
+  window.SpeechRecognition = function () {
+    const session = { start: vi.fn(), stop: vi.fn(), abort: vi.fn() }
+    sessions.push(session)
+    return session
+  }
+  const onInsert = vi.fn()
+  render(<PixelDictation conversationId="one" onInsert={onInsert} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Dictate message' }))
+  const first = sessions[0]
+  act(() => first.onresult({ results: [[{ transcript: 'Already received' }]] }))
+  fireEvent.click(screen.getByRole('button', { name: 'Stop dictation' }))
+  expect(first.stop).toHaveBeenCalledOnce()
+  expect(first.abort).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel dictation' }))
+  expect(first.abort).toHaveBeenCalledOnce()
+  expect(screen.getByRole('status')).toHaveTextContent('Text already received is kept')
+  fireEvent.click(screen.getByRole('button', { name: 'Dictate message' }))
+  act(() => { first.onresult({ results: [[{ transcript: 'Late old words' }]] }); first.onend() })
+  expect(screen.getByRole('button', { name: 'Stop dictation' })).toHaveAttribute('aria-pressed', 'true')
+  act(() => sessions[1].onresult({ results: [[{ transcript: 'New words' }]] }))
+  expect(onInsert.mock.calls).toEqual([['Already received '], ['New words ']])
+})


### PR DESCRIPTION
## Why this matters
Clicking Stop calls the browser speech recognizer's asynchronous stop(), then disables the only dictation control until an end/error event arrives. A delayed or stalled provider leaves the user unable to cancel capture finalization or start a new recording without changing conversations.

Expose Cancel dictation while finishing. The first Stop still accepts final transcripts; an explicit subsequent Cancel aborts the pending recognizer, retains text already inserted, and tells the user pending speech was discarded. Identity checks reject callbacks from the cancelled session even after a new session starts. No timeout silently discards speech.

## Overlap check
Searched open/closed PRs for dictation/speech and PixelDictation.jsx. #4106 preserves final results after Stop and #4117 handles cumulative result lists; this preserves both behaviors and adds an explicit recovery action for the pending-stop state. #4027 is the original beta UI umbrella. No existing cancellation PR was found.

## Validation
- New rendered-component regression failed on public-beta because the Cancel action was absent; passed after the fix.
- `npx vitest run src/components/PixelDictationCancel.test.jsx src/components/PixelDictation.test.jsx`: 8 passed, including retained final speech, conversation changes, old callbacks after cancellation/restart, and permission handling.
- Focused ESLint: 0 errors (existing JSX unused-import warnings); git diff --check and scoped pre-commit passed.

Browser-independent state handling is covered with a SpeechRecognition double; live browser/provider audio was not exercised. No backend, persisted format, or platform installer changes. Reverting restores the previous disabled finishing button.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
