### PR TITLE
fix(templates): retain pending apply dialog ownership

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -175,7 +175,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
       }
       onApplied?.()
     } catch (err) {
-      setError(err.name === 'AbortError' ? 'Request timed out' : 'Failed to apply template')
+      setError(err.name === 'AbortError' ? 'Request timed out. Close and check extension status before retrying.' : 'Failed to apply template')
     } finally {
       setApplying(false)
     }

--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -15,7 +15,7 @@ const fetchJson = async (url, options = {}) => {
   try {
     const response = await fetch(url, { ...options, signal: c.signal })
     const data = await response.json()
-    if (c.signal.aborted) throw new DOMException('Request timed out', 'AbortError')
+    if (c.signal.aborted) throw new globalThis.DOMException('Request timed out', 'AbortError')
     return { ok: response.ok, status: response.status, data }
   } finally {
     clearTimeout(t)

--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -13,7 +13,10 @@ const fetchJson = async (url, options = {}) => {
   const c = new AbortController()
   const t = setTimeout(() => c.abort(), options.timeout || 30000)
   try {
-    return await fetch(url, { ...options, signal: c.signal })
+    const response = await fetch(url, { ...options, signal: c.signal })
+    const data = await response.json()
+    if (c.signal.aborted) throw new DOMException('Request timed out', 'AbortError')
+    return { ok: response.ok, status: response.status, data }
   } finally {
     clearTimeout(t)
   }
@@ -133,6 +136,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
   const [error, setError] = useState(null)
   const [applied, setApplied] = useState(false)
   const [applyResult, setApplyResult] = useState(null)
+  const requestClose = () => { if (!applying) onClose() }
 
   const Icon = ICON_MAP[template.icon] || Package
 
@@ -142,7 +146,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
     try {
       const res = await fetchJson(`/api/templates/${template.id}/preview`, { method: 'POST' })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      setPreviewData(await res.json())
+      setPreviewData(res.data)
     } catch (err) {
       setError(err.name === 'AbortError' ? 'Request timed out' : 'Failed to load preview')
     } finally {
@@ -151,6 +155,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
   }
 
   const handleApply = async () => {
+    if (applying) return
     setApplying(true)
     setError(null)
     try {
@@ -159,7 +164,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
         timeout: TEMPLATE_APPLY_TIMEOUT_MS,
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      const data = await res.json()
+      const data = res.data
       setApplyResult(data)
       if (data.failed_services?.length > 0 || data.skipped_services?.length > 0) {
         setApplied('partial')
@@ -184,7 +189,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
   const changes = previewData?.changes || {}
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={requestClose}>
       <div
         className="bg-theme-card border border-theme-border rounded-xl p-6 max-w-lg mx-4 w-full"
         onClick={e => e.stopPropagation()}
@@ -203,7 +208,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
               <p className="text-xs text-theme-text-muted">{template.description}</p>
             </div>
           </div>
-          <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text transition-colors">
+          <button onClick={requestClose} disabled={applying} className="text-theme-text-muted hover:text-theme-text transition-colors disabled:opacity-50">
             <X size={18} />
           </button>
         </div>
@@ -326,10 +331,12 @@ export function TemplatePreview({ template, onClose, onApplied }) {
         )}
 
         {/* Actions */}
+        {applying && <p role="status" className="mt-4 text-xs text-theme-text-muted">Applying template. Keep this dialog open while the services are prepared.</p>}
         <div className="flex justify-end gap-3 mt-4">
           <button
-            onClick={onClose}
-            className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
+            onClick={requestClose}
+            disabled={applying}
+            className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors disabled:opacity-50"
           >
             {applied ? 'Close' : 'Cancel'}
           </button>

--- a/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.pending.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.pending.test.jsx
@@ -1,0 +1,41 @@
+import { act, fireEvent, render, screen, within } from '@testing-library/react'
+import { TemplatePicker } from '../TemplatePicker'
+
+afterEach(() => { vi.unstubAllGlobals(); vi.useRealTimers() })
+
+test.each([true, false])('retains the apply dialog until the request settles (success=%s)', async success => {
+  let finish
+  const fetchMock = vi.fn(async url => url.endsWith('/preview')
+    ? { ok: true, json: async () => ({ changes: { to_enable: ['n8n'] } }) }
+    : new Promise(resolve => { finish = resolve }))
+  vi.stubGlobal('fetch', fetchMock)
+  render(<TemplatePicker templates={[{ id: 'workflows', name: 'Workflows', services: ['n8n'] }]} />)
+  fireEvent.click(screen.getByRole('button', { name: /Workflows/ }))
+  fireEvent.click(await screen.findByRole('button', { name: 'Apply Template' }))
+  const dialog = screen.getByRole('dialog')
+  fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+  fireEvent.click(within(dialog).getAllByRole('button')[0])
+  fireEvent.click(dialog.parentElement)
+  expect(screen.getByRole('dialog')).toBe(dialog)
+  fireEvent.click(screen.getByRole('button', { name: 'Apply Template' }))
+  expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/apply'))).toHaveLength(1)
+  await act(async () => finish({ ok: success, status: success ? 200 : 503, json: async () => ({ enabled_count: 1 }) }))
+  fireEvent.click(screen.getByRole('button', { name: success ? 'Close' : 'Cancel' }))
+  expect(screen.queryByRole('dialog')).toBeNull()
+})
+
+test('unlocks dismissal when the apply response body reaches its deadline', async () => {
+  vi.stubGlobal('fetch', vi.fn(async (url, { signal }) => url.endsWith('/preview')
+    ? { ok: true, json: async () => ({ changes: { to_enable: ['n8n'] } }) }
+    : { ok: true, json: () => new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(new DOMException('Timed out', 'AbortError')))) }))
+  render(<TemplatePicker templates={[{ id: 'workflows', name: 'Workflows', services: ['n8n'] }]} />)
+  fireEvent.click(screen.getByRole('button', { name: /Workflows/ }))
+  const apply = await screen.findByRole('button', { name: 'Apply Template' })
+  vi.useFakeTimers()
+  await act(async () => fireEvent.click(apply))
+  expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
+  await act(async () => vi.advanceTimersByTimeAsync(30 * 60 * 1000))
+  expect(screen.getByText('Request timed out')).toBeVisible()
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  expect(screen.queryByRole('dialog')).toBeNull()
+})

--- a/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.pending.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.pending.test.jsx
@@ -35,7 +35,7 @@ test('unlocks dismissal when the apply response body reaches its deadline', asyn
   await act(async () => fireEvent.click(apply))
   expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled()
   await act(async () => vi.advanceTimersByTimeAsync(30 * 60 * 1000))
-  expect(screen.getByText('Request timed out')).toBeVisible()
+  expect(screen.getByText('Request timed out. Close and check extension status before retrying.')).toBeVisible()
   fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
   expect(screen.queryByRole('dialog')).toBeNull()
 })

--- a/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.pending.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.pending.test.jsx
@@ -27,7 +27,7 @@ test.each([true, false])('retains the apply dialog until the request settles (su
 test('unlocks dismissal when the apply response body reaches its deadline', async () => {
   vi.stubGlobal('fetch', vi.fn(async (url, { signal }) => url.endsWith('/preview')
     ? { ok: true, json: async () => ({ changes: { to_enable: ['n8n'] } }) }
-    : { ok: true, json: () => new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(new DOMException('Timed out', 'AbortError')))) }))
+    : { ok: true, json: () => new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(new globalThis.DOMException('Timed out', 'AbortError')))) }))
   render(<TemplatePicker templates={[{ id: 'workflows', name: 'Workflows', services: ['n8n'] }]} />)
   fireEvent.click(screen.getByRole('button', { name: /Workflows/ }))
   const apply = await screen.findByRole('button', { name: 'Apply Template' })


