### PR TITLE
feat(talk): copy reply Markdown with honest clipboard receipts

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TalkReplyCopy.jsx
+++ b/ods/extensions/services/dashboard/src/components/TalkReplyCopy.jsx
@@ -1,0 +1,25 @@
+import {useEffect,useRef,useState} from 'react'
+
+export default function TalkReplyCopy({text}) {
+  const [state,setState]=useState('idle')
+  const version=useRef(0)
+  const pending=useRef(false)
+  useEffect(()=>()=>{version.current++},[])
+  async function copy(){
+    if(pending.current)return
+    pending.current=true
+    const current=++version.current
+    setState('copying')
+    let timer
+    try {
+      await Promise.race([navigator.clipboard.writeText(text),new Promise((_,reject)=>{timer=setTimeout(()=>reject(new Error('Clipboard deadline')),10000)})])
+      if(current===version.current)setState('copied')
+    } catch {if(current===version.current)setState('failed')}
+    finally {clearTimeout(timer);pending.current=false}
+  }
+  return <div className="mt-2 text-xs">
+    <button type="button" onClick={copy} disabled={state==='copying'} className="rounded border border-zinc-300 px-2 py-1">{state==='copying'?'Copying reply?':'Copy reply'}</button>
+    {state==='copied'&&<p role="status">Reply copied.</p>}
+    {state==='failed'&&<><p role="alert">Clipboard unavailable or unconfirmed. Select the Markdown below to copy manually.</p><textarea aria-label="Reply Markdown for manual copying" className="mt-2 h-28 w-full bg-white p-2 font-mono" readOnly value={text} onFocus={e=>e.target.select()}/></>}
+  </div>
+}

--- a/ods/extensions/services/dashboard/src/components/TalkReplyCopy.jsx
+++ b/ods/extensions/services/dashboard/src/components/TalkReplyCopy.jsx
@@ -18,7 +18,7 @@ export default function TalkReplyCopy({text}) {
     finally {clearTimeout(timer);pending.current=false}
   }
   return <div className="mt-2 text-xs">
-    <button type="button" onClick={copy} disabled={state==='copying'} className="rounded border border-zinc-300 px-2 py-1">{state==='copying'?'Copying reply?':'Copy reply'}</button>
+    <button type="button" onClick={copy} disabled={state==='copying'} className="rounded border border-zinc-300 px-2 py-1">{state==='copying'?'Copying reply...':'Copy reply'}</button>
     {state==='copied'&&<p role="status">Reply copied.</p>}
     {state==='failed'&&<><p role="alert">Clipboard unavailable or unconfirmed. Select the Markdown below to copy manually.</p><textarea aria-label="Reply Markdown for manual copying" className="mt-2 h-28 w-full bg-white p-2 font-mono" readOnly value={text} onFocus={e=>e.target.select()}/></>}
   </div>

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.copy.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.copy.test.jsx
@@ -1,4 +1,4 @@
-import {fireEvent,screen} from '@testing-library/react'
+import {act,fireEvent,screen} from '@testing-library/react'
 import {render} from '../test/test-utils'
 import ODSTalk from './ODSTalk'
 const reply='Run **diagnostics** with `ods doctor`.\n\n```sh\nods status\n```'
@@ -7,7 +7,7 @@ beforeEach(()=>{
   const frames=[{type:'complete',text:reply,status:'ok'},{type:'done'}]
   vi.stubGlobal('fetch',vi.fn(async url=>url==='/api/talk/status'?{ok:true,json:async()=>({capabilities:{text_chat:true}})}:{ok:true,body:{getReader:()=>({read:async()=>frames.length?{done:false,value:new TextEncoder().encode(`data: ${JSON.stringify(frames.shift())}\n\n`)}:{done:true},cancel:async()=>{},releaseLock:()=>{}})}}))
 })
