### PR TITLE
fix(integrations): keep service details on the current snapshot

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.freshness.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.freshness.test.jsx
@@ -1,0 +1,23 @@
+import {fireEvent,render,screen,waitFor,within} from '@testing-library/react'
+import ServiceMap from './ServiceMap'
+const snapshot=status=>({services:[{id:'ape',name:'APE',status,port:7890}]})
+afterEach(()=>vi.unstubAllGlobals())
+it('refreshes selected details and removes them when the service disappears',async()=>{
+  const fetch=vi.fn().mockResolvedValueOnce({ok:true,json:async()=>snapshot('healthy')}).mockResolvedValueOnce({ok:true,json:async()=>snapshot('down')}).mockResolvedValue({ok:true,json:async()=>({services:[]})})
+  vi.stubGlobal('fetch',fetch)
+  render(<ServiceMap/>);
+  fireEvent.click(await screen.findByRole('button',{name:'APE: healthy'}))
+  fireEvent(document,new Event('visibilitychange'))
+  await screen.findByRole('button',{name:'APE: down'})
+  const detail=screen.getByRole('button',{name:'Close service details'}).parentElement.parentElement
+  expect(within(detail).getByText('down')).toBeVisible()
+  fireEvent(document,new Event('visibilitychange'))
+  await waitFor(()=>expect(screen.queryByRole('button',{name:'Close service details'})).toBeNull())
+})
+it('marks the retained map stale after a refresh failure',async()=>{
+  vi.stubGlobal('fetch',vi.fn().mockResolvedValueOnce({ok:true,json:async()=>snapshot('healthy')}).mockRejectedValue(new Error('offline')))
+  render(<ServiceMap/>);await screen.findByRole('button',{name:'APE: healthy'})
+  fireEvent(document,new Event('visibilitychange'))
+  expect(await screen.findByRole('alert')).toHaveTextContent('last successful snapshot')
+  expect(screen.getByRole('button',{name:'APE: healthy'})).toBeVisible()
+})

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -320,7 +320,7 @@ function CompactIntegrations({ nodes, edges, refresh, error }) {
 
 export default function ServiceMap({ compact = false }) {
   const [topology, setTopology] = useState({ nodes: [], edges: [] })
-  const [selectedNode, setSelectedNode] = useState(null)
+  const [selectedNodeId, setSelectedNodeId] = useState(null)
   const [loading, setLoading] = useState(true)
   const [actualSize, setActualSize] = useState(false)
   const [error, setError] = useState(null)
@@ -332,7 +332,9 @@ export default function ServiceMap({ compact = false }) {
     try {
       const response = await fetch('/api/status')
       if (!response.ok) throw new Error('Failed to fetch service status')
-      setTopology(buildTopology(await response.json()))
+      const next = buildTopology(await response.json())
+      setTopology(next)
+      setSelectedNodeId(current => next.nodes.some(node => node.id === current) ? current : null)
       setError(null)
     } catch (err) {
       setError(err.message)
@@ -354,6 +356,7 @@ export default function ServiceMap({ compact = false }) {
   }, [fetchTopology])
 
   const { nodes, edges } = topology
+  const selectedNode = nodes.find(node => node.id === selectedNodeId) || null
   const { positions, layerY, svgWidth, svgHeight } = useMemo(() => computeLayout(nodes), [nodes])
   const counts = useMemo(() => ({
     healthy: nodes.filter(node => node.status === 'healthy').length,
@@ -388,6 +391,7 @@ export default function ServiceMap({ compact = false }) {
         <div className="flex items-center gap-2 rounded-lg border border-theme-border bg-theme-card px-3 py-2 font-mono text-xs text-theme-text-muted"><RefreshCw size={12} className="text-theme-accent" />live · 10s</div>
       </div>
 
+      {error && <p role="alert" className="mb-4 text-sm text-red-400">Showing the last successful snapshot. Status could not be refreshed: {error}</p>}
       <div className="mb-4 flex flex-wrap gap-4 text-xs text-theme-text-muted">
         <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-green-400" />Healthy</span>
         <span className="flex items-center gap-1.5"><span className="h-2 w-2 rounded-full bg-yellow-400" />Degraded</span>
@@ -417,7 +421,7 @@ export default function ServiceMap({ compact = false }) {
             return <path key={`${edge.source}-${edge.target}`} d={edgePath(source, target)} fill="none" stroke={color} strokeWidth="1.8" strokeOpacity={edge.status === 'healthy' ? 0.72 : 0.32} strokeDasharray={edge.status === 'healthy' ? undefined : '5 4'} markerEnd={`url(#arrow-${edge.label.replaceAll(' ', '-')})`} />
           })}
 
-          {nodes.map(node => positions[node.id] && <ServiceNode key={node.id} node={node} pos={positions[node.id]} selected={selectedNode?.id === node.id} onSelect={setSelectedNode} />)}
+          {nodes.map(node => positions[node.id] && <ServiceNode key={node.id} node={node} pos={positions[node.id]} selected={selectedNode?.id === node.id} onSelect={node => setSelectedNodeId(node.id)} />)}
         </svg>
         </div>
 
@@ -426,7 +430,7 @@ export default function ServiceMap({ compact = false }) {
           {edgeLabels.map(label => <span key={label} className="flex items-center gap-1.5 text-xs text-theme-text-muted"><span className="inline-block h-2 w-2 rounded-full" style={{ background: EDGE_META[label] || '#6b7280' }} />{label}</span>)}
         </div>
 
-        <DetailPanel node={selectedNode} edges={edges} onClose={() => setSelectedNode(null)} />
+        <DetailPanel node={selectedNode} edges={edges} onClose={() => setSelectedNodeId(null)} />
       </div>
     </div>
   )


### PR DESCRIPTION
## Why this matters
The full service map stores the selected node object, so polling can show a down node beside a healthy detail panel with an obsolete service URL. Keep only selection identity, derive details from the current snapshot and clear vanished selections. Mark retained full-map data stale when refresh fails, as the compact surface already reports failures.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed all ServiceMap production-file PRs including #3844 indirect dependency impact, #3274 helper coverage and #2757 close labels. None reconciles selected detail data with polling or reports stale full-map snapshots.

## Validation
- ServiceMap.freshness.test.jsx and ServiceMap.test.jsx: focused suite passed; production polling updates selected status, removes disappeared service details and exposes retained stale data after network failure.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `831d1bf011b5bc06bc8a7b37bc026a2d275bfe61`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `831d1bf011b5bc06bc8a7b37bc026a2d275bfe61`.
