### PR TITLE
fix(usage): recover polling after stalled requests and bodies

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -75,6 +75,7 @@ function emptyReport(start, end, detail = null) {
   }
 }
 
+const USAGE_POLL_TIMEOUT_MS = 15000
 const USAGE_HISTORY_KEY = 'ods-usage-summary-history-v1'
 // Per-period sparkline depth, and an overall guard so the entry never grows
 // without limit once several periods share the store.
@@ -155,28 +156,46 @@ function useUsageReport(range, reloadToken = 0) {
   useEffect(() => {
     let cancelled = false
     let inFlight = false
-    const controller = new AbortController()
+    let cancelLoad = null
     const prevRange = monthRange(addMonths(range.anchor, -1))
 
     async function load({ silent = false } = {}) {
       if (inFlight || cancelled) return
       inFlight = true
+      const controller = new AbortController()
+      let timeoutId
+      const deadline = new Promise((_, reject) => {
+        cancelLoad = () => {
+          reject(new DOMException('Usage poll cancelled', 'AbortError'))
+          controller.abort()
+        }
+        timeoutId = window.setTimeout(() => {
+          reject(new Error('Usage request timed out'))
+          controller.abort()
+        }, USAGE_POLL_TIMEOUT_MS)
+      })
       if (!silent) setLoading(true)
       if (!silent) setError(null)
       try {
-        const [currentRes, previousRes, readinessRes] = await Promise.all([
-          fetch(`/api/usage/report?start=${range.start}&end=${range.end}`, {signal:controller.signal}),
-          fetch(`/api/usage/report?start=${prevRange.start}&end=${prevRange.end}`, {signal:controller.signal}),
-          fetch('/api/usage/readiness', {signal:controller.signal}),
-        ])
-        if (!currentRes.ok) throw new Error(`Usage API returned HTTP ${currentRes.status}`)
-        const current = await currentRes.json()
-        const previous = previousRes.ok ? await previousRes.json() : null
-        const usageReadiness = readinessRes.ok ? await readinessRes.json() : {
-          ...EMPTY_READINESS,
-          status: 'unavailable',
-          detail: `Usage readiness API returned HTTP ${readinessRes.status}`,
-        }
+        // Include response bodies in the deadline; only the winning poll
+        // may publish state or append history.
+        const pending = (async () => {
+          const [currentRes, previousRes, readinessRes] = await Promise.all([
+            fetch(`/api/usage/report?start=${range.start}&end=${range.end}`, {signal:controller.signal}),
+            fetch(`/api/usage/report?start=${prevRange.start}&end=${prevRange.end}`, {signal:controller.signal}),
+            fetch('/api/usage/readiness', {signal:controller.signal}),
+          ])
+          if (!currentRes.ok) throw new Error(`Usage API returned HTTP ${currentRes.status}`)
+          const current = await currentRes.json()
+          const previous = previousRes.ok ? await previousRes.json() : null
+          const usageReadiness = readinessRes.ok ? await readinessRes.json() : {
+            ...EMPTY_READINESS,
+            status: 'unavailable',
+            detail: `Usage readiness API returned HTTP ${readinessRes.status}`,
+          }
+          return {current, previous, usageReadiness}
+        })()
+        const {current, previous, usageReadiness} = await Promise.race([pending, deadline])
         if (!cancelled) {
           setError(null)
           setReport({
@@ -200,6 +219,9 @@ function useUsageReport(range, reloadToken = 0) {
           setPreviousReport(null)
         }
       } finally {
+        window.clearTimeout(timeoutId)
+        controller.abort()
+        cancelLoad = null
         inFlight = false
         if (!cancelled) setLoading(false)
       }
@@ -213,7 +235,7 @@ function useUsageReport(range, reloadToken = 0) {
     document.addEventListener('visibilitychange', onVisibility)
     return () => {
       cancelled = true
-      controller.abort()
+      cancelLoad?.()
       window.clearInterval(intervalId)
       document.removeEventListener('visibilitychange', onVisibility)
     }

--- a/ods/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Usage.jsx
@@ -166,7 +166,7 @@ function useUsageReport(range, reloadToken = 0) {
       let timeoutId
       const deadline = new Promise((_, reject) => {
         cancelLoad = () => {
-          reject(new DOMException('Usage poll cancelled', 'AbortError'))
+          reject(new globalThis.DOMException('Usage poll cancelled', 'AbortError'))
           controller.abort()
         }
         timeoutId = window.setTimeout(() => {

--- a/ods/extensions/services/dashboard/src/pages/UsagePolling.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/UsagePolling.test.jsx
@@ -1,0 +1,74 @@
+import {act, cleanup, screen} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import Usage from './Usage'
+
+const report = count => ({
+  period:{start:'2026-09-01',end:'2026-09-30'},
+  source:{status:'ok'},summary:{total_tokens:count},daily:[],models:[],services:[],
+})
+const response = data => ({ok:true,json:async () => data})
+const settle = async () => {await act(async () => {})}
+
+beforeEach(() => {
+  vi.useFakeTimers({toFake:['Date','setTimeout','clearTimeout','setInterval','clearInterval']})
+  vi.setSystemTime(new Date('2026-09-12T12:00:00Z'))
+  localStorage.clear()
+})
+afterEach(() => {cleanup();vi.useRealTimers();vi.unstubAllGlobals()})
+
+it.each(['report headers','report body','readiness body'])(
+  'recovers after stalled %s without accepting its late result',
+  async phase => {
+    let resolveOld
+    const pending = new Promise(resolve => {resolveOld = resolve})
+    const signals = []
+    let calls = 0
+    vi.stubGlobal('fetch', vi.fn((url, options) => {
+      const call = calls++
+      signals.push(options.signal)
+      const readiness = String(url).includes('/readiness')
+      if (call < 3) {
+        if (phase === 'report headers' && call === 0) return pending
+        if ((phase === 'report body' && call === 0) || (phase === 'readiness body' && readiness)) {
+          return Promise.resolve({ok:true,json:() => pending})
+        }
+      }
+      return Promise.resolve(response(readiness ? {status:'ready'} : report(call < 3 ? 900 : 123)))
+    }))
+    const mounted = render(<Usage/>)
+    await settle()
+    expect(screen.getByRole('button',{name:'Refresh usage'})).toBeDisabled()
+    await act(async () => {await vi.advanceTimersByTimeAsync(15000)})
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not load usage')
+    expect(screen.getByRole('button',{name:'Refresh usage'})).toBeEnabled()
+    expect(signals.slice(0,3).every(signal => signal.aborted)).toBe(true)
+    await act(async () => {await vi.advanceTimersByTimeAsync(5000)})
+    expect(screen.getByText('Recorded activity · refreshes every 10s')).toBeVisible()
+    expect(screen.getByText('123')).toBeVisible()
+    expect(calls).toBe(6)
+    await act(async () => {
+      resolveOld(phase === 'report headers' ? response(report(900)) : phase === 'readiness body' ? {status:'ready'} : report(900))
+    })
+    expect(screen.getByText('123')).toBeVisible()
+    expect(screen.queryByText('900')).not.toBeInTheDocument()
+    mounted.unmount()
+    await act(async () => {await vi.advanceTimersByTimeAsync(60000)})
+    expect(calls).toBe(6)
+    expect(vi.getTimerCount()).toBe(0)
+  },
+)
+
+it('aborts an unfinished poll and removes its deadline when unmounted', async () => {
+  const signals = []
+  vi.stubGlobal('fetch', vi.fn((_url, options) => {
+    signals.push(options.signal)
+    return new Promise(() => {})
+  }))
+  const mounted = render(<Usage/>)
+  await settle()
+  mounted.unmount()
+  await act(async () => {await vi.advanceTimersByTimeAsync(0)})
+  expect(signals).toHaveLength(3)
+  expect(signals.every(signal => signal.aborted)).toBe(true)
+  expect(vi.getTimerCount()).toBe(0)
+})


### PR DESCRIPTION
## Why this matters
A stalled Usage fetch or JSON body leaves inFlight true indefinitely. The page stays Updating, disables Refresh, and skips every subsequent polling tick.

Give each complete poll a 15-second deadline and its own abort controller. A timeout follows the existing visible error path and releases the next normal 10-second polling tick. Only the winning poll can publish state or append history; late responses cannot overwrite recovered data. Unmount/range changes cancel the poll and clear its deadline.

## Overlap check
Searched open/closed usage timeout/polling PRs and Usage.jsx changes. #3043 isolates auxiliary endpoint failures, #4349 corrects UTC month selection, and #3051 guards readiness actions. None gives a stalled poll a terminal deadline. #3043 touches the loading block and requires combined review.

## Validation
- Rendered Usage tests stall current-report headers, current-report JSON, and readiness JSON. Each checks visible timeout, aborted signals, successful next poll, ignored late result and no later fetch after unmount.
- These 3 recovery cases fail on public-beta. An additional unmount case verifies cancellation and timer cleanup.
- All 13 Usage/UsagePolling tests pass.
- Command: npx vitest run src/pages/UsagePolling.test.jsx src/pages/Usage.test.jsx
- git diff --check passes. Existing auxiliary failure policy, hidden-tab suppression and polling cadence are retained.
- Browser fixtures exercise response lifecycle; no live Token Spy deployment was tested. Revert this commit to remove the deadline.

## AI Assistance
Codex assisted with reproduction, lifecycle implementation and component regression validation.

## Batch verification
This head (983dfce69cdf) is included in the [15-PR integration commit](https://github.com/0xacee/ODS/commit/9372cebc1582fcaf026c847ab917322dfca793d5). All fifteen new heads merge without textual conflicts. Combined dashboard validation: 920 tests pass with two workers; lint has zero errors and the production build passes. Default unbounded local execution hit four existing DOM timing failures tracked by #4348.

With #3043/#4349: keep the complete-poll race around #3043 allSettled loading, propagate this poll signal to all three fetches, and retain UTC range handling. Adapt the older auxiliary-failure test to the current Models/Costs tabs. All 47 combined Usage tests pass. See the [backlog compatibility commit](https://github.com/0xacee/ODS/commit/d54033f841ba4a05e2c3a36040b1351bc0c7761a); its manual resolutions are integration evidence, not changes to those existing PR branches.

The follow-up commit explicitly references browser globals through globalThis to satisfy the repository ESLint configuration. Focused tests and lint were rerun; the current GitHub head checks pass.
