### PR TITLE
feat(preview): extract exact line ranges from verified source

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.excerpt.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.excerpt.test.jsx
@@ -1,5 +1,5 @@
 import {webcrypto,createHash} from 'node:crypto'
-import {fireEvent,render,screen} from '@testing-library/react'
+import {act,fireEvent,render,screen} from '@testing-library/react'
 import PixelPreviewSource from './PixelPreviewSource'
 
 const text='first\r\n<script>inert</script>\r\nlast\n'
@@ -9,7 +9,7 @@ beforeEach(()=>{
   Object.defineProperty(navigator,'clipboard',{configurable:true,value:{writeText:vi.fn().mockResolvedValue()}})
 })
 afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
-function setup(){return render(<PixelPreviewSource preview={{siteId:'site-'+'a'.repeat(24),entrySha256:createHash('sha256').update(text).digest('hex')}}/>)}
+function setup(value=text){return render(<PixelPreviewSource preview={{siteId:'site-'+'a'.repeat(24),entrySha256:createHash('sha256').update(value).digest('hex')}}/>)}
 it('copies only the chosen verified lines with original line endings',async()=>{
   const {container}=setup()
   fireEvent.click(await screen.findByText('Extract lines'))
@@ -31,4 +31,32 @@ it('rejects invalid ranges and offers manual selection when clipboard fails',asy
   fireEvent.click(screen.getByRole('button',{name:'Copy excerpt'}))
   expect(await screen.findByRole('alert')).toHaveTextContent('Select the excerpt')
   expect(screen.getByLabelText('Selected source excerpt')).toHaveValue(text.replaceAll('\r\n','\n'))
+})
+
+it.each([32768,32769])('enforces the 64 KiB limit in UTF-8 bytes (%s multibyte characters)',async count=>{
+  const value='?'.repeat(count)
+  fetch.mockResolvedValue({ok:true,arrayBuffer:async()=>new TextEncoder().encode(value).buffer})
+  setup(value)
+  fireEvent.click(await screen.findByText('Extract lines'))
+  const copy=screen.getByRole('button',{name:'Copy excerpt'})
+  if(count===32768){
+    expect(copy).toBeEnabled()
+    fireEvent.click(copy)
+    await screen.findByText('Excerpt copied.')
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(value)
+  }else{
+    expect(copy).toBeDisabled()
+    expect(screen.getByRole('alert')).toHaveTextContent('within 64 KiB')
+    expect(screen.queryByLabelText('Selected source excerpt')).toBeNull()
+  }
+})
+it('does not confirm an old clipboard request after the selected range changes',async()=>{
+  let resolve
+  navigator.clipboard.writeText.mockReturnValue(new Promise(done=>{resolve=done}))
+  setup();fireEvent.click(await screen.findByText('Extract lines'))
+  fireEvent.click(screen.getByRole('button',{name:'Copy excerpt'}))
+  fireEvent.change(screen.getByLabelText('End line'),{target:{value:'1'}})
+  await act(async()=>resolve())
+  expect(screen.queryByText('Excerpt copied.')).toBeNull()
+  expect(screen.getByLabelText('Selected source excerpt')).toHaveValue('first\n')
 })

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.excerpt.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.excerpt.test.jsx
@@ -34,7 +34,7 @@ it('rejects invalid ranges and offers manual selection when clipboard fails',asy
 })
 
 it.each([32768,32769])('enforces the 64 KiB limit in UTF-8 bytes (%s multibyte characters)',async count=>{
-  const value='?'.repeat(count)
+  const value='\u00e9'.repeat(count)
   fetch.mockResolvedValue({ok:true,arrayBuffer:async()=>new TextEncoder().encode(value).buffer})
   setup(value)
   fireEvent.click(await screen.findByText('Extract lines'))

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.excerpt.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.excerpt.test.jsx
@@ -1,0 +1,34 @@
+import {webcrypto,createHash} from 'node:crypto'
+import {fireEvent,render,screen} from '@testing-library/react'
+import PixelPreviewSource from './PixelPreviewSource'
+
+const text='first\r\n<script>inert</script>\r\nlast\n'
+beforeEach(()=>{
+  vi.stubGlobal('crypto',webcrypto)
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,arrayBuffer:async()=>new TextEncoder().encode(text).buffer})))
+  Object.defineProperty(navigator,'clipboard',{configurable:true,value:{writeText:vi.fn().mockResolvedValue()}})
+})
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
+function setup(){return render(<PixelPreviewSource preview={{siteId:'site-'+'a'.repeat(24),entrySha256:createHash('sha256').update(text).digest('hex')}}/>)}
+it('copies only the chosen verified lines with original line endings',async()=>{
+  const {container}=setup()
+  fireEvent.click(await screen.findByText('Extract lines'))
+  fireEvent.change(screen.getByLabelText('Start line'),{target:{value:'2'}})
+  fireEvent.change(screen.getByLabelText('End line'),{target:{value:'3'}})
+  fireEvent.click(screen.getByRole('button',{name:'Copy excerpt'}))
+  await screen.findByText('Excerpt copied.')
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith('<script>inert</script>\r\nlast\n')
+  expect(container.querySelector('script')).toBeNull()
+})
+it('rejects invalid ranges and offers manual selection when clipboard fails',async()=>{
+  setup()
+  fireEvent.click(await screen.findByText('Extract lines'))
+  fireEvent.change(screen.getByLabelText('Start line'),{target:{value:'9'}})
+  expect(screen.getByRole('button',{name:'Copy excerpt'})).toBeDisabled()
+  expect(navigator.clipboard.writeText).not.toHaveBeenCalled()
+  fireEvent.change(screen.getByLabelText('Start line'),{target:{value:'1'}})
+  navigator.clipboard.writeText.mockRejectedValue(new Error('denied'))
+  fireEvent.click(screen.getByRole('button',{name:'Copy excerpt'}))
+  expect(await screen.findByRole('alert')).toHaveTextContent('Select the excerpt')
+  expect(screen.getByLabelText('Selected source excerpt')).toHaveValue(text.replaceAll('\r\n','\n'))
+})

