### PR TITLE
fix(brave-search): cancel upstream work when clients disconnect

### DIFF
--- a/ods/extensions/services/brave-search/proxy.mjs
+++ b/ods/extensions/services/brave-search/proxy.mjs
@@ -90,11 +90,12 @@ if (parsedBraveUrl.username || parsedBraveUrl.password || parsedBraveUrl.hash) {
 }
 
 function send(res, status, body) {
+  if (res.destroyed) return;
   res.writeHead(status, { "content-type": "application/json" });
   res.end(JSON.stringify(body));
 }
 
-async function callBrave(query, count, offset) {
+async function callBrave(query, count, offset, signal) {
   const url = new URL(parsedBraveUrl);
   url.searchParams.set("q", query);
   url.searchParams.set("count", String(count));
@@ -116,7 +117,7 @@ async function callBrave(query, count, offset) {
       // redirecting upstream could receive the subscription token. The Brave
       // API never redirects; refuse rather than follow.
       redirect: "error",
-      signal: ctrl.signal,
+      signal: AbortSignal.any([ctrl.signal, signal]),
     });
   } finally {
     clearTimeout(timer);
@@ -126,10 +127,10 @@ async function callBrave(query, count, offset) {
 // Shared upstream call. Maps transport failures to a tagged shape so each
 // route can render them in its own error contract (/v1 as 5xx, searxng
 // compat as unresponsive_engines).
-async function fetchBraveWeb(query, count, offset) {
+async function fetchBraveWeb(query, count, offset, signal) {
   let upstream;
   try {
-    upstream = await callBrave(query, count, offset);
+    upstream = await callBrave(query, count, offset, signal);
   } catch (err) {
     if (err && err.name === "AbortError") {
       return { error: "timeout" };
@@ -152,7 +153,7 @@ async function fetchBraveWeb(query, count, offset) {
   }
 }
 
-async function handleV1Search(res, params) {
+async function handleV1Search(res, params, signal) {
   const query = params.get("q");
   if (!query) {
     send(res, 400, { error: "missing_query_param_q" });
@@ -162,7 +163,7 @@ async function handleV1Search(res, params) {
   const requested = Number(params.get("count") ?? 5);
   const count = Math.min(20, Math.max(1, Number.isFinite(requested) ? Math.trunc(requested) : 5));
 
-  const outcome = await fetchBraveWeb(query, count, 0);
+  const outcome = await fetchBraveWeb(query, count, 0, signal);
   if (outcome.error === "timeout") {
     send(res, 504, { error: "upstream_timeout" });
     return;
@@ -279,7 +280,7 @@ const SEARXNG_ERROR_TEXT = {
   invalid_json: "invalid JSON",
 };
 
-async function handleSearxngSearch(res, params) {
+async function handleSearxngSearch(res, params, signal) {
   const format = params.get("format");
   if (format !== "json") {
     send(res, 400, { error: "unsupported_format", detail: "only format=json is supported" });
@@ -319,7 +320,7 @@ async function handleSearxngSearch(res, params) {
   const pageno = Number.isFinite(requestedPage) ? Math.trunc(requestedPage) : 1;
   const offset = Math.min(9, Math.max(0, pageno - 1));
 
-  const outcome = await fetchBraveWeb(query, SEARXNG_PAGE_SIZE, offset);
+  const outcome = await fetchBraveWeb(query, SEARXNG_PAGE_SIZE, offset, signal);
   if (outcome.error) {
     const reason =
       outcome.error === "http_error"
@@ -336,6 +337,9 @@ async function handleSearxngSearch(res, params) {
 // ── router ──────────────────────────────────────────────────────────────────
 
 const server = http.createServer(async (req, res) => {
+  const disconnected = new AbortController();
+  const onClose = () => { if (!res.writableEnded) disconnected.abort(); };
+  res.on("close", onClose);
   try {
     const parsed = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
 
@@ -345,7 +349,7 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (req.method === "GET" && parsed.pathname === "/search" && SEARXNG_COMPAT) {
-      await handleSearxngSearch(res, parsed.searchParams);
+      await handleSearxngSearch(res, parsed.searchParams, disconnected.signal);
       return;
     }
 
@@ -354,14 +358,17 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
-    await handleV1Search(res, parsed.searchParams);
+    await handleV1Search(res, parsed.searchParams, disconnected.signal);
   } catch (error) {
+    if (disconnected.signal.aborted) return;
     console.error(`brave-search: request failed: ${error instanceof Error ? error.message : "unknown error"}`);
     if (!res.headersSent) {
       send(res, 500, { error: "internal_error" });
     } else {
       res.destroy();
     }
+  } finally {
+    res.removeListener("close", onClose);
   }
 });
 

--- a/ods/tests/test-brave-search-searxng-compat.mjs
+++ b/ods/tests/test-brave-search-searxng-compat.mjs
@@ -23,6 +23,7 @@ let failures = 0;
 let redirectTarget = "";
 let redirectedRequests = 0;
 const observedTokens = [];
+let pendingDisconnect;
 
 function check(name, cond, detail) {
   if (cond) {
@@ -66,7 +67,15 @@ function stubHandler(req, res) {
     res.writeHead(status, { "content-type": "application/json" });
     res.end(body);
   };
-  if (q === "err500") {
+  if (q === "disconnect-headers" || q === "disconnect-body") {
+    const pending = pendingDisconnect;
+    if (q === "disconnect-body") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.write("{");
+    }
+    res.on("close", pending.closed);
+    pending.started(res);
+  } else if (q === "err500") {
     respond(500, "{}");
   } else if (q === "err429") {
     respond(429, "{}");
@@ -371,6 +380,36 @@ async function testCompatEnabled(base) {
   }
 }
 
+async function testClientDisconnect(base) {
+  console.log("downstream disconnect cancellation:");
+  for (const route of ["/v1/search?", "/search?format=json&"]) {
+    for (const phase of ["headers", "body"]) {
+      let entered, closed;
+      const started = new Promise(resolve => { entered = resolve; });
+      const upstreamClosed = new Promise(resolve => { closed = resolve; });
+      pendingDisconnect = { started: entered, closed: () => closed(true) };
+      const request = http.get(base + route + "q=disconnect-" + phase);
+      request.on("error", () => {});
+      let timer, upstream;
+      try {
+        upstream = await started;
+        request.destroy();
+        const cancelled = await Promise.race([
+          upstreamClosed,
+          new Promise(resolve => { timer = setTimeout(() => resolve(false), 500); }),
+        ]);
+        check(route + " aborts upstream during " + phase, cancelled === true);
+      } finally {
+        clearTimeout(timer);
+        request.destroy();
+        upstream?.destroy();
+      }
+    }
+  }
+  const healthy = await getJson(base, "/health");
+  check("proxy remains healthy after cancelled searches", healthy.status === 200);
+}
+
 // ── main ────────────────────────────────────────────────────────────────────
 
 const stub = http.createServer(stubHandler);
@@ -402,6 +441,7 @@ try {
   await testV1Route(plainBase);
   await testCompatDisabled(plainBase);
   await testCompatEnabled(compatBase);
+  await testClientDisconnect(compatBase);
 
   console.log("env validation:");
   await expectStartupFailure(


### PR DESCRIPTION
## Why this matters
A caller can disconnect from either search route while the proxy continues fetching Brave headers or reading its response. The upstream connection remains occupied even though no caller can receive the result.

Propagate downstream response closure into the upstream fetch signal, retain it during body consumption, and remove the response listener when handling finishes. Closed clients receive no attempted error response.

## Overlap check
Searched open/closed Brave disconnect/cancellation PRs and proxy.mjs changes. #3805 keeps the timeout active during response-body reads; this change handles caller disconnection. #2734 concerns caller authentication, #2998 malformed results, and #3052 blank queries. Each remains independently applicable; #3805 touches the same transport and needs combined review.

## Risk and validation
- Target public-beta; not merge-ready pending independent review and live service smoke.
- Real proxy child processes and a loopback upstream test disconnection before headers and during an unfinished body on both /v1/search and the SearXNG-compatible /search route.
- Before: all four cancellation assertions fail. After: the upstream observes closure in all four cases and the proxy remains healthy.
- Complete existing contract harness passes, including result shapes, pagination, error mapping, redirect credential protection and environment validation.
- Command: bash ods/tests/test-brave-search-searxng-compat.sh
- git diff --check passes. Tested with local fixtures, without a real Brave key or paid search request.
- Cancelling the HTTP transport does not prove cancellation of work already accepted by Brave. Revert the commit to roll back.

## AI Assistance
Codex assisted with lifecycle analysis, implementation and real HTTP regression validation. Independent human review is pending.

## Batch verification
This head (31a7de53d136) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #3805: manually resolve the shared transport block by keeping its timer around fetchBraveWeb and passing the combined timeout/disconnect signal to callBrave. The real HTTP harness passes with both behaviors. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.
