### PR TITLE
fix(pixel): reject special search inputs without blocking setup

### DIFF
--- a/ods/extensions/services/pixel-agent/host/native_search.py
+++ b/ods/extensions/services/pixel-agent/host/native_search.py
@@ -38,7 +38,9 @@ def checked(path, *, directory=False, private=False):
 
 
 def read_private(path):
-    flags = os.O_RDONLY | os.O_NOFOLLOW
+    # Open without waiting for a FIFO peer, then enforce the regular-file
+    # contract on the descriptor before reading. O_NONBLOCK is inert on files.
+    flags = os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK
     fd = os.open(path, flags)
     try:
         info = os.fstat(fd)

--- a/ods/tests/test_pixel_native_search.py
+++ b/ods/tests/test_pixel_native_search.py
@@ -10,6 +10,8 @@ import hashlib
 import importlib.util
 import io
 import json
+import os
+import subprocess
 from pathlib import Path
 import tarfile
 import tempfile
@@ -83,6 +85,34 @@ class NativeSearchTests(unittest.TestCase):
         with self.assertRaises(OSError):
             ns.select_provider(link)
         self.assertEqual(answers.read_text(), '{}')
+
+    def test_cli_rejects_fifo_answers_and_cache_without_waiting_for_a_writer(self):
+        for mode in ("answers", "cache"):
+            with self.subTest(mode=mode):
+                base = self.root / mode
+                base.mkdir(mode=0o700)
+                special = base / ("answers.json" if mode == "answers" else f"parallel-{ns.VERSION}.tgz")
+                os.mkfifo(special, 0o600)
+                before = special.lstat()
+                args = ["--answers-file", str(special)] if mode == "answers" else ["--base-dir", str(base)]
+                try:
+                    result = subprocess.run([sys.executable, ns.__file__, *args],
+                                            capture_output=True, text=True, timeout=3)
+                except subprocess.TimeoutExpired:
+                    self.fail("native search CLI blocked opening a FIFO before checking its type")
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("owner-private regular file", result.stderr)
+                self.assertNotIn("Traceback", result.stderr)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(special.lstat().st_ino, before.st_ino)
+                self.assertFalse((base / f"parallel-{ns.VERSION}").exists())
+
+        answers = self.root / "regular.json"
+        answers.write_text('{"webSearchProvider":"parallel-free"}')
+        answers.chmod(0o600)
+        result = subprocess.run([sys.executable, ns.__file__, "--answers-file", str(answers)],
+                                capture_output=True, text=True, timeout=3, check=True)
+        self.assertEqual(result.stdout, "parallel-free\n")
 
     def test_archive_rejects_unsafe_names_and_duplicates(self):
         for name in ["package/../escape", "/escape", "package//empty", "package/./dot",


### PR DESCRIPTION
## Why this matters
The native search installer opens onboarding answers and cached archives before verifying that the opened object is a regular file. An owner-private FIFO blocks that open indefinitely when no writer is present, so setup never reaches its existing rejection or download timeout.

Open these read-only inputs in nonblocking mode, then apply the existing descriptor ownership, type and size checks before reading. Regular-file reads retain their behavior.

## Overlap check
Searched open/closed native search FIFO PRs and production-file changes to host/native_search.py. No overlapping repair found. #4125 only adjusts POSIX test collection.

## Risk and validation
- Target public-beta; not merge-ready because this is installer input handling, pending independent review and installer smoke.
- Regression invokes the actual CLI in subprocesses with real FIFOs at the answers and cache paths, without a FIFO writer.
- Before: both CLI invocations time out. After: both promptly exit 1 with a bounded regular-file error, preserve the special files, and publish no plugin tree. A normal private answers file still succeeds.
- All 11 native search tests pass, including immutable provisioning, pinned archive integrity and symlink/permission checks.
- Command: python3 -m unittest discover -s ods/tests -p test_pixel_native_search.py
- git diff --check passes. No npm download or live runtime installation was performed. Revert the commit to roll back.

## AI Assistance
Codex assisted with investigation, implementation and subprocess regression validation. Independent human review is pending.

## Batch verification
This head (c1a20934c53b) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.
