### PR TITLE
ci: enable clean public-beta verification

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - public-beta
 
 jobs:
   frontend:

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - public-beta
 
 jobs:
   powershell-lint:

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -2,9 +2,9 @@ name: Python Lint
 
 on:
   push:
-    branches: [main]
+    branches: [main, public-beta]
   pull_request:
-    branches: [main]
+    branches: [main, public-beta]
 
 permissions:
   contents: read

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -2,9 +2,9 @@ name: ShellCheck
 
 on:
   push:
-    branches: [main]
+    branches: [main, public-beta]
   pull_request:
-    branches: [main]
+    branches: [main, public-beta]
 
 permissions:
   contents: read

--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - public-beta
 
 permissions:
   contents: read

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -2,9 +2,9 @@ name: Secret Scan
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, public-beta]
   push:
-    branches: [main]
+    branches: [main, public-beta]
 
 permissions:
   contents: read

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - public-beta
 
 jobs:
   pixel-advice-host-stdlib:

--- a/.github/workflows/type-check-python.yml
+++ b/.github/workflows/type-check-python.yml
@@ -2,12 +2,12 @@ name: Python Type Check
 
 on:
   push:
-    branches: [main]
+    branches: [main, public-beta]
     paths:
       - "ods/**/*.py"
       - ".github/workflows/type-check-python.yml"
   pull_request:
-    branches: [main]
+    branches: [main, public-beta]
     paths:
       - "ods/**/*.py"
       - ".github/workflows/type-check-python.yml"

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -2,13 +2,13 @@ name: Validate Extensions Catalog
 
 on:
   push:
-    branches: [main]
+    branches: [main, public-beta]
     paths:
       - 'ods/extensions/library/services/*/manifest.yaml'
       - 'ods/scripts/generate-extensions-catalog.py'
       - 'ods/config/extensions-catalog.json'
   pull_request:
-    branches: [main]
+    branches: [main, public-beta]
     paths:
       - 'ods/extensions/library/services/*/manifest.yaml'
       - 'ods/scripts/generate-extensions-catalog.py'

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -2,7 +2,7 @@ name: Validate Docker Compose
 
 on:
   push:
-    branches: [main]
+    branches: [main, public-beta]
     paths:
       - "ods/docker-compose*.yml"
       - "ods/installers/**/*compose*.yml"
@@ -10,7 +10,7 @@ on:
       - "ods/scripts/resolve-compose-stack.sh"
       - ".github/workflows/validate-compose.yml"
   pull_request:
-    branches: [main]
+    branches: [main, public-beta]
     paths:
       - "ods/docker-compose*.yml"
       - "ods/installers/**/*compose*.yml"

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - main
       - master
+      - public-beta
 
 jobs:
   env-schema:

--- a/ods/bin/pixel_provider/advice_python.py
+++ b/ods/bin/pixel_provider/advice_python.py
@@ -21,7 +21,8 @@ def candidates():
     paths=[Path(sys.executable)]
     for prefix in ('/usr/bin','/usr/local/bin','/opt/homebrew/bin'):
         paths.extend(Path(prefix)/('python'+version) for version in ('3.14','3.13','3.12','3.11'))
-    result=[]; seen=set()
+    result=[]
+    seen=set()
     for path in paths:
         try:
             binary=path.resolve(strict=True)

--- a/ods/bin/pixel_provider/advice_setup.py
+++ b/ods/bin/pixel_provider/advice_setup.py
@@ -88,7 +88,8 @@ class SetupJobs:
 
     def start(self,body):
         import fcntl
-        body=validate_start(body); path=self._job(body['requestId'])
+        body=validate_start(body)
+        path=self._job(body['requestId'])
         fingerprint=hashlib.sha256(_json(body)).hexdigest()
         with self.mutex,ProviderStore(self.providers)._locked(False):
             self.root.mkdir(mode=0o700,exist_ok=True)
@@ -167,9 +168,11 @@ class SetupJobs:
                 elif cancelled():
                     result=dict(status='cancelled',error=None)
                 with ProviderStore(path)._locked(True):
-                    _write_private(path/'result.json',_json(result)); _sync_dir(path)
+                    _write_private(path/'result.json',_json(result))
+                    _sync_dir(path)
             finally:
-                os.close(running); os.close(slot)
+                os.close(running)
+                os.close(slot)
 
     def cancel(self,job_id):
         path=self._job(job_id)
@@ -177,7 +180,8 @@ class SetupJobs:
             with ProviderStore(path)._locked(True):
                 if not (path/'result.json').exists():
                     try:
-                        _write_private(path/'cancel.json',_json({'cancel':True})); _sync_dir(path)
+                        _write_private(path/'cancel.json',_json({'cancel':True}))
+                        _sync_dir(path)
                     except FileExistsError:
                         pass
         return self.status(job_id)

--- a/ods/bin/pixel_provider/advice_setup_worker.py
+++ b/ods/bin/pixel_provider/advice_setup_worker.py
@@ -41,7 +41,8 @@ def main():
         # Close output descriptors so it cannot prevent normal result EOF.
         group=os.getpgrp()
         if os.fork()==0:
-            os.close(1); os.close(2)
+            os.close(1)
+            os.close(2)
             try:
                 os.read(0,1)
             finally:

--- a/ods/bin/pixel_provider/handoff_approvals.py
+++ b/ods/bin/pixel_provider/handoff_approvals.py
@@ -24,7 +24,8 @@ def decode_large(raw,limit=FRAME_LIMIT):
     if type(raw) is not bytes or not raw or len(raw)>limit:
         raise StoreError('invalid-handoff-document')
     try:
-        text=raw.decode('utf-8'); _check_depth(text)
+        text=raw.decode('utf-8')
+        _check_depth(text)
         return json.loads(text,object_pairs_hook=_pairs,parse_float=_float,parse_constant=_constant)
     except (ValueError,RecursionError):
         raise StoreError('invalid-handoff-document') from None
@@ -146,7 +147,9 @@ class HandoffApprovals:
         import fcntl
         lock=ProviderStore(path)._open_file(fd,'running.lock')
         try:
-            try: fcntl.flock(lock,fcntl.LOCK_EX|fcntl.LOCK_NB); return False
+            try:
+                fcntl.flock(lock,fcntl.LOCK_EX|fcntl.LOCK_NB)
+                return False
             except BlockingIOError: return True
         finally: os.close(lock)
 
@@ -194,10 +197,13 @@ class HandoffApprovals:
                     for entry in entries:
                         if RUN_ID.fullmatch(entry.name): names.append(entry.name)
                         if len(names)>4096: raise StoreError('handoff-history-limit')
-        items=[]; unavailable=0
+        items=[]
+        unavailable=0
         for name in names:
             try: result=self.status(name)
-            except (StoreError,OSError): unavailable+=1; continue
+            except (StoreError,OSError):
+                unavailable+=1
+                continue
             if result['status']=='pending': items.append(result)
         return {'items':sorted(items,key=lambda row:row['expiresAt']),'unavailableCount':unavailable}
 
@@ -214,13 +220,15 @@ class HandoffApprovals:
         path=self._path(body.get('runId'))
         with ProviderStore(self.providers)._locked(False),ProviderStore(self.root)._locked(False):
             with ProviderStore(path)._locked(True) as fd:
-                claim,_=self._read(path,fd); self._validate_decision(body,claim)
+                claim,_=self._read(path,fd)
+                self._validate_decision(body,claim)
                 previous=self._optional(path,fd,'decision.json')
                 if previous is not None:
                     if previous!=body: raise StoreError('handoff-decision-conflict')
                 else:
                     if self._state(path,fd,claim)!='pending': raise StoreError('handoff-no-longer-pending')
-                    _write_private(path/'decision.json',_json(body)); os.fsync(fd)
+                    _write_private(path/'decision.json',_json(body))
+                    os.fsync(fd)
         return self.status(body['runId'],checkpoint=True)
 
     def publish(self,checkpoint_json,digest,timeout_seconds):
@@ -233,7 +241,9 @@ class PendingHandoff:
             raise StoreError('invalid-handoff-publication')
         self.raw=checkpoint_json.encode('utf-8')
         checkpoint=validate_checkpoint(self.raw,digest)
-        self.manager=manager; self.path=manager._path(checkpoint['runId']); self.lock=None
+        self.manager=manager
+        self.path=manager._path(checkpoint['runId'])
+        self.lock=None
         self.claim={'runId':checkpoint['runId'],'checkpointDigest':digest,'checkpointBytes':len(self.raw),
                     'recipient':checkpoint['recipient'],'expiresAt':int(manager.clock())+timeout_seconds}
 
@@ -249,15 +259,19 @@ class PendingHandoff:
                     if self.path.exists() or self.path.is_symlink(): raise StoreError('handoff-run-replayed')
                     if sum(1 for item in manager.root.iterdir() if RUN_ID.fullmatch(item.name))>=4096:
                         raise StoreError('handoff-history-limit')
-                    self.path.mkdir(mode=0o700); os.fsync(root_fd)
+                    self.path.mkdir(mode=0o700)
+                    os.fsync(root_fd)
                     with ProviderStore(self.path)._locked(True) as fd:
                         self.lock=ProviderStore(self.path)._open_file(fd,'running.lock',create=True)
                         fcntl.flock(self.lock,fcntl.LOCK_EX|fcntl.LOCK_NB)
                         _write_private(self.path/'checkpoint.json',self.raw)
-                        _write_private(self.path/'claim.json',_json(self.claim)); os.fsync(fd)
+                        _write_private(self.path/'claim.json',_json(self.claim))
+                        os.fsync(fd)
             return self
         except BaseException:
-            if self.lock is not None: os.close(self.lock); self.lock=None
+            if self.lock is not None:
+                os.close(self.lock)
+                self.lock=None
             raise
 
     def receipt(self):
@@ -285,10 +299,13 @@ class PendingHandoff:
                 decision=self.manager._optional(self.path,fd,'decision.json')
                 self.manager._validate_decision(decision,claim)
                 if decision['approved']!=(status=='approved'): raise StoreError('invalid-handoff-result')
-            _write_private(self.path/'result.json',_json({'status':status})); os.fsync(fd)
+            _write_private(self.path/'result.json',_json({'status':status}))
+            os.fsync(fd)
 
     def __exit__(self,*_args):
-        if self.lock is not None: os.close(self.lock); self.lock=None
+        if self.lock is not None:
+            os.close(self.lock)
+            self.lock=None
 
 
 def get_manager(data_dir):

--- a/ods/bin/pixel_provider/handoff_worker.py
+++ b/ods/bin/pixel_provider/handoff_worker.py
@@ -38,14 +38,17 @@ def main():
         return 2
     import resource
     resource.setrlimit(resource.RLIMIT_CORE,(0,0))
-    stopped=threading.Event(); done=threading.Event(); armed=threading.Event()
+    stopped=threading.Event()
+    done=threading.Event()
+    armed=threading.Event()
     signal.signal(signal.SIGTERM,lambda *_:stopped.set())
     signal.signal(signal.SIGINT,lambda *_:stopped.set())
     def watch():
         if not armed.wait(10): os._exit(125)
         while not done.is_set() and not stopped.is_set():
             if select.select([0],[],[],.05)[0]:
-                os.read(0,1); stopped.set()
+                os.read(0,1)
+                stopped.set()
         if stopped.is_set() and not done.wait(2): os._exit(125)
     threading.Thread(target=watch,daemon=True,name='handoff-parent-watch').start()
     try:
@@ -53,14 +56,16 @@ def main():
         manager=HandoffApprovals(sys.argv[2])
         publication=manager.publish(value['checkpointJson'],value['checkpointDigest'],value['timeoutSeconds'])
         if select.select([0],[],[],0)[0]: raise StoreError('handoff-parent-disconnected')
-        armed.set(); deadline=time.monotonic()+value['timeoutSeconds']
+        armed.set()
+        deadline=time.monotonic()+value['timeoutSeconds']
         with publication:
             while not stopped.is_set() and time.monotonic()<deadline:
                 receipt=publication.receipt()
                 if receipt is not None:
                     if stopped.is_set(): break
                     raw=json.dumps(receipt,separators=(',',':')).encode()
-                    sys.stdout.buffer.write(struct.pack('!I',len(raw))+raw); sys.stdout.buffer.flush()
+                    sys.stdout.buffer.write(struct.pack('!I',len(raw))+raw)
+                    sys.stdout.buffer.flush()
                     publication.finish('approved' if receipt['approved'] else 'declined')
                     return 0
                 stopped.wait(.05)
@@ -70,7 +75,8 @@ def main():
         sys.stderr.write('handoff-worker-unavailable\n')
         return 1
     finally:
-        done.set(); armed.set()
+        done.set()
+        armed.set()
 
 
 if __name__=='__main__':

--- a/ods/bin/pixel_provider/route_worker.py
+++ b/ods/bin/pixel_provider/route_worker.py
@@ -73,7 +73,9 @@ def main():
         while not done.is_set() and not stopped.is_set():
             remaining = deadline-time.monotonic()
             if remaining<=0:
-                reason[0]='deadline'; stopped.set(); break
+                reason[0]='deadline'
+                stopped.set()
+                break
             try:
                 if select.select([0],[],[],min(.05,remaining))[0]:
                     extra = os.read(0,1)
@@ -95,7 +97,8 @@ def main():
         claim = LeaseClaim(sys.argv[2],value['runId'],value['sessionId'],value['expectedRevision'])
         if select.select([0],[],[],0)[0]:
             raise StoreError('provider-parent-disconnected')