### PR DESCRIPTION
## Why this matters
Extensions -> template preview permits a thirty-minute apply operation. Previously Cancel, the header close button or the backdrop could unmount the pending operation; reopening the template reset its UI lock and allowed another apply before the first returned.

Keep dismissal and repeated apply disabled while the request is pending, show an explicit progress message, then unlock after success or failure. Keep the existing request deadline active through JSON body consumption so a stalled body cannot permanently lock the dialog.

## Overlap check
Searched open/closed PRs by template, close, applying, dismissal and TemplatePicker.jsx. #3312 moves preview loading out of render; #2756 labels the close button; #1891 establishes apply results and long-running requests. None preserves pending dismissal ownership. #4353 fixes body deadlines for a separate Owner Access workflow. This PR's body deadline is required to bound its new dismissal guard.

## Validation
Three rendered picker regressions cover success/failure with attempted Cancel/header/backdrop dismissal, no second apply, and a stalled JSON body reaching the existing 30-minute deadline and unlocking Cancel. The dismissal regression failed on base. All 13 template tests pass (including the existing long-running apply and partial result contracts). Focused ESLint: 0 errors. No live service installation was attempted.

## Lifecycle and limitations
Preview -> explicit Apply -> pending (dismissal locked) -> result/error -> dismissal available. The server still owns installation, locking and state reconciliation. This prevents reopening duplicates inside this dialog; browser reload, navigation and multiple tabs remain outside its scope. A timeout is not evidence that installation failed: close and inspect extension status before retrying. The existing post-apply refresh remains intact. Reverting changes only UI behavior and creates no persisted migration.

## Batch integration receipt

Validated with the other 19 public-beta PRs on [integration commit ce0d0132](https://github.com/tang-vu/DreamServer/commit/ce0d013224fe3f31e250bdc9c1f4abc32e5e9d2f), based on upstream f5f49b7d. All 20 patches compose without conflicts in creation order; no new PR requires another to fix its own behavior. For shared files, use #4325 before #4327 and #4339 before #4356 as the tested order.

- Final combined dashboard: 118 test files / 932 tests pass; ESLint 0 errors (575 warnings); production build passes.
- Affected API suites: 292 pass. APE full suite: 52 pass. Scoped pre-commit secret/private-key/large-file checks and git diff --check pass.
- Native Linux make gate reaches an existing CLI-update failure also reproduced on the untouched base; #3159 supplies its separate fix. BATS: 419/421 pass, with the same two baseline failures (non-GNU OSTYPE fixture detects the real WSL host; skip-Docker fixture lacks production helpers). Smoke tests and installer simulation pass. These are explicit validation gaps, not a claim that the whole release gate is green.

Latest candidate 5c2911eb: 32 successful CI checks, 4 skipped. An earlier openSUSE mirror/package-download failure is resolved on the final run. Follow-ups 43cb66c0 and 5c2911eb fix lint and make timeout recovery guidance explicit; final combined validation includes both.
