### PR TITLE
fix(pixel): release unfinished research error responses

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/perplexica-research.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/perplexica-research.mjs
@@ -169,6 +169,8 @@ export function createPerplexicaResearchTool(deps = {}) {
           : "Perplexica research was unavailable or did not finish correctly. No completed research answer was returned. Check the installed Perplexica service and its model/search configuration before retrying.",
         { status: interrupted ? (signal?.aborted ? "cancelled" : "timed_out") : "unavailable", researchSubmitted: researchStarted, upstreamCancellationVerified: false }, true);
       } finally {
+        // Release unread error bodies as well as any completed request resources.
+        controller.abort();
         clearTimeout(timer);
         signal?.removeEventListener("abort", abort);
       }

--- a/ods/extensions/services/pixel-agent/tests/research_response_cleanup.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/research_response_cleanup.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { createPerplexicaResearchTool } from '../plugin/perplexica-research.mjs';
+
+for (const stage of ['config', 'search']) {
+  test(`releases an unfinished HTTP error body from research ${stage}`, async () => {
+    let markClosed;
+    const closed = new Promise(resolve => {markClosed = resolve;});
+    const server = http.createServer((request, response) => {
+      if (stage === 'search' && request.url === '/api/config') {
+        response.setHeader('Content-Type', 'application/json');
+        response.end(JSON.stringify({values:{preferences:{
+          defaultChatProvider:'local', defaultChatModel:'chat',
+          defaultEmbeddingProvider:'local', defaultEmbeddingModel:'embed',
+        }}}));
+        return;
+      }
+      response.on('close', markClosed);
+      response.writeHead(503, {'Content-Type':'text/plain'});
+      response.write('Unavailable');
+      // Keep the failed body open: the client must release it after rejecting status.
+    });
+    await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+    let timer;
+    try {
+      const tool = createPerplexicaResearchTool({port:server.address().port, env:{}});
+      const result = await tool.execute('failed-http', {query:'Research public facts'});
+      assert.equal(result.details.status, 'unavailable');
+      await Promise.race([closed, new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error('Failed response connection was retained')), 1000);
+      })]);
+    } finally {
+      clearTimeout(timer);
+      server.closeAllConnections();
+      await new Promise(resolve => server.close(resolve));
+    }
+  });
+}


### PR DESCRIPTION
## Why this matters

When Perplexica returns an HTTP error with a body that remains open, Pixel returns an unavailable result but leaves the fetch connection alive. Repeated retries can retain those responses until transport or garbage collection eventually cleans them up.

Abort the request-owned controller in final cleanup, including rejected configuration and search responses. This releases client resources; it does not claim that Perplexica cancelled a submitted research task.

## Overlap check

Searched open and closed upstream PRs for “Perplexica response cleanup cancel” and reviewed `perplexica-research.mjs` overlaps. #4328 addresses UTF-8 decoding in the same module; this change handles connection lifetime and composes independently. The broader Portal proposals do not provide this error-body cleanup.

## Validation

- Real loopback HTTP servers return 503 and deliberately keep configuration/search bodies open. Both regressions fail before the fix and observe connection closure afterward.
- `node --test ods/extensions/services/pixel-agent/tests/research_response_cleanup.test.mjs ods/extensions/services/pixel-agent/tests/perplexica_research.test.mjs`: 12 passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; medium risk, read/request resource cleanup. Existing success, partial-answer and cancellation receipts pass their tests. No live Perplexica model run was performed. No persisted state; revert restores previous cleanup. Independent of #4328, with combined validation planned for the batch.

## AI Assistance

Codex assisted with diagnosis, implementation, real-HTTP regression tests and this description. Independent human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