-        duration[0]=value['timeoutSeconds']; armed.set()
+        duration[0]=value['timeoutSeconds']
+        armed.set()
         phase = 'snapshot'
         value = scoped_request(sys.argv[2], value)
         session = ProviderSession(sys.argv[2],expected_revision=value['expectedRevision'],
@@ -126,7 +129,8 @@ def main():
         sys.stderr.write('provider-lease-worker-failed:'+phase+'\n')
         return 1
     finally:
-        done.set(); armed.set()
+        done.set()
+        armed.set()
 
 
 if __name__=='__main__':

--- a/ods/bin/pixel_provider/runtime_gateway.py
+++ b/ods/bin/pixel_provider/runtime_gateway.py
@@ -210,7 +210,8 @@ def create_app(config,credentials,token,*,events=None,client_factory=None):
             attempts = 0
             for provider in candidates:
                 if cooldown.get(provider['id'],0)>time.monotonic():
-                    event(provider,'cooldown'); continue
+                    event(provider,'cooldown')
+                    continue
                 attempts += 1
                 event(provider,'attempt',attempt=attempts)
                 try:
@@ -230,8 +231,10 @@ def create_app(config,credentials,token,*,events=None,client_factory=None):
                     if upstream.status_code in TRANSIENT:
                         event(provider,'transient-failure',upstreamStatus=upstream.status_code)
                         cooldown[provider['id']] = time.monotonic()+30
-                        await upstream.aclose(); upstream = None
-                        await client.aclose(); client = None
+                        await upstream.aclose()
+                        upstream = None
+                        await client.aclose()
+                        client = None
                         await guarded(asyncio.sleep(min(.1*attempts,1)))
                         continue
                     if upstream.status_code != 200:
@@ -306,9 +309,11 @@ def create_app(config,credentials,token,*,events=None,client_factory=None):
                     event(provider,'transient-transport-failure')
                     cooldown[provider['id']] = time.monotonic()+30
                     if upstream:
-                        await upstream.aclose(); upstream = None
+                        await upstream.aclose()
+                        upstream = None
                     if client:
-                        await client.aclose(); client = None
+                        await client.aclose()
+                        client = None
                     await guarded(asyncio.sleep(min(.1*attempts,1)))
                     continue
             raise RuntimeErrorCode('provider-attempts-exhausted')

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1201,14 +1201,14 @@ def dict_key_path_setter_safe(d: dict, path_keys: list, value: any) -> dict:
     if (not isinstance(path_keys, (list, tuple)) or not 1 <= len(path_keys) <= 128
             or any(type(key) not in (str, int) for key in path_keys)):
         return d
-    
+
     current = d
     for key in path_keys[:-1]:
         k_str = key
         if k_str not in current or not isinstance(current[k_str], dict):
             current[k_str] = {}
         current = current[k_str]
-    
+
     final_key = path_keys[-1]
     current[final_key] = value
     return d
@@ -1256,7 +1256,7 @@ def list_deduplicate_by_key_safe(items: list, key_or_attr: any) -> list:
         return []
     if key_or_attr is None or not isinstance(key_or_attr, (str, int)):
         return list(items)
-    
+
     seen = set()
     structured = []
     missing = object()
@@ -1287,7 +1287,7 @@ def list_deduplicate_by_key_safe(items: list, key_or_attr: any) -> list:
                 structured.append(val)
                 result.append(item)
             continue
-        
+
         if key_val not in seen:
             seen.add(key_val)
             result.append(item)
@@ -1321,9 +1321,9 @@ def dict_flatten_nested_safe(d: dict, separator: str = '.', max_depth: int = 10)
     if type(max_depth) is not int or max_depth < 1:
         max_depth = 10
     max_depth = min(max_depth, 128)
-    
+
     result = {}
-    
+
     # Iterative traversal avoids Python recursion limits. Cycles and depth
     # boundaries remain leaf values, just like other unflattened dictionaries.
     pending = [(d, '', 0, frozenset({id(d)}))]
@@ -1336,7 +1336,7 @@ def dict_flatten_nested_safe(d: dict, separator: str = '.', max_depth: int = 10)
                 pending.append((v, new_key, depth + 1, ancestors | {id(v)}))
             else:
                 result[new_key] = v
-    
+
     return result
 
 
@@ -1352,7 +1352,7 @@ def numeric_exponential_moving_average_safe(values: list, alpha: float = 0.2) ->
         alpha = 0.2
     if alpha <= 0 or alpha > 1:
         alpha = 0.2
-    
+
     valid_vals = []
     for v in values:
         if isinstance(v, (int, float)) and not isinstance(v, bool):
@@ -1364,7 +1364,7 @@ def numeric_exponential_moving_average_safe(values: list, alpha: float = 0.2) ->
                 valid_vals.append(number)
     if not valid_vals:
         return []
-    
+
     ema = []
     current = valid_vals[0]
     ema.append(current)

--- a/ods/extensions/services/dashboard-api/routers/pixel_advice.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_advice.py
@@ -59,7 +59,8 @@ async def body_for(request,action):
             raise HTTPException(413,'Advisory request exceeds size limit')
         raw.extend(chunk)
     try:
-        text=bytes(raw).decode('utf-8'); _check_depth(text)
+        text=bytes(raw).decode('utf-8')
+        _check_depth(text)
         body=json.loads(text,object_pairs_hook=_pairs,parse_float=_float,parse_constant=_constant)
         if not isinstance(body,dict) or set(body) != (FIELDS if action == 'start' else {'jobId'}):
             raise ValueError()

--- a/ods/extensions/services/dashboard-api/routers/pixel_advice_runtime.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_advice_runtime.py
@@ -66,7 +66,8 @@ async def request_body(request,action):
             raise HTTPException(413,'Setup request exceeds size limit')
         raw.extend(part)
     try:
-        text=bytes(raw).decode(); _check_depth(text)
+        text=bytes(raw).decode()
+        _check_depth(text)
         value=json.loads(text,object_pairs_hook=_pairs,parse_float=_float,parse_constant=_constant)
         if not isinstance(value,dict) or set(value)!=(FIELDS if action=='prepare' else {'jobId'}):
             raise ValueError()

--- a/ods/extensions/services/dashboard-api/routers/pixel_settings.py
+++ b/ods/extensions/services/dashboard-api/routers/pixel_settings.py
@@ -104,11 +104,11 @@ async def export_workspace_snapshot(_key: str = Depends(verify_api_key)):
     try:
         settings_raw = await request_agent_json("GET", "/v1/pixel/settings", timeout=10)
         settings = normalize_response(settings_raw)
-        
+
         providers_raw = await request_agent_json("GET", "/v1/pixel/providers", timeout=10)
         from pixel_provider_public import normalize_public
         providers = normalize_public(providers_raw)
-        
+
         content = {
             "schemaVersion": 1,
             "type": "ods-workspace-snapshot",

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_advice.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_advice.py
@@ -1,4 +1,3 @@
-import copy
 import hashlib
 import uuid
 from unittest.mock import AsyncMock,patch
@@ -30,7 +29,8 @@ def result():
 def client(monkeypatch):
     import security
     monkeypatch.setattr(security,'DASHBOARD_API_KEY','test-key-12345')
-    app=FastAPI(); app.include_router(api.router)
+    app=FastAPI()
+    app.include_router(api.router)
     with TestClient(app) as client:
         yield client
 
@@ -80,7 +80,8 @@ def test_bad_response_is_rejected_without_leak(client,host,change):
 
 @pytest.mark.parametrize('trusted',[None,0,'',True])
 def test_only_explicit_untrusted_false_is_accepted(client,host,trusted):
-    host.return_value=result(); host.return_value['result']['trusted']=trusted
+    host.return_value=result()
+    host.return_value['result']['trusted']=trusted
     assert client.post('/api/pixel/advice/start',headers=KEY,json=body()).status_code==502
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_advice_runtime.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_advice_runtime.py
@@ -20,16 +20,19 @@ def job():
 def client(monkeypatch):
     import security
     monkeypatch.setattr(security,'DASHBOARD_API_KEY','test-key-12345')
-    app=FastAPI(); app.include_router(api.router)
+    app=FastAPI()
+    app.include_router(api.router)
     with TestClient(app) as client: yield client
 
 @pytest.fixture
 def host():
     with patch.object(api,'request_agent_json',new_callable=AsyncMock) as mock:
-        mock.return_value=state(); yield mock
+        mock.return_value=state()
+        yield mock
 
 def test_auth_before_host_and_no_cache(client,host):
-    assert client.get('/api/pixel/advice-runtime').status_code==401; host.assert_not_called()
+    assert client.get('/api/pixel/advice-runtime').status_code==401
+    host.assert_not_called()
     result=client.get('/api/pixel/advice-runtime',headers=KEY)
     assert result.status_code==200 and result.json()==state() and result.headers['cache-control']=='no-store'
 

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_connection_import.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_connection_import.py
@@ -65,7 +65,8 @@ def test_one_request_no_save_no_key_response_preserves_tools_false(owner):
     lambda body: body.update(bundle='x' * 32769), lambda body: body.update(confirmedEndpoint=[]),
 ])
 def test_bad_requests_do_not_reach_host(owner, change):
-    body, _ = fixture(); change(body)
+    body, _ = fixture()
+    change(body)
     response = post(owner, json=body)
     assert response.status_code == 400 and KEY not in response.text
     owner[1].assert_not_called()
@@ -85,7 +86,9 @@ def test_body_cap_before_host(owner):
     lambda value: value['metadata'].update(maxOutputTokens=True),
 ])
 def test_bad_host_results_are_not_forwarded(owner, change):
-    body, value = fixture(); value = deepcopy(value); change(value)
+    body, value = fixture()
+    value = deepcopy(value)
+    change(value)
     owner[1].return_value = value
     response = post(owner, json=body)
     assert response.status_code == 502 and KEY not in response.text

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_handoff.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_handoff.py
@@ -32,7 +32,8 @@ def decision():
 def client(monkeypatch):
     import security
     monkeypatch.setattr(security,'DASHBOARD_API_KEY','test-key-12345')
-    app=FastAPI(); app.include_router(api.router)
+    app=FastAPI()
+    app.include_router(api.router)
     with TestClient(app) as client: yield client
 
 
@@ -63,7 +64,8 @@ def test_decision_exact_once(client,host):
 
 
 def test_list_never_contains_checkpoint(client,host):
-    metadata=result(); metadata.pop('checkpointJson')
+    metadata=result()
+    metadata.pop('checkpointJson')
     host.return_value=dict(items=[metadata],unavailableCount=0)
     assert client.post('/api/pixel/handoff/list',headers=KEY,json={}).json()==host.return_value
     host.return_value=dict(items=[result()],unavailableCount=0)

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_inference_readiness.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_inference_readiness.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import patch
 
 import pytest
-from test_pixel import FakeClient, FakeResponse, pixel, pixel_env
+from test_pixel import FakeClient, FakeResponse, pixel, pixel_env as pixel_env
 
 
 @pytest.fixture(autouse=True)

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_providers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_providers.py
@@ -1,4 +1,4 @@
-from host_agent_client import AgentUnavailable, AgentHTTPError, AgentProtocolError
+from host_agent_client import AgentUnavailable
 import copy
 import json
 from unittest.mock import AsyncMock, patch

--- a/ods/extensions/services/dashboard-api/tests/test_pixel_scopes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_pixel_scopes.py
@@ -20,7 +20,8 @@ def result():
 def client(monkeypatch):
     import security
     monkeypatch.setattr(security, 'DASHBOARD_API_KEY', 'test-key-12345')
-    app = FastAPI(); app.include_router(api.router)
+    app = FastAPI()
+    app.include_router(api.router)
     with TestClient(app) as client: yield client
 
 
@@ -53,7 +54,8 @@ def test_invalid_host_projection_rejected(client, host, field, value):
 
 
 def test_preserves_exact_case_and_task_identity(client, host):
-    task = str(uuid.uuid4()); host.return_value.update(taskId=task, revision=1)
+    task = str(uuid.uuid4())
+    host.return_value.update(taskId=task, revision=1)
     body = dict(chatId='Chat_A', taskId=task, expectedRevision=0)
     assert client.post('/api/pixel/provider-scopes/begin', json=body, headers=KEY).status_code == 200
     assert host.call_args.kwargs['payload'] == body

--- a/ods/extensions/services/model-router/tests/test_client_cancellation.py
+++ b/ods/extensions/services/model-router/tests/test_client_cancellation.py
@@ -5,7 +5,7 @@ import time
 
 import httpx
 import pytest
-from test_router import router  # noqa: F401
+from test_router import router as router
 
 
 @pytest.mark.parametrize('phase', ['admission','route-queue','headers','json-body','stream-body'])

--- a/ods/extensions/services/model-router/tests/test_shared_route_pinning.py
+++ b/ods/extensions/services/model-router/tests/test_shared_route_pinning.py
@@ -4,7 +4,7 @@ import time
 
 import httpx
 import pytest
-from test_router import router  # noqa: F401
+from test_router import router as router
 
 
 def _make_pins(catalog=None, model=None, route=None):

--- a/ods/extensions/services/model-router/tests/test_state_publication_fixture.py
+++ b/ods/extensions/services/model-router/tests/test_state_publication_fixture.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from test_router import router  # noqa: F401
+from test_router import router as router
 
 
 def test_requests_keep_the_previous_route_while_fixture_writes_replacement(router, monkeypatch):

--- a/ods/extensions/services/pixel-agent/tests/fixtures/handoff-owner-api.py
+++ b/ods/extensions/services/pixel-agent/tests/fixtures/handoff-owner-api.py
@@ -75,7 +75,9 @@ if args.dashboard:
     def page(path):
         return FileResponse(dashboard/'index.html',headers={'Cache-Control':'no-store'})
 
-sock=socket.socket(); sock.bind(('127.0.0.1',0)); sock.listen(64)
+sock=socket.socket()
+sock.bind(('127.0.0.1',0))
+sock.listen(64)
 ready=Path(args.ready)
 fd=os.open(ready,os.O_WRONLY|os.O_CREAT|os.O_EXCL,0o600)
 with os.fdopen(fd,'w') as stream:

