### PR TITLE
Drop the unused sys-info crate dependency

### DIFF
--- a/installer/src-tauri/Cargo.lock
+++ b/installer/src-tauri/Cargo.lock
@@ -656,7 +656,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "sys-info",
  "tauri",
  "tauri-build",
  "tokio",
@@ -3248,7 +3247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sys-info"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"

--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -10,7 +10,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 which = "7"
-sys-info = "0.9"
 
 [build-dependencies]
 tauri-build = { version = "2", features = [] }


### PR DESCRIPTION
Removed sys-info = "0.9" from dependencies and cleaned up Cargo.lock. The crate was never imported or used in the code. This drops a build-time C compiler requirement with no functional impact.