### PR TITLE
fix(extensions): use native modal dependency confirmation

### DIFF
--- a/ods/extensions/services/dashboard/src/components/DependencyBadges.jsx
+++ b/ods/extensions/services/dashboard/src/components/DependencyBadges.jsx
@@ -1,4 +1,5 @@
 import { AlertTriangle } from 'lucide-react'
+import { useEffect, useRef } from 'react'
 
 const STATUS_DOTS = {
   enabled: 'bg-green-500',
@@ -41,16 +42,25 @@ export function DependencyBadges({ dependsOn, dependencyStatus }) {
  * Shows when enabling a service that has missing dependencies.
  */
 export function DependencyConfirmDialog({ ext, missingDeps, onConfirm, onCancel }) {
+  const dialog = useRef(null), cancel = useRef(null)
+  const visible = Boolean(ext && missingDeps?.length)
+  useEffect(() => {
+    if (!visible) return
+    const previous = document.activeElement
+    const element = dialog.current
+    element.showModal()
+    cancel.current?.focus()
+    return () => { element.close(); if (previous?.isConnected) previous.focus() }
+  }, [visible])
   if (!ext || !missingDeps || missingDeps.length === 0) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onCancel}>
+    <dialog ref={dialog} aria-label="Enable dependencies"
+      className="fixed inset-0 m-0 h-screen w-screen max-h-none max-w-none border-0 p-0 bg-black/50 flex items-center justify-center z-50"
+      onCancel={event => { event.preventDefault(); onCancel() }} onClick={onCancel}>
       <div
         className="bg-theme-card border border-theme-border rounded-xl p-6 max-w-md mx-4"
         onClick={e => e.stopPropagation()}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Enable dependencies"
       >
         <h3 className="text-lg font-semibold text-theme-text mb-2">
           Enable Dependencies
@@ -71,7 +81,7 @@ export function DependencyConfirmDialog({ ext, missingDeps, onConfirm, onCancel 
         <div className="flex justify-end gap-3">
           <button
             onClick={onCancel}
-            autoFocus
+            ref={cancel}
             className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
           >
             Cancel
@@ -84,7 +94,7 @@ export function DependencyConfirmDialog({ ext, missingDeps, onConfirm, onCancel 
           </button>
         </div>
       </div>
-    </div>
+    </dialog>
   )
 }
 

--- a/ods/extensions/services/dashboard/src/components/DependencyDialog.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/DependencyDialog.test.jsx
@@ -1,0 +1,36 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { DependencyConfirmDialog } from './DependencyBadges'
+
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function () { this.open = true }
+  HTMLDialogElement.prototype.close = function () { this.open = false }
+})
+afterEach(() => { cleanup(); delete HTMLDialogElement.prototype.showModal; delete HTMLDialogElement.prototype.close })
+
+test('opens a native modal, cancels with Escape and restores the invoking control', () => {
+  const trigger = document.createElement('button')
+  document.body.append(trigger)
+  trigger.focus()
+  const onConfirm = vi.fn(), onCancel = vi.fn()
+  const view = render(<DependencyConfirmDialog ext={{ name: 'Voice service' }} missingDeps={['tts']} onConfirm={onConfirm} onCancel={onCancel} />)
+  const dialog = screen.getByRole('dialog', { name: 'Enable dependencies' })
+  expect(screen.getByRole('button', { name: 'Cancel' })).toHaveFocus()
+  fireEvent(dialog, new Event('cancel', { cancelable: true }))
+  expect(onCancel).toHaveBeenCalledOnce()
+  expect(onConfirm).not.toHaveBeenCalled()
+  expect(dialog.tagName).toBe('DIALOG')
+  expect(dialog).toHaveAttribute('open')
+  view.unmount()
+  expect(trigger).toHaveFocus()
+  trigger.remove()
+})
+
+test('only explicit Enable All accepts the displayed dependency list', () => {
+  const onConfirm = vi.fn(), onCancel = vi.fn()
+  render(<DependencyConfirmDialog ext={{ name: 'Voice service' }} missingDeps={['tts', 'whisper']} onConfirm={onConfirm} onCancel={onCancel} />)
+  fireEvent.click(screen.getByText('whisper'))
+  expect(onConfirm).not.toHaveBeenCalled()
+  expect(onCancel).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: 'Enable All' }))
+  expect(onConfirm).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
## Why this matters
Extensions uses DependencyConfirmDialog before enabling additional services. The old div declared aria-modal but did not make the background inert, contain keyboard focus, handle Escape, or restore the invoking control. Keyboard users could leave the confirmation and interact with underlying extension controls.

Use the browser's native modal dialog. Focus Cancel on entry, translate the cancel event into the existing cancellation callback, and restore the connected invoking control on dismissal. Enable All remains the sole affirmative action; the existing mutation handler owns service enablement and reconciliation.

## Overlap check
Searched open/closed PR files for DependencyBadges.jsx and dependency confirmation/modal keywords. No existing PR changes this component. The reachable consumer is Extensions.jsx's missing-dependency confirmation. This does not change extension dependency resolution or lifecycle plans.

## Validation
- Rendered regression failed on base because the cancel event did not invoke cancellation; passed after the change.
- `npx vitest run src/components/DependencyDialog.test.jsx`: 2 passed. Covers safe initial focus, cancellation without enablement, focus restoration and explicit confirmation.
- Scoped pre-commit and git diff --check passed; focused ESLint 0 errors.

JSDOM tests stub native dialog open/close; the real Chromium focus and inertness checks are recorded below. No service was enabled during validation. No storage/API changes; revert restores the old confirmation wrapper.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Chromium on Windows, using the real component and CSS with mocked API data: initial focus, Tab/Shift+Tab, inert background, Escape, and trigger focus restoration all pass. Screenshots were visually inspected. No services were enabled or artifacts imported in this browser check.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
