### PR TITLE
fix(integrations): complete service detail keyboard navigation

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.focus.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.focus.test.jsx
@@ -1,4 +1,4 @@
-import {fireEvent,render,screen} from '@testing-library/react'
+import {act,fireEvent,render,screen} from '@testing-library/react'
 import ServiceMap from './ServiceMap'
 afterEach(()=>vi.unstubAllGlobals())
 it.each([false,true])('moves focus into details and Escape restores the service trigger (compact=%s)',async compact=>{
@@ -12,5 +12,20 @@ it.each([false,true])('moves focus into details and Escape restores the service 
   expect(close).toHaveFocus()
   fireEvent.keyDown(close,{key:'Escape'})
   expect(screen.queryByRole('button',{name:'Close service details'})).toBeNull()
+  expect(trigger).toHaveFocus()
+})
+
+it('keeps focus on an active detail link across polling and restores it on Close',async()=>{
+  const fetch=vi.fn().mockResolvedValue({ok:true,json:async()=>({services:[{id:'ape',name:'APE',status:'healthy',port:7890}]})})
+  vi.stubGlobal('fetch',fetch)
+  render(<ServiceMap compact/>)
+  const trigger=await screen.findByRole('button',{name:/APE/})
+  fireEvent.click(trigger)
+  const link=screen.getByRole('link',{name:'Open service'})
+  link.focus()
+  await act(async()=>fireEvent(document,new Event('visibilitychange')))
+  expect(fetch).toHaveBeenCalledTimes(2)
+  expect(link).toHaveFocus()
+  fireEvent.click(screen.getByRole('button',{name:'Close service details'}))
   expect(trigger).toHaveFocus()
 })

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.focus.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.focus.test.jsx
@@ -1,0 +1,16 @@
+import {fireEvent,render,screen} from '@testing-library/react'
+import ServiceMap from './ServiceMap'
+afterEach(()=>vi.unstubAllGlobals())
+it.each([false,true])('moves focus into details and Escape restores the service trigger (compact=%s)',async compact=>{
+  vi.stubGlobal('fetch',vi.fn().mockResolvedValue({ok:true,json:async()=>({services:[{id:'ape',name:'APE',status:'healthy',port:7890}]})}))
+  render(<ServiceMap compact={compact}/>)
+  const trigger=await screen.findByRole('button',{name:/APE/})
+  trigger.focus()
+  if(compact)fireEvent.click(trigger)
+  else fireEvent.keyDown(trigger,{key:'Enter'})
+  const close=screen.getByRole('button',{name:'Close service details'})
+  expect(close).toHaveFocus()
+  fireEvent.keyDown(close,{key:'Escape'})
+  expect(screen.queryByRole('button',{name:'Close service details'})).toBeNull()
+  expect(trigger).toHaveFocus()
+})

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -200,7 +200,7 @@ function ServiceNode({ node, pos, selected, onSelect, compact = false }) {
   const meta = statusMeta(node.status)
   const label = compact ? node.name.replace(/\s*\(.*\)$/, '') : node.name
   return (
-    <g role="button" tabIndex={0} aria-label={`${node.name}: ${node.status}`} onClick={() => onSelect(node)} onKeyDown={event => {
+    <g role="button" tabIndex={0} aria-label={`${node.name}: ${node.status}`} onClick={event => { event.currentTarget.focus(); onSelect(node) }} onKeyDown={event => {
       if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); onSelect(node) }
     }} className="cursor-pointer">
       <title>{node.name}: {node.status}</title>
@@ -223,6 +223,17 @@ function ServiceNode({ node, pos, selected, onSelect, compact = false }) {
 }
 
 function DetailPanel({ node, edges, onClose, inline = false }) {
+  const closeControl = useRef(null)
+  const opener = useRef(null)
+  useEffect(() => {
+    if (!node) return
+    opener.current = document.activeElement
+    closeControl.current?.focus()
+  }, [node?.id])
+  function dismiss() {
+    onClose()
+    if (opener.current?.isConnected) opener.current.focus()
+  }
   if (!node) return null
   const meta = statusMeta(node.status)
   const upstream = edges.filter(edge => edge.target === node.id)
@@ -230,13 +241,13 @@ function DetailPanel({ node, edges, onClose, inline = false }) {
   const url = serviceUrl(node)
 
   return (
-    <div className={inline ? 'integration-detail' : 'absolute top-4 right-4 z-10 w-72 overflow-hidden rounded-xl border border-theme-border bg-theme-card shadow-2xl'}>
+    <div role="region" aria-label={`Service details: ${node.name}`} onKeyDown={event => { if (event.key === 'Escape') { event.stopPropagation(); dismiss() } }} className={inline ? 'integration-detail' : 'absolute top-4 right-4 z-10 w-72 overflow-hidden rounded-xl border border-theme-border bg-theme-card shadow-2xl'}>
       <div className="flex items-center justify-between border-b border-theme-border px-4 py-3">
         <div className="flex items-center gap-2">
           <span className={`h-2.5 w-2.5 rounded-full ${meta.dot}`} />
           <span className="text-sm font-semibold text-theme-text">{node.name}</span>
         </div>
-        <button onClick={onClose} aria-label="Close service details" className="text-theme-text-muted hover:text-theme-text"><X size={16} /></button>
+        <button ref={closeControl} onClick={dismiss} aria-label="Close service details" className="text-theme-text-muted hover:text-theme-text"><X size={16} /></button>
       </div>
       <div className="space-y-3 px-4 py-3 text-xs">
         <div className="flex justify-between"><span className="text-theme-text-muted">Status</span><span className={meta.text}>{node.status}</span></div>
@@ -296,7 +307,7 @@ function CompactIntegrations({ nodes, edges, refresh, error }) {
     {!visible.length ? <p className="integrations-empty">{nodes.length ? 'No matching services.' : 'No services reported.'}</p> : view === 'list' ? <div className="integrations-list">
       {LAYERS.map(layer => {
         const members = visible.filter(node => node.category === layer).sort((a, b) => a.name.localeCompare(b.name))
-        return members.length > 0 && <section key={layer}><h3>{LAYER_LABELS[layer].toLowerCase().replace('-', ' ')}</h3>{members.map(node => <button type="button" key={node.id} onClick={() => setSelectedId(node.id)} aria-pressed={selectedId === node.id}><span className="integration-name"><span className={`integration-dot ${statusMeta(node.status).dot}`} /><span>{node.name}</span></span><span className="integration-status">{node.status.replaceAll('_', ' ')}{node.port && <small>:{node.port}</small>}</span></button>)}</section>
+        return members.length > 0 && <section key={layer}><h3>{LAYER_LABELS[layer].toLowerCase().replace('-', ' ')}</h3>{members.map(node => <button type="button" key={node.id} onClick={event => { event.currentTarget.focus(); setSelectedId(node.id) }} aria-pressed={selectedId === node.id}><span className="integration-name"><span className={`integration-dot ${statusMeta(node.status).dot}`} /><span>{node.name}</span></span><span className="integration-status">{node.status.replaceAll('_', ' ')}{node.port && <small>:{node.port}</small>}</span></button>)}</section>
       })}
     </div> : <div className="integrations-map" role="region" aria-label="Service topology" tabIndex={0}>
       <p>Known dependencies · select a service to highlight its connections</p>


### PR DESCRIPTION
## Why this matters
Selecting a service opens details away from the keyboard focus, forcing users to traverse the map again to reach its controls. Focus the detail close control on a new selection, label the detail region, support Escape and restore focus to the service trigger in both compact and full layouts.

## Overlap check
Searched open and closed upstream PRs by semantic title and the changed production files using a complete GitHub PR file inventory (through #4443, 2026-09-12). Reviewed ServiceMap file history, #2757 icon labels and #3844 dependency exploration; no detail focus lifecycle is implemented there. Batch freshness PR reconciles polled node data, while this PR independently repairs keyboard navigation.

## Validation
- ServiceMap.focus.test.jsx and ServiceMap.test.jsx: 7 passed; both layouts move focus into details and Escape closes and returns focus to the original service.
- Regression tested against unchanged public-beta before the fix; focused suite passes after the fix.
- `git diff --check` and pre-commit checks on all changed files: passed.
- Candidate: `e284e8c192db76b51455e304e939b77894aa0408`. Base: `9fc9f610` (`public-beta`).
- Combined validation and known baseline failures are recorded below.

## Scope and rollback
This browser change applies to the same dashboard bundle on Linux, macOS and Windows. Tests exercise the production component/hook with controlled browser events and I/O; no live-device or hardware behavior is claimed. No host/service configuration or persisted format changes. Revert this commit to restore the previous behavior.


## Batch integration receipt (2026-09-12)
- Published integration head: [a945f8a1](https://github.com/tang-vu/DreamServer/commit/a945f8a14940e22220c01c8c06a41632e7fceaa1), combining all 20 candidate branches from public-beta `9fc9f610`.
- Dashboard: `npm test -- --maxWorkers=4` **939 tests passed in 118 files**; `npm run lint` **0 errors, 577 warnings**; `npm run build` **passed**.
- Talk API: `python -m pytest tests/test_talk.py tests/test_talk_attachment_encoding.py -q` **45 passed**.
- Linux validation at integration predecessor `2a35c1e5`: `make lint`, all four platform dispatch/smoke scripts, and installer simulation **passed**. Later changes add tests and adjust two progress labels only.
- Full `make gate` is **not green locally**: the installer noninteractive-sudo test has two failures reproduced unchanged on base `9fc9f610`. BATS has **416/421 passing**, with five WSL/root-environment failures also reproduced on that base. These are recorded limits, not passing gates. Full-repository private-key scanning also flags pre-existing test fixtures; changed-file pre-commit checks pass.
- Browser tests use DOM/I/O fixtures; no live inference, physical GPU, microphone, Safari/native-dialog interaction or hardware deployment is claimed.

### Merge coordination
Suggested sequence: #4444, #4445, #4446, #4447, #4448, #4449, #4450, #4451, #4453, #4454, #4455, #4456, #4457, #4458, #4459, #4460, #4461, #4462, #4463, #4464. Each PR is independently based on public-beta; the sequence is for applying and verifying the combined batch, not a claim of stacked base branches.
Three textual reconciliations are preserved in the integration head: #4459 retains #4447 reader cleanup/terminal framing plus stop-abort guards; #4461 combines the GFM and copy-component imports; #4463 retains both the caption-limit notice and jump-to-latest action. Other merges applied automatically. Rerun the focused suites and combined dashboard checks after upstream integration; revert the relevant PR commit to roll back its behavior. No upstream PR has been merged by this batch.

Current PR candidate: `e284e8c192db76b51455e304e939b77894aa0408`.

Follow-up `e284e8c1` verifies that polling does not steal focus from an active service link (8 ServiceMap tests passed). An earlier cross-platform run failed in unchanged RemoteProvider draft loading while this PR focus suite passed: https://github.com/Osmantic/ODS/actions/runs/34677296102 . Subsequent candidate checks run on the follow-up head.
