### PR TITLE
fix(models): use a native modal for artifact inspection

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceDialogKeyboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceDialogKeyboard.test.jsx
@@ -1,0 +1,30 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import HuggingFaceModelBrowser from './HuggingFaceModelBrowser'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  HTMLDialogElement.prototype.showModal = function () { this.open = true }
+  HTMLDialogElement.prototype.close = function () { this.open = false }
+})
+afterEach(() => {
+  cleanup(); vi.useRealTimers(); vi.unstubAllGlobals()
+  delete HTMLDialogElement.prototype.showModal; delete HTMLDialogElement.prototype.close
+})
+
+test('focuses artifact inspection, cancels without importing and restores the repository button', async () => {
+  const fetchMock = vi.fn(async url => ({ ok: true, json: async () => url.includes('/search?')
+    ? { models: [{ id: 'author/model', author: 'author' }] }
+    : { id: 'author/model', artifacts: [], url: 'https://huggingface.co/author/model' } }))
+  vi.stubGlobal('fetch', fetchMock)
+  render(<HuggingFaceModelBrowser />)
+  await act(async () => vi.advanceTimersByTimeAsync(350))
+  const trigger = screen.getByRole('button', { name: 'Choose file' })
+  trigger.focus()
+  await act(async () => fireEvent.click(trigger))
+  const dialog = screen.getByRole('dialog')
+  expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus()
+  fireEvent(dialog, new Event('cancel', { cancelable: true }))
+  expect(screen.queryByRole('dialog')).toBeNull()
+  expect(trigger).toHaveFocus()
+  expect(fetchMock.mock.calls.every(([url]) => !url.endsWith('/import'))).toBe(true)
+})

--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
@@ -289,8 +289,20 @@ function RepositoryRow({ model, onInspect }) {
 }
 
 function ArtifactDialog({ model, details, loading, error, gpu, downloadBusy, importingArtifact, onClose, onImport, onRetry }) {
+  const dialog = useRef(null)
+  const closeButton = useRef(null)
+  useEffect(() => {
+    const previous = document.activeElement
+    const element = dialog.current
+    element.showModal()
+    closeButton.current?.focus()
+    return () => {
+      element.close()
+      if (previous?.isConnected) previous.focus()
+    }
+  }, [])
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm" role="dialog" aria-modal="true" aria-label={`Choose a GGUF from ${model.id}`}>
+    <dialog ref={dialog} onCancel={event => { event.preventDefault(); onClose() }} className="fixed inset-0 m-0 h-screen w-screen max-h-none max-w-none border-0 z-50 flex items-center justify-center bg-black/75 p-4 backdrop-blur-sm" aria-label={`Choose a GGUF from ${model.id}`}>
       <div className="max-h-[88vh] w-full max-w-5xl overflow-hidden rounded-lg border border-white/[0.1] bg-[#090910] shadow-2xl">
         <header className="flex items-start justify-between gap-4 border-b border-white/[0.07] px-5 py-4">
           <div className="min-w-0">
@@ -300,7 +312,7 @@ function ArtifactDialog({ model, details, loading, error, gpu, downloadBusy, imp
             </div>
             <p className="mt-1 text-xs text-theme-text-muted">Select an exact, integrity-qualified GGUF artifact.</p>
           </div>
-          <button type="button" onClick={onClose} disabled={Boolean(importingArtifact)} className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/[0.08] text-theme-text-muted hover:text-theme-text disabled:opacity-40" title="Close">
+          <button ref={closeButton} type="button" onClick={onClose} disabled={Boolean(importingArtifact)} className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-white/[0.08] text-theme-text-muted hover:text-theme-text disabled:opacity-40" title="Close">
             <X size={15} />
           </button>
         </header>
@@ -374,7 +386,7 @@ function ArtifactDialog({ model, details, loading, error, gpu, downloadBusy, imp
           )}
         </div>
       </div>
-    </div>
+    </dialog>
   )
 }
 

--- a/ods/extensions/services/dashboard/src/pages/Models.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.test.jsx
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Models from './Models'
 
@@ -31,11 +31,16 @@ function baseDownloadState(overrides = {}) {
 }
 
 beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = function () { this.open = true }
+  HTMLDialogElement.prototype.close = function () { this.open = false }
   document.documentElement.dataset.theme = 'light'
   useDownloadProgressMock.mockReturnValue(baseDownloadState())
 })
 
 afterEach(() => {
+  cleanup()
+  delete HTMLDialogElement.prototype.showModal
+  delete HTMLDialogElement.prototype.close
   delete document.documentElement.dataset.theme
 })
 


### PR DESCRIPTION
The Hub artifact picker now opens as a native modal, focuses Close, handles Escape through the existing import guard, and restores focus to the repository trigger when closed.

## Why this matters
Model Library -> Hugging Face -> Choose file previously left keyboard focus on the background repository list. Its ARIA modal attributes did not contain focus or implement Escape, making artifact inspection difficult with a keyboard.

## Overlap check
Searched open/closed PRs by Hugging Face, dialog, keyboard, focus and HuggingFaceModelBrowser.jsx. #2755 labels the close button; #3050 cancels details requests; #3203 covers formatting. #4339 addresses search response races in a separate effect. None establishes this modal lifecycle. #4341 fixes a different dependency-confirmation workflow.

## Validation
A rendered-browser-component regression failed on the base because Close did not receive focus; it now passes (1 test). It asserts cancel performs no import and restores focus. Focused ESLint: 0 errors. Native Tab containment is provided by showModal; JSDOM stubs do not validate browser inertness. Native Chromium validation is recorded below.

## Tradeoffs and rollback
The existing guard continues to prevent closing during import. Import authorization, API calls and artifact verification are unchanged. Reverting only restores the previous overlay. Uses the modern native dialog API supported by the dashboard's target browsers.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Chromium on Windows, using the real component and CSS with mocked API data: initial focus, Tab/Shift+Tab, inert background, Escape, and trigger focus restoration all pass. Screenshots were visually inspected. No services were enabled or artifacts imported in this browser check.

Follow-up 2dfa8cc6 updates the existing Models page test's native-dialog stubs; all 44 page and dialog tests pass. This fixes the CI integration test failure without weakening the production modal API.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
