### PR TITLE
fix(auth): stop session bootstrap when its route is disabled

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useSessionBootstrapLifetime.test.jsx
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useSessionBootstrapLifetime.test.jsx
@@ -1,0 +1,45 @@
+import {StrictMode} from 'react'
+import {act, cleanup, renderHook} from '@testing-library/react'
+import {useSessionBootstrap} from '../useSessionBootstrap'
+
+const deferred = () => {let resolve; return {promise:new Promise(done => {resolve=done}), resolve:value=>resolve(value)}}
+beforeEach(() => {vi.stubGlobal('fetch', vi.fn()); vi.spyOn(console, 'warn').mockImplementation(() => {})})
+afterEach(() => {cleanup(); vi.restoreAllMocks(); vi.unstubAllGlobals()})
+
+it.each(['disable', 'unmount'])('does not mint from a late verification after %s', async change => {
+  const pending = deferred()
+  fetch.mockReturnValue(pending.promise)
+  const hook = renderHook(({enabled}) => useSessionBootstrap(enabled), {initialProps:{enabled:true}})
+  const signal = fetch.mock.calls[0][1].signal
+  if (change === 'disable') hook.rerender({enabled:false})
+  else hook.unmount()
+  await act(async () => {pending.resolve({ok:false, status:401})})
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(signal?.aborted).toBe(true)
+  expect(console.warn).not.toHaveBeenCalled()
+})
+
+it('keeps StrictMode setup replay usable without a stale verification minting', async () => {
+  const pending = []
+  fetch.mockImplementation(url => {
+    if (url.includes('admin-session')) return Promise.resolve({ok:true})
+    const request = deferred(); pending.push(request); return request.promise
+  })
+  renderHook(() => useSessionBootstrap(true), {wrapper:({children}) => <StrictMode>{children}</StrictMode>})
+  await act(async () => {pending.forEach(request => request.resolve({ok:false, status:401}))})
+  const calls = fetch.mock.calls
+  expect(calls.filter(([url]) => url.includes('admin-session'))).toHaveLength(1)
+  expect(calls.at(-1)[1].signal?.aborted).toBe(false)
+})
+
+it('starts a fresh verification after leaving and returning to an enabled route', async () => {
+  fetch.mockResolvedValue({ok:true})
+  const hook = renderHook(({enabled}) => useSessionBootstrap(enabled), {initialProps:{enabled:false}})
+  expect(fetch).not.toHaveBeenCalled()
+  await act(async () => {hook.rerender({enabled:true})})
+  await act(async () => {hook.rerender({enabled:true})})
+  expect(fetch).toHaveBeenCalledTimes(1)
+  hook.rerender({enabled:false})
+  await act(async () => {hook.rerender({enabled:true})})
+  expect(fetch).toHaveBeenCalledTimes(2)
+})

--- a/ods/extensions/services/dashboard/src/hooks/useSessionBootstrap.js
+++ b/ods/extensions/services/dashboard/src/hooks/useSessionBootstrap.js
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect } from 'react'
 
 /**
  * Ensure the dashboard user has a valid `ods-session` cookie.
@@ -25,19 +25,16 @@ import { useEffect, useRef } from 'react'
  * From the user's POV: open dashboard → sidebar's Hermes link just
  * works. No invite-to-yourself dance.
  *
- * Runs once per mount. Re-runs only if the page is reloaded — which is
- * fine, the verify-session call is cheap (one signature check, no
- * DB lookups). If session_signer isn't configured server-side the
+ * Runs once per enabled route lifetime, including a fresh verification after
+ * returning from the public Talk route. Leaving that lifetime cancels browser
+ * work; an already accepted mint remains owned by the server. If session_signer isn't configured server-side the
  * admin-session POST 503s; we surface that in console as a hint to
  * set ODS_SESSION_SECRET, but don't block the dashboard.
  */
 export function useSessionBootstrap(enabled = true) {
-  const ran = useRef(false)
-
   useEffect(() => {
     if (!enabled) return
-    if (ran.current) return
-    ran.current = true
+    const controller = new AbortController()
 
     const run = async () => {
       try {
@@ -45,7 +42,9 @@ export function useSessionBootstrap(enabled = true) {
           // Include the cookie if the browser has one — that's how
           // verify-session decides whether to return 200 or 401.
           credentials: 'same-origin',
+          signal: controller.signal,
         })
+        if (controller.signal.aborted) return
         if (verify.ok) return  // session already present
 
         // 401 (or any non-2xx, e.g. 503 if dashboard-api is mid-restart) —
@@ -54,13 +53,16 @@ export function useSessionBootstrap(enabled = true) {
         const mint = await fetch('/api/auth/admin-session', {
           method: 'POST',
           credentials: 'same-origin',
+          signal: controller.signal,
         })
+        if (controller.signal.aborted) return
         if (mint.ok) return
 
         // 503 = ODS_SESSION_SECRET not configured. The dashboard still
         // works; cookie-gated services won't. Surface the hint quietly.
         if (mint.status === 503) {
           const body = await mint.json().catch(() => ({}))
+          if (controller.signal.aborted) return
           console.warn(
             '[ods-session] could not mint admin session:',
             body.detail || 'server misconfigured',
@@ -74,10 +76,11 @@ export function useSessionBootstrap(enabled = true) {
         // just the Hermes / chat tiles will route them to the invite page.
         console.warn('[ods-session] admin-session returned', mint.status)
       } catch (err) {
-        console.warn('[ods-session] bootstrap failed:', err)
+        if (!controller.signal.aborted) console.warn('[ods-session] bootstrap failed:', err)
       }
     }
 
     run()
+    return () => controller.abort()
   }, [enabled])
 }


### PR DESCRIPTION
## Why this matters
App disables owner-session bootstrap on public Talk routes, but a pending verification could still POST admin-session after navigation there or after unmount. Bind requests and the verify-to-mint transition to the effect's AbortSignal. Returning to an enabled route gets a fresh verification; StrictMode cleanup does not strand a permanent run-once flag.

## Overlap check
Searched open/closed useSessionBootstrap and session bootstrap unmount cancel. #3191 adds basic branch coverage; #3098 changes which HTTP statuses permit minting; this PR preserves existing status policy and fixes request lifetime. #3818 changes App routing but not this hook's cancellation. Tests use a distinct file.

## Validation
Four lifecycle regressions fail on the base. All 16 hook/App tests pass: disabled and unmounted late responses cannot mint, StrictMode produces one active mint, returning to an enabled route verifies again, and the public Talk route remains excluded.
An already accepted POST can still finish server-side; aborting a browser request does not revoke a session. No endpoint authorization or cookie policy changes. Kept draft for independent authentication review; no live session mint was exercised.

Developed with AI assistance.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
