### PR TITLE
fix(preview): inspect deeply nested published files

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelTaskFiles.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTaskFiles.test.jsx
@@ -52,3 +52,24 @@ it('cancels a response as soon as its byte limit is exceeded', async () => {
   await expect(readBoundedBytes(stream,10)).rejects.toThrow('Oversized')
   expect(cancel).toHaveBeenCalledOnce(); expect(releaseLock).toHaveBeenCalledOnce()
 })
+
+it('opens host-published files nested deeper than the project-directory selector limit', async () => {
+  const path = Array.from({length:14}, (_, i) => `level${i}`).join('/') + '/app.js'
+  const deepManifest = {...manifest, files:[{...files[0], path}, files[1]]}
+  vi.stubGlobal('fetch', vi.fn(async url => response(url.endsWith('__ods_manifest__.json')
+    ? JSON.stringify(deepManifest) : js)))
+  render(<PixelTaskFiles preview={preview}/>)
+  fireEvent.click(await screen.findByRole('button', {name:name => name.includes(path)}))
+  await waitFor(() => expect(screen.getByRole('button', {name:'Copy code'})).toBeEnabled())
+  expect(screen.getByLabelText(`Code for ${path}`).textContent).toContain(js)
+  expect(fetch).toHaveBeenLastCalledWith(`/pixel-preview/${preview.siteId}/${path}`,
+    expect.objectContaining({cache:'no-store'}))
+})
+
+it.each(['level/../app.js', '/level/app.js', 'level//app.js', 'level/%2e%2e/app.js'])(
+  'still rejects unsafe manifest paths: %s', async path => {
+    vi.stubGlobal('fetch', vi.fn(async () => response(JSON.stringify({
+      ...manifest, files:[{...files[0], path}, files[1]],
+    }))))
+    await expect(loadSnapshotFiles(preview)).rejects.toThrow()
+  })

--- a/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
@@ -1,7 +1,6 @@
 const DIGEST = /^[a-f0-9]{64}$/
 export const isSnapshotId = value => typeof value === 'string' && /^site-[a-f0-9]{24}$/.test(value)
 export const isArtifactPath = value => typeof value === 'string' && value.length <= 1664
-  && value.split('/').length <= 13
   && value.split('/').every(part => /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(part))
 
 export async function readBoundedBytes(response, maximum) {


### PR DESCRIPTION
## Why this matters

The host accepts a site with fourteen nested asset directories and produces a valid manifest, but Dashboard rejects the entire file inventory because its artifact validator permits only thirteen path components. Users lose access to all task files, including index.html, after a successful publication.

Remove that unsupported component-count restriction. The existing total path length, per-component length, character allowlist and traversal rejection still apply.

## Overlap check

Searched open and closed PRs for “preview nested file depth” and “pixelArtifacts.js depth”, and checked recent changed-file metadata. #3385 is a broad Portal proposal. #4321 changes hashing support for LAN HTTP; it does not address nested artifact paths.

## Validation

- Published a real temporary site using the host's `publish_snapshot()` and `snapshot_manifest()`; a 14-directory JS asset was accepted.
- UI regression lists that manifest and opens its digest-verified source. It fails before the validator change.
- Focused TaskFiles, ArtifactDownload and SnapshotChanges suites: 19 passed; traversal/absolute/empty/encoded escape paths remain rejected.
- Dashboard lint and production build passed.
- `git diff --check`: passed.

## Risk and release lane

Public beta; low risk, browser-side file inspection. The existing 1,664-character path limit remains in place. No publication permissions, source bytes or server request routing change. No live browser/fleet run was performed. Revert restores the former component cap without migration.

## AI Assistance

Codex assisted with diagnosis, host reproduction, implementation, tests and this description. Human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
