### PR TITLE
docs(installer): define Assistant-First phase 0

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -121,6 +121,9 @@ jobs:
           bash tests/test-install-docs.sh
           bash tests/test-hosted-bootstrap-verifier.sh
 
+      - name: Assistant-First Baseline Receipt Contract
+        run: python3 tests/test_capture_assistant_first_baseline.py
+
       - name: Fleet Host Lock Contract
         run: bash tests/test-fleet-host-lock.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -34,6 +34,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-installer-contracts.sh
 	@bash tests/test-external-services.sh
 	@bash tests/test-resolve-compose-resilient.sh
+	@python3 tests/test_capture_assistant_first_baseline.py
 	@bash tests/test-phase03-multigpu-tty.sh
 	@bash tests/contracts/test-preflight-fixtures.sh
 	@bash tests/test-preflight-resolver-bug.sh

--- a/ods/docs/ADR-ASSISTANT-FIRST.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST.md
@@ -1,0 +1,131 @@
+# ADR: Assistant-First installation and on-demand extensions
+
+**Date:** 2026-09-11
+
+**Status:** Accepted for public-beta implementation
+
+**Initial qualification:** Linux hosts already supported by the assistant runtime
+
+## Context
+
+ODS currently recommends a broad installation even when a user initially needs
+only a conversational assistant. Optional applications can therefore consume
+download time, disk, memory, ports, and upgrade surface before the user asks for
+them. ODS already has a bundled extension catalog and protected lifecycle APIs,
+but the installer and manifests still encode several services as unconditional
+or fixed dependencies.
+
+The desired experience is a small first installation followed by deterministic,
+owner-approved extension changes requested through either conversation or the
+Extensions UI. The language model may help interpret intent. It must not decide
+the dependency graph, approve its own work, receive secrets, or execute shell or
+container commands directly.
+
+## Decision
+
+### 1. Add an opt-in profile before changing the default
+
+`assistant-first` will be additive and opt-in for at least one public-beta
+cycle. Existing `full`, `core`, and `custom` selections, command-line flags, and
+saved `.compose-flags` remain compatibility contracts and escape hatches.
+Promotion to the recommended default is a later qualification decision, not a
+Phase 1 side effect.
+
+### 2. Separate identity, service ownership, and profile activation
+
+Public assistant name, avatar, and descriptive language are user-configurable
+and product-neutral. Existing internal `pixel-*` service IDs may remain until a
+separate compatibility migration because they are routing and ownership keys,
+not public identity.
+
+`config/core-service-ids.json` remains the reserved built-in namespace used to
+prevent extension collisions. It does not mean every listed service runs in
+every profile. The resolved Compose graph and manifest ownership determine
+which services are active for a particular installation.
+
+### 3. Define the candidate minimum explicitly
+
+The candidate Assistant-First runtime is:
+
+- the host assistant runtime, ingress, lifecycle executor, planner, and
+  approval/receipt boundary;
+- `dashboard`, `dashboard-api`, and the internally named `pixel-edge`
+  compatibility service;
+- exactly one provider satisfying a versioned `inference-route` capability;
+- the bundled catalog and extension lifecycle machinery.
+
+Basic chat does not require a `web-search` provider. Open WebUI, Perplexica,
+SearXNG, remote-provider transport, voice, RAG, workflows, image generation,
+observability, and other catalog applications are optional. `model-router` and
+any other uncertain service remain in the candidate core until an installed
+journey proves the assistant and lifecycle paths work without them.
+
+### 4. Resolve capabilities deterministically
+
+Manifests declare versioned `provides`, `requires`, optional requirements, and
+`conflicts`. ODS code resolves those declarations against the catalog,
+lockfile, policy, platform capabilities, and observed host-state revision. The
+same inputs must produce byte-identical canonical plan bytes and the same
+SHA-256. Stable ordering is defined by the solver, not by model output or
+filesystem enumeration.
+
+### 5. Keep authority outside the assistant
+
+The assistant may search and inspect the catalog and request a plan through a
+narrow typed API. ODS code performs dependency solving, compatibility and
+resource checks, conflict detection, canonicalization, and execution. Every
+composite mutation initially requires one external owner approval bound to the
+exact plan hash, catalog revision, observed-state revision, actor, and expiry.
+A changed or stale plan requires a new approval.
+
+The assistant never receives the Docker socket, root access, a shell, secret
+values, or approval authority. An awaiting-approval or running operation is
+never represented as completed.
+
+### 6. Give desired state and recovery one owner
+
+The extension manager owns a versioned desired-state lockfile. The lifecycle
+executor owns an append-only operation journal and idempotency keys. Execution
+stages and verifies artifacts before changing the active graph, records
+compensating actions where atomicity is impossible, and reconciles every
+nonterminal transaction after restart. No second component independently
+rewrites the lockfile or silently re-plans an approved operation.
+
+### 7. Preserve data by default
+
+Disable and remove are distinct from data purge. Removal preserves extension
+data by default. Purging named data is a separate destructive action with its
+own exact plan and owner approval. Backups, lockfile revisions, definition
+digests, configuration references, and data ownership metadata participate in
+update and rollback.
+
+### 8. Qualify capabilities, not distribution names
+
+Initial installed qualification targets supported Ubuntu 24.04, Debian 12, and
+already-qualified WSL2/systemd environments. Existing ODS operating-system
+paths are not removed. Additional hosts qualify by lifecycle, secret-storage,
+service-management, backup, update, and rollback capabilities rather than by a
+marketing or distribution-name shortcut.
+
+## Consequences
+
+- Phase 0 adds a read-only measurement receipt and this contract; it does not
+  change installer or runtime behavior.
+- Phase 1 must make optional services structurally absent from the resolved
+  graph so image discovery cannot pull them accidentally.
+- Later phases add Manifest v2, canonical composite planning, transactional
+  execution, typed configuration, lockfile/adoption/offline behavior, and real
+  installed qualification.
+- Source tests and CI are necessary but cannot substitute for fresh installed
+  assistant, extension, recovery, update, and rollback journeys.
+
+## Rejected alternatives
+
+- **Let the model compose shell or Docker operations.** This bypasses
+  deterministic policy, approval, and recovery boundaries.
+- **Treat every reserved built-in ID as always-on.** Collision protection and
+  profile activation are different concerns.
+- **Hide an optional service only in the UI.** If it remains in the resolved
+  Compose graph, image download and runtime collision risks remain.
+- **Delete data during ordinary removal.** Destructive purge requires a
+  separately named and approved operation.

