### PR TITLE
fix(usage): avoid overflowing inclusive calendar ranges

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -46,12 +46,8 @@ def _parse_date(value: str) -> date:
 
 
 def _date_range(start_day: date, end_day: date) -> list[str]:
-    days = []
-    current = start_day
-    while current <= end_day:
-        days.append(current.isoformat())
-        current += timedelta(days=1)
-    return days
+    return [(start_day + timedelta(days=offset)).isoformat()
+            for offset in range((end_day - start_day).days + 1)]
 
 
 def _empty_report(start: str, end: str, status: str = "unavailable", detail: str | None = None) -> dict[str, Any]:

--- a/ods/extensions/services/dashboard-api/tests/test_usage_calendar_boundary.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage_calendar_boundary.py
@@ -1,0 +1,21 @@
+"""Valid inclusive report ranges must not step past Python's last date."""
+import pytest
+from unittest.mock import AsyncMock
+
+
+@pytest.mark.parametrize("start, days", [("9999-12-31", 1), ("9999-12-30", 2), ("9999-01-01", 365)])
+def test_report_includes_last_calendar_day(test_client, monkeypatch, start, days):
+    import routers.usage as usage
+
+    monkeypatch.setattr(usage, "TOKEN_SPY_URL", "")
+    monkeypatch.setattr(usage, "_fetch_local_runtime_counters", AsyncMock(return_value=[]))
+    response = test_client.get(
+        f"/api/usage/report?start={start}&end=9999-12-31",
+        headers=test_client.auth_headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert len(payload["daily"]) == days
+    assert payload["daily"][0]["date"] == start
+    assert payload["daily"][-1]["date"] == "9999-12-31"
+    assert payload["source"]["status"] == "unavailable"


### PR DESCRIPTION
## Why this matters
The authenticated Usage report API accepts inclusive YYYY-MM-DD ranges of up to 366 days. A valid request ending at 9999-12-31 passes both gates but crashes with OverflowError when the empty-report generator increments past the last day. Reproduction: GET /api/usage/report?start=9999-12-31&end=9999-12-31 with Token Spy unavailable.

Generate only the inclusive offsets within the validated range. No date beyond end is constructed. Existing reversed/oversized/invalid-calendar handling and report shape are preserved. This is API boundary correctness, not a claim of a practical security vulnerability.

## Overlap check
Searched open/closed usage.py PRs and usage/date/overflow keywords. Inspected #3773: it changes _parse_date input handling only. #1859 caps spans and #1682 handles invalid calendar inputs; neither handles a valid range ending at date.max. Runtime-scrape PRs #4064/#4002 are unrelated.

## Validation
- Three real authenticated HTTP regressions failed on base with OverflowError at the post-end increment.
- `python -m pytest tests/test_usage_calendar_boundary.py tests/test_usage.py -q`: 27 passed under WSL, including one-day/two-day/full-year upper-bound ranges and the existing leap-year/reversed/oversized/invalid-date cases.
- Scoped pre-commit and git diff --check passed.

No live telemetry service used; the explicit unavailable-Token-Spy production path is exercised with local runtime counters disabled in the fixture. No persisted data change; revert only affects range generation.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
