### PR TITLE
fix(pixel): contain invalid host observation output

### DIFF
--- a/ods/extensions/services/pixel-agent/host/system_observe.py
+++ b/ods/extensions/services/pixel-agent/host/system_observe.py
@@ -56,7 +56,7 @@ def _run(
             timeout=timeout,
             env=environment,
         )
-    except (OSError, subprocess.SubprocessError):
+    except (OSError, subprocess.SubprocessError, UnicodeDecodeError):
         return None
     if (
         len(result.stdout.encode("utf-8", "replace")) > MAX_OUTPUT
@@ -136,6 +136,8 @@ def _native_tailscale_state() -> tuple[bool, str, bool] | None:
     try:
         value = json.loads(result.stdout)
     except json.JSONDecodeError:
+        return True, "unknown", False
+    if not isinstance(value, dict):
         return True, "unknown", False
     raw = str(value.get("BackendState", "")).strip().casefold()
     states = {

--- a/ods/extensions/services/pixel-agent/tests/test_system_observe.py
+++ b/ods/extensions/services/pixel-agent/tests/test_system_observe.py
@@ -4,6 +4,9 @@ if sys.platform == "win32":
     raise SkipTest("Requires POSIX host ownership, file locks, or Unix sockets; run under Linux/WSL")
 
 import importlib.util
+import contextlib
+import io
+import json
 import socket
 import pathlib
 import stat
@@ -20,6 +23,41 @@ SPEC.loader.exec_module(system_observe)
 
 
 class SystemObserveTests(unittest.TestCase):
+    def test_cli_keeps_invalid_command_bytes_out_of_observation_receipts(self):
+        for action in ("gpu", "tailscale"):
+            for descriptor in (1, 2):
+                with self.subTest(action=action, descriptor=descriptor), tempfile.TemporaryDirectory() as directory:
+                    executable = pathlib.Path(directory) / "observer"
+                    executable.write_text(
+                        f"#!{sys.executable}\nimport os\nos.write({descriptor}, bytes([255]))\n",
+                        encoding="utf-8",
+                    )
+                    executable.chmod(0o700)
+                    output = io.StringIO()
+                    with mock.patch.object(system_observe, "_trusted_executable", return_value=str(executable)), \
+                         contextlib.redirect_stdout(output):
+                        self.assertEqual(system_observe.main(["observer", action]), 0)
+                    value = json.loads(output.getvalue())
+                    if action == "gpu":
+                        self.assertFalse(value["available"])
+                        self.assertEqual(value["devices"], [])
+                    else:
+                        self.assertEqual(value["state"], "unknown")
+                        self.assertFalse(value["serviceRunning"])
+
+    def test_tailscale_cli_rejects_non_object_status_without_crashing(self):
+        for payload in ("null", "[]", "42", '"running"'):
+            with self.subTest(payload=payload):
+                result = mock.Mock(returncode=0, stdout=payload, stderr="")
+                output = io.StringIO()
+                with mock.patch.object(system_observe, "_trusted_executable", return_value="/usr/bin/tailscale"), \
+                     mock.patch.object(system_observe, "_run", return_value=result), \
+                     contextlib.redirect_stdout(output):
+                    self.assertEqual(system_observe.main(["observer", "tailscale"]), 0)
+                value = json.loads(output.getvalue())
+                self.assertEqual(value["state"], "unknown")
+                self.assertFalse(value["serviceRunning"])
+
     def test_gpu_output_is_bounded_and_omits_device_identifiers(self):
         result = mock.Mock(
             returncode=0,


### PR DESCRIPTION
## Why this matters
The read-only `host.gpu` and `host.tailscale` Operations actions must return an honest observation when their host command cannot be decoded. A real child process writing a non-UTF-8 byte to either stdout or stderr currently raises `UnicodeDecodeError` through the CLI. A JSON scalar from the Tailscale command similarly raises `AttributeError`.

Handle decoding failure at the subprocess boundary and require an object before reading Tailscale state. GPU observations remain unavailable; installed Tailscale reports unknown and not running. Invalid bytes are never replaced with invented device facts.

## Overlap check
Searched open and closed PR titles for Tailscale, host observations, peer probes and non-UTF-8 output; searched PR bodies for `system_observe` and the changed production path `ods/extensions/services/pixel-agent/host/system_observe.py`. #4351 changes IPv6 interface scope in peer probes; these changes affect command decoding and Tailscale status shape, with no overlapping behavior. #3221/#2082 concern the separate dashboard Tailscale router.

## Risk and validation
- Release lane: `public-beta`; medium risk, read-only host observation.
- Regression exercises `main()` and parses its JSON receipt, with real child processes writing invalid stdout/stderr bytes. Additional cases cover scalar/null/array Tailscale JSON.
- Before the fix: 8 subcase errors. After the fix: all 11 system-observer tests pass.
- `python3 -m unittest discover -s ods/extensions/services/pixel-agent/tests -p test_system_observe.py`
- `git diff --check` passes.

Validated on Linux/WSL. No live GPU or Tailscale service qualification is claimed; no command, network scope, privilege, or state mutation changes. Reverting this commit restores the previous parser behavior.

## AI Assistance
Codex helped inspect the production path, implement the fix and regression tests, and run validation. Maintainer review is pending.

## Batch verification
This head (252fb67936f1) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #4401 and #4351: the combined observer suite passes 14 tests. The two new observer PRs merge in either order without a textual conflict. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.