--- a/ods/docs/INSTALLER-ARCHITECTURE.md
+++ b/ods/docs/INSTALLER-ARCHITECTURE.md
@@ -206,3 +206,5 @@ bash tests/integration-test.sh
 - [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) — Backend runtime contract format
 - [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) - Phase
   ownership, idempotency, and validation expectations
+- [ADR-ASSISTANT-FIRST.md](ADR-ASSISTANT-FIRST.md) - Assistant-First profile,
+  authority, capability resolution, and qualification decisions

--- a/ods/scripts/capture-assistant-first-baseline.py
+++ b/ods/scripts/capture-assistant-first-baseline.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Capture a bounded, read-only ODS installation baseline receipt."""
+
+from __future__ import annotations
+
+import argparse
+from decimal import Decimal, InvalidOperation
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from urllib.parse import urlsplit
+
+
+MAX_COMMAND_OUTPUT = 16 * 1024 * 1024
+MAX_FLAGS_BYTES = 64 * 1024
+LABEL_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._ -]{0,63}")
+HEX_REVISION_RE = re.compile(r"[0-9a-f]{40,64}")
+MEMORY_RE = re.compile(r"^([0-9]+(?:\.[0-9]+)?)\s*([kmgt]?i?b)$", re.I)
+MEMORY_FACTORS = {
+    "b": 1,
+    "kb": 1000,
+    "kib": 1024,
+    "mb": 1000**2,
+    "mib": 1024**2,
+    "gb": 1000**3,
+    "gib": 1024**3,
+    "tb": 1000**4,
+    "tib": 1024**4,
+}
+
+
+class MeasurementError(RuntimeError):
+    """A bounded measurement could not be completed safely."""
+
+
+def _label(value: str, field: str) -> str:
+    if not LABEL_RE.fullmatch(value):
+        raise MeasurementError(f"{field} must be a short printable label")
+    return value
+
+
+def _tool(env_name: str, default: str) -> str:
+    value = os.environ.get(env_name, default)
+    if not value or "\x00" in value or "\n" in value or "\r" in value:
+        raise MeasurementError(f"{env_name} is invalid")
+    return value
+
+
+def _run(argv: list[str], timeout: int = 30) -> subprocess.CompletedProcess[bytes]:
+    try:
+        result = subprocess.run(
+            argv,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise MeasurementError(f"read-only command unavailable: {Path(argv[0]).name}") from exc
+    if len(result.stdout) > MAX_COMMAND_OUTPUT or len(result.stderr) > MAX_COMMAND_OUTPUT:
+        raise MeasurementError("read-only command output exceeded its limit")
+    return result
+
+
+def _within(root: Path, candidate: Path) -> bool:
+    try:
+        candidate.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _compose_file(root: Path, value: str) -> tuple[Path, str]:
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = root / candidate
+    resolved = candidate.resolve(strict=True)
+    if not resolved.is_file() or not _within(root, resolved):
+        raise MeasurementError("compose files must be regular files inside --root")
+    return resolved, resolved.relative_to(root).as_posix()
+
+
+def _compose_files(root: Path, explicit: list[str]) -> list[tuple[Path, str]]:
+    values = list(explicit)
+    if not values:
+        flags_path = root / ".compose-flags"
+        if flags_path.is_file():
+            raw = flags_path.read_bytes()
+            if len(raw) > MAX_FLAGS_BYTES:
+                raise MeasurementError(".compose-flags exceeds its size limit")
+            try:
+                tokens = shlex.split(raw.decode("utf-8", errors="strict"), posix=True)
+            except (UnicodeDecodeError, ValueError) as exc:
+                raise MeasurementError(".compose-flags is invalid") from exc
+            index = 0
+            while index < len(tokens):
+                token = tokens[index]
+                if token in {"-f", "--file"}:
+                    index += 1
+                    if index >= len(tokens):
+                        raise MeasurementError(".compose-flags ends before a file value")
+                    values.append(tokens[index])
+                elif token.startswith("--file=") and token[7:]:
+                    values.append(token[7:])
+                else:
+                    raise MeasurementError(".compose-flags contains an unsupported argument")
+                index += 1
+        else:
+            for fallback in ("docker-compose.yml", "docker-compose.base.yml"):
+                if (root / fallback).is_file():
+                    values.append(fallback)
+                    break
+    if not values:
+        raise MeasurementError("no Compose files were supplied or discovered")
+
+    files: list[tuple[Path, str]] = []
+    seen: set[Path] = set()
+    for value in values:
+        resolved, relative = _compose_file(root, value)
+        if resolved not in seen:
+            files.append((resolved, relative))
+            seen.add(resolved)
+    return files
+
+
+def _compose_prefix(docker: str, files: list[tuple[Path, str]]) -> list[str]:
+    argv = [docker, "compose"]
+    for path, _ in files:
+        argv.extend(("-f", str(path)))
+    return argv
+
+
+def _resolved_graph(prefix: list[str]) -> tuple[list[str], list[str]]:
+    result = _run([*prefix, "config", "--format", "json"])
+    if result.returncode != 0:
+        raise MeasurementError("docker compose config could not render the resolved graph")
+    try:
+        value = json.loads(result.stdout.decode("utf-8", errors="strict"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise MeasurementError("docker compose config returned invalid JSON") from exc
+    services_value = value.get("services") if isinstance(value, dict) else None
+    if not isinstance(services_value, dict):
+        raise MeasurementError("docker compose config omitted the services object")
+
+    services = sorted({name for name in services_value if isinstance(name, str) and name})
+    images = sorted(
+        {
+            image.strip()
+            for service in services_value.values()
+            if isinstance(service, dict)
+            for image in [service.get("image")]
+            if isinstance(image, str) and image.strip()
+        }
+    )
+    if len(services) > 256 or len(images) > 256:
+        raise MeasurementError("resolved Compose graph exceeds its bounded size")
+    return services, images
+
+
+def _git_head(git: str, root: Path) -> str | None:
+    try:
+        result = _run([git, "-C", str(root), "rev-parse", "HEAD"], timeout=5)
+    except MeasurementError:
+        return None
+    value = result.stdout.decode("ascii", errors="ignore").strip()
+    return value if result.returncode == 0 and HEX_REVISION_RE.fullmatch(value) else None
+
+
+def _install_bytes(du: str, root: Path) -> int | None:
+    try:
+        result = _run([du, "-sb", "--", str(root)], timeout=60)
+    except MeasurementError:
+        return None
+    token = result.stdout.split(maxsplit=1)[0] if result.stdout else b""
+    return int(token) if result.returncode == 0 and token.isdigit() else None
+
+
+def _container_ids(prefix: list[str]) -> list[str] | None:
+    try:
+        result = _run([*prefix, "ps", "-q"])
+    except MeasurementError:
+        return None
+    if result.returncode != 0:
+        return None
+    values = {
+        line.strip()
+        for line in result.stdout.decode("ascii", errors="ignore").splitlines()
+        if re.fullmatch(r"[0-9a-f]{12,64}", line.strip())
+    }
+    return sorted(values)
+
+
+def _image_bytes(docker: str, images: list[str]) -> tuple[int, int, int]:
+    total = 0
+    present = 0
+    for image in images:
+        try:
+            result = _run([docker, "image", "inspect", "--format", "{{.Size}}", image])
+        except MeasurementError:
+            continue
+        value = result.stdout.decode("ascii", errors="ignore").strip()
+        if result.returncode == 0 and value.isdigit():
+            total += int(value)
+            present += 1
+    return total, present, len(images) - present
+
+
+def _memory_bytes(value: str) -> int:
+    match = MEMORY_RE.fullmatch(value.strip())
+    if not match:
+        raise ValueError("invalid memory value")
+    return int(Decimal(match.group(1)) * MEMORY_FACTORS[match.group(2).lower()])
+
+
+def _idle_sample(docker: str, container_ids: list[str] | None) -> dict[str, object]:
+    if container_ids is None:
+        return {"available": False, "containerCount": None, "cpuPercent": None, "memoryBytes": None}
+    if not container_ids:
+        return {"available": True, "containerCount": 0, "cpuPercent": 0.0, "memoryBytes": 0}
+    try:
+        result = _run(
+            [docker, "stats", "--no-stream", "--format", "{{json .}}", *container_ids],
+            timeout=60,
+        )
+    except MeasurementError:
+        return {"available": False, "containerCount": len(container_ids), "cpuPercent": None, "memoryBytes": None}
+    if result.returncode != 0:
+        return {"available": False, "containerCount": len(container_ids), "cpuPercent": None, "memoryBytes": None}
+
+    cpu = Decimal(0)
+    memory = 0
+    try:
+        for line in result.stdout.decode("utf-8", errors="strict").splitlines():
+            row = json.loads(line)
+            cpu += Decimal(str(row["CPUPerc"]).strip().removesuffix("%"))
+            used = str(row["MemUsage"]).split("/", 1)[0].strip()
+            memory += _memory_bytes(used)
+    except (UnicodeDecodeError, json.JSONDecodeError, KeyError, InvalidOperation, ValueError):
+        return {"available": False, "containerCount": len(container_ids), "cpuPercent": None, "memoryBytes": None}
+    return {
+        "available": True,
+        "containerCount": len(container_ids),
+        "cpuPercent": float(cpu),
+        "memoryBytes": memory,
+    }
+
+
+def _readiness(curl: str, raw_url: str | None) -> dict[str, object]:
+    if raw_url is None:
+        return {"attempted": False, "ready": None, "statusCode": None}
+    parsed = urlsplit(raw_url)
+    if (
+        parsed.scheme != "http"
+        or parsed.hostname not in {"127.0.0.1", "localhost", "::1"}
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise MeasurementError("assistant readiness URL must be credential-free loopback HTTP")
+    try:
+        result = _run(
+            [curl, "--silent", "--show-error", "--max-time", "5", "--output", os.devnull, "--write-out", "%{http_code}", raw_url],
+            timeout=10,
+        )
+    except MeasurementError:
+        return {"attempted": True, "ready": False, "statusCode": None}
+    text = result.stdout.decode("ascii", errors="ignore").strip()
+    status = int(text) if text.isdigit() and len(text) == 3 else None
+    return {"attempted": True, "ready": result.returncode == 0 and status is not None and 200 <= status < 300, "statusCode": status}
+
+
+def _nonnegative_decimal(raw: str | None) -> float | None:
+    if raw is None:
+        return None
+    try:
+        value = Decimal(raw)
+    except InvalidOperation as exc:
+        raise MeasurementError("startup-to-ready must be a non-negative number") from exc
+    if not value.is_finite() or value < 0:
+        raise MeasurementError("startup-to-ready must be a non-negative number")
+    return float(value)
+
+
+def _write_receipt(path: Path, value: dict[str, object]) -> None:
+    parent = path.parent.resolve(strict=True)
+    if path.exists() and path.is_symlink():
+        raise MeasurementError("output path must not be a symlink")
+    payload = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    if len(payload) > 256 * 1024:
+        raise MeasurementError("measurement receipt exceeds its size limit")
+    handle = tempfile.NamedTemporaryFile(prefix=".ods-baseline-", dir=parent, delete=False)
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--inference-route", required=True)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--compose-file", action="append", default=[])
+    parser.add_argument("--startup-to-ready-seconds")
+    parser.add_argument("--assistant-ready-url")
+    args = parser.parse_args(argv)
+
+    try:
+        root = args.root.resolve(strict=True)
+        if not root.is_dir():
+            raise MeasurementError("--root must be a directory")
+        profile = _label(args.profile, "profile")
+        route = _label(args.inference_route, "inference route")
+        files = _compose_files(root, args.compose_file)
+        docker = _tool("ODS_MEASURE_DOCKER", "docker")
+        git = _tool("ODS_MEASURE_GIT", "git")
+        du = _tool("ODS_MEASURE_DU", "du")
+        curl = _tool("ODS_MEASURE_CURL", "curl")
+        prefix = _compose_prefix(docker, files)
+        services, images = _resolved_graph(prefix)
+        ids = _container_ids(prefix)
+        image_bytes, image_present, image_missing = _image_bytes(docker, images)
+        receipt: dict[str, object] = {
+            "schemaVersion": 1,
+            "kind": "ods-assistant-first-baseline",
+            "observedAt": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "source": {"gitHead": _git_head(git, root)},
+            "selection": {
+                "profile": profile,
+                "inferenceRoute": route,
+                "composeFiles": [relative for _, relative in files],
+            },
+            "resolved": {"services": services, "images": images},
+            "footprint": {
+                "installBytes": _install_bytes(du, root),
+                "localImageBytes": image_bytes,
+                "localImageCount": image_present,
+                "missingImageCount": image_missing,
+                "runningContainerCount": None if ids is None else len(ids),
+            },
+            "idleSample": _idle_sample(docker, ids),
+            "startupToReadySeconds": _nonnegative_decimal(args.startup_to_ready_seconds),
+            "assistantReadiness": _readiness(curl, args.assistant_ready_url),
+        }
+        _write_receipt(args.output.resolve(), receipt)
+    except (MeasurementError, OSError) as exc:
+        print(f"capture-assistant-first-baseline: {exc}", file=sys.stderr)
+        return 2
+    print(str(args.output))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test_capture_assistant_first_baseline.py
+++ b/ods/tests/test_capture_assistant_first_baseline.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for the read-only Assistant-First baseline receipt."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "capture-assistant-first-baseline.py"
+
+
+def _executable(path: Path, source: str) -> Path:
+    path.write_text(textwrap.dedent(source).lstrip(), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+    return path
+
+
+class BaselineReceiptTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name)
+        self.install = self.base / "install"
+        self.install.mkdir()
+        (self.install / "docker-compose.base.yml").write_text("services: {}\n", encoding="utf-8")
+        (self.install / "docker-compose.cpu.yml").write_text("services: {}\n", encoding="utf-8")
+        (self.install / ".compose-flags").write_text(
+            "-f docker-compose.base.yml -f docker-compose.cpu.yml\n", encoding="utf-8"
+        )
+        self.log = self.base / "docker.log"
+        self.docker = _executable(
+            self.base / "docker",
+            r'''
+            #!/usr/bin/env python3
+            import json, os, sys
+            args = sys.argv[1:]
+            missing = os.environ.get("FAKE_EVIDENCE_MISSING") == "1"
+            with open(os.environ["FAKE_DOCKER_LOG"], "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(args) + "\n")
+            if args[0] == "compose" and "config" in args:
+                print(json.dumps({"services": {
+                    "voice": {"image": "example/voice:1", "environment": {"TOKEN": "must-not-leak"}},
+                    "dashboard": {"image": "example/dashboard:1"},
+                    "duplicate": {"image": "example/dashboard:1"}
+                }}))
+            elif args[0] == "compose" and "ps" in args and not missing:
+                print("a" * 12)
+                print("b" * 12)
+            elif args[:2] == ["image", "inspect"] and not missing:
+                print("100" if args[-1] == "example/dashboard:1" else "200")
+            elif args[0] == "stats":
+                print(json.dumps({"CPUPerc": "1.25%", "MemUsage": "1MiB / 2MiB"}))
+                print(json.dumps({"CPUPerc": "2.50%", "MemUsage": "512KiB / 1MiB"}))
+            else:
+                sys.exit(9)
+            ''',
+        )
+        self.git = _executable(
+            self.base / "git",
+            """
+            #!/usr/bin/env python3
+            import os, sys
+            if os.environ.get("FAKE_EVIDENCE_MISSING") == "1":
+                sys.exit(1)
+            print("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+            """,
+        )
+        self.du = _executable(
+            self.base / "du",
+            """
+            #!/usr/bin/env python3
+            import os, sys
+            if os.environ.get("FAKE_EVIDENCE_MISSING") == "1":
+                sys.exit(1)
+            print("4096\\tfixture")
+            """,
+        )
+        self.curl = _executable(
+            self.base / "curl",
+            """
+            #!/usr/bin/env python3
+            print("204", end="")
+            """,
+        )
+        self.env = {
+            **os.environ,
+            "FAKE_DOCKER_LOG": str(self.log),
+            "ODS_MEASURE_DOCKER": str(self.docker),
+            "ODS_MEASURE_GIT": str(self.git),
+            "ODS_MEASURE_DU": str(self.du),
+            "ODS_MEASURE_CURL": str(self.curl),
+        }
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def _run(self, *extra: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--root",
+                str(self.install),
+                "--profile",
+                "core",
+                "--inference-route",
+                "local-cpu",
+                "--output",
+                str(self.base / "receipt.json"),
+                *extra,
+            ],
+            capture_output=True,
+            text=True,
+            env=self.env,
+            check=False,
+        )
+
+    def test_receipt_is_sorted_bounded_and_secret_free(self) -> None:
+        result = self._run(
+            "--startup-to-ready-seconds",
+            "4.5",
+            "--assistant-ready-url",
+            "http://127.0.0.1:3001/health",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        raw = (self.base / "receipt.json").read_text(encoding="utf-8")
+        self.assertNotIn("must-not-leak", raw)
+        self.assertNotIn("environment", raw)
+        self.assertNotIn("127.0.0.1", raw)
+        receipt = json.loads(raw)
+        self.assertEqual(receipt["selection"]["composeFiles"], ["docker-compose.base.yml", "docker-compose.cpu.yml"])
+        self.assertEqual(receipt["resolved"]["services"], ["dashboard", "duplicate", "voice"])
+        self.assertEqual(receipt["resolved"]["images"], ["example/dashboard:1", "example/voice:1"])
+        self.assertEqual(receipt["footprint"]["installBytes"], 4096)
+        self.assertEqual(receipt["footprint"]["localImageBytes"], 300)
+        self.assertEqual(receipt["footprint"]["localImageCount"], 2)
+        self.assertEqual(receipt["footprint"]["missingImageCount"], 0)
+        self.assertEqual(receipt["footprint"]["runningContainerCount"], 2)
+        self.assertEqual(receipt["idleSample"]["cpuPercent"], 3.75)
+        self.assertEqual(receipt["idleSample"]["memoryBytes"], 1572864)
+        self.assertEqual(receipt["startupToReadySeconds"], 4.5)
+        self.assertEqual(receipt["assistantReadiness"], {"attempted": True, "ready": True, "statusCode": 204})
+
+        calls = [json.loads(line) for line in self.log.read_text(encoding="utf-8").splitlines()]
+        forbidden = {"build", "create", "down", "kill", "pull", "remove", "restart", "rm", "run", "start", "stop", "up", "update"}
+        self.assertTrue(calls)
+        self.assertFalse(any(forbidden.intersection(call) for call in calls))
+
+    def test_explicit_compose_files_override_saved_flags(self) -> None:
+        result = self._run("--compose-file", "docker-compose.cpu.yml")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        receipt = json.loads((self.base / "receipt.json").read_text(encoding="utf-8"))
+        self.assertEqual(receipt["selection"]["composeFiles"], ["docker-compose.cpu.yml"])
+
+    def test_unavailable_runtime_evidence_is_explicit(self) -> None:
+        self.env["FAKE_EVIDENCE_MISSING"] = "1"
+        result = self._run()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        receipt = json.loads((self.base / "receipt.json").read_text(encoding="utf-8"))
+        self.assertIsNone(receipt["source"]["gitHead"])
+        self.assertIsNone(receipt["footprint"]["installBytes"])
+        self.assertEqual(receipt["footprint"]["localImageBytes"], 0)
+        self.assertEqual(receipt["footprint"]["localImageCount"], 0)
+        self.assertEqual(receipt["footprint"]["missingImageCount"], 2)
+        self.assertIsNone(receipt["footprint"]["runningContainerCount"])
+        self.assertEqual(
+            receipt["idleSample"],
+            {"available": False, "containerCount": None, "cpuPercent": None, "memoryBytes": None},
+        )
+        self.assertEqual(
+            receipt["assistantReadiness"],
+            {"attempted": False, "ready": None, "statusCode": None},
+        )
+
+    def test_invalid_inputs_fail_before_measurement(self) -> None:
+        missing = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True, check=False)
+        self.assertNotEqual(missing.returncode, 0)
+        external = self._run("--compose-file", str(self.base / "outside.yml"))
+        self.assertNotEqual(external.returncode, 0)
+        non_loopback = self._run("--assistant-ready-url", "https://example.com/health")
+        self.assertNotEqual(non_loopback.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Phase 0 of the Assistant-First installation plan:

- records the installer, capability, authority, identity, state, data, and qualification decisions in an ADR;
- adds a bounded read-only baseline receipt command for resolved Compose services/images, local footprint, idle resource sampling, startup timing, and loopback assistant readiness;
- adds isolated tests proving deterministic ordering, deduplication, explicit unavailable evidence, secret omission, and the absence of mutating Docker commands;
- wires the contract test into the Linux workflow and `make test`.

## Stack

This PR is intentionally stacked on #4396 (`feat/generic-assistant-identity`). It does not merge or duplicate that identity change.

## Safety boundaries

The measurement command runs only read operations (`compose config`, `compose ps`, `image inspect`, `stats`, `git rev-parse`, `du`, and an optional credential-free loopback HTTP probe). It never pulls, builds, creates, starts, stops, or removes a container and never writes raw Compose configuration, environment values, container IDs, hostnames, or probe URLs into the receipt.

This phase changes no installer choice, Compose graph, runtime service, deployment, or live installation.

## Validation

- `python3 ods/tests/test_capture_assistant_first_baseline.py` — 4 tests passed under WSL/Linux
- `python3 -m py_compile ods/scripts/capture-assistant-first-baseline.py ods/tests/test_capture_assistant_first_baseline.py`
- `git diff --check`
- Existing `bash ods/tests/test-doc-links.sh` still reports its pre-existing `CONTRIBUTING.md` working-directory failure on both the base and this branch; the new ADR link resolves.

## Qualification status

Source contract and measurement tooling only. Cold Full/Core measurements and real installed Assistant-First journeys remain later qualification evidence; this PR does not claim them.
