### PR TITLE
fix(talk): render inline code and structured Markdown correctly

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import {
   AlertCircle, CheckCircle2, Loader2, Mic, Paperclip, RefreshCw,
   Send, Volume2, VolumeX,
@@ -22,10 +23,11 @@ const MARKDOWN_COMPONENTS = {
   a: ({ href, children }) => (
     <a href={href} target="_blank" rel="noreferrer" className="underline decoration-zinc-400 underline-offset-2 hover:decoration-zinc-700">{children}</a>
   ),
-  code: ({ inline, children }) => inline
-    ? <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-[13px] text-zinc-800">{children}</code>
-    : <code className="block whitespace-pre-wrap break-words rounded bg-zinc-100 p-2 font-mono text-[13px] text-zinc-800">{children}</code>,
-  pre: ({ children }) => <pre className="my-2 overflow-x-auto rounded bg-zinc-100">{children}</pre>,
+  code: ({ className, children }) => <code className={`rounded bg-zinc-100 px-1 py-0.5 font-mono text-[13px] text-zinc-800 ${className || ''}`}>{children}</code>,
+  pre: ({ children }) => <pre className="my-2 overflow-x-auto rounded bg-zinc-100 p-2 [&>code]:block [&>code]:whitespace-pre [&>code]:p-0">{children}</pre>,
+  table: ({ children }) => <div className="my-2 overflow-x-auto"><table className="w-full border-collapse text-left">{children}</table></div>,
+  th: ({ children }) => <th className="border border-zinc-300 px-2 py-1 font-semibold">{children}</th>,
+  td: ({ children }) => <td className="border border-zinc-300 px-2 py-1">{children}</td>,
   blockquote: ({ children }) => <blockquote className="my-2 border-l-2 border-zinc-300 pl-3 italic text-zinc-700">{children}</blockquote>,
   hr: () => <hr className="my-3 border-zinc-200" />,
 }
@@ -852,7 +854,7 @@ function MessageBubble({ message }) {
           </>
         ) : (
           <div className="space-y-0 text-[15px] leading-6">
-            <ReactMarkdown components={MARKDOWN_COMPONENTS}>{message.text}</ReactMarkdown>
+            <ReactMarkdown remarkPlugins={[remarkGfm]} components={MARKDOWN_COMPONENTS}>{message.text}</ReactMarkdown>
           </div>
         )}
         {message.warning && (

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.markdown.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.markdown.test.jsx
@@ -1,0 +1,26 @@
+import { fireEvent, screen } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import ODSTalk from './ODSTalk'
+
+afterEach(() => vi.unstubAllGlobals())
+
+test('renders inline commands, fenced code and GFM structures from a Talk reply', async () => {
+  const text = 'Run `ods doctor` first.\n\n```bash\nods status\n```\n\n| Service | State |\n| --- | --- |\n| LLM | Ready |\n\n- [x] Verified\n\n~~Obsolete~~'
+  const frames = [{type:'complete', text, status:'ok'}, {type:'done'}]
+  const reader = {read:async () => frames.length ? {done:false,value:new TextEncoder().encode(`data: ${JSON.stringify(frames.shift())}\n\n`)} : {done:true}, cancel:async()=>{},releaseLock:()=>{}}
+  vi.stubGlobal('fetch', vi.fn(async url => url === '/api/talk/status'
+    ? {ok:true,json:async()=>({capabilities:{text_chat:true}})}
+    : {ok:true,body:{getReader:()=>reader}}))
+  render(<ODSTalk />)
+  await screen.findByText('Ready')
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Show diagnostics'}})
+  fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  const inline = await screen.findByText('ods doctor')
+  expect(inline.tagName).toBe('CODE')
+  expect(inline).not.toHaveClass('block')
+  expect(screen.getByText('ods status').closest('pre')).toBeInTheDocument()
+  expect(screen.getByRole('table')).toHaveTextContent('LLMReady')
+  expect(screen.getByRole('checkbox')).toBeChecked()
+  expect(screen.getByRole('checkbox')).toBeDisabled()
+  expect(screen.getByText('Obsolete').tagName).toBe('DEL')
+})


### PR DESCRIPTION
## Why this matters
Talk treats every code span as a block because react-markdown 10 no longer supplies an inline flag. Ordinary commands interrupt sentences, while model tables and task lists appear as raw syntax. Style fenced code through its pre parent and enable the already installed GFM parser, keeping raw HTML disabled.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Semantic search found #3845 conversation export, which does not change message rendering. Reviewed ODSTalk production-file history; no existing PR fixes inline rendering or GFM message structures.

## Validation
- ODSTalk.markdown.test.jsx plus ODSTalk.test.jsx: 16 passed; streamed replies assert inline code, fenced code, table cells, disabled task checkboxes and strikethrough.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `24d638a9d80cda792731c5d4d5d1fe6819ad7ba8`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `24d638a9d80cda792731c5d4d5d1fe6819ad7ba8`.
