### PR TITLE
fix(preview): settle artifact download deadlines and cleanup

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.jsx
@@ -11,17 +11,28 @@ export default function PixelArtifactDownload({ preview, file }) {
     const controller = new AbortController()
     pending.current = controller
     setState('loading')
-    const timeout = setTimeout(() => controller.abort(), 12000)
+    let timeout
     try {
-      const bytes = await loadArtifactBytes(preview, file, controller.signal)
+      const bytes = await Promise.race([
+        loadArtifactBytes(preview, file, controller.signal),
+        new Promise((_, reject) => {
+          timeout = setTimeout(() => {
+            controller.abort()
+            reject(new Error('Artifact verification timed out'))
+          }, 12000)
+        }),
+      ])
       if (controller.signal.aborted) return
       const url = URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }))
-      const link = document.createElement('a')
-      link.href = url
-      link.download = file.path.split('/').at(-1)
-      document.body.append(link)
-      try { link.click() } finally {
-        link.remove()
+      let link
+      try {
+        link = document.createElement('a')
+        link.href = url
+        link.download = file.path.split('/').at(-1)
+        document.body.append(link)
+        link.click()
+      } finally {
+        link?.remove()
         // Give the browser a task to consume the URL before releasing it.
         setTimeout(() => URL.revokeObjectURL(url), 1000)
       }

--- a/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.lifecycle.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelArtifactDownload.lifecycle.test.jsx
@@ -1,0 +1,55 @@
+import {act, fireEvent, render, screen} from '@testing-library/react'
+import {createHash} from 'node:crypto'
+import PixelArtifactDownload from './PixelArtifactDownload'
+
+const bytes = new TextEncoder().encode('verified artifact')
+const digest = createHash('sha256').update(bytes).digest('hex')
+const preview = {siteId:'site-'+'a'.repeat(24)}
+const file = {path:'index.html', bytes:bytes.byteLength, sha256:digest}
+const hash = () => Uint8Array.from(digest.match(/../g), part => parseInt(part,16)).buffer
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.stubGlobal('fetch',vi.fn(async () => ({ok:true,arrayBuffer:async () => bytes.buffer})))
+  vi.stubGlobal('crypto',{subtle:{digest:vi.fn(async () => hash())}})
+  vi.spyOn(URL,'createObjectURL').mockReturnValue('blob:artifact')
+  vi.spyOn(URL,'revokeObjectURL').mockImplementation(() => {})
+  vi.spyOn(HTMLAnchorElement.prototype,'click').mockImplementation(() => {})
+})
+afterEach(() => {vi.useRealTimers();vi.restoreAllMocks();vi.unstubAllGlobals()})
+
+it('expires a pending digest, permits retry and ignores late verification',async () => {
+  let finish
+  crypto.subtle.digest.mockImplementationOnce(() => new Promise(resolve => {finish=resolve}))
+  render(<PixelArtifactDownload preview={preview} file={file}/>)
+  const button = screen.getByRole('button',{name:'Download index.html'})
+  await act(async () => {fireEvent.click(button)})
+  expect(crypto.subtle.digest).toHaveBeenCalledOnce()
+  await act(async () => {await vi.advanceTimersByTimeAsync(12000)})
+  expect(button).toBeEnabled()
+  expect(screen.getByRole('alert')).toHaveTextContent('Download could not be verified')
+  expect(URL.createObjectURL).not.toHaveBeenCalled()
+  await act(async () => {fireEvent.click(button)})
+  expect(screen.getByRole('status')).toHaveTextContent('Verified download started')
+  await act(async () => {finish(hash())})
+  expect(HTMLAnchorElement.prototype.click).toHaveBeenCalledOnce()
+  expect(screen.queryByRole('alert')).toBeNull()
+})
+
+it.each(['creation','attachment'])('releases verified bytes when link %s fails',async stage => {
+  render(<PixelArtifactDownload preview={preview} file={file}/>)
+  if (stage === 'attachment') {
+    vi.spyOn(document.body,'append').mockImplementation(() => {throw new Error('Attachment refused')})
+  } else {
+    const create = document.createElement.bind(document)
+    vi.spyOn(document,'createElement').mockImplementation((tag,...args) => {
+      if(tag === 'a') throw new Error('Creation refused')
+      return create(tag,...args)
+    })
+  }
+  await act(async () => {fireEvent.click(screen.getByRole('button',{name:'Download index.html'}))})
+  expect(screen.getByRole('alert')).toHaveTextContent('Download could not be verified')
+  await act(async () => {await vi.advanceTimersByTimeAsync(1000)})
+  expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:artifact')
+  expect(document.querySelector('a[download]')).toBeNull()
+})


### PR DESCRIPTION
## Why this matters
A verified-file download can remain disabled forever when its 12-second deadline expires during SHA-256 calculation: aborting fetch does not cancel WebCrypto. The late-result branch returns without settling the button. Link creation or attachment failures also leave the downloaded Blob URL allocated.

Race the complete verification operation against the deadline, report a retryable failure, and release Blob URLs even if link setup fails. Late verification cannot start an obsolete download or overwrite a successful retry.

## Overlap check
Searched open/closed PRs for artifact download and changed files in `PixelArtifactDownload.jsx`. #4139 introduced downloads; #4321 adds HTTP-LAN digest support in `pixelArtifacts.js`; #4325 bounds source rendering. Neither covers terminal download state or link setup cleanup. #4352 covers the separate Usage CSV exporter.

## Risk and validation
- `public-beta`, medium risk; dashboard download lifecycle.
- Three new regressions fail on the base: verification outliving its deadline, link creation failure, and link attachment failure.
- 15 focused tests pass across `PixelArtifactDownload.lifecycle.test.jsx`, `PixelArtifactDownload.test.jsx`, and `PixelPreviewSource.test.jsx`, including exact binary bytes, tamper rejection, retry and source replacement.
- Dashboard production build passes; full lint reports 0 errors and 560 existing warnings; `git diff --check` passes.
- Commands: `npx vitest run src/components/PixelArtifactDownload.lifecycle.test.jsx src/components/PixelArtifactDownload.test.jsx src/components/PixelPreviewSource.test.jsx --maxWorkers=2`, `npm run build`, `npm run lint`.

Tests drive the rendered control with fetched bytes and delayed digest completion. Browser download-dialog smoke is deferred; no network or integrity policy changes. Revert the commit to roll back.

## AI Assistance
Codex assisted with reproduction, code, tests and validation. Maintainer review is pending.

## Batch verification
This head (0d4748fa0127) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.
