### PR TITLE
fix(talk): retain oversized drafts before API rejection

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.caption-limit.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.caption-limit.test.jsx
@@ -1,0 +1,28 @@
+﻿import {fireEvent,render,screen} from '@testing-library/react'
+import ODSTalk from './ODSTalk'
+
+beforeEach(()=>vi.stubGlobal('fetch',vi.fn(url=>url==='/api/talk/status' ? Promise.resolve({ok:true,json:async()=>({capabilities:{text_chat:true}})}) : new Promise(()=>{}))))
+afterEach(()=>vi.unstubAllGlobals())
+it('retains an oversized caption and attachment without an invalid POST',async()=>{
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.change(document.querySelector('input[type=file]'),{target:{files:[new File(['contents'],'keep.txt',{type:'text/plain'})]}})
+  const field=screen.getByPlaceholderText('Message ODS')
+  fireEvent.change(field,{target:{value:'x'.repeat(8001)}})
+  expect(screen.getByRole('button',{name:'Send message'})).toBeDisabled()
+  expect(screen.getByRole('alert')).toHaveTextContent('8,000')
+  fireEvent.submit(field.closest('form'))
+  expect(fetch).toHaveBeenCalledTimes(1)
+  expect(field.value).toHaveLength(8001)
+  expect(screen.getByText('keep.txt')).toBeInTheDocument()
+  fireEvent.change(field,{target:{value:'short caption'}})
+  expect(screen.getByRole('button',{name:'Send message'})).toBeEnabled()
+  expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+})
+it('counts Unicode code points like the Python API instead of UTF-16 units',async()=>{
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  const text=String.fromCodePoint(0x1f680).repeat(8000)
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:text}})
+  expect(screen.getByRole('button',{name:'Send message'})).toBeEnabled()
+  fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  expect(JSON.parse(fetch.mock.calls[1][1].body).text).toBe(text)
+})

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -38,6 +38,7 @@ const welcomeMessage = {
 }
 
 const TALK_STATUS_RETRY_MS = 1000
+const MAX_MESSAGE_CHARS = 8000
 
 function makeId(prefix) {
   if (globalThis.crypto?.randomUUID) return `${prefix}-${globalThis.crypto.randomUUID()}`
@@ -369,7 +370,7 @@ export default function ODSTalk() {
     // Allow an attachment with no text — the backend supplies a default
     // prompt for images ("Describe what you see in this image."). Without
     // either a caption or an attachment, there's nothing to send.
-    if (!clean && !attachment) return
+    if ((!clean && !attachment) || Array.from(clean).length > MAX_MESSAGE_CHARS) return
     if (sending || status !== 'ready') return
     setSending(true)
 
@@ -642,7 +643,8 @@ export default function ODSTalk() {
 
   // Send is enabled either with text OR an attachment (an image alone is a
   // valid message — the model gets a default "describe this" prompt).
-  const canSend = (input.trim().length > 0 || pendingAttachment) && !sending && status === 'ready'
+  const captionTooLong = Array.from(input.trim()).length > MAX_MESSAGE_CHARS
+  const canSend = !captionTooLong && (input.trim().length > 0 || pendingAttachment) && !sending && status === 'ready'
 
   return (
     <div className="pixel-app ods-talk min-h-dvh bg-theme-bg text-theme-text antialiased">
@@ -711,6 +713,7 @@ export default function ODSTalk() {
         )}
 
         <form onSubmit={submit} className="sticky bottom-0 bg-theme-bg p-3">
+          {captionTooLong && <p id="talk-caption-limit" role="alert" className="mb-2 text-sm text-red-600">Shorten the message to 8,000 characters before sending. Your draft and attachment are kept.</p>}
           {/* Attachment preview strip — appears above the input bar between
               pick and send. Shows a thumbnail for images, a generic icon for
               text/code files, with an X to discard. */}
@@ -761,6 +764,8 @@ export default function ODSTalk() {
               }}
               rows={1}
               placeholder="Message ODS"
+              aria-invalid={captionTooLong || undefined}
+              aria-describedby={captionTooLong ? 'talk-caption-limit' : undefined}
               className="max-h-32 min-h-11 flex-1 resize-none bg-transparent px-1 py-2.5 text-[16px] leading-6 text-zinc-950 outline-none placeholder:text-zinc-400"
               disabled={status === 'expired'}
             />


### PR DESCRIPTION
## Why this matters
Talk accepts arbitrary caption length locally, clears the composer, then receives HTTP 413 from the shipped 8000-character API limit. Validate the same Unicode code-point limit before either text or attachment submission, keep the full draft/file for editing, and explain the limit next to the composer. Valid 8000-code-point emoji messages remain accepted.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Searched all ODSTalk.jsx PRs and title keywords for caption/length/oversized messages. #2778 concerns empty server-side uploads; #3063 concerns duplicate sends. No existing PR implements the client caption contract. Other batch Talk fixes touch separate event/stream blocks.

## Validation
- ODSTalk.caption-limit.test.jsx plus ODSTalk.test.jsx: 17 passed. Oversized caption/file preservation, direct form-submit guard, recovery after editing and Unicode boundary parity are covered.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `5d3da6d709a6de50f092d64f32954732ccf971b9`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `5d3da6d709a6de50f092d64f32954732ccf971b9`.