-afterEach(()=>vi.unstubAllGlobals())
+afterEach(()=>{vi.useRealTimers();vi.unstubAllGlobals()})
 async function answer(){render(<ODSTalk/>);await screen.findByText('Ready');fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Help'}});fireEvent.click(screen.getByRole('button',{name:'Send message'}));return screen.findByRole('button',{name:'Copy reply'})}
 it('copies original Markdown rather than flattened rendered text',async()=>{
   fireEvent.click(await answer())
@@ -19,5 +19,19 @@ it('offers the exact source for manual copying when clipboard permission is deni
   fireEvent.click(await answer())
   expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard unavailable')
   expect(screen.getByLabelText('Reply Markdown for manual copying')).toHaveValue(reply)
+  expect(screen.queryByText('Reply copied.')).toBeNull()
+})
+
+it('recovers from a clipboard request that never confirms without accepting its late receipt',async()=>{
+  const button=await answer()
+  let resolve
+  navigator.clipboard.writeText.mockReturnValue(new Promise(done=>{resolve=done}))
+  vi.useFakeTimers()
+  fireEvent.click(button)
+  expect(button).toBeDisabled()
+  await act(async()=>vi.advanceTimersByTimeAsync(10000))
+  expect(screen.getByRole('alert')).toHaveTextContent('unconfirmed')
+  expect(screen.getByRole('button',{name:'Copy reply'})).toBeEnabled()
+  await act(async()=>resolve())
   expect(screen.queryByText('Reply copied.')).toBeNull()
 })

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.copy.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.copy.test.jsx
@@ -1,0 +1,23 @@
+import {fireEvent,screen} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import ODSTalk from './ODSTalk'
+const reply='Run **diagnostics** with `ods doctor`.\n\n```sh\nods status\n```'
+beforeEach(()=>{
+  Object.defineProperty(navigator,'clipboard',{configurable:true,value:{writeText:vi.fn().mockResolvedValue()}})
+  const frames=[{type:'complete',text:reply,status:'ok'},{type:'done'}]
+  vi.stubGlobal('fetch',vi.fn(async url=>url==='/api/talk/status'?{ok:true,json:async()=>({capabilities:{text_chat:true}})}:{ok:true,body:{getReader:()=>({read:async()=>frames.length?{done:false,value:new TextEncoder().encode(`data: ${JSON.stringify(frames.shift())}\n\n`)}:{done:true},cancel:async()=>{},releaseLock:()=>{}})}}))
+})
+afterEach(()=>vi.unstubAllGlobals())
+async function answer(){render(<ODSTalk/>);await screen.findByText('Ready');fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Help'}});fireEvent.click(screen.getByRole('button',{name:'Send message'}));return screen.findByRole('button',{name:'Copy reply'})}
+it('copies original Markdown rather than flattened rendered text',async()=>{
+  fireEvent.click(await answer())
+  await screen.findByText('Reply copied.')
+  expect(navigator.clipboard.writeText).toHaveBeenCalledWith(reply)
+})
+it('offers the exact source for manual copying when clipboard permission is denied',async()=>{
+  navigator.clipboard.writeText.mockRejectedValue(new Error('denied'))
+  fireEvent.click(await answer())
+  expect(await screen.findByRole('alert')).toHaveTextContent('Clipboard unavailable')
+  expect(screen.getByLabelText('Reply Markdown for manual copying')).toHaveValue(reply)
+  expect(screen.queryByText('Reply copied.')).toBeNull()
+})

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
+import TalkReplyCopy from '../components/TalkReplyCopy'
 import {
   AlertCircle, CheckCircle2, Loader2, Mic, Paperclip, RefreshCw,
   Send, Volume2, VolumeX,
@@ -855,6 +856,7 @@ function MessageBubble({ message }) {
             <ReactMarkdown components={MARKDOWN_COMPONENTS}>{message.text}</ReactMarkdown>
           </div>
         )}
+        {!user && message.id !== 'welcome' && message.status === 'done' && message.text && <TalkReplyCopy key={message.text} text={message.text}/>}
         {message.warning && (
           <p className="mt-2 text-xs text-amber-600">{message.warning}</p>
         )}


### PR DESCRIPTION
## Why this matters
Selecting rendered Talk replies loses Markdown fences and formatting needed to reuse commands or documentation. Add an explicit copy action on completed assistant replies using the original text, bounded clipboard confirmation and an exact selectable source when permission fails.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed Talk file history and copy/export semantic search. #3845 exports whole conversations; this copies a single completed reply without serializing conversation history. No existing single-reply action was found.

## Validation
- ODSTalk.copy.test.jsx and ODSTalk.test.jsx: 17 passed; streamed Markdown copies exactly, denied clipboard access shows manual source and never claims success.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `847cac733cfd8343d27460c9518ac884f4ee2d98`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `847cac733cfd8343d27460c9518ac884f4ee2d98`.

Follow-up `847cac73` verifies clipboard deadline recovery and rejection of a late success receipt (18 Talk tests passed).
