### PR TITLE
fix(pixel-edge): preserve SSE event boundaries

### DIFF
--- a/ods/extensions/services/pixel-edge/pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/pixel_edge.py
@@ -561,6 +561,14 @@ def _rewrite_json_response(raw: bytes, fallback: str) -> bytes:
     return json.dumps(parsed).encode("utf-8")
 
 
+def _normalize_sse_line(line: bytes) -> bytes:
+    # CRLF and the optional space after "data:" carry the same SSE field.
+    line = line.removesuffix(b"\r")
+    if line.startswith(b"data:") and not line.startswith(b"data: "):
+        line = b"data: " + line[5:]
+    return line
+
+
 def _sse_event(line: bytes):
     if not line.startswith(b"data: ") or line == b"data: [DONE]":
         return None, None, None
@@ -956,11 +964,11 @@ async def _stream_upstream(
             if content is None and finish_reason is None:
                 await response.write(line + b"\n")
         await response.write(
-            _fallback_sse_line(template, empty_reply_fallback, finished=False) + b"\n"
+            _fallback_sse_line(template, empty_reply_fallback, finished=False) + b"\n\n"
         )
         if synthesize_finish:
             await response.write(
-                _fallback_sse_line(template, empty_reply_fallback, finished=True) + b"\n"
+                _fallback_sse_line(template, empty_reply_fallback, finished=True) + b"\n\n"
             )
         pending = []
 
@@ -972,6 +980,7 @@ async def _stream_upstream(
             while b"\n" in buffered:
                 line, _, remainder = buffered.partition(b"\n")
                 buffered = bytearray(remainder)
+                line = _normalize_sse_line(line)
                 if cancel_event is not None and cancel_event.is_set():
                     pending = []
                     await response.write(b"data: [DONE]\n\n")
@@ -1044,7 +1053,7 @@ async def _stream_upstream(
         if buffered:
             if len(buffered) > _MAX_SSE_LINE:
                 raise ValueError("SSE line exceeded limit")
-            line = bytes(buffered)
+            line = _normalize_sse_line(bytes(buffered))
             if line.rstrip(b"\r") == b"data: [DONE]" and activity is not None:
                 activity["terminal"] = True
             if line.startswith(b"data: ") and line != b"data: [DONE]":

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -103,6 +103,12 @@ async def _upstream_chat(request):
         )
         await resp.prepare(request)
         async for chunk in generate():
+            if data.get("sse_no_space"):
+                chunk = chunk.replace(b"data: ", b"data:")
+            if data.get("sse_crlf"):
+                chunk = chunk.replace(b"\n", b"\r\n")
+            if data.get("sse_without_finish") and b'"delta":{}' in chunk:
+                continue
             await resp.write(chunk)
         await resp.write_eof()
         return resp
@@ -1431,6 +1437,35 @@ class TestPrivateUrlBoundary(BaseEdgeTest):
 # ---------------------------------------------------------------------------
 
 class TestSSE(BaseEdgeTest):
+    async def test_fallback_frames_are_independently_decodable_sse_events(self):
+        for no_space in (False, True):
+            for crlf in (False, True):
+                for without_finish in (False, True):
+                    with self.subTest(no_space=no_space, crlf=crlf, without_finish=without_finish):
+                        async with self.client.post(
+                            "http://localhost/v1/chat/completions", headers=self.auth(),
+                            json={"model": "pixel/default", "stream": True,
+                                  "messages": [{"role": "user", "content": "testing 123"}],
+                                  "trigger_reserved": True, "sse_no_space": no_space,
+                                  "sse_crlf": crlf, "sse_without_finish": without_finish},
+                        ) as response:
+                            self.assertEqual(response.status, 200)
+                            body = await response.text()
+                        events = []
+                        for frame in body.replace("\r\n", "\n").split("\n\n"):
+                            fields = [line[5:].removeprefix(" ") for line in frame.split("\n")
+                                      if line.startswith("data:")]
+                            if fields:
+                                events.append("\n".join(fields))
+                        self.assertEqual(events[-1], "[DONE]")
+                        packets = [json.loads(event) for event in events[:-1]]
+                        self.assertTrue(all(packet.get("model") == "pixel/default" for packet in packets))
+                        text = "".join(packet["choices"][0].get("delta", {}).get("content", "")
+                                       for packet in packets)
+                        self.assertEqual(text, self.pe._SHORT_TEST_REPLY)
+                        self.assertEqual(sum(packet["choices"][0].get("finish_reason") == "stop"
+                                             for packet in packets), 1)
+
     async def test_sse_streams_incrementally(self):
         async with self.client.post(
             "http://localhost/v1/chat/completions",


### PR DESCRIPTION
## Why this matters
When Pixel Edge replaces a reserved or empty upstream reply, it writes its generated content and finish JSON with only one newline between them. A standard SSE consumer joins those data lines into one event, which cannot be decoded as JSON. CRLF terminators and the optional space after `data:` can also bypass rewriting or terminal handling.

Terminate each generated event with a blank line and normalize CRLF/data-field spacing before the existing rewriter. Preserve the public model alias, exactly one fallback reply, one stop event, and the final DONE marker. This follows the [SSE field and event rules](https://html.spec.whatwg.org/multipage/server-sent-events.html#parsing-an-event-stream).

## Overlap check
Searched open/closed PRs for Pixel SSE, stream framing and changes to `pixel-edge/pixel_edge.py`. #3984 concerns the separate Open Interpreter extension. #1933 concerns the model-router holdback buffer. #4120 bounds restored dashboard lookups. No overlapping Pixel Edge event-boundary fix found.

## Risk and validation
- `public-beta`; high-risk proxy surface, not merge-ready pending independent review and live client smoke.
- Real HTTP requests through the edge's Unix-socket transport exercise eight combinations of LF/CRLF, optional data spacing, and upstream finish presence. The test parses complete SSE events, not individual JSON lines.
- Before: all eight combinations fail. After: all four SSE tests pass, including the eight new subcases, incremental normal output and upstream errors.
- Full edge suite: 110 tests run; 108 pass, two existing Python 3.13 socket-cleanup errors tracked by #4330. The base edge subtree matches the previously validated baseline; neither failing cleanup path changes here.
- `python -m unittest discover -s ods/extensions/services/pixel-edge/tests -p test_pixel_edge.py -k TestSSE`
- `git diff --check` passes.

This handles LF/CRLF single-line JSON events used by the upstream protocol; it does not claim a complete general-purpose EventSource implementation. No authentication, routing, or cancellation authority changes. Revert the commit to roll back.

## AI Assistance
Codex assisted with protocol analysis, implementation, socket-level tests and validation. Maintainer review is pending.

## Batch verification
This head (74ff0066099d) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #4405: 113 edge tests run; 111 pass with the same two pre-existing Python 3.13 socket-cleanup errors. Adding the existing #4330 test cleanup produces 113/113 passing. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.
