### PR TITLE
feat(preview): download a complete verified publication ZIP

### DIFF
--- a/ods/extensions/services/dashboard/package-lock.json
+++ b/ods/extensions/services/dashboard/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@paper-design/shaders-react": "^0.0.80",
+        "fflate": "0.8.3",
         "gsap": "^3.12.7",
         "lucide-react": "^0.441.0",
         "react": "^18.3.1",
@@ -3052,6 +3053,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/ods/extensions/services/dashboard/package.json
+++ b/ods/extensions/services/dashboard/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@paper-design/shaders-react": "^0.0.80",
+    "fflate": "0.8.3",
     "gsap": "^3.12.7",
     "lucide-react": "^0.441.0",
     "react": "^18.3.1",

--- a/ods/extensions/services/dashboard/src/components/PixelPublicationDownload.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPublicationDownload.jsx
@@ -1,0 +1,62 @@
+﻿import {useEffect,useRef,useState} from 'react'
+import {zipSync} from 'fflate'
+import {loadSnapshotFiles,loadArtifactBytes} from '../lib/pixelArtifacts'
+
+export default function PixelPublicationDownload({preview}) {
+  const pending=useRef(null)
+  const [state,setState]=useState({status:'idle'})
+  useEffect(()=>()=>{pending.current?.abort();pending.current=null},[])
+  function cancel() {
+    pending.current?.abort();pending.current=null
+    setState({status:'idle'})
+  }
+  async function download() {
+    if(pending.current)return
+    const controller=new AbortController()
+    pending.current=controller
+    setState({status:'working',done:0})
+    let rejectAbort
+    const aborted=new Promise((_,reject)=>{
+      rejectAbort=()=>reject(new Error('Download cancelled or timed out'))
+      controller.signal.addEventListener('abort',rejectAbort,{once:true})
+    })
+    const timer=setTimeout(()=>controller.abort(),30000)
+    try {
+      const collect=async()=>{
+        const files=await loadSnapshotFiles(preview,controller.signal)
+        const entries=Object.create(null)
+        for(const file of files){
+          controller.signal.throwIfAborted()
+          const bytes=await loadArtifactBytes(preview,file,controller.signal)
+          controller.signal.throwIfAborted()
+          entries[file.path]=new Uint8Array(bytes)
+          if(pending.current===controller)setState({status:'working',done:Object.keys(entries).length,total:files.length})
+        }
+        // The manifest contract caps input at 128 files / 16 MiB. Store ZIP
+        // entries without compression so packaging has bounded CPU cost.
+        return zipSync(entries,{level:0})
+      }
+      const bytes=await Promise.race([collect(),aborted])
+      if(pending.current!==controller)return
+      const url=URL.createObjectURL(new Blob([bytes],{type:'application/zip'}))
+      const anchor=document.createElement('a')
+      try {
+        anchor.href=url;anchor.download=`ods-${preview.siteId}.zip`
+        document.body.append(anchor);anchor.click()
+      } finally {anchor.remove();setTimeout(()=>URL.revokeObjectURL(url),1000)}
+      setState({status:'done'})
+    } catch {
+      if(pending.current===controller)setState({status:'error'})
+    } finally {
+      clearTimeout(timer)
+      controller.signal.removeEventListener('abort',rejectAbort)
+      if(pending.current===controller)pending.current=null
+    }
+  }
+  return <div className="px-3 pb-2 text-xs">
+    <button type="button" disabled={state.status==='working'} onClick={download}>Download publication ZIP</button>
+    {state.status==='working' && <><span role="status"> Verifying files {state.done}{state.total ? ` of ${state.total}` : ''}…</span> <button type="button" onClick={cancel}>Cancel ZIP download</button></>}
+    {state.status==='done' && <p role="status">Publication download started.</p>}
+    {state.status==='error' && <p role="alert">The complete publication could not be verified or downloaded. No partial archive was saved. Try again.</p>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelPublicationDownload.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPublicationDownload.test.jsx
@@ -1,0 +1,60 @@
+import {act,fireEvent,render,screen,waitFor} from '@testing-library/react'
+import {unzipSync} from 'fflate'
+import PixelTaskFiles from './PixelTaskFiles'
+import {loadSnapshotFiles,loadArtifactBytes} from '../lib/pixelArtifacts'
+vi.mock('../lib/pixelArtifacts',()=>({loadSnapshotFiles:vi.fn(),loadArtifactBytes:vi.fn()}))
+vi.mock('./PixelPreviewSource',()=>({default:()=>null}))
+const preview={siteId:'site-'+ 'a'.repeat(24),sha256:'b'.repeat(64),files:2,bytes:12}
+const files=[{path:'index.html',bytes:5},{path:'assets/site.css',bytes:7}]
+let blob
+beforeEach(()=>{
+  loadSnapshotFiles.mockResolvedValue(files)
+  loadArtifactBytes.mockImplementation(async(_preview,file)=>new TextEncoder().encode(file.path==='index.html'?'hello':'a{b:c;}').buffer)
+  vi.spyOn(URL,'createObjectURL').mockImplementation(value=>{blob=value;return 'blob:archive'})
+  vi.spyOn(URL,'revokeObjectURL').mockImplementation(()=>{})
+  vi.spyOn(HTMLAnchorElement.prototype,'click').mockImplementation(()=>{})
+})
+afterEach(()=>{vi.restoreAllMocks();vi.clearAllMocks();vi.useRealTimers()})
+it('downloads all verified publication paths and original bytes as a ZIP',async()=>{
+  render(<PixelTaskFiles preview={preview}/>);await screen.findByText('index.html')
+  fireEvent.click(screen.getByRole('button',{name:'Download publication ZIP'}))
+  await screen.findByText('Publication download started.')
+  const data=await new Promise((resolve,reject)=>{const reader=new globalThis.FileReader();reader.onload=()=>resolve(reader.result);reader.onerror=reject;reader.readAsArrayBuffer(blob)})
+  const archive=unzipSync(new Uint8Array(data))
+  expect(Object.keys(archive)).toEqual(files.map(file=>file.path))
+  expect(new TextDecoder().decode(archive['assets/site.css'])).toBe('a{b:c;}')
+  expect(loadArtifactBytes).toHaveBeenCalledTimes(2)
+  expect(document.querySelector('a[download]')).toBeNull()
+})
+it('never downloads a partial archive if verification fails',async()=>{
+  loadArtifactBytes.mockRejectedValue(new Error('digest mismatch'))
+  render(<PixelTaskFiles preview={preview}/>);await screen.findByText('index.html')
+  fireEvent.click(screen.getByRole('button',{name:'Download publication ZIP'}))
+  expect(await screen.findByRole('alert')).toHaveTextContent('could not be verified')
+  expect(URL.createObjectURL).not.toHaveBeenCalled()
+})
+it('cancels pending verification and ignores its late completion',async()=>{
+  let resolve,signal
+  loadArtifactBytes.mockImplementation((_p,_f,s)=>{signal=s;return new Promise(r=>{resolve=r})})
+  render(<PixelTaskFiles preview={preview}/>);await screen.findByText('index.html')
+  fireEvent.click(screen.getByRole('button',{name:'Download publication ZIP'}))
+  await waitFor(()=>expect(signal).toBeTruthy())
+  fireEvent.click(screen.getByRole('button',{name:'Cancel ZIP download'}))
+  await act(async()=>resolve(new Uint8Array(5).buffer))
+  expect(signal.aborted).toBe(true)
+  expect(URL.createObjectURL).not.toHaveBeenCalled()
+  expect(loadArtifactBytes).toHaveBeenCalledTimes(1)
+})
+
+it('releases the UI when a verifier never settles',async()=>{
+  vi.useFakeTimers()
+  loadArtifactBytes.mockImplementation(()=>new Promise(()=>{}))
+  const view=render(<PixelTaskFiles preview={preview}/>)
+  await act(async()=>{})
+  fireEvent.click(screen.getByRole('button',{name:'Download publication ZIP'}))
+  await act(async()=>{await vi.advanceTimersByTimeAsync(30000)})
+  expect(screen.getByRole('alert')).toHaveTextContent('could not be verified')
+  expect(screen.getByRole('button',{name:'Download publication ZIP'})).toBeEnabled()
+  expect(URL.createObjectURL).not.toHaveBeenCalled()
+  view.unmount()
+})

--- a/ods/extensions/services/dashboard/src/components/PixelTaskFiles.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelTaskFiles.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { ArrowLeft, Search } from 'lucide-react'
 import { loadSnapshotFiles } from '../lib/pixelArtifacts'
 import PixelPreviewSource from './PixelPreviewSource'
+import PixelPublicationDownload from './PixelPublicationDownload'
 import { PixelLanguageBadge } from './PixelCodeBlock'
 
 const fileType = file => {
@@ -46,6 +47,7 @@ export default function PixelTaskFiles({preview}) {
     {error ? <div role="alert" className="pixel-file-empty"><p>Task files could not be verified.</p><button type="button" onClick={() => setAttempt(value => value + 1)}>Try again</button></div>
       : !files ? <p role="status" className="pixel-file-empty">Verifying published files…</p>
         : <>
+          <PixelPublicationDownload key={`${preview.siteId}/${preview.sha256}`} preview={preview}/>
           <p className="pixel-file-caption" role="status">Showing {shown.length} of {files.length} files · {shown.reduce((total, file) => total + file.bytes, 0).toLocaleString()} bytes</p>
           <ul className="pixel-task-file-list">{shown.map(file => {
             return <li key={file.path}><button type="button" aria-current={selected?.path === file.path ? 'true' : undefined} onClick={() => setSelected(file)}><PixelLanguageBadge path={file.path}/><span>{file.path}</span><small>{file.bytes < 1024 ? `${file.bytes} B` : `${(file.bytes / 1024).toFixed(1)} KB`}</small></button></li>


### PR DESCRIPTION
## Why this matters
Workbench currently downloads one published file at a time, which loses the practical ability to take a multi-file site offline with its assets. Add one ZIP action that reads the verified manifest, verifies every original file through the existing artifact loader, retains paths, and exports only a complete archive. Cancellation, a 30-second total deadline, progress, duplicate-click prevention and object-URL cleanup are included. Only the published snapshot is exported. fflate 0.8.3 is pinned; ZIP entries are stored without compression to bound CPU work within the existing 128-file/16-MiB contract. API follows https://github.com/101arrowz/fflate documentation.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Searched ZIP/archive/publication download titles and PixelTaskFiles.jsx/package file changes. #4139 and #4402 handle individual file downloads; #4226 changes publication input types. None exports an entire verified publication. Hash availability on HTTP LAN follows the existing artifact loader and pending #4321; this PR does not duplicate that fix.

## Validation
- Publication download (4 tests), TaskFiles and FileBrowser suites: 15 tests passed across focused runs. ZIP round-trip asserts paths and bytes; verification failure, cancellation and a permanently pending verifier produce no archive. Vite production build passed.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `603f8cc8e1c0a0e976bb28191b7273786d73a102`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `603f8cc8e1c0a0e976bb28191b7273786d73a102`.
