### PR TITLE
feat(settings): add configuration category typeahead

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PanelSelect.jsx
+++ b/ods/extensions/services/dashboard/src/components/PanelSelect.jsx
@@ -7,6 +7,7 @@ export default function PanelSelect({ label, value, onChange, options, disabled 
   const id = useId(), root = useRef(null), trigger = useRef(null)
   const [open, setOpen] = useState(false)
   const [active, setActive] = useState(0)
+  const typed = useRef({text:'', time:0})
   const selected = options.findIndex(option => option.value === value)
   const choose = index => {
     if (!options[index]) return
@@ -24,6 +25,24 @@ export default function PanelSelect({ label, value, onChange, options, disabled 
     if (open) root.current?.querySelector(`[id="${id}-option-${active}"]`)?.scrollIntoView?.({ block: 'nearest' })
   }, [open, active, id])
   const keyDown = event => {
+    if (disabled || !options.length || event.nativeEvent.isComposing || event.ctrlKey || event.metaKey || event.altKey) return
+    if (event.key.length === 1 && event.key !== ' ') {
+      event.preventDefault()
+      const time = Date.now()
+      const text = (open && time - typed.current.time < 700 ? typed.current.text : '') + event.key.toLocaleLowerCase()
+      typed.current = {text:text.slice(0, 256), time}
+      const repeated = [...text].every(char => char === text[0])
+      const prefix = repeated ? text[0] : text
+      const from = open ? active : Math.max(0, selected)
+      for (let step = repeated ? 1 : 0; step < options.length + (repeated ? 1 : 0); step++) {
+        const index = (from + step) % options.length
+        if (options[index].label.toLocaleLowerCase().startsWith(prefix)) {
+          setActive(index); setOpen(true); break
+        }
+      }
+      return
+    }
+    typed.current = {text:'', time:0}
     if (event.key === 'Escape' && open) { event.preventDefault(); event.stopPropagation(); setOpen(false); return }
     if (event.key === 'Tab') { setOpen(false); return }
     if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) {

--- a/ods/extensions/services/dashboard/src/components/PanelSelectTypeahead.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PanelSelectTypeahead.test.jsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import PanelSelect from './PanelSelect'
+
+const options = ['Configuration', 'GPU backend', 'GPU memory', 'Network'].map(label => ({ value: label, label }))
+
+test('finds a category by typed prefix without committing until Enter', () => {
+  const onChange = vi.fn()
+  render(<PanelSelect label="Category" options={options} value="Configuration" onChange={onChange} />)
+  const select = screen.getByRole('combobox')
+  select.focus()
+  for (const key of 'net') fireEvent.keyDown(select, { key })
+  expect(select).toHaveAttribute('aria-activedescendant', screen.getByRole('option', { name: 'Network' }).id)
+  expect(onChange).not.toHaveBeenCalled()
+  expect(select).toHaveFocus()
+  fireEvent.keyDown(select, { key: 'Enter' })
+  expect(onChange).toHaveBeenCalledWith('Network')
+})
+
+test('cycles repeated initials and leaves IME or modified shortcuts alone', () => {
+  render(<PanelSelect label="Category" options={options} value="Configuration" onChange={vi.fn()} />)
+  const select = screen.getByRole('combobox')
+  fireEvent.keyDown(select, { key: 'n', ctrlKey: true })
+  fireEvent.keyDown(select, { key: 'n', isComposing: true })
+  expect(select).toHaveAttribute('aria-expanded', 'false')
+  fireEvent.keyDown(select, { key: 'g' })
+  expect(select).toHaveAttribute('aria-activedescendant', screen.getByRole('option', { name: 'GPU backend' }).id)
+  fireEvent.keyDown(select, { key: 'g' })
+  expect(select).toHaveAttribute('aria-activedescendant', screen.getByRole('option', { name: 'GPU memory' }).id)
+  fireEvent.keyDown(select, { key: 'Escape' })
+  fireEvent.keyDown(select, { key: 'n' })
+  expect(select).toHaveAttribute('aria-activedescendant', screen.getByRole('option', { name: 'Network' }).id)
+})


### PR DESCRIPTION
## Why this matters
Settings replaces a native category select with PanelSelect. It supports arrow navigation but ignores typed category names, making a long configuration list unnecessarily slow to navigate by keyboard. Add prefix navigation and repeated-initial cycling while retaining focus on the combobox and committing only on Enter/Space.

This is an optional usability enhancement described by the WAI-ARIA combobox pattern, not a claim that every select-only widget is required to implement it: https://www.w3.org/WAI/ARIA/apg/patterns/combobox/#keyboardinteraction

## Overlap check
Searched open/closed PRs touching PanelSelect.jsx and typeahead/category/keyboard keywords. #4224 preserves highlighted selection when option arrays refresh; this adds printable-character navigation. It retains existing index state so #4224 remains independently useful and should be reconciled when merged. #4210 introduced the contained selector.

## Validation
- Two rendered interaction tests failed on base where printable characters did nothing.
- `npx vitest run src/components/PanelSelectTypeahead.test.jsx src/components/PanelSelect.test.jsx`: 5 passed. Covers prefix search, repeated-letter cycling, explicit commit, Escape reset, IME/modified-key exclusion, existing arrows, pointer selection and disabled/empty lists.
- Focused ESLint 0 errors; scoped pre-commit and git diff --check passed.

Prefix accumulation expires after 700 ms and is capped at 256 characters. No configuration value is saved by navigation alone. Screen-reader announcement relies on existing aria-activedescendant; a live assistive-technology session was not run. Revert removes only typeahead.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

## Merge coordination

Not merge-ready until reconciled with open #4224: both touch the category keyboard handler. A tested resolution is [4e7f55e9](https://github.com/tang-vu/DreamServer/commit/4e7f55e9), which retains #4224's active option identity and sets activeValue from the typeahead match. All 7 combined selector tests pass. The independent branch remains based on public-beta; do not merge both heads without this reconciliation.

Latest candidate CI: 32 successful checks, 4 skipped. Independent human review of filesystem/authorization changes remains required despite green CI.


## Review status update — 2026-09-15

Ready for review at the author's request. **Not merge-ready.** The branch conflicts with public-beta. Preserve the tested typeahead behavior while reconciling the category control with overlapping #4224; the previously recorded comparison and union are not proof that this PR head is mergeable.

Reviewed head: 72fdafa7cd50a1bccfa6143059e1d81d1c156752. Changing draft status does not bypass these gates or authorize a merge.
