### PR TITLE
fix(gpu): preserve gaps and timestamps in history charts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/GPUChart.jsx
+++ b/ods/extensions/services/dashboard/src/components/GPUChart.jsx
@@ -1,22 +1,27 @@
 import { memo } from 'react'
 
 // SVG polyline sparkline — no external deps
-function Sparkline({ values, color, height = 48, width = '100%' }) {
-  const data = (values || []).filter(v => v != null)
-  if (data.length < 2) {
+function Sparkline({ values, timestamps, color, height = 48, width = '100%' }) {
+  const data = values || []
+  const measured = data.filter(Number.isFinite)
+  if (!measured.length) {
     return <div className="h-12 bg-zinc-800/50 rounded" />
   }
 
   const W = 300 // internal viewBox width
   const H = height
-  const max = Math.max(...data, 1)
-  const pts = data
-    .map((v, i) => {
-      const x = (i / (data.length - 1)) * W
-      const y = H - (v / max) * (H - 4) - 2
-      return `${x.toFixed(1)},${y.toFixed(1)}`
-    })
-    .join(' ')
+  const max = Math.max(...measured, 1)
+  const times = timestamps.map(value => new Date(value).getTime())
+  const span = times.at(-1) - times[0]
+  const segments = []
+  let segment = []
+  data.forEach((value, index) => {
+    if (!Number.isFinite(value)) { segment = []; return }
+    if (!segment.length) segments.push(segment)
+    const x = span > 0 ? (times[index] - times[0]) / span * W : W / 2
+    const y = H - (value / max) * (H - 4) - 2
+    segment.push([x.toFixed(1), y.toFixed(1)])
+  })
 
   return (
     <svg
@@ -25,7 +30,9 @@ function Sparkline({ values, color, height = 48, width = '100%' }) {
       style={{ width, height }}
       className="block"
     >
-      <polyline points={pts} fill="none" stroke={color} strokeWidth="2" strokeLinejoin="round" />
+      {segments.map((points, index) => points.length === 1
+        ? <circle key={index} cx={points[0][0]} cy={points[0][1]} r="2" fill={color}/>
+        : <polyline key={index} points={points.map(point => point.join(',')).join(' ')} fill="none" stroke={color} strokeWidth="2" strokeLinejoin="round" />)}
     </svg>
   )
 }
@@ -75,7 +82,7 @@ export const GPUChart = memo(function GPUChart({ history, gpuIndex }) {
                   {latest != null ? (Number.isInteger(latest) ? latest : latest.toFixed(1)) : '—'}
                 </span>
               </div>
-              <Sparkline values={values} color={color} height={36} />
+              <Sparkline values={values} timestamps={timestamps} color={color} height={36} />
             </div>
           )
         })}

--- a/ods/extensions/services/dashboard/src/components/GPUChart.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/GPUChart.test.jsx
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react'
+import { GPUChart } from './GPUChart'
+
+test('keeps unavailable GPU samples as gaps at their real timestamps', () => {
+  const history = { timestamps: [0, 5000, 10000, 30000, 35000].map(time => new Date(time).toISOString()),
+    gpus: { 0: { utilization: [10, 20, null, 30, 40] } } }
+  const { container } = render(<GPUChart history={history} gpuIndex={0} />)
+  const graph = container.querySelector('svg')
+  const segments = graph.querySelectorAll('polyline')
+  expect(segments).toHaveLength(2)
+  expect(segments[0].getAttribute('points').split(' ').map(point => point.split(',')[0])).toEqual(['0.0', '42.9'])
+  expect(segments[1].getAttribute('points').split(' ').map(point => point.split(',')[0])).toEqual(['257.1', '300.0'])
+})
+
+test('shows an isolated valid sample without stretching it across missing samples', () => {
+  const history = { timestamps: [0, 5000, 10000].map(time => new Date(time).toISOString()),
+    gpus: { 0: { utilization: [null, 0, null] } } }
+  const { container } = render(<GPUChart history={history} gpuIndex={0} />)
+  expect(container.querySelectorAll('polyline')).toHaveLength(0)
+  expect(container.querySelector('circle')).toHaveAttribute('cx', '150.0')
+})


### PR DESCRIPTION
## Why this matters
GET /api/gpu/history deliberately emits null for unavailable metrics or GPUs absent from a sample. GPUChart removed those entries before computing equally spaced points, stretching earlier measurements over later timestamps and drawing a line across missing telemetry. Delayed polling also appeared equally spaced.

Retain the sample indexes, place points using the API timestamps, and break the line at unavailable values. An isolated measured sample is a dot. A measured zero remains valid; a completely unavailable metric keeps the empty placeholder. The data and sampling API are unchanged.

## Overlap check
Searched open/closed PRs by GPUChart.jsx and GPU history/chart keywords. #3710 adds API query controls, #3711 exports CSV, #3206 adds GPUMonitor tests, and #656 introduced the monitor. None corrects the sparkline's compression of missing samples. Reachable path: GPUMonitor -> GPUChart <- routers/gpu.py:gpu_history, which explicitly inserts nulls.

## Validation
- Two rendered-chart regressions failed on base: one continuous line across a missing sample, and no isolated measured zero. Both pass after the change.
- `npx vitest run src/components/GPUChart.test.jsx src/components/GPUCard.test.jsx`: 4 passed. Tests assert segment separation and timestamp-based coordinates, including a 20-second gap.
- Focused ESLint: 0 errors; scoped pre-commit and git diff --check passed.

No live GPU probe performed; the tests use the actual history endpoint's documented array shape. Autoscaling remains unchanged. Revert restores the previous drawing without affecting retained telemetry.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
