### PR TITLE
feat(extensions): expose guarded transaction API

### DIFF
--- a/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
@@ -1,0 +1,53 @@
+# ADR: Assistant First Transaction API Boundary
+
+**Status:** Accepted for source integration; disabled by default
+
+## Decision
+
+ODS exposes a separate, fail-closed HTTP boundary for composite extension
+transactions:
+
+- `POST /api/extensions/transactions` accepts only a six-field request intent
+  and an idempotency key. The server supplies the catalog, observed host state,
+  policy, actor, and timestamps, rebuilds the canonical plan, and persists it
+  in `awaiting_approval`.
+- `POST /api/extensions/transactions/{id}/approval` accepts only the exact plan
+  hash and requires an owner-scoped, HMAC-signed browser session. An API key,
+  admin/guest/legacy cookie, assistant, or model cannot approve.
+- `GET /api/extensions/transactions/{id}` requires the API key and returns the
+  reviewable plan plus durable state. Approval output is limited to a boolean,
+  timestamp, and hashed owner-session audit identity.
+- `POST /api/extensions/transactions/{id}/execute` requires the API key and
+  accepts only the exact plan hash. It calls an injected synchronous executor;
+  operations, configuration values, secrets, shell or Docker commands,
+  approval material, and purge intent are not request fields.
+
+Every response is `Cache-Control: no-store`. Request JSON is size-bounded and
+rejects duplicate keys, floating-point values, constants, coercion, and extra
+fields. Destructive data purge remains a separate future action and approval.
+
+## Runtime composition
+
+The router performs no import-time filesystem work. It resolves one immutable
+`TransactionRuntime` from FastAPI application state only after the environment
+feature gate `ODS_ASSISTANT_TRANSACTIONS_ENABLED` is enabled. Tests inject the
+same runtime seam. A missing runtime or executor fails with 503.
+
+Execution provenance is rechecked inside the executor's service locks against
+the current catalog revision, policy revision, normalized observed-state
+revision, canonical stored plan hash, and selected definition digests.
+
+## Why disabled by default
+
+ODS does not yet have a production composition that supplies both an
+authoritative observed-state provider and lifecycle adapters with durable,
+synchronous completion evidence. Existing single-extension endpoints may
+queue work, and a submitted or HTTP 202 operation is not completion. Enabling
+mutation before those adapters and cross-path locks are qualified would create
+false-success and collision risks.
+
+The API therefore remains unavailable by default. Later phases may install the
+runtime only after they add typed configuration, durable observation,
+cross-path locking, backup/restore, strict offline behavior, and real Linux
+qualification. Existing Full, Core, Custom, planning, and single-extension
+routes remain unchanged.

