### PR TITLE
fix(ape): expire pending approvals and unused grants

### DIFF
--- a/ods/config/ape/policy.yaml
+++ b/ods/config/ape/policy.yaml
@@ -16,6 +16,11 @@
 #                      "action: require_approval" (a third decision tier; the
 #                      /verify response gains optional `decision` and
 #                      `approval_token` fields, retried through POST /approve).
+#                      Pending approval tokens expire after 15 minutes. A granted
+#                      one-shot retry expires 15 minutes after approval. Restart
+#                      does not renew either window; expired requests must be
+#                      verified again. These runtime limits cannot be disabled
+#                      by this policy file.
 #   circuit_breaker  — trips to deny-all when the deny ratio over a rolling
 #                      window is too high; tripped state is persisted across
 #                      restarts under /data/ape/state.json.

--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -260,6 +260,14 @@ _MAX_SAMPLES_PER_WINDOW = 20000
 _MAX_BREAKER_SAMPLES = 5000
 _MAX_PENDING_APPROVALS = 1000
 _MAX_PENDING_GRANTS = 1000
+# A human decision and its unused one-shot grant each have a 15-minute window.
+# Persisted timestamps survive restarts; missing/future timestamps authorize nothing.
+APPROVAL_TTL_SECONDS = 15 * 60
+
+
+def _approval_fresh(record: dict, field: str, now: float) -> bool:
+    timestamp = record.get(field)
+    return type(timestamp) in (int, float) and 0 <= now - timestamp < APPROVAL_TTL_SECONDS
 
 
 def _empty_state() -> dict[str, Any]:
@@ -366,6 +374,11 @@ def _prune_state(now: float) -> None:
     ][-_MAX_BREAKER_SAMPLES:]
     if cb.get("tripped_until", 0.0) and cb["tripped_until"] < now:
         cb["tripped_until"] = 0.0
+
+    for collection, field in (("approvals", "issued_at"), ("grants", "granted_at")):
+        for key, record in list(_state[collection].items()):
+            if not _approval_fresh(record, field, now):
+                del _state[collection][key]
 
     if len(_state["approvals"]) > _MAX_PENDING_APPROVALS:
         # Drop the oldest pending approvals by issued timestamp.
