### PR TITLE
feat(extensions): add typed configuration contracts

### DIFF
--- a/ods/docs/ADR-ASSISTANT-FIRST-TYPED-CONFIGURATION.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-TYPED-CONFIGURATION.md
@@ -1,0 +1,51 @@
+# ADR: Assistant First Typed Configuration Contract
+
+**Status:** Accepted for source integration; no secret storage or runtime
+activation in this phase
+
+## Decision
+
+Manifest v2 configuration validation is structured data, not an executable
+regular expression or a prose string. The bounded v1 vocabulary is:
+
+- `minLength` and `maxLength` for strings and URLs;
+- `minimum` and `maximum` for integers; and
+- a required, non-empty `choices` list for enums.
+
+Boolean fields do not accept a validation object. Bounds are strict JSON
+integers, exclude booleans, use the interoperable safe-integer range, and must
+be ordered. Enum choices are unique, bounded strings. URL fields accept only
+absolute HTTP or HTTPS URLs with a hostname and reject credentials, fragments,
+raw whitespace, backslashes, invalid ports, and control characters.
+
+The typed-configuration module accepts a stored plan envelope plus the expected
+hash from the durable transaction record, verifies both that external binding
+and the canonical plan bytes, and derives fields only from
+`plan.selectedServices`. Those services and `plan.definitions` must be an exact
+one-to-one set. A caller cannot supply a smaller service list to omit required
+configuration. Shared keys must have byte-equivalent normalized contracts.
+
+The public schema retains every field needed to render and validate a form:
+key, type, required status, secret status, source, restart behavior, and
+structured validation. Non-secret defaults are also public. Secret defaults
+are forbidden. The schema hash covers the complete normalized contract,
+including secret-field metadata, but never a submitted value.
+
+Submissions are split into non-secret values and secret values. Keys must be
+declared, appear in the correct side, and have `source: user`; both sides receive
+the same type and bounds validation. The validation receipt contains only plan
+and schema hashes, present key names, and applied non-secret default names.
+
+## Security boundary
+
+This module does not store, return, wrap, serialize, or claim custody over a
+secret value. Its exceptions include stable codes and public field identifiers
+only. Phase 4B must fetch the envelope from the durable transaction store rather
+than accept a caller-supplied envelope, validate and persist secrets inside a
+host-owned process, return opaque references and presence state, and revalidate
+the exact schema and plan hashes immediately before apply.
+
+No plan, lockfile, chat transcript, model context, API response, browser
+persistence, log, diagnostic, or receipt may contain a secret value. The
+transaction feature remains disabled until that host-owned composition and the
+actual lifecycle adapters are qualified.

--- a/ods/extensions/library/schema/service-manifest.v2.json
+++ b/ods/extensions/library/schema/service-manifest.v2.json
@@ -320,7 +320,24 @@
                   "secret": { "type": "boolean" },
                   "source": { "type": "string", "enum": ["user", "generated", "system", "provider"] },
                   "restart_behavior": { "type": "string", "enum": ["none", "service", "stack"] },
