### PR TITLE
fix(talk): require stream completion and preserve partial replies

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.completion.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.completion.test.jsx
@@ -1,0 +1,37 @@
+﻿import {fireEvent,render,screen,waitFor} from '@testing-library/react'
+import ODSTalk from './ODSTalk'
+
+afterEach(() => vi.unstubAllGlobals())
+async function start(frames, holdOpen=false) {
+  let read=false
+  const reader={read:vi.fn(async () => {
+    if(!read){read=true;return {value:new TextEncoder().encode(frames.map(frame=>`data: ${JSON.stringify(frame)}\n\n`).join('')),done:false}}
+    return holdOpen ? new Promise(()=>{}) : {done:true}
+  }),cancel:vi.fn(async()=>{}),releaseLock:vi.fn()}
+  vi.stubGlobal('fetch',vi.fn(async url => url==='/api/talk/status'
+    ? {ok:true,json:async()=>({capabilities:{text_chat:true}})}
+    : {ok:true,body:{getReader:()=>reader}}))
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Explain'}})
+  fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  return reader
+}
+it('keeps partial text but reports EOF without completion as interrupted',async()=>{
+  await start([{type:'delta',text:'Partial answer'}])
+  await screen.findByRole('button',{name:'Retry last message'})
+  expect(screen.getByText('Partial answer')).toBeInTheDocument()
+  expect(screen.getByText(/ended before completion/i)).toBeInTheDocument()
+})
+it('settles on done without waiting for a proxy to close the body',async()=>{
+  const reader=await start([{type:'complete',text:'Final answer'},{type:'done'}],true)
+  await screen.findByText('Final answer')
+  await waitFor(()=>expect(reader.cancel).toHaveBeenCalledOnce())
+  expect(reader.releaseLock).toHaveBeenCalledOnce()
+  expect(screen.queryByRole('button',{name:'Retry last message'})).not.toBeInTheDocument()
+})
+it('retains streamed text next to the terminal server error',async()=>{
+  await start([{type:'delta',text:'Useful partial'},{type:'error',detail:'Worker stopped'},{type:'done'}])
+  await screen.findByRole('button',{name:'Retry last message'})
+  expect(screen.getByText('Useful partial')).toBeInTheDocument()
+  expect(screen.getByText('Worker stopped')).toBeInTheDocument()
+})

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -450,61 +450,70 @@ export default function ODSTalk() {
       const reader = resp.body.getReader()
       const decoder = new TextDecoder()
       let buffer = ''
+      let completed = false
       // SSE frames are separated by a blank line (\n\n). Buffer partial frames
       // across reads — chunked transport can split mid-frame. Lines starting
       // with ``:`` are SSE comments (keepalives); we discard them by filtering
       // for ``data:`` only below.
-      while (true) {
-        const { value, done } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        let sepIdx
-        while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
-          const frame = buffer.slice(0, sepIdx)
-          buffer = buffer.slice(sepIdx + 2)
-          const dataLines = frame.split('\n').filter(line => line.startsWith('data:'))
-          if (dataLines.length === 0) continue
-          const json = dataLines.map(l => l.slice(5).trimStart()).join('\n')
-          let payload
-          try {
-            payload = JSON.parse(json)
-          } catch {
-            continue
-          }
-          if (payload.type === 'delta' && typeof payload.text === 'string') {
-            assembled += payload.text
-            const snapshot = assembled
-            // Once token deltas start arriving the spinner caption is no
-            // longer useful — clear it so the assistant bubble shows the
-            // live text instead. `status: null` signals MessageBubble to
-            // render the accumulated text rather than a spinner.
-            setMessages(items => items.map(item =>
-              item.id === assistantId
-                ? { ...item, text: snapshot, status: 'pending', statusLabel: null, statusTool: null, statusDetail: null }
-                : item,
-            ))
-          } else if (payload.type === 'status') {
-            // Friendly progress caption from the bridge (e.g. "Searching the
-            // web…"). Replaces the default "Thinking…" while a tool is in
-            // flight. label=null means "tool done; flip back to default."
-            const label = typeof payload.label === 'string' ? payload.label : null
-            const tool = typeof payload.tool === 'string' ? payload.tool : null
-            const detail = typeof payload.detail === 'string' ? payload.detail : null
-            setMessages(items => items.map(item =>
-              item.id === assistantId
-                ? { ...item, statusLabel: label, statusTool: tool, statusDetail: detail }
-                : item,
-            ))
-          } else if (payload.type === 'complete') {
-            if (typeof payload.text === 'string' && payload.text) assembled = payload.text
-            finalWarning = payload.warning || null
-          } else if (payload.type === 'error') {
-            errorDetail = payload.detail || 'Hermes did not finish the response.'
+      try {
+        streamLoop: while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          let sepIdx
+          while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
+            const frame = buffer.slice(0, sepIdx)
+            buffer = buffer.slice(sepIdx + 2)
+            const dataLines = frame.split('\n').filter(line => line.startsWith('data:'))
+            if (dataLines.length === 0) continue
+            const json = dataLines.map(l => l.slice(5).trimStart()).join('\n')
+            let payload
+            try {
+              payload = JSON.parse(json)
+            } catch {
+              continue
+            }
+            if (payload.type === 'delta' && typeof payload.text === 'string') {
+              assembled += payload.text
+              const snapshot = assembled
+              // Once token deltas start arriving the spinner caption is no
+              // longer useful — clear it so the assistant bubble shows the
+              // live text instead. `status: null` signals MessageBubble to
+              // render the accumulated text rather than a spinner.
+              setMessages(items => items.map(item =>
+                item.id === assistantId
+                  ? { ...item, text: snapshot, status: 'pending', statusLabel: null, statusTool: null, statusDetail: null }
+                  : item,
+              ))
+            } else if (payload.type === 'status') {
+              // Friendly progress caption from the bridge (e.g. "Searching the
+              // web…"). Replaces the default "Thinking…" while a tool is in
+              // flight. label=null means "tool done; flip back to default."
+              const label = typeof payload.label === 'string' ? payload.label : null
+              const tool = typeof payload.tool === 'string' ? payload.tool : null
+              const detail = typeof payload.detail === 'string' ? payload.detail : null
+              setMessages(items => items.map(item =>
+                item.id === assistantId
+                  ? { ...item, statusLabel: label, statusTool: tool, statusDetail: detail }
+                  : item,
+              ))
+            } else if (payload.type === 'done') {
+              break streamLoop
+            } else if (payload.type === 'complete') {
+              completed = true
+              if (typeof payload.text === 'string' && payload.text) assembled = payload.text
+              finalWarning = payload.warning || null
+            } else if (payload.type === 'error') {
+              errorDetail = payload.detail || 'Hermes did not finish the response.'
+            }
           }
         }
-      }
 
+      } finally {
+        try { await reader.cancel() } finally { reader.releaseLock() }
+      }
       if (errorDetail) throw new Error(errorDetail)
