### PR TITLE
fix(talk): cancel obsolete speech before playback begins

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -86,6 +86,14 @@ export default function ODSTalk() {
   // Track the currently-playing TTS state so we can shut down whatever
   // is in flight before starting the next reply's audio.
   const activeSpeechRef = useRef(null)
+  const speechRequestRef = useRef(null)
+  const speechMountedRef = useRef(false)
+  const speechEnabledRef = useRef(spokenReplies)
+  speechEnabledRef.current = spokenReplies
+  useEffect(() => {
+    speechMountedRef.current = true
+    return () => {speechMountedRef.current = false; speechRequestRef.current?.abort()}
+  }, [])
   // One persistent Audio element reused across all replies. iOS Safari's
   // audio session model is single-element-per-page; if we create a new
   // Audio() per turn (the obvious React-y pattern), the OS audio router
@@ -198,6 +206,8 @@ export default function ODSTalk() {
   // ObjectURL. The same element keeps its hold on the audio session
   // across turns, so the next play() lands without contention.
   const stopActiveSpeech = useCallback(() => {
+    speechRequestRef.current?.abort()
+    speechRequestRef.current = null
     const prev = activeSpeechRef.current
     activeSpeechRef.current = null
     if (!prev) return
@@ -218,20 +228,26 @@ export default function ODSTalk() {
     }
   }, [])
 
+  useEffect(() => {if (!spokenReplies) stopActiveSpeech()}, [spokenReplies, stopActiveSpeech])
+
   const speak = useCallback(async (text) => {
-    if (!spokenReplies || !voiceState.tts || !text.trim()) return
+    if (!speechMountedRef.current || !speechEnabledRef.current || !voiceState.tts || !text.trim()) return
     // ALWAYS stop the previous Audio/MediaSource before starting a new
     // one. Even if the previous one is still buffering chunks, the user
     // has clearly moved on (a new reply text has arrived).
     stopActiveSpeech()
+    const controller = new AbortController()
+    speechRequestRef.current = controller
     try {
       const body = new FormData()
       body.set('text', text)
       const resp = await fetch('/api/talk/speak', {
         method: 'POST',
+        signal: controller.signal,
         body,
         credentials: 'same-origin',
       })
+      if (controller.signal.aborted) {await resp.body?.cancel(); return}
       if (!resp.ok || !resp.body) return
 
       // Preferred path: MediaSource API plays MP3 chunks as they arrive
@@ -312,6 +328,7 @@ export default function ODSTalk() {
               sb.addEventListener('error', reject, { once: true })
               sb.appendBuffer(value)
             })
+            if (controller.signal.aborted || activeSpeechRef.current !== session) break
             if (!started) {
               started = true
               // play() returns a Promise on modern browsers. If iOS
@@ -347,6 +364,7 @@ export default function ODSTalk() {
       // The dashboard-api is still streaming on the network — we just
       // wait until it's all here before starting playback.
       const blob = await resp.blob()
+      if (controller.signal.aborted) return
       const url = URL.createObjectURL(blob)
       const audio = getSharedAudio()
       audio.src = url

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.speech-ownership.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.speech-ownership.test.jsx
@@ -1,0 +1,46 @@
+import {act,fireEvent,render,screen,waitFor} from '@testing-library/react'
+import ODSTalk from './ODSTalk'
+
+const deferred=()=>{let resolve;return {promise:new Promise(r=>{resolve=r}),resolve:value=>resolve(value)}}
+let audio
+beforeEach(()=>{
+  localStorage.clear()
+  audio={play:vi.fn(async()=>{}),pause:vi.fn(),addEventListener:vi.fn(),paused:false}
+  vi.stubGlobal('Audio',class {constructor(){return audio}})
+  vi.stubGlobal('MediaSource',undefined)
+  vi.spyOn(URL,'createObjectURL').mockReturnValue('blob:speech')
+  vi.spyOn(URL,'revokeObjectURL').mockImplementation(()=>{})
+})
+afterEach(()=>{vi.restoreAllMocks();vi.unstubAllGlobals();localStorage.clear()})
+async function start(speech){
+  vi.stubGlobal('fetch',vi.fn(url=>{
+    if(url==='/api/talk/status') return Promise.resolve({ok:true,json:async()=>({capabilities:{text_chat:true,tts:true}})})
+    if(url==='/api/talk/speak') return speech.promise
+    let read=false
+    return Promise.resolve({ok:true,body:{getReader:()=>({cancel:async()=>{},releaseLock:()=>{},read:async()=>read?{done:true}:(read=true,{done:false,value:new TextEncoder().encode('data: {"type":"complete","text":"Spoken answer"}\n\ndata: {"type":"done"}\n\n')})})}})
+  }))
+  const view=render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.click(screen.getByRole('button',{name:'Turn spoken replies on'}))
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Speak'}})
+  fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  await waitFor(()=>expect(fetch).toHaveBeenCalledWith('/api/talk/speak',expect.any(Object)))
+  return view
+}
+it('turning speech off aborts pending synthesis and rejects a late response',async()=>{
+  const speech=deferred();await start(speech)
+  const options=fetch.mock.calls.find(([url])=>url==='/api/talk/speak')[1]
+  fireEvent.click(screen.getByRole('button',{name:'Turn spoken replies off'}))
+  const cancel=vi.fn(async()=>{})
+  await act(async()=>speech.resolve({ok:true,body:{cancel},blob:async()=>new Blob(['audio'])}))
+  expect(options.signal?.aborted).toBe(true)
+  expect(audio.play).not.toHaveBeenCalled()
+  expect(cancel).toHaveBeenCalledOnce()
+})
+it('does not play a late iOS-style blob after unmount',async()=>{
+  const speech=deferred(),body=deferred();const view=await start(speech)
+  await act(async()=>speech.resolve({ok:true,body:{},blob:()=>body.promise}))
+  view.unmount()
+  await act(async()=>body.resolve(new Blob(['audio'])))
+  expect(audio.play).not.toHaveBeenCalled()
+  expect(URL.createObjectURL).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Why this matters
Turning spoken replies off does not cancel synthesis, and leaving Talk while the iOS blob is downloading can start audible playback after unmount. Own each synthesis request with an AbortController, reject responses/blobs after cancellation, and consult the live speaker preference before starting speech from an older reply closure. Existing playback is stopped when the toggle is turned off.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Inspected #3177: it cleans resources already registered in activeSpeechRef but cannot cancel fetch/blob work before that registration. #2959 handles microphone capture and #3175 handles backend TTS HTTP errors. This change owns pre-playback synthesis and the speaker toggle; it does not replace their active-resource cleanup.

## Validation
- ODSTalk.speech-ownership.test.jsx plus ODSTalk.test.jsx: 17 passed. Both late-response and late-blob regressions failed before the fix; request abortion and absence of playback/object URLs are asserted.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `590fce0822142fae7da1442c2bb5f9f7e2765f11`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `590fce0822142fae7da1442c2bb5f9f7e2765f11`.
