### PR TITLE
test(pixel): cover restored preview metadata and unlisted selections

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.jsx
@@ -1,5 +1,12 @@
 export default function PixelPreviewHistory({previews, selected, onSelect}) {
-  const versions = [...new Map(previews.map(preview => [preview.siteId,preview])).values()]
+  const retained = new Map()
+  for (const preview of previews) {
+    // Content-addressed IDs recur when a user restores an earlier snapshot.
+    // Order each distinct snapshot by its latest retained publication.
+    retained.delete(preview.siteId)
+    retained.set(preview.siteId, preview)
+  }
+  const versions = [...retained.values()]
   const currentListed = versions.some(preview => preview.siteId === selected.siteId)
   if (versions.length + (currentListed ? 0 : 1) < 2) return null
   const latest = versions.at(-1)

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewHistory.test.jsx
@@ -1,0 +1,31 @@
+import {render, screen, fireEvent} from '@testing-library/react'
+import PixelPreviewHistory from './PixelPreviewHistory'
+
+const first = {siteId:'site-' + 'a'.repeat(24), relativeDirectory:'original'}
+const second = {siteId:'site-' + 'b'.repeat(24), relativeDirectory:'edited'}
+const restored = {...first, relativeDirectory:'restored'}
+
+it('treats a restored content-addressed snapshot as the latest publication', () => {
+  const onSelect = vi.fn()
+  render(<PixelPreviewHistory previews={[first, second, restored]} selected={second} onSelect={onSelect}/>)
+  const options = screen.getAllByRole('option')
+  expect(options).toHaveLength(2)
+  expect(options.at(-1)).toHaveTextContent('restored · Latest retained')
+  fireEvent.click(screen.getByRole('button', {name:'Show latest publication'}))
+  expect(onSelect).toHaveBeenCalledExactlyOnceWith(restored)
+})
+
+it('does not call the currently restored snapshot an earlier publication', () => {
+  render(<PixelPreviewHistory previews={[first, second, restored]} selected={restored} onSelect={vi.fn()}/>)
+  expect(screen.queryByText('Viewing an earlier saved publication.')).not.toBeInTheDocument()
+  expect(screen.queryByRole('button', {name:'Show latest publication'})).not.toBeInTheDocument()
+})
+
+it('keeps an unlisted selected publication selectable while returning to the latest retained snapshot', () => {
+  const onSelect = vi.fn()
+  const outside = {...first, siteId:'site-' + 'c'.repeat(24)}
+  render(<PixelPreviewHistory previews={[first, second, restored]} selected={outside} onSelect={onSelect}/>)
+  expect(screen.getByRole('combobox')).toHaveValue(outside.siteId)
+  fireEvent.click(screen.getByRole('button', {name:'Show latest publication'}))
+  expect(onSelect).toHaveBeenCalledExactlyOnceWith(restored)
+})


### PR DESCRIPTION
## Why this matters
Retained previews need to select the latest metadata when content-addressed IDs recur. A currently selected publication can also be outside the retained turn history. These component tests cover the exact restored object delivered to the selection callback, its updated directory label, current-restored status, and navigation from an unlisted selection.

## Overlap check
The production ordering fix is now on public-beta through #4323. Compared both implementations and tests: the production algorithms are equivalent. This updated PR retains only three component tests. The upstream page regression uses identical metadata for repeated A snapshots and begins with a listed selection; this PR additionally verifies changed metadata for recurring IDs and the unlisted-selection path. The current production file matches upstream byte for byte.

## Validation
- `npm test -- --maxWorkers=2 src/components/PixelPreviewHistory.test.jsx src/pages/PixelPreviewHistory.test.jsx src/pages/PixelRepublishedPreview.test.jsx`: 6 passed across 3 files.
- Focused ESLint: 0 errors, 1 existing JSX usage warning.
- `npm run build`: passed.
- Merge public-beta commit d49ad4bbc760be319de7f4c9b9a93b1f18fe3922 in follow-up e5629339bba3a276a033ec88fe9623812ace6275; resolve the comment-only conflict using the upstream text. Current-head CI is pending.

## Risk and scope
Tests only. No runtime change, storage migration, hardware qualification, or live publication run is claimed. Reverting removes the added coverage. This is maintenance of an existing PR, not a new contribution in the September 14 batch.

AI assisted the code comparison, tests, validation, and description. Independent human review remains pending.
