### PR TITLE
fix(gpu): recover monitoring after stalled response bodies

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useGPUDetailed.recovery.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useGPUDetailed.recovery.test.js
@@ -1,0 +1,30 @@
+import {act, renderHook} from '@testing-library/react'
+import {useGPUDetailed} from '../useGPUDetailed'
+
+beforeEach(() => {vi.useFakeTimers(); vi.stubGlobal('fetch', vi.fn())})
+afterEach(() => {vi.useRealTimers(); vi.unstubAllGlobals()})
+const ok = value => ({ok:true, json:async () => value})
+it('releases a stalled body and polls again after the deadline', async () => {
+  let signal
+  fetch.mockImplementation((_url, options) => {
+    signal ||= options?.signal
+    return Promise.resolve({ok:true,json:() => new Promise(() => {})})
+  })
+  const {result,unmount} = renderHook(() => useGPUDetailed())
+  await act(async () => {await vi.advanceTimersByTimeAsync(15000)})
+  expect(result.current.loading).toBe(false)
+  expect(result.current.error).toMatch(/timed out/i)
+  expect(signal.aborted).toBe(true)
+  fetch.mockResolvedValue(ok({fresh:true}))
+  await act(async () => {await vi.advanceTimersByTimeAsync(20000)})
+  expect(result.current.detailed).toEqual({fresh:true})
+  expect(result.current.error).toBeNull()
+  unmount()
+})
+it('aborts the active poll on unmount', async () => {
+  let signal
+  fetch.mockImplementation((_url,options) => {signal=options?.signal;return new Promise(() => {})})
+  const {unmount}=renderHook(() => useGPUDetailed())
+  unmount()
+  expect(signal?.aborted).toBe(true)
+})

--- a/ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js
+++ b/ods/extensions/services/dashboard/src/hooks/useGPUDetailed.js
@@ -13,25 +13,39 @@ export function useGPUDetailed() {
   const fetchInFlight = useRef(false)
 
   useEffect(() => {
+    let disposed = false
+    let activeController = null
     const fetchAll = async () => {
       if (document.hidden) return
       if (fetchInFlight.current) return
       fetchInFlight.current = true
+      const controller = new AbortController()
+      activeController = controller
+      let rejectAbort
+      const aborted = new Promise((_, reject) => {
+        rejectAbort = () => reject(new Error('GPU status request timed out'))
+        controller.signal.addEventListener('abort', rejectAbort, {once:true})
+      })
+      const timer = setTimeout(() => controller.abort(), 15000)
       try {
-        const [detRes, histRes, topoRes] = await Promise.all([
-          fetch('/api/gpu/detailed'),
-          fetch('/api/gpu/history'),
-          fetch('/api/gpu/topology'),
-        ])
-        if (detRes.ok) setDetailed(await detRes.json())
-        if (histRes.ok) setHistory(await histRes.json())
-        if (topoRes.ok) setTopology(await topoRes.json())
+        const snapshot = Promise.all(['detailed', 'history', 'topology'].map(async endpoint => {
+          const response = await fetch(`/api/gpu/${endpoint}`, {signal:controller.signal})
+          return response.ok ? response.json() : undefined
+        }))
+        const [details, samples, links] = await Promise.race([snapshot, aborted])
+        if (disposed) return
+        if (details !== undefined) setDetailed(details)
+        if (samples !== undefined) setHistory(samples)
+        if (links !== undefined) setTopology(links)
         setError(null)
       } catch (err) {
-        setError(err.message)
+        if (!disposed) setError(err.message)
       } finally {
+        clearTimeout(timer)
+        controller.signal.removeEventListener('abort', rejectAbort)
+        if (activeController === controller) activeController = null
         fetchInFlight.current = false
-        setLoading(false)
+        if (!disposed) setLoading(false)
       }
     }
 
@@ -40,6 +54,8 @@ export function useGPUDetailed() {
     const onVisibility = () => { if (!document.hidden) fetchAll() }
     document.addEventListener('visibilitychange', onVisibility)
     return () => {
+      disposed = true
+      activeController?.abort()
       clearInterval(interval)
       document.removeEventListener('visibilitychange', onVisibility)
     }


### PR DESCRIPTION
## Why this matters
GPU Monitor stops refreshing permanently when any of its three HTTP responses or JSON bodies stalls: fetchInFlight stays true and every later poll is skipped. Bound the complete snapshot read to 15 seconds, abort outstanding fetches, and release the polling lock. Leaving the page aborts the active request and prevents late state writes.

## Behavioral invariant
A stalled poll must settle and allow later scheduled polls to recover. Snapshot reads publish only while their effect is live. Existing hidden-tab and HTTP-response behavior is preserved.

## Overlap check
Searched open and closed Osmantic/ODS PR titles for GPU polling/recovery and the complete PR file inventory for useGPUDetailed.js. Inspected #3025 and #3313: they handle HTTP errors and initial hidden-tab loading, without a total request/body deadline or unmount cancellation. This PR does not duplicate those HTTP/initial-load changes. The file may require reconciliation if those main-targeted PRs are merged into beta later.

## Validation
- Regression on the unchanged beta: stalled-body recovery and unmount cancellation both failed.
- `npm test -- --maxWorkers=1 src/hooks/__tests__/useGPUDetailed.recovery.test.js`: 2 passed.
- Dashboard ESLint: passed with existing warnings. Vite production build: passed.
- `git diff --check`: passed.
- Validation was repeated in a clean Linux checkout; the final integration receipt and baseline gate limitations are recorded below.
- Full pre-commit scan: gitleaks, ShellCheck and large-file checks passed; private-key detection flags pre-existing test fixtures in test-remote-provider-egress-policy.py and test_host_agent.py. No secret-bearing files changed here.

Browser-network behavior is exercised through controlled fetch/body promises, not a live GPU host. Reverting this commit restores the previous polling behavior; no persisted state or backend contract changes.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `3fd723015a96d208960b742598aa183301f18b7e`.
