### PR TITLE
fix(library): keep catalog position when the panel resizes

### DIFF
--- a/ods/extensions/services/dashboard/src/components/FittedLibraryPage.jsx
+++ b/ods/extensions/services/dashboard/src/components/FittedLibraryPage.jsx
@@ -20,9 +20,10 @@ export default function FittedLibraryPage({items, label, children, minimumItems 
   const measured = useRef({width: 0, row: 0})
   const [capacity, setCapacity] = useState(4)
   const [availableHeight, setAvailableHeight] = useState(0)
-  const [page, setPage] = useState(1)
+  // Anchor pagination to an item, so resizing cannot jump to unrelated entries.
+  const [firstItem, setFirstItem] = useState(0)
   const pages = Math.max(1, Math.ceil(items.length / capacity))
-  const current = Math.min(page, pages)
+  const current = Math.min(Math.floor(firstItem / capacity) + 1, pages)
   useEffect(() => {
     const element = root.current
     if (!element) return
@@ -57,7 +58,7 @@ export default function FittedLibraryPage({items, label, children, minimumItems 
       {pages > 1 && <nav className="dashboard-pagination" aria-label={`${label} pages`}>
         {fittedPageNumbers(current, pages).map(number => typeof number === 'string'
           ? <span key={number} aria-hidden="true">…</span>
-          : <button key={number} aria-label={`Page ${number}`} aria-current={number === current ? 'page' : undefined} onClick={() => setPage(number)}>{number}</button>)}
+          : <button key={number} aria-label={`Page ${number}`} aria-current={number === current ? 'page' : undefined} onClick={() => setFirstItem((number - 1) * capacity)}>{number}</button>)}
       </nav>}
     </footer>}
   </section>

--- a/ods/extensions/services/dashboard/src/components/FittedLibraryPage.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/FittedLibraryPage.test.jsx
@@ -36,3 +36,22 @@ it('fits the actual utility panel and paginates without dropping entries', () =>
   expect(screen.getByText('Item 9')).toBeVisible()
   expect(screen.getByText('9–10 of 10')).toBeVisible()
 })
+
+it('keeps the current catalog item visible when the utility panel shrinks and grows', () => {
+  vi.stubGlobal('ResizeObserver', class {observe(){} disconnect(){}})
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function () {
+    return {top:this.classList.contains('fitted-library-page') ? 100 : 0,width:420,height:144}
+  })
+  const height=vi.spyOn(HTMLElement.prototype,'clientHeight','get').mockReturnValue(742)
+  render(<div className="portal-panel-content"><FittedLibraryPage label="Catalog" items={Array.from({length:20},(_,i)=>i)}>{items=>items.map(i=><article className="extension-entry" key={i}>Entry {i}</article>)}</FittedLibraryPage></div>)
+  fireEvent.click(screen.getByRole('button',{name:'Page 2'}))
+  expect(screen.getByText('Entry 4')).toBeVisible()
+  height.mockReturnValue(454)
+  fireEvent(window,new Event('resize'))
+  expect(screen.getByText('Entry 4')).toBeVisible()
+  expect(screen.getByRole('button',{name:'Page 3'})).toHaveAttribute('aria-current','page')
+  height.mockReturnValue(742)
+  fireEvent(window,new Event('resize'))
+  expect(screen.getByText('Entry 4')).toBeVisible()
+  expect(screen.getByRole('button',{name:'Page 2'})).toHaveAttribute('aria-current','page')
+})


### PR DESCRIPTION
## Why this matters
Models and Extensions change their page capacity with panel height. Persisting the page number makes shrinking the panel jump backwards to unrelated entries and growing it skip ahead. Persist the first item index instead, derive the visible page from capacity, and keep the inspected item visible across resize.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). FittedLibraryPage.jsx is introduced by #4027 and refined in merged #4207. Semantic resize/pagination searches and the complete changed-file inventory contain no anchor-preservation fix. Existing minimum model counts and bounded pagination slots are preserved.

## Validation
- FittedLibraryPage.test.jsx: 5 passed. The new component regression navigates to page two, shrinks to half capacity, grows back, and asserts the same catalog entry remains visible and page indicators reconcile.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `71ad39c3ed652af577c8b79ea97ef643d6ab12f6`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `71ad39c3ed652af577c8b79ea97ef643d6ab12f6`.
