### PR TITLE
Extract hardcoded URL and error message constants

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -4,6 +4,8 @@ use serde::Serialize;
 use std::sync::Mutex;
 
 const ALLOWED_FEATURES: &[&str] = &["voice", "workflows", "rag", "image_gen", "all"];
+const ODS_SERVER_URL: &str = "http://localhost:3000";
+const BROWSER_OPEN_ERROR: &str = "Failed to open browser";
 
 // ---- System Check ----
 
@@ -247,27 +249,26 @@ pub fn get_install_state() -> InstallState {
 
 #[tauri::command]
 pub fn open_ods() -> Result<(), String> {
-    let url = "http://localhost:3000";
     #[cfg(target_os = "windows")]
     {
         std::process::Command::new("cmd")
-            .args(["/C", "start", url])
+            .args(["/C", "start", ODS_SERVER_URL])
             .spawn()
-            .map_err(|e| format!("Failed to open browser: {}", e))?;
+            .map_err(|e| format!("{}: {}", BROWSER_OPEN_ERROR, e))?;
     }
     #[cfg(target_os = "macos")]
     {
         std::process::Command::new("open")
-            .arg(url)
+            .arg(ODS_SERVER_URL)
             .spawn()
-            .map_err(|e| format!("Failed to open browser: {}", e))?;
+            .map_err(|e| format!("{}: {}", BROWSER_OPEN_ERROR, e))?;
     }
     #[cfg(target_os = "linux")]
     {
         std::process::Command::new("xdg-open")
-            .arg(url)
+            .arg(ODS_SERVER_URL)
             .spawn()
-            .map_err(|e| format!("Failed to open browser: {}", e))?;
+            .map_err(|e| format!("{}: {}", BROWSER_OPEN_ERROR, e))?;
     }
     Ok(())
 }


### PR DESCRIPTION
Extracted the hardcoded ODS server URL (http://localhost:3000) and the repeated browser error message into module-level constants (ODS_SERVER_URL and BROWSER_OPEN_ERROR). This eliminates string duplication and makes the port/message easier to update in one place.