### PR TITLE
fix(invites): keep deadlines active through JSON body reads

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -15,7 +15,13 @@ const fetchJson = async (url, init = {}, ms = 8000) => {
   const c = new AbortController()
   const t = setTimeout(() => c.abort(), ms)
   try {
-    return await fetch(url, { ...init, signal: c.signal })
+    const response = await fetch(url, { ...init, signal: c.signal })
+    // The deadline includes reading JSON, not just receiving HTTP headers.
+    // Keep parsing failures lazy so existing status/error handlers still apply.
+    const body = await response.json().then(value => ({ value }), error => ({ error }))
+    if (c.signal.aborted) throw new Error('Access request timed out. Refresh the list before trying another action.')
+    return { ok: response.ok, status: response.status,
+      json: () => body.error ? Promise.reject(body.error) : Promise.resolve(body.value) }
   } finally {
     clearTimeout(t)
   }

--- a/ods/extensions/services/dashboard/src/pages/InvitesBodyDeadline.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/InvitesBodyDeadline.test.jsx
@@ -1,0 +1,28 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import Invites from './Invites'
+
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals() })
+
+test('recovers from stalled inventory JSON after HTTP headers arrive', async () => {
+  vi.useFakeTimers()
+  let stalled = true, signal
+  vi.stubGlobal('fetch', vi.fn(async (url, options) => {
+    if (url.endsWith('/list') && stalled) {
+      signal = options.signal
+      return { ok: true, status: 200, json: () => new Promise((_, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('Body aborted')), { once: true })
+      }) }
+    }
+    return { ok: true, status: 200, json: async () => url.endsWith('/list') ? { tokens: [] } : { ready: true } }
+  }))
+  await act(async () => render(<Invites />))
+  await act(async () => vi.advanceTimersByTimeAsync(8000))
+  expect(signal.aborted).toBe(true)
+  expect(screen.getByRole('alert')).toHaveTextContent('timed out')
+  const refresh = screen.getByRole('button', { name: 'Refresh setup owner links' })
+  expect(refresh).toBeEnabled()
+  stalled = false
+  await act(async () => fireEvent.click(refresh))
+  expect(screen.getByText('No owner cards yet')).toBeVisible()
+  expect(screen.queryByRole('alert')).toBeNull()
+})


### PR DESCRIPTION
## Why this matters
The Owner access request helper cleared its 8-second deadline as soon as fetch returned headers. A stalled list, owner-status, generation or QR JSON body could then leave loading/submitting active indefinitely. A rendered regression reproduces the list case: HTTP 200 arrives, JSON never completes, and the page cannot refresh.

Read the body under the original AbortController deadline. Preserve the callers' response status and deferred JSON-error handling using a small result adapter. Timeout messages request a list refresh before another action; nothing is automatically retried.

## Overlap check
Searched open/closed Invites.jsx PRs. Inspected #3038 (isolate owner-status failures): it changes Promise.all to allSettled, not the fetch/body deadline. #3833 ignores obsolete refreshes, #3846 filters inventory, and #2327 handles clipboard. None covers the body phase. The helper remains compatible with their existing ok/status/json callers.

## Validation
- New rendered page test failed on base: the request signal remained un-aborted after 8 seconds and the skeleton could not recover.
- `npx vitest run src/pages/InvitesBodyDeadline.test.jsx src/pages/Invites.test.jsx`: 7 passed, including explicit refresh recovery, existing revocation, generation payloads, and QR flows.
- Focused ESLint 0 errors; scoped pre-commit and git diff --check passed.

A timeout does not prove a server mutation failed. The UI asks for reconciliation and performs no retry; the existing server remains authoritative. Tests simulate the browser's body-read AbortError path, with no live card issued or revoked. Revert restores the headers-only deadline.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
