### PR TITLE
fix(dashboard): keep search matches inside conversation excerpts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelConversationContentSearch.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelConversationContentSearch.test.jsx
@@ -58,3 +58,18 @@ it('does not match a metadata-only value or create synthetic conversation conten
   search('hiddenmagic')
   expect(screen.getByText('No matching conversations or actions.')).toBeVisible()
 })
+
+it('keeps a complete long matching phrase after preceding context', () => {
+  const phrase = 'matching phrase '.repeat(15).trim()
+  chat('long-phrase', [{role:'user', content:'Find this reply'}, {role:'assistant', content:'x'.repeat(300) + phrase + 'z'.repeat(300)}])
+  search(phrase)
+  const snippet = screen.getByText(/^Reply: …/)
+  expect(snippet.textContent).toContain(phrase)
+  expect(snippet.textContent.length).toBeLessThan(phrase.length + 70)
+})
+
+it('maps case-expanded Unicode prefixes back to retained text offsets', () => {
+  chat('unicode-offset', [{role:'user', content:'Find this reply'}, {role:'assistant', content:'İ'.repeat(300) + ' exact phrase ' + 'z'.repeat(300)}])
+  search('EXACT PHRASE')
+  expect(screen.getByText(/^Reply: …/).textContent).toContain('exact phrase')
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelConversationSearch.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelConversationSearch.js
@@ -8,10 +8,25 @@ export function conversationExcerpt(chat, query) {
     {label:'Draft', text:typeof chat.draft === 'string' ? chat.draft : ''},
   ]
   for (const {label, text} of fields) {
-    const at = text.toLocaleLowerCase().indexOf(needle)
+    const folded = text.toLocaleLowerCase()
+    const at = folded.indexOf(needle)
     if (at < 0) continue
-    const start = Math.max(0, at - 48)
-    const end = Math.min(text.length, start + Math.max(180, needle.length))
+    // Case conversion can expand a character (for example İ -> i + dot).
+    // Locate boundaries in the original text before choosing surrounding context.
+    const originalOffset = (offset, roundUp) => {
+      if (folded.length === text.length) return offset
+      let low = 0, high = text.length
+      while (low < high) {
+        const middle = Math.floor((low + high) / 2)
+        if (text.slice(0, middle).toLocaleLowerCase().length < offset) low = middle + 1
+        else high = middle
+      }
+      return !roundUp && text.slice(0, low).toLocaleLowerCase().length > offset ? low - 1 : low
+    }
+    const matchStart = originalOffset(at, false)
+    const matchEnd = originalOffset(at + needle.length, true)
+    const start = Math.max(0, matchStart - 48)
+    const end = Math.min(text.length, Math.max(start + 180, matchEnd))
     return `${label}: ${start ? '…' : ''}${text.slice(start, end).replace(/\s+/g, ' ')}${end < text.length ? '…' : ''}`
   }
   return null


### PR DESCRIPTION
## Why this matters
Global conversation search finds a retained reply but can display an excerpt that omits the match. Long queries lose their final 48 characters; case-expanding Unicode before a match shifts the excerpt into unrelated text. Map folded offsets back to retained text and ensure the excerpt includes the complete match while keeping ordinary excerpts bounded.

## Overlap check
Searched open/closed conversation search excerpt PRs and pixelConversationSearch.js changed files. #4142 introduced global content search. #4255 adds navigation within the current conversation and does not change this file or fix global excerpts; #3385 is broader Portal work.

## Validation
Two component regressions fail on the base (long literal phrase and repeated İ prefix). The content-search, command-search and IME suites now pass all 15 tests. Scoped ESLint has no errors; two existing JSX unused-import warnings remain.
The tests exercise the search dialog against saved conversations, including exact conversation selection, metadata exclusion and inert text. No model request, storage format or search-result ordering changes.

Developed with AI assistance.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
