### PR TITLE
fix(pixel): enforce the promotion RPC total deadline

### DIFF
--- a/ods/extensions/services/pixel-agent/plugin/download-promote.mjs
+++ b/ods/extensions/services/pixel-agent/plugin/download-promote.mjs
@@ -158,12 +158,14 @@ export function requestPromotion(
 ) {
   return new Promise((resolve, reject) => {
     let settled = false;
+    let deadline;
     let total = 0;
     const chunks = [];
     const socket = net.createConnection({ path: socketPath });
     const finish = (error, value) => {
       if (settled) return;
       settled = true;
+      clearTimeout(deadline);
       signal?.removeEventListener("abort", onAbort);
       socket.destroy();
       if (error) reject(error);
@@ -175,7 +177,8 @@ export function requestPromotion(
       return;
     }
     signal?.addEventListener("abort", onAbort, { once: true });
-    socket.setTimeout(timeoutMs, () => finish(new Error("exact-download promotion timed out")));
+    // A response that trickles bytes must not renew the total RPC budget.
+    deadline = setTimeout(() => finish(new Error("exact-download promotion timed out")), timeoutMs);
     socket.on("error", (error) => finish(error));
     socket.on("connect", () => {
       socket.write(`${JSON.stringify(request)}\n`);

--- a/ods/extensions/services/pixel-agent/tests/download_promote.test.mjs
+++ b/ods/extensions/services/pixel-agent/tests/download_promote.test.mjs
@@ -1,8 +1,14 @@
 import test from "node:test";
+import net from "node:net";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { once } from "node:events";
 import assert from "node:assert/strict";
 import {
   createDownloadPromoteTool,
   normalizePromotionParams,
+  requestPromotion,
 } from "../plugin/download-promote.mjs";
 
 const boundary =
@@ -159,4 +165,47 @@ test("fails closed on transport errors and mismatched service evidence", async (
     assert.equal(result.details.status, "failed");
     assert.doesNotMatch(result.content[0].text, /socket|\/run|authority/);
   }
+});
+
+test("promotion tool enforces a total deadline despite a trickling host response", { skip: process.platform === "win32" }, async (t) => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "ods-promote-deadline-"));
+  const socketPath = path.join(directory, "rpc.sock");
+  const connections = new Set();
+  let peerClosed = false;
+  const server = net.createServer((socket) => {
+    connections.add(socket);
+    socket.on("error", () => {});
+    socket.on("data", () => {});
+    // Valid JSON whitespace keeps an idle timeout alive, but must not extend
+    // the tool's total request budget.
+    const drip = setInterval(() => socket.write(" "), 20);
+    const completion = setTimeout(() => socket.end(JSON.stringify(success(normalizePromotionParams(params))) + "\n"), 600);
+    socket.on("close", () => {
+      clearInterval(drip);
+      clearTimeout(completion);
+      connections.delete(socket);
+      peerClosed = true;
+    });
+  });
+  t.after(async () => {
+    for (const socket of connections) socket.destroy();
+    await new Promise(resolve => server.close(resolve));
+    await rm(directory, { recursive: true, force: true });
+  });
+  server.listen(socketPath);
+  await once(server, "listening");
+  let failure;
+  const tool = createDownloadPromoteTool({
+    request: async (request, options) => {
+      try { return await requestPromotion(request, { ...options, socketPath, timeoutMs: 120 }); }
+      catch (error) { failure = error; throw error; }
+    },
+  });
+  const result = await tool.execute("trickling-host", params);
+  assert.equal(result.isError, true);
+  assert.match(failure.message, /timed out/);
+  assert.doesNotMatch(JSON.stringify(result), /rpc.sock|trickling-host/);
+  // The deadline must also tear down the actual Unix connection.
+  await new Promise(resolve => setTimeout(resolve, 30));
+  assert.equal(peerClosed, true);
 });


### PR DESCRIPTION
## Why this matters
The artifact-promotion bridge uses a socket idle timeout for its 120-second RPC budget. A host response that keeps sending a few bytes renews that timeout indefinitely, keeping the agent tool pending beyond its intended deadline.

Use one total-duration timer from request setup, and clear it in the shared settlement path. Expiry tears down the socket and returns the existing sanitized failure result. This bounds the bridge wait; it does not claim to undo a host operation already published.

## Overlap check
Searched open/closed promotion timeout, deadline and cancellation PRs, plus production-file changes to plugin/download-promote.mjs. No overlapping repair found. #4092 covers unread dashboard artifact bodies; #4335 adds cancellation to the separate workspace-preview tool.

## Risk and validation
- Target public-beta; not merge-ready because this bridges a host publication boundary, pending independent review and live promoter smoke.
- A real Unix-socket peer sends valid JSON whitespace repeatedly, then a valid receipt. The public tool must time out and close its connection rather than accept the late receipt.
- Before: the new regression fails because the late receipt is accepted. After: all eight download-promotion tests pass.
- Command: node --test ods/extensions/services/pixel-agent/tests/download_promote.test.mjs
- git diff --check passes. The socket test runs on POSIX/WSL and skips native Windows.
- Request/receipt validation and create-only publication authority are unchanged. Revert the commit to roll back.

## AI Assistance
Codex assisted with timeout analysis, implementation and real-socket regression validation. Independent human review is pending.

## Batch verification
This head (79f825eaeaf3) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.
