### PR TITLE
fix(pixel): expire stale handoff consent on the client

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelHandoffApproval.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelHandoffApproval.jsx
@@ -38,6 +38,7 @@ export default function PixelHandoffApproval({ label = 'Review handoffs' }) {
   const [warning, setWarning] = useState('')
   const [busy, setBusy] = useState(false)
   const [uncertain, setUncertain] = useState(false)
+  const [now, setNow] = useState(Date.now)
   const generation = useRef(0)
   const inFlight = useRef(false)
   const controllers = useRef(new Set())
@@ -46,6 +47,17 @@ export default function PixelHandoffApproval({ label = 'Review handoffs' }) {
   const previousDigest = useRef(null)
 
   const clearConsent = useCallback(() => { setReviewed(false); setCloud(false); setCost(false) }, [])
+  useEffect(() => {
+    if (!open || preview?.status !== 'pending') return
+    const tick = () => {
+      const time = Date.now()
+      setNow(time)
+      if (time >= preview.expiresAt * 1000) clearConsent()
+    }
+    tick()
+    const timer = setInterval(tick, 1000)
+    return () => clearInterval(timer)
+  }, [open, preview?.status, preview?.expiresAt, clearConsent])
   const request = useCallback(async (action, body) => {
     const controller = new AbortController()
     controllers.current.add(controller)
@@ -107,6 +119,7 @@ export default function PixelHandoffApproval({ label = 'Review handoffs' }) {
 
   const decide = async approved => {
     if (inFlight.current || busy || uncertain || preview?.status !== 'pending' ||
+        Date.now() >= preview.expiresAt * 1000 ||
         approved && (!reviewed || preview.recipient.kind === 'cloud' && !(cloud && cost))) return
     inFlight.current = true; setBusy(true); setError('')
     const current = generation.current
@@ -134,7 +147,8 @@ export default function PixelHandoffApproval({ label = 'Review handoffs' }) {
     else if (!event.shiftKey && document.activeElement === last) { event.preventDefault(); first.focus() }
   }
   const recipient = preview?.recipient
-  const pending = preview?.status === 'pending' && !busy && !uncertain
+  const expired = preview?.status === 'pending' && now >= preview.expiresAt * 1000
+  const pending = preview?.status === 'pending' && !expired && !busy && !uncertain
 
   return <>
     <button ref={trigger} type="button" className={button} onClick={() => { clearConsent(); setOpen(true) }}>{label}</button>
@@ -156,6 +170,7 @@ export default function PixelHandoffApproval({ label = 'Review handoffs' }) {
         {!runId && !items.length && <p className="my-3 text-sm">No pending handoffs.</p>}
         {preview && <div className="mt-3 space-y-3 break-words">
           <p>Handoff: {preview.status}. Approval is permission to proceed, not evidence that inference completed.</p>
+          {expired && <p role="status">This approval window has expired on this device. Reload the handoff to check the server state.</p>}
           <p className="text-sm">Recipient: {recipient.label} ({recipient.kind}) · {recipient.model}<br />Endpoint: {recipient.baseUrl}<br />
             Saved revision: {recipient.revision}. Previous leader: {recipient.previousProviderId}.<br />
             Approval expires: {new Date(preview.expiresAt * 1000).toLocaleString()}.</p>

--- a/ods/extensions/services/dashboard/src/components/PixelHandoffExpiration.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelHandoffExpiration.test.jsx
@@ -1,0 +1,35 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import PixelHandoffApproval from './PixelHandoffApproval'
+
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); localStorage.clear() })
+
+test('expires visible consent locally while a status refresh is stalled', async () => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-11T00:00:00Z'))
+  const runId = '5c292c25-9368-4d9a-83cd-1e14d34cb128'
+  const recipient = { kind: 'local', scope: 'run', label: 'Local provider' }
+  const checkpointJson = JSON.stringify({ schemaVersion: 1, runId, agentId: 'pixel',
+    dataScope: 'conversation-and-this-run-tool-results', returnAction: 'configured-leader-on-next-run', messages: [], recipient })
+  localStorage.setItem('ods.pixel.handoff.run.v1', runId)
+  let reads = 0
+  const fetchMock = vi.fn(async url => {
+    if (url.endsWith('/list')) {
+      if (reads++) return new Promise(() => {})
+      return { ok: true, json: async () => ({ items: [], unavailableCount: 0 }) }
+    }
+    return { ok: true, json: async () => ({ runId, recipient, checkpointJson,
+      checkpointDigest: 'a'.repeat(64), status: 'pending', expiresAt: Date.now() / 1000 + 3 }) }
+  })
+  vi.stubGlobal('fetch', fetchMock)
+  render(<PixelHandoffApproval />)
+  await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Review handoffs' })))
+  const consent = screen.getByLabelText('I reviewed this recipient and checkpoint and approve the stated run scope')
+  fireEvent.click(consent)
+  expect(screen.getByRole('button', { name: 'Approve this run' })).toBeEnabled()
+  await act(async () => vi.advanceTimersByTimeAsync(3000))
+  expect(screen.getByRole('button', { name: 'Approve this run' })).toBeDisabled()
+  expect(screen.getByRole('button', { name: 'Decline handoff' })).toBeDisabled()
+  expect(consent).not.toBeChecked()
+  expect(screen.getByRole('status')).toHaveTextContent('approval window has expired')
+  expect(fetchMock.mock.calls.every(([url]) => !url.endsWith('/decide'))).toBe(true)
+})


### PR DESCRIPTION
**Ready for independent review (2026-09-15).** Candidate `fc92e96a27a31cc77854787a124c0e70c2e3ecc1` has a successful GitHub check rollup and no base-branch conflict at this review snapshot. This supersedes earlier draft-status wording only. All validation gaps, migration requirements, live gates and independent human review requirements below remain in force; this is not a merge-ready approval.

## Why this matters
A handoff preview includes expiresAt, and the approval manager rejects decisions at or after that timestamp (ods/bin/pixel_provider/handoff_approvals.py). The UI nevertheless keeps checked consent and enabled decision buttons while its next status request is delayed. It offers a decision the displayed approval window no longer permits.

Expire the visible controls independently of polling, clear consent, and explain that the device clock says the window expired. A wall-clock check at the decision boundary also prevents a click between timer ticks. Server authority and the exact run/digest decision payload remain unchanged.

## Overlap check
Searched open and closed PRs for handoff expiration/consent and PixelHandoffApproval.jsx. Only #4027 introduces the UI; no dedicated expiration fix exists. This changes the approval UI, independent of sharing-token expiration (#4118) and runtime handoff authorization.

## Validation
- Rendered UI regression reproduced enabled approval after expiration while a refresh stalled; failed on base, passed with the fix.
- `npx vitest run src/components/PixelHandoffExpiration.test.jsx src/components/PixelHandoffApproval.test.jsx`: 8 passed, including cloud consent, exact decision payload, changed digest, uncertain outcomes and terminal states.
- Focused ESLint 0 errors; scoped pre-commit and git diff --check passed.

Clock skew can disable controls early: the message explicitly identifies the device clock and requests a server refresh. The server remains authoritative; no claim of a new security boundary. Timer cleans up when closed, terminal, or unmounted. No live provider transfer was performed. Still requires independent review of consent UI. Revert restores polling-only freshness without modifying stored approvals.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Independent human review of filesystem/authorization changes remains required despite green CI.
