### PR TITLE
Use only required tokio features instead of full feature set

### DIFF
--- a/installer/src-tauri/Cargo.toml
+++ b/installer/src-tauri/Cargo.toml
@@ -8,7 +8,7 @@ description = "ODS One-Click Installer"
 tauri = { version = "2", features = [] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt", "macros"] }
 which = "7"
 sys-info = "0.9"
 


### PR DESCRIPTION
Reduced tokio's feature set from ["full"] to ["rt", "macros"]. The installer only uses tokio::task::spawn_blocking() for running the installation in a background thread. The "full" feature set was unnecessary and bloats the build; the minimal required features provide the needed functionality with smaller dependency footprint.