--- a/ods/extensions/services/dashboard-api/extension_transaction_runtime.py
+++ b/ods/extensions/services/dashboard-api/extension_transaction_runtime.py
@@ -1,0 +1,121 @@
+"""Dependency-injected runtime for Assistant First extension transactions."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from assistant_first_planner import (
+    PlanningError,
+    adapt_manifest,
+    canonical_json_bytes,
+    normalize_host_state,
+)
+from extension_planning_contract import (
+    computed_catalog_revision,
+    computed_policy_revision,
+    manifest_from_catalog_entry,
+)
+
+
+CatalogProvider = Callable[[], tuple[list[dict[str, Any]], str]]
+ObservedStateProvider = Callable[[], dict[str, Any]]
+PolicyProvider = Callable[[], dict[str, Any]]
+Clock = Callable[[], str]
+
+
+@dataclass(frozen=True)
+class TransactionRuntime:
+    """All authority used by a transaction request, supplied as one object."""
+
+    store: Any
+    catalog: CatalogProvider
+    observed_state: ObservedStateProvider
+    policy: PolicyProvider
+    clock: Clock
+    executor: Any | None = None
+
+
+class CurrentInputsProvenanceVerifier:
+    """Require the stored plan to match all current authoritative inputs."""
+
+    def __init__(
+        self,
+        *,
+        catalog: CatalogProvider,
+        observed_state: ObservedStateProvider,
+        policy: PolicyProvider,
+    ) -> None:
+        self._catalog = catalog
+        self._observed_state = observed_state
+        self._policy = policy
+
+    def verify(self, plan_hash: str, envelope: dict[str, Any]) -> bool:
+        try:
+            if not isinstance(plan_hash, str) or len(plan_hash) != 64:
+                return False
+            if not isinstance(envelope, dict) or envelope.get("planHash") != plan_hash:
+                return False
+            plan = envelope.get("plan")
+            if not isinstance(plan, dict):
+                return False
+            if hashlib.sha256(canonical_json_bytes(plan)).hexdigest() != plan_hash:
+                return False
+
+            catalog_result = self._catalog()
+            if not isinstance(catalog_result, tuple) or len(catalog_result) != 2:
+                return False
+            catalog, supplied_catalog_revision = catalog_result
+            if not isinstance(catalog, list) or any(
+                not isinstance(entry, dict) for entry in catalog
+            ):
+                return False
+            if computed_catalog_revision(catalog) != supplied_catalog_revision:
+                return False
+            if supplied_catalog_revision != envelope.get("catalogRevision"):
+                return False
+
+            policy = self._policy()
+            if not isinstance(policy, dict):
+                return False
+            if computed_policy_revision(policy) != envelope.get("policyRevision"):
+                return False
+
+            observed_state = self._observed_state()
+            if not isinstance(observed_state, dict):
+                return False
+            normalized_state = normalize_host_state(observed_state)
+            observed_revision = hashlib.sha256(
+                canonical_json_bytes(normalized_state)
+            ).hexdigest()
+            if observed_revision != envelope.get("observedStateRevision"):
+                return False
+
+            current_definitions = {}
+            for entry in catalog:
+                record = adapt_manifest(manifest_from_catalog_entry(entry))
+                current_definitions[record["id"]] = record["definitionSha256"]
+            stored_definitions = plan.get("definitions")
+            selected_services = plan.get("selectedServices")
+            if not isinstance(stored_definitions, list) or not isinstance(
+                selected_services, list
+            ):
+                return False
+            stored_digests = {
+                item.get("id"): item.get("definitionSha256")
+                for item in stored_definitions
+                if isinstance(item, dict)
+            }
+            if set(stored_digests) != set(selected_services):
+                return False
+            if any(
+                current_definitions.get(service_id)
+                != stored_digests.get(service_id)
+                for service_id in selected_services
+            ):
+                return False
+        except (KeyError, TypeError, ValueError, PlanningError):
+            return False
+        return True

--- a/ods/extensions/services/dashboard-api/extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/extension_transactions.py
@@ -1606,7 +1606,13 @@ class TransactionStore:
                 "sequence": next_seq,
             }
 
-    def approve(self, transaction_id, approval_data, current_time):
+    def _approve_record(self, transaction_id, approval_data, current_time):
+        """Replay a complete trusted approval record for low-level recovery tests.
+
+        Production callers must use ``approve_exact`` so the HTTP authentication
+        boundary supplies the owner identity while this store derives every
+        other approval field from its immutable transaction data.
+        """
         _validate_timestamp(current_time)
         if not isinstance(approval_data, dict):
             raise ApprovalError("invalid-approval-data")

--- a/ods/extensions/services/dashboard-api/extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/extension_transactions.py
@@ -1343,8 +1343,70 @@ class TransactionStore:
             )
 
         idem_path = self._idem_path(binding_data["idempotencyKey"])
-        _write_immutable(idem_path, canonical_json_bytes(index_data), 0o600)
+        if self._entry_exists(idem_path):
+            self._load_index(idem_path, transaction_id, binding_data)
+        else:
+            _write_immutable(idem_path, canonical_json_bytes(index_data), 0o600)
         return self._read_transaction(transaction_id)
+
+    @staticmethod
+    def _request_matches_binding(envelope, actor, idempotency_key, binding):
+        return (
+            binding["actor"] == actor
+            and binding["idempotencyKey"] == idempotency_key
+            and binding["catalogRevision"] == envelope["catalogRevision"]
+            and binding["observedStateRevision"]
+            == envelope["observedStateRevision"]
+            and binding["planHash"] == envelope["planHash"]
+            and binding["policyRevision"] == envelope["policyRevision"]
+        )
+
+    def _recover_by_idempotency_key(
+        self, envelope, actor, idempotency_key
+    ):
+        """Find and finish a durable create prefix whose index was not written."""
+        matches = []
+        try:
+            entries = list(os.scandir(str(self._tx_dir)))
+        except OSError as exc:
+            raise IntegrityError("transaction-dir-read-failed") from exc
+        if len(entries) > MAX_LIST_RESULTS:
+            raise IntegrityError("transaction-list-too-large")
+        for entry in entries:
+            if TXN_ID_RE.fullmatch(entry.name) is None:
+                continue
+            tx_dir = self._tx_path(entry.name)
+            binding_path = tx_dir / "binding.json"
+            if not self._entry_exists(binding_path):
+                continue
+            binding = self._load_binding(tx_dir, entry.name)
+            if binding["idempotencyKey"] == idempotency_key:
+                matches.append((entry.name, tx_dir, binding))
+        if not matches:
+            return None
+        if len(matches) != 1:
+            raise IdempotencyConflict("idempotency-drift")
+
+        transaction_id, tx_dir, binding = matches[0]
+        if not self._request_matches_binding(
+            envelope, actor, idempotency_key, binding
+        ):
+            raise IdempotencyConflict("idempotency-drift")
+        index_data = dict(binding)
+        index_data["transactionId"] = transaction_id
+        try:
+            repaired = self._recover_create(
+                tx_dir,
+                transaction_id,
+                envelope,
+                binding,
+                index_data,
+            )
+        except IdempotencyConflict:
+            raise
+        except TransactionError as exc:
+            raise IntegrityError("incomplete-transaction") from exc
+        return self._existing_descriptor(transaction_id, repaired)
 
     def create(self, envelope, actor, idempotency_key, timestamp, current_time):
         _validate_timestamp(timestamp)
@@ -1360,30 +1422,59 @@ class TransactionStore:
         if vu and vu <= current_time:
             raise ValidationRejected("expired")
 
-        txn_id = _derive_transaction_id(envelope, actor, idempotency_key, timestamp)
-        binding_data = {
-            "actor": actor,
-            "catalogRevision": envelope["catalogRevision"],
-            "createdAt": timestamp,
-            "idempotencyKey": idempotency_key,
-            "observedStateRevision": envelope["observedStateRevision"],
-            "planHash": envelope["planHash"],
-            "policyRevision": envelope["policyRevision"],
-        }
-        index_data = dict(binding_data)
-        index_data["transactionId"] = txn_id
-
         with self._lock:
             idem_path = self._idem_path(idempotency_key)
             if self._entry_exists(idem_path):
                 try:
-                    self._load_index(idem_path, txn_id, binding_data)
-                    existing = self._read_transaction(txn_id)
+                    index = _decode_canonical_object(
+                        idem_path, INDEX_KEYS, "idempotency-index"
+                    )
+                    transaction_id = index["transactionId"]
+                    tx_dir = self._tx_path(transaction_id)
+                    binding = self._load_binding(tx_dir, transaction_id)
+                    self._load_index(idem_path, transaction_id, binding)
+                    if not self._request_matches_binding(
+                        envelope, actor, idempotency_key, binding
+                    ):
+                        raise IdempotencyConflict("idempotency-drift")
+                    try:
+                        existing = self._read_transaction(transaction_id)
+                    except IntegrityError:
+                        index_data = dict(binding)
+                        index_data["transactionId"] = transaction_id
+                        existing = self._recover_create(
+                            tx_dir,
+                            transaction_id,
+                            envelope,
+                            binding,
+                            index_data,
+                        )
                 except (IntegrityError, TransactionError) as exc:
                     raise IdempotencyConflict("idempotency-drift") from exc
                 if existing["envelope"] != envelope:
                     raise IdempotencyConflict("idempotency-drift")
-                return self._existing_descriptor(txn_id, existing)
+                return self._existing_descriptor(transaction_id, existing)
+
+            recovered = self._recover_by_idempotency_key(
+                envelope, actor, idempotency_key
+            )
+            if recovered is not None:
+                return recovered
+
+            txn_id = _derive_transaction_id(
+                envelope, actor, idempotency_key, timestamp
+            )
+            binding_data = {
+                "actor": actor,
+                "catalogRevision": envelope["catalogRevision"],
+                "createdAt": timestamp,
+                "idempotencyKey": idempotency_key,
+                "observedStateRevision": envelope["observedStateRevision"],
+                "planHash": envelope["planHash"],
+                "policyRevision": envelope["policyRevision"],
+            }
+            index_data = dict(binding_data)
+            index_data["transactionId"] = txn_id
 
             tx_dir = self._tx_path(txn_id)
             if self._entry_exists(tx_dir):
@@ -1629,6 +1720,124 @@ class TransactionStore:
                 "transactionId": transaction_id,
                 "state": "approved",
                 "sequence": next_seq,
+            }
+
+    def approve_exact(
+        self,
+        transaction_id,
+        expected_plan_hash,
+        approved_by,
+        approved_at,
+        current_time,
+    ):
+        """Approve one stored plan from server-owned immutable binding data.
+
+        The HTTP boundary supplies only the path transaction ID, the hash the
+        owner reviewed, the hashed owner-session audit identity, and server
+        timestamps.  Actor, revisions, idempotency key, and expiry always come
+        from the durable transaction itself.
+        """
+        _validate_timestamp(approved_at)
+        _validate_timestamp(current_time)
+        if approved_at > current_time:
+            raise ApprovalError("future-approval")
+        if not isinstance(expected_plan_hash, str) or not HEX64_RE.fullmatch(
+            expected_plan_hash
+        ):
+            raise ApprovalError("invalid-plan-hash")
+        if (
+            not isinstance(approved_by, str)
+            or re.fullmatch(r"owner-[0-9a-f]{16}", approved_by) is None
+        ):
+            raise ApprovalError("invalid-owner-approval-identity")
+        try:
+            _validate_approver_id(approved_by)
+        except ValidationRejected as exc:
+            raise ApprovalError("invalid-approval-data", exc.code) from exc
+
+        with self._lock:
+            try:
+                loaded = self._read_transaction(
+                    transaction_id, allow_unjournaled_approval=True
+                )
+            except TransactionError as exc:
+                raise ApprovalError(exc.code, exc.detail) from exc
+            tx_dir = loaded["txDir"]
+            envelope = loaded["envelope"]
+            binding = loaded["binding"]
+            records = loaded["journal"]
+            if envelope["planHash"] != expected_plan_hash:
+                raise ApprovalError("plan-hash-mismatch")
+
+            current_state = loaded["state"]
+            if current_state == "approved":
+                if loaded["approval"]["approvedBy"] == approved_by:
+                    return {
+                        "transactionId": transaction_id,
+                        "state": "approved",
+                        "sequence": len(records),
+                        "noop": True,
+                    }
+                raise ApprovalError("approval-conflict")
+            if current_state != "awaiting_approval":
+                raise ApprovalError("wrong-state", current_state)
+
+            approval_path = tx_dir / "approval.json"
+            if loaded["approval"] is not None:
+                if loaded["approval"]["approvedBy"] != approved_by:
+                    raise ApprovalError("approval-conflict")
+                approval_record = loaded["approval"]
+            else:
+                approval_record = {
+                    "actor": binding["actor"],
+                    "approvedAt": approved_at,
+                    "approvedBy": approved_by,
+                    "catalogRevision": envelope["catalogRevision"],
+                    "idempotencyKey": binding["idempotencyKey"],
+                    "observedStateRevision": envelope["observedStateRevision"],
+                    "planHash": envelope["planHash"],
+                    "policyRevision": envelope["policyRevision"],
+                    "transactionId": transaction_id,
+                    "validUntil": envelope["plan"]["validUntil"],
+                }
+                if not binding["createdAt"] <= approved_at:
+                    raise ApprovalError("approval-before-transaction")
+                if not approved_at < approval_record["validUntil"]:
+                    raise ApprovalError("approval-expired")
+                if not current_time < approval_record["validUntil"]:
+                    raise ApprovalError("approval-expired")
+                _write_immutable(
+                    approval_path,
+                    canonical_json_bytes(approval_record),
+                    0o600,
+                )
+                if (
+                    self._load_approval(
+                        tx_dir, transaction_id, envelope, binding
+                    )
+                    != approval_record
+                ):
+                    raise IntegrityError("approval-write-verify-failed")
+
+            next_seq = len(records) + 1
+            line = _journal_entry(
+                transaction_id,
+                next_seq,
+                "approved",
+                envelope["planHash"],
+                approval_record["approvedAt"],
+                binding["actor"],
+            )
+            _journal_append(
+                tx_dir / "journal.jsonl",
+                line,
+                expected_actor=binding["actor"],
+            )
+            return {
+                "transactionId": transaction_id,
+                "state": "approved",
+                "sequence": next_seq,
+                "noop": False,
             }
 
     def read(self, transaction_id):

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -84,6 +84,7 @@ from routers import (
     pixel_advice_runtime,
     pixel_sharing,
     extension_planning,
+    extension_transactions,
 )
 from settings import (
     _ENV_ASSIGNMENT_RE, _ENV_COMMENTED_ASSIGNMENT_RE, _SETTINGS_APPLY_ALLOWED_SERVICES, _parse_env_text, _read_env_map_from_path,
@@ -1204,6 +1205,7 @@ app.include_router(pixel_scopes.router)
 app.include_router(pixel_advice_runtime.router)
 app.include_router(pixel_sharing.router)
 app.include_router(extension_planning.router)
+app.include_router(extension_transactions.router)
 
 
 # ================================================================

--- a/ods/extensions/services/dashboard-api/routers/extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/routers/extension_transactions.py
@@ -1,0 +1,298 @@
+"""Fail-closed HTTP boundary for Assistant First extension transactions."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, TypeVar
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from assistant_first_planner import PlanningError
+from extension_transaction_runtime import TransactionRuntime
+from extension_transactions import (
+    ApprovalError,
+    IdempotencyConflict,
+    IntegrityError,
+    TransactionError,
+    TransitionError,
+    ValidationRejected,
+)
+from plan_provenance import authorize_plan
+from routers.auth import require_owner_approval_session
+from security import verify_api_key
+
+
+router = APIRouter(prefix="/api/extensions/transactions", tags=["extensions"])
+MAX_REQUEST_BYTES = 64 * 1024
+_ENABLED_VALUES = frozenset({"1", "true", "yes", "on"})
+_Model = TypeVar("_Model", bound=BaseModel)
+
+
+class CreateTransactionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    intent: dict[str, Any]
+    idempotencyKey: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"
+    )
+
+
+class ExactHashRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    planHash: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"
+    )
+
+
+def _feature_enabled() -> bool:
+    return (
+        os.environ.get("ODS_ASSISTANT_TRANSACTIONS_ENABLED", "").strip().lower()
+        in _ENABLED_VALUES
+    )
+
+
+def get_transaction_runtime(request: Request) -> TransactionRuntime:
+    """Resolve one explicitly installed runtime after the feature gate."""
+    if not _feature_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail="Not found",
+            headers={"Cache-Control": "no-store"},
+        )
+    runtime = getattr(request.app.state, "extension_transaction_runtime", None)
+    if not isinstance(runtime, TransactionRuntime):
+        raise HTTPException(
+            status_code=503,
+            detail="Extension transaction runtime is unavailable",
+            headers={"Cache-Control": "no-store"},
+        )
+    return runtime
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    value: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate-key")
+        value[key] = item
+    return value
+
+
+def _reject_number(_value: str) -> None:
+    raise ValueError("floating-point-values-are-not-accepted")
+
+
+async def _request_model(request: Request, model_type: type[_Model]) -> _Model:
+    payload = bytearray()
+    async for chunk in request.stream():
+        payload.extend(chunk)
+        if len(payload) > MAX_REQUEST_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail="Transaction request is too large",
+                headers={"Cache-Control": "no-store"},
+            )
+    try:
+        decoded = json.loads(
+            bytes(payload).decode("utf-8", errors="strict"),
+            object_pairs_hook=_pairs,
+            parse_float=_reject_number,
+            parse_constant=_reject_number,
+        )
+        return model_type.model_validate(decoded)
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        TypeError,
+        ValueError,
+        ValidationError,
+    ) as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid transaction request",
+            headers={"Cache-Control": "no-store"},
+        ) from exc
+
+
+def _error_response(exc: Exception) -> JSONResponse:
+    code = getattr(exc, "code", "transaction-unavailable")
+    if not isinstance(code, str):
+        code = "transaction-unavailable"
+    if code == "not-found":
+        status_code = 404
+    elif isinstance(exc, ValidationRejected):
+        status_code = 422
+    elif isinstance(exc, (IdempotencyConflict, ApprovalError, TransitionError)):
+        status_code = 409
+    elif isinstance(exc, IntegrityError):
+        status_code = 503
+    else:
+        status_code = 503
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": code}},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+def _planning_error_response(exc: PlanningError) -> JSONResponse:
+    provider_errors = {
+        "invalid-catalog-provider",
+        "invalid-observed-state-provider",
+        "invalid-policy-provider",
+        "catalog-revision-mismatch",
+    }
+    if exc.code in provider_errors:
+        status_code = 503
+    elif exc.code.startswith(
+        (
+            "invalid-",
+            "duplicate-",
+            "extra-",
+            "unknown-",
+            "unused-",
+            "config-secret-",
+        )
+    ):
+        status_code = 422
+    else:
+        status_code = 409
+    return JSONResponse(
+        status_code=status_code,
+        content={"error": {"code": exc.code}},
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.post("")
+async def create_transaction(
+    request: Request,
+    runtime: TransactionRuntime = Depends(get_transaction_runtime),
+    _api_key: str = Depends(verify_api_key),
+) -> JSONResponse:
+    """Build a server-authoritative plan and persist it awaiting approval."""
+    model = await _request_model(request, CreateTransactionRequest)
+    try:
+        envelope = authorize_plan(
+            model.intent,
+            catalog=runtime.catalog,
+            observed_state=runtime.observed_state,
+            policy=runtime.policy,
+        )
+    except PlanningError as exc:
+        return _planning_error_response(exc)
+    timestamp = runtime.clock()
+    try:
+        descriptor = runtime.store.create(
+            envelope,
+            "assistant-manager",
+            model.idempotencyKey,
+            timestamp,
+            timestamp,
+        )
+    except TransactionError as exc:
+        return _error_response(exc)
+    return JSONResponse(
+        status_code=200 if descriptor.get("duplicate") is True else 201,
+        content={
+            "schema": "ods.assistant-first.transaction-proposal.v1",
+            **descriptor,
+            "envelope": envelope,
+        },
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.post("/{transaction_id}/approval")
+async def approve_transaction(
+    transaction_id: str,
+    request: Request,
+    approved_by: str = Depends(require_owner_approval_session),
+    runtime: TransactionRuntime = Depends(get_transaction_runtime),
+) -> JSONResponse:
+    """Bind one owner browser session to one exact stored plan hash."""
+    model = await _request_model(request, ExactHashRequest)
+    timestamp = runtime.clock()
+    try:
+        result = runtime.store.approve_exact(
+            transaction_id,
+            model.planHash,
+            approved_by,
+            timestamp,
+            timestamp,
+        )
+    except TransactionError as exc:
+        return _error_response(exc)
+    return JSONResponse(content=result, headers={"Cache-Control": "no-store"})
+
+
+@router.get("/{transaction_id}")
+async def transaction_status(
+    transaction_id: str,
+    runtime: TransactionRuntime = Depends(get_transaction_runtime),
+    _api_key: str = Depends(verify_api_key),
+) -> JSONResponse:
+    """Return reviewable plan and durable progress without approval secrets."""
+    try:
+        loaded = runtime.store.read(transaction_id)
+    except TransactionError as exc:
+        return _error_response(exc)
+    envelope = loaded["envelope"]
+    approval = loaded["approval"]
+    safe_approval = {
+        "approved": approval is not None,
+        "approvedAt": approval.get("approvedAt") if approval else None,
+        "approvedBy": approval.get("approvedBy") if approval else None,
+    }
+    return JSONResponse(
+        content={
+            "schema": "ods.assistant-first.transaction-status.v1",
+            "transactionId": loaded["transactionId"],
+            "planHash": envelope["planHash"],
+            "catalogRevision": envelope["catalogRevision"],
+            "observedStateRevision": envelope["observedStateRevision"],
+            "policyRevision": envelope["policyRevision"],
+            "state": loaded["state"],
+            "sequence": loaded["sequence"],
+            "plan": envelope["plan"],
+            "journal": loaded["journal"],
+            "approval": safe_approval,
+        },
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.post("/{transaction_id}/execute")
+async def execute_transaction(
+    transaction_id: str,
+    request: Request,
+    runtime: TransactionRuntime = Depends(get_transaction_runtime),
+    _api_key: str = Depends(verify_api_key),
+) -> JSONResponse:
+    """Execute only an exact stored and approved transaction, synchronously."""
+    model = await _request_model(request, ExactHashRequest)
+    if runtime.executor is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Extension transaction execution is unavailable",
+            headers={"Cache-Control": "no-store"},
+        )
+    try:
+        result = runtime.executor.execute(transaction_id, model.planHash)
+    except TransactionError as exc:
+        return _error_response(exc)
+    return JSONResponse(
+        content={
+            "transactionId": result.transaction_id,
+            "planHash": model.planHash,
+            "finalState": result.final_state,
+            "sequence": result.sequence,
+            "appliedServices": result.applied_services,
+            "error": result.error,
+        },
+        headers={"Cache-Control": "no-store"},
+    )

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_api.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_api.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import routers.extension_transactions as transaction_api
+import security
+import session_signer
+from extension_transaction_runtime import TransactionRuntime
+from plan_provenance import validate_request_intent
+
+
+API_KEY = "transaction-test-key"
+NOW = "2026-09-11T12:00:00Z"
+PLAN_HASH = "a" * 64
+IDEMPOTENCY_KEY = "b" * 64
+TX_ID = "txn-" + "c" * 24
+
+
+def envelope() -> dict:
+    return {
+        "schema": "ods.assistant-first.plan-envelope.v1",
+        "planId": "plan-" + PLAN_HASH[:24],
+        "catalogRevision": "d" * 64,
+        "observedStateRevision": "e" * 64,
+        "policyRevision": "f" * 64,
+        "planHash": PLAN_HASH,
+        "plan": {
+            "schema": "ods.assistant-first.plan.v1",
+            "validUntil": "2026-10-01T00:00:00Z",
+            "selectedServices": ["notes"],
+            "operations": [{"serviceId": "notes", "action": "install"}],
+            "requiredSecretKeys": ["NOTES_API_KEY"],
+            "dataEffects": [],
+            "rollbackEffects": [],
+            "warnings": [],
+        },
+    }
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.created = []
+        self.approved = []
+        self.record = {
+            "transactionId": TX_ID,
+            "envelope": envelope(),
+            "state": "awaiting_approval",
+            "sequence": 2,
+            "journal": [
+                {"sequence": 1, "state": "planned"},
+                {"sequence": 2, "state": "awaiting_approval"},
+            ],
+            "approval": None,
+        }
+
+    def create(self, plan, actor, key, timestamp, current_time):
+        self.created.append((plan, actor, key, timestamp, current_time))
+        duplicate = len(self.created) > 1
+        self.record["envelope"] = plan
+        return {
+            "transactionId": TX_ID,
+            "planHash": plan["planHash"],
+            "state": "awaiting_approval",
+            "sequence": 2,
+            "duplicate": duplicate,
+        }
+
+    def approve_exact(
+        self, transaction_id, plan_hash, approved_by, approved_at, current_time
+    ):
+        self.approved.append(
+            (transaction_id, plan_hash, approved_by, approved_at, current_time)
+        )
+        self.record["state"] = "approved"
+        self.record["sequence"] = 3
+        self.record["approval"] = {
+            "approvedBy": approved_by,
+            "approvedAt": approved_at,
+            "actor": "assistant-manager",
+            "idempotencyKey": IDEMPOTENCY_KEY,
+        }
+        return {"transactionId": transaction_id, "state": "approved", "sequence": 3}
+
+    def read(self, transaction_id):
+        if transaction_id != TX_ID:
+            from extension_transactions import TransactionError
+
+            raise TransactionError("not-found")
+        return self.record
+
+
+class FakeExecutor:
+    def __init__(self) -> None:
+        self.calls = []
+
+    def execute(self, transaction_id, plan_hash):
+        self.calls.append((transaction_id, plan_hash))
+        return SimpleNamespace(
+            transaction_id=transaction_id,
+            final_state="committed",
+            sequence=10,
+            applied_services=["notes"],
+            error=None,
+        )
+
+
+def create_body(**intent_changes) -> dict:
+    intent = {
+        "requestedServices": ["notes"],
+        "requestedCapabilities": [],
+        "providerPreferences": {},
+        "validUntil": "2026-10-01T00:00:00Z",
+        "missingConfigKeys": [],
+        "missingSecretKeys": ["NOTES_API_KEY"],
+    }
+    intent.update(intent_changes)
+    return {"intent": intent, "idempotencyKey": IDEMPOTENCY_KEY}
+
+
+@pytest.fixture()
+def api(monkeypatch):
+    monkeypatch.setenv("ODS_ASSISTANT_TRANSACTIONS_ENABLED", "true")
+    monkeypatch.setattr(security, "DASHBOARD_API_KEY", API_KEY)
+    session_signer._set_secret_for_tests("phase3c-session-secret")
+    store = FakeStore()
+    executor = FakeExecutor()
+    calls = []
+
+    def catalog():
+        return ([{"id": "server-catalog"}], "1" * 64)
+
+    def observed_state():
+        return {"source": "server-state"}
+
+    def policy():
+        return {"source": "server-policy"}
+
+    def authorize(intent, *, catalog, observed_state, policy):
+        normalized = validate_request_intent(intent)
+        calls.append(
+            {
+                "intent": normalized,
+                "catalog": catalog(),
+                "observedState": observed_state(),
+                "policy": policy(),
+            }
+        )
+        return envelope()
+
+    monkeypatch.setattr(transaction_api, "authorize_plan", authorize)
+    app = FastAPI()
+    app.include_router(transaction_api.router)
+    app.state.extension_transaction_runtime = TransactionRuntime(
+        store=store,
+        catalog=catalog,
+        observed_state=observed_state,
+        policy=policy,
+        clock=lambda: NOW,
+        executor=executor,
+    )
+    with TestClient(app) as client:
+        yield SimpleNamespace(
+            client=client,
+            store=store,
+            executor=executor,
+            authorize_calls=calls,
+            headers={"Authorization": f"Bearer {API_KEY}"},
+        )
+
+
+def test_disabled_and_unconfigured_runtime_fail_before_store_creation(
+    monkeypatch, tmp_path
+):
+    app = FastAPI()
+    app.include_router(transaction_api.router)
+    with TestClient(app) as client:
+        monkeypatch.delenv("ODS_ASSISTANT_TRANSACTIONS_ENABLED", raising=False)
+        response = client.post("/api/extensions/transactions", json=create_body())
+        assert response.status_code == 404
+        assert list(tmp_path.iterdir()) == []
+
+        monkeypatch.setenv("ODS_ASSISTANT_TRANSACTIONS_ENABLED", "true")
+        response = client.post("/api/extensions/transactions", json=create_body())
+        assert response.status_code == 503
+        assert list(tmp_path.iterdir()) == []
+
+
+def test_create_requires_api_key_and_uses_only_server_providers(api):
+    assert api.client.post(
+        "/api/extensions/transactions", json=create_body()
+    ).status_code == 401
+
+    response = api.client.post(
+        "/api/extensions/transactions", json=create_body(), headers=api.headers
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["state"] == "awaiting_approval"
+    assert body["envelope"] == envelope()
+    assert body.get("finalState") is None
+    assert api.store.created == [
+        (envelope(), "assistant-manager", IDEMPOTENCY_KEY, NOW, NOW)
+    ]
+    assert api.authorize_calls == [
+        {
+            "intent": {
+                "requested_services": ("notes",),
+                "requested_capabilities": (),
+                "provider_preferences": {},
+                "valid_until": "2026-10-01T00:00:00Z",
+                "missing_config_keys": (),
+                "missing_secret_keys": ("NOTES_API_KEY",),
+            },
+            "catalog": ([{"id": "server-catalog"}], "1" * 64),
+            "observedState": {"source": "server-state"},
+            "policy": {"source": "server-policy"},
+        }
+    ]
+
+
+def test_create_retry_reports_duplicate_without_completion(api):
+    first = api.client.post(
+        "/api/extensions/transactions", json=create_body(), headers=api.headers
+    )
+    second = api.client.post(
+        "/api/extensions/transactions", json=create_body(), headers=api.headers
+    )
+    assert first.status_code == 201
+    assert second.status_code == 200
+    assert second.json()["duplicate"] is True
+    assert second.json()["state"] == "awaiting_approval"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {**create_body(), "operations": []},
+        create_body(catalogRevision="1" * 64),
+        create_body(observedStateRevision="2" * 64),
+        create_body(policyRevision="3" * 64),
+        create_body(actor="assistant-manager"),
+        create_body(approval={"required": False}),
+        create_body(secretValue="do-not-accept"),
+        create_body(shell="docker compose up"),
+        create_body(purge=True),
+    ],
+)
+def test_create_rejects_caller_controlled_authority(body, api):
+    response = api.client.post(
+        "/api/extensions/transactions", json=body, headers=api.headers
+    )
+    assert response.status_code == 422
+    assert api.store.created == []
+
+
+def test_create_rejects_duplicate_keys_floats_and_oversize(api):
+    duplicate = (
+        '{"intent":{"requestedServices":[],"requestedServices":[]},'
+        f'"idempotencyKey":"{IDEMPOTENCY_KEY}"}}'
+    )
+    response = api.client.post(
+        "/api/extensions/transactions",
+        content=duplicate,
+        headers={**api.headers, "Content-Type": "application/json"},
+    )
+    assert response.status_code == 422
+
+    body = create_body()
+    body["intent"]["providerPreferences"] = {"capability@1": 1.5}
+    response = api.client.post(
+        "/api/extensions/transactions", json=body, headers=api.headers
+    )
+    assert response.status_code == 422
+
+    response = api.client.post(
+        "/api/extensions/transactions",
+        content=b"{" + b" " * transaction_api.MAX_REQUEST_BYTES + b"}",
+        headers={**api.headers, "Content-Type": "application/json"},
+    )
+    assert response.status_code == 413
+
+
+@pytest.mark.parametrize("scope", ["guest", "admin"])
+def test_only_owner_cookie_can_approve(scope, api):
+    cookie = session_signer.issue_scoped(scope, ttl_seconds=60)
+    api.client.cookies.set("ods-session", cookie)
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/approval",
+        json={"planHash": PLAN_HASH},
+    )
+    assert response.status_code == 403
+    assert api.store.approved == []
+
+
+def test_legacy_cookie_and_api_key_cannot_approve(api):
+    legacy = session_signer.issue(ttl_seconds=60)
+    api.client.cookies.set("ods-session", legacy)
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/approval",
+        json={"planHash": PLAN_HASH},
+    )
+    assert response.status_code == 403
+
+    api.client.cookies.delete("ods-session")
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/approval",
+        json={"planHash": PLAN_HASH},
+        headers=api.headers,
+    )
+    assert response.status_code == 403
+    assert api.store.approved == []
+
+
+def test_owner_approval_passes_only_exact_hash_and_hashed_identity(api):
+    cookie = session_signer.issue_scoped("owner", ttl_seconds=60)
+    approved_by = session_signer.owner_approval_identity(cookie)
+    api.client.cookies.set("ods-session", cookie)
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/approval",
+        json={"planHash": PLAN_HASH},
+    )
+    assert response.status_code == 200
+    assert api.store.approved == [(TX_ID, PLAN_HASH, approved_by, NOW, NOW)]
+    assert "approval" not in response.request.content.decode("utf-8")
+
+
+def test_approval_rejects_extra_fields(api):
+    cookie = session_signer.issue_scoped("owner", ttl_seconds=60)
+    api.client.cookies.set("ods-session", cookie)
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/approval",
+        json={"planHash": PLAN_HASH, "approvedBy": "assistant-manager"},
+    )
+    assert response.status_code == 422
+    assert api.store.approved == []
+
+
+def test_status_is_no_store_and_redacts_approval_binding(api):
+    api.store.record["approval"] = {
+        "approvedBy": "owner-" + "1" * 16,
+        "approvedAt": NOW,
+        "actor": "assistant-manager",
+        "idempotencyKey": IDEMPOTENCY_KEY,
+        "validUntil": "2026-10-01T00:00:00Z",
+    }
+    response = api.client.get(
+        f"/api/extensions/transactions/{TX_ID}", headers=api.headers
+    )
+    assert response.status_code == 200
+    assert response.headers["cache-control"] == "no-store"
+    approval = response.json()["approval"]
+    assert approval == {
+        "approved": True,
+        "approvedAt": NOW,
+        "approvedBy": "owner-" + "1" * 16,
+    }
+    assert IDEMPOTENCY_KEY not in response.text
+    assert response.json()["plan"]["requiredSecretKeys"] == ["NOTES_API_KEY"]
+
+
+def test_execute_requires_api_key_and_passes_only_id_and_hash(api):
+    path = f"/api/extensions/transactions/{TX_ID}/execute"
+    assert api.client.post(path, json={"planHash": PLAN_HASH}).status_code == 401
+    response = api.client.post(
+        path, json={"planHash": PLAN_HASH}, headers=api.headers
+    )
+    assert response.status_code == 200
+    assert api.executor.calls == [(TX_ID, PLAN_HASH)]
+    assert response.json()["finalState"] == "committed"
+
+    rejected = api.client.post(
+        path,
+        json={"planHash": PLAN_HASH, "operations": []},
+        headers=api.headers,
+    )
+    assert rejected.status_code == 422
+    assert api.executor.calls == [(TX_ID, PLAN_HASH)]
+
+
+def test_execute_is_unavailable_without_injected_executor(api):
+    runtime = api.client.app.state.extension_transaction_runtime
+    api.client.app.state.extension_transaction_runtime = TransactionRuntime(
+        store=runtime.store,
+        catalog=runtime.catalog,
+        observed_state=runtime.observed_state,
+        policy=runtime.policy,
+        clock=runtime.clock,
+        executor=None,
+    )
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/execute",
+        json={"planHash": PLAN_HASH},
+        headers=api.headers,
+    )
+    assert response.status_code == 503
+    assert response.headers["cache-control"] == "no-store"
+
+
+def test_main_registers_transaction_routes():
+    from main import app
+
+    paths = {route.path for route in app.routes}
+    assert "/api/extensions/transactions" in paths
+    assert "/api/extensions/transactions/{transaction_id}/approval" in paths
+    assert "/api/extensions/transactions/{transaction_id}" in paths
+    assert "/api/extensions/transactions/{transaction_id}/execute" in paths
+
+
+def test_main_csrf_blocks_cross_origin_owner_approval(test_client, monkeypatch):
+    monkeypatch.setenv("ODS_ASSISTANT_TRANSACTIONS_ENABLED", "true")
+    session_signer._set_secret_for_tests("phase3c-session-secret")
+    owner_cookie = session_signer.issue_scoped("owner", ttl_seconds=60)
+    test_client.cookies.set("ods-session", owner_cookie)
+
+    response = test_client.post(
+        f"/api/extensions/transactions/{TX_ID}/approval",
+        json={"planHash": PLAN_HASH},
+        headers={
+            "Origin": "https://evil.invalid",
+            "Sec-Fetch-Site": "cross-site",
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {
+        "detail": "Cross-origin state-changing request rejected."
+    }

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_executor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_executor.py
@@ -289,7 +289,7 @@ class AlwaysTrueVerifier:
 def create_and_approve(store, envelope: dict):
     """Create a transaction and approve it, returning (descriptor, txn_id)."""
     descriptor = store.create(envelope, ACTOR, IDEMPOTENCY_KEY, CREATED_AT, NOW)
-    store.approve(descriptor["transactionId"], approval_for(descriptor, envelope), NOW)
+    store._approve_record(descriptor["transactionId"], approval_for(descriptor, envelope), NOW)
     return descriptor
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_runtime.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_runtime.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+
+import assistant_first_planner as planner
+from extension_planning_contract import computed_catalog_revision
+from extension_transaction_runtime import CurrentInputsProvenanceVerifier
+from test_plan_provenance import HOST_STATE, POLICY, authorize, catalog_entry, intent
+
+
+def build_current_envelope(entries=None, state=None, policy=None):
+    entries = entries or [catalog_entry("notes")]
+    state = state or copy.deepcopy(HOST_STATE)
+    policy = policy or copy.deepcopy(POLICY)
+    envelope = authorize(
+        intent(requestedServices=["notes"]),
+        entries=entries,
+        state=state,
+        policy=policy,
+    )
+    return envelope, entries, state, policy
+
+
+def verifier(entries, state, policy):
+    return CurrentInputsProvenanceVerifier(
+        catalog=lambda: (entries, computed_catalog_revision(entries)),
+        observed_state=lambda: state,
+        policy=lambda: policy,
+    )
+
+
+def test_current_inputs_verifier_accepts_only_exact_current_envelope():
+    envelope, entries, state, policy = build_current_envelope()
+    check = verifier(entries, state, policy)
+    assert check.verify(envelope["planHash"], envelope) is True
+
+
+def test_current_inputs_verifier_rejects_catalog_state_and_policy_drift():
+    envelope, entries, state, policy = build_current_envelope()
+
+    drifted_catalog = copy.deepcopy(entries)
+    drifted_catalog[0]["planning"]["version"] = "1.2.4"
+    assert verifier(drifted_catalog, state, policy).verify(
+        envelope["planHash"], envelope
+    ) is False
+
+    drifted_state = copy.deepcopy(state)
+    drifted_state["available"]["diskBytes"] -= 1
+    assert verifier(entries, drifted_state, policy).verify(
+        envelope["planHash"], envelope
+    ) is False
+
+    drifted_policy = copy.deepcopy(policy)
+    drifted_policy["allowExperimental"] = True
+    assert verifier(entries, state, drifted_policy).verify(
+        envelope["planHash"], envelope
+    ) is False
+
+
+def test_current_inputs_verifier_rejects_selected_definition_tampering():
+    envelope, entries, state, policy = build_current_envelope()
+    tampered = copy.deepcopy(envelope)
+    tampered["plan"]["definitions"][0]["definitionSha256"] = "f" * 64
+    tampered_hash = hashlib.sha256(
+        planner.canonical_json_bytes(tampered["plan"])
+    ).hexdigest()
+    tampered["planHash"] = tampered_hash
+    tampered["planId"] = "plan-" + tampered_hash[:24]
+
+    assert verifier(entries, state, policy).verify(tampered_hash, tampered) is False
+
+
+def test_current_inputs_verifier_fails_closed_on_provider_shape():
+    envelope, _entries, state, policy = build_current_envelope()
+    check = CurrentInputsProvenanceVerifier(
+        catalog=lambda: [],
+        observed_state=lambda: state,
+        policy=lambda: policy,
+    )
+    assert check.verify(envelope["planHash"], envelope) is False

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transactions.py
@@ -282,7 +282,7 @@ def test_operational_assistant_actor_is_allowed_but_cannot_approve(tmp_path):
         approvedBy="assistant-manager",
     )
     with pytest.raises(transactions.ApprovalError) as caught:
-        store.approve(descriptor["transactionId"], approval, NOW)
+        store._approve_record(descriptor["transactionId"], approval, NOW)
     assert caught.value.code == "invalid-approval-data"
 
 
@@ -362,8 +362,8 @@ def test_approval_is_exact_bound_and_idempotent(tmp_path):
     descriptor = create(store, envelope)
     approval = approval_for(descriptor, envelope)
 
-    accepted = store.approve(descriptor["transactionId"], approval, NOW)
-    duplicate = store.approve(descriptor["transactionId"], approval, NOW)
+    accepted = store._approve_record(descriptor["transactionId"], approval, NOW)
+    duplicate = store._approve_record(descriptor["transactionId"], approval, NOW)
     assert accepted["state"] == "approved"
     assert duplicate["noop"] is True
     assert store.read(descriptor["transactionId"])["approval"] == approval
@@ -389,7 +389,7 @@ def test_approval_rejects_binding_drift_and_assistant_actors(tmp_path, changes, 
     envelope = build_envelope()
     descriptor = create(store, envelope)
     with pytest.raises(transactions.ApprovalError) as caught:
-        store.approve(
+        store._approve_record(
             descriptor["transactionId"],
             approval_for(descriptor, envelope, **changes),
             NOW,
@@ -411,10 +411,10 @@ def test_approval_replay_repairs_crash_between_record_and_journal(
 
     monkeypatch.setattr(transactions, "_journal_append", fail_before_journal)
     with pytest.raises(transactions.TransactionError, match="injected-crash"):
-        store.approve(descriptor["transactionId"], approval, NOW)
+        store._approve_record(descriptor["transactionId"], approval, NOW)
     monkeypatch.setattr(transactions, "_journal_append", original)
 
-    repaired = store.approve(descriptor["transactionId"], approval, NOW)
+    repaired = store._approve_record(descriptor["transactionId"], approval, NOW)
     assert repaired["state"] == "approved"
     assert store.read(descriptor["transactionId"])["sequence"] == 3
 
@@ -423,7 +423,7 @@ def test_reserve_requires_unexpired_exact_approval(tmp_path):
     store = transactions.TransactionStore(tmp_path / "transactions")
     envelope = build_envelope()
     descriptor = create(store, envelope)
-    store.approve(descriptor["transactionId"], approval_for(descriptor), NOW)
+    store._approve_record(descriptor["transactionId"], approval_for(descriptor), NOW)
 
     with pytest.raises(transactions.TransitionError) as caught:
         store.transition(
@@ -561,7 +561,7 @@ def test_transition_persists_exact_bounded_step_metadata(tmp_path):
     store = transactions.TransactionStore(tmp_path / "transactions")
     envelope = build_envelope()
     descriptor = create(store, envelope)
-    store.approve(descriptor["transactionId"], approval_for(descriptor), NOW)
+    store._approve_record(descriptor["transactionId"], approval_for(descriptor), NOW)
 
     metadata = {
         "step": {
@@ -581,7 +581,7 @@ def test_transition_persists_exact_bounded_step_metadata(tmp_path):
 def test_transition_rejects_non_step_or_secret_metadata(tmp_path):
     store = transactions.TransactionStore(tmp_path / "transactions")
     descriptor = create(store)
-    store.approve(descriptor["transactionId"], approval_for(descriptor), NOW)
+    store._approve_record(descriptor["transactionId"], approval_for(descriptor), NOW)
 
     with pytest.raises(transactions.ValidationRejected, match="invalid-metadata-keys"):
         store.transition(

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transactions.py
@@ -654,3 +654,231 @@ def test_hardlinked_binding_fails_closed(tmp_path):
     os.link(binding, tmp_path / "binding-copy")
     with pytest.raises(transactions.IntegrityError, match="link-count"):
         store.read(descriptor["transactionId"])
+
+
+def test_http_retry_reuses_first_created_at(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    first = create(store, envelope)
+    later = "2026-09-11T13:00:00Z"
+
+    replay = store.create(envelope, ACTOR, IDEMPOTENCY_KEY, later, later)
+
+    assert replay == {**first, "duplicate": True}
+    loaded = store.read(first["transactionId"])
+    assert loaded["journal"][0]["timestamp"] == CREATED_AT
+
+
+def test_http_retry_recovers_prefix_without_idempotency_index(
+    tmp_path, monkeypatch
+):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    original = transactions._journal_append
+    calls = 0
+
+    def fail_after_first(path, line, expected_actor=None):
+        nonlocal calls
+        calls += 1
+        result = original(path, line, expected_actor)
+        if calls == 1:
+            raise transactions.TransactionError("injected-crash")
+        return result
+
+    monkeypatch.setattr(transactions, "_journal_append", fail_after_first)
+    with pytest.raises(transactions.TransactionError, match="injected-crash"):
+        create(store, envelope)
+    monkeypatch.setattr(transactions, "_journal_append", original)
+
+    later = "2026-09-11T13:00:00Z"
+    replay = store.create(envelope, ACTOR, IDEMPOTENCY_KEY, later, later)
+    assert replay["duplicate"] is True
+    assert store.read(replay["transactionId"])["sequence"] == 2
+    assert store.read(replay["transactionId"])["journal"][0]["timestamp"] == CREATED_AT
+
+
+@pytest.mark.parametrize(
+    ("actor", "envelope"),
+    [
+        ("other-owner", None),
+        (ACTOR, "calendar"),
+    ],
+)
+def test_http_retry_rejects_actor_or_plan_drift(tmp_path, actor, envelope):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    create(store)
+    candidate = build_envelope(envelope) if envelope else build_envelope()
+    later = "2026-09-11T13:00:00Z"
+
+    with pytest.raises(transactions.IdempotencyConflict) as caught:
+        store.create(candidate, actor, IDEMPOTENCY_KEY, later, later)
+    assert caught.value.code == "idempotency-drift"
+
+
+def test_exact_owner_approval_uses_only_durable_binding(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    descriptor = create(store, envelope, actor="assistant-manager")
+    approved_by = "owner-" + "c" * 16
+
+    result = store.approve_exact(
+        descriptor["transactionId"],
+        envelope["planHash"],
+        approved_by,
+        APPROVED_AT,
+        NOW,
+    )
+
+    assert result == {
+        "transactionId": descriptor["transactionId"],
+        "state": "approved",
+        "sequence": 3,
+        "noop": False,
+    }
+    approval = store.read(descriptor["transactionId"])["approval"]
+    assert approval == approval_for(
+        descriptor,
+        envelope,
+        actor="assistant-manager",
+        approvedBy=approved_by,
+    )
+
+
+def test_exact_owner_approval_is_idempotent(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    descriptor = create(store, envelope)
+    args = (
+        descriptor["transactionId"],
+        envelope["planHash"],
+        "owner-" + "d" * 16,
+        APPROVED_AT,
+        NOW,
+    )
+    store.approve_exact(*args)
+    replay = store.approve_exact(*args)
+    assert replay["noop"] is True
+    assert replay["sequence"] == 3
+
+
+def test_exact_owner_approval_retry_ignores_later_server_timestamp(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    descriptor = create(store, envelope)
+    owner = "owner-" + "d" * 16
+    store.approve_exact(
+        descriptor["transactionId"],
+        envelope["planHash"],
+        owner,
+        APPROVED_AT,
+        NOW,
+    )
+
+    replay = store.approve_exact(
+        descriptor["transactionId"],
+        envelope["planHash"],
+        owner,
+        "2026-09-11T13:00:00Z",
+        "2026-09-11T13:00:00Z",
+    )
+
+    assert replay["noop"] is True
+    loaded = store.read(descriptor["transactionId"])
+    assert loaded["approval"]["approvedAt"] == APPROVED_AT
+    assert loaded["journal"][-1]["timestamp"] == APPROVED_AT
+
+
+@pytest.mark.parametrize(
+    ("plan_hash", "approved_by", "approved_at", "current_time", "code"),
+    [
+        ("f" * 64, "owner-" + "c" * 16, APPROVED_AT, NOW, "plan-hash-mismatch"),
+        (
+            "expected",
+            "assistant-manager",
+            APPROVED_AT,
+            NOW,
+            "invalid-owner-approval-identity",
+        ),
+        ("expected", "owner-" + "c" * 16, VALID_UNTIL, VALID_UNTIL, "approval-expired"),
+    ],
+)
+def test_exact_owner_approval_rejects_invalid_binding(
+    tmp_path, plan_hash, approved_by, approved_at, current_time, code
+):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    descriptor = create(store, envelope)
+    selected_hash = envelope["planHash"] if plan_hash == "expected" else plan_hash
+
+    with pytest.raises(transactions.ApprovalError) as caught:
+        store.approve_exact(
+            descriptor["transactionId"],
+            selected_hash,
+            approved_by,
+            approved_at,
+            current_time,
+        )
+    assert caught.value.code == code
+
+
+def test_exact_owner_approval_repairs_write_before_journal_crash(
+    tmp_path, monkeypatch
+):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    descriptor = create(store, envelope)
+    original = transactions._journal_append
+
+    def fail_journal(*args, **kwargs):
+        raise transactions.TransactionError("injected-crash")
+
+    monkeypatch.setattr(transactions, "_journal_append", fail_journal)
+    with pytest.raises(transactions.TransactionError, match="injected-crash"):
+        store.approve_exact(
+            descriptor["transactionId"],
+            envelope["planHash"],
+            "owner-" + "e" * 16,
+            APPROVED_AT,
+            NOW,
+        )
+    monkeypatch.setattr(transactions, "_journal_append", original)
+
+    repaired = store.approve_exact(
+        descriptor["transactionId"],
+        envelope["planHash"],
+        "owner-" + "e" * 16,
+        "2026-09-11T13:00:00Z",
+        "2026-09-11T13:00:00Z",
+    )
+    assert repaired["state"] == "approved"
+    loaded = store.read(descriptor["transactionId"])
+    assert loaded["sequence"] == 3
+    assert loaded["approval"]["approvedAt"] == APPROVED_AT
+    assert loaded["journal"][-1]["timestamp"] == APPROVED_AT
+
+
+def test_exact_owner_approval_serializes_concurrent_calls(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_envelope()
+    descriptor = create(store, envelope)
+    results = []
+
+    def approve():
+        results.append(
+            store.approve_exact(
+                descriptor["transactionId"],
+                envelope["planHash"],
+                "owner-" + "f" * 16,
+                APPROVED_AT,
+                NOW,
+            )
+        )
+
+    threads = [threading.Thread(target=approve) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert sorted(result["noop"] for result in results) == [False, True]


### PR DESCRIPTION
## Phase 3C: guarded transaction API integration

Stacks on #4443. This phase exposes the Phase 3 transaction engine through an opt-in, fail-closed API boundary while keeping production execution disabled until later runtime composition and qualification phases.

## What changed

- add server-authoritative transaction creation from the six-field intent contract
- require an owner-scoped browser session for exact-plan-hash approval; API keys, admin/guest/legacy sessions, assistants, and models cannot approve
- expose API-key-protected status and exact-hash execution endpoints
- inject catalog, observed state, policy, clock, store, executor, and current-input provenance verification
- recover idempotent create/approval retries without rebinding timestamps or caller authority
- keep `ODS_ASSISTANT_TRANSACTIONS_ENABLED` off by default and fail closed when runtime/executor composition is absent
- redact approval binding data and return `Cache-Control: no-store`
- document the boundary and why execution remains disabled

## Refreshed-stack evidence

- exact head: `e68cd9afd1249dab3ced33aad2dff9215712020b`
- exact tree: `a54ac674217bd57f91e38f02e5581bdc647cd42a`
- refreshed parent: Phase 3B head `7d573e67612a6f6200f321f9019b2dfcb4999953`
- retained original Phase 3C head as first parent: `55fc9738a06fde5e8e1b821e6c94f8d12ac02b03`
- phase delta over refreshed parent: 9 files, +1,458/-28
- restacked with a normal merge commit and normal push; no force push or history rewrite

## Acceptance evidence

- exact refreshed Linux tree: `119 passed` across transaction API, runtime, executor, and store suites
- same exact tree: `240 passed` across lower provenance, planning, and scoped-session suites
- prior branch evidence retained: Windows focused suite 82 passed / 92 POSIX-only skipped; Linux exact-SHA suite 174 passed
- changed-file Ruff E/F/W profile and `git diff --check`: passed
- cross-origin owner approval is rejected by the main application CSRF middleware
- independent read-only API review found no blockers across server-authoritative create, owner-only approval, exact hash binding, retry/idempotency, redaction, and no-store behavior
- independent runtime review concern was resolved by tracing the mandatory `ProvenanceVerifier` call inside the executor: production execution remains intentionally uncomposed and returns 503 until a later phase
- GitHub exact-head CI: 32 successful checks and four intentionally skipped Claude-review jobs; no failures
- GitHub reports the PR `CLEAN` and `MERGEABLE`

## Boundaries

- no merge, install, deployment, live-service mutation, or destructive purge
- no claim of Docker or installed-device acceptance
- existing Full/Core/Custom and single-extension paths remain unchanged