-                  "validation": { "type": "string", "maxLength": 256 },
+                  "validation": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "properties": {
+                      "choices": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 128,
+                        "uniqueItems": true,
+                        "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+                      },
+                      "minLength": { "type": "integer", "minimum": 0, "maximum": 65536 },
+                      "maxLength": { "type": "integer", "minimum": 0, "maximum": 65536 },
+                      "minimum": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+                      "maximum": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 }
+                    },
+                    "additionalProperties": false
+                  },
                   "default": { "type": ["string", "integer", "boolean"] }
                 },
                 "allOf": [

--- a/ods/extensions/schema/service-manifest.v2.json
+++ b/ods/extensions/schema/service-manifest.v2.json
@@ -320,7 +320,24 @@
                   "secret": { "type": "boolean" },
                   "source": { "type": "string", "enum": ["user", "generated", "system", "provider"] },
                   "restart_behavior": { "type": "string", "enum": ["none", "service", "stack"] },
-                  "validation": { "type": "string", "maxLength": 256 },
+                  "validation": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "properties": {
+                      "choices": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 128,
+                        "uniqueItems": true,
+                        "items": { "type": "string", "minLength": 1, "maxLength": 256 }
+                      },
+                      "minLength": { "type": "integer", "minimum": 0, "maximum": 65536 },
+                      "maxLength": { "type": "integer", "minimum": 0, "maximum": 65536 },
+                      "minimum": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 },
+                      "maximum": { "type": "integer", "minimum": -9007199254740991, "maximum": 9007199254740991 }
+                    },
+                    "additionalProperties": false
+                  },
                   "default": { "type": ["string", "integer", "boolean"] }
                 },
                 "allOf": [

--- a/ods/extensions/services/dashboard-api/assistant_first_planner.py
+++ b/ods/extensions/services/dashboard-api/assistant_first_planner.py
@@ -13,6 +13,7 @@ import re
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlsplit
 
 
 _ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
@@ -31,6 +32,7 @@ _SEMVER_RE = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 _DRIVER_VERSION_RE = re.compile(r"^[0-9A-Za-z][0-9A-Za-z._-]{0,63}$")
+_ENCODED_CONTROL_RE = re.compile(r"%(?:0[0-9a-f]|1[0-9a-f]|7f)", re.IGNORECASE)
 
 _PLANNING_FIELDS = frozenset(
     {
@@ -72,6 +74,12 @@ _RESOURCE_FIELDS = frozenset(
 _CONFIG_FIELDS = frozenset(
     {"key", "type", "required", "secret", "source", "restart_behavior", "validation", "default"}
 )
+_CONFIG_VALIDATION_FIELDS = frozenset(
+    {"choices", "minLength", "maxLength", "minimum", "maximum"}
+)
+_MAX_CONFIG_STRING_LENGTH = 65_536
+_MAX_ENUM_CHOICES = 128
+_MAX_SAFE_INTEGER = (1 << 53) - 1
 _ARTIFACT_FIELDS = frozenset({"images", "builds"})
 _IMAGE_FIELDS = frozenset({"reference", "digest", "download_bytes"})
 _BUILD_FIELDS = frozenset({"source", "revision", "context_digest", "output", "download_bytes"})
@@ -194,6 +202,126 @@ def _text(value: Any, field: str, *, maximum: int, allow_empty: bool = False) ->
 def _enum(value: Any, field: str, allowed: frozenset[str]) -> str:
     if not isinstance(value, str) or value not in allowed:
         _fail("invalid-enum", field=field)
+    return value
+
+
+def _configuration_validation(
+    value: Any,
+    config_type: str,
+    field: str,
+) -> dict[str, Any]:
+    """Normalize the bounded, non-executable Manifest v2 validation contract."""
+    spec = _mapping(value, field)
+    keys = set(spec)
+    if not keys or not keys <= _CONFIG_VALIDATION_FIELDS:
+        _fail("invalid-config-validation-fields", field=field, fields=sorted(keys))
+
+    allowed = {
+        "string": frozenset({"minLength", "maxLength"}),
+        "url": frozenset({"minLength", "maxLength"}),
+        "integer": frozenset({"minimum", "maximum"}),
+        "enum": frozenset({"choices"}),
+        "boolean": frozenset(),
+    }[config_type]
+    if not keys <= allowed:
+        _fail("incompatible-config-validation", field=field, configType=config_type)
+
+    normalized: dict[str, Any] = {}
+    if "choices" in spec:
+        choices = list(
+            _unique_strings(
+                spec.get("choices"),
+                f"{field}.choices",
+                lambda item, item_field: _text(item, item_field, maximum=256),
+            )
+        )
+        if not choices or len(choices) > _MAX_ENUM_CHOICES:
+            _fail("invalid-config-choices", field=f"{field}.choices")
+        normalized["choices"] = choices
+
+    for key in ("minLength", "maxLength"):
+        if key in spec:
+            normalized[key] = _integer(
+                spec.get(key), f"{field}.{key}", 0, _MAX_CONFIG_STRING_LENGTH
+            )
+    for key in ("minimum", "maximum"):
+        if key in spec:
+            normalized[key] = _integer(
+                spec.get(key), f"{field}.{key}", -_MAX_SAFE_INTEGER, _MAX_SAFE_INTEGER
+            )
+
+    if normalized.get("minLength", 0) > normalized.get(
+        "maxLength", _MAX_CONFIG_STRING_LENGTH
+    ):
+        _fail("invalid-config-validation-range", field=field)
+    if normalized.get("minimum", -_MAX_SAFE_INTEGER) > normalized.get(
+        "maximum", _MAX_SAFE_INTEGER
+    ):
+        _fail("invalid-config-validation-range", field=field)
+    return normalized
+
+
+def _configuration_value(
+    value: Any,
+    config_type: str,
+    validation: Mapping[str, Any] | None,
+    field: str,
+) -> Any:
+    """Validate one non-secret manifest default without executing manifest code."""
+    if config_type == "integer":
+        if type(value) is not int:
+            _fail("invalid-config-default", field=field)
+    elif config_type == "boolean":
+        if type(value) is not bool:
+            _fail("invalid-config-default", field=field)
+    elif config_type in {"string", "url", "enum"}:
+        if not isinstance(value, str) or len(value) > _MAX_CONFIG_STRING_LENGTH:
+            _fail("invalid-config-default", field=field)
+        if any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in value
+        ):
+            _fail("invalid-config-default", field=field)
+    else:  # pragma: no cover - the caller has already normalized the enum
+        _fail("invalid-config-default", field=field)
+
+    rules = validation or {}
+    if config_type in {"string", "url"}:
+        if len(value) < rules.get("minLength", 0) or len(value) > rules.get(
+            "maxLength", _MAX_CONFIG_STRING_LENGTH
+        ):
+            _fail("invalid-config-default", field=field)
+    if config_type == "integer" and (
+        value < rules.get("minimum", -_MAX_SAFE_INTEGER)
+        or value > rules.get("maximum", _MAX_SAFE_INTEGER)
+    ):
+        _fail("invalid-config-default", field=field)
+    if config_type == "enum" and value not in rules.get("choices", ()):
+        _fail("invalid-config-default", field=field)
+    if config_type == "url":
+        if (
+            any(character.isspace() for character in value)
+            or "\\" in value
+            or _ENCODED_CONTROL_RE.search(value) is not None
+        ):
+            _fail("invalid-config-default", field=field)
+        try:
+            parsed = urlsplit(value)
+            port = parsed.port
+        except ValueError:
+            _fail("invalid-config-default", field=field)
+        if (
+            parsed.scheme not in {"http", "https"}
+            or not parsed.hostname
+            or not parsed.hostname.isascii()
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.fragment
+            or port is not None and not 1 <= port <= 65535
+        ):
+            _fail("invalid-config-default", field=field)
     return value
 
 
@@ -439,22 +567,20 @@ def adapt_manifest(manifest: Any) -> dict[str, Any]:
             ),
         }
         if "validation" in spec:
-            normalized["validation"] = _text(
-                spec.get("validation"), f"{field}.validation", maximum=256, allow_empty=True
+            normalized["validation"] = _configuration_validation(
+                spec.get("validation"),
+                normalized["type"],
+                f"{field}.validation",
             )
+        if normalized["type"] == "enum" and "validation" not in normalized:
+            _fail("missing-config-validation", field=f"{field}.validation")
         if "default" in spec:
-            default = spec.get("default")
-            if type(default) not in {str, int, bool}:
-                _fail("invalid-config-default", field=field)
-            expected_type = normalized["type"]
-            valid_default = (
-                (expected_type == "integer" and type(default) is int)
-                or (expected_type == "boolean" and type(default) is bool)
-                or (expected_type in {"string", "url", "enum"} and type(default) is str)
+            normalized["default"] = _configuration_value(
+                spec.get("default"),
+                normalized["type"],
+                normalized.get("validation"),
+                f"{field}.default",
             )
-            if not valid_default:
-                _fail("invalid-config-default", field=field)
-            normalized["default"] = default
         configuration.append(normalized)
     configuration.sort(key=lambda item: item["key"])
 

--- a/ods/extensions/services/dashboard-api/extension_configuration.py
+++ b/ods/extensions/services/dashboard-api/extension_configuration.py
@@ -1,0 +1,518 @@
+"""Pure typed-configuration boundary for stored Assistant First plans.
+
+The module has no filesystem, host-agent, framework, or secret-store access.
+It verifies the stored plan, derives the complete configuration contract from
+that plan, validates a split submission, and returns redacted metadata only.
+Secret custody is deliberately deferred to the host-owned Phase 4B boundary.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+from urllib.parse import urlsplit
+
+
+_PLAN_SCHEMA = "ods.assistant-first.plan.v1"
+_SCHEMA = "ods.assistant-first.configuration-schema.v1"
+_RECEIPT_SCHEMA = "ods.assistant-first.configuration-validation.v1"
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_ENCODED_CONTROL_RE = re.compile(r"%(?:0[0-9a-f]|1[0-9a-f]|7f)", re.IGNORECASE)
+_REQUIRED_CONTRACT_KEYS = frozenset(
+    {"key", "type", "required", "secret", "source", "restartBehavior"}
+)
+_OPTIONAL_CONTRACT_KEYS = frozenset({"validation", "default"})
+_VALID_TYPES = frozenset({"string", "integer", "boolean", "url", "enum"})
+_VALID_SOURCES = frozenset({"user", "generated", "system", "provider"})
+_VALID_RESTARTS = frozenset({"none", "service", "stack"})
+_VALIDATION_KEYS = frozenset(
+    {"choices", "minLength", "maxLength", "minimum", "maximum"}
+)
+_MAX_STRING_LENGTH = 65_536
+_MAX_ENUM_CHOICES = 128
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_MAX_DEFINITIONS = 512
+_MAX_CONFIGURATION_FIELDS = 2_048
+_MAX_JSON_DEPTH = 32
+_MAX_JSON_NODES = 50_000
+
+
+class ExtensionConfigurationError(ValueError):
+    """Stable validation error whose message never contains submitted values."""
+
+    def __init__(self, code: str, **details: Any) -> None:
+        super().__init__(code)
+        self.code = code
+        self.details = copy.deepcopy(details)
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "details": copy.deepcopy(self.details)}
+
+    def __repr__(self) -> str:
+        return f"ExtensionConfigurationError({self.code!r})"
+
+
+def _fail(code: str, **details: Any) -> None:
+    raise ExtensionConfigurationError(code, **details)
+
+
+def _json_shape(value: Any, *, depth: int = 0, budget: list[int] | None = None) -> None:
+    """Bound attacker-controlled material before canonical serialization."""
+    if budget is None:
+        budget = [_MAX_JSON_NODES]
+    budget[0] -= 1
+    if budget[0] < 0 or depth > _MAX_JSON_DEPTH:
+        _fail("configuration-input-too-large")
+    if value is None or type(value) in {bool, int}:
+        return
+    if type(value) is float:
+        _fail("float-not-canonical")
+    if isinstance(value, str):
+        if len(value) > _MAX_STRING_LENGTH or _has_control(value):
+            _fail("invalid-configuration-text")
+        return
+    if type(value) is dict:
+        if len(value) > _MAX_CONFIGURATION_FIELDS:
+            _fail("configuration-input-too-large")
+        if any(not isinstance(key, str) for key in value):
+            _fail("invalid-configuration-object-key")
+        for key, item in value.items():
+            _json_shape(key, depth=depth + 1, budget=budget)
+            _json_shape(item, depth=depth + 1, budget=budget)
+        return
+    if type(value) is list:
+        if len(value) > _MAX_JSON_NODES:
+            _fail("configuration-input-too-large")
+        for item in value:
+            _json_shape(item, depth=depth + 1, budget=budget)
+        return
+    _fail("invalid-configuration-json-type")
+
+
+def _canonical_json_bytes(value: Any) -> bytes:
+    _json_shape(value)
+    try:
+        document = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError):
+        _fail("invalid-configuration-json")
+    return (document + "\n").encode("utf-8", errors="strict")
+
+
+def _mapping(value: Any, field: str) -> Mapping[str, Any]:
+    if type(value) is not dict or any(not isinstance(key, str) for key in value):
+        _fail("invalid-configuration-object", field=field)
+    return value
+
+
+def _sequence(value: Any, field: str) -> list[Any]:
+    if type(value) is not list:
+        _fail("invalid-configuration-list", field=field)
+    return value
+
+
+def _has_control(value: str) -> bool:
+    return any(
+        ord(character) < 32
+        or ord(character) == 127
+        or 0xD800 <= ord(character) <= 0xDFFF
+        for character in value
+    )
+
+
+def _safe_key_list(value: Any, field: str) -> list[str]:
+    result: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(_sequence(value, field)):
+        if not isinstance(item, str) or _KEY_RE.fullmatch(item) is None:
+            _fail("invalid-configuration-key", field=f"{field}[{index}]")
+        if item in seen:
+            _fail("duplicate-configuration-key", field=field, key=item)
+        seen.add(item)
+        result.append(item)
+    return result
+
+
+def _normalize_validation(value: Any, config_type: str, field: str) -> dict[str, Any]:
+    rules = _mapping(value, field)
+    keys = set(rules)
+    if not keys or not keys <= _VALIDATION_KEYS:
+        _fail("invalid-validation-fields", field=field, fields=sorted(keys))
+    allowed = {
+        "string": frozenset({"minLength", "maxLength"}),
+        "url": frozenset({"minLength", "maxLength"}),
+        "integer": frozenset({"minimum", "maximum"}),
+        "enum": frozenset({"choices"}),
+        "boolean": frozenset(),
+    }[config_type]
+    if not keys <= allowed:
+        _fail("incompatible-validation", field=field, configType=config_type)
+
+    normalized: dict[str, Any] = {}
+    if "choices" in rules:
+        choices: list[str] = []
+        seen: set[str] = set()
+        for index, choice in enumerate(_sequence(rules["choices"], f"{field}.choices")):
+            if (
+                not isinstance(choice, str)
+                or not choice
+                or len(choice) > 256
+                or _has_control(choice)
+            ):
+                _fail("invalid-enum-choice", field=f"{field}.choices[{index}]")
+            if choice in seen:
+                _fail("duplicate-enum-choice", field=f"{field}.choices", choice=choice)
+            seen.add(choice)
+            choices.append(choice)
+        if not choices or len(choices) > _MAX_ENUM_CHOICES:
+            _fail("invalid-enum-choices", field=f"{field}.choices")
+        normalized["choices"] = choices
+
+    for key in ("minLength", "maxLength"):
+        if key in rules:
+            bound = rules[key]
+            if type(bound) is not int or not 0 <= bound <= _MAX_STRING_LENGTH:
+                _fail("invalid-validation-bound", field=f"{field}.{key}")
+            normalized[key] = bound
+    for key in ("minimum", "maximum"):
+        if key in rules:
+            bound = rules[key]
+            if (
+                type(bound) is not int
+                or not -_MAX_SAFE_INTEGER <= bound <= _MAX_SAFE_INTEGER
+            ):
+                _fail("invalid-validation-bound", field=f"{field}.{key}")
+            normalized[key] = bound
+
+    if normalized.get("minLength", 0) > normalized.get("maxLength", _MAX_STRING_LENGTH):
+        _fail("invalid-validation-range", field=field)
+    if normalized.get("minimum", -_MAX_SAFE_INTEGER) > normalized.get(
+        "maximum", _MAX_SAFE_INTEGER
+    ):
+        _fail("invalid-validation-range", field=field)
+    return normalized
+
+
+def _validate_url(value: str, field: str) -> None:
+    if (
+        any(character.isspace() for character in value)
+        or "\\" in value
+        or _ENCODED_CONTROL_RE.search(value) is not None
+    ):
+        _fail("invalid-configuration-url", field=field)
+    try:
+        parsed = urlsplit(value)
+        hostname = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        _fail("invalid-configuration-url", field=field)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not hostname
+        or not hostname.isascii()
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.fragment
+        or port is not None
+        and not 1 <= port <= 65535
+    ):
+        _fail("invalid-configuration-url", field=field)
+
+
+def _validate_value(value: Any, contract: Mapping[str, Any], field: str) -> None:
+    config_type = contract["type"]
+    if config_type == "integer":
+        if type(value) is not int:
+            _fail("invalid-configuration-value-type", field=field)
+    elif config_type == "boolean":
+        if type(value) is not bool:
+            _fail("invalid-configuration-value-type", field=field)
+    elif config_type in {"string", "url", "enum"}:
+        if (
+            not isinstance(value, str)
+            or len(value) > _MAX_STRING_LENGTH
+            or _has_control(value)
+        ):
+            _fail("invalid-configuration-value-type", field=field)
+    else:  # pragma: no cover - normalized contracts cannot reach this branch
+        _fail("invalid-configuration-type", field=field)
+
+    rules = contract.get("validation", {})
+    if config_type in {"string", "url"}:
+        if len(value) < rules.get("minLength", 0):
+            _fail("configuration-value-too-short", field=field)
+        if len(value) > rules.get("maxLength", _MAX_STRING_LENGTH):
+            _fail("configuration-value-too-long", field=field)
+    if config_type == "integer":
+        if value < rules.get("minimum", -_MAX_SAFE_INTEGER):
+            _fail("configuration-value-too-small", field=field)
+        if value > rules.get("maximum", _MAX_SAFE_INTEGER):
+            _fail("configuration-value-too-large", field=field)
+    if config_type == "enum" and value not in rules["choices"]:
+        _fail("invalid-configuration-choice", field=field)
+    if config_type == "url":
+        _validate_url(value, field)
+
+
+def _normalize_contract(value: Any, field: str) -> dict[str, Any]:
+    item = _mapping(value, field)
+    keys = set(item)
+    if not _REQUIRED_CONTRACT_KEYS <= keys or not keys <= (
+        _REQUIRED_CONTRACT_KEYS | _OPTIONAL_CONTRACT_KEYS
+    ):
+        _fail("invalid-configuration-contract-fields", field=field, fields=sorted(keys))
+    key = item["key"]
+    if not isinstance(key, str) or _KEY_RE.fullmatch(key) is None:
+        _fail("invalid-configuration-key", field=f"{field}.key")
+    config_type = item["type"]
+    if config_type not in _VALID_TYPES:
+        _fail("invalid-configuration-type", field=f"{field}.type", key=key)
+    if type(item["required"]) is not bool or type(item["secret"]) is not bool:
+        _fail("invalid-configuration-contract", field=field, key=key)
+    if (
+        item["source"] not in _VALID_SOURCES
+        or item["restartBehavior"] not in _VALID_RESTARTS
+    ):
+        _fail("invalid-configuration-contract", field=field, key=key)
+
+    normalized: dict[str, Any] = {
+        "key": key,
+        "type": config_type,
+        "required": item["required"],
+        "secret": item["secret"],
+        "source": item["source"],
+        "restartBehavior": item["restartBehavior"],
+    }
+    if "validation" in item:
+        normalized["validation"] = _normalize_validation(
+            item["validation"], config_type, f"{field}.validation"
+        )
+    if config_type == "enum" and "validation" not in normalized:
+        _fail("missing-enum-validation", field=f"{field}.validation", key=key)
+    if "default" in item:
+        if item["secret"]:
+            _fail("secret-default-forbidden", field=field, key=key)
+        _validate_value(item["default"], normalized, f"{field}.default")
+        normalized["default"] = copy.deepcopy(item["default"])
+    return normalized
+
+
+def _verified_plan(
+    envelope: Any,
+    expected_plan_hash: str,
+) -> tuple[Mapping[str, Any], str]:
+    outer = _mapping(envelope, "envelope")
+    plan = _mapping(outer.get("plan"), "envelope.plan")
+    plan_hash = outer.get("planHash")
+    if (
+        not isinstance(expected_plan_hash, str)
+        or _HASH_RE.fullmatch(expected_plan_hash) is None
+    ):
+        _fail("invalid-expected-plan-hash")
+    if not isinstance(plan_hash, str) or _HASH_RE.fullmatch(plan_hash) is None:
+        _fail("invalid-plan-hash")
+    if plan_hash != expected_plan_hash:
+        _fail("stored-plan-hash-mismatch")
+    if plan.get("schema") != _PLAN_SCHEMA:
+        _fail("invalid-plan-schema")
+    snapshot = copy.deepcopy(plan)
+    actual = hashlib.sha256(_canonical_json_bytes(snapshot)).hexdigest()
+    if actual != plan_hash:
+        _fail("plan-hash-mismatch")
+    return snapshot, plan_hash
+
+
+def _configuration_contracts(plan: Mapping[str, Any]) -> dict[str, dict[str, Any]]:
+    selected = _sequence(plan.get("selectedServices"), "plan.selectedServices")
+    if len(selected) > _MAX_DEFINITIONS:
+        _fail("too-many-selected-services")
+    selected_ids: list[str] = []
+    selected_seen: set[str] = set()
+    for index, service_id in enumerate(selected):
+        if not isinstance(service_id, str) or _ID_RE.fullmatch(service_id) is None:
+            _fail("invalid-selected-service", field=f"plan.selectedServices[{index}]")
+        if service_id in selected_seen:
+            _fail("duplicate-selected-service", serviceId=service_id)
+        selected_seen.add(service_id)
+        selected_ids.append(service_id)
+
+    definitions = _sequence(plan.get("definitions"), "plan.definitions")
+    if len(definitions) > _MAX_DEFINITIONS:
+        _fail("too-many-definitions")
+    by_id: dict[str, Mapping[str, Any]] = {}
+    for index, raw_definition in enumerate(definitions):
+        definition = _mapping(raw_definition, f"plan.definitions[{index}]")
+        service_id = definition.get("id")
+        if not isinstance(service_id, str) or _ID_RE.fullmatch(service_id) is None:
+            _fail("invalid-definition-service", field=f"plan.definitions[{index}].id")
+        if service_id in by_id:
+            _fail("duplicate-service-definition", serviceId=service_id)
+        by_id[service_id] = definition
+    if set(by_id) != selected_seen:
+        _fail(
+            "selected-definition-mismatch",
+            missing=sorted(selected_seen - set(by_id)),
+            extra=sorted(set(by_id) - selected_seen),
+        )
+
+    contracts: dict[str, dict[str, Any]] = {}
+    for service_id in selected_ids:
+        raw_configuration = _sequence(
+            by_id[service_id].get("configuration"),
+            f"definition.{service_id}.configuration",
+        )
+        if len(raw_configuration) > _MAX_CONFIGURATION_FIELDS:
+            _fail("too-many-configuration-fields", serviceId=service_id)
+        for index, raw_contract in enumerate(raw_configuration):
+            contract = _normalize_contract(
+                raw_contract, f"definition.{service_id}.configuration[{index}]"
+            )
+            key = contract["key"]
+            previous = contracts.get(key)
+            if previous is not None and previous != contract:
+                _fail("configuration-contract-conflict", key=key)
+            contracts[key] = contract
+
+    required_config = sorted(
+        key
+        for key, item in contracts.items()
+        if item["required"] and not item["secret"]
+    )
+    required_secrets = sorted(
+        key for key, item in contracts.items() if item["required"] and item["secret"]
+    )
+    if (
+        _safe_key_list(plan.get("requiredConfigKeys"), "plan.requiredConfigKeys")
+        != required_config
+    ):
+        _fail("required-configuration-contract-mismatch")
+    if (
+        _safe_key_list(plan.get("requiredSecretKeys"), "plan.requiredSecretKeys")
+        != required_secrets
+    ):
+        _fail("required-secret-contract-mismatch")
+    return {key: contracts[key] for key in sorted(contracts)}
+
+
+def configuration_contracts(
+    envelope: Any,
+    *,
+    expected_plan_hash: str,
+) -> dict[str, dict[str, Any]]:
+    """Derive all contracts from one externally anchored stored plan."""
+    plan, _ = _verified_plan(envelope, expected_plan_hash)
+    return _configuration_contracts(plan)
+
+
+def _configuration_schema_document(
+    contracts: Mapping[str, Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema": _SCHEMA,
+        "fields": [copy.deepcopy(contracts[key]) for key in sorted(contracts)],
+    }
+
+
+def configuration_schema(
+    envelope: Any,
+    *,
+    expected_plan_hash: str,
+) -> dict[str, Any]:
+    """Return complete public metadata without a value or secret default."""
+    plan, plan_hash = _verified_plan(envelope, expected_plan_hash)
+    contracts = _configuration_contracts(plan)
+    document = _configuration_schema_document(contracts)
+    return {
+        **document,
+        "planHash": plan_hash,
+        "schemaHash": hashlib.sha256(_canonical_json_bytes(document)).hexdigest(),
+    }
+
+
+def validate_configuration_submission(
+    envelope: Any,
+    values: Any,
+    secret_values: Any,
+    *,
+    expected_plan_hash: str,
+) -> dict[str, Any]:
+    """Validate user input and return only redacted presence/default metadata."""
+    plan, plan_hash = _verified_plan(envelope, expected_plan_hash)
+    contracts = _configuration_contracts(plan)
+    value_map = _mapping(values, "values")
+    secret_map = _mapping(secret_values, "secretValues")
+    value_keys = set(value_map)
+    secret_keys = set(secret_map)
+    if value_keys & secret_keys:
+        _fail("duplicate-submission-key", keys=sorted(value_keys & secret_keys))
+    unknown = (value_keys | secret_keys) - set(contracts)
+    if unknown:
+        _fail("unknown-configuration-key", keys=sorted(unknown))
+    wrong_values = sorted(key for key in value_keys if contracts[key]["secret"])
+    wrong_secrets = sorted(key for key in secret_keys if not contracts[key]["secret"])
+    if wrong_values:
+        _fail("secret-in-nonsecret-values", keys=wrong_values)
+    if wrong_secrets:
+        _fail("nonsecret-in-secret-values", keys=wrong_secrets)
+
+    submitted = value_keys | secret_keys
+    restricted = sorted(key for key in submitted if contracts[key]["source"] != "user")
+    if restricted:
+        _fail("configuration-source-restricted", keys=restricted)
+    missing_config = sorted(
+        key
+        for key, item in contracts.items()
+        if item["source"] == "user"
+        and item["required"]
+        and not item["secret"]
+        and "default" not in item
+        and key not in value_keys
+    )
+    missing_secrets = sorted(
+        key
+        for key, item in contracts.items()
+        if item["source"] == "user"
+        and item["required"]
+        and item["secret"]
+        and key not in secret_keys
+    )
+    if missing_config or missing_secrets:
+        _fail(
+            "missing-required-configuration",
+            configKeys=missing_config,
+            secretKeys=missing_secrets,
+        )
+
+    for key in sorted(value_keys):
+        _validate_value(value_map[key], contracts[key], f"values.{key}")
+    for key in sorted(secret_keys):
+        _validate_value(secret_map[key], contracts[key], f"secretValues.{key}")
+
+    schema_document = _configuration_schema_document(contracts)
+    schema_hash = hashlib.sha256(_canonical_json_bytes(schema_document)).hexdigest()
+    return {
+        "schema": _RECEIPT_SCHEMA,
+        "planHash": plan_hash,
+        "schemaHash": schema_hash,
+        "presentConfigKeys": sorted(value_keys),
+        "presentSecretKeys": sorted(secret_keys),
+        "appliedDefaultKeys": sorted(
+            key
+            for key, item in contracts.items()
+            if item["source"] == "user"
+            and not item["secret"]
+            and "default" in item
+            and key not in value_keys
+        ),
+    }

--- a/ods/extensions/services/dashboard-api/tests/test_assistant_first_planner.py
+++ b/ods/extensions/services/dashboard-api/tests/test_assistant_first_planner.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 
+import extension_configuration as configuration
+
 
 MODULE = Path(__file__).resolve().parents[1] / "assistant_first_planner.py"
 SPEC = importlib.util.spec_from_file_location("assistant_first_planner", MODULE)
@@ -617,6 +619,135 @@ def test_manifest_rejects_wrong_typed_defaults_and_duplicate_artifact_outputs() 
     }
     duplicate_data["service"]["planning"]["data"] = [entry, copy.deepcopy(entry)]
     error("duplicate-value", lambda: planner.adapt_manifest(duplicate_data))
+
+
+def test_manifest_normalizes_bounded_non_executable_configuration_validation() -> None:
+    record = manifest("app")
+    record["service"]["planning"]["configuration"] = [
+        {
+            "key": "MODE",
+            "type": "enum",
+            "required": True,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+            "validation": {"choices": ["remote", "local"]},
+            "default": "local",
+        },
+        {
+            "key": "WORKERS",
+            "type": "integer",
+            "required": False,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+            "validation": {"minimum": 1, "maximum": 8},
+            "default": 4,
+        },
+    ]
+    adapted = planner.adapt_manifest(record)
+    assert adapted["configuration"][0]["validation"] == {
+        "choices": ["local", "remote"]
+    }
+    assert adapted["configuration"][1]["validation"] == {
+        "minimum": 1,
+        "maximum": 8,
+    }
+
+
+@pytest.mark.parametrize(
+    ("config_type", "validation", "code"),
+    [
+        ("string", "^[a-z]+$", "invalid-field-type"),
+        ("string", {"pattern": "^[a-z]+$"}, "invalid-config-validation-fields"),
+        ("string", {"minimum": 1}, "incompatible-config-validation"),
+        ("integer", {"minimum": True}, "invalid-integer"),
+        ("integer", {"minimum": 8, "maximum": 1}, "invalid-config-validation-range"),
+        ("enum", None, "missing-config-validation"),
+        ("enum", {"choices": []}, "invalid-config-choices"),
+        ("enum", {"choices": ["one", "one"]}, "duplicate-value"),
+        ("boolean", {"minLength": 1}, "incompatible-config-validation"),
+    ],
+)
+def test_manifest_rejects_unsafe_or_incompatible_configuration_validation(
+    config_type: str,
+    validation,
+    code: str,
+) -> None:
+    record = manifest("app")
+    item = {
+        "key": "VALUE",
+        "type": config_type,
+        "required": True,
+        "secret": False,
+        "source": "user",
+        "restart_behavior": "service",
+    }
+    if validation is not None:
+        item["validation"] = validation
+    record["service"]["planning"]["configuration"] = [item]
+    error(code, lambda: planner.adapt_manifest(record))
+
+
+def test_manifest_default_must_satisfy_validation_and_url_contract() -> None:
+    bounded = manifest("app")
+    bounded["service"]["planning"]["configuration"] = [
+        {
+            "key": "WORKERS",
+            "type": "integer",
+            "required": True,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+            "validation": {"minimum": 2, "maximum": 8},
+            "default": 1,
+        }
+    ]
+    error("invalid-config-default", lambda: planner.adapt_manifest(bounded))
+
+    invalid_url = manifest("app")
+    invalid_url["service"]["planning"]["configuration"] = [
+        {
+            "key": "ENDPOINT",
+            "type": "url",
+            "required": True,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+            "default": "https://user:password@example.invalid",
+        }
+    ]
+    error("invalid-config-default", lambda: planner.adapt_manifest(invalid_url))
+
+
+def test_planner_output_is_accepted_by_the_typed_configuration_boundary() -> None:
+    record = manifest("provider")
+    record["service"]["planning"]["configuration"] = [
+        {
+            "key": "ENDPOINT",
+            "type": "url",
+            "required": True,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+            "validation": {"minLength": 8, "maxLength": 256},
+        },
+        {
+            "key": "TOKEN",
+            "type": "string",
+            "required": True,
+            "secret": True,
+            "source": "user",
+            "restart_behavior": "service",
+            "validation": {"minLength": 16},
+        },
+    ]
+    plan = build([record], requested_services=["provider"])
+    schema = configuration.configuration_schema(
+        plan, expected_plan_hash=plan["planHash"]
+    )
+    assert schema["planHash"] == plan["planHash"]
+    assert [item["key"] for item in schema["fields"]] == ["ENDPOINT", "TOKEN"]
 
 
 def test_all_shared_configuration_keys_must_have_identical_contracts() -> None:

--- a/ods/extensions/services/dashboard-api/tests/test_extension_configuration.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_configuration.py
@@ -1,0 +1,551 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+
+import pytest
+
+import extension_configuration as configuration
+
+
+def contract(
+    key: str,
+    *,
+    config_type: str = "string",
+    required: bool = True,
+    secret: bool = False,
+    source: str = "user",
+    validation: dict | None = None,
+    default: object | None = None,
+) -> dict:
+    result = {
+        "key": key,
+        "type": config_type,
+        "required": required,
+        "secret": secret,
+        "source": source,
+        "restartBehavior": "service",
+    }
+    if validation is not None:
+        result["validation"] = validation
+    if default is not None:
+        result["default"] = default
+    return result
+
+
+def envelope(*definitions: tuple[str, list[dict]]) -> dict:
+    required_config = sorted(
+        {
+            item["key"]
+            for _, items in definitions
+            for item in items
+            if item["required"] and not item["secret"]
+        }
+    )
+    required_secrets = sorted(
+        {
+            item["key"]
+            for _, items in definitions
+            for item in items
+            if item["required"] and item["secret"]
+        }
+    )
+    plan = {
+        "schema": "ods.assistant-first.plan.v1",
+        "selectedServices": [service_id for service_id, _ in definitions],
+        "definitions": [
+            {"id": service_id, "configuration": copy.deepcopy(items)}
+            for service_id, items in definitions
+        ],
+        "requiredConfigKeys": required_config,
+        "requiredSecretKeys": required_secrets,
+    }
+    serialized = json.dumps(
+        plan,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return {
+        "schema": "ods.assistant-first.plan-envelope.v1",
+        "planHash": hashlib.sha256((serialized + "\n").encode()).hexdigest(),
+        "plan": plan,
+    }
+
+
+def error(code: str, call) -> configuration.ExtensionConfigurationError:
+    with pytest.raises(configuration.ExtensionConfigurationError) as caught:
+        call()
+    assert caught.value.code == code
+    return caught.value
+
+
+def contracts(stored: dict) -> dict[str, dict]:
+    return configuration.configuration_contracts(
+        stored, expected_plan_hash=stored["planHash"]
+    )
+
+
+def schema(stored: dict) -> dict:
+    return configuration.configuration_schema(
+        stored, expected_plan_hash=stored["planHash"]
+    )
+
+
+def submit(stored: dict, values: dict, secrets: dict) -> dict:
+    return configuration.validate_configuration_submission(
+        stored,
+        values,
+        secrets,
+        expected_plan_hash=stored["planHash"],
+    )
+
+
+def test_contracts_are_derived_only_from_stored_selected_services() -> None:
+    stored = envelope(("notes", [contract("NOTES_PATH")]))
+    assert contracts(stored) == {"NOTES_PATH": contract("NOTES_PATH")}
+
+
+def test_plan_hash_is_verified_before_contract_extraction() -> None:
+    stored = envelope(("notes", [contract("NOTES_PATH")]))
+    stored["plan"]["definitions"][0]["configuration"] = []
+    error("plan-hash-mismatch", lambda: contracts(stored))
+
+
+def test_caller_must_supply_the_external_stored_plan_hash_anchor() -> None:
+    stored = envelope(("notes", [contract("NOTES_PATH")]))
+    error(
+        "stored-plan-hash-mismatch",
+        lambda: configuration.configuration_contracts(
+            stored, expected_plan_hash="0" * 64
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("unsafe_value", "code"),
+    [
+        (1.5, "float-not-canonical"),
+        ("x" * 65_537, "invalid-configuration-text"),
+    ],
+    ids=["float", "oversized-string"],
+)
+def test_plan_canonicalization_rejects_unsafe_json_shapes(
+    unsafe_value, code: str
+) -> None:
+    stored = envelope(("notes", []))
+    stored["plan"]["unsafe"] = unsafe_value
+    rehash(stored)
+    error(code, lambda: contracts(stored))
+
+
+def test_plan_canonicalization_rejects_cycles() -> None:
+    stored = envelope(("notes", []))
+    stored["plan"]["cycle"] = stored["plan"]
+    error("configuration-input-too-large", lambda: contracts(stored))
+
+
+@pytest.mark.parametrize(
+    ("mutation", "code"),
+    [
+        (
+            lambda plan: plan["definitions"].append(
+                {"id": "extra", "configuration": []}
+            ),
+            "selected-definition-mismatch",
+        ),
+        (
+            lambda plan: plan["definitions"].append(
+                copy.deepcopy(plan["definitions"][0])
+            ),
+            "duplicate-service-definition",
+        ),
+        (
+            lambda plan: plan["definitions"].clear(),
+            "selected-definition-mismatch",
+        ),
+        (
+            lambda plan: plan["selectedServices"].append("notes"),
+            "duplicate-selected-service",
+        ),
+    ],
+)
+def test_selected_services_and_definitions_are_one_to_one(mutation, code: str) -> None:
+    stored = envelope(("notes", []))
+    mutation(stored["plan"])
+    stored = rehash(stored)
+    error(code, lambda: contracts(stored))
+
+
+def rehash(stored: dict) -> dict:
+    plan = stored["plan"]
+    serialized = json.dumps(
+        plan,
+        ensure_ascii=False,
+        allow_nan=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    stored["planHash"] = hashlib.sha256((serialized + "\n").encode()).hexdigest()
+    return stored
+
+
+def test_identical_shared_contract_is_deduplicated() -> None:
+    shared = contract("SHARED")
+    stored = envelope(("one", [shared]), ("two", [shared]))
+    assert list(contracts(stored)) == ["SHARED"]
+
+
+def test_conflicting_shared_contract_is_rejected() -> None:
+    stored = envelope(
+        ("one", [contract("SHARED")]),
+        ("two", [contract("SHARED", required=False)]),
+    )
+    error(
+        "configuration-contract-conflict",
+        lambda: contracts(stored),
+    )
+
+
+def test_required_key_summaries_must_match_derived_contracts() -> None:
+    stored = envelope(("notes", [contract("NOTES_PATH")]))
+    stored["plan"]["requiredConfigKeys"] = []
+    rehash(stored)
+    error(
+        "required-configuration-contract-mismatch",
+        lambda: contracts(stored),
+    )
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda item: item.update(extra="unexpected"),
+        lambda item: item.update(key="lowercase"),
+        lambda item: item.update(source="caller"),
+        lambda item: item.update(restartBehavior="host"),
+    ],
+)
+def test_contract_metadata_is_exact_and_strict(mutation) -> None:
+    item = contract("VALUE")
+    mutation(item)
+    stored = envelope(("notes", [item]))
+    error(
+        "invalid-configuration-contract-fields"
+        if "extra" in item
+        else "invalid-configuration-key"
+        if item["key"] == "lowercase"
+        else "invalid-configuration-contract",
+        lambda: contracts(stored),
+    )
+
+
+def test_secret_schema_keeps_metadata_but_never_default_or_value() -> None:
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract(
+                    "API_TOKEN",
+                    secret=True,
+                    validation={"minLength": 16, "maxLength": 64},
+                )
+            ],
+        )
+    )
+    field = schema(stored)["fields"][0]
+    assert field == {
+        "key": "API_TOKEN",
+        "type": "string",
+        "required": True,
+        "secret": True,
+        "source": "user",
+        "restartBehavior": "service",
+        "validation": {"minLength": 16, "maxLength": 64},
+    }
+    assert "default" not in field
+    assert "value" not in field
+
+
+def test_schema_hash_binds_secret_contract_metadata() -> None:
+    first = envelope(("provider", [contract("TOKEN", secret=True)]))
+    second = envelope(("provider", [contract("TOKEN", secret=True, required=False)]))
+    assert schema(first)["schemaHash"] != schema(second)["schemaHash"]
+
+
+@pytest.mark.parametrize(
+    "validation",
+    [
+        "not-an-object",
+        {},
+        {"pattern": "^safe$"},
+        {"minimum": 1},
+        {"minLength": True},
+        {"minLength": 5, "maxLength": 4},
+    ],
+)
+def test_string_validation_is_structured_bounded_and_non_executable(validation) -> None:
+    stored = envelope(("notes", [contract("NAME", validation=validation)]))
+    error(
+        "invalid-configuration-object"
+        if isinstance(validation, str)
+        else "invalid-validation-fields"
+        if not validation or "pattern" in validation
+        else "incompatible-validation"
+        if "minimum" in validation
+        else "invalid-validation-bound"
+        if validation.get("minLength") is True
+        else "invalid-validation-range",
+        lambda: contracts(stored),
+    )
+
+
+@pytest.mark.parametrize(
+    "validation",
+    [None, {"choices": []}, {"choices": ["one", "one"]}, {"maxLength": 4}],
+)
+def test_enum_requires_unique_nonempty_choices(validation) -> None:
+    stored = envelope(
+        ("provider", [contract("MODE", config_type="enum", validation=validation)])
+    )
+    expected = {
+        "None": "missing-enum-validation",
+        "{'choices': []}": "invalid-enum-choices",
+        "{'choices': ['one', 'one']}": "duplicate-enum-choice",
+        "{'maxLength': 4}": "incompatible-validation",
+    }[str(validation)]
+    error(expected, lambda: contracts(stored))
+
+
+def test_secret_default_is_rejected_without_echoing_it() -> None:
+    sentinel = "do-not-echo-private-token"
+    stored = envelope(("provider", [contract("TOKEN", secret=True, default=sentinel)]))
+    caught = error(
+        "secret-default-forbidden",
+        lambda: contracts(stored),
+    )
+    assert sentinel not in str(caught)
+    assert sentinel not in repr(caught)
+    assert sentinel not in json.dumps(caught.as_dict())
+
+
+def test_default_must_satisfy_its_declared_validation() -> None:
+    stored = envelope(
+        (
+            "notes",
+            [
+                contract(
+                    "WORKERS",
+                    config_type="integer",
+                    validation={"minimum": 2, "maximum": 8},
+                    default=1,
+                )
+            ],
+        )
+    )
+    error(
+        "configuration-value-too-small",
+        lambda: contracts(stored),
+    )
+
+
+def test_required_nonsecret_default_satisfies_an_omitted_submission() -> None:
+    stored = envelope(
+        ("notes", [contract("WORKERS", config_type="integer", default=4)])
+    )
+    receipt = submit(stored, {}, {})
+    assert receipt["appliedDefaultKeys"] == ["WORKERS"]
+    assert receipt["presentConfigKeys"] == []
+
+
+def test_zero_default_and_optional_subset_are_preserved_as_presence_metadata() -> None:
+    stored = envelope(
+        (
+            "notes",
+            [
+                contract("COUNT", config_type="integer", default=0),
+                contract("LABEL", required=False),
+            ],
+        )
+    )
+    receipt = submit(stored, {"LABEL": "chosen"}, {})
+    assert receipt["appliedDefaultKeys"] == ["COUNT"]
+    assert receipt["presentConfigKeys"] == ["LABEL"]
+
+
+def test_non_user_required_field_is_not_a_user_submission_requirement() -> None:
+    stored = envelope(
+        (
+            "notes",
+            [contract("GENERATED", source="generated")],
+        )
+    )
+    assert submit(stored, {}, {})["presentConfigKeys"] == []
+
+
+def test_required_user_config_and_secret_are_reported_by_key_only() -> None:
+    stored = envelope(
+        (
+            "provider",
+            [contract("ENDPOINT"), contract("TOKEN", secret=True)],
+        )
+    )
+    caught = error(
+        "missing-required-configuration",
+        lambda: submit(stored, {}, {}),
+    )
+    assert caught.as_dict()["details"] == {
+        "configKeys": ["ENDPOINT"],
+        "secretKeys": ["TOKEN"],
+    }
+
+
+def test_submission_enforces_secret_split_and_source() -> None:
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract("TOKEN", secret=True),
+                contract("GENERATED", source="generated", required=False),
+            ],
+        )
+    )
+    error(
+        "secret-in-nonsecret-values",
+        lambda: submit(stored, {"TOKEN": "private"}, {}),
+    )
+    error(
+        "configuration-source-restricted",
+        lambda: submit(
+            stored, {"GENERATED": "caller-controlled"}, {"TOKEN": "private"}
+        ),
+    )
+
+
+def test_secret_value_is_validated_but_absent_from_receipt_and_errors() -> None:
+    sentinel = "short-private-value"
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract(
+                    "TOKEN",
+                    secret=True,
+                    validation={"minLength": 32},
+                )
+            ],
+        )
+    )
+    caught = error(
+        "configuration-value-too-short",
+        lambda: submit(stored, {}, {"TOKEN": sentinel}),
+    )
+    assert sentinel not in str(caught)
+    assert sentinel not in repr(caught)
+    assert sentinel not in json.dumps(caught.as_dict())
+
+
+def test_valid_submission_receipt_contains_presence_only() -> None:
+    sentinel = "private-value-1234567890"
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract("ENDPOINT", config_type="url"),
+                contract("TOKEN", secret=True, validation={"minLength": 16}),
+            ],
+        )
+    )
+    receipt = submit(
+        stored,
+        {"ENDPOINT": "https://example.invalid/v1"},
+        {"TOKEN": sentinel},
+    )
+    assert receipt["presentConfigKeys"] == ["ENDPOINT"]
+    assert receipt["presentSecretKeys"] == ["TOKEN"]
+    assert sentinel not in json.dumps(receipt)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "ftp://example.invalid",
+        "https://",
+        "https://user:password@example.invalid",
+        "https://example.invalid/path#fragment",
+        "https://example.invalid:99999",
+        "https://exa mple.invalid",
+        "https://example.invalid/%0aheader",
+        "https://еxample.invalid",
+    ],
+)
+def test_url_validation_is_absolute_credentialless_and_bounded(value: str) -> None:
+    stored = envelope(("provider", [contract("ENDPOINT", config_type="url")]))
+    error(
+        "invalid-configuration-url",
+        lambda: submit(stored, {"ENDPOINT": value}, {}),
+    )
+
+
+def test_http_is_allowed_for_explicit_local_routes() -> None:
+    stored = envelope(("provider", [contract("ENDPOINT", config_type="url")]))
+    receipt = submit(stored, {"ENDPOINT": "http://127.0.0.1:11434/v1"}, {})
+    assert receipt["presentConfigKeys"] == ["ENDPOINT"]
+
+
+def test_integer_rejects_boolean_and_enforces_bounds() -> None:
+    stored = envelope(
+        (
+            "notes",
+            [
+                contract(
+                    "WORKERS",
+                    config_type="integer",
+                    validation={"minimum": 1, "maximum": 8},
+                )
+            ],
+        )
+    )
+    error(
+        "invalid-configuration-value-type",
+        lambda: submit(stored, {"WORKERS": True}, {}),
+    )
+    error(
+        "configuration-value-too-large",
+        lambda: submit(stored, {"WORKERS": 9}, {}),
+    )
+
+
+def test_enum_submission_must_match_a_declared_choice() -> None:
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract(
+                    "MODE",
+                    config_type="enum",
+                    validation={"choices": ["local", "external"]},
+                )
+            ],
+        )
+    )
+    error(
+        "invalid-configuration-choice",
+        lambda: submit(stored, {"MODE": "other"}, {}),
+    )
+
+
+def test_unknown_and_duplicate_submission_keys_fail_closed() -> None:
+    stored = envelope(("notes", [contract("PATH", required=False)]))
+    error(
+        "unknown-configuration-key",
+        lambda: submit(stored, {"UNKNOWN": "value"}, {}),
+    )
+    error(
+        "duplicate-submission-key",
+        lambda: submit(stored, {"PATH": "one"}, {"PATH": "two"}),
+    )

--- a/ods/tests/test-validate-manifest-schema.sh
+++ b/ods/tests/test-validate-manifest-schema.sh
@@ -271,6 +271,37 @@ YAML
 assert_success "v2 planning manifest routes to the v2 schema" \
     env ODS_MANIFEST_DIRS="$CASE_ROOT" bash "$VALIDATOR"
 
+python3 - "$SCHEMA_V2" "$CASE_ROOT/case/manifest.yaml" <<'PY'
+import copy
+import json
+import sys
+
+import jsonschema
+import yaml
+
+schema = json.loads(open(sys.argv[1], encoding="utf-8").read())
+manifest = yaml.safe_load(open(sys.argv[2], encoding="utf-8"))
+validator = jsonschema.validators.validator_for(schema)(schema)
+
+structured = copy.deepcopy(manifest)
+structured["service"]["planning"]["configuration"][0]["validation"] = {
+    "minLength": 1,
+    "maxLength": 64,
+}
+assert not list(validator.iter_errors(structured))
+
+legacy_string = copy.deepcopy(manifest)
+legacy_string["service"]["planning"]["configuration"][0]["validation"] = "^[a-z]+$"
+assert list(validator.iter_errors(legacy_string))
+
+executable_pattern = copy.deepcopy(manifest)
+executable_pattern["service"]["planning"]["configuration"][0]["validation"] = {
+    "pattern": "^[a-z]+$"
+}
+assert list(validator.iter_errors(executable_pattern))
+PY
+pass "v2 configuration validation is structured and non-executable"
+
 cat >> "$CASE_ROOT/case/manifest.yaml" <<'YAML'
     secret_values:
       TEST_TOKEN: forbidden


### PR DESCRIPTION
## Summary
- replace Manifest v2 configuration validation strings with bounded structured contracts
- derive typed forms only from the externally anchored stored plan and its exact selected services
- validate non-secret and secret submissions without returning or retaining secret values
- add complete schema hashing, strict URL/type/default checks, and source-of-truth schema tests

## Security boundaries
- caller-selected service subsets are not accepted
- arbitrary regular-expression validation is not supported
- the expected plan hash must come from the durable transaction record
- secret defaults are forbidden; receipts expose only key presence
- secret custody and runtime activation remain deferred to the next guarded phase

## Validation
- Windows focused suite: 197 passed, 92 skipped
- Linux exact-SHA suite: 289 passed
- changed-file Ruff E/F/W: clean
- Manifest schema source-of-truth suite: passed
- git diff/checks: clean

## Stack
Depends on #4452. This PR is intentionally based on `feat/assistant-first-phase-3c-api-integration` and should be reviewed/landed after it.