### PR TITLE
fix(talk): preserve attachments and composition on keyboard send

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -754,9 +754,9 @@ export default function ODSTalk() {
               value={input}
               onChange={event => setInput(event.target.value)}
               onKeyDown={event => {
-                if (event.key === 'Enter' && !event.shiftKey) {
+                if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing) {
                   event.preventDefault()
-                  if (canSend) sendText(input)
+                  if (canSend) submit(event)
                 }
               }}
               rows={1}

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.keyboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.keyboard.test.jsx
@@ -1,0 +1,32 @@
+﻿import {fireEvent, render, screen, waitFor} from '@testing-library/react'
+import ODSTalk from './ODSTalk'
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(url => url === '/api/talk/status'
+    ? Promise.resolve({ok:true,json:async () => ({capabilities:{text_chat:true}})})
+    : new Promise(() => {})))
+})
+afterEach(() => vi.unstubAllGlobals())
+it.each(['Enter', 'button'])('sends the selected file and caption using %s', async method => {
+  render(<ODSTalk/>); await screen.findByText('Ready')
+  const file = new File(['original bytes'], 'notes.txt', {type:'text/plain'})
+  fireEvent.change(document.querySelector('input[type=file]'), {target:{files:[file]}})
+  const field=screen.getByPlaceholderText('Message ODS')
+  fireEvent.change(field, {target:{value:'Summarize'}})
+  if(method==='Enter') fireEvent.keyDown(field,{key:'Enter'})
+  else fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  await waitFor(() => expect(fetch).toHaveBeenCalledWith('/api/talk/attachment',expect.any(Object)))
+  const options=fetch.mock.calls.find(([url]) => url==='/api/talk/attachment')[1]
+  expect(options.body.get('text')).toBe('Summarize')
+  expect(options.body.get('file').name).toBe('notes.txt')
+  expect(fetch.mock.calls.some(([url]) => url==='/api/talk/message/stream')).toBe(false)
+})
+it('keeps IME confirmation and Shift+Enter in the composer', async () => {
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  const field=screen.getByPlaceholderText('Message ODS')
+  fireEvent.change(field,{target:{value:'composition draft'}})
+  fireEvent.keyDown(field,{key:'Enter',isComposing:true})
+  fireEvent.keyDown(field,{key:'Enter',shiftKey:true})
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(field).toHaveValue('composition draft')
+})


### PR DESCRIPTION
## Why this matters
The Talk composer has two submit paths: the button includes the pending attachment, while Enter calls sendText(input) and silently sends only the caption. Route Enter through the form submit handler and leave IME confirmation/Shift+Enter in the composer. The same selected file and caption now reach the same multipart API regardless of input method.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Inspected ODSTalk.jsx history and #3063 (duplicate-submission guard), #3177/#2959 (media cleanup), #3845 (exports), and #4215 (reinstall/attachment display). None changes the keyboard attachment/composition handler.

## Validation
- ODSTalk.keyboard.test.jsx plus ODSTalk.test.jsx: 18 passed. Before the fix the Enter attachment and IME cases failed; button parity already passed.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `afe73182495fb96dc4d382248922dbd119751036`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `afe73182495fb96dc4d382248922dbd119751036`.
