### PR TITLE
fix(talk): preserve reading position during streamed replies

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -79,6 +79,8 @@ export default function ODSTalk() {
   // caption in the textarea before submitting.
 
   const bottomRef = useRef(null)
+  const followReplyRef = useRef(true)
+  const [readingEarlier, setReadingEarlier] = useState(false)
   const fileInputRef = useRef(null)
   const recorderRef = useRef(null)
   const recordingChunksRef = useRef([])
@@ -173,8 +175,25 @@ export default function ODSTalk() {
   }, [refreshStatus, retryStatusRefresh, status, statusAttempt])
 
   useEffect(() => {
-    bottomRef.current?.scrollIntoView?.({ block: 'end' })
+    function trackPosition() {
+      const root = document.scrollingElement || document.documentElement
+      const top = document.scrollingElement ? root.scrollTop : window.scrollY
+      const height = Math.max(root.scrollHeight, document.body.scrollHeight)
+      const nearBottom = height - top - window.innerHeight <= 64
+      followReplyRef.current = nearBottom
+      setReadingEarlier(!nearBottom)
+    }
+    window.addEventListener('scroll', trackPosition, {passive:true})
+    return () => window.removeEventListener('scroll', trackPosition)
+  }, [])
+  useEffect(() => {
+    if (followReplyRef.current) bottomRef.current?.scrollIntoView?.({ block: 'end' })
   }, [messages])
+  function jumpToLatest() {
+    followReplyRef.current = true
+    setReadingEarlier(false)
+    bottomRef.current?.scrollIntoView?.({block:'end'})
+  }
 
   useEffect(() => {
     try {
@@ -711,6 +730,7 @@ export default function ODSTalk() {
         )}
 
         <form onSubmit={submit} className="sticky bottom-0 bg-theme-bg p-3">
+          {readingEarlier && <button type="button" onClick={jumpToLatest} className="mb-2 rounded-full border border-zinc-300 bg-white px-3 py-2 text-sm text-zinc-800">Jump to latest reply</button>}
           {/* Attachment preview strip — appears above the input bar between
               pick and send. Shows a thumbnail for images, a generic icon for
               text/code files, with an X to discard. */}

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.scroll.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.scroll.test.jsx
@@ -1,0 +1,27 @@
+import {act,fireEvent,screen} from '@testing-library/react'
+import {render} from '../test/test-utils'
+import ODSTalk from './ODSTalk'
+afterEach(()=>{vi.unstubAllGlobals();vi.restoreAllMocks()})
+it('pauses automatic scrolling while reading earlier content and resumes on demand',async()=>{
+  let emit
+  vi.stubGlobal('fetch',vi.fn(async url=>url==='/api/talk/status'?{ok:true,json:async()=>({capabilities:{text_chat:true}})}:{ok:true,body:{getReader:()=>({read:()=>new Promise(resolve=>{emit=text=>resolve({done:false,value:new TextEncoder().encode(`data: ${JSON.stringify({type:'delta',text})}\n\n`)})}),cancel:async()=>{},releaseLock:()=>{}})}}))
+  const scroll=vi.fn()
+  Object.defineProperty(globalThis.Element.prototype,'scrollIntoView',{configurable:true,value:scroll})
+  render(<ODSTalk/>);await screen.findByText('Ready')
+  fireEvent.change(screen.getByPlaceholderText('Message ODS'),{target:{value:'Long answer'}})
+  fireEvent.click(screen.getByRole('button',{name:'Send message'}))
+  await act(async()=>{})
+  await act(async()=>emit('First part'))
+  Object.defineProperty(document.documentElement,'scrollHeight',{configurable:true,value:3000})
+  Object.defineProperty(window,'innerHeight',{configurable:true,value:800})
+  Object.defineProperty(window,'scrollY',{configurable:true,value:300})
+  fireEvent.scroll(window)
+  scroll.mockClear()
+  await act(async()=>emit(' second part'))
+  expect(scroll).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button',{name:'Jump to latest reply'}))
+  expect(scroll).toHaveBeenCalledOnce()
+  scroll.mockClear()
+  await act(async()=>emit(' third part'))
+  expect(scroll).toHaveBeenCalledOnce()
+})


### PR DESCRIPTION
## Why this matters
Every streamed token scrolls the page to the latest bubble, pulling readers away from earlier instructions they are reviewing. Follow new content only while the viewport remains near the bottom; scrolling away pauses following and an explicit Jump to latest reply action resumes it.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed ODSTalk history and scroll/read-position semantic search. #4219 covers the distinct Pixel conversation surface; this change handles the standalone Talk document scroll container and does not alter Pixel.

## Validation
- ODSTalk.scroll.test.jsx and ODSTalk.test.jsx: 16 passed; stream updates respect a scrolled-away viewport and resume after the rendered jump action. DOM scroll metrics are controlled; mobile-device layout remains unverified.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `3c9e6f3ada8e4bd1f79480926c060d4329589e75`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `3c9e6f3ada8e4bd1f79480926c060d4329589e75`.
