### PR TITLE
Add explicit return type annotation to openODSserver function

### DIFF
--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -111,4 +111,4 @@ export const getInstallProgress = () =>
 export const getInstallState = () =>
   invoke<InstallState>("get_install_state");
 
-export const openODSserver = () => invoke("open_ods");
+export const openODSserver = () => invoke<void>("open_ods");


### PR DESCRIPTION
Added explicit <void> return type annotation to the openODSserver() function in useTauri.ts. This improves type safety and consistency—all other Tauri command wrappers have explicit return types, and this one should too.