### PR TITLE
fix(preview): serve static assets with query suffixes

### DIFF
--- a/ods/extensions/services/pixel-agent/host/workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/host/workspace_preview.py
@@ -524,7 +524,10 @@ class PreviewHandler(http.server.BaseHTTPRequestHandler):
 
     def _target(self) -> tuple[pathlib.Path, bytes] | None:
         parsed = urllib.parse.urlsplit(self.path)
-        if parsed.query or parsed.fragment:
+        # Static snapshot queries (for example style.css?v=2) do not select
+        # different bytes or authority. Match the private relay's path-only
+        # lookup; never interpret a query as a source or filesystem path.
+        if parsed.fragment:
             return None
         try:
             decoded = urllib.parse.unquote(parsed.path, errors="strict")
@@ -534,6 +537,8 @@ class PreviewHandler(http.server.BaseHTTPRequestHandler):
         if len(parts) < 1 or SITE_ID.fullmatch(parts[0]) is None:
             return None
         site_id = parts[0]
+        if parsed.query and len(parts) > 1 and parts[1].startswith("__ods_"):
+            return None
         if self.server.internal_proxy:  # type: ignore[attr-defined]
             expected_host = "portal-preview.internal" if PROFILE_ID is not None else "pixel-preview.internal"
         else:

--- a/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/tests/test_workspace_preview.py
@@ -427,3 +427,51 @@ def test_unix_http_preview_accepts_only_the_internal_relay_authority():
             finally:
                 server.shutdown()
                 thread.join(timeout=5)
+
+
+def test_http_snapshot_ignores_asset_queries_without_changing_path_or_bytes():
+    with tempfile.TemporaryDirectory() as temporary:
+        root = pathlib.Path(temporary)
+        workspace, previews = root / "workspace", root / "previews"
+        workspace.mkdir(mode=0o700)
+        previews.mkdir(mode=0o700)
+        site = workspace / "site"
+        site.mkdir(mode=0o700)
+        page = b'<link rel="stylesheet" href="style.css?v=2"><script src="app.js?build=abc"></script>'
+        assets = {"index.html": page, "style.css": b"body{color:purple}", "app.js": b"document.title='Ready'"}
+        for name, data in assets.items():
+            (site / name).write_bytes(data)
+            (site / name).chmod(0o600)
+        receipt = MODULE.publish_snapshot(workspace, previews, "site", os.getuid())
+        with MODULE.PreviewHTTPServer(("127.0.0.1", 0), previews) as server:
+            thread = threading.Thread(target=server.serve_forever, daemon=True)
+            thread.start()
+            port = server.server_address[1]
+            host = f"{receipt['siteId']}.localhost:{port}"
+
+            def request(path, method="GET", authority=host):
+                connection = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+                try:
+                    connection.request(method, path, headers={"Host": authority})
+                    response = connection.getresponse()
+                    return response.status, dict(response.getheaders()), response.read()
+                finally:
+                    connection.close()
+
+            try:
+                for name, expected in assets.items():
+                    path = f"/{receipt['siteId']}/{name}?v=2&path=../../secret"
+                    status, headers, body = request(path)
+                    assert status == 200
+                    assert body == expected
+                    assert headers["X-Preview-SHA256"] == hashlib.sha256(expected).hexdigest()
+                    assert headers["Cache-Control"] == "no-store"
+                    assert "form-action 'none'" in headers["Content-Security-Policy"]
+                    status, head, body = request(path, "HEAD")
+                    assert status == 200 and body == b""
+                    assert int(head["Content-Length"]) == len(expected)
+                assert request(f"/{receipt['siteId']}/../secret?v=2")[0] == 404
+                assert request(f"/{receipt['siteId']}/style.css?v=2", authority="wrong.localhost")[0] == 404
+            finally:
+                server.shutdown()
+                thread.join(timeout=5)


### PR DESCRIPTION
## Why this matters
Published HTML commonly references style.css?v=2 or app.js?build=abc. The localhost preview listener returned 404 for those immutable assets, even though the private relay already uses path-only asset lookup. Ignore query suffixes for ordinary snapshot files while preserving strict host/path validation and query rejection on reserved __ods_ metadata/view routes.

## Overlap check
Searched open/closed preview query cache busting and workspace preview query parameters; checked workspace_preview.py changed files. #4085 handles UTF-8 headers, #4083 final-newline diffs, and #4226 named project files. None covers static asset query suffixes. The batch's nested-directory relay fix addresses a different route/path case.

## Validation
A real loopback HTTP regression fails on the base (404) and passes for HTML, CSS and JavaScript GET/HEAD requests with query suffixes. It checks exact bytes, digest, content length, no-store and CSP, plus traversal and wrong-host rejection. All 12 workspace-preview tests pass, including existing reserved metadata query rejection.
Linux/WSL listener exercised; no deployed remote preview or browser rendering claimed. Snapshot bytes, file selection, host authorization and CSP are unchanged. Kept draft for independent HTTP-boundary review.

Developed with AI assistance.


## Batch integration receipt
Candidate: [2349c4533cc2](https://github.com/0xacee/ODS/commit/2349c4533cc2ded6c6b7dda5d017469102e9e42c); upstream public-beta base: f5f49b7d58c24a5b86b91650890a1b715f64c5a8. All 20 current batch heads are included and merged without conflicts. Shared-file pairs #4328/#4334 and #4329/#4330 also merge cleanly in either order; no required order within this batch.
Combined validation: 920 dashboard tests, 1,062 Pixel Node tests (1 skipped), 379 Pixel host tests (2 skipped; 58 subtests) and 111 edge tests (17 subtests) passed. Dashboard lint has 0 errors / 563 warnings; production build passes. Python suites were run before the frontend-only follow-ups, with an identical Python subtree.
Latest batch CI: 19 PRs have all applicable checks successful; #4349 has the documented openSUSE infrastructure failure. This receipt does not replace the independent human/live gates declared above. No deployment, fleet activation or hardware qualification is claimed.
