### PR TITLE
fix(models): reject obsolete Hub search response bodies

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
@@ -45,12 +45,13 @@ export default function HuggingFaceModelBrowser({ gpu, downloadBusy, onImportSta
         const params = new URLSearchParams({ q: query.trim(), sort, limit: '20' })
         const response = await fetch(`/api/models/huggingface/search?${params}`, { signal: controller.signal })
         const body = await responseJson(response)
+        if (controller.signal.aborted) return
         if (!response.ok) throw new Error(errorMessage(body, 'Hugging Face search failed'))
         setResults(Array.isArray(body.models) ? body.models : [])
         setAuthenticated(Boolean(body.authenticated))
         setStale(Boolean(body.stale))
       } catch (requestError) {
-        if (requestError?.name !== 'AbortError') setError(requestError.message)
+        if (!controller.signal.aborted && requestError?.name !== 'AbortError') setError(requestError.message)
       } finally {
         if (!controller.signal.aborted) setLoading(false)
       }

--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceSearchRace.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceSearchRace.test.jsx
@@ -1,0 +1,29 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import HuggingFaceModelBrowser from './HuggingFaceModelBrowser'
+
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals() })
+
+test.each(['resolve', 'abort'])('keeps the current Hub search when an obsolete response body completes: %s', async outcome => {
+  vi.useFakeTimers()
+  let resolveOld, rejectOld
+  const oldBody = new Promise((resolve, reject) => { resolveOld = resolve; rejectOld = reject })
+  const model = { id: 'current/new-model', author: 'current', name: 'new-model' }
+  const fetchMock = vi.fn()
+    .mockResolvedValueOnce({ ok: true, json: () => oldBody })
+    .mockResolvedValueOnce({ ok: true, json: async () => ({ models: [model], authenticated: true, stale: false }) })
+  vi.stubGlobal('fetch', fetchMock)
+  render(<HuggingFaceModelBrowser />)
+  await act(async () => vi.advanceTimersByTimeAsync(350))
+  fireEvent.change(screen.getByPlaceholderText('Search repositories, authors, or model families...'), { target: { value: 'new-model' } })
+  expect(fetchMock.mock.calls[0][1].signal.aborted).toBe(true)
+  await act(async () => vi.advanceTimersByTimeAsync(350))
+  expect(screen.getByText('Authenticated')).toBeVisible()
+  await act(async () => {
+    if (outcome === 'abort') rejectOld(new globalThis.DOMException('Aborted body', 'AbortError'))
+    else resolveOld({ models: [{ id: 'old/wrong-model', author: 'old' }], authenticated: false, stale: true })
+  })
+  expect(screen.getByText('Authenticated')).toBeVisible()
+  expect(screen.getByText('1 repositories')).toBeVisible()
+  expect(screen.queryByText('Cached snapshot')).toBeNull()
+  expect(screen.queryByText('old/wrong-model')).toBeNull()
+})


### PR DESCRIPTION
## Why this matters
Changing the Hub query aborts the previous search, but responseJson catches a response-body AbortError and returns {}. The old search then clears the new result list and authentication/cache indicators. An already-completed old body can also overwrite newer results after a query change.

Check the search controller after body parsing and before every error update. Only the current request may publish its result or error; debounce timing and explicit Retry search remain unchanged.

## Overlap check
Searched all open/closed PRs touching HuggingFaceModelBrowser.jsx and search/race keywords. Inspected #3050's patch: it cancels repository detail requests only, not Hub searches. #2755 labels the dialog close button; #3203 tests formatters; #1968 introduced discovery; #4027 is the beta UI umbrella. This independent search effect does not alter details/import behavior.

## Validation
- Rendered search regressions fail on base for both late successful JSON and aborted body parsing after the newer search succeeds; both pass with the fix.
- `npx vitest run src/components/model-library/HuggingFaceSearchRace.test.jsx`: 2 passed.
- Scoped pre-commit and git diff --check passed. Focused ESLint checked separately.

No live Hugging Face request or model import was performed. Regression tests operate through the real search box and delayed response-body boundary. No persistence changes; revert restores the former stale-result behavior.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