@@ -546,7 +559,8 @@ def consume_grant(
     gkey = _grant_key(session_id, tool_name, intent, _args_hash(args))
     with _STATE_LOCK:
         grants = _state.setdefault("grants", {})
-        return grants.pop(gkey, None)
+        grant = grants.pop(gkey, None)
+        return grant if grant and _approval_fresh(grant, "granted_at", time.time()) else None
 
 
 def record_window_sample(
@@ -970,6 +984,9 @@ async def approve(req: ApproveRequest, request: Request,
             return ApproveResponse(
                 granted=False,
                 reason="unknown or already-consumed approval token")
+        if not _approval_fresh(rec, "issued_at", time.time()):
+            save_state()
+            return ApproveResponse(granted=False, reason="approval token expired; verify the action again")
         # Persist a one-shot bypass tightly keyed to the approved action.
         gkey = _grant_key(
             rec.get("session"),

--- a/ods/extensions/services/ape/tests/test_approval_expiration.py
+++ b/ods/extensions/services/ape/tests/test_approval_expiration.py
@@ -1,0 +1,55 @@
+"""Exercise expiry through authenticated policy decisions, including restart."""
+import pytest
+
+POLICY = """
+version: 1
+intents:
+  ReadFile: {mode: allow}
+rate_limit: {requests_per_minute: 100000}
+windowed_limits:
+  enabled: true
+  intents:
+    ReadFile:
+      day: {limit: 1, action: require_approval}
+circuit_breaker: {enabled: false}
+"""
+ACTION = {"tool_name": "read_file", "args": {"path": "/x"}, "session_id": "expiry"}
+
+
+def escalate(client):
+    assert client.post("/verify", json=ACTION).json()["allowed"] is True
+    return client.post("/verify", json=ACTION).json()["approval_token"]
+
+
+@pytest.mark.parametrize("restart", [False, True])
+@pytest.mark.parametrize("age, granted", [(899, True), (900, False)])
+def test_pending_approval_expiration(make_client, monkeypatch, restart, age, granted):
+    client, app = make_client(policy_yaml=POLICY)
+    clock = [2_000_000_000.0]
+    monkeypatch.setattr(app.time, "time", lambda: clock[0])
+    token = escalate(client)
+    clock[0] += age
+    if restart:
+        client, app = make_client()
+    result = client.post("/approve", json={"approval_token": token})
+    assert result.status_code == 200
+    assert result.json()["granted"] is granted
+    assert client.post("/verify", json=ACTION).json()["allowed"] is granted
+
+
+@pytest.mark.parametrize("age, allowed", [(899, True), (900, False)])
+@pytest.mark.parametrize("restart", [False, True])
+def test_unused_grant_expires_without_renewal(make_client, monkeypatch, age, allowed, restart):
+    client, app = make_client(policy_yaml=POLICY)
+    clock = [2_000_000_000.0]
+    monkeypatch.setattr(app.time, "time", lambda: clock[0])
+    token = escalate(client)
+    assert client.post("/approve", json={"approval_token": token}).json()["granted"] is True
+    clock[0] += age
+    if restart:
+        client, app = make_client()
+    result = client.post("/verify", json=ACTION)
+    assert result.status_code == 200
+    assert result.json()["allowed"] is allowed
+    if allowed:
+        assert client.post("/verify", json=ACTION).json()["decision"] == "require_approval"

--- a/ods/tests/pixel_inference/test_advice_setup_process.py
+++ b/ods/tests/pixel_inference/test_advice_setup_process.py
@@ -19,7 +19,8 @@ pytestmark=pytest.mark.skipif(sys.platform!='linux',reason='Linux process-state 
 
 def live(pid):
     try: return Path(f'/proc/{pid}/stat').read_text().split(') ',1)[1].split()[0]!='Z'
-    except FileNotFoundError: return False
+    # A process can disappear after procfs opens stat but before read completes.
+    except (FileNotFoundError, ProcessLookupError): return False
 
 
 def until(check,seconds=5):


### PR DESCRIPTION
## Why this matters
APE persisted pending approval tokens and unused one-shot grants without an age limit. An old /verify escalation could be approved much later, and an old approved grant could bypass an exhausted window indefinitely, including after process restart. This confirms #4187 through actual authenticated endpoints.

Pending tokens now expire 15 minutes after issued_at; unused grants expire 15 minutes after granted_at. The exact boundary is exclusive (899 seconds valid, 900 expired). Missing, nonnumeric, nonfinite or future timestamps authorize nothing. Restart retains timestamps and cannot renew the window. Expired pending tokens are consumed and their rejection persisted; expired grants are consumed without bypass, so /verify evaluates the ordinary policy again. Startup also prunes stale approval state.

## Overlap check
Searched open/closed APE main.py and approval/expiry/governance PRs. #2012 prunes state on save but has no approval lifetime; #2975 bounds audit reads; #3174 provisions API keys; #3987/#4200 redact tokens; #4171 changes advisory defaults. None expires either authorization stage. Both stages are intentionally fixed together so one cannot retain an indefinite bypass after the other is bounded.

## Validation
- Initial endpoint regressions failed on base: expired pending approval minted a grant; expired unused grant authorized a retry after restart.
- `python -m pytest tests -q` in ods/extensions/services/ape: 52 passed under WSL.
- Eight new HTTP cases cover 899/900-second boundaries, pending and granted stages, with/without restart, plus preserved one-shot consumption. Existing tests cover exact action scope, hard policy denials and persistence.
- Scoped pre-commit and git diff --check passed.

## Review and compatibility
Kept draft: independent human review is required for this authorization-policy change and the fixed 15-minute choice. Clients waiting longer must re-verify and obtain fresh approval. Existing records use their saved issued_at/granted_at, so no state migration is needed. Clock rollback rejects future-dated grants. A delayed human approval does not extend a prior grant; it creates a separately bounded retry window.

No live agent/tool action was executed; tests use an always-allowed read intent behind an exhausted daily window. Windows/Linux container behavior shares this code; only WSL Python was executed locally. Reverting removes the expiration guard and can re-enable retained old state: rollback should clear pending approvals/grants under an operator-controlled maintenance stop, without discarding audit history.

Fixes #4187.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

CI follow-up b3ca5b0b reuses the exact procfs exit-race repair already present in #4255, after this PR's real CI run raised ProcessLookupError while observing an exiting process. All 6 process-lifecycle cases pass locally. This is a reused CI prerequisite, not another counted PR.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
