### PR TITLE
fix(pixel): collect activity for the configured agent

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/index.js
+++ b/ods/extensions/services/pixel-agent/plugin/index.js
@@ -52,7 +52,7 @@ const AGENT_ID = process.env.PIXEL_AGENT_ID ?? "pixel";
 const ABORT_BODY_LIMIT = 256;
 const OPENAI_RUN_ID = /^chatcmpl_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const toolLoopGuardRegistry = createToolLoopGuardRegistry();
-const taskActivity = createTaskActivity();
+const taskActivity = createTaskActivity({agentId:AGENT_ID});
 let execCancellationControl;
 let accessRuntime;
 const managedRuntimeRegistry = createManagedRuntimeRegistry();

--- a/ods/extensions/services/pixel-agent/plugin/task-activity.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/task-activity.mjs
@@ -36,9 +36,9 @@ function failedResult(event) {
   return false;
 }
 
-export function createTaskActivity({now = () => new Date().toISOString(), maximumRuns = 64, maximumCalls = 512} = {}) {
+export function createTaskActivity({agentId = 'pixel', now = () => new Date().toISOString(), maximumRuns = 64, maximumCalls = 512} = {}) {
   const runs = new Map();
-  const identify = (event, context) => context?.agentId === 'pixel' ? context.runId ?? event?.runId : undefined;
+  const identify = (event, context) => context?.agentId === agentId ? context.runId ?? event?.runId : undefined;
   function begin(event, context) {
     const id = identify(event, context);
     if (!RUN.test(id ?? '')) return;
@@ -78,7 +78,7 @@ export function createTaskActivity({now = () => new Date().toISOString(), maximu
     begin,
     activeForUser(user) {
       if (typeof user !== 'string' || !/^ods-[a-f0-9]{64}$/.test(user)) return null;
-      const matches = [...runs.values()].filter(run => run.state === 'running' && run.sessionKey === `agent:pixel:openai-user:${user}`);
+      const matches = [...runs.values()].filter(run => run.state === 'running' && run.sessionKey === `agent:${agentId}:openai-user:${user}`);
       // Ambiguity is not evidence: never guess which run belongs to this turn.
       return matches.length === 1 ? this.projection(matches[0].runId) : null;
     },

--- a/ods/extensions/services/pixel-agent/tests/task_activity.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/task_activity.test.mjs
@@ -78,3 +78,24 @@ test('rejects cross-run, unbounded, extra-field, duplicate and impossible projec
     {...value,calls:2,activities:[{kind:'read',calls:1,failures:0,blocked:0},{kind:'read',calls:1,failures:0,blocked:0}]}];
   for (const item of invalid) assert.equal(parseTaskActivity(item,runId),null);
 });
+
+test('configured agent activity binds to that agent and its exact user session', () => {
+  const recorder = createTaskActivity({now, agentId:'assistant'});
+  const user = 'ods-' + 'a'.repeat(64);
+  const context = {...ctx, agentId:'assistant', sessionKey:`agent:assistant:openai-user:${user}`};
+  recorder.begin({}, {...ctx, sessionKey:`agent:pixel:openai-user:${user}`});
+  assert.equal(recorder.projection(runId), null);
+  recorder.begin({}, context);
+  recorder.before({toolName:'read'}, {...context, toolCallId:'a'});
+  recorder.after({result:{}}, {...context, toolCallId:'a'});
+  const active = recorder.activeForUser(user);
+  assert.equal(active?.runId, runId);
+  assert.equal(active.calls, 1);
+  assert.equal(parseTaskActivity(active, runId), active);
+  assert.equal(recorder.activeForUser('ods-' + 'b'.repeat(64)), null);
+  recorder.finish({success:true}, ctx);
+  assert.equal(recorder.activeForUser(user)?.state, 'running');
+  recorder.finish({success:true}, context);
+  assert.equal(recorder.activeForUser(user), null);
+  assert.equal(recorder.projection(runId).state, 'completed');
+});


### PR DESCRIPTION
## Why this matters
When PIXEL_AGENT_ID selects a nondefault agent, plugin hooks use that configured ID but the workbench activity collector accepts only literal pixel. Valid running tasks therefore have no activity projection. Pass the existing configuration into the collector and use the same ID for hook identity and exact opaque-user session matching.

## Overlap check
Searched open and closed PRs for task activity custom agent ID and task-activity.mjs agentId, and compared changed-file entries. #4207 introduces the collector; #3385 is broader agent work. Neither addresses the configured-ID mismatch.

## Validation
node --test ods/extensions/services/pixel-agent/tests/task_activity.test.mjs: 6 passed. The new lifecycle regression fails on the base, then verifies configured-agent observations, default-agent exclusion, user isolation, schema acceptance and terminal settlement. Production callers are the registered hooks and authenticated activity endpoint in plugin/index.js.

No endpoint authorization, projection schema or default agent behavior changes. Tested on Linux/WSL; no live custom-agent deployment was available.

Developed with AI assistance.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
