### PR TITLE
fix(inference): close responses arriving during cancellation

### DIFF
--- a/ods/extensions/services/pixel-inference/app/main.py
+++ b/ods/extensions/services/pixel-inference/app/main.py
@@ -117,20 +117,26 @@ def _prepare(payload, grant):
 
 async def _guarded(awaitable, watcher):
     work = asyncio.ensure_future(awaitable)
+    transferred = False
     try:
         done, _ = await asyncio.wait((work, watcher), return_when=asyncio.FIRST_COMPLETED)
         if watcher in done:
-            if work.done() and not work.cancelled() and work.exception() is None:
-                orphan = work.result()
-                if isinstance(orphan, httpx.Response):
-                    await orphan.aclose()
             await watcher
-        return await work
+        result = await work
+        transferred = True
+        return result
     finally:
         if not work.done():
             work.cancel()
             with suppress(asyncio.CancelledError):
                 await work
+        # Cancellation may finish the transport with headers instead of raising.
+        # Until returned to the caller, this response is still ours to close.
+        if not transferred and not work.cancelled() and work.exception() is None:
+            orphan = work.result()
+            if isinstance(orphan, httpx.Response):
+                with anyio.CancelScope(shield=True):
+                    await orphan.aclose()
 
 
 def create_app(store=None, router_url=None, client=None):

--- a/ods/extensions/services/pixel-inference/tests/test_inference_sharing.py
+++ b/ods/extensions/services/pixel-inference/tests/test_inference_sharing.py
@@ -343,3 +343,44 @@ def test_disconnect_before_stream_iterator_starts_still_cleans_up():
         await asyncio.wait_for(response({'type':'http','asgi':{'spec_version':'2.3'}}, receive, send), 2)
         assert cleaned == [True]
     asyncio.run(exercise())
+
+
+@pytest.mark.parametrize("ending", ["cancel", "deadline"])
+def test_response_arriving_during_cancellation_is_closed_and_admission_released(state, ending):
+    async def exercise():
+        store, token = state
+        doc = store.load()
+        doc["devices"][0]["deadlineSeconds"] = 1
+        store.save(doc, expected_revision=doc["revision"])
+        entered = asyncio.Event()
+        response_stream = Stream([])
+
+        async def handler(request):
+            if request.method == "GET":
+                return backend(request)
+            entered.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                # Model headers can arrive as the pending transport unwinds.
+                return httpx.Response(200, stream=response_stream,
+                                      headers={"content-type": "application/json"})
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as upstream:
+            app = gateway.create_app(store, "http://127.0.0.1:9099", upstream)
+            async with app.router.lifespan_context(app):
+                async with httpx.AsyncClient(transport=httpx.ASGITransport(app), base_url="http://test") as client:
+                    auth = {"Authorization": "Bearer " + token}
+                    task = asyncio.create_task(client.post("/v1/chat/completions", json=body(), headers=auth))
+                    await asyncio.wait_for(entered.wait(), 2)
+                    if ending == "cancel":
+                        task.cancel()
+                        with pytest.raises(asyncio.CancelledError):
+                            await task
+                    else:
+                        response = await asyncio.wait_for(task, 2)
+                        assert response.status_code == 504
+                        assert response.json()["error"]["type"] == "inference_deadline"
+                    assert response_stream.closed
+                    assert (await client.get("/v1/models", headers=auth)).status_code == 200
+    asyncio.run(exercise())


### PR DESCRIPTION
## Why this matters
A cancelled or expired inference request can receive upstream headers while its transport unwinds cancellation. The guard previously checked for an orphan before awaiting that unwind, so this response escaped both the guard and the route's cleanup. Repeated cancellations could retain pooled upstream connections.

Track response ownership until it is returned. After cancelling and awaiting unfinished work, close any response that was not transferred to the caller, with cancellation-shielded cleanup.

## Overlap check
Searched open and closed PR titles and production-file changes for inference cancellation, deadlines, response cleanup and pixel-inference/app/main.py. #4124 addresses Python 3.10 timeout compatibility; no overlapping orphan-response repair found.

## Risk and validation
- Target: public-beta. High-risk inference sharing/proxy surface; not merge-ready pending independent review and live transport cancellation smoke.
- Regression drives real ASGI chat requests through the application and an HTTPX transport that returns headers while cancellation unwinds. Covers caller cancellation and the device deadline, verifies response closure, then successfully admits another authenticated request.
- Before: both new cases fail because the response stream stays open.
- After: all 37 inference sharing tests pass.
- Command: `python -m pytest -q ods/extensions/services/pixel-inference/tests/test_inference_sharing.py`
- `git diff --check` passes. One existing Starlette/AnyIO deprecation warning.
- Authentication, grant limits and response ownership after successful return retain their contracts. Revert the commit to roll back.

## AI Assistance
Codex assisted with investigation, implementation, ASGI regression tests and validation. Independent human review is pending.

## Batch verification
This head (bef24516ca77) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.
