### PR TITLE
test(dashboard): stabilize concurrent DOM suite execution

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -358,6 +358,9 @@ test('compact views keep the connection draft and never apply changes on navigat
   globalThis.fetch.mockResolvedValue(response(statusPayload))
   render(createElement(RemoteProvider, { compact: true }))
   await screen.findByRole('button', { name: 'Connection', exact: true })
+  // Navigation is mounted before the initial status has hydrated the form.
+  // Exercise view switching only once that independent request has settled.
+  await waitFor(() => expect(screen.getByLabelText('Base URL')).toHaveValue(statusPayload.routeState.provider.baseUrl))
   expect(screen.queryByRole('heading', { name: 'Egress' })).toBeNull()
   fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://draft.example/v1' } })
   fireEvent.click(screen.getByRole('button', { name: 'Diagnostics', exact: true }))

--- a/ods/extensions/services/dashboard/vitest.config.js
+++ b/ods/extensions/services/dashboard/vitest.config.js
@@ -4,6 +4,9 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   test: {
+    // Each worker owns a jsdom/React environment. Bound concurrent DOM suites
+    // so larger CPU counts do not turn bounded async checks into timeouts.
+    maxWorkers: 2,
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.js'],


### PR DESCRIPTION
## Why this matters
The complete dashboard suite now starts 102 jsdom test files. On this WSL host, the unbounded default run had 5 timing failures (889 passed) while the same base with --maxWorkers=2 passed all 894 tests. Bound worker concurrency in the shared Vitest configuration so npm test, watch and coverage use a predictable DOM-environment budget. Test deadlines and assertions remain intact.

## Overlap check
Searched open/closed vitest workers concurrency and checked vitest.config.js / dashboard workflow changed files. #4027 introduced broader UI work; #4297 changes API validation. No matching worker-budget PR found.

## Validation
Base default: 5 failed / 889 passed, 79.87 s.
Base with two workers: 894 passed, 197.57 s.
Candidate npm test with the checked-in configuration: 894 passed / 102 files, 192.06 s.
Existing async React warnings remain. This trades peak parallel throughput for reliable bounded tests; it does not change shipped dashboard code. It is not proof that every CI timing failure shares this cause. Cross-platform CI runs the same npm test command on Linux, macOS and Windows.

Developed with AI assistance.


## Follow-up validation
Windows CI exposed a separate fixture race: the compact remote-provider test waited for a navigation button that exists before initial form hydration. It now waits for the persisted Base URL before editing and switching views, preserving its original draft-retention assertions. All 12 RemoteProvider tests pass. Worker limiting alone did not eliminate every suite race.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