--- a/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelPreviewSource.jsx
@@ -3,6 +3,7 @@ import { loadArtifactBytes } from '../lib/pixelArtifacts'
 import { PixelCodeLines, PixelLanguageBadge } from './PixelCodeBlock'
 import PixelArtifactDownload from './PixelArtifactDownload'
 import PixelSourceFind from './PixelSourceFind'
+import PixelSourceExcerpt from './PixelSourceExcerpt'
 
 
 const TEXT_LANGUAGES = {html:'html',htm:'html',css:'css',scss:'scss',js:'javascript',mjs:'javascript',cjs:'javascript',jsx:'javascript',ts:'typescript',tsx:'typescript',py:'python',sh:'bash',yml:'yaml',yaml:'yaml',toml:'ini',json:'json',svg:'xml',xml:'xml',md:'markdown',markdown:'markdown',txt:'text',map:'json',csv:'text',tsv:'text'}
@@ -46,7 +47,7 @@ export default function PixelPreviewSource({ preview, file }) {
     {error && <div role="alert"><p>{error}</p><button type="button" onClick={() => setAttempt(value => value + 1)}>Retry source</button></div>}
     <div className="pixel-code-block">
       <header className="code-block-header"><PixelLanguageBadge path={path}/><span title={path}>{path}</span><PixelArtifactDownload key={`${preview.siteId}/${path}/${expectedDigest}`} preview={preview} file={{path, sha256:expectedDigest, bytes:file?.bytes}}/>{language && <button type="button" aria-label="Copy code" onClick={copy} disabled={source === null}>{copied ? 'Copied' : 'Copy'}</button>}</header>
-      {source !== null && <><PixelSourceFind key={`${preview.siteId}/${path}/${expectedDigest}`} source={source} codeRef={codeRef}/><pre ref={codeRef} tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre></>}
+      {source !== null && <><PixelSourceExcerpt key={`${preview.siteId}/${path}/${expectedDigest}`} source={source}/><PixelSourceFind key={`${preview.siteId}/${path}/${expectedDigest}`} source={source} codeRef={codeRef}/><pre ref={codeRef} tabIndex={0} aria-label={`Code for ${path}`}><PixelCodeLines source={source} language={language}/></pre></>}
 
     </div>
     {(source !== null || binarySize !== null) && <p className="pixel-source-verification">Published snapshot · SHA-256 verified{binarySize !== null ? ` · ${binarySize.toLocaleString()} bytes` : ''}</p>}

--- a/ods/extensions/services/dashboard/src/components/PixelSourceExcerpt.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSourceExcerpt.jsx
@@ -1,0 +1,41 @@
+import {useEffect,useMemo,useRef,useState} from 'react'
+
+export default function PixelSourceExcerpt({source}) {
+  const lines=useMemo(()=>source.match(/[^\n]*\n|[^\n]+$/g) || [''],[source])
+  const [start,setStart]=useState('1')
+  const [end,setEnd]=useState(String(lines.length))
+  const [notice,setNotice]=useState('')
+  const [error,setError]=useState('')
+  const [busy,setBusy]=useState(false)
+  const revision=useRef(0)
+  useEffect(()=>()=>{revision.current++},[])
+  const first=Number(start),last=Number(end)
+  const valid=Number.isInteger(first)&&Number.isInteger(last)&&first>=1&&last>=first&&last<=lines.length
+  const excerpt=valid ? lines.slice(first-1,last).join('') : ''
+  const bounded=new TextEncoder().encode(excerpt).length<=65536
+  function change(setter,value){revision.current++;setter(value);setNotice('');setError('');setBusy(false)}
+  async function copy(){
+    if(!valid||!bounded||busy)return
+    const current=++revision.current
+    setBusy(true);setNotice('');setError('')
+    try {
+      await navigator.clipboard.writeText(excerpt)
+      if(current===revision.current)setNotice('Excerpt copied.')
+    } catch {
+      if(current===revision.current)setError('Clipboard unavailable. Select the excerpt below and copy manually.')
+    } finally {if(current===revision.current)setBusy(false)}
+  }
+  return <details className="my-2 rounded border border-theme-border p-2">
+    <summary className="cursor-pointer text-xs">Extract lines</summary>
+    <p className="my-2 text-xs">Select a range from this verified file ({lines.length} lines). Excerpts are limited to 64 KiB.</p>
+    <div className="flex flex-wrap items-center gap-2 text-xs">
+      <label>Start line<input className="ml-2 w-20 bg-theme-bg" type="number" min="1" max={lines.length} value={start} onChange={e=>change(setStart,e.target.value)}/></label>
+      <label>End line<input className="ml-2 w-20 bg-theme-bg" type="number" min="1" max={lines.length} value={end} onChange={e=>change(setEnd,e.target.value)}/></label>
+      <button type="button" disabled={!valid||!bounded||busy} onClick={copy}>{busy?'Copying excerpt?':'Copy excerpt'}</button>
+    </div>
+    {!valid&&<p role="alert">Choose an inclusive range between 1 and {lines.length}.</p>}
+    {valid&&!bounded&&<p role="alert">Choose fewer lines to keep the excerpt within 64 KiB.</p>}
+    {valid&&bounded&&<textarea aria-label="Selected source excerpt" className="my-2 h-32 w-full bg-theme-bg p-2 font-mono text-xs" readOnly value={excerpt} onFocus={e=>e.target.select()}/>}
+    {notice&&<p role="status">{notice}</p>}{error&&<p role="alert">{error}</p>}
+  </details>
+}

--- a/ods/extensions/services/dashboard/src/components/PixelSourceExcerpt.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelSourceExcerpt.jsx
@@ -31,7 +31,7 @@ export default function PixelSourceExcerpt({source}) {
     <div className="flex flex-wrap items-center gap-2 text-xs">
       <label>Start line<input className="ml-2 w-20 bg-theme-bg" type="number" min="1" max={lines.length} value={start} onChange={e=>change(setStart,e.target.value)}/></label>
       <label>End line<input className="ml-2 w-20 bg-theme-bg" type="number" min="1" max={lines.length} value={end} onChange={e=>change(setEnd,e.target.value)}/></label>
-      <button type="button" disabled={!valid||!bounded||busy} onClick={copy}>{busy?'Copying excerpt?':'Copy excerpt'}</button>
+      <button type="button" disabled={!valid||!bounded||busy} onClick={copy}>{busy?'Copying excerpt...':'Copy excerpt'}</button>
     </div>
     {!valid&&<p role="alert">Choose an inclusive range between 1 and {lines.length}.</p>}
     {valid&&!bounded&&<p role="alert">Choose fewer lines to keep the excerpt within 64 KiB.</p>}


### PR DESCRIPTION
## Why this matters
Reviewing a published file currently requires copying the entire source or manually selecting highlighted lines. Add an inclusive line-range excerpt with exact original line endings, a 64 KiB copy bound, explicit invalid-range feedback and a selectable manual-copy field. Only already verified source is used; no extra fetch or execution occurs.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed #4233 line navigation, #4251 wrapping, #4223 whole-source clipboard receipts and #4145 search. These navigate or copy the whole source; none produces a bounded exact line-range excerpt. The new component is independent of their search and clipboard implementations.

## Validation
- PixelPreviewSource.excerpt.test.jsx and PixelPreviewSource.test.jsx: 11 passed; exercises verified fetch through source UI, CRLF range copying, inert markup, invalid ranges and clipboard-denied manual selection.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `ccfec1b5d58c74a99cfbcb09873ba99e977818c1`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `ccfec1b5d58c74a99cfbcb09873ba99e977818c1`.

Follow-ups `6610a004` / `ccfec1b5` add exact 64 KiB UTF-8 boundary and obsolete-copy receipt regressions (14 source tests passed), with an explicit Unicode escape for Windows-shell-safe fixtures. An earlier CI run failed in unchanged advice-process `/proc` cleanup probing with ProcessLookupError: https://github.com/Osmantic/ODS/actions/runs/34676762063 . GitHub denied rerunning that job without repository admin rights; subsequent candidate checks run on the follow-up head.
