### PR TITLE
fix(dashboard): preserve unseen cross-tab profile updates at save

### DIFF
--- a/ods/extensions/services/dashboard/src/components/settings/ProfileSettings.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/ProfileSettings.jsx
@@ -38,7 +38,7 @@ export default function ProfileSettings() {
   function submit(event) {
     event.preventDefault()
     if (busy) return
-    try {setDraft(saveProfile(draft));setError('');setNotice('Profile saved.')}
+    try {setDraft(saveProfile(draft, saved));setError('');setNotice('Profile saved.')}
     catch {setError('Your profile could not be saved. Browser storage may be full or disabled.');setNotice('')}
   }
   return <form className="profile-settings" aria-label="Your profile" onSubmit={submit}>

--- a/ods/extensions/services/dashboard/src/components/settings/ProfileSettings.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/ProfileSettings.test.jsx
@@ -92,3 +92,24 @@ it('preserves an unsaved photo removal while synchronizing an untouched name',()
   fireEvent.click(screen.getByRole('button',{name:'Save profile'}))
   expect(readProfile()).toEqual({name:'Updated elsewhere',photo:''})
 })
+
+it('preserves a photo committed before its cross-tab storage event arrives', () => {
+  saveProfile({name:'Original'})
+  render(<ProfileSettings/>)
+  fireEvent.change(screen.getByRole('textbox',{name:'Display name'}),{target:{value:'My new name'}})
+  // Another tab has committed; this tab has not received its queued event.
+  localStorage.setItem(PROFILE_KEY,JSON.stringify({name:'Original',photo:PHOTO}))
+  fireEvent.click(screen.getByRole('button',{name:'Save profile'}))
+  expect(readProfile()).toEqual({name:'My new name',photo:PHOTO})
+  expect(screen.getByRole('img',{name:'My new name profile photo'})).toBeVisible()
+})
+
+it('preserves an unseen saved name while explicitly removing the photo', () => {
+  saveProfile({name:'Original',photo:PHOTO})
+  render(<ProfileSettings/>)
+  fireEvent.click(screen.getByRole('button',{name:'Remove photo'}))
+  localStorage.setItem(PROFILE_KEY,JSON.stringify({name:'Updated elsewhere',photo:PHOTO}))
+  fireEvent.click(screen.getByRole('button',{name:'Save profile'}))
+  expect(readProfile()).toEqual({name:'Updated elsewhere',photo:''})
+  expect(screen.getByRole('textbox',{name:'Display name'})).toHaveValue('Updated elsewhere')
+})

--- a/ods/extensions/services/dashboard/src/lib/localProfile.js
+++ b/ods/extensions/services/dashboard/src/lib/localProfile.js
@@ -13,8 +13,16 @@ export function readProfile() {
   try {return normalizeProfile(JSON.parse(localStorage.getItem(PROFILE_KEY) || '{}'))}
   catch {return normalizeProfile({})}
 }
-export function saveProfile(value) {
+export function saveProfile(value, previous = null) {
   const profile = normalizeProfile(value)
+  if (previous) {
+    // Storage events are queued across tabs. Preserve already-committed values
+    // for fields this form did not edit, even before that event is delivered.
+    const current = readProfile()
+    for (const field of ['name', 'photo']) {
+      if (profile[field] === previous[field]) profile[field] = current[field]
+    }
+  }
   // Never silently report success if browser storage is unavailable/full.
   localStorage.setItem(PROFILE_KEY, JSON.stringify(profile))
   window.dispatchEvent(new Event(EVENT))


### PR DESCRIPTION
## Why this matters
Saving a display name can erase a profile photo another tab just saved if its queued storage event has not arrived. The form only reconciles delivered events and previously wrote its entire stale snapshot.

At Save, preserve current persisted values for fields the form did not edit. Explicit local edits, including photo removal, still win. This closes the already-committed update window; localStorage remains last-writer-wins for truly concurrent writes.

## Overlap check
Searched open/closed profile storage/tab PRs and ProfileSettings.jsx/localProfile.js changes. Merged #4079 reconciles storage events while preserving dirty fields. This fixes the separate save-before-event-delivery window in that same user flow. No open PR covers this case.

## Validation
- Rendered ProfileSettings regressions save a name after an unseen remote photo commit, and remove a photo after an unseen remote name commit.
- Both fail on public-beta before the fix; all 9 ProfileSettings tests pass afterward.
- Command: npx vitest run src/components/settings/ProfileSettings.test.jsx
- git diff --check passes.
- No schema/storage-key changes. Reverting restores the previous whole-snapshot save behavior.

## AI Assistance
Codex assisted with reproduction, implementation and component regression tests.

## Batch verification
This head (27308c5dda7a) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.
