### PR TITLE
fix(advice): isolate the modal with the native dialog lifecycle

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.jsx
@@ -67,21 +67,14 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
 
   useEffect(() => { if (open) void load() }, [open, load])
   useEffect(() => {
-    if (open) panel.current?.querySelector('button')?.focus()
+    if (!open) return
+    const dialog = panel.current
+    dialog.showModal()
+    dialog.querySelector('button')?.focus()
+    return () => { dialog.close() }
   }, [open])
 
   function close() { setOpen(false); setRuntimeReady(false); trigger.current?.focus() }
-  function dialogKey(event) {
-    if (event.key === 'Escape') { event.stopPropagation(); close(); return }
-    if (event.key !== 'Tab') return
-    const controls = [...panel.current.querySelectorAll('button, input, textarea, select, a[href]')].filter(el => !el.disabled)
-    const first = controls[0], last = controls.at(-1)
-    if (event.shiftKey && (document.activeElement === first || !panel.current.contains(document.activeElement))) {
-      event.preventDefault(); last?.focus()
-    } else if (!event.shiftKey && (document.activeElement === last || !panel.current.contains(document.activeElement))) {
-      event.preventDefault(); first?.focus()
-    }
-  }
 
   const inspect = useCallback(async () => {
     if (!jobId || polling.current || inFlight.current) return
@@ -154,8 +147,7 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
 
   return <>
     <button ref={trigger} type="button" className={button} onClick={() => setOpen(true)}>Ask for advice{jobId ? ' · tracked' : ''}</button>
-    {open && <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-3">
-      <section ref={panel} role="dialog" aria-modal="true" aria-labelledby="pixel-advice-title" onKeyDown={dialogKey} className="max-h-[90dvh] w-full max-w-2xl space-y-4 overflow-y-auto rounded-xl border border-theme-border bg-theme-card p-4 text-theme-text">
+    {open && <dialog ref={panel} aria-labelledby="pixel-advice-title" onCancel={event => { event.preventDefault(); close() }} className="m-auto backdrop:bg-black/60 max-h-[90dvh] w-full max-w-2xl space-y-4 overflow-y-auto rounded-xl border border-theme-border bg-theme-card p-4 text-theme-text">
         <div className="flex items-center justify-between gap-3"><h2 id="pixel-advice-title" className="font-semibold">Ask for advice</h2><button className={button} onClick={close}>Close advice</button></div>
         <p className="text-sm">Only the capsule below and a fixed tools-free advisory instruction are sent. Your chat, files, memory, and tools are not included automatically. The current leader and execution permissions stay unchanged.</p>
         <PixelAdviceRuntime onReadyChange={setRuntimeReady} />
@@ -188,7 +180,6 @@ export default function PixelAdvice({ onInsert, canInsert = true }) {
           </div>}
           <button className={button} disabled={!ready || submitting || !capsule.trim() || new TextEncoder().encode(capsule).length > 16384 || (advisor?.kind === 'cloud' && (!cloud || !cost))} onClick={submit}>Send reviewed capsule</button>
         </>}
-      </section>
-    </div>}
+    </dialog>}
   </>
 }

--- a/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelAdvice.test.jsx
@@ -31,7 +31,11 @@ async function setup({ kind, post, onInsert = vi.fn() } = {}) {
   return { fetchMock, onInsert, ...view }
 }
 
-beforeEach(() => localStorage.clear())
+beforeEach(() => {
+  localStorage.clear()
+  Object.defineProperty(globalThis.HTMLDialogElement.prototype, 'showModal', {configurable:true, value:vi.fn(function () { this.setAttribute('open', '') })})
+  Object.defineProperty(globalThis.HTMLDialogElement.prototype, 'close', {configurable:true, value:vi.fn(function () { this.removeAttribute('open') })})
+})
 afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals(); localStorage.clear() })
 
 it('sends only reviewed capsule and fixed selected revision once, stores only job ID', async () => {
@@ -136,15 +140,12 @@ it('closing panel does not start, stop, or change the chat', async () => {
   expect(JSON.stringify(localStorage)).not.toContain('Private draft')
 })
 
-it('keeps keyboard focus in the dialog and Escape returns it to the trigger', async () => {
+it('focuses the close control and native cancellation returns to the trigger', async () => {
   await setup()
-  const close = screen.getByRole('button', { name: 'Close advice' })
-  expect(close).toHaveFocus()
-  fireEvent.keyDown(close, { key: 'Tab', shiftKey: true })
-  expect(screen.getByLabelText('Capsule to send')).toHaveFocus()
-  fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+  expect(screen.getByRole('button', {name:'Close advice'})).toHaveFocus()
+  fireEvent(screen.getByRole('dialog'), new Event('cancel', {cancelable:true}))
   expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
-  expect(screen.getByRole('button', { name: 'Ask for advice' })).toHaveFocus()
+  expect(screen.getByRole('button', {name:/Ask for advice/})).toHaveFocus()
 })
 
 it('ignores an old pending status response after forgetting and starting a new job', async () => {
@@ -170,4 +171,20 @@ it('ignores an old pending status response after forgetting and starting a new j
   expect(screen.queryByText('<img src=x onerror=alert(1)> Advice')).not.toBeInTheDocument()
   expect(localStorage.getItem(key)).toBe(nextId)
   expect(fetchMock.mock.calls.filter(([url]) => url.endsWith('/start'))).toHaveLength(1)
+})
+
+
+it('opens a native modal and cancellation preserves the tracked job', async () => {
+  localStorage.setItem(key, id)
+  const {fetchMock} = await setup({post:async()=>response(job('running'))})
+  const dialog = screen.getByRole('dialog')
+  expect(dialog.tagName).toBe('DIALOG')
+  expect(dialog).toHaveAttribute('open')
+  fireEvent(dialog, new Event('cancel', {cancelable:true}))
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  expect(localStorage.getItem(key)).toBe(id)
+  expect(fetchMock.mock.calls.filter(([url])=>url.endsWith('/cancel'))).toHaveLength(0)
+  expect(screen.getByRole('button',{name:/Ask for advice/})).toHaveFocus()
+  fireEvent.click(screen.getByRole('button',{name:/Ask for advice/}))
+  expect(screen.getByRole('dialog')).toHaveAttribute('open')
 })


### PR DESCRIPTION
## Why this matters
The advice panel declares aria-modal but only traps Tab on a section: browser focus and background interaction remain available outside it. Use showModal so the browser supplies modal isolation and native Escape cancellation; closing still preserves tracked jobs and returns focus, without posting a cancel request.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed PixelAdvice changes #4229 provider inspection ownership, #4228 UUID availability, #4102 terminal receipts and #4396 naming; none implements native modal lifecycle or background isolation.

## Validation
- PixelAdvice.test.jsx and PixelAdviceRuntime.test.jsx: 21 passed, including native-open/cancel/reopen and preserved tracked job without cancellation. DOM tests mock showModal/close; native browser focus trapping itself is not simulated.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `9473778ed9347eed477e30fab88c175d30026df0`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `9473778ed9347eed477e30fab88c175d30026df0`.
