### PR TITLE
fix(talk): keep status checks owned by the latest request

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -80,6 +80,8 @@ export default function ODSTalk() {
 
   const bottomRef = useRef(null)
   const fileInputRef = useRef(null)
+  const talkStatusRequestRef = useRef(null)
+  const talkStatusMountedRef = useRef(false)
   const recorderRef = useRef(null)
   const recordingChunksRef = useRef([])
   const streamControllerRef = useRef(null)
@@ -115,18 +117,34 @@ export default function ODSTalk() {
   }, [])
 
   const refreshStatus = useCallback(async () => {
+    if (!talkStatusMountedRef.current) return
+    talkStatusRequestRef.current?.abort()
+    const controller = new AbortController()
+    talkStatusRequestRef.current = controller
+    let rejectAbort
+    const aborted = new Promise((_, reject) => {
+      rejectAbort = () => reject(new Error('ODS Talk status request timed out.'))
+      controller.signal.addEventListener('abort', rejectAbort, {once:true})
+    })
+    const timer = setTimeout(() => controller.abort(), 30000)
     setRetryStatusRefresh(false)
     setStatus('loading')
     try {
-      const resp = await fetch('/api/talk/status', { credentials: 'same-origin' })
-      if (resp.status === 401) {
+      const read = async () => {
+        const resp = await fetch('/api/talk/status', { credentials: 'same-origin', signal:controller.signal })
+        if (resp.status === 401) return {expired:true}
+        if (!resp.ok) throw new Error(await parseError(resp, 'ODS Talk is not ready.'))
+        return {data:await resp.json()}
+      }
+      const result = await Promise.race([read(), aborted])
+      if (!talkStatusMountedRef.current || talkStatusRequestRef.current !== controller) return
+      if (result.expired) {
         setStatus('expired')
         setStatusText('Session expired. Scan the owner card again.')
         setRetryStatusRefresh(false)
         return
       }
-      if (!resp.ok) throw new Error(await parseError(resp, 'ODS Talk is not ready.'))
-      const data = await resp.json()
+      const data = result.data
       const capabilities = data.capabilities || {}
       const compatibilityReason = data.reason || data.modelCompatibility?.hermesTalk?.reason || ''
       setVoiceState({
@@ -144,13 +162,26 @@ export default function ODSTalk() {
       setStatusText('Ready')
       setRetryStatusRefresh(false)
     } catch (err) {
+      if (!talkStatusMountedRef.current || talkStatusRequestRef.current !== controller) return
       setStatus('offline')
       setStatusText(err.message || 'ODS Talk is offline.')
       setRetryStatusRefresh(true)
+    } finally {
+      clearTimeout(timer)
+      controller.signal.removeEventListener('abort', rejectAbort)
+      if (talkStatusRequestRef.current === controller) talkStatusRequestRef.current = null
     }
   }, [liveMicSupported])
 
-  useEffect(() => { refreshStatus() }, [refreshStatus])
+  useEffect(() => {
+    talkStatusMountedRef.current = true
+    refreshStatus()
+    return () => {
+      talkStatusMountedRef.current = false
+      talkStatusRequestRef.current?.abort()
+      talkStatusRequestRef.current = null
+    }
+  }, [refreshStatus])
 
   // Poll while offline. A one-shot setTimeout does not reschedule here: a
   // failed retry sets `status` and `retryStatusRefresh` to the values they

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.status-ownership.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.status-ownership.test.jsx
@@ -1,0 +1,24 @@
+﻿import {act,fireEvent,render,screen,waitFor} from '@testing-library/react'
+import ODSTalk from './ODSTalk'
+const ready=()=>({ok:true,status:200,json:async()=>({capabilities:{text_chat:true}})})
+afterEach(()=>{vi.unstubAllGlobals();vi.useRealTimers()})
+it.each([true,false])('keeps the newest session verdict when older response resolves (expired=%s)',async expired=>{
+  let finish
+  vi.stubGlobal('fetch',vi.fn().mockImplementationOnce(()=>new Promise(r=>{finish=r})).mockResolvedValueOnce(expired?{status:401}:ready()))
+  render(<ODSTalk/>)
+  fireEvent.click(screen.getByRole('button',{name:'Refresh ODS Talk status'}))
+  await waitFor(()=>expect(screen.getByPlaceholderText('Message ODS').disabled).toBe(expired))
+  await act(async()=>finish(expired?ready():{status:401}))
+  expect(screen.getByPlaceholderText('Message ODS').disabled).toBe(expired)
+  if(!expired)expect(screen.getByText('Ready')).toBeInTheDocument()
+})
+it('settles a stuck status JSON body and permits a later refresh',async()=>{
+  vi.useFakeTimers()
+  vi.stubGlobal('fetch',vi.fn().mockResolvedValueOnce({ok:true,status:200,json:()=>new Promise(()=>{})}).mockResolvedValue(ready()))
+  render(<ODSTalk/>)
+  await act(async()=>{await vi.advanceTimersByTimeAsync(30000)})
+  expect(screen.getAllByText(/status request timed out/i).length).toBeGreaterThan(0)
+  fireEvent.click(screen.getByRole('button',{name:'Refresh ODS Talk status'}))
+  await act(async()=>{})
+  expect(screen.getByText('Ready')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Why this matters
A delayed earlier status request can overwrite a newer authentication verdict, and a stalled response body leaves Talk checking forever. Abort superseded requests, accept results only from the current owner, and bound the complete status fetch plus JSON read to 30 seconds so manual retry remains usable.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed Talk status and retry history including #1928; that work schedules offline retries and does not own overlapping status responses or bound body reads. Other batch Talk changes concern sending, streaming and audio rather than status ownership.

## Validation
- ODSTalk.status-ownership.test.jsx plus ODSTalk.test.jsx: 18 passed; regressions cover both reversed authentication outcomes and stalled-body timeout followed by refresh.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `c5c9a192005d8dfdc4609937ef0f0c9d546a9191`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `c5c9a192005d8dfdc4609937ef0f0c9d546a9191`.
