### PR TITLE
feat(dashboard): restore liquid-metal ODS opening

### DIFF
--- a/ods/extensions/services/dashboard/src/App.jsx
+++ b/ods/extensions/services/dashboard/src/App.jsx
@@ -107,7 +107,7 @@ function App() {
   if (firstRun) {
     return (
       <div className="min-h-screen bg-theme-bg text-theme-text">
-        {!splashDone && <SplashScreen onComplete={() => {
+        {!splashDone && <SplashScreen preview={new URLSearchParams(location.search).get('intro') === 'preview'} onComplete={() => {
           setStorageValue('sessionStorage', 'ods-splash-shown', '1')
           setSplashDone(true)
         }} />}
@@ -126,7 +126,7 @@ function App() {
     <PortalIdentityProvider>
     <div className={`pixel-app flex min-h-screen bg-theme-bg text-theme-text relative ${sidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
       <WallpaperVideo />
-      {!splashDone && <SplashScreen onComplete={() => {
+      {!splashDone && <SplashScreen preview={new URLSearchParams(location.search).get('intro') === 'preview'} onComplete={() => {
         setStorageValue('sessionStorage', 'ods-splash-shown', '1')
         setSplashDone(true)
       }} />}

--- a/ods/extensions/services/dashboard/src/components/SplashMetalOrb.jsx
+++ b/ods/extensions/services/dashboard/src/components/SplashMetalOrb.jsx
@@ -1,0 +1,60 @@
+import {useEffect, useId, useRef} from 'react'
+import {gsap} from 'gsap'
+import {CustomEase} from 'gsap/CustomEase'
+
+gsap.registerPlugin(CustomEase)
+
+// Restore the original ODS opening's orbit choreography (4b3d668c),
+// with a chrome reflection ramp instead of the former neon palette.
+export default function SplashMetalOrb() {
+  const svgRef = useRef(null)
+  const gradient = useId().replace(/:/g, '')
+  useEffect(() => {
+    const media = window.matchMedia?.('(prefers-reduced-motion: reduce)')
+    if (media?.matches) return
+    const svg = svgRef.current
+    let cleanup
+    const ctx = gsap.context(() => {
+      const ease = CustomEase.create('odsMetalOrb', 'M0,0 C0.2,0 0.432,0.147 0.507,0.374 0.59,0.629 0.822,1 1,1')
+      const orbit = gsap.timeline({repeat: -1})
+      svg.querySelectorAll('.ell').forEach((el, index) => {
+        const offset = index + 1
+        gsap.set(el, {opacity: 1 - offset / 34})
+        const loop = gsap.timeline({repeat: -1, defaults: {duration: 1, ease}})
+          .to(el, {attr: {rx: 180 + offset * 3.8, ry: 180 - offset * 2.3}, strokeWidth: 5})
+          .to(el, {attr: {rx: 180, ry: 180}, strokeWidth: 36})
+          .to(el, {duration: 2, rotation: -360, transformOrigin: '50% 50%'}, 0)
+          .timeScale(0.5)
+        orbit.add(loop, offset / 31)
+      })
+      // Begin with a formed object, avoiding an empty first frame.
+      orbit.totalTime(1.8)
+      const sync = () => orbit.paused(document.hidden || Boolean(media?.matches))
+      sync()
+      document.addEventListener('visibilitychange', sync)
+      media?.addEventListener?.('change', sync)
+      cleanup = () => {
+        document.removeEventListener('visibilitychange', sync)
+        media?.removeEventListener?.('change', sync)
+      }
+    }, svg)
+    return () => {cleanup?.(); ctx.revert()}
+  }, [])
+  return <svg ref={svgRef} className="ods-opening-orb" viewBox="0 0 800 600" aria-hidden="true" focusable="false">
+    <defs>
+      <linearGradient id={gradient} x1="8%" y1="0%" x2="90%" y2="100%">
+        <stop offset="0" stopColor="#202328"/>
+        <stop offset=".19" stopColor="#8d969e"/>
+        <stop offset=".29" stopColor="#f4f6f8"/>
+        <stop offset=".34" stopColor="#555c64"/>
+        <stop offset=".48" stopColor="#121518"/>
+        <stop offset=".57" stopColor="#656e78"/>
+        <stop offset=".65" stopColor="#e9edf1"/>
+        <stop offset=".69" stopColor="#fff"/>
+        <stop offset=".77" stopColor="#59616a"/>
+        <stop offset="1" stopColor="#171a1d"/>
+      </linearGradient>
+    </defs>
+    {Array.from({length: 31}, (_, index) => <ellipse key={index} className="ell" cx="400" cy="300" rx="180" ry="180" fill="none" stroke={`url(#${gradient})`} strokeWidth="2"/>)}
+  </svg>
+}

--- a/ods/extensions/services/dashboard/src/components/SplashScreen.jsx
+++ b/ods/extensions/services/dashboard/src/components/SplashScreen.jsx
@@ -1,28 +1,39 @@
-import { useCallback, useEffect, useRef } from 'react'
-import ODSLogo from './ODSLogo'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import SplashMetalOrb from './SplashMetalOrb'
 
-export default function SplashScreen({ onComplete }) {
+export default function SplashScreen({ onComplete, preview = false }) {
+  const [leaving, setLeaving] = useState(false)
   const completed = useRef(false)
+  const onCompleteRef = useRef(onComplete)
+  onCompleteRef.current = onComplete
+  const exitTimer = useRef(null)
   const complete = useCallback(() => {
     if (completed.current) return
     completed.current = true
-    onComplete?.()
-  }, [onComplete])
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      onCompleteRef.current?.()
+      return
+    }
+    setLeaving(true)
+    exitTimer.current = window.setTimeout(() => onCompleteRef.current?.(), 400)
+  }, [])
   useEffect(() => {
     if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
       complete()
       return
     }
-    const timer = window.setTimeout(complete, 1400)
+    const timer = preview ? null : window.setTimeout(complete, 3200)
     const onKey = event => { if (event.key === 'Escape') complete() }
     window.addEventListener('keydown', onKey)
-    return () => { window.clearTimeout(timer); window.removeEventListener('keydown', onKey) }
-  }, [complete])
-  return <div role="dialog" aria-modal="true" aria-label="ODS" className="ods-opening">
-    <div className="ods-opening-emblem"><ODSLogo /></div>
+    return () => { window.clearTimeout(timer); window.clearTimeout(exitTimer.current); window.removeEventListener('keydown', onKey) }
+  }, [complete, preview])
+  return <div role="dialog" aria-modal="true" aria-label="ODS" className={`ods-opening${leaving ? ' is-leaving' : ''}`}>
+    <SplashMetalOrb />
+    <div className="ods-opening-content">
     <h1 className="ods-opening-wordmark">ODS</h1>
     <div className="ods-opening-track" aria-hidden="true"><span /></div>
-    <p>Opening your workspace</p>
+    <p role="status">Opening your workspace</p>
     <button type="button" aria-label="Skip splash screen" onClick={complete}>Continue</button>
+    </div>
   </div>
 }

--- a/ods/extensions/services/dashboard/src/components/__tests__/SplashScreen.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/SplashScreen.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import SplashScreen from '../SplashScreen' // eslint-disable-line no-unused-vars
 
 vi.mock('gsap', () => {
@@ -9,6 +9,8 @@ vi.mock('gsap', () => {
       add: vi.fn(() => timeline),
       progress: vi.fn(() => timeline),
       timeScale: vi.fn(() => timeline),
+      totalTime: vi.fn(() => timeline),
+      paused: vi.fn(() => timeline),
     }
 
     return timeline
@@ -54,6 +56,7 @@ describe('SplashScreen', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   test('renders accessible loading dialog with skip control', () => {
@@ -62,8 +65,8 @@ describe('SplashScreen', () => {
     expect(screen.getByRole('dialog', { name: 'ODS' })).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: 'ODS', level: 1 })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Skip splash screen' })).toBeInTheDocument()
-    expect(container.querySelector('img')).toHaveAttribute('src', '/osmantic-isolated-os.png')
-    expect(container.querySelectorAll('.ell')).toHaveLength(0)
+    expect(container.querySelector('.ods-opening-orb')).toHaveAttribute('aria-hidden', 'true')
+    expect(container.querySelectorAll('.ell')).toHaveLength(31)
   })
 
   test('completes immediately when reduced motion is requested', () => {
@@ -89,8 +92,28 @@ describe('SplashScreen', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Skip splash screen' }))
     fireEvent.keyDown(window, { key: 'Escape' })
-    vi.advanceTimersByTime(300)
+    act(() => vi.advanceTimersByTime(400))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('finishes on time even when the parent refreshes its callback', () => {
+    const onComplete = vi.fn()
+    const view = render(<SplashScreen onComplete={() => {}} />)
+    act(() => vi.advanceTimersByTime(2000))
+    view.rerender(<SplashScreen onComplete={onComplete} />)
+    act(() => vi.advanceTimersByTime(1600))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('preview stays open until dismissed and cleans its exit timer on unmount', () => {
+    const onComplete = vi.fn()
+    const view = render(<SplashScreen preview onComplete={onComplete} />)
+    act(() => vi.advanceTimersByTime(10000))
+    expect(onComplete).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', {name: 'Skip splash screen'}))
+    view.unmount()
+    act(() => vi.advanceTimersByTime(400))
+    expect(onComplete).not.toHaveBeenCalled()
   })
 })

--- a/ods/extensions/services/dashboard/src/pixel-workspace.css
+++ b/ods/extensions/services/dashboard/src/pixel-workspace.css
@@ -26,7 +26,15 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 /* Native menus need opaque option colors; translucent select fills do not carry over on Windows. */
 select, select option, select optgroup { color-scheme:dark; }
 select option, select optgroup { background-color:rgb(var(--theme-card)); color:rgb(var(--theme-text)); }
-.ods-opening { position:fixed; inset:0; z-index:100; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:18px; background:#111212; color:#969aa2; font-family:Inter,system-ui,sans-serif; font-size:13px; }
+.ods-opening { position:fixed; inset:0; z-index:9999; display:flex; align-items:center; justify-content:center; isolation:isolate; overflow:hidden; background:#101112; color:#a2a7ae; font-family:Inter,system-ui,sans-serif; font-size:14px; opacity:1; transition:opacity .4s ease; }
+.ods-opening.is-leaving { opacity:0; pointer-events:none; }
+.ods-opening-orb { position:absolute; width:min(110vw,960px); height:min(100vh,760px); pointer-events:none; }
+.ods-opening-content { position:relative; display:flex; flex-direction:column; align-items:center; gap:20px; padding:40px; }
+.ods-opening-content::before { content:''; position:absolute; inset:-70px; z-index:-1; background:radial-gradient(ellipse,#101112 15%,#101112d9 38%,#10111200 70%); pointer-events:none; }
+.ods-opening-content .ods-opening-wordmark { font-size:clamp(44px,7vw,68px); line-height:1.1; font-weight:500; letter-spacing:.12em; margin:0 0 8px; }
+.ods-opening-content p { margin:0; }
+.ods-opening button:hover { background:#ffffff0b; color:#fff; border-color:#70757c; }
+.ods-opening button:focus-visible { outline:2px solid #cdd2d8; outline-offset:5px; }
 .ods-opening-emblem { animation:ods-opening-in .5s ease-out both; }
 .ods-opening-wordmark { font-family:Inter,system-ui,sans-serif; font-size:48px; font-weight:600; letter-spacing:.16em; padding-left:.16em; color:#e2e4e7; background:linear-gradient(110deg,#7e858c 10%,#f7f8f9 35%,#a2a8b0 48%,#fff 58%,#727a84 85%); background-size:220% 100%; background-clip:text; -webkit-background-clip:text; -webkit-text-fill-color:transparent; animation:ods-metal-sweep 2.2s ease-in-out infinite; }
 .ods-opening-track { width:100px; height:2px; background:#2c3034; overflow:hidden; }


### PR DESCRIPTION
## Summary
Restore the original ODS SVG/GSAP orbit choreography with silver/chrome reflections and the current Inter typography. Keep the workspace UI unchanged.
- Short automatic opening with fade-out and Continue/Escape controls.
- Stable completion timer despite parent status refreshes; cancel pending work on unmount.
- Reduced-motion bypass and hidden-tab animation pause.
- Optional ?intro=preview lets users view the opening until they dismiss it.

## AI Assistance
Codex restored and adapted the original animation, implemented regression tests, and performed local visual/build validation. The maintainer reviewed the local result and explicitly requested this PR and merge.

## Release Lane
- [x] Next-minor work targeting the next feature/minor release
Target: public-beta (maintainer-requested beta integration, not stable).

## Changed Surface
- [x] Dashboard UI
No installer, backend, dependency, auth, network, or service configuration changes.

## Risk And Validation
- Risk level: Medium (dashboard opening only).
- [x] git diff --check
- [x] Focused tests listed below
- [x] Dashboard lint/test/build

Results:
- Focused ESLint: zero errors.
- SplashScreen regression tests: 5 passed, covering skip, reduced motion, callback refresh, preview mode and cleanup.
- npm run build: passed on Windows.
- Docker production dashboard image build: passed.
- Browser QA: visible metallic orbit motion and Inter font verified; Continue closes the opening, normal entry dismisses automatically, preview stays open.
- Locally deployed dashboard responds normally; Pixel reports Owner agent ready.

## Operational Change Check
- [x] This is not an operational change.

## Notes For Reviewers
Reuses the existing GSAP dependency and original ODS animation. No external assets or fonts added. Full installation/hardware fleet not rerun for this UI-only change. Rollback is a revert and dashboard rebuild. Local deployment override is not included in the PR.