### PR TITLE
fix(pixel): respond to touch selection changes

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelSelectionActions.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSelectionActions.jsx
@@ -24,6 +24,7 @@ export default function PixelSelectionActions({ disabled, conversationId, onInse
     const outside = event => { if (!toolbar.current?.contains(event.target)) setSelection(null) }
     const escape = event => { if (event.key === 'Escape') setSelection(null) }
     const hide = () => setSelection(null)
+    document.addEventListener('selectionchange', update)
     document.addEventListener('mouseup', update)
     document.addEventListener('keyup', update)
     document.addEventListener('pointerdown', outside)
@@ -31,6 +32,7 @@ export default function PixelSelectionActions({ disabled, conversationId, onInse
     window.addEventListener('scroll', hide, true)
     window.addEventListener('resize', hide)
     return () => {
+      document.removeEventListener('selectionchange', update)
       document.removeEventListener('mouseup', update); document.removeEventListener('keyup', update)
       document.removeEventListener('pointerdown', outside); document.removeEventListener('keydown', escape)
       window.removeEventListener('scroll', hide, true); window.removeEventListener('resize', hide)

--- a/ods/extensions/services/dashboard/src/components/PixelSelectionActions.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSelectionActions.test.jsx
@@ -38,3 +38,13 @@ test('Escape hides the toolbar until a new selection and switching clears it', (
   view.rerender(<><p data-pixel-response="">Answer</p><PixelSelectionActions conversationId="two" onInsert={() => {}}/></>)
   expect(screen.queryByRole('toolbar')).not.toBeInTheDocument()
 })
+
+test('responds to touch selection changes and clears a collapsed selection', () => {
+  render(<><p data-pixel-response="">Touch answer</p><PixelSelectionActions onInsert={() => {}}/></>)
+  const value = selection(screen.getByText('Touch answer').firstChild)
+  fireEvent(document, new Event('selectionchange'))
+  expect(screen.getByRole('toolbar')).toBeVisible()
+  value.isCollapsed = true
+  fireEvent(document, new Event('selectionchange'))
+  expect(screen.queryByRole('toolbar')).not.toBeInTheDocument()
+})


### PR DESCRIPTION
## Why this matters
Selecting reply text with mobile selection handles emits selectionchange without mouseup or keyup. The response-action toolbar never appears. Subscribe to selection changes and remove the listener on cleanup; preserve the existing same-reply, length and active-task guards. Collapsing the selection removes the toolbar.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). PixelSelectionActions.jsx appears only in #4027, the existing workspace implementation. No open or closed PR addresses touch selection events; the mouse and keyboard behavior stays covered.

## Validation
- PixelSelectionActions.test.jsx: 4 tests passed, including touch-style selectionchange, collapse, mixed-message rejection and Escape/conversation changes.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `7ffbc88978e3c68da7b353caa97914122b80f44b`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `7ffbc88978e3c68da7b353caa97914122b80f44b`.
