### PR TITLE
fix(pixel): honor cancelled preview publication requests

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/workspace-preview.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/workspace-preview.mjs
@@ -106,7 +106,8 @@ function validResponse(value, request) {
   return value;
 }
 
-function socketRequest(payload, socketPath = SOCKET_PATH) {
+function socketRequest(payload, { socketPath = SOCKET_PATH, signal } = {}) {
+  if (signal?.aborted) return Promise.reject(new Error("Pixel workspace preview cancelled"));
   return new Promise((resolve, reject) => {
     const connection = net.createConnection({ path: socketPath });
     const chunks = [];
@@ -115,9 +116,13 @@ function socketRequest(payload, socketPath = SOCKET_PATH) {
     const finish = (callback, value) => {
       if (settled) return;
       settled = true;
+      signal?.removeEventListener("abort", onAbort);
       connection.destroy();
       callback(value);
     };
+    const onAbort = () => finish(reject, new Error("Pixel workspace preview cancelled"));
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
     connection.setTimeout(30_000);
     connection.on("connect", () => {
       connection.end(`${JSON.stringify(payload)}\n`);
@@ -173,7 +178,9 @@ function failedResult(code) {
   return {
     content: [{
       type: "text",
-      text: code
+      text: code === "cancelled"
+        ? "Pixel stopped waiting for preview publication. A request already accepted by the host may still complete; no new verified preview receipt is returned."
+        : code
         ? `ODS could not publish the preview. ${FAILURE_MESSAGES[code]} Do not claim a localhost URL is live until publication succeeds.`
         : "ODS could not publish a verified browser preview. Keep the site files in the workspace, correct the reported file or entry-point problem if one was returned, and do not claim a localhost URL is live.",
     }],
@@ -205,10 +212,12 @@ export function createWorkspacePreviewTool({ request = socketRequest } = {}) {
         },
       },
     },
-    execute: async (_toolCallId, params) => {
+    execute: async (_toolCallId, params, signal) => {
       try {
+        signal?.throwIfAborted();
         const normalized = normalizeWorkspacePreviewParams(params);
-        const raw = await request(normalized);
+        const raw = await request(normalized, { signal });
+        signal?.throwIfAborted();
         const failureCode = validatedFailureCode(raw);
         if (failureCode) return failedResult(failureCode);
         const response = validResponse(raw, normalized);
@@ -222,7 +231,7 @@ export function createWorkspacePreviewTool({ request = socketRequest } = {}) {
           details: response,
         };
       } catch {
-        return failedResult();
+        return failedResult(signal?.aborted ? "cancelled" : undefined);
       }
     },
   };
@@ -232,4 +241,5 @@ export const testing = Object.freeze({
   BOUNDARY,
   validRelativeDirectory,
   validResponse,
+  socketRequest,
 });

--- a/ods/extensions/services/pixel-agent/tests/workspace_preview_cancellation.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/workspace_preview_cancellation.test.mjs
@@ -53,3 +53,26 @@ test('cancellation settles a stalled publication socket without claiming host ca
     fs.rmSync(root, {recursive:true, force:true});
   }
 });
+
+test('a late valid receipt cannot revive a cancelled publication wait', async () => {
+  const controller = new AbortController();
+  const sha256 = 'a'.repeat(64);
+  const siteId = 'site-' + sha256.slice(0, 24);
+  const receipt = {
+    schemaVersion:1, kind:'ods-pixel-workspace-preview', status:'succeeded',
+    relativeDirectory:'site', siteId, port:9437,
+    url:`http://${siteId}.localhost:9437/${siteId}/`,
+    files:1, bytes:40, sha256, entryFile:'index.html', entrySha256:'b'.repeat(64),
+    httpStatus:200, readbackVerified:true, executable:false, overwritten:false,
+    boundary:testing.BOUNDARY,
+  };
+  const tool = createWorkspacePreviewTool({request:async () => {
+    controller.abort();
+    return receipt;
+  }});
+  const result = await tool.execute('late-receipt', {relativeDirectory:'site'}, controller.signal);
+  assert.equal(result.isError, true);
+  assert.equal(result.details.errorCode, 'cancelled');
+  assert.equal(result.details.siteId, undefined);
+  assert.match(result.content[0].text, /may still complete/);
+});

--- a/ods/extensions/services/pixel-agent/tests/workspace_preview_cancellation.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/workspace_preview_cancellation.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import fs from 'node:fs';
+import path from 'node:path';
+import {tmpdir} from 'node:os';
+import {createWorkspacePreviewTool, testing} from '../plugin/workspace-preview.mjs';
+
+test('an already cancelled tool call sends no publication request', async () => {
+  let requests = 0;
+  const controller = new AbortController();
+  controller.abort();
+  const tool = createWorkspacePreviewTool({request:async () => {requests++; return {};}});
+  const result = await tool.execute('cancelled', {relativeDirectory:'site'}, controller.signal);
+  assert.equal(requests, 0);
+  assert.equal(result.details.errorCode, 'cancelled');
+  assert.equal(result.isError, true);
+});
+
+test('cancellation settles a stalled publication socket without claiming host cancellation',
+  {skip:process.platform === 'win32' ? 'Requires the POSIX preview service Unix socket' : false}, async () => {
+  const root = fs.mkdtempSync(path.join(tmpdir(), 'pixel-preview-abort-'));
+  const socketPath = path.join(root, 'preview.sock');
+  const sockets = new Set();
+  let received;
+  const ready = new Promise(resolve => {received = resolve;});
+  const server = net.createServer({allowHalfOpen:true}, socket => {
+    sockets.add(socket);
+    socket.on('error', error => { if (error.code !== 'ECONNRESET') throw error; });
+    socket.on('data', received);
+    socket.on('close', () => sockets.delete(socket));
+  });
+  await new Promise(resolve => server.listen(socketPath, resolve));
+  let timer;
+  try {
+    const controller = new AbortController();
+    const tool = createWorkspacePreviewTool({
+      request:(payload, options) => testing.socketRequest(payload, {...options, socketPath}),
+    });
+    const pending = tool.execute('pending', {relativeDirectory:'site'}, controller.signal);
+    await ready;
+    controller.abort();
+    const result = await Promise.race([pending, new Promise((_, reject) => {
+      timer = setTimeout(() => reject(new Error('Preview ignored cancellation')), 1000);
+    })]);
+    assert.equal(result.details.errorCode, 'cancelled');
+    assert.match(result.content[0].text, /may still complete/);
+    assert.equal(result.isError, true);
+  } finally {
+    clearTimeout(timer);
+    for (const socket of sockets) socket.destroy();
+    await new Promise(resolve => server.close(resolve));
+    fs.rmSync(root, {recursive:true, force:true});
+  }
+});


### PR DESCRIPTION
## Why this matters

The preview tool ignores its AbortSignal. A call already cancelled by the runtime still sends a publication request, and stopping an in-flight call leaves the socket wait active until its timeout.

Reject cancelled calls before transport, pass the signal through the private socket adapter, and discard replies after cancellation. The result states that an already-accepted host publication may still complete; it does not claim server-side cancellation or return a newly verified receipt.

## Overlap check

Searched open and closed PRs for “workspace preview cancellation signal” and checked recent changed-file metadata. #4214 handles Workbench delivery and stopped-response presentation; #3385 is a broad Portal proposal. Neither returned scope wires cancellation into the existing publication tool.

## Validation

- Pre-cancelled public-tool regression fails before the change and sends zero requests after it.
- A real stalled Unix-socket server exercises in-flight cancellation and prompt settlement.
- `node --test ods/extensions/services/pixel-agent/tests/workspace_preview*.test.mjs ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs`: 512 passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; medium risk, private publication transport. Draft for independent review of cancellation semantics. The host remains responsible for accepted work and immutable snapshots; client cancellation only stops waiting. Linux/WSL socket validation completed; the Unix-socket test is explicitly inapplicable on Windows. No live agent run was performed. Revert restores the earlier wait behavior.

## AI Assistance

Codex assisted with diagnosis, implementation, tool/socket regression tests and this description. Human review remains required.


## Follow-up validation
Added a public-tool regression for a valid receipt arriving after cancellation. All 12 preview tests pass on the follow-up. An earlier unrelated PortalIdentityContext CI timing failure remains recorded; the follow-up head has a fresh CI run.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
