### PR TITLE
fix(pixel-edge): bound pending SSE prelude memory

### DIFF
--- a/ods/extensions/services/pixel-edge/pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/pixel_edge.py
@@ -105,6 +105,8 @@ _CONNECT_TIMEOUT = 5
 _TOTAL_TIMEOUT = 1980
 _SOCK_READ_TIMEOUT = 1980
 _MAX_SSE_LINE = 1024 * 1024
+_MAX_SSE_PENDING_BYTES = 1024 * 1024
+_MAX_SSE_PENDING_LINES = 4096
 
 _UPSTREAM_REWRITE = "openclaw/default"
 _PIXEL_REWRITE = "pixel/default"
@@ -940,17 +942,29 @@ async def _stream_upstream(
     await response.prepare(request)
     buffered = bytearray()
     pending = []
+    pending_bytes = 0
     pending_text = ""
     passthrough = False
 
+    def queue_pending(line, event, content, finish_reason):
+        nonlocal pending_bytes
+        # The line cap alone does not bound many small reasoning/empty frames.
+        size = len(line) + 1
+        if (pending_bytes + size > _MAX_SSE_PENDING_BYTES
+                or len(pending) >= _MAX_SSE_PENDING_LINES):
+            raise ValueError("SSE prelude exceeded limit")
+        pending.append((line, event, content, finish_reason))
+        pending_bytes += size
+
     async def flush_pending():
-        nonlocal pending
+        nonlocal pending, pending_bytes
         for item in pending:
             await response.write(item[0] + b"\n")
         pending = []
+        pending_bytes = 0
 
     async def replace_pending(template: dict, *, synthesize_finish: bool):
-        nonlocal pending
+        nonlocal pending, pending_bytes
         # Preserve role/metadata events, but never expose the reserved text.
         for line, _event, content, finish_reason in pending:
             if content is None and finish_reason is None:
@@ -963,6 +977,7 @@ async def _stream_upstream(
                 _fallback_sse_line(template, empty_reply_fallback, finished=True) + b"\n"
             )
         pending = []
+        pending_bytes = 0
 
     try:
         async for chunk in resp.content.iter_any():
@@ -1027,7 +1042,7 @@ async def _stream_upstream(
                     passthrough = True
                     continue
 
-                pending.append((line, event, content, finish_reason))
+                queue_pending(line, event, content, finish_reason)
                 if content is not None:
                     pending_text += content
                     normalized = pending_text.strip()
@@ -1053,7 +1068,7 @@ async def _stream_upstream(
                 await response.write(line)
             else:
                 event, content, finish_reason = _sse_event(line)
-                pending.append((line, event, content, finish_reason))
+                queue_pending(line, event, content, finish_reason)
         if not passthrough and pending:
             normalized = pending_text.strip()
             if not normalized or normalized in _RESERVED_ASSISTANT_REPLIES:

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -19,6 +19,7 @@ from pathlib import Path
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 import warnings
 
 warnings.filterwarnings("ignore", message=".*Sending a large body.*")
@@ -75,6 +76,18 @@ async def _upstream_chat(request):
 
     if stream:
         async def generate():
+            if data.get("prelude_kind"):
+                kind = data["prelude_kind"]
+                line = {
+                    "reasoning": b'data: {"choices":[{"delta":{"reasoning_content":"private reasoning"}}]}',
+                    "whitespace": b'data: {"choices":[{"delta":{"content":" "}}]}',
+                    "blank": b"",
+                }[kind]
+                for _ in range(data.get("prelude_count", 100)):
+                    yield line + b"\n\n"
+                if data.get("prelude_tail"):
+                    yield line
+                    return
             if data.get("trigger_cancel_wait"):
                 yield b'data: {"id":"1","model":"openclaw/default","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
                 request.app["stream_started"].set()
@@ -1680,3 +1693,39 @@ class TestChatActivity(BaseEdgeTest):
 if __name__ == "__main__":
     unittest.main()
 
+
+class TestSSEPreludeBudget(BaseEdgeTest):
+    async def test_many_small_prelude_frames_fail_without_leaking_or_fallback(self):
+        for kind in ("reasoning", "whitespace", "blank"):
+            with self.subTest(kind=kind), patch.object(self.pe, "_MAX_SSE_PENDING_BYTES", 1024, create=True), patch.object(self.pe, "_MAX_SSE_PENDING_LINES", 32, create=True):
+                async with self.client.post(
+                    "http://localhost/v1/chat/completions", headers=self.auth(),
+                    json={"model": "pixel/default", "messages": [], "stream": True,
+                          "prelude_kind": kind},
+                ) as response:
+                    self.assertEqual(response.status, 200)
+                    self.assertEqual(await response.text(),
+                        'data: {"error":"upstream error"}\n\ndata: [DONE]\n\n')
+
+    async def test_eof_tail_counts_toward_pending_budget(self):
+        with patch.object(self.pe, "_MAX_SSE_PENDING_BYTES", 100, create=True):
+            async with self.client.post(
+                "http://localhost/v1/chat/completions", headers=self.auth(),
+                json={"model": "pixel/default", "messages": [], "stream": True,
+                      "prelude_kind": "reasoning", "prelude_count": 1, "prelude_tail": True},
+            ) as response:
+                self.assertEqual(await response.text(),
+                    'data: {"error":"upstream error"}\n\ndata: [DONE]\n\n')
+
+    async def test_short_reasoning_prelude_still_streams_normal_answer(self):
+        with patch.object(self.pe, "_MAX_SSE_PENDING_BYTES", 1024, create=True):
+            async with self.client.post(
+                "http://localhost/v1/chat/completions", headers=self.auth(),
+                json={"model": "pixel/default", "messages": [], "stream": True,
+                      "prelude_kind": "reasoning", "prelude_count": 2},
+            ) as response:
+                body = await response.text()
+                self.assertIn("private reasoning", body)
+                self.assertIn("openclaw/default is assistant text", body)
+                self.assertNotIn('"error"', body)
+                self.assertTrue(body.endswith("data: [DONE]\n\n"))


### PR DESCRIPTION
## Why this matters
Pixel Edge holds role, reasoning and whitespace frames until it can decide whether to replace a reserved/empty reply. Limiting each SSE line does not bound that queue: an upstream can send arbitrarily many small frames before visible content, retaining both raw bytes and parsed objects.

Bound the pending prelude to 1 MiB and 4,096 lines. Count the final unterminated line too, and reset accounting when pending output is flushed. Exceeding either budget produces the existing sanitized stream error and closes the relay; normal short preludes still reach the client.

## Overlap check
Searched open/closed SSE buffer PRs and all available production-file changes. #1933 handles the separate model-router service. #4403 repairs Pixel Edge event framing; it does not bound this queue. #4396 changes identity naming. This PR is independently based on public-beta; combined integration with #4403 will be checked.

## Risk and validation
- High-risk proxy surface; not merge-ready pending independent review and live model smoke.
- Unix-socket HTTP regression covers reasoning frames, whitespace content, many empty lines, an EOF tail, and a normal short reasoning prelude.
- Before: four regression subcases fail. After: all six SSE tests pass.
- Command: python -m unittest discover -s ods/extensions/services/pixel-edge/tests -p test_pixel_edge.py -k TestSSE
- git diff --check passes.
- No real upstream completion is inferred from the locally generated error/DONE frame. Very large preludes now fail explicitly rather than consuming unbounded memory.
- Existing full-suite Python 3.13 socket-teardown failures remain tracked by #4330; unrelated to this change. Revert the commit to roll back.

## AI Assistance
Codex assisted with memory-bound analysis, implementation and socket-level regression validation. Independent human review is pending.

## Batch verification
This head (5e737969be78) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #4403: 113 edge tests run; 111 pass with the same two pre-existing Python 3.13 socket-cleanup errors. Adding the existing #4330 test cleanup produces 113/113 passing. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.
