### PR TITLE
fix(usage): cover control and Unicode CSV formula prefixes

### DIFF
--- a/ods/extensions/services/dashboard/src/components/usage/UsageCsvExport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageCsvExport.test.jsx
@@ -1,0 +1,39 @@
+import {fireEvent, render, screen} from '@testing-library/react'
+import UsageView from './UsageView'
+
+afterEach(() => {vi.restoreAllMocks();vi.unstubAllGlobals()})
+
+async function exportRow(row) {
+  const createObjectURL = vi.fn(() => 'blob:usage')
+  vi.stubGlobal('URL', {createObjectURL, revokeObjectURL:vi.fn()})
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  render(<UsageView report={{source:{status:'ok'},models:[row]}}
+    readiness={{status:'ready'}} range={{start:'2026-09-01'}}/>)
+  fireEvent.click(screen.getByRole('button', {name:'Models', exact:true}))
+  fireEvent.click(screen.getByRole('button', {name:'Export CSV'}))
+  const blob = createObjectURL.mock.calls[0][0]
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result)
+    reader.onerror = () => reject(reader.error)
+    reader.readAsText(blob)
+  })
+}
+
+it.each(['=', '+', '-', '@', '\t', '\r', '\n', '＝', '＋', '－', '＠'])(
+  'exports metadata beginning with %j as quoted text',
+  async prefix => {
+    const value = prefix + 'SUM(1,2)"'
+    const csv = await exportRow({model:value,provider:value,service:value,input_tokens:1})
+    expect(csv.split('\r\n')[0]).toMatch(/^model,provider,service,/)
+    const expectedCell = '"' + "'" + value.replaceAll('"', '""') + '"'
+    expect(csv.slice(csv.indexOf('\r\n') + 2).startsWith(
+      [expectedCell, expectedCell, expectedCell, '"1"'].join(','),
+    )).toBe(true)
+  },
+)
+
+it('preserves ordinary Unicode, embedded newlines, commas and quotes', async () => {
+  const csv = await exportRow({model:'模型\nv2',provider:'a,b',service:'say "hello"',input_tokens:1})
+  expect(csv).toContain('"模型\nv2","a,b","say ""hello""","1"')
+})

--- a/ods/extensions/services/dashboard/src/components/usage/UsageCsvExport.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageCsvExport.test.jsx
@@ -13,7 +13,7 @@ async function exportRow(row) {
   fireEvent.click(screen.getByRole('button', {name:'Export CSV'}))
   const blob = createObjectURL.mock.calls[0][0]
   return new Promise((resolve, reject) => {
-    const reader = new FileReader()
+    const reader = new globalThis.FileReader()
     reader.onload = () => resolve(reader.result)
     reader.onerror = () => reject(reader.error)
     reader.readAsText(blob)

--- a/ods/extensions/services/dashboard/src/components/usage/UsageView.jsx
+++ b/ods/extensions/services/dashboard/src/components/usage/UsageView.jsx
@@ -28,7 +28,7 @@ const seriesInfo = {input:{field:'input_tokens',label:'Input',color:'#dce1e5'},o
 
 export function csvForRows(rows) {
   const fields=['model','provider','service','input_tokens','output_tokens','cache_read_tokens','cache_write_tokens','requests','cost_usd','cost_source']
-  const cell=value=>`"${String(value ?? '').replace(/^[=+@\-\t\r]/,"'$&").replaceAll('"','""')}"`
+  const cell=value=>`"${String(value ?? '').replace(/^[=+@\-\t\r\n＝＋－＠]/,"'$&").replaceAll('"','""')}"`
   return [fields.join(','),...rows.map(row=>fields.map(key=>cell(row[key])).join(','))].join('\r\n')
 }
 


### PR DESCRIPTION
## Why this matters
Usage CSV exports apply a text prefix to formula-like metadata, but omit leading LF and full-width equals/plus/minus/at signs. Model, provider and service labels can therefore bypass that existing export treatment.

Extend the same quoted-cell encoding to these prefixes. Ordinary Unicode and embedded newlines remain unchanged. The relevant control/Unicode cases are documented by [OWASP WSTG](https://wstg.owasp.org/latest/4-Web_Application_Security_Testing/07-Injection/21-CSV_Injection/).

## Overlap check
Searched open/closed CSV/formula PRs and UsageView.jsx changes. #4345 preserves unknown numeric values, #4352 handles download lifecycle, and #3839 targets the older Usage.jsx exporter. #4218 exports reply tables. None covers this active UsageView prefix gap; #4345/#4352 require combined review because they share the file.

## Risk and validation
- not merge-ready pending independent review and spreadsheet import checks. This is an encoding hardening change, not a claim of universal formula prevention or safe Excel save/reopen behavior.
- Tests click Models then Export CSV and read the actual generated Blob, covering 11 risky prefixes in all three metadata cells, plus ordinary Unicode/newline/comma/quote preservation.
- Before: 5 prefix cases fail. After: all 33 export, UsageView and Usage page tests pass.
- Command: npx vitest run src/components/usage/UsageCsvExport.test.jsx src/components/usage/UsageView.test.jsx src/pages/Usage.test.jsx
- git diff --check passes. No spreadsheet application was exercised.
- No API/storage changes; revert the commit to restore the previous prefix set.

## AI Assistance
Codex assisted with contract research, implementation and user-action export regressions.

## Batch verification
This head (1ce3311137f2) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #4345/#4352: retain this prefix set, #4345 numeric availability mapping and telemetrySource argument, and #4352 download cleanup. The shared CSV block needs manual resolution; all combined Usage tests pass. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.

The follow-up commit explicitly references browser globals through globalThis to satisfy the repository ESLint configuration. Focused tests and lint were rerun; the current GitHub head checks pass.