--- a/ods/tests/pixel_inference/test_activation_config.py
+++ b/ods/tests/pixel_inference/test_activation_config.py
@@ -75,7 +75,8 @@ def test_restore_preserves_unrelated_changes_and_new_parent_contents(config):
 
 @pytest.mark.parametrize('leaf', ['model', 'provider', 'binding'])
 def test_restore_refuses_drift_without_echoing_config(config, leaf):
-    plan = make(config); current = copy.deepcopy(plan['document'])
+    plan = make(config)
+    current = copy.deepcopy(plan['document'])
     if leaf == 'model': current['agents']['list'][0]['model'] = 'never-echo-secret'
     elif leaf == 'provider': current['models']['providers']['ods-policy']['apiKey'] = 'never-echo-secret'
     else: current['plugins']['entries']['pixel-ods']['config']['managedProvider']['revision'] += 1
@@ -114,7 +115,8 @@ def test_collision_and_unqualified_config_refused(config, kind):
 def test_restore_rejects_malformed_private_plan(config):
     plan = make(config)
     for key, value in [('schemaVersion', True), ('fields', {}), ('parents', {'bad': True})]:
-        bad = copy.deepcopy(plan); bad[key] = value
+        bad = copy.deepcopy(plan)
+        bad[key] = value
         with pytest.raises(StoreError): restore_activation(plan['document'], bad)
 
 
@@ -185,7 +187,8 @@ def test_preexisting_empty_parents_are_preserved(config, parent):
                                   'parent-order', 'present-provider', 'wrong-after', 'binding-version',
                                   'preview-drift', 'extra-plan-key'])
 def test_private_plan_schema_and_fixed_projection_are_validated(config, tamper):
-    plan = make(config); current = copy.deepcopy(plan['document'])
+    plan = make(config)
+    current = copy.deepcopy(plan['document'])
     if tamper == 'unknown-field': plan['fields']['arbitrary.path'] = plan['fields']['model']
     elif tamper == 'missing-field': del plan['fields']['model']
     elif tamper == 'false-presence': plan['fields']['model']['present'] = False
