### PR TITLE
fix(dashboard): contain denied storage access during crash recovery

### DIFF
--- a/ods/extensions/services/dashboard/src/utils/__tests__/staleAssetRecovery.test.js
+++ b/ods/extensions/services/dashboard/src/utils/__tests__/staleAssetRecovery.test.js
@@ -82,7 +82,7 @@ describe('browser-denied sessionStorage access', () => {
   beforeEach(() => {
     descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage')
     Object.defineProperty(globalThis, 'sessionStorage', {configurable:true, get() {
-      throw new DOMException('Storage access denied', 'SecurityError')
+      throw new globalThis.DOMException('Storage access denied', 'SecurityError')
     }})
   })
   afterEach(() => {Object.defineProperty(globalThis, 'sessionStorage', descriptor)})

--- a/ods/extensions/services/dashboard/src/utils/__tests__/staleAssetRecovery.test.js
+++ b/ods/extensions/services/dashboard/src/utils/__tests__/staleAssetRecovery.test.js
@@ -76,3 +76,37 @@ describe('stale asset recovery', () => {
     expect(globalThis.sessionStorage.getItem(RECOVERY_KEY)).toBeNull()
   })
 })
+
+describe('browser-denied sessionStorage access', () => {
+  let descriptor
+  beforeEach(() => {
+    descriptor = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage')
+    Object.defineProperty(globalThis, 'sessionStorage', {configurable:true, get() {
+      throw new DOMException('Storage access denied', 'SecurityError')
+    }})
+  })
+  afterEach(() => {Object.defineProperty(globalThis, 'sessionStorage', descriptor)})
+
+  it('leaves stale-asset recovery to the error boundary without an unprotected reload', () => {
+    const reload = vi.fn()
+    expect(recoverFromStaleAsset(new Error('Loading chunk 9 failed'), {reload})).toBe(false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('does not replace an unrelated application error with a storage exception', () => {
+    expect(recoverFromStaleAsset(new Error('Render failed'))).toBe(false)
+  })
+
+  it('allows the normal startup cleanup timer to finish', () => {
+    expect(() => clearStaleAssetRecovery()).not.toThrow()
+  })
+
+  it('still supports explicitly provided storage without reading the browser getter', () => {
+    const storage = {getItem:vi.fn(() => null), setItem:vi.fn(), removeItem:vi.fn()}
+    const reload = vi.fn()
+    expect(recoverFromStaleAsset(new Error('Loading chunk 9 failed'), {storage, reload})).toBe(true)
+    clearStaleAssetRecovery(storage)
+    expect(reload).toHaveBeenCalledOnce()
+    expect(storage.removeItem).toHaveBeenCalledWith(RECOVERY_KEY)
+  })
+})

--- a/ods/extensions/services/dashboard/src/utils/staleAssetRecovery.js
+++ b/ods/extensions/services/dashboard/src/utils/staleAssetRecovery.js
@@ -25,7 +25,7 @@ export function isStaleAssetError(error) {
  * render a useful fallback instead of entering a reload loop.
  */
 export function recoverFromStaleAsset(error, {
-  storage = globalThis.sessionStorage,
+  storage,
   reload = () => globalThis.location.reload(),
   href = globalThis.location?.href || '',
   now = Date.now(),
@@ -33,6 +33,7 @@ export function recoverFromStaleAsset(error, {
   if (!isStaleAssetError(error)) return false
 
   try {
+    if (storage === undefined) storage = globalThis.sessionStorage
     const previous = JSON.parse(storage.getItem(RECOVERY_KEY) || 'null')
     if (previous?.at && now - previous.at < RECOVERY_WINDOW_MS) return false
 
@@ -46,8 +47,9 @@ export function recoverFromStaleAsset(error, {
   return true
 }
 
-export function clearStaleAssetRecovery(storage = globalThis.sessionStorage) {
+export function clearStaleAssetRecovery(storage) {
   try {
+    if (storage === undefined) storage = globalThis.sessionStorage
     storage.removeItem(RECOVERY_KEY)
   } catch {
     // Storage can be disabled without preventing normal dashboard use.


### PR DESCRIPTION
## Why this matters
When the browser denies sessionStorage itself, evaluating the default parameter throws before stale-asset recovery enters its try block. This can replace the original error inside main.jsx's ErrorBoundary, and the normal 30-second marker cleanup also throws. Acquire default storage inside the existing guarded boundary so manual recovery remains available without an unprotected reload loop.

## Overlap check
Searched open/closed staleAssetRecovery, stale asset sessionStorage getter, and stale asset storage blocked; checked the utility's changed-file entries. #1968 includes earlier asset recovery work; no matching denied-getter fix found. Other storage fixes target separate PWA/version consumers.

## Validation
Three new default-path regressions fail on the base. All 14 recovery tests pass after the fix, including actual getter-thrown SecurityError, unrelated error preservation, scheduled-cleanup entry point and explicitly injected storage.
Production callers are main.jsx componentDidCatch, vite:preloadError and componentDidMount's cleanup timer. No change to reload limits or genuine application-error detection.

Developed with AI assistance.


## Follow-up validation
Qualified globalThis.DOMException in the denied-storage regression to satisfy the repository ESLint globals. Scoped ESLint and all 14 recovery tests pass on the follow-up.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
