### PR TITLE
fix(pixel): preserve IPv6 interface scope in peer probes

### DIFF
--- a/ods/extensions/services/pixel-agent/host/system_observe.py
+++ b/ods/extensions/services/pixel-agent/host/system_observe.py
@@ -285,6 +285,10 @@ def _resolve_peer(target: str) -> list[tuple[int, str, str]]:
         if family not in {socket.AF_INET, socket.AF_INET6}:
             continue
         address = str(ipaddress.ip_address(sockaddr[0]))
+        # Link-local IPv6 names can resolve on more than one interface. The
+        # scope is part of the endpoint, not an interchangeable duplicate.
+        if family == socket.AF_INET6 and sockaddr[3] and "%" not in address:
+            address = f"{address}%{sockaddr[3]}"
         if address in seen:
             continue
         seen.add(address)
@@ -364,7 +368,11 @@ def _probe_icmp(family: int, address: str) -> bool | None:
 
 
 def _probe_tcp(family: int, address: str, port: int) -> bool:
-    endpoint = (address, port) if family == socket.AF_INET else (address, port, 0, 0)
+    if family == socket.AF_INET6:
+        host, separator, interface = address.partition("%")
+        endpoint = (host, port, 0, int(interface) if separator else 0)
+    else:
+        endpoint = (address, port)
     try:
         with socket.socket(family, socket.SOCK_STREAM) as connection:
             connection.settimeout(0.4)

--- a/ods/extensions/services/pixel-agent/tests/test_system_observe.py
+++ b/ods/extensions/services/pixel-agent/tests/test_system_observe.py
@@ -147,6 +147,29 @@ class SystemObserveTests(unittest.TestCase):
             "tcp": [{"port": 22, "open": True}, {"port": 3389, "open": False}],
         }])
 
+    def test_link_local_peer_retains_resolved_interface_for_each_probe(self):
+        records = [
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fe80::1234", 0, 0, 3)),
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("fe80::1234", 0, 0, 4)),
+        ]
+        tailscale = {"available": False, "found": False, "online": None, "addresses": []}
+        connection = mock.MagicMock()
+        connection.__enter__.return_value = connection
+        connection.connect_ex.side_effect = lambda endpoint: 0 if endpoint[3] == 3 else 113
+        with mock.patch.object(system_observe.socket, "getaddrinfo", return_value=records), \
+             mock.patch.object(system_observe.socket, "socket", return_value=connection), \
+             mock.patch.object(system_observe, "_tailscale_peer_status", return_value=tailscale), \
+             mock.patch.object(system_observe, "_probe_icmp", return_value=False) as icmp:
+            value = system_observe.observe_network_peer("printer.local", "443")
+        self.assertTrue(value["reachable"])
+        self.assertEqual([row["address"] for row in value["addresses"]], ["fe80::1234%3", "fe80::1234%4"])
+        self.assertEqual([row["tcp"] for row in value["addresses"]],
+                         [[{"port": 443, "open": True}], [{"port": 443, "open": False}]])
+        self.assertEqual(connection.connect_ex.call_args_list,
+                         [mock.call(("fe80::1234", 443, 0, 3)), mock.call(("fe80::1234", 443, 0, 4))])
+        self.assertEqual(icmp.call_args_list,
+                         [mock.call(socket.AF_INET6, "fe80::1234%3"), mock.call(socket.AF_INET6, "fe80::1234%4")])
+
     def test_network_peer_rejects_public_resolution_and_unbounded_ports(self):
         records = [
             (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("203.0.113.7", 0)),

--- a/ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/tool_loop_guard.test.mjs
@@ -14712,3 +14712,25 @@ for (const transport of ["direct", "tool-search"]) {
     });
   }
 }
+
+test("scoped IPv6 peer observations remain verifiable host receipts", () => {
+  const guard = createToolLoopGuard();
+  guard.observeRun({agentId:"pixel", runId:"run-1", sessionId:"session-1"}, "pixel", {
+    prompt:"Probe Strixy on the local network port 443.",
+  });
+  const params = {actions:["host.network-peer"], peer:"Strixy", ports:[443]};
+  assert.deepEqual(call(guard, "pixel_ods_host_observe", {event:{params}}), {params});
+  afterCall(guard, "pixel_ods_host_observe", {event:{params, result:{details:{
+    jobId:"ops-1234567890123-abcdef123456", status:"succeeded", waitTimedOut:false,
+    steps:[{stepId:"observe-1", target:"ods-host", action:"host.network-peer", exitCode:0,
+      stdout:JSON.stringify({schemaVersion:1, kind:"ods-host-network-peer", target:"Strixy", ports:[443],
+        resolved:true, reachable:true, addresses:[{address:"fe80::1234%3", family:"ipv6", scope:"link-local",
+          icmpReachable:false, tcp:[{port:443, open:true}]}],
+        tailscale:{available:false, found:false, online:null, addresses:[]}}),
+      stderr:"", outputTruncated:{stdout:false, stderr:false}, riskSignals:[]}],
+  }}}});
+  const verification = guard.verificationForRun("run-1");
+  assert.equal(verification.status, "passed");
+  assert.match(verification.text, /fe80::1234%3/);
+  assert.match(verification.text, /open TCP 443/);
+});


### PR DESCRIPTION
## Why this matters
host.network-peer accepts a named private peer, including an mDNS name resolving to link-local IPv6. getaddrinfo supplies the interface in sockaddr[3], but the observer discarded it and connected with scope 0. This reported reachable services as closed and collapsed identical link-local addresses on distinct interfaces.
Carry the resolver's numeric scope in the address, pass it to TCP endpoints and retain it in ICMP probes and the content-free receipt.

## Overlap check
Searched open/closed IPv6 link local scope peer and system_observe scope, plus system_observe.py changed files. #2085 scrubs IPv6 in privacy-shield; #3385 is broader Portal work. No matching scoped peer-probe fix found.

## Validation
Public observe_network_peer regression fails on the base and passes with two resolver-provided interfaces, correct TCP endpoints, ICMP arguments and per-interface results. All 10 system-observe tests pass, including public-network rejection and exact Tailscale peer binding.
All 502 tool-loop-guard tests pass; a new receipt test verifies the existing consumer accepts scoped IPv6 and retains its evidence.
Linux/WSL tests use resolver/socket fixtures. No real remote IPv6 host was probed. Kept draft for independent network-boundary review; this does not expand allowed peers or ports.

Developed with AI assistance.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
