### PR TITLE
fix(talk): retry recorded audio with its original bytes

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.audio-retry.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.audio-retry.test.jsx
@@ -1,0 +1,31 @@
+import {fireEvent,render,screen,waitFor} from '@testing-library/react'
+import ODSTalk from './ODSTalk'
+
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
+it('retries the original recorded file through the audio endpoint',async()=>{
+  vi.stubGlobal('isSecureContext',true)
+  vi.stubGlobal('navigator',{mediaDevices:{getUserMedia:vi.fn(async()=>({getTracks:()=>[{stop:vi.fn()}]}))}})
+  vi.stubGlobal('MediaRecorder',class {
+    state='inactive';mimeType='audio/webm'
+    start(){this.state='recording'}
+    stop(){this.state='inactive';this.ondataavailable({data:new Blob(['original voice'],{type:this.mimeType})});this.onstop()}
+  })
+  let requests=0
+  vi.stubGlobal('fetch',vi.fn(async url=>{
+    if(url==='/api/talk/status')return {ok:true,json:async()=>({capabilities:{text_chat:true,audio_message:true}})}
+    if(url==='/api/talk/audio-message')return ++requests===1 ? {ok:false,status:503,json:async()=>({detail:'Speech service offline'})} : {ok:true,json:async()=>({transcript:'My original words',text:'Recovered reply'})}
+    return {ok:false,status:400,json:async()=>({detail:'Wrong retry endpoint'})}
+  }))
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.click(screen.getByRole('button',{name:'Record voice'}))
+  fireEvent.click(await screen.findByRole('button',{name:'Stop recording'}))
+  await screen.findByText('Speech service offline')
+  fireEvent.click(screen.getByRole('button',{name:'Retry last message'}))
+  await waitFor(()=>expect(requests).toBe(2))
+  const sends=fetch.mock.calls.filter(([url])=>url==='/api/talk/audio-message')
+  const retriedFile=sends[1][1].body.get('file')
+  expect(retriedFile.name).toBe('recording.webm')
+  expect(await new Promise((resolve,reject)=>{const reader=new FileReader();reader.onload=()=>resolve(reader.result);reader.onerror=reject;reader.readAsText(retriedFile)})).toBe('original voice')
+  expect(await screen.findByText('My original words')).toBeInTheDocument()
+  expect(fetch.mock.calls.some(([url])=>url==='/api/talk/message/stream')).toBe(false)
+})

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.audio-retry.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.audio-retry.test.jsx
@@ -25,7 +25,7 @@ it('retries the original recorded file through the audio endpoint',async()=>{
   const sends=fetch.mock.calls.filter(([url])=>url==='/api/talk/audio-message')
   const retriedFile=sends[1][1].body.get('file')
   expect(retriedFile.name).toBe('recording.webm')
-  expect(await new Promise((resolve,reject)=>{const reader=new FileReader();reader.onload=()=>resolve(reader.result);reader.onerror=reject;reader.readAsText(retriedFile)})).toBe('original voice')
+  expect(await new Promise((resolve,reject)=>{const reader=new globalThis.FileReader();reader.onload=()=>resolve(reader.result);reader.onerror=reject;reader.readAsText(retriedFile)})).toBe('original voice')
   expect(await screen.findByText('My original words')).toBeInTheDocument()
   expect(fetch.mock.calls.some(([url])=>url==='/api/talk/message/stream')).toBe(false)
 })

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -538,7 +538,7 @@ export default function ODSTalk() {
     const assistantId = makeId('assistant')
     setMessages(items => [
       ...items,
-      { id: userId, role: 'user', text: 'Voice message', status: 'pending' },
+      { id: userId, role: 'user', text: 'Voice message', audioFileForRetry: file, status: 'pending' },
       { id: assistantId, role: 'assistant', text: '', status: 'pending' },
     ])
 
@@ -637,7 +637,8 @@ export default function ODSTalk() {
 
   const retryLast = () => {
     const lastUser = [...messages].reverse().find(message => message.role === 'user' && message.status !== 'pending')
-    if (lastUser) sendText(lastUser.text, { attachment: lastUser.attachmentForRetry || null })
+    if (lastUser?.audioFileForRetry) sendAudioFile(lastUser.audioFileForRetry)
+    else if (lastUser) sendText(lastUser.text, { attachment: lastUser.attachmentForRetry || null })
   }
 
   // Send is enabled either with text OR an attachment (an image alone is a


### PR DESCRIPTION
## Why this matters
After transcription or inference fails for a recorded voice message, Retry last message currently sends the placeholder text Voice message to the text endpoint. Retain the original File in the in-memory user message and dispatch retries through the audio endpoint so transcription receives the same recording. Text and attachment retries keep their current routes.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Searched voice/audio/retry titles and all ODSTalk.jsx changes. #2959 is recorder teardown, #3177 is playback/image cleanup, and the existing image retry behavior is covered in the baseline suite. None retains or routes the failed audio recording on retry.

## Validation
- ODSTalk.audio-retry.test.jsx plus ODSTalk.test.jsx: 16 passed. The regression records through MediaRecorder, fails the audio API, retries via the UI, and checks original file bytes and the recovered transcript.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `8cfa20f0f30d3432464d3546c92fa29e1239f115`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `8cfa20f0f30d3432464d3546c92fa29e1239f115`.

Follow-up `8cfa20f0` qualifies the FileReader test global for ESLint; focused validation passed.
