### PR TITLE
fix(usage): clean up CSV downloads and surface export failures

### DIFF
--- a/ods/extensions/services/dashboard/src/components/usage/UsageCsvDownload.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageCsvDownload.test.jsx
@@ -1,0 +1,53 @@
+import {cleanup, render, screen, fireEvent} from '@testing-library/react'
+import UsageView from './UsageView'
+
+function show() {
+  render(<UsageView report={{source:{status:'ok'}, summary:{}, models:[
+    {model:'Selected model', provider:'local', input_tokens:42},
+    {model:'Other model', provider:'cloud', input_tokens:10},
+  ]}} readiness={{status:'ready'}} range={{start:'2026-05-01'}}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Models', exact:true}))
+  fireEvent.change(screen.getByLabelText('Search models'), {target:{value:'Selected'}})
+}
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('URL', {createObjectURL:vi.fn(() => 'blob:usage-csv'), revokeObjectURL:vi.fn()})
+})
+afterEach(() => {cleanup(); vi.runOnlyPendingTimers(); vi.useRealTimers(); vi.restoreAllMocks(); vi.unstubAllGlobals()})
+
+it('activates a connected download link and releases its URL after activation', () => {
+  const clicked = []
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function () {
+    clicked.push({connected:this.isConnected, href:this.href, download:this.download})
+  })
+  show()
+  fireEvent.click(screen.getByRole('button', {name:'Export CSV'}))
+  expect(clicked).toEqual([{connected:true, href:'blob:usage-csv', download:'ods-usage-by-model.csv'}])
+  expect(document.querySelector('a[download]')).toBeNull()
+  expect(URL.revokeObjectURL).not.toHaveBeenCalled()
+  vi.advanceTimersByTime(1000)
+  expect(URL.revokeObjectURL).toHaveBeenCalledExactlyOnceWith('blob:usage-csv')
+  expect(URL.createObjectURL.mock.calls[0][0]).toBeInstanceOf(Blob)
+})
+
+it('reports allocation failure and allows a fresh export without changing filters', () => {
+  URL.createObjectURL.mockImplementationOnce(() => {throw new Error('allocation denied')})
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  show()
+  fireEvent.click(screen.getByRole('button', {name:'Export CSV'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('CSV export could not be started')
+  expect(screen.getByLabelText('Search models')).toHaveValue('Selected')
+  fireEvent.click(screen.getByRole('button', {name:'Export CSV'}))
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  expect(URL.createObjectURL).toHaveBeenCalledTimes(2)
+})
+
+it('releases resources and reports failure if browser download activation throws', () => {
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {throw new Error('blocked')})
+  show()
+  fireEvent.click(screen.getByRole('button', {name:'Export CSV'}))
+  expect(screen.getByRole('alert')).toHaveTextContent('CSV export could not be started')
+  expect(document.querySelector('a[download]')).toBeNull()
+  vi.advanceTimersByTime(1000)
+  expect(URL.revokeObjectURL).toHaveBeenCalledExactlyOnceWith('blob:usage-csv')
+})

--- a/ods/extensions/services/dashboard/src/components/usage/UsageView.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageView.jsx
@@ -111,13 +111,32 @@ function Trend({label,data,keys,available,currency=false,gapDays=1}) {
 }
 
 function ModelView({rows,telemetrySource}) {
+  const [exportError,setExportError]=useState(false)
   const [query,setQuery]=useState(''),[provider,setProvider]=useState('all'),[service,setService]=useState('all'),[source,setSource]=useState('all'),[page,setPage]=useState(0)
   const filtered=useMemo(()=>rows.filter(row=>(provider==='all'||metadataValue(row.provider)===provider)&&(service==='all'||metadataValue(row.service)===service)&&(source==='all'||metadataValue(row.cost_source)===source)&&[row.model,row.provider,row.service,row.cost_source].some(value=>String(value || '').toLowerCase().includes(query.trim().toLowerCase()))).sort((a,b)=>tokens(b)-tokens(a)),[rows,query,provider,service,source])
   useEffect(()=>setPage(0),[query,provider,service,source])
   const count=Math.max(1,Math.ceil(filtered.length/8)), current=Math.min(page,count-1)
-  function exportCsv(){const url=URL.createObjectURL(new Blob([csvForRows(filtered)],{type:'text/csv;charset=utf-8'}));const link=document.createElement('a');link.href=url;link.download='ods-usage-by-model.csv';link.click();URL.revokeObjectURL(url)}
+  function exportCsv() {
+    let url, link
+    setExportError(false)
+    try {
+      url = URL.createObjectURL(new Blob([csvForRows(filtered)], {type:'text/csv;charset=utf-8'}))
+      link = document.createElement('a')
+      link.href = url
+      link.download = 'ods-usage-by-model.csv'
+      document.body.append(link)
+      link.click()
+    } catch {
+      setExportError(true)
+    } finally {
+      link?.remove()
+      // Let browser activation consume the URL before releasing its bytes.
+      if (url) setTimeout(() => URL.revokeObjectURL(url), 1000)
+    }
+  }
   return <>
     <header className="usage-section-title"><div><h2>Usage by Model</h2><p>Ordered by recorded token volume</p></div><button className="usage-text-button" disabled={!filtered.length} onClick={exportCsv}><Download size={14}/>Export CSV</button></header>
+    {exportError && <p role="alert" className="usage-notice">CSV export could not be started. Try again; your report and filters are unchanged.</p>}
     <label className="usage-search"><Search size={14}/><input aria-label="Search models" placeholder="Search models..." value={query} onChange={event=>setQuery(event.target.value)}/></label>
     <details className="usage-filter-details"><summary>Filters{provider!=='all'||service!=='all'||source!=='all' ? ' · active' : ''}</summary><div className="usage-filters">{[['All Providers','provider',provider,setProvider],['All Services','service',service,setService],['All Sources','cost_source',source,setSource]].map(([label,key,value,set])=><select key={key} aria-label={label} value={value} onChange={event=>set(event.target.value)}><option value="all">{label}</option>{[...new Set([...rows.map(row=>metadataValue(row[key])), ...(value==='all' ? [] : [value])])].map(option=><option key={option} value={option}>{sourceNames[option] || option}</option>)}</select>)}</div></details>
     <div className="usage-model-list">{filtered.slice(current*8,current*8+8).map(row=><details key={`${row.model}-${row.provider}-${row.service}-${row.cost_source}`} className="usage-model-row"><summary><span className="usage-model-name"><strong title={row.model}>{row.model || 'Unknown model'}</strong><small>{row.provider || 'unknown'} · {row.service || 'unknown'}</small></span><span className="usage-model-total">{compactNumber(tokens(row))}<small>tokens</small></span><ChevronRight size={13}/></summary><dl>{[['Input',integer(row.input_tokens)],['Output',integer(row.output_tokens)],['Cache read',integer(row.cache_read_tokens)],['Cache write',integer(row.cache_write_tokens)],['Requests',requestLabel(row,telemetrySource)],['Cost',costLabel(row)],['Source',sourceNames[row.cost_source] || 'Unknown cost']].map(([label,value])=><div key={label}><dt>{label}</dt><dd>{value}</dd></div>)}</dl></details>)}</div>


### PR DESCRIPTION
## Why this matters
The Usage CSV action immediately revoked a detached download URL and left exceptions from URL allocation or activation unhandled. A failed export gave the user no recovery feedback, and activation failures leaked the URL. Activate a connected link, remove it in finally, defer URL cleanup, and display a retryable error while retaining the selected report/filter.

## Overlap check
Searched open/closed usage CSV download revoke and usage export CSV error, plus UsageView.jsx changed files. #3847 ranks rows in the older Usage table; #3839 fixes CSV escaping. Neither covers this refined view's download resource lifecycle. Existing CSV formatting and formula escaping remain unchanged.

## Validation
Three new button-level regressions fail on the base (including two uncaught failures). All 15 UsageView/CSV tests now pass: connected link activation, delayed single cleanup, allocation/activation failure and retry with retained filter, plus existing CSV escaping and token fields.
Tests use browser API fixtures; they prove activation and resource ownership, not that an external browser wrote a file to disk. No report requests or billing calculations change.

Developed with AI assistance.


## Later overlap review
#4345 independently preserves unknown counters/costs in CSV. A final changed-file audit found it also changes exportCsv; git merge-tree confirms a textual conflict. Neither is a redundant subset: when merging both, retain #4345's csvForRows(filtered, telemetrySource) call and formatter tests inside this PR's try/finally download lifecycle. #4345 is not included in the 20-PR candidate below.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
