### PR TITLE
fix(talk): validate attachments before discarding the draft

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.attachment-preflight.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.attachment-preflight.test.jsx
@@ -1,0 +1,23 @@
+import {fireEvent,screen} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import ODSTalk from './ODSTalk'
+beforeEach(()=>{
+  vi.stubGlobal('fetch',vi.fn(async()=>({ok:true,json:async()=>({capabilities:{text_chat:true}})})))
+  URL.createObjectURL=vi.fn(()=> 'blob:photo');URL.revokeObjectURL=vi.fn()
+})
+afterEach(()=>vi.unstubAllGlobals())
+it.each([['big.png','image/png',10*1024*1024+1],['big.txt','text/plain',5*1024*1024+1],['document.pdf','application/pdf',20]])('rejects %s before clearing the caption or allocating a preview',async(name,type,size)=>{
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Keep this caption'}})
+  const file=new File(['x'],name,{type});Object.defineProperty(file,'size',{value:size})
+  fireEvent.change(screen.getByLabelText('Attach image or file',{selector:'input'}),{target:{files:[file]}})
+  await screen.findByRole('alert')
+  expect(screen.getByPlaceholderText('Message ODS')).toHaveValue('Keep this caption')
+  expect(URL.createObjectURL).not.toHaveBeenCalled()
+  expect(fetch).toHaveBeenCalledTimes(1)
+})
+it('recognizes an octet-stream camera photo by its extension',async()=>{
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.change(screen.getByLabelText('Attach image or file',{selector:'input'}),{target:{files:[new File(['photo'],'CAMERA.JPG',{type:'application/octet-stream'})]}})
+  expect(screen.getByAltText('Attachment preview')).toHaveAttribute('src','blob:photo')
+})

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -74,6 +74,7 @@ export default function ODSTalk() {
   })
 
   const [pendingAttachment, setPendingAttachment] = useState(null)
+  const [attachmentError, setAttachmentError] = useState('')
   // {file: File, previewUrl: string|null, kind: 'image'|'text', name: string}
   // Held in state between picking a file and sending — lets the user add a
   // caption in the textarea before submitting.
@@ -609,7 +610,15 @@ export default function ODSTalk() {
 
   const handleAttachmentPicked = useCallback((file) => {
     if (!file || sending || status === 'expired') return
-    const isImage = (file.type || '').startsWith('image/')
+    const mime = (file.type || '').split(';', 1)[0].toLowerCase().trim()
+    const extension = (file.name || '').split('.').pop().toLowerCase()
+    const isImage = mime.startsWith('image/') || ['avif','bmp','gif','heic','heif','jpeg','jpg','png','webp'].includes(extension)
+    const isText = ['text/plain','text/markdown','text/csv','text/x-markdown','application/json','application/xml','text/xml','application/x-yaml','text/yaml','text/x-yaml'].includes(mime)
+      || ['txt','md','markdown','csv','json','yaml','yml','log','py','js','ts','tsx','jsx','html','css','sh'].includes(extension)
+    if (!isImage && !isText) { setAttachmentError('This file type is not supported. Choose an image, text or code file.'); return }
+    const limit = (isImage ? 10 : 5) * 1024 * 1024
+    if (file.size > limit) { setAttachmentError(`Choose ${isImage ? 'an image up to 10' : 'a text file up to 5'} MiB.`); return }
+    setAttachmentError('')
     const previewUrl = isImage ? URL.createObjectURL(file) : null
     setPendingAttachment(prev => {
       // Revoke a previous blob URL before swapping in a new one so the
@@ -714,6 +723,7 @@ export default function ODSTalk() {
           {/* Attachment preview strip — appears above the input bar between
               pick and send. Shows a thumbnail for images, a generic icon for
               text/code files, with an X to discard. */}
+          {attachmentError && <p role="alert" className="mb-2 text-sm text-red-700">{attachmentError}</p>}
           {pendingAttachment && (
             <AttachmentPreview
               attachment={pendingAttachment}


### PR DESCRIPTION
## Why this matters
The browser accepts oversize and unsupported files, then clears the caption before the API rejects them. Mirror the shipped 10 MiB image and 5 MiB text limits and accepted categories before staging a file, preserve the draft on rejection, and recognize octet-stream phone images by the same filename fallback as the API.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed attachment history including #1334 and #2778. The latter rejects empty uploads at the API boundary; this PR does not add empty-upload handling. No existing PR preflights browser size/type or matches filename-based image previews. Batch #4448 handles caption character length, not file validation.

## Validation
- ODSTalk.attachment-preflight.test.jsx and ODSTalk.test.jsx: 19 passed; oversize image/text and unsupported PDF preserve captions without fetch/preview allocation, and octet-stream JPG displays an image preview. Limits and categories compared against routers/talk.py.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `5813eff570bcea6ed00b7aa93bff622b6d3f21a8`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `5813eff570bcea6ed00b7aa93bff622b6d3f21a8`.
