### PR TITLE
fix(usage): preserve unknown values in CSV exports

### DIFF
--- a/ods/extensions/services/dashboard/src/components/usage/UsageCsvAvailability.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageCsvAvailability.test.jsx
@@ -1,0 +1,29 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import UsageView from './UsageView'
+
+afterEach(() => { vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+test('exports unavailable counters and unknown costs as empty cells, preserving measured zero', async () => {
+  let artifact
+  vi.stubGlobal('URL', { createObjectURL: vi.fn(blob => { artifact = blob; return 'blob:test' }), revokeObjectURL: vi.fn() })
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  const models = [
+    { model: 'Unknown', requests: 0, cost_usd: 0, cost_source: 'untracked', input_tokens: 30 },
+    { model: 'Local', requests: 0, cost_usd: 0, cost_source: 'local_zero_cost', input_tokens: 20 },
+    { model: 'Billed', requests: 2, cost_usd: 0, cost_source: 'actual_billed', input_tokens: 10 },
+  ]
+  render(<UsageView report={{ source: { status: 'ok', local_runtime: { request_count_available: false } }, summary: {}, models }}
+    readiness={{ status: 'ready' }} range={{ start: '2026-09-01' }} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Models', exact: true }))
+  fireEvent.click(screen.getByRole('button', { name: 'Export CSV' }))
+  const csv = await new Promise((resolve, reject) => {
+    const reader = new globalThis.FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = reject
+    reader.readAsText(artifact)
+  })
+  const rows = csv.split('\r\n').slice(1).map(row => row.split(',').map(cell => cell.slice(1, -1)))
+  expect(rows.map(row => [row[0], row[7], row[8], row[9]])).toEqual([
+    ['Unknown', '', '', 'untracked'], ['Local', '', '0', 'local_zero_cost'], ['Billed', '2', '0', 'actual_billed'],
+  ])
+})

--- a/ods/extensions/services/dashboard/src/components/usage/UsageView.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageView.jsx
@@ -16,9 +16,10 @@ const sourceDescription = {
   local_zero_cost:'Local inference has no external API bill. Hardware and electricity costs are not included.',
   untracked:'No reliable pricing or billing source. Cost is unknown, not zero.',
 }
+const pricedCostAvailable = row => ['actual_billed','priced_from_tokens'].includes(row.cost_source) && row.cost_usd != null && row.cost_usd !== '' && Number.isFinite(Number(row.cost_usd))
 const costLabel = row => {
   if (row.cost_source === 'local_zero_cost') return 'Local'
-  if (!['actual_billed','priced_from_tokens'].includes(row.cost_source) || row.cost_usd == null || row.cost_usd === '' || !Number.isFinite(Number(row.cost_usd))) return '—'
+  if (!pricedCostAvailable(row)) return '—'
   return money(row.cost_usd)
 }
 const metadataValue = value => value || 'unknown'
@@ -26,10 +27,14 @@ const requestCountAvailable = (row, source) => row.requests != null && Number.is
 const requestLabel = (row, source) => requestCountAvailable(row,source) ? integer(row.requests) : '—'
 const seriesInfo = {input:{field:'input_tokens',label:'Input',color:'#dce1e5'},output:{field:'output_tokens',label:'Output',color:'#909ba8'},cache:{label:'Cache',color:'#66717d'}}
 
-export function csvForRows(rows) {
+export function csvForRows(rows, telemetrySource) {
   const fields=['model','provider','service','input_tokens','output_tokens','cache_read_tokens','cache_write_tokens','requests','cost_usd','cost_source']
   const cell=value=>`"${String(value ?? '').replace(/^[=+@\-\t\r]/,"'$&").replaceAll('"','""')}"`
-  return [fields.join(','),...rows.map(row=>fields.map(key=>cell(row[key])).join(','))].join('\r\n')
+  return [fields.join(','),...rows.map(row => {
+    const values = {...row, requests:requestCountAvailable(row,telemetrySource) ? row.requests : null,
+      cost_usd:row.cost_source === 'local_zero_cost' ? 0 : pricedCostAvailable(row) ? row.cost_usd : null}
+    return fields.map(key=>cell(values[key])).join(',')
+  })].join('\r\n')
 }
 
 export default function UsageView({compact=false,report,readiness,loading,error,range,onPrevious,onNext,onRefresh,actionState,onAction}) {
@@ -115,7 +120,7 @@ function ModelView({rows,telemetrySource}) {
   const filtered=useMemo(()=>rows.filter(row=>(provider==='all'||metadataValue(row.provider)===provider)&&(service==='all'||metadataValue(row.service)===service)&&(source==='all'||metadataValue(row.cost_source)===source)&&[row.model,row.provider,row.service,row.cost_source].some(value=>String(value || '').toLowerCase().includes(query.trim().toLowerCase()))).sort((a,b)=>tokens(b)-tokens(a)),[rows,query,provider,service,source])
   useEffect(()=>setPage(0),[query,provider,service,source])
   const count=Math.max(1,Math.ceil(filtered.length/8)), current=Math.min(page,count-1)
-  function exportCsv(){const url=URL.createObjectURL(new Blob([csvForRows(filtered)],{type:'text/csv;charset=utf-8'}));const link=document.createElement('a');link.href=url;link.download='ods-usage-by-model.csv';link.click();URL.revokeObjectURL(url)}
+  function exportCsv(){const url=URL.createObjectURL(new Blob([csvForRows(filtered,telemetrySource)],{type:'text/csv;charset=utf-8'}));const link=document.createElement('a');link.href=url;link.download='ods-usage-by-model.csv';link.click();URL.revokeObjectURL(url)}
   return <>
     <header className="usage-section-title"><div><h2>Usage by Model</h2><p>Ordered by recorded token volume</p></div><button className="usage-text-button" disabled={!filtered.length} onClick={exportCsv}><Download size={14}/>Export CSV</button></header>
     <label className="usage-search"><Search size={14}/><input aria-label="Search models" placeholder="Search models..." value={query} onChange={event=>setQuery(event.target.value)}/></label>


### PR DESCRIPTION
## Why this matters
Usage deliberately displays an em dash for unavailable request counters and untracked costs. Export CSV wrote the underlying placeholder zero instead, making an unavailable local counter look like zero calls and unknown external cost look free in the downloaded report.

Use the same availability rules for display and CSV. Empty numeric cells mean unavailable; real billed zero and local zero external API cost stay numeric zero, with cost_source retained. Existing CSV columns, quote escaping and formula neutralization remain intact.

## Overlap check
Searched open/closed PR files for UsageView.jsx and usage CSV/export/unknown-counter keywords. #4109 retains filter selections and #4027 introduces the view; neither preserves missing-data semantics in exports. Backend date and runtime-counter changes affect different production paths.

## Validation
- A rendered Models -> Export CSV test reads the actual generated Blob. It failed on base with misleading zero cells, then passed after the fix.
- `npx vitest run src/components/usage/UsageCsvAvailability.test.jsx src/components/usage/UsageView.test.jsx`: 13 passed, including existing formula/quote escaping, filtering and displayed counter availability.
- Scoped pre-commit and git diff --check passed; focused ESLint checked separately.

CSV consumers must treat empty numeric cells as unavailable rather than zero. No server, billing, or persisted telemetry changes. Spreadsheet application rendering was not exercised. Revert restores raw placeholder export values.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
