### PR TITLE
Simplify inefficient stderr line collection in error reporting

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -156,16 +156,11 @@ pub fn run_install(
         let _ = s.save();
         Ok(())
     } else {
-        let detail = stderr_lines
-            .iter()
-            .rev()
-            .take(10)
-            .cloned()
-            .collect::<Vec<String>>()
-            .into_iter()
-            .rev()
-            .collect::<Vec<String>>()
-            .join("\n");
+        let detail = if stderr_lines.len() > 10 {
+            stderr_lines[stderr_lines.len() - 10..].join("\n")
+        } else {
+            stderr_lines.join("\n")
+        };
         if detail.is_empty() {
             Err("Installation failed. Check logs for details.".into())
         } else {


### PR DESCRIPTION
Refactored the stderr collection logic in run_install() error handling. Replaced a confusing 3-step reverse/take/reverse pattern with a straightforward conditional slice (stderr_lines[stderr_lines.len() - 10..]). The behavior is identical but the intent is now clear.