@@ -213,7 +216,8 @@ def test_result_has_no_mutable_aliases_to_config_plan_or_module_constants(config
 
 @pytest.mark.parametrize('kind', ['agents', 'missing-agent', 'duplicate-agent', 'models', 'plugin'])
 def test_restore_rejects_structural_corruption_before_mutation(config, kind):
-    plan = make(config); current = copy.deepcopy(plan['document'])
+    plan = make(config)
+    current = copy.deepcopy(plan['document'])
     if kind == 'agents': current['agents'] = None
     elif kind == 'missing-agent': current['agents']['list'] = [{'id': 'other'}]
     elif kind == 'duplicate-agent': current['agents']['list'].append({'id': 'pixel'})
@@ -267,7 +271,8 @@ def test_update_preserves_original_absence_and_unrelated_owner_edits(config, mis
 
 @pytest.mark.parametrize('revision', [True, 5.0, -1, 3, 4, 2**53])
 def test_update_requires_a_strictly_newer_valid_revision(config, revision):
-    plan = make(config); before = copy.deepcopy(plan)
+    plan = make(config)
+    before = copy.deepcopy(plan)
     with pytest.raises(StoreError): update(plan['document'], plan, revision=revision)
     assert plan == before
 
@@ -280,7 +285,8 @@ def test_update_refuses_reusing_activation_identity(config):
 
 @pytest.mark.parametrize('leaf', ['model', 'provider', 'binding'])
 def test_update_refuses_managed_drift_without_mutation(config, leaf):
-    plan = make(config); current = copy.deepcopy(plan['document'])
+    plan = make(config)
+    current = copy.deepcopy(plan['document'])
     if leaf == 'model': current['agents']['list'][0]['model'] = 'never-echo-secret'
     elif leaf == 'provider': current['models']['providers']['ods-policy']['apiKey'] = 'never-echo-secret'
     else: current['plugins']['entries']['pixel-ods']['config']['managedProvider']['revision'] = 99
@@ -291,7 +297,8 @@ def test_update_refuses_managed_drift_without_mutation(config, leaf):
 
 @pytest.mark.parametrize('kind', ['disabled', 'conversation-denied', 'global-tools', 'pixel-tools'])
 def test_update_rechecks_current_activation_eligibility(config, kind):
-    plan = make(config); current = copy.deepcopy(plan['document'])
+    plan = make(config)
+    current = copy.deepcopy(plan['document'])
     if kind == 'disabled': current['plugins']['entries']['pixel-ods']['enabled'] = False
     elif kind == 'conversation-denied': current['plugins']['entries']['pixel-ods']['hooks']['allowConversationAccess'] = False
     else:

--- a/ods/tests/pixel_inference/test_advice.py
+++ b/ods/tests/pixel_inference/test_advice.py
@@ -1,5 +1,4 @@
 import asyncio
-import copy
 import json
 import os
 from pathlib import Path
@@ -27,8 +26,11 @@ def request(**changes):
 
 @pytest.fixture
 def saved(tmp_path):
-    root = tmp_path/'providers'; root.mkdir(mode=0o700)
-    config = configuration(); config['revision']=0; config['roles']['advisor']='backup'
+    root = tmp_path/'providers'
+    root.mkdir(mode=0o700)
+    config = configuration()
+    config['revision']=0
+    config['roles']['advisor']='backup'
     result = CredentialStore(root).save_public(dict(expectedRevision=0,document=public_config(config),
         credentialChanges={'backup':dict(action='set',value='fixture-advisor-key')}))
     return root,result
@@ -45,7 +47,8 @@ def response(content='Check the assumption.',**message):
 
 def test_only_exact_capsule_and_instruction_reach_advisor(saved):
     root,original = saved
-    body = request(); call = AdvisoryCall(root,body)
+    body = request()
+    call = AdvisoryCall(root,body)
     requests = []
     def handler(req):
         requests.append(req)
@@ -83,7 +86,8 @@ def test_advisor_cannot_return_executable_tools(saved,message):
 
 def test_cloud_needs_both_transfer_and_unknown_cost_agreement(saved):
     root,config = saved
-    config['providers'][1]['kind']='cloud'; config['policy']['allowCloud']=True
+    config['providers'][1]['kind']='cloud'
+    config['policy']['allowCloud']=True
     CredentialStore(root).save_public(dict(expectedRevision=1,document=config,
         credentialChanges={'backup':dict(action='set',value='fictional-not-real-cloud-key')}))
     with pytest.raises(StoreError,match='cloud-transfer-confirmation-required'):
@@ -101,7 +105,8 @@ def test_revision_target_and_budget_are_bound(saved):
         with pytest.raises(StoreError,match=error):
             AdvisoryCall(saved[0],request(**changes))
     root,config = saved
-    config['providers'][1]['contextTokens']=1024; config['providers'][1]['maxOutputTokens']=512
+    config['providers'][1]['contextTokens']=1024
+    config['providers'][1]['maxOutputTokens']=512
     CredentialStore(root).save_public(dict(expectedRevision=1,document=config))
     with pytest.raises(StoreError,match='advice-context-limit'):
         AdvisoryCall(root,request(expectedRevision=2,capsule='a'*700))

--- a/ods/tests/pixel_inference/test_advice_http.py
+++ b/ods/tests/pixel_inference/test_advice_http.py
@@ -12,13 +12,14 @@ import threading
 
 import pytest
 
-from test_advice import saved,request
+from test_advice import saved as saved, request
 from pixel_provider.advice import AdvisoryCall
 from pixel_provider.vault import CredentialStore
 
 
 def test_cancel_closes_real_upstream_connection(saved):
-    entered=threading.Event(); disconnected=threading.Event()
+    entered=threading.Event()
+    disconnected=threading.Event()
     class Handler(BaseHTTPRequestHandler):
         def log_message(self,*args): pass
         def do_POST(self):
@@ -28,7 +29,8 @@ def test_cancel_closes_real_upstream_connection(saved):
             if readable and self.connection.recv(1,socket.MSG_PEEK)==b'':
                 disconnected.set()
     server=ThreadingHTTPServer(('127.0.0.1',0),Handler)
-    worker=threading.Thread(target=server.serve_forever,daemon=True); worker.start()
+    worker=threading.Thread(target=server.serve_forever,daemon=True)
+    worker.start()
     root,config=saved
     config['providers'][1]['baseUrl']=f'http://127.0.0.1:{server.server_port}/v1'
     CredentialStore(root).save_public(dict(expectedRevision=1,document=config,
@@ -39,4 +41,6 @@ def test_cancel_closes_real_upstream_connection(saved):
             asyncio.run(call.execute(cancelled=entered.is_set))
         assert entered.is_set() and disconnected.wait(1), 'Stop did not close the upstream TCP request'
     finally:
-        server.shutdown(); server.server_close(); worker.join(3)
+        server.shutdown()
+        server.server_close()
+        worker.join(3)

--- a/ods/tests/pixel_inference/test_advice_jobs.py
+++ b/ods/tests/pixel_inference/test_advice_jobs.py
@@ -1,11 +1,9 @@
 import asyncio
-import json
 import multiprocessing
 import os
 from pathlib import Path
 import sys
 import time
-import uuid
 
 import pytest
 
@@ -47,14 +45,16 @@ def wait(manager,job_id):
 
 @pytest.fixture
 def manager(tmp_path):
-    root=tmp_path/'providers'; root.mkdir(mode=0o700)
+    root=tmp_path/'providers'
+    root.mkdir(mode=0o700)
     FakeCall.calls=0
     return AdvisoryJobs(root,call_factory=FakeCall)
 
 
 def test_idempotent_start_and_conflict_and_no_capsule_on_disk(manager):
     body=request()
-    manager.start(body); manager.start(body)
+    manager.start(body)
+    manager.start(body)
     with pytest.raises(StoreError,match='advice-request-conflict'):
         manager.start(dict(body,capsule='different'))
     result=wait(manager,body['requestId'])
@@ -69,7 +69,8 @@ def test_idempotent_start_and_conflict_and_no_capsule_on_disk(manager):
 def test_two_global_slots_across_independent_managers_and_cancel(manager):
     other=AdvisoryJobs(manager.providers,call_factory=FakeCall)
     a,b,c=request(),request(),request()
-    manager.start(a); other.start(b)
+    manager.start(a)
+    other.start(b)
     with pytest.raises(StoreError,match='advice-busy'):
         AdvisoryJobs(manager.providers,call_factory=FakeCall).start(c)
     other.cancel(a['requestId'])
@@ -81,30 +82,35 @@ def test_two_global_slots_across_independent_managers_and_cancel(manager):
 
 
 def test_status_does_not_leak_descriptors(manager):
-    body=request(); manager.start(body)
+    body=request()
+    manager.start(body)
     initial=len(os.listdir('/proc/self/fd'))
     for _ in range(100):
         manager.status(body['requestId'])
     assert len(os.listdir('/proc/self/fd')) <= initial
-    manager.cancel(body['requestId']); wait(manager,body['requestId'])
+    manager.cancel(body['requestId'])
+    wait(manager,body['requestId'])
 
 
 def child_job(root,body,ready):
     jobs=AdvisoryJobs(root,call_factory=FakeCall)
-    jobs.start(body); ready.set()
+    jobs.start(body)
+    ready.set()
     time.sleep(30)
 
 
 def test_process_loss_is_interrupted_never_automatic_replay(manager):
     context=multiprocessing.get_context('fork')
-    ready=context.Event(); body=request()
+    ready=context.Event()
+    body=request()
     child=context.Process(target=child_job,args=(manager.providers,body,ready))
     child.start()
     try:
         assert ready.wait(3)
         assert manager.status(body['requestId'])['status']=='running'
     finally:
-        child.terminate(); child.join(3)
+        child.terminate()
+        child.join(3)
     assert not child.is_alive()
     assert manager.status(body['requestId'])['status']=='interrupted'
     assert manager.start(body)['status']=='interrupted'
@@ -113,7 +119,9 @@ def test_process_loss_is_interrupted_never_automatic_replay(manager):
 
 def test_symlink_job_and_public_directory_fail_closed(manager,tmp_path):
     manager.root.mkdir(mode=0o700)
-    body=request(); target=tmp_path/'outside'; target.mkdir(mode=0o700)
+    body=request()
+    target=tmp_path/'outside'
+    target.mkdir(mode=0o700)
     (manager.root/body['requestId']).symlink_to(target,target_is_directory=True)
     with pytest.raises(StoreError):
         manager.start(body)

--- a/ods/tests/pixel_inference/test_advice_process.py
+++ b/ods/tests/pixel_inference/test_advice_process.py
@@ -110,10 +110,12 @@ def test_no_ambient_secrets_and_request_not_in_argv(tmp_path,monkeypatch):
 
 def test_inherited_lock_survives_parent_descriptor_close(tmp_path):
     import fcntl
-    lock=tmp_path/'lock'; ready=tmp_path/'ready'
+    lock=tmp_path/'lock'
+    ready=tmp_path/'ready'
     fd=os.open(lock,os.O_CREAT|os.O_RDWR,0o600)
     fcntl.flock(fd,fcntl.LOCK_EX|fcntl.LOCK_NB)
-    stop=threading.Event(); errors=[]
+    stop=threading.Event()
+    errors=[]
     cmd=command(tmp_path,f"open({str(ready)!r},'w').write('ready')\ntime.sleep(20)\n")
     def run():
         try:
@@ -122,24 +124,28 @@ def test_inherited_lock_survives_parent_descriptor_close(tmp_path):
             pass
         except BaseException as error:
             errors.append(error)
-    thread=threading.Thread(target=run); thread.start()
+    thread=threading.Thread(target=run)
+    thread.start()
     try:
         deadline=time.monotonic()+3
         while not ready.exists() and time.monotonic()<deadline:
             time.sleep(.01)
         assert ready.exists()
-        os.close(fd); fd=None
+        os.close(fd)
+        fd=None
         probe=os.open(lock,os.O_RDWR)
         try:
             with pytest.raises(BlockingIOError):
                 fcntl.flock(probe,fcntl.LOCK_EX|fcntl.LOCK_NB)
-            stop.set(); thread.join(3)
+            stop.set()
+            thread.join(3)
             assert not thread.is_alive() and not errors
             fcntl.flock(probe,fcntl.LOCK_EX|fcntl.LOCK_NB)
         finally:
             os.close(probe)
     finally:
-        stop.set(); thread.join(3)
+        stop.set()
+        thread.join(3)
         if fd is not None:
             os.close(fd)
 

--- a/ods/tests/pixel_inference/test_advice_runtime.py
+++ b/ods/tests/pixel_inference/test_advice_runtime.py
@@ -10,14 +10,15 @@ sys.path.insert(0,str(Path(__file__).resolve().parents[2]/'bin'))
 from pixel_provider import advice_runtime as runtime
 from pixel_provider.advice_jobs import AdvisoryJobs
 from pixel_provider.store import StoreError
-from test_advice import request,saved
+from test_advice import request, saved as saved
 
 pytestmark=pytest.mark.skipif(os.name != 'posix',reason='POSIX private runtime')
 
 
 @pytest.fixture
 def provision(tmp_path,monkeypatch):
-    root=tmp_path/'providers'; root.mkdir(mode=0o700)
+    root=tmp_path/'providers'
+    root.mkdir(mode=0o700)
     # This is a simulated provisioner, not interpreter qualification. Hosted
     # tool-cache ownership/modes are outside our control; never relax production
     # custody or chmod a shared Python installation to make this fixture pass.
@@ -28,7 +29,9 @@ def provision(tmp_path,monkeypatch):
     def install(command,**kwargs):
         calls.append(command)
         if 'venv' in command:
-            target=Path(command[-1]); target.mkdir(mode=0o700); (target/'bin').mkdir(mode=0o700)
+            target=Path(command[-1])
+            target.mkdir(mode=0o700)
+            (target/'bin').mkdir(mode=0o700)
             (target/'bin'/'python').symlink_to(binary)
         if '--report' in command:
             report=Path(command[command.index('--report')+1])
@@ -91,9 +94,11 @@ def test_install_requires_confirmation_and_exact_revision(provision,changes,code
 
 
 def test_mtime_preserving_runtime_tamper_fails_closed_and_can_reprepare(provision):
-    root,_=provision; first=prepare(root)
+    root,_=provision
+    first=prepare(root)
     path=root/'advice-runtimes'/first['runtimeId']/'source'/'pixel_provider'/'advice.py'
-    old=path.stat(); path.write_bytes(path.read_bytes()+b'\n#tampered\n')
+    old=path.stat()
+    path.write_bytes(path.read_bytes()+b'\n#tampered\n')
     os.utime(path,ns=(old.st_atime_ns,old.st_mtime_ns))
     assert runtime.runtime_status(root)['status']=='drift'
     with pytest.raises(StoreError,match='drift'):
@@ -104,16 +109,19 @@ def test_mtime_preserving_runtime_tamper_fails_closed_and_can_reprepare(provisio
 
 
 def test_foreign_symlink_and_public_runtime_fail_closed(provision,tmp_path):
-    root,_=provision; first=prepare(root)
+    root,_=provision
+    first=prepare(root)
     leaf=root/'advice-runtimes'/first['runtimeId']
     (leaf/'foreign').symlink_to('/etc/passwd')
     assert runtime.runtime_status(root)['status']=='drift'
-    (leaf/'foreign').unlink(); leaf.chmod(0o755)
+    (leaf/'foreign').unlink()
+    leaf.chmod(0o755)
     assert runtime.runtime_status(root)['status']=='drift'
 
 
 def test_failed_repair_keeps_pointer_and_inactive_evidence(provision,monkeypatch):
-    root,_=provision; first=prepare(root)
+    root,_=provision
+    first=prepare(root)
     leaf=root/'advice-runtimes'/first['runtimeId']
     (leaf/'requirements.txt').write_text('changed')
     old=(root/'advice-runtime.json').read_bytes()
@@ -127,14 +135,16 @@ def test_failed_repair_keeps_pointer_and_inactive_evidence(provision,monkeypatch
 
 
 def test_missing_runtime_does_not_claim_or_read_capsule(saved):
-    root,_=saved; body=request()
+    root,_=saved
+    body=request()
     with pytest.raises(StoreError,match='advice-runtime-missing'):
         AdvisoryJobs(root).start(body)
     assert not (root/'advice-jobs'/body['requestId']).exists()
 
 
 def test_interpreter_custody_drift_before_credential_pass(provision,monkeypatch):
-    root,_=provision; prepare(root)
+    root,_=provision
+    prepare(root)
     original=runtime.digest_file
     binary=root/'fixture-python'
     monkeypatch.setattr(runtime,'digest_file',lambda path:'f'*64 if path==binary else original(path))
@@ -145,7 +155,8 @@ def test_interpreter_custody_drift_before_credential_pass(provision,monkeypatch)
 
 @pytest.mark.parametrize('unsafe',['group-write','other-write','hardlink'])
 def test_unsafe_interpreter_rejected_before_provision(provision,unsafe):
-    root,calls=provision; binary=root/'fixture-python'
+    root,calls=provision
+    binary=root/'fixture-python'
     if unsafe=='hardlink':
         os.link(binary,root/'second-name')
     else:

--- a/ods/tests/pixel_inference/test_advice_setup.py
+++ b/ods/tests/pixel_inference/test_advice_setup.py
@@ -33,8 +33,11 @@ def wait(jobs,job_id):
 
 @pytest.fixture
 def harness(tmp_path,monkeypatch):
-    root=tmp_path/'providers'; root.mkdir(mode=0o700)
-    entered=threading.Event(); release=threading.Event(); calls=[]
+    root=tmp_path/'providers'
+    root.mkdir(mode=0o700)
+    entered=threading.Event()
+    release=threading.Event()
+    calls=[]
     control={'publish':True,'cancelAfterPublish':False,'lie':False}
     monkeypatch.setattr(setup,'source_digest',lambda:'a'*64)
     def candidate(identity):
@@ -47,12 +50,14 @@ def harness(tmp_path,monkeypatch):
                     runtimeId=receipt['runtime']['id'] if receipt['runtime'] else None)
     monkeypatch.setattr(setup,'runtime_status',status)
     def runner(command,value,*,cancelled,deadline_seconds,lock_fds):
-        calls.append(copy.deepcopy(value)); entered.set()
+        calls.append(copy.deepcopy(value))
+        entered.set()
         assert len(lock_fds)==2 and value['lockFds']==list(lock_fds)
         while not release.wait(.01):
             if cancelled(): raise asyncio.CancelledError()
         if control['publish']:
-            store=RuntimeStore(root); receipt=store.load()
+            store=RuntimeStore(root)
+            receipt=store.load()
             store.save(dict(revision=receipt['revision'],schemaVersion=1,runtime=dict(
                 id='runtime-'+value['requestId'].replace('-',''),sourceSha256='a'*64,treeSha256='c'*64,
                 interpreter='/fixture/python',interpreterSha256='d'*64)),expected_revision=receipt['revision'])
@@ -63,22 +68,27 @@ def harness(tmp_path,monkeypatch):
 
 
 def test_durable_idempotent_setup_and_conflicting_uuid(harness):
-    jobs,entered,release,calls,_=harness; request=body()
-    jobs.start(request); assert entered.wait(2)
+    jobs,entered,release,calls,_=harness
+    request=body()
+    jobs.start(request)
+    assert entered.wait(2)
     assert jobs.start(request)['status']=='running'
     with pytest.raises(StoreError,match='conflict'):
         jobs.start(dict(request,expectedRevision=1))
     assert jobs.latest()['jobId']==request['requestId']
-    release.set(); result=wait(jobs,request['requestId'])
+    release.set()
+    result=wait(jobs,request['requestId'])
     assert result['status']=='completed' and len(calls)==1
     assert jobs.start(request)==result
     assert not (jobs.providers/'provider-config.json').exists()
 
 
 def test_global_single_installer_slot_and_cancellation(harness):
-    jobs,entered,release,calls,_=harness; request=body()
+    jobs,entered,release,calls,_=harness
+    request=body()
     try:
-        jobs.start(request); assert entered.wait(2)
+        jobs.start(request)
+        assert entered.wait(2)
         other=setup.SetupJobs(jobs.providers,runner=jobs.runner)
         with pytest.raises(StoreError,match='setup-busy'): other.start(body())
         other.cancel(request['requestId'])
@@ -88,20 +98,29 @@ def test_global_single_installer_slot_and_cancellation(harness):
 
 
 def test_late_cancel_reports_actual_publication(harness):
-    jobs,_,release,_,control=harness; control['cancelAfterPublish']=True
-    request=body(); jobs.start(request); release.set()
+    jobs,_,release,_,control=harness
+    control['cancelAfterPublish']=True
+    request=body()
+    jobs.start(request)
+    release.set()
     assert wait(jobs,request['requestId'])['status']=='completed'
     assert jobs.cancel(request['requestId'])['status']=='completed'
 
 
 def test_child_reply_without_pointer_never_means_installed(harness):
-    jobs,_,release,_,control=harness; control.update(publish=False,lie=True)
-    request=body(); jobs.start(request); release.set()
+    jobs,_,release,_,control=harness
+    control.update(publish=False,lie=True)
+    request=body()
+    jobs.start(request)
+    release.set()
     assert wait(jobs,request['requestId'])['status']=='failed'
 
 
 def test_lost_terminal_receipt_reconciles_without_replay(harness):
-    jobs,_,release,calls,_=harness; request=body(); jobs.start(request); release.set()
+    jobs,_,release,calls,_=harness
+    request=body()
+    jobs.start(request)
+    release.set()
     assert wait(jobs,request['requestId'])['status']=='completed'
     jobs.threads[request['requestId']].join(2)
     (jobs.root/request['requestId']/'result.json').unlink()
@@ -110,8 +129,12 @@ def test_lost_terminal_receipt_reconciles_without_replay(harness):
 
 
 def test_interrupted_without_pointer_is_not_replayed(harness):
-    jobs,_,release,calls,control=harness; control['publish']=False
-    request=body(); jobs.start(request); release.set(); wait(jobs,request['requestId'])
+    jobs,_,release,calls,control=harness
+    control['publish']=False
+    request=body()
+    jobs.start(request)
+    release.set()
+    wait(jobs,request['requestId'])
     jobs.threads[request['requestId']].join(2)
     (jobs.root/request['requestId']/'result.json').unlink()
     assert jobs.start(request)['status']=='interrupted' and len(calls)==1
@@ -127,7 +150,8 @@ def test_no_arbitrary_path_and_validation_before_claim(harness,change):
 
 @pytest.mark.parametrize('change',[dict(expectedRevision=1),dict(sourceSha256='c'*64),dict(candidateId='c'*64)])
 def test_stale_source_revision_or_candidate_before_claim(harness,change):
-    jobs,_,_,calls,_=harness; request=body(**change)
+    jobs,_,_,calls,_=harness
+    request=body(**change)
     with pytest.raises(StoreError): jobs.start(request)
     assert not calls and not (jobs.root/request['requestId']).exists()
 

--- a/ods/tests/pixel_inference/test_advice_setup_process.py
+++ b/ods/tests/pixel_inference/test_advice_setup_process.py
@@ -33,7 +33,8 @@ def until(check,seconds=5):
 @pytest.mark.parametrize('loss',['eof','eof-staggered-kill','supervisor-sigkill','worker-exit','supervisor-success','supervisor-error'])
 def test_parent_loss_reaps_installer_descendants_and_keeps_slot_until_exit(tmp_path,loss):
     import fcntl
-    group_marker=tmp_path/'group'; descendant_marker=tmp_path/'descendant'
+    group_marker=tmp_path/'group'
+    descendant_marker=tmp_path/'descendant'
     wrapper=tmp_path/'worker.py'
     grandchild=f"import os,signal,time; from pathlib import Path; signal.signal(signal.SIGTERM,signal.SIG_IGN); Path({str(descendant_marker)!r}).write_text(str(os.getpid())); time.sleep(60)"
     wrapper.write_text(f'''
@@ -79,15 +80,18 @@ run_worker({command!r},{request!r},cancelled=lambda:False,deadline_seconds=40,lo
         command=[sys.executable,'-I','-S','-B',str(supervisor)]
     process=subprocess.Popen(command,stdin=subprocess.PIPE,stdout=subprocess.DEVNULL,stderr=subprocess.DEVNULL,
                              start_new_session=True,pass_fds=tuple(locks))
-    group=None; descendant=None
+    group=None
+    descendant=None
     probe=os.open(tmp_path/'slot',os.O_RDWR)
     try:
         if not loss.startswith('supervisor-'):
-            process.stdin.write(encode_frame(request)); process.stdin.flush()
+            process.stdin.write(encode_frame(request))
+            process.stdin.flush()
         for fd in locks: os.close(fd)
         locks=[]
         until(lambda:descendant_marker.exists() and descendant_marker.stat().st_size>0)
-        group=int(group_marker.read_text()); descendant=int(descendant_marker.read_text())
+        group=int(group_marker.read_text())
+        descendant=int(descendant_marker.read_text())
         assert live(group) and live(descendant)
         with pytest.raises(BlockingIOError): fcntl.flock(probe,fcntl.LOCK_EX|fcntl.LOCK_NB)
         if loss=='worker-exit':
@@ -115,4 +119,5 @@ run_worker({command!r},{request!r},cancelled=lambda:False,deadline_seconds=40,lo
             with contextlib.suppress(ProcessLookupError): os.killpg(group,signal.SIGKILL)
         if process.poll() is None: process.kill()
         process.wait(timeout=3)
-        process.stdin.close(); os.close(probe)
+        process.stdin.close()
+        os.close(probe)

--- a/ods/tests/pixel_inference/test_advice_worker.py
+++ b/ods/tests/pixel_inference/test_advice_worker.py
@@ -14,7 +14,7 @@ import time
 
 import pytest
 
-from test_advice import request,saved
+from test_advice import request, saved as saved
 from pixel_provider.advice import AdvisoryCall
 from pixel_provider.advice_process import run_worker
 from pixel_provider.store import StoreError
@@ -26,7 +26,9 @@ SCRIPT=Path(__file__).resolve().parents[2]/'bin'/'pixel_provider'/'advice_worker
 
 @pytest.fixture
 def upstream(saved):
-    entered=threading.Event(); disconnected=threading.Event(); requests=[]
+    entered=threading.Event()
+    disconnected=threading.Event()
+    requests=[]
     options={'hold':False}
     class Handler(BaseHTTPRequestHandler):
         def log_message(self,*args): pass
@@ -38,10 +40,13 @@ def upstream(saved):
                     disconnected.set()
             else:
                 payload=json.dumps(dict(model='backup',choices=[dict(message=dict(role='assistant',content='Use a small canary.'))])).encode()
-                self.send_response(200); self.send_header('Content-Length',str(len(payload))); self.end_headers()
+                self.send_response(200)
+                self.send_header('Content-Length',str(len(payload)))
+                self.end_headers()
                 self.wfile.write(payload)
     server=ThreadingHTTPServer(('127.0.0.1',0),Handler)
-    thread=threading.Thread(target=server.serve_forever,daemon=True); thread.start()
+    thread=threading.Thread(target=server.serve_forever,daemon=True)
+    thread.start()
     root,config=saved
     config['providers'][1]['baseUrl']=f'http://127.0.0.1:{server.server_port}/v1'
     CredentialStore(root).save_public(dict(expectedRevision=1,document=config,
@@ -50,7 +55,9 @@ def upstream(saved):
     try:
         yield call,options,entered,disconnected,requests
     finally:
-        server.shutdown(); server.server_close(); thread.join(3)
+        server.shutdown()
+        server.server_close()
+        thread.join(3)
 
 
 def payload(call):
@@ -67,7 +74,8 @@ def test_actual_worker_completion(upstream):
 
 
 def test_actual_worker_cancellation_closes_model_socket(upstream):
-    call,options,entered,disconnected,requests=upstream; options['hold']=True
+    call,options,entered,disconnected,requests=upstream
+    options['hold']=True
     with pytest.raises(asyncio.CancelledError):
         run_worker([sys.executable,'-I','-B',str(SCRIPT)],payload(call),cancelled=entered.is_set,deadline_seconds=5)
     assert disconnected.wait(3) and len(requests)==1
@@ -85,7 +93,8 @@ def orphan_driver(value,lock):
 
 def test_parent_sigkill_closes_upstream_and_releases_inherited_lock(upstream,tmp_path):
     import fcntl
-    call,options,entered,disconnected,requests=upstream; options['hold']=True
+    call,options,entered,disconnected,requests=upstream
+    options['hold']=True
     lock=tmp_path/'job.lock'
     parent=multiprocessing.get_context('spawn').Process(target=orphan_driver,args=(payload(call),lock))
     parent.start()
@@ -95,7 +104,8 @@ def test_parent_sigkill_closes_upstream_and_releases_inherited_lock(upstream,tmp
         try:
             with pytest.raises(BlockingIOError):
                 fcntl.flock(probe,fcntl.LOCK_EX|fcntl.LOCK_NB)
-            parent.kill(); parent.join(3)
+            parent.kill()
+            parent.join(3)
             assert not parent.is_alive() and disconnected.wait(3)
             deadline=time.monotonic()+3
             while True:
@@ -110,11 +120,14 @@ def test_parent_sigkill_closes_upstream_and_releases_inherited_lock(upstream,tmp
             os.close(probe)
     finally:
         if parent.is_alive():
-            parent.kill(); parent.join(3)
+            parent.kill()
+            parent.join(3)
 
 
 def test_snapshot_reconstruction_uses_no_vault_and_is_independent(saved,monkeypatch):
-    root,_=saved; original=AdvisoryCall(root,request()); snapshot=original.snapshot()
+    root,_=saved
+    original=AdvisoryCall(root,request())
+    snapshot=original.snapshot()
     def forbidden(*args,**kwargs):
         raise AssertionError('worker read the vault')
     monkeypatch.setattr(CredentialStore,'load',forbidden)
@@ -133,6 +146,8 @@ def test_snapshot_reconstruction_uses_no_vault_and_is_independent(saved,monkeypa
     lambda s:s['credentials'].update(backup=None),
 ])
 def test_snapshot_rejects_recipient_revision_and_privacy_drift(saved,mutation):
-    root,_=saved; snapshot=copy.deepcopy(AdvisoryCall(root,request()).snapshot()); mutation(snapshot)
+    root,_=saved
+    snapshot=copy.deepcopy(AdvisoryCall(root,request()).snapshot())
+    mutation(snapshot)
     with pytest.raises((StoreError,ValueError)):
         AdvisoryCall.from_snapshot(snapshot)

--- a/ods/tests/pixel_inference/test_client.py
+++ b/ods/tests/pixel_inference/test_client.py
@@ -160,7 +160,8 @@ def test_agent_inherits_admission_if_supervisor_closes_its_handle(client_dir):
             pass
     finally:
         if child.poll() is None:
-            child.kill(); child.wait()
+            child.kill()
+            child.wait()
 
 
 def test_ambient_profile_not_inherited(client_dir,monkeypatch):
@@ -252,7 +253,8 @@ time.sleep(120)
         assert record['status'] == 'interrupted'
     finally:
         if owner.poll() is None:
-            owner.kill(); owner.wait()
+            owner.kill()
+            owner.wait()
         for pid in pids:
             try:
                 os.kill(pid,signal.SIGKILL)

--- a/ods/tests/pixel_inference/test_connection_import.py
+++ b/ods/tests/pixel_inference/test_connection_import.py
@@ -133,4 +133,7 @@ def test_actual_stalled_response_child_is_killed_and_reaped(monkeypatch):
         assert mod._lock.acquire(blocking=False)
         mod._lock.release()
     finally:
-        release.set(); peer.shutdown(); peer.server_close(); thread.join(timeout=2)
+        release.set()
+        peer.shutdown()
+        peer.server_close()
+        thread.join(timeout=2)

--- a/ods/tests/pixel_inference/test_connection_transport.py
+++ b/ods/tests/pixel_inference/test_connection_transport.py
@@ -40,7 +40,9 @@ def server(status=200,body=None):
     try:
         yield conn,calls
     finally:
-        service.shutdown(); thread.join(timeout=3); service.server_close()
+        service.shutdown()
+        thread.join(timeout=3)
+        service.server_close()
 
 
 def test_probe_success_ignores_proxy_environment(monkeypatch):

--- a/ods/tests/pixel_inference/test_connection_tunnel.py
+++ b/ods/tests/pixel_inference/test_connection_tunnel.py
@@ -32,7 +32,8 @@ def test_real_half_close_and_owned_ssh_cleanup(tmp_path):
     fake.chmod(0o700)
     async def check():
         with socket.socket() as sock:
-            sock.bind(('127.0.0.1',0)); port = sock.getsockname()[1]
+            sock.bind(('127.0.0.1',0))
+            port = sock.getsockname()[1]
         stop,ready = asyncio.Event(),asyncio.Event()
         server = asyncio.create_task(serve_tunnel(ssh_bin=str(fake),target='fixture',remote_port=4005,
             listen_port=port,stop=stop,ready=ready.set))
@@ -40,12 +41,16 @@ def test_real_half_close_and_owned_ssh_cleanup(tmp_path):
         try:
             await asyncio.wait_for(ready.wait(),3)
             reader,writer = await asyncio.open_connection('127.0.0.1',port)
-            writer.write(b'request'); await writer.drain(); writer.write_eof()
+            writer.write(b'request')
+            await writer.drain()
+            writer.write_eof()
             assert await asyncio.wait_for(reader.read(),3) == b'reply:request'
         finally:
             if writer:
-                writer.close(); await writer.wait_closed()
-            stop.set(); await asyncio.wait_for(server,8)
+                writer.close()
+                await writer.wait_closed()
+            stop.set()
+            await asyncio.wait_for(server,8)
         with pytest.raises(OSError):
             await asyncio.open_connection('127.0.0.1',port)
     asyncio.run(check())
@@ -59,7 +64,8 @@ def test_stop_reaps_active_forwarding_process(tmp_path):
     fake.chmod(0o700)
     async def check():
         with socket.socket() as sock:
-            sock.bind(('127.0.0.1',0)); port = sock.getsockname()[1]
+            sock.bind(('127.0.0.1',0))
+            port = sock.getsockname()[1]
         stop,ready = asyncio.Event(),asyncio.Event()
         task = asyncio.create_task(serve_tunnel(ssh_bin=str(fake),target='fixture',remote_port=4005,
             listen_port=port,stop=stop,ready=ready.set))
@@ -68,14 +74,17 @@ def test_stop_reaps_active_forwarding_process(tmp_path):
             await asyncio.wait_for(ready.wait(),3)
             reader,writer = await asyncio.open_connection('127.0.0.1',port)
             pid = int(await asyncio.wait_for(reader.readline(),3))
-            stop.set(); await asyncio.wait_for(task,8)
+            stop.set()
+            await asyncio.wait_for(task,8)
             assert await asyncio.wait_for(reader.read(),3) == b''
             with pytest.raises(ProcessLookupError):
                 os.kill(pid,0)
         finally:
-            stop.set(); await asyncio.wait_for(task,8)
+            stop.set()
+            await asyncio.wait_for(task,8)
             if writer:
-                writer.close(); await writer.wait_closed()
+                writer.close()
+                await writer.wait_closed()
     asyncio.run(check())
 
 
@@ -90,12 +99,14 @@ def test_cancel_during_spawn_acquires_and_reaps_child(tmp_path,monkeypatch):
         children = []
         async def delayed(*args,**kw):
             child = await original(*args,**kw)
-            children.append(child); spawned.set()
+            children.append(child)
+            spawned.set()
             await release.wait()
             return child
         monkeypatch.setattr(asyncio,'create_subprocess_exec',delayed)
         with socket.socket() as sock:
-            sock.bind(('127.0.0.1',0)); port = sock.getsockname()[1]
+            sock.bind(('127.0.0.1',0))
+            port = sock.getsockname()[1]
         task = asyncio.create_task(serve_tunnel(ssh_bin=str(fake),target='fixture',remote_port=4005,
             listen_port=port,stop=stop,ready=ready.set))
         writer = None
@@ -103,16 +114,22 @@ def test_cancel_during_spawn_acquires_and_reaps_child(tmp_path,monkeypatch):
             await asyncio.wait_for(ready.wait(),3)
             reader,writer = await asyncio.open_connection('127.0.0.1',port)
             await asyncio.wait_for(spawned.wait(),3)
-            stop.set(); await asyncio.sleep(0); await asyncio.sleep(0)
-            release.set(); await asyncio.wait_for(task,8)
+            stop.set()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            release.set()
+            await asyncio.wait_for(task,8)
             assert children[0].returncode is not None
             assert await asyncio.wait_for(reader.read(),3) == b''
         finally:
-            release.set(); stop.set()
+            release.set()
+            stop.set()
             if writer:
-                writer.close(); await writer.wait_closed()
+                writer.close()
+                await writer.wait_closed()
             await asyncio.wait_for(task,8)
             for child in children:
                 if child.returncode is None:
-                    child.kill(); await child.wait()
+                    child.kill()
+                    await child.wait()
     asyncio.run(check())

--- a/ods/tests/pixel_inference/test_handoff_approvals.py
+++ b/ods/tests/pixel_inference/test_handoff_approvals.py
@@ -24,7 +24,8 @@ WORKER=Path(__file__).resolve().parents[2]/'bin/pixel_provider/handoff_worker.py
 
 @pytest.fixture
 def manager(tmp_path):
-    providers=tmp_path/'providers'; providers.mkdir(mode=0o700)
+    providers=tmp_path/'providers'
+    providers.mkdir(mode=0o700)
     return HandoffApprovals(providers)
 
 
@@ -39,7 +40,8 @@ def decide(manager,value,digest,approved=True,cloud=False,cost=False):
 
 
 def test_large_exact_preview_and_custody(manager):
-    value,_,_=checkpoint(); value['prompt']='Private unicode ★ '*30000
+    value,_,_=checkpoint()
+    value['prompt']='Private unicode ★ '*30000
     raw,digest=encode(value)
     assert 256*1024<len(raw.encode())<CHECKPOINT_LIMIT
     with manager.publish(raw,digest,60) as pending:
@@ -57,7 +59,8 @@ def test_large_exact_preview_and_custody(manager):
 
 @pytest.mark.parametrize('cloud,cost',[(False,False),(True,False),(False,True),(True,True)])
 def test_cloud_requires_both_consents(manager,cloud,cost):
-    value,_,_=checkpoint(); value['recipient'].update(kind='cloud',baseUrl='https://api.example/v1')
+    value,_,_=checkpoint()
+    value['recipient'].update(kind='cloud',baseUrl='https://api.example/v1')
     raw,digest=encode(value)
     with manager.publish(raw,digest,60) as pending:
         if cloud and cost:
@@ -69,7 +72,8 @@ def test_cloud_requires_both_consents(manager,cloud,cost):
 
 
 def test_expiry_and_immutable_replay_claim(manager):
-    clock=[1000000]; manager.clock=lambda:clock[0]
+    clock=[1000000]
+    manager.clock=lambda:clock[0]
     value,raw,digest=checkpoint()
     with manager.publish(raw,digest,1) as pending:
         clock[0]+=2
@@ -96,7 +100,8 @@ def test_final_approval_requires_real_matching_decision(manager):
     with manager.publish(raw,digest,60) as pending:
         with pytest.raises(StoreError): pending.finish('approved')
         path=manager.root/value['runId']/'result.json'
-        path.write_text('{"status":"approved"}'); path.chmod(0o600)
+        path.write_text('{"status":"approved"}')
+        path.chmod(0o600)
         with pytest.raises(StoreError): manager.status(value['runId'])
 
 
@@ -120,7 +125,8 @@ def test_polling_retained_terminal_claims_does_not_read_transcripts(manager,monk
 def test_partial_abandoned_publication_does_not_hide_valid_pending_run(manager):
     value,raw,digest=checkpoint()
     with manager.publish(raw,digest,60):
-        partial=manager.root/str(uuid.uuid4()); partial.mkdir(mode=0o700)
+        partial=manager.root/str(uuid.uuid4())
+        partial.mkdir(mode=0o700)
         result=manager.pending()
         assert result['unavailableCount']==1
         assert [row['runId'] for row in result['items']]==[value['runId']]
@@ -128,7 +134,8 @@ def test_partial_abandoned_publication_does_not_hide_valid_pending_run(manager):
 
 
 def test_concurrent_conflicting_owner_decisions_have_one_immutable_winner(manager):
-    value,raw,digest=checkpoint(); barrier=threading.Barrier(2)
+    value,raw,digest=checkpoint()
+    barrier=threading.Barrier(2)
     with manager.publish(raw,digest,60) as pending:
         def attempt(approved):
             barrier.wait(timeout=3)
@@ -150,7 +157,9 @@ def test_concurrent_conflicting_owner_decisions_have_one_immutable_winner(manage
     {'messages':[{'role':'assistant','content':[{'type':'toolCall','id':'missing'}]}]},
     {'prompt':'x'*CHECKPOINT_LIMIT}])
 def test_incomplete_history_and_oversize_rejected(manager,change):
-    value,_,_=checkpoint(); value.update(change); raw,digest=encode(value)
+    value,_,_=checkpoint()
+    value.update(change)
+    raw,digest=encode(value)
     with pytest.raises(StoreError): manager.publish(raw,digest,60)
 
 
@@ -165,13 +174,16 @@ def start_worker(manager,timeout=3):
     body=json.dumps(dict(schemaVersion=1,checkpointJson=raw,checkpointDigest=digest,timeoutSeconds=timeout)).encode()
     process=subprocess.Popen([sys.executable,'-I','-B',str(WORKER),'--provider-directory',str(manager.providers)],
         stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE,start_new_session=True)
-    process.stdin.write(struct.pack('!I',len(body))+body); process.stdin.flush()
+    process.stdin.write(struct.pack('!I',len(body))+body)
+    process.stdin.flush()
     deadline=time.monotonic()+3
     while time.monotonic()<deadline:
         if (manager.root/value['runId']/'claim.json').exists(): return process,value,digest
         assert process.poll() is None
         time.sleep(.02)
-    process.kill(); process.wait(); pytest.fail('publication did not appear')
+    process.kill()
+    process.wait()
+    pytest.fail('publication did not appear')
 
 
 @pytest.mark.parametrize('approved',[True,False])
@@ -186,7 +198,9 @@ def test_actual_private_worker_returns_exact_receipt_and_exits(manager,approved)
         assert process.stdout.read()==b''
         assert manager.status(value['runId'])['status']==('approved' if approved else 'declined')
     finally:
-        if process.poll() is None: process.kill(); process.wait()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
         for stream in (process.stdin,process.stdout,process.stderr): stream.close()
 
 
@@ -195,7 +209,9 @@ def test_actual_worker_loss_and_deadline_never_authorize(manager,mode):
     process,value,digest=start_worker(manager,1 if mode=='deadline' else 3)
     try:
         if mode=='eof': process.stdin.close()
-        elif mode=='extra-frame': process.stdin.write(b'x'); process.stdin.flush()
+        elif mode=='extra-frame':
+            process.stdin.write(b'x')
+            process.stdin.flush()
         elif mode=='sigkill': process.kill()
         assert process.wait(timeout=5)!=0
         assert process.stdout.read()==b''
@@ -205,5 +221,7 @@ def test_actual_worker_loss_and_deadline_never_authorize(manager,mode):
             raw,_=encode(dict(checkpoint()[0],runId=value['runId']))
             with manager.publish(raw,hashlib.sha256(raw.encode()).hexdigest(),60): pass
     finally:
-        if process.poll() is None: process.kill(); process.wait()
+        if process.poll() is None:
+            process.kill()
+            process.wait()
         for stream in (process.stdin,process.stdout,process.stderr): stream.close()

--- a/ods/tests/pixel_inference/test_handoff_host.py
+++ b/ods/tests/pixel_inference/test_handoff_host.py
@@ -26,7 +26,8 @@ def checkpoint():
 
 @pytest.fixture
 def host(tmp_path):
-    fixture.HostHTTP.setUpClass(); fixture.HostHTTP.agent.DATA_DIR=tmp_path
+    fixture.HostHTTP.setUpClass()
+    fixture.HostHTTP.agent.DATA_DIR=tmp_path
     try: yield fixture.HostHTTP,tmp_path
     finally: fixture.HostHTTP.tearDownClass()
 
@@ -55,7 +56,8 @@ def test_pristine_list_no_state_or_public_publish(host):
 
 def test_real_owner_preview_decision_and_conflict(host):
     (host[1]/'pixel-providers').mkdir(mode=0o700)
-    manager=get_manager(host[1]); value,raw,digest=checkpoint()
+    manager=get_manager(host[1])
+    value,raw,digest=checkpoint()
     with manager.publish(raw,digest,60) as pending:
         assert request(host,'list',{})[1]['items'][0]['runId']==value['runId']
         status,result,cache=request(host,'status',{'runId':value['runId']})
@@ -82,7 +84,8 @@ def test_strict_and_bounded_json(host):
 
 def test_interrupted_cannot_be_approved(host):
     (host[1]/'pixel-providers').mkdir(mode=0o700)
-    manager=get_manager(host[1]); value,raw,digest=checkpoint()
+    manager=get_manager(host[1])
+    value,raw,digest=checkpoint()
     with manager.publish(raw,digest,60): pass
     assert request(host,'status',{'runId':value['runId']})[1]['status']=='interrupted'
     decision=dict(runId=value['runId'],checkpointDigest=digest,approved=True,allowCloud=False,acceptUnknownCost=False)

--- a/ods/tests/pixel_inference/test_provider_policy.py
+++ b/ods/tests/pixel_inference/test_provider_policy.py
@@ -22,14 +22,16 @@ def test_order_only_automatic_roles_and_no_mutation():
 @pytest.mark.parametrize('field,value',[('contextTokens',16384),('maxOutputTokens',128),
     ('supportsTools',False),('enabled',False)])
 def test_incompatible_backup_is_explicitly_skipped(field,value):
-    config = configuration(); config['providers'][1][field]=value
+    config = configuration()
+    config['providers'][1][field]=value
     selected,skipped = select_candidates(config,payload())
     assert [p['id'] for p in selected]==['primary']
     assert skipped==[{'providerId':'backup','reason':'incompatible-backup'}]
 
 
 def test_max_attempts_and_cloud_checks():
-    config = configuration(); config['policy']['maxAttempts']=1
+    config = configuration()
+    config['policy']['maxAttempts']=1
     assert len(select_candidates(config,payload())[0])==1
     config['providers'][1]['kind']='cloud'
     with pytest.raises(StoreError,match='cloud-not-authorized'):
@@ -38,19 +40,22 @@ def test_max_attempts_and_cloud_checks():
 
 @pytest.mark.parametrize('model',['ods/pixel','pixel/default','openclaw/default'])
 def test_route_cycles_rejected(model):
-    config = configuration(); config['providers'][1]['model']=model
+    config = configuration()
+    config['providers'][1]['model']=model
     with pytest.raises(StoreError,match='provider-route-cycle'):
         select_candidates(config,payload())
 
 
 def test_reasoning_requirement_preserved():
-    config = configuration(); config['providers'][0]['reasoning']=True
+    config = configuration()
+    config['providers'][0]['reasoning']=True
     selected,skipped = select_candidates(config,payload())
     assert [p['id'] for p in selected]==['primary'] and len(skipped)==1
 
 
 def test_unsupported_leader_and_disabled_policy():
-    config = configuration(); config['providers'][0]['supportsTools']=False
+    config = configuration()
+    config['providers'][0]['supportsTools']=False
     with pytest.raises(StoreError,match='leader-incompatible'):
         select_candidates(config,payload())
     config['enabled']=False

--- a/ods/tests/pixel_inference/test_provider_runtime.py
+++ b/ods/tests/pixel_inference/test_provider_runtime.py
@@ -1,5 +1,4 @@
 import asyncio
-from copy import deepcopy
 import json
 from pathlib import Path
 import sys
@@ -65,7 +64,8 @@ def test_backup_receives_exact_completed_tool_history_and_own_key():
 def test_auth_config_and_redirect_never_fall_back(status):
     calls = []
     def handler(request):
-        calls.append(request); return httpx.Response(status)
+        calls.append(request)
+        return httpx.Response(status)
     app = make_app(handler)
     async def check():
         first = await request_to(app,payload())
@@ -88,7 +88,8 @@ def test_refusal_is_a_response_not_a_failure():
 def test_total_attempt_budget_and_terminal_lease():
     calls = []
     def handler(request):
-        calls.append(request); return httpx.Response(503)
+        calls.append(request)
+        return httpx.Response(503)
     app = make_app(handler)
     async def check():
         assert (await request_to(app,payload())).json()['error']['code'] == 'provider-attempts-exhausted'
@@ -98,10 +99,12 @@ def test_total_attempt_budget_and_terminal_lease():
 
 
 def test_smaller_backup_is_not_sent_tool_history():
-    config = configuration(); config['providers'][1]['contextTokens'] = 16384
+    config = configuration()
+    config['providers'][1]['contextTokens'] = 16384
     calls = []
     def handler(request):
-        calls.append(request); return httpx.Response(503)
+        calls.append(request)
+        return httpx.Response(503)
     response = asyncio.run(request_to(make_app(handler,config),payload()))
     assert response.status_code == 400 and len(calls)==1
 
@@ -109,8 +112,10 @@ def test_smaller_backup_is_not_sent_tool_history():
 def test_missing_output_budget_is_bounded():
     calls = []
     def handler(request):
-        calls.append(json.loads(request.content)); return answer(request)
-    body = payload(); del body['max_tokens']
+        calls.append(json.loads(request.content))
+        return answer(request)
+    body = payload()
+    del body['max_tokens']
     asyncio.run(request_to(make_app(handler),body))
     assert calls[0]['max_tokens']==1024
 
@@ -118,7 +123,8 @@ def test_missing_output_budget_is_bounded():
 def test_policy_copy_pins_revision():
     config,events = configuration(),[]
     app = make_app(answer,config,events)
-    config['revision'] = 100; config['roles']['leader']='backup'
+    config['revision'] = 100
+    config['roles']['leader']='backup'
     result = asyncio.run(request_to(app,payload()))
     assert result.headers['x-ods-provider-revision']=='4'
     assert result.headers['x-ods-provider']=='primary'
@@ -158,7 +164,8 @@ def test_partial_stream_never_splices_backup():
 
 
 def test_one_deadline_cancels_waiting_headers():
-    config = configuration(); config['policy']['deadlineSeconds']=1
+    config = configuration()
+    config['policy']['deadlineSeconds']=1
     cancelled = []
     async def handler(request):
         try:

--- a/ods/tests/pixel_inference/test_provider_scopes.py
+++ b/ods/tests/pixel_inference/test_provider_scopes.py
@@ -16,8 +16,10 @@ pytestmark = pytest.mark.skipif(os.name != 'posix', reason='private POSIX scope 
 
 @pytest.fixture
 def store(tmp_path):
-    root = tmp_path / 'pixel-providers'; root.mkdir(mode=0o700)
-    config = default_config(); config['enabled'] = True
+    root = tmp_path / 'pixel-providers'
+    root.mkdir(mode=0o700)
+    config = default_config()
+    config['enabled'] = True
     config['providers'] = [dict(id=name, label=name, kind='local', baseUrl='http://127.0.0.1:10001/v1',
         model=name, contextTokens=32768, maxOutputTokens=4096, supportsTools=True,
         supportsVision=False, reasoning=False, credentialRef=None, enabled=True) for name in ('leader', 'stronger')]
@@ -63,7 +65,9 @@ def test_explicit_task_lives_across_runs_until_owner_end(store):
 
 
 def test_conversation_survives_task_end_and_explicit_return(store):
-    begin(store); select(store, 'conversation'); select(store, 'task')
+    begin(store)
+    select(store, 'conversation')
+    select(store, 'task')
     assert change(store, 'return', scope='task')['effectiveScope'] == 'conversation'
     assert change(store, 'end')['effectiveScope'] == 'conversation'
     assert begin(store)['effectiveScope'] == 'conversation'
@@ -80,7 +84,9 @@ def test_task_uuid_replay_is_global_and_survives_new_store_instance(store):
 
 
 def test_conversation_override_beats_new_task_default_after_end(store):
-    begin(store); select(store, 'conversation'); select(store, 'default')
+    begin(store)
+    select(store, 'conversation')
+    select(store, 'default')
     change(store, 'end')
     state = begin(ScopeStore(store.directory))
     assert state['defaultSnapshot'] is not None and state['effectiveScope'] == 'conversation'
@@ -100,7 +106,8 @@ def test_default_applies_only_to_new_explicit_tasks(store):
 
 def test_ingress_case_sensitive_hash_binding_and_other_sessions(store):
     import hashlib
-    begin(store); select(store, 'task')
+    begin(store)
+    select(store, 'task')
     assert native_key('Chat_A') == 'agent:pixel:openai-user:ods-' + hashlib.sha256(b'Chat_A').hexdigest()
     assert store.resolve(native_key('chat_a'), 1) is None
     for key in ('Chat_A', 'agent:pixel:openai-user:Chat_A', 'agent:other:openai-user:ods-'+'a'*64, None):
@@ -108,7 +115,8 @@ def test_ingress_case_sensitive_hash_binding_and_other_sessions(store):
 
 
 def test_stale_scope_and_provider_revisions_fail_closed(store):
-    begin(store); select(store, 'task')
+    begin(store)
+    select(store, 'task')
     with pytest.raises(StoreError, match='stale-revision'):
         store.change('return', dict(chatId='Chat_A', taskId=store.status('Chat_A')['taskId'], scope='task', expectedRevision=0))
     config = ProviderStore(store.directory).load()
@@ -138,7 +146,9 @@ def test_concurrent_writers_have_one_winner_and_unchanged_provider_config(store)
     initial = begin(store)
     body = dict(chatId='Chat_A', taskId=initial['taskId'], expectedRevision=initial['revision'], scope='conversation')
     def attempt():
-        try: store.change('return', body); return 'saved'
+        try:
+            store.change('return', body)
+            return 'saved'
         except StoreError as error: return error.code
     with ThreadPoolExecutor(max_workers=2) as pool:
         assert sorted(pool.map(lambda _: attempt(), range(2))) == ['saved', 'stale-revision']
@@ -151,7 +161,8 @@ def test_private_storage_and_corruption_are_not_silently_reset(store):
     assert path.stat().st_mode & 0o777 == 0o600
     path.chmod(0o644)
     with pytest.raises(StoreError, match='unsafe-file'): store.status('Chat_A')
-    path.chmod(0o600); path.write_text('{"revision":1,"revision":0}')
+    path.chmod(0o600)
+    path.write_text('{"revision":1,"revision":0}')
     with pytest.raises(StoreError, match='malformed-json'): store.status('Chat_A')
 
 
@@ -173,7 +184,8 @@ def test_wrong_task_cannot_end_or_change_selection(store):
 
 def test_native_worker_freezes_selection_without_granting_checkpoint_approval(store):
     from pixel_provider.route_worker import scoped_request, validate_request
-    begin(store); select(store, 'task')
+    begin(store)
+    select(store, 'task')
     request = dict(schemaVersion=1, runId=str(uuid.uuid4()), sessionId=str(uuid.uuid4()),
         expectedRevision=1, confirmed=True, allowCloud=False, timeoutSeconds=60, scopeSessionKey=native_key('Chat_A'))
     frozen = scoped_request(store.directory, validate_request(request))

--- a/ods/tests/pixel_inference/test_provider_session.py
+++ b/ods/tests/pixel_inference/test_provider_session.py
@@ -17,8 +17,10 @@ pytestmark = pytest.mark.skipif(os.name != 'posix',reason='POSIX adapter')
 
 @pytest.fixture
 def saved(tmp_path):
-    root = tmp_path/'providers'; root.mkdir(mode=0o700)
-    config = configuration(); config['revision']=0
+    root = tmp_path/'providers'
+    root.mkdir(mode=0o700)
+    config = configuration()
+    config['revision']=0
     result = CredentialStore(root).save_public({'document':public_config(config),'expectedRevision':0,
         'credentialChanges':{'backup':{'action':'set','value':'test-private-backup-key'}}})
     return root,result
@@ -32,7 +34,8 @@ def test_confirmation_revision_and_credential_snapshot(saved):
         ProviderSession(root,expected_revision=0,confirmed=True)
     session = ProviderSession(root,expected_revision=1,confirmed=True)
     assert session.credentials['backup']=='test-private-backup-key'
-    edited = dict(config); edited['roles']=dict(config['roles'],leader='backup',backups=['primary'])
+    edited = dict(config)
+    edited['roles']=dict(config['roles'],leader='backup',backups=['primary'])
     CredentialStore(root).save_public({'document':edited,'expectedRevision':1})
     assert session.config['roles']['leader']=='primary'
     assert session.config['revision']==1
@@ -97,8 +100,10 @@ def test_run_overlay_preserves_tools_and_original_and_stops_listener(saved,tmp_p
     session = ProviderSession(root,expected_revision=1,confirmed=True)
     config = {'models':{'providers':{}},'agents':{'defaults':{'sandbox':{'mode':'all'}},'list':[{'id':'fixture'}]},
         'tools':{'exec':{'host':'sandbox'},'fs':{'workspaceOnly':True}}}
-    source = tmp_path/'openclaw.json'; _write_private(source,_json(config))
-    run = tmp_path/'run'; run.mkdir(mode=0o700)
+    source = tmp_path/'openclaw.json'
+    _write_private(source,_json(config))
+    run = tmp_path/'run'
+    run.mkdir(mode=0o700)
     with session.activate(run,{'OPENCLAW_CONFIG_PATH':str(source)},'fixture') as env:
         effective = json.loads(read_private(Path(env['OPENCLAW_CONFIG_PATH'])))
         assert effective['tools']==config['tools']

--- a/ods/tests/pixel_inference/test_route_worker.py
+++ b/ods/tests/pixel_inference/test_route_worker.py
@@ -16,7 +16,7 @@ import pytest
 import threading
 from http.server import BaseHTTPRequestHandler,ThreadingHTTPServer
 
-from test_provider_session import saved  # shared private provider fixture
+from test_provider_session import saved as saved  # shared private provider fixture
 from pixel_provider.advice_frames import encode_frame,read_frame
 from pixel_provider.advice_process import worker_environment
 from pixel_provider.lease_claim import LeaseClaim
@@ -37,7 +37,8 @@ def launch(root,body):
     child = subprocess.Popen([sys.executable,'-I','-B',str(BIN/'pixel_provider/route_worker.py'),
         '--provider-directory',str(root)],stdin=subprocess.PIPE,stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,bufsize=0,env=worker_environment())
-    child.stdin.write(encode_frame(body)); child.stdin.flush()
+    child.stdin.write(encode_frame(body))
+    child.stdin.flush()
     return child
 
 
@@ -53,8 +54,12 @@ def close(child):
     if child.stdin and not child.stdin.closed:
         child.stdin.close()
     try: child.wait(timeout=5)
-    except subprocess.TimeoutExpired: child.kill(); child.wait(timeout=3); raise
-    child.stdout.close(); child.stderr.close()
+    except subprocess.TimeoutExpired:
+        child.kill()
+        child.wait(timeout=3)
+        raise
+    child.stdout.close()
+    child.stderr.close()
 
 
 def port_closed(lease):
@@ -70,7 +75,8 @@ def process_live(pid):
 
 
 def test_claim_consumed_and_live_slot_released(saved):
-    root,_=saved; body=request()
+    root,_=saved
+    body=request()
     with LeaseClaim(root,body['runId'],body['sessionId'],1) as claim:
         claim.finish('closed')
     with pytest.raises(StoreError,match='provider-run-replayed'):
@@ -78,7 +84,8 @@ def test_claim_consumed_and_live_slot_released(saved):
 
 
 def test_incomplete_claim_denies_replay_without_consuming_a_live_slot(saved,monkeypatch):
-    root,_=saved; body=request()
+    root,_=saved
+    body=request()
     with monkeypatch.context() as patch:
         patch.setattr(lease_claim,'_write_private',lambda *_: (_ for _ in ()).throw(OSError('write fault')))
         with pytest.raises(StoreError):
@@ -94,30 +101,39 @@ def test_unsafe_slot_fails_closed_instead_of_using_another_slot(saved):
     root,_=saved
     with LeaseClaim(root,str(uuid.uuid4()),'initialize',1): pass
     slot=root/'route-leases'/'slot-0.lock'
-    target=root/'provider-config.json'; original=target.read_bytes()
-    slot.unlink(); slot.symlink_to(target)
+    target=root/'provider-config.json'
+    original=target.read_bytes()
+    slot.unlink()
+    slot.symlink_to(target)
     with pytest.raises(StoreError,match='unsafe-file'):
         with LeaseClaim(root,str(uuid.uuid4()),'denied',1): pass
     assert target.read_bytes()==original
 
 
 def test_concurrent_duplicate_processes_emit_exactly_one_lease(saved):
-    root,_=saved; body=request(); children=[launch(root,body),launch(root,body)]; leases=[]
+    root,_=saved
+    body=request()
+    children=[launch(root,body),launch(root,body)]
+    leases=[]
     try:
         for child in children:
             assert select.select([child.stdout],[],[],6)[0]
             try: leases.append(read_frame(child.stdout)['lease'])
             except StoreError:
-                child.wait(timeout=3); assert child.returncode!=0
+                child.wait(timeout=3)
+                assert child.returncode!=0
         assert len(leases)==1
     finally:
         for child in children: close(child)
 
 
 def test_lease_refuses_wrong_token_then_closes_and_cannot_replay(saved):
-    root,_ = saved; body=request(); child=launch(root,body)
+    root,_ = saved
+    body=request()
+    child=launch(root,body)
     try:
-        lease=ready(child)['lease']; assert not port_closed(lease)
+        lease=ready(child)['lease']
+        assert not port_closed(lease)
         response=httpx.post(lease['baseUrl']+'/chat/completions',json={},headers={'Authorization':'Bearer wrong'})
         assert response.status_code==401
         if sys.platform=='linux':
@@ -129,18 +145,23 @@ def test_lease_refuses_wrong_token_then_closes_and_cannot_replay(saved):
     assert json.loads(metadata)['status']=='closed' and lease['token'] not in metadata
     replay=launch(root,body)
     try:
-        replay.wait(timeout=4); assert replay.returncode!=0 and replay.stdout.read()==b''
+        replay.wait(timeout=4)
+        assert replay.returncode!=0 and replay.stdout.read()==b''
     finally: close(replay)
 
 
 @pytest.mark.parametrize('loss',['eof','extra','sigkill','sigterm','sigint','deadline'])
 def test_process_loss_closes_listener_releases_slots_and_keeps_claim(saved,loss):
-    root,_=saved; body=request(); body['timeoutSeconds']=1 if loss=='deadline' else 30
+    root,_=saved
+    body=request()
+    body['timeoutSeconds']=1 if loss=='deadline' else 30
     child=launch(root,body)
     try:
         lease=ready(child)['lease']
         if loss=='eof': child.stdin.close()
-        elif loss=='extra': child.stdin.write(b'x'); child.stdin.flush()
+        elif loss=='extra':
+            child.stdin.write(b'x')
+            child.stdin.flush()
         elif loss=='sigkill': child.kill()
         elif loss in ('sigterm','sigint'): child.send_signal(signal.SIGTERM if loss=='sigterm' else signal.SIGINT)
         child.wait(timeout=5)
@@ -156,12 +177,16 @@ def test_process_loss_closes_listener_releases_slots_and_keeps_claim(saved,loss)
 
 
 def test_two_live_slots_and_busy_refusal_cannot_replay(saved):
-    root,_=saved; a=launch(root,request()); b=launch(root,request()); denied=request()
+    root,_=saved
+    a=launch(root,request())
+    b=launch(root,request())
+    denied=request()
     c=None
     try:
         la,lb=ready(a)['lease'],ready(b)['lease']
         assert la['baseUrl']!=lb['baseUrl'] and la['token']!=lb['token']
-        c=launch(root,denied); c.wait(timeout=4)
+        c=launch(root,denied)
+        c.wait(timeout=4)
         assert c.returncode!=0 and c.stdout.read()==b''
     finally:
         for child in (a,b,c):
@@ -173,15 +198,22 @@ def test_two_live_slots_and_busy_refusal_cannot_replay(saved):
 @pytest.mark.parametrize('change',[{'expectedRevision':0},{'confirmed':False},{'allowCloud':'false'},
     {'timeoutSeconds':0},{'runId':'../unsafe'},{'sessionId':''}])
 def test_invalid_or_stale_requests_have_no_listener(saved,change):
-    root,_=saved; body=request(); body.update(change); child=launch(root,body)
+    root,_=saved
+    body=request()
+    body.update(change)
+    child=launch(root,body)
     try:
-        child.wait(timeout=5); assert child.returncode!=0 and child.stdout.read()==b''
+        child.wait(timeout=5)
+        assert child.returncode!=0 and child.stdout.read()==b''
     finally: close(child)
 
 
 @pytest.mark.parametrize('loss',['eof','sigkill'])
 def test_inflight_upstream_disconnect_and_replay_denial(saved,loss):
-    root,config=saved; received=threading.Event(); disconnected=threading.Event(); finish=threading.Event()
+    root,config=saved
+    received=threading.Event()
+    disconnected=threading.Event()
+    finish=threading.Event()
     calls=[]
     class Handler(BaseHTTPRequestHandler):
         def log_message(self,*_): pass
@@ -190,14 +222,19 @@ def test_inflight_upstream_disconnect_and_replay_denial(saved,loss):
             received.set()
             while not finish.is_set():
                 if select.select([self.connection],[],[],.05)[0] and self.connection.recv(1,socket.MSG_PEEK)==b'':
-                    disconnected.set(); return
+                    disconnected.set()
+                    return
     upstream=ThreadingHTTPServer(('127.0.0.1',0),Handler)
-    server_thread=threading.Thread(target=upstream.serve_forever,daemon=True); server_thread.start()
+    server_thread=threading.Thread(target=upstream.serve_forever,daemon=True)
+    server_thread.start()
     config['providers'][0]['baseUrl']=f'http://127.0.0.1:{upstream.server_port}/v1'
     config['roles']['backups']=[]
     CredentialStore(root).save_public(dict(document=config,expectedRevision=1,
         credentialChanges={'primary':dict(action='set',value='fixture-upstream-secret')}))
-    body=request(); body['expectedRevision']=2; child=launch(root,body); client_thread=None
+    body=request()
+    body['expectedRevision']=2
+    child=launch(root,body)
+    client_thread=None
     try:
         lease=ready(child)['lease']
         def call():
@@ -206,26 +243,35 @@ def test_inflight_upstream_disconnect_and_replay_denial(saved,loss):
                     messages=[dict(role='user',content='hold')]),
                     headers={'Authorization':'Bearer '+lease['token']},timeout=8)
             except httpx.HTTPError: pass
-        client_thread=threading.Thread(target=call); client_thread.start()
+        client_thread=threading.Thread(target=call)
+        client_thread.start()
         assert received.wait(3)
         if loss=='sigkill': child.kill()
         else: child.stdin.close()
         child.wait(timeout=5)
         assert disconnected.wait(3) and port_closed(lease)
-        client_thread.join(timeout=3); assert not client_thread.is_alive()
+        client_thread.join(timeout=3)
+        assert not client_thread.is_alive()
         replay=launch(root,body)
         try:
-            replay.wait(timeout=4); assert replay.returncode!=0 and replay.stdout.read()==b''
+            replay.wait(timeout=4)
+            assert replay.returncode!=0 and replay.stdout.read()==b''
         finally: close(replay)
         assert len(calls)==1
     finally:
-        close(child); finish.set(); upstream.shutdown(); upstream.server_close(); server_thread.join(2)
+        close(child)
+        finish.set()
+        upstream.shutdown()
+        upstream.server_close()
+        server_thread.join(2)
         if client_thread: client_thread.join(9)
 
 
 @pytest.mark.skipif(sys.platform!='linux',reason='Linux orphan process state')
 def test_supervisor_sigkill_closes_orphan_listener(saved,tmp_path):
-    root,_=saved; body=request(); supervisor=tmp_path/'supervisor.py'
+    root,_=saved
+    body=request()
+    supervisor=tmp_path/'supervisor.py'
     supervisor.write_text('''
 import os,subprocess,sys,time
 sys.path.insert(0,sys.argv[1])
@@ -244,8 +290,12 @@ time.sleep(60)
         stdin=subprocess.PIPE,stdout=subprocess.PIPE,stderr=subprocess.PIPE,env=worker_environment())
     worker_pid=None
     try:
-        parent.stdin.write(encode_frame(body)); parent.stdin.flush(); value=ready(parent)
-        worker_pid=value['pid']; parent.kill(); parent.wait(timeout=2)
+        parent.stdin.write(encode_frame(body))
+        parent.stdin.flush()
+        value=ready(parent)
+        worker_pid=value['pid']
+        parent.kill()
+        parent.wait(timeout=2)
         deadline=time.monotonic()+5
         while process_live(worker_pid) and time.monotonic()<deadline: time.sleep(.02)
         assert not process_live(worker_pid) and port_closed(value['lease'])
@@ -253,7 +303,8 @@ time.sleep(60)
             with LeaseClaim(root,str(uuid.uuid4()),'replacement-b',1): pass
         replay=launch(root,body)
         try:
-            replay.wait(timeout=4); assert replay.returncode!=0 and replay.stdout.read()==b''
+            replay.wait(timeout=4)
+            assert replay.returncode!=0 and replay.stdout.read()==b''
         finally: close(replay)
     finally:
         if parent.poll() is None: parent.kill()

--- a/ods/tests/pixel_inference/test_runtime_custody.py
+++ b/ods/tests/pixel_inference/test_runtime_custody.py
@@ -43,7 +43,9 @@ def artifact(tmp_path, monkeypatch):
     source_entry.write_bytes(b'# fixture only\n')
     source_entry.chmod(0o600)
     node, python, launcher = tmp_path / 'node', tmp_path / 'python', tmp_path / 'launcher'
-    for path in (node, python): path.write_bytes(b'not executable fixture\n'); path.chmod(0o755)
+    for path in (node, python):
+        path.write_bytes(b'not executable fixture\n')
+        path.chmod(0o755)
     launcher.write_text('#!/bin/sh\nexec /usr/bin/env -u NODE_OPTIONS -u NODE_PATH '+str(node)+' '+str(runtime)+'/openclaw.mjs "$@"\n')
     launcher.chmod(0o755)
     manifest = {'runtime': r.tree_manifest(runtime), 'source': r.tree_manifest(source),

--- a/ods/tests/pixel_inference/test_scopes_host.py
+++ b/ods/tests/pixel_inference/test_scopes_host.py
@@ -4,7 +4,7 @@ import os
 import uuid
 
 import pytest
-from test_handoff_host import host  # shared real stdlib host fixture
+from test_handoff_host import host as host  # shared real stdlib host fixture
 
 pytestmark = pytest.mark.skipif(os.name != 'posix', reason='POSIX scope storage')
 

--- a/ods/tests/pixel_inference/test_service_activation.py
+++ b/ods/tests/pixel_inference/test_service_activation.py
@@ -59,7 +59,9 @@ def lifecycle(participant):  # noqa: F811 - imported pytest fixture
                 self.stopped = True
                 raise AccessError('host-command-failed')
             self.stopped = False
-            if self.failure != 'same-identity': self.pid += 1; self.started += 1000
+            if self.failure != 'same-identity':
+                self.pid += 1
+                self.started += 1000
             self.live_binding = json.loads(self.config.read_bytes())['plugins']['entries']['pixel-ods'].get('config', {}).get('managedProvider')
             return ''
         if 'daemon-reload' in args:
@@ -164,7 +166,9 @@ def test_previously_stopped_unit_is_not_started_or_service_files_written(lifecyc
 def test_drift_refuses_before_service_write(lifecycle, drift):
     p, b = lifecycle, lifecycle.bridge
     b.config.write_bytes(b.after)
-    if drift == 'custody': b.record['runtimeCustody'] = 'a' * 64; atomic_json(b.state / 'transition.json', b.record)
+    if drift == 'custody':
+        b.record['runtimeCustody'] = 'a' * 64
+        atomic_json(b.state / 'transition.json', b.record)
     if drift == 'boundary': b.boundary += '\nNoNewPrivileges=no'
     if drift == 'definition': b.definition = '/tmp/unreviewed'
     with pytest.raises(AccessError): callback(p)

--- a/ods/tests/pixel_inference/test_service_environment.py
+++ b/ods/tests/pixel_inference/test_service_environment.py
@@ -180,7 +180,9 @@ def test_unsafe_service_files_refused(participant, tmp_path, kind):
     target.chmod(0o600)
     if kind == 'symlink': p.environment.symlink_to(target)
     if kind == 'hardlink': os.link(target, p.environment)
-    if kind == 'writable': p.environment.write_bytes(b'x'); p.environment.chmod(0o666)
+    if kind == 'writable':
+        p.environment.write_bytes(b'x')
+        p.environment.chmod(0o666)
     if kind == 'directory': p.environment.mkdir()
     if kind == 'parent': p.environment.parent.chmod(0o777)
     with pytest.raises(AccessError): p.apply(b.record)

--- a/ods/tests/pixel_settings/test_projection.py
+++ b/ods/tests/pixel_settings/test_projection.py
@@ -27,7 +27,8 @@ def caps(**changes):
 
 
 def test_context_output_projection_preserves_provider_routing_auth_access_and_input():
-    source = config(); before = copy.deepcopy(source)
+    source = config()
+    before = copy.deepcopy(source)
     plan = plan_preferences(source, {"contextTokens": 65536, "maxOutputTokens": 8192}, caps())
     result = plan["document"]
     assert source == before
@@ -57,7 +58,8 @@ def test_rollback_keeps_unrelated_concurrent_edits_and_created_siblings():
 
 
 def test_repeated_changes_and_reset_restore_original_not_last_override():
-    original = config(); original["agents"]["list"][0]["contextTokens"] = 32768
+    original = config()
+    original["agents"]["list"][0]["contextTokens"] = 32768
     preferences = {"contextTokens": 65536, "maxOutputTokens": 8192, "verbosity": "full"}
     first = plan_preferences(original, preferences, caps())
     changes = merge_preferences(preferences, {"contextTokens": 49152})
@@ -86,7 +88,8 @@ def test_empty_preferences_do_not_create_containers_or_change_owner_values():
 
 
 def test_agent_order_changes_do_not_retarget_preferences():
-    source = config(); source["agents"]["list"].append({"id": "other", "verboseDefault": "on"})
+    source = config()
+    source["agents"]["list"].append({"id": "other", "verboseDefault": "on"})
     plan = plan_preferences(source, {"verbosity": "full"}, caps(pixelOnlyRuntime=False))
     plan["document"]["agents"]["list"].reverse()
     restored = restore_preferences(plan["document"], plan["state"])
@@ -95,7 +98,8 @@ def test_agent_order_changes_do_not_retarget_preferences():
 
 
 def test_actual_multiagent_config_overrules_false_isolation_claim():
-    source = config(); source["agents"]["list"].append({"id": "other"})
+    source = config()
+    source["agents"]["list"].append({"id": "other"})
     with pytest.raises(SettingsError, match="pixel-isolation"):
         plan_preferences(source, {"contextTokens": 65536}, caps())
 
@@ -138,7 +142,8 @@ def test_unowned_context_change_is_not_replaced_by_stale_baseline_budget():
 ])
 def test_drift_refuses_without_partial_mutation(change):
     plan = plan_preferences(config(), {"verbosity": "full"}, caps())
-    change(plan["document"]); before = copy.deepcopy(plan["document"])
+    change(plan["document"])
+    before = copy.deepcopy(plan["document"])
     with pytest.raises(SettingsError, match="drift"):
         restore_preferences(plan["document"], plan["state"])
     assert plan["document"] == before
@@ -155,6 +160,7 @@ def test_drift_refuses_without_partial_mutation(change):
     lambda s: s["baseBudgets"].update(contextTokens=True),
 ])
 def test_malformed_state_cannot_target_unowned_policy(corrupt):
-    plan = plan_preferences(config(), {"verbosity": "full"}, caps()); corrupt(plan["state"])
+    plan = plan_preferences(config(), {"verbosity": "full"}, caps())
+    corrupt(plan["state"])
     with pytest.raises(SettingsError):
         restore_preferences(plan["document"], plan["state"])


### PR DESCRIPTION
## Why this matters
Six verification workflows exclude PRs targeting public-beta, and all eleven workflows with push branch filters exclude beta pushes. Applying the existing Python lint command to this branch also reports 326 findings, so enabling the omitted check alone leaves beta CI failing.

Include public-beta in the existing event filters and clear those findings without changing production behavior: split semicolon-separated statements while retaining their control-flow suites, remove whitespace on blank lines, explicitly re-export imported pytest fixtures, and remove seven unused test imports. Fixture aliases preserve pytest discovery and eliminate false unused/redefinition diagnostics.

## Overlap check
Searched open/closed beta CI/Ruff/workflow PRs and PRs touching the eleven workflow files. #4215 adds reinstall tests, #3370/#2542/#2488 address permissions, and #2908 publishes API reports. #4242/#4244 change API lifecycle/routing; #3385/#3818 are broader Portal work. None clears this branch's lint findings while repairing its event filters. The Python edits are limited to reported findings; no test or runtime function is removed.

## Validation
- Exact existing command: ruff check ods/ --select E,F,W --ignore E501,E701,E731,E741,E402
- Before: 268 E702, 11 W293, 13 F401 and 34 F811 findings. After: zero findings.
- Verified parsed Python ASTs across all 47 edited Python files: production logic and test bodies are identical. The only import differences are redundant same-name fixture aliases and seven explicitly enumerated unused test imports.
- Provider/inference owner contracts: 784 passed.
- Dashboard API: 2,699 passed, 2 skipped.
- Settings: 277 passed, 3 skipped.
- Model router: 74 passed.
- Isolated host stdlib import/runtime-status check passes.
- Existing deprecation/resource warnings remain; no tests are removed or marked skipped by this change.
- YAML event regression: 17 filtered push/PR lists excluded beta before; all eleven workflows now admit beta. Existing branch entries, path filters, jobs, permissions and step-failure policies remain unchanged.
- git diff --check passes.

Commands (from ods unless stated otherwise):
- python -m pytest tests/pixel_inference -q
- python -m pytest tests/pixel_settings -q
- python -m pytest tests -q (from extensions/services/dashboard-api and extensions/services/model-router separately)
- python -I -S tests/pixel_inference/check_advice_stdlib.py

## Rollout
Open for review. This changes verification coverage and lint-compatible source presentation, not deployment or branch protection. Catalog retains its path filter; a workflow/Python-only PR does not select that job. The existing non-blocking mypy policy remains unchanged. Direct upstream beta-push selection is deferred until merge.

Revert the event-filter commit to restore earlier trigger selection; the Python cleanup can remain independently.

## AI Assistance
Codex assisted with the event audit, targeted source cleanup, AST equivalence checks and behavioral validation.

## Final CI and batch check
Head 7b631777ffd907086c2592bdc27486624417048b: all 47 GitHub checks completed, 39 successful and eight skipped; no failures. [Ruff run](https://github.com/Osmantic/ODS/actions/runs/34675344918) is green.

The [updated 15-PR integration commit](https://github.com/0xacee/ODS/commit/ebef85b5a0b5d88f22a9ff1ffcf61169de97c788) accepts this cleanup without conflicts and also passes the full Ruff command. The dashboard subtree is unchanged from the previously verified 920-test, lint-clean, successful-build candidate.