+      if (!completed) throw new Error('The response ended before completion. You can retry this message.')
       const reply = assembled || 'I did not get a response back.'
       setMessages(items => items.map(item =>
         item.id === assistantId
@@ -519,7 +528,7 @@ export default function ODSTalk() {
       } else {
         setMessages(items => items.map(item =>
           item.id === assistantId
-            ? { ...item, text: err.message || 'Something went wrong.', status: 'error' }
+            ? { ...item, text: assembled || err.message || 'Something went wrong.', status: 'error', warning: assembled ? err.message : null }
             : item,
         ))
       }

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
@@ -30,6 +30,8 @@ const sseResponse = (frames, { status = 200, chunks, holdOpen = false } = {}) =>
     : frameBytes
   let idx = 0
   const reader = {
+    cancel: async () => {},
+    releaseLock: () => {},
     read: async () => {
       if (idx >= chunkGroups.length) {
         // ``holdOpen`` keeps the reader awaiting indefinitely after the final


### PR DESCRIPTION
## Why this matters
An interrupted connection currently becomes a successful reply even without the complete event; a done event is ignored until the socket closes, and terminal errors erase useful streamed text. Honor done, require a completion receipt before success, retain partial text beside the failure, and cancel/release the reader on exit. The backend already emits complete/error followed by done for both text and attachments.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). ODSTalk.jsx history and semantic stream/completion searches found #3801 (server generator cancellation), #3175 (TTS errors), #3171 (vision choices) and #3063 (duplicate sends). None repairs the browser terminal-event contract. #4446 touches the keyboard handler; the changes are independent and will be integrated together.

## Validation
- ODSTalk.completion.test.jsx plus ODSTalk.test.jsx: 18 passed. Three regressions cover truncated EOF, done with an open socket, and preservation of partial output after a server error.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `37d07f842da8b1d58221bded1b8627919f58f940`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `37d07f842da8b1d58221bded1b8627919f58f940`.
