### PR TITLE
fix(talk): decode text attachments without silent corruption

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -668,7 +668,7 @@ def _classify_attachment(file: UploadFile) -> str:
     application/octet-stream. We deliberately keep the accept-set narrow on
     this v1 surface — chat, not document ingestion.
     """
-    ct = (file.content_type or "").lower()
+    ct = (file.content_type or "").split(";", 1)[0].strip().lower()
     name = (file.filename or "").lower()
     ext = "." + name.rsplit(".", 1)[-1] if "." in name else ""
 
@@ -695,6 +695,20 @@ def _image_content_type(file: UploadFile) -> str:
     name = (file.filename or "").lower()
     ext = "." + name.rsplit(".", 1)[-1] if "." in name else ""
     return _IMAGE_EXTENSION_MIMES.get(ext, "image/png")
+
+
+def _decode_text_attachment(data: bytes) -> str:
+    encoding = "utf-16" if data.startswith((b"\xff\xfe", b"\xfe\xff")) else "utf-8-sig"
+    try:
+        content = data.decode(encoding)
+    except UnicodeDecodeError:
+        raise HTTPException(
+            status_code=422,
+            detail="Text attachments must be valid UTF-8 or BOM-marked UTF-16.",
+        ) from None
+    if "\0" in content:
+        raise HTTPException(status_code=422, detail="Text attachments must not contain binary NUL bytes.")
+    return content
 
 
 @router.post("/api/talk/attachment")
@@ -746,10 +760,7 @@ async def talk_attachment(
     data = await file.read(MAX_DOC_BYTES + 1)
     if len(data) > MAX_DOC_BYTES:
         raise HTTPException(status_code=413, detail=f"File is too large (max {MAX_DOC_BYTES // (1024 * 1024)} MB).")
-    try:
-        content = data.decode("utf-8")
-    except UnicodeDecodeError:
-        content = data.decode("utf-8", errors="replace")
+    content = _decode_text_attachment(data)
     if len(content) > MAX_DOC_CHARS:
         content = content[:MAX_DOC_CHARS] + f"\n\n[Truncated — file was {len(data):,} bytes, showing first {MAX_DOC_CHARS:,} chars]"
 

--- a/ods/extensions/services/dashboard-api/tests/test_talk_attachment_encoding.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk_attachment_encoding.py
@@ -1,0 +1,51 @@
+﻿from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.fixture
+def attachment_client(test_client, monkeypatch):
+    import routers.talk as talk
+    import session_signer
+
+    monkeypatch.setenv('ODS_SESSION_SECRET', 'attachment-encoding-test-secret')
+    session_signer._set_secret_for_tests('attachment-encoding-test-secret')
+    test_client.cookies.set('ods-session', session_signer.issue(ttl_seconds=3600))
+    monkeypatch.setattr(talk, '_require_hermes_talk_compatible', AsyncMock())
+    prompts = []
+
+    async def stream(_session, text, _request):
+        prompts.append(text)
+        yield b'data: {"type":"done"}\n\n'
+
+    monkeypatch.setattr(talk, '_stream_hermes_sse', stream)
+    return test_client, prompts
+
+
+@pytest.mark.parametrize('encoding', ['utf-8-sig', 'utf-16', 'utf-16-be'])
+def test_text_attachment_preserves_bom_marked_unicode(attachment_client, encoding):
+    client, prompts = attachment_client
+    text = 'Original text: \u65e5\u672c\u8a9e \U0001f680'
+    data = text.encode(encoding)
+    if encoding == 'utf-16-be':
+        data = b'\xfe\xff' + data
+    response = client.post('/api/talk/attachment', files={'file': ('notes.txt', data, 'text/plain')})
+    assert response.status_code == 200, response.text
+    assert text in prompts[0]
+    assert '\ufffd' not in prompts[0]
+    assert '\ufeff' not in prompts[0]
+
+
+@pytest.mark.parametrize('data', [b'\xffbroken', b'hello\x00world'])
+def test_binary_or_invalid_text_never_reaches_inference(attachment_client, data):
+    client, prompts = attachment_client
+    response = client.post('/api/talk/attachment', files={'file': ('notes.txt', data, 'text/plain')})
+    assert response.status_code == 422, response.text
+    assert not prompts
+
+
+def test_parameterized_text_mime_without_extension(attachment_client):
+    client, prompts = attachment_client
+    response = client.post('/api/talk/attachment', files={'file': ('notes', b'exact content', 'text/plain; charset=utf-8')})
+    assert response.status_code == 200, response.text
+    assert 'exact content' in prompts[0]


### PR DESCRIPTION
## Why this matters
Text attachment uploads currently decode arbitrary bytes with replacement characters. Windows UTF-16 files become corrupt model input, binary NUL bytes reach the prompt, and MIME parameters reject otherwise supported extensionless text files. Decode UTF-8 and BOM-marked UTF-16 strictly, consume the BOM, reject undecodable/binary input before inference, and normalize MIME parameters. Existing size/truncation limits remain in force.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Inspected all talk.py PRs and searched attachment/encoding/UTF/binary titles. #2778 handles empty uploads, #2534 handles backend URLs, and #2821 handles transcript log reading rather than user file bytes. None fixes attachment decoding. The six failing HTTP regressions establish the production path.

## Validation
- pytest tests/test_talk_attachment_encoding.py tests/test_talk.py: 45 passed. All six new HTTP cases failed on unchanged beta: UTF-8 BOM, UTF-16 LE/BE, invalid bytes, binary NUL and parameterized text MIME.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `25dcde0a8815fcb6342ab0f122658eabe3d19112`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
Shared dashboard-api code serves Linux, macOS and Windows installations; HTTP multipart tests use a real signed Talk session with inference transport replaced by a recording stream. This does not alter session authentication or invoke a live model. Non-UTF text must be converted by the user instead of being silently corrupted. Revert the commit to restore prior decoding; no persisted state migration.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `25dcde0a8815fcb6342ab0f122658eabe3d19112`.
