### PR TITLE
fix(usage): select reporting months in UTC

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -36,24 +36,24 @@ function pad2(value) {
 }
 
 function toDateKey(date) {
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`
+  return `${date.getUTCFullYear()}-${pad2(date.getUTCMonth() + 1)}-${pad2(date.getUTCDate())}`
 }
 
 function monthRange(anchor = new Date()) {
-  const start = new Date(anchor.getFullYear(), anchor.getMonth(), 1)
-  const end = new Date(anchor.getFullYear(), anchor.getMonth() + 1, 0)
+  const start = new Date(Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth(), 1))
+  const end = new Date(Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth() + 1, 0))
   return { start: toDateKey(start), end: toDateKey(end), anchor: start }
 }
 
 function addMonths(date, delta) {
-  return new Date(date.getFullYear(), date.getMonth() + delta, 1)
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + delta, 1))
 }
 
 function emptyReport(start, end, detail = null) {
-  const startDate = new Date(`${start}T00:00:00`)
-  const endDate = new Date(`${end}T00:00:00`)
+  const startDate = new Date(`${start}T00:00:00Z`)
+  const endDate = new Date(`${end}T00:00:00Z`)
   const daily = []
-  for (let cursor = new Date(startDate); cursor <= endDate; cursor.setDate(cursor.getDate() + 1)) {
+  for (let cursor = new Date(startDate); cursor <= endDate; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
     daily.push({
       date: toDateKey(cursor),
       spend_usd: 0,

--- a/ods/extensions/services/dashboard/src/pages/UsageUtcMonth.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/UsageUtcMonth.test.jsx
@@ -14,6 +14,8 @@ afterEach(() => {cleanup(); vi.useRealTimers(); vi.unstubAllGlobals()})
 it.each([
   ['2026-08-31T23:30:00Z', '2026-08-01', '2026-08-31', 'August 2026'],
   ['2026-09-01T00:30:00Z', '2026-09-01', '2026-09-30', 'September 2026'],
+  ['2026-12-31T23:30:00Z', '2026-12-01', '2026-12-31', 'December 2026'],
+  ['2027-01-01T00:30:00Z', '2027-01-01', '2027-01-31', 'January 2027'],
 ])('requests and labels the current UTC month at %s', async (instant, start, end, label) => {
   vi.setSystemTime(new Date(instant))
   await act(async () => {render(<Usage/>)})

--- a/ods/extensions/services/dashboard/src/pages/UsageUtcMonth.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/UsageUtcMonth.test.jsx
@@ -1,0 +1,31 @@
+import {cleanup, render, screen, fireEvent, act} from '@testing-library/react'
+import Usage from './Usage'
+
+beforeEach(() => {
+  vi.useFakeTimers({toFake:['Date']})
+  vi.stubGlobal('fetch', vi.fn(async url => ({
+    ok:true, json:async () => String(url).includes('/readiness')
+      ? {actions:{}}
+      : {source:{status:'ok'}, summary:{}, daily:[], models:[], services:[]},
+  })))
+})
+afterEach(() => {cleanup(); vi.useRealTimers(); vi.unstubAllGlobals()})
+
+it.each([
+  ['2026-08-31T23:30:00Z', '2026-08-01', '2026-08-31', 'August 2026'],
+  ['2026-09-01T00:30:00Z', '2026-09-01', '2026-09-30', 'September 2026'],
+])('requests and labels the current UTC month at %s', async (instant, start, end, label) => {
+  vi.setSystemTime(new Date(instant))
+  await act(async () => {render(<Usage/>)})
+  expect(fetch).toHaveBeenCalledWith(`/api/usage/report?start=${start}&end=${end}`, expect.any(Object))
+  expect(screen.getByText(label)).toBeVisible()
+})
+
+it('navigates the leap-year boundary using UTC months', async () => {
+  vi.setSystemTime(new Date('2024-03-01T00:30:00Z'))
+  await act(async () => {render(<Usage/>)})
+  await act(async () => {fireEvent.click(screen.getByRole('button', {name:'Previous month'}))})
+  expect(fetch).toHaveBeenLastCalledWith('/api/usage/readiness', expect.any(Object))
+  expect(fetch).toHaveBeenCalledWith('/api/usage/report?start=2024-02-01&end=2024-02-29', expect.any(Object))
+  expect(screen.getByText('February 2024')).toBeVisible()
+})


### PR DESCRIPTION
## Why this matters
Usage labels and daily buckets explicitly use UTC, but the page selected and advanced months using the browser's local calendar. In Vietnam at September 1 06:30 (August 31 23:30 UTC), opening Usage requested September and hid the active UTC month. Use UTC calendar operations consistently for selection, navigation and empty daily buckets.

## Overlap check
Searched open/closed usage UTC month timezone and Usage.jsx changed files. #3043 isolates auxiliary fetch failures; #4109 retains model filters; neither changes calendar selection. No matching UTC-month fix found.

## Validation
The new page regression fails on the base with TZ=Asia/Ho_Chi_Minh. All 16 Usage page/history/calendar tests pass separately in UTC, Asia/Ho_Chi_Minh and America/Los_Angeles. Boundary coverage includes both sides of UTC midnight and leap-year month navigation; assertions inspect actual fetch URLs and visible month labels.
The report API schema and date-bounded aggregation are unchanged.

Developed with AI assistance.


## Follow-up validation
Added both sides of a UTC year transition to the page-level calendar regression; all 5 calendar cases pass with TZ=Asia/Ho_Chi_Minh. An earlier openSUSE distro job failed fetching repository metadata/package dependencies, outside the changed dashboard surface; the follow-up head has a fresh CI run.


## Current CI limitation
Current head has 31 successful checks, 4 skipped, and one failed openSUSE distro job. The job cannot install jq/rsync after repository metadata/key retrieval fails. This reproduces across both heads, outside the changed dashboard files. Job rerun via GitHub API is denied with HTTP 403 (admin rights required). Kept draft pending infrastructure recovery or maintainer rerun; the three dashboard platform checks pass.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
