### PR TITLE
fix: enforce container stop before restore to prevent data corruption (#4159)

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -100,7 +100,8 @@ OPTIONS:
     -l, --list              List available backups
     -f, --force             Skip confirmation prompts
     -d, --dry-run           Show what would be restored without doing it
-    -s, --stop-containers   Stop containers before restore (recommended)
+    -s, --stop-containers   Stop containers before restore (DEFAULT)
+                                MANDATORY to prevent data corruption during restore.
     --data-only             Restore only user data, not config
     --config-only           Restore only config, not user data
     --skip-verify           Skip checksum verification (NOT RECOMMENDED)
@@ -385,7 +386,8 @@ stop_containers() {
     if docker compose down; then
         log_success "Containers stopped"
     else
-        log_warn "Some containers may not have stopped cleanly"
+        log_error "Containers failed to stop. Aborting to prevent data corruption."
+        return 1
     fi
 }
 
@@ -526,6 +528,10 @@ do_restore() {
 
     # Dry run mode
     if [[ "$dry_run" == "true" ]]; then
+        # Even in dry run, we should show if containers would be stopped
+        if [[ "$stop_first" == "true" ]]; then
+            log_step "Dry Run: Would stop containers"
+        fi
         dry_run_preview "$backup_dir" "$restore_data" "$restore_config"
         return 0
     fi
@@ -545,7 +551,9 @@ do_restore() {
 
     # Stop containers if requested
     if [[ "$stop_first" == "true" ]]; then
-        stop_containers
+        if ! stop_containers; then
+            return 1
+        fi
     fi
 
     # Perform restore
@@ -573,7 +581,7 @@ main() {
     local backup_id=""
     local force="false"
     local dry_run="false"
-    local stop_first="false"
+    local stop_first="true"
     local restore_data="true"
     local restore_config="true"
     local list_mode="false"

--- a/ods/tests/test-restore-gate.sh
+++ b/ods/tests/test-restore-gate.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Mock setup
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+# Create mock ODS structure
+mkdir -p "$TEST_DIR/data/open-webui"
+touch "$TEST_DIR/docker-compose.yml"
+mkdir -p "$TEST_DIR/.backups/test-backup"
+touch "$TEST_DIR/.backups/test-backup/manifest.json"
+echo '{"manifest_version": "1.0", "backup_date": "2026-01-01", "backup_type": "full"}' > "$TEST_DIR/.backups/test-backup/manifest.json"
+mkdir -p "$TEST_DIR/.backups/test-backup/data/open-webui"
+touch "$TEST_DIR/.backups/test-backup/data/open-webui/testfile"
+
+# Copy real lib/rsync.sh to mock dir to avoid source error
+mkdir -p "$TEST_DIR/lib"
+cp ods/lib/rsync.sh "$TEST_DIR/lib/rsync.sh"
+
+# Mock docker compose to fail
+mkdir -p "$TEST_DIR/bin"
+cat << 'EOF' > "$TEST_DIR/bin/docker"
+#!/bin/bash
+if [[ "$*" == *"compose down"* ]]; then
+    echo "Error: docker compose down failed" >&2
+    exit 1
+fi
+# Force trigger stop_containers logic by returning a match for the ODS_DIR basename
+if [[ "$*" == *"compose ls"* ]]; then
+    echo "$(basename "$ODS_DIR")"
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$TEST_DIR/bin/docker"
+
+# Add mock bin to PATH
+export PATH="$TEST_DIR/bin:$PATH"
+export ODS_DIR="$TEST_DIR"
+
+# Create a wrapper to run ods-restore.sh with the mocked environment
+# We use -f to skip confirmation and a specific backup ID
+# We force stop_first="true" (default)
+
+echo "Running test: restore should abort if stop_containers fails..."
+if bash ods/ods-restore.sh -f test-backup; then
+    echo "FAIL: ods-restore.sh succeeded despite docker compose down failure"
+    exit 1
+else
+    echo "SUCCESS: ods-restore.sh aborted as expected"
+fi
+
+# Verify no data was modified (the mock testfile should NOT be in ODS_DIR)
+if [[ -f "$TEST_DIR/data/open-webui/testfile" ]]; then
+    echo "FAIL: Data was restored despite container stop failure"
+    exit 1
+fi
+
+echo "All gates passed."


### PR DESCRIPTION
## Summary
Prevents potential data corruption by making container shutdown mandatory and fail-closed during the restore process.
- Change --stop-containers from optional to default/mandatory.
- Update stop_containers to return failure instead of warning.
- Ensure do_restore aborts immediately if containers fail to stop.

## Test plan
- [x] Functional Test: bash ods/tests/test-restore-safety.sh
- [x] Regression Test: bash ods/tests/test-restore-gate.sh