### PR TITLE
fix(dashboard): isolate keyboard focus in the opening screen

### DIFF
--- a/ods/extensions/services/dashboard/src/components/SplashScreen.jsx
+++ b/ods/extensions/services/dashboard/src/components/SplashScreen.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import SplashMetalOrb from './SplashMetalOrb'
 
 export default function SplashScreen({ onComplete, preview = false }) {
+  const dialog = useRef(null)
   const [leaving, setLeaving] = useState(false)
   const completed = useRef(false)
   const onCompleteRef = useRef(onComplete)
@@ -18,16 +19,19 @@ export default function SplashScreen({ onComplete, preview = false }) {
     exitTimer.current = window.setTimeout(() => onCompleteRef.current?.(), 400)
   }, [])
   useEffect(() => {
+    const node = dialog.current
+    node.showModal()
+    return () => node.close()
+  }, [])
+  useEffect(() => {
     if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
       complete()
       return
     }
     const timer = preview ? null : window.setTimeout(complete, 3200)
-    const onKey = event => { if (event.key === 'Escape') complete() }
-    window.addEventListener('keydown', onKey)
-    return () => { window.clearTimeout(timer); window.clearTimeout(exitTimer.current); window.removeEventListener('keydown', onKey) }
+    return () => { window.clearTimeout(timer); window.clearTimeout(exitTimer.current) }
   }, [complete, preview])
-  return <div role="dialog" aria-modal="true" aria-label="ODS" className={`ods-opening${leaving ? ' is-leaving' : ''}`}>
+  return <dialog ref={dialog} aria-label="ODS" onCancel={event => { event.preventDefault(); complete() }} className={`ods-opening${leaving ? ' is-leaving' : ''}`}>
     <SplashMetalOrb />
     <div className="ods-opening-content">
     <h1 className="ods-opening-wordmark">ODS</h1>
@@ -35,5 +39,5 @@ export default function SplashScreen({ onComplete, preview = false }) {
     <p role="status">Opening your workspace</p>
     <button type="button" aria-label="Skip splash screen" onClick={complete}>Continue</button>
     </div>
-  </div>
+  </dialog>
 }

--- a/ods/extensions/services/dashboard/src/components/__tests__/SplashScreen.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/SplashScreen.test.jsx
@@ -38,9 +38,14 @@ vi.mock('gsap/CustomEase', () => ({
   },
 }))
 
+if (!HTMLDialogElement.prototype.showModal) HTMLDialogElement.prototype.showModal = function () {}
+if (!HTMLDialogElement.prototype.close) HTMLDialogElement.prototype.close = function () {}
+
 describe('SplashScreen', () => {
   beforeEach(() => {
     vi.useFakeTimers()
+    vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(function () { this.setAttribute('open', '') })
+    vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(function () { this.removeAttribute('open') })
     vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
     vi.stubGlobal('cancelAnimationFrame', vi.fn())
     vi.stubGlobal('matchMedia', vi.fn(() => ({
@@ -69,7 +74,29 @@ describe('SplashScreen', () => {
     expect(container.querySelectorAll('.ell')).toHaveLength(31)
   })
 
-  test('completes immediately when reduced motion is requested', () => {
+  test('uses browser modal isolation and releases it on unmount', () => {
+    const view = render(<SplashScreen preview onComplete={() => {}} />)
+    const dialog = screen.getByRole('dialog', { name: 'ODS' })
+    expect(dialog.tagName).toBe('DIALOG')
+    expect(dialog).toHaveAttribute('open')
+    view.unmount()
+    expect(dialog).not.toHaveAttribute('open')
+  })
+
+  test('Escape keeps modal isolation during the exit animation and completes once', () => {
+    const onComplete = vi.fn()
+    render(<SplashScreen preview onComplete={onComplete} />)
+    const dialog = screen.getByRole('dialog', { name: 'ODS' })
+    const event = new Event('cancel', { cancelable: true })
+    fireEvent(dialog, event)
+    expect(event.defaultPrevented).toBe(true)
+    expect(dialog).toHaveAttribute('open')
+    expect(onComplete).not.toHaveBeenCalled()
+    act(() => vi.advanceTimersByTime(400))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('completes immediately when reduced motion is requested' , () => {
     const onComplete = vi.fn()
     globalThis.matchMedia = vi.fn(() => ({
       matches: true,

--- a/ods/extensions/services/dashboard/src/pixel-workspace.css
+++ b/ods/extensions/services/dashboard/src/pixel-workspace.css
@@ -26,7 +26,7 @@ body { font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFon
 /* Native menus need opaque option colors; translucent select fills do not carry over on Windows. */
 select, select option, select optgroup { color-scheme:dark; }
 select option, select optgroup { background-color:rgb(var(--theme-card)); color:rgb(var(--theme-text)); }
-.ods-opening { position:fixed; inset:0; z-index:9999; display:flex; align-items:center; justify-content:center; isolation:isolate; overflow:hidden; background:#101112; color:#a2a7ae; font-family:Inter,system-ui,sans-serif; font-size:14px; opacity:1; transition:opacity .4s ease; }
+.ods-opening { width:100%; height:100%; max-width:none; max-height:none; margin:0; padding:0; border:0; position:fixed; inset:0; z-index:9999; display:flex; align-items:center; justify-content:center; isolation:isolate; overflow:hidden; background:#101112; color:#a2a7ae; font-family:Inter,system-ui,sans-serif; font-size:14px; opacity:1; transition:opacity .4s ease; }
 .ods-opening.is-leaving { opacity:0; pointer-events:none; }
 .ods-opening-orb { position:absolute; width:min(110vw,960px); height:min(100vh,760px); pointer-events:none; }
 .ods-opening-content { position:relative; display:flex; flex-direction:column; align-items:center; gap:20px; padding:40px; }


### PR DESCRIPTION
## Why this matters
The opening screen announces a modal dialog but is an ordinary overlay. Keyboard focus can stay on or move into the hidden workspace, especially in the indefinitely open intro preview.

Use the browser's modal dialog lifecycle, which isolates the workspace and moves focus into the opening screen. Handle native Escape cancellation through the existing fade/completion path, retaining modality until unmount. Explicit dialog dimensions preserve the full-screen appearance.

## Overlap check
Searched open/closed splash focus PRs and production changes to SplashScreen.jsx. #4395 restored the animation and is the base of this change. #2194 is the older merged splash implementation. No open keyboard-isolation repair found.

## Risk and validation
- Medium-risk frontend change against public-beta.
- Before: both new lifecycle/Escape regressions fail. After: all seven SplashScreen tests pass.
- Production build passes; lint has zero errors (existing repository warnings).
- Real Chromium smoke with mocked API responses verifies native :modal state, forward/backward Tab isolation, Escape and Continue dismissal, and full-screen bounds at 1280x800 and 390x844. Both screenshots visually inspected.
- Commands: npm test -- --run src/components/__tests__/SplashScreen.test.jsx; npm run build; npm run lint.
- git diff --check passes. API fixtures do not claim a live backend test.
- Revert this commit to roll back.

## AI Assistance
Codex assisted with implementation, regression tests and real-browser keyboard/visual validation.

## Batch verification
This head (c97d696b55d3) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.
