### PR TITLE
fix(workspace): keep panel drags owned by one pointer

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PanelResizeHandle.jsx
+++ b/ods/extensions/services/dashboard/src/components/PanelResizeHandle.jsx
@@ -2,6 +2,11 @@ import { useRef } from 'react'
 
 export default function PanelResizeHandle({ width, onResize, label = 'Resize workspace panel', container = '.portal-workspace', minimum = 320 }) {
   const drag = useRef(null)
+  function endDrag(event) {
+    if (drag.current?.pointerId !== event.pointerId) return
+    drag.current = null
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId)
+  }
   function resize(element, next) {
     const available = element.closest(container)?.clientWidth || 1200
     const maximum = Math.max(minimum, available - 320)
@@ -9,15 +14,15 @@ export default function PanelResizeHandle({ width, onResize, label = 'Resize wor
   }
   return <div className="portal-panel-resizer" role="separator" aria-label={label} aria-orientation="vertical" aria-valuemin={minimum} aria-valuenow={width} tabIndex={0}
     onPointerDown={event => {
-      if (event.button !== 0) return
-      drag.current = {x:event.clientX, width:event.currentTarget.parentElement.getBoundingClientRect().width}
+      if (event.button !== 0 || drag.current) return
+      drag.current = {pointerId:event.pointerId, x:event.clientX, width:event.currentTarget.parentElement.getBoundingClientRect().width}
       event.currentTarget.setPointerCapture(event.pointerId)
       event.preventDefault()
     }}
-    onPointerMove={event => { if (drag.current) resize(event.currentTarget, drag.current.width + drag.current.x - event.clientX) }}
-    onPointerUp={event => { drag.current = null; if (event.currentTarget.hasPointerCapture(event.pointerId)) event.currentTarget.releasePointerCapture(event.pointerId) }}
-    onPointerCancel={() => { drag.current = null }}
-    onLostPointerCapture={() => { drag.current = null }}
+    onPointerMove={event => { if (drag.current?.pointerId === event.pointerId) resize(event.currentTarget, drag.current.width + drag.current.x - event.clientX) }}
+    onPointerUp={endDrag}
+    onPointerCancel={endDrag}
+    onLostPointerCapture={endDrag}
     onDoubleClick={event => resize(event.currentTarget, 440)}
     onKeyDown={event => {
       if (!['ArrowLeft','ArrowRight','Home'].includes(event.key)) return

--- a/ods/extensions/services/dashboard/src/components/PanelResizeHandle.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PanelResizeHandle.test.jsx
@@ -3,9 +3,9 @@ import { afterEach, expect, it, vi } from 'vitest'
 import PanelResizeHandle from './PanelResizeHandle'
 afterEach(cleanup)
 
-function pointer(element, type, x, button = 0) {
+function pointer(element, type, x, button = 0, pointerId = 1) {
   const event = new MouseEvent(type, {bubbles:true,clientX:x,button})
-  Object.defineProperty(event,'pointerId',{value:1})
+  Object.defineProperty(event,'pointerId',{value:pointerId})
   fireEvent(element,event)
 }
 
@@ -57,4 +57,32 @@ it('supports keyboard resizing and a reset with bounded widths', () => {
   expect(resize).toHaveBeenLastCalledWith(408)
   fireEvent.keyDown(handle, {key:'Home'})
   expect(resize).toHaveBeenLastCalledWith(440)
+})
+
+it('keeps a drag owned by its starting pointer until that pointer ends it', () => {
+  const resize = vi.fn()
+  const { container } = render(<aside><PanelResizeHandle width={440} onResize={resize} /></aside>)
+  container.querySelector('aside').getBoundingClientRect = () => ({ width: 440 })
+  const handle = screen.getByRole('separator')
+  handle.setPointerCapture = vi.fn()
+  handle.hasPointerCapture = () => true
+  handle.releasePointerCapture = vi.fn()
+  pointer(handle, 'pointerdown', 560)
+  pointer(handle, 'pointerdown', 800, 0, 2)
+  pointer(handle, 'pointermove', 700, 0, 2)
+  expect(resize).not.toHaveBeenCalled()
+  expect(handle.setPointerCapture).toHaveBeenCalledTimes(1)
+  for (const type of ['pointerup', 'pointercancel', 'lostpointercapture']) {
+    pointer(handle, type, 700, 0, 2)
+    pointer(handle, 'pointermove', 500)
+    expect(resize).toHaveBeenLastCalledWith(500)
+    resize.mockClear()
+  }
+  expect(handle.releasePointerCapture).not.toHaveBeenCalled()
+  pointer(handle, 'pointercancel', 500)
+  pointer(handle, 'pointermove', 400)
+  expect(resize).not.toHaveBeenCalled()
+  pointer(handle, 'pointerdown', 560, 0, 2)
+  pointer(handle, 'pointermove', 520, 0, 2)
+  expect(resize).toHaveBeenLastCalledWith(480)
 })


### PR DESCRIPTION
## Why this matters
Both the Portal workspace and Pixel preview use PanelResizeHandle. A second touch on the separator could replace the active drag origin, move the panel, or cancel the first finger's drag. Resizing must remain owned by the pointer that began it.

Store pointerId with the drag and accept move/end/cancel/capture-loss events only from that pointer. Ignore additional pointer-down events until the owner ends the drag. Existing width bounds, keyboard control and reset behavior remain intact.

## Overlap check
Searched open/closed PRs for resizer, pointer, dragging and the changed production file PanelResizeHandle.jsx. Only #4027 introduces this component; no independent pointer-ownership repair was found. This scope does not change panel persistence or layout geometry.

## Validation
Added a public component-event regression covering two pointer IDs, unrelated move/up/cancel/lost-capture, owner cancellation and a subsequent drag. It failed on base with an unexpected resize to 540, then passed with the fix. All 4 PanelResizeHandle tests pass; focused ESLint has 0 errors. Physical multi-touch hardware remains untested. 

## Tradeoffs and rollback
Only one pointer may resize a given separator at a time. Reverting restores the previous event handling; no persisted data changes.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate CI: 32 successful checks, 4 skipped. Draft status on filesystem/authorization changes is retained for independent human review despite green CI.
