### PR TITLE
feat(talk): stop streamed replies without losing received text

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -456,6 +456,7 @@ export default function ODSTalk() {
       // for ``data:`` only below.
       while (true) {
         const { value, done } = await reader.read()
+        controller.signal.throwIfAborted()
         if (done) break
         buffer += decoder.decode(value, { stream: true })
         let sepIdx
@@ -504,6 +505,7 @@ export default function ODSTalk() {
         }
       }
 
+      controller.signal.throwIfAborted()
       if (errorDetail) throw new Error(errorDetail)
       const reply = assembled || 'I did not get a response back.'
       setMessages(items => items.map(item =>
@@ -514,8 +516,9 @@ export default function ODSTalk() {
       speak(reply)
     } catch (err) {
       if (err.name === 'AbortError') {
-        // User-initiated cancellation. Drop the placeholder bubble silently.
-        setMessages(items => items.filter(item => item.id !== assistantId))
+        setMessages(items => items.map(item => item.id === assistantId
+          ? {...item, text:assembled || 'Response stopped.', status:'done', statusLabel:null, statusTool:null, statusDetail:null, warning:'Response stopped. The reply may be incomplete.'}
+          : item))
       } else {
         setMessages(items => items.map(item =>
           item.id === assistantId
@@ -788,6 +791,9 @@ export default function ODSTalk() {
               {sending ? <Loader2 size={18} className="animate-spin" /> : <Send size={18} />}
             </button>
           </div>
+          {sending && streamControllerRef.current && <div className="mt-2 flex justify-end">
+            <button type="button" onClick={() => streamControllerRef.current?.abort()} className="rounded border border-zinc-300 px-3 py-2 text-sm">Stop response</button>
+          </div>}
           {messages.some(message => message.status === 'error') && (
             <div className="mt-2 flex justify-end">
               <button type="button" onClick={retryLast} className="text-sm font-medium text-zinc-700">

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.stop.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.stop.test.jsx
@@ -1,0 +1,26 @@
+﻿import {fireEvent,screen,waitFor} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import ODSTalk from './ODSTalk'
+afterEach(()=>vi.unstubAllGlobals())
+it('stops a live response, retains received text and permits another message',async()=>{
+  let signal,readCount=0
+  vi.stubGlobal('fetch',vi.fn(async(url,options)=>{
+    if(url==='/api/talk/status')return {ok:true,json:async()=>({capabilities:{text_chat:true}})}
+    signal=options.signal
+    return {ok:true,body:{getReader:()=>({cancel:async()=>{},releaseLock:()=>{},read:async()=>{
+      if(readCount++===0)return {done:false,value:new TextEncoder().encode('data: {"type":"delta","text":"Useful partial reply"}\n\n')}
+      return new Promise((_,reject)=>signal.addEventListener('abort',()=>reject(new globalThis.DOMException('Stopped','AbortError')),{once:true}))
+    }})}}
+  }))
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Explain'}})
+  fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  await screen.findByText('Useful partial reply')
+  fireEvent.click(screen.getByRole('button',{name:'Stop response'}))
+  await screen.findByText('Response stopped. The reply may be incomplete.')
+  expect(signal.aborted).toBe(true)
+  expect(screen.getByText('Useful partial reply')).toBeVisible()
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Next'}})
+  await waitFor(()=>expect(screen.getByRole('button',{name:'Send message'})).toBeEnabled())
+})
+


### PR DESCRIPTION
## Why this matters
Talk exposes no way to stop a long text or attachment reply without leaving the page. Add an explicit Stop response action using the existing request AbortController, retain partial text with an incomplete-reply warning, suppress speech after cancellation and release the composer when the request settles.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed #3801 Hermes server-generator cancellation, which changes backend cleanup and remains independent. This PR adds the browser action and partial-result receipt; batch #4447 owns terminal stream framing and reader cleanup.

## Validation
- ODSTalk.stop.test.jsx and ODSTalk.test.jsx: 16 passed; a live partial SSE reply is cancelled through the rendered control and the composer becomes usable. No claim that disconnect reverses tools or proves server inference termination.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `037426fdfece1f893b45dfeb349dd856694c6598`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `037426fdfece1f893b45dfeb349dd856694c6598`.
