### PR TITLE
fix(pixel): retain broker job IDs after readback failures

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/host-observe.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/host-observe.mjs
@@ -59,13 +59,22 @@ function toolResult(value) {
   };
 }
 
+class BrokerReadbackError extends Error {
+  constructor(jobId) {
+    super("Broker submission or result could not be verified");
+    this.jobId = jobId;
+  }
+}
+
 function errorResult(
   text = "Pixel could not complete the read-only ODS host observation.",
-  boundaryNotice = BOUNDARY
+  boundaryNotice = BOUNDARY,
+  jobId
 ) {
+  const next = jobId ? `Check job ${jobId} with pixel_ops_job_get or pixel_ops_job_wait; do not resubmit until its state is known. Submission or completion could not be confirmed.` : null;
   return {
-    content: [{ type: "text", text }],
-    details: { status: "unavailable", boundaryNotice },
+    content: [{ type: "text", text: next ? `${text} ${next}` : text }],
+    details: { status: "unavailable", boundaryNotice, ...(jobId ? {jobId, next} : {}) },
     isError: true,
   };
 }
@@ -264,13 +273,18 @@ async function observeHost(
     boundary:
       "Request only. The external broker compiles policy and decides whether execution is permitted.",
   };
-  await publishRequest(jobId, request, requestDir);
-  return waitForTerminal(jobId, {
-    resultDir,
-    timeoutMs,
-    pollIntervalMs,
-    boundaryNotice: BOUNDARY,
-  });
+  try {
+    await publishRequest(jobId, request, requestDir);
+    return await waitForTerminal(jobId, {
+      resultDir,
+      timeoutMs,
+      pollIntervalMs,
+      boundaryNotice: BOUNDARY,
+    });
+  } catch {
+    // A linked request can survive either result-read or submission-cleanup errors.
+    throw new BrokerReadbackError(jobId);
+  }
 }
 
 async function proposeHostCommand(
@@ -290,13 +304,18 @@ async function proposeHostCommand(
     boundary:
       "Request only. The external broker compiles an immutable plan and decides whether execution is permitted.",
   };
-  await publishRequest(jobId, request, requestDir);
-  return waitForTerminal(jobId, {
-    resultDir,
-    timeoutMs,
-    pollIntervalMs,
-    boundaryNotice: HOST_COMMAND_BOUNDARY,
-  });
+  try {
+    await publishRequest(jobId, request, requestDir);
+    return await waitForTerminal(jobId, {
+      resultDir,
+      timeoutMs,
+      pollIntervalMs,
+      boundaryNotice: HOST_COMMAND_BOUNDARY,
+    });
+  } catch {
+    // A linked request can survive either result-read or submission-cleanup errors.
+    throw new BrokerReadbackError(jobId);
+  }
 }
 
 export function createHostObserveTool({
@@ -364,8 +383,9 @@ export function createHostObserveTool({
           ...receipt,
           ...(odsStatusProjection ? { odsStatusProjection } : {}),
         });
-      } catch {
-        return errorResult();
+      } catch (failure) {
+        return errorResult(undefined, BOUNDARY,
+          failure instanceof BrokerReadbackError ? failure.jobId : undefined);
       }
     },
   };
@@ -469,10 +489,11 @@ export function createHostCommandProposeTool({
           pollIntervalMs,
         });
         return toolResult(receipt);
-      } catch {
+      } catch (failure) {
         return errorResult(
           "Pixel could not submit or verify the protected ODS host command proposal.",
-          HOST_COMMAND_BOUNDARY
+          HOST_COMMAND_BOUNDARY,
+          failure instanceof BrokerReadbackError ? failure.jobId : undefined
         );
       }
     },

--- a/ods/extensions/services/pixel-agent/tests/host_observe.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/host_observe.test.mjs
@@ -367,3 +367,37 @@ test("host command adapter rejects a result whose embedded job ID does not match
     await rm(root, { recursive: true, force: true });
   }
 });
+
+for (const [name, factory, params] of [
+  ['observation', createHostObserveTool, {actions:['host.kernel']}],
+  ['command proposal', createHostCommandProposeTool, {command:'uname -sr'}],
+]) {
+  test(`${name} retains its submitted identity when result readback fails`, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pixel-host-readback-'));
+    const requestDir = join(root, 'requests'), resultDir = join(root, 'results');
+    await mkdir(requestDir); await mkdir(resultDir);
+    try {
+      const tool = factory({requestDir, resultDir, timeoutMs:2000, pollIntervalMs:5});
+      const pending = tool.execute('readback-failure', params);
+      let names = [];
+      for (let attempt=0; attempt<200 && !names.length; attempt++) {
+        names = (await readdir(requestDir)).filter(name => name.endsWith('.json'));
+        if (!names.length) await delay(5);
+      }
+      assert.equal(names.length, 1);
+      const request = JSON.parse(await readFile(join(requestDir, names[0]), 'utf8'));
+      await publishResult(join(resultDir, names[0]), {
+        jobId:'ops-1234567890123-aaaaaaaaaaaa', status:'succeeded',
+        privateResult:'must not escape a mismatched receipt',
+      });
+      const result = await pending;
+      assert.equal(result.isError, true);
+      assert.equal(result.details.status, 'unavailable');
+      assert.equal(result.details.jobId, request.jobId);
+      assert.match(result.content[0].text, new RegExp(request.jobId));
+      assert.match(result.content[0].text, /do not resubmit/i);
+      assert.doesNotMatch(JSON.stringify(result), /privateResult|must not escape/);
+      assert.deepEqual((await readdir(requestDir)).filter(name => name.endsWith('.json')), names);
+    } finally { await rm(root, {recursive:true, force:true}); }
+  });
+}


### PR DESCRIPTION
## Why this matters

A host observation or protected command proposal can be queued successfully, then fail to read its result. The adapter currently returns only “unavailable” and loses the job ID, making it difficult to inspect existing work before retrying. For command proposals this can lead to duplicate approval requests.

Carry the locally generated job identity through submission/readback failures and include a bounded instruction to inspect that job before resubmitting. Mismatched result data remains rejected, the result remains an error, and no approval or execution is inferred.

## Overlap check

Searched open and closed PRs for “host observation proposal receipt failure job” and “host-observe.mjs job identity”, and reviewed recent changed-file metadata. The existing extension-read adapter already preserves this identity; this PR closes the separate gap in host observations and command proposals. The broader Portal proposal #3385 does not address these failure paths.

## Validation

- Public tool regressions queue real request files, publish a mismatched result and assert the original job ID survives without leaking the foreign result or creating another request.
- `node --test ods/extensions/services/pixel-agent/tests/host_observe.test.mjs ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs`: 513 passed.
- Existing invalid-input, immutable approval and successful receipt tests pass.
- `git diff --check`: passed.

## Risk and release lane

Public beta; broker error receipts. Draft for independent human review. A returned ID identifies an attempted submission, not proof that the broker accepted or completed it. Tests exercise file transport on Linux/WSL; no live broker execution or approval was performed. No state migration; rollback is a revert.

## AI Assistance

Codex assisted with diagnosis, implementation, request/result regression tests and this description. Human review remains required.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
