### PR TITLE
perf(pixel): overlap bounded peer reachability probes

### DIFF
--- a/ods/extensions/services/pixel-agent/host/system_observe.py
+++ b/ods/extensions/services/pixel-agent/host/system_observe.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+from concurrent.futures import ThreadPoolExecutor
 import ipaddress
 import json
 import os
@@ -387,20 +388,25 @@ def observe_network_peer(target: str, ports: str = "") -> dict:
         parsed = ipaddress.ip_address(raw)
         resolved.append((socket.AF_INET if parsed.version == 4 else socket.AF_INET6, raw, "tailscale"))
         known.add(raw)
-    observations = []
-    for family, address, scope in resolved:
-        icmp = _probe_icmp(family, address)
-        tcp = [
-            {"port": port, "open": _probe_tcp(family, address, port)}
-            for port in normalized_ports
+    # Submit the already-validated, bounded peer/port set together. Serial
+    # timeouts can consume the broker's entire 30-second action deadline.
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        pending = [
+            (address, family, scope, pool.submit(_probe_icmp, family, address),
+             [(port, pool.submit(_probe_tcp, family, address, port))
+              for port in normalized_ports])
+            for family, address, scope in resolved
         ]
-        observations.append({
-            "address": address,
-            "family": "ipv4" if family == socket.AF_INET else "ipv6",
-            "scope": scope,
-            "icmpReachable": icmp,
-            "tcp": tcp,
-        })
+        observations = [
+            {
+                "address": address,
+                "family": "ipv4" if family == socket.AF_INET else "ipv6",
+                "scope": scope,
+                "icmpReachable": icmp.result(),
+                "tcp": [{"port": port, "open": result.result()} for port, result in tcp],
+            }
+            for address, family, scope, icmp, tcp in pending
+        ]
     reachable = tailscale["online"] is True or any(
         item["icmpReachable"] is True or any(port["open"] for port in item["tcp"])
         for item in observations

--- a/ods/extensions/services/pixel-agent/tests/test_system_observe.py
+++ b/ods/extensions/services/pixel-agent/tests/test_system_observe.py
@@ -8,6 +8,7 @@ import socket
 import pathlib
 import stat
 import tempfile
+import threading
 import unittest
 from unittest import mock
 
@@ -114,6 +115,54 @@ class SystemObserveTests(unittest.TestCase):
             root = pathlib.Path(directory)
             with mock.patch.object(pathlib.Path, "lstat", return_value=mock.Mock(st_mode=stat.S_IFDIR | 0o777, st_uid=0)):
                 self.assertEqual(system_observe._trusted_interop_sockets(root), [])
+
+    def test_peer_probes_overlap_with_a_bounded_pool_and_preserve_receipt_order(self):
+        addresses = [f"192.168.1.{index}" for index in range(10, 14)]
+        ports = list(range(8000, 8008))
+        ready = threading.Event()
+        lock = threading.Lock()
+        active = 0
+        maximum = 0
+        calls = []
+
+        def probe(family, address, port=None):
+            nonlocal active, maximum
+            with lock:
+                active += 1
+                maximum = max(maximum, active)
+                calls.append((family, address, port))
+                if active == 8:
+                    ready.set()
+            try:
+                self.assertTrue(ready.wait(2), "peer probes ran serially")
+                return port == 8003 if port is not None else None
+            finally:
+                with lock:
+                    active -= 1
+
+        tailscale = {"available": False, "found": False, "online": None, "addresses": []}
+        with mock.patch.object(system_observe, "_resolve_peer",
+                               return_value=[(socket.AF_INET, address, "lan") for address in addresses]), \
+             mock.patch.object(system_observe, "_tailscale_peer_status", return_value=tailscale), \
+             mock.patch.object(system_observe, "_probe_icmp", side_effect=probe), \
+             mock.patch.object(system_observe, "_probe_tcp", side_effect=probe):
+            value = system_observe.observe_network_peer("peer", ",".join(map(str, ports)))
+        self.assertEqual(maximum, 8)
+        self.assertEqual(len(calls), 36)
+        self.assertTrue(value["reachable"])
+        self.assertEqual([item["address"] for item in value["addresses"]], addresses)
+        for item in value["addresses"]:
+            self.assertIsNone(item["icmpReachable"])
+            self.assertEqual(item["tcp"], [{"port": port, "open": port == 8003} for port in ports])
+
+    def test_rejected_resolution_starts_no_peer_probes(self):
+        with mock.patch.object(system_observe, "_resolve_peer", side_effect=ValueError("private network boundary")), \
+             mock.patch.object(system_observe, "_probe_tcp") as tcp, \
+             mock.patch.object(system_observe, "_probe_icmp") as icmp, \
+             self.assertRaisesRegex(ValueError, "private network boundary"):
+            system_observe.observe_network_peer("public.example", "443")
+        tcp.assert_not_called()
+        icmp.assert_not_called()
 
     def test_private_network_peer_reports_only_bounded_exact_peer_evidence(self):
         records = [


### PR DESCRIPTION
## Why this matters
A read-only `host.network-peer` request can check four resolved addresses and eight ports. The observer runs every ICMP/TCP probe serially: their configured timeouts can consume 28.8 seconds, before DNS and Tailscale status, against the broker's 30-second action deadline. An unreachable peer can therefore produce no diagnostic receipt.

Run only the already-validated probe set in an eight-worker pool. Preserve resolver order, requested port order, unknown ICMP results and the existing receipt schema. Public destinations are still rejected before any probe starts.

## Overlap check
Searched open/closed PRs for network-peer, peer concurrency/timeouts and changes to `ods/extensions/services/pixel-agent/host/system_observe.py`. #4351 retains IPv6 interface scope; #4400 handles invalid command output. Neither changes probe scheduling. No dependency on either fix.

## Risk and validation
- Release lane: `public-beta`; network observation only. No additional peers, ports, retries, authentication or mutations.
- All 11 system-observer tests pass. A synchronization-based regression fails on the serial implementation and verifies exactly eight concurrent workers, all 36 expected probes and stable result order. Rejected resolution starts no probes.
- `python3 -m unittest discover -s ods/extensions/services/pixel-agent/tests -p test_system_observe.py`
- `git diff --check` passes.
- Controlled 100 ms probe fixture: 3.6 seconds of serial probe work; pooled execution measured 0.505 seconds on Linux/WSL. This is a scheduling benchmark, not a live network latency claim.

DNS and Tailscale discovery retain their existing deadlines; this does not claim an absolute end-to-end deadline. Live LAN/IPv6 smoke and independent network-boundary review remain pending; this PR is open for review and is not merge-ready until those checks are complete. Rollback is a commit revert to serial probes.

## AI Assistance
Codex assisted with analysis, implementation, regression tests and the benchmark. Maintainer review is pending.

## Batch verification
This head (2b7806137625) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #4400 and #4351: the combined observer suite passes 14 tests. No dependency on the IPv6 change is required. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.
