### PR TITLE
feat(extensions): add host-owned secret custody

### DIFF
--- a/ods/bin/assistant_first_secret_store.py
+++ b/ods/bin/assistant_first_secret_store.py
@@ -1,0 +1,575 @@
+"""Host-owned custody for Assistant First extension configuration secrets.
+
+The store is deliberately Linux/POSIX-only for the first qualification phase.
+It never returns secret values and never places them in exception messages.
+Every record is bound to one transaction, plan hash, and configuration schema
+hash; callers receive only an opaque reference and presence metadata.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hmac
+import json
+import os
+import re
+import secrets
+import stat
+import threading
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+try:  # pragma: no cover - unavailable by design on native Windows
+    import fcntl
+except ImportError:  # pragma: no cover - native Windows
+    fcntl = None
+
+
+STAGE_REQUEST_SCHEMA = "ods.assistant-first.secret-stage-request.v1"
+STATUS_REQUEST_SCHEMA = "ods.assistant-first.secret-status-request.v1"
+DELETE_REQUEST_SCHEMA = "ods.assistant-first.secret-delete-request.v1"
+RECORD_SCHEMA = "ods.assistant-first.secret-record.v1"
+STATUS_SCHEMA = "ods.assistant-first.secret-status.v1"
+
+_TRANSACTION_RE = re.compile(r"^txn-[0-9a-f]{24}$")
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+_REFERENCE_RE = re.compile(r"^secret-v1-[0-9a-f]{48}$")
+_MAX_SECRET_KEYS = 128
+_MAX_SECRET_VALUE_LENGTH = 65_536
+_MAX_RECORD_BYTES = 256 * 1024
+_MAX_SAFE_INTEGER = (1 << 53) - 1
+_CLOEXEC = getattr(os, "O_CLOEXEC", 0)
+_DIRECTORY_FLAGS = (
+    os.O_RDONLY
+    | getattr(os, "O_DIRECTORY", 0)
+    | getattr(os, "O_NOFOLLOW", 0)
+    | _CLOEXEC
+)
+_FILE_NOFOLLOW = getattr(os, "O_NOFOLLOW", 0)
+_TEMPORARY_RE = re.compile(r"^\.txn-[0-9a-f]{24}\.json\.[0-9a-f]{24}\.tmp$")
+
+
+class SecretStoreError(RuntimeError):
+    """Stable, value-free failure safe to project across the host API."""
+
+    def __init__(self, code: str) -> None:
+        self.code = code
+        super().__init__(code)
+
+    def __repr__(self) -> str:
+        return f"SecretStoreError({self.code!r})"
+
+
+def _fail(code: str) -> None:
+    raise SecretStoreError(code)
+
+
+def _exact_dict(value: Any, keys: frozenset[str], code: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        _fail(code)
+    return value
+
+
+def _safe_text(value: Any, pattern: re.Pattern[str], code: str) -> str:
+    if not isinstance(value, str) or pattern.fullmatch(value) is None:
+        _fail(code)
+    return value
+
+
+def _safe_secret_scalar(value: Any) -> None:
+    if type(value) is bool:
+        return
+    if type(value) is int:
+        if not -_MAX_SAFE_INTEGER <= value <= _MAX_SAFE_INTEGER:
+            _fail("invalid-secret-value")
+        return
+    if isinstance(value, str):
+        if not value or len(value) > _MAX_SECRET_VALUE_LENGTH:
+            _fail("invalid-secret-value")
+        for character in value:
+            point = ord(character)
+            if point == 0 or point == 127 or 0xD800 <= point <= 0xDFFF:
+                _fail("invalid-secret-value")
+            if point < 32 and character not in "\r\n\t":
+                _fail("invalid-secret-value")
+        return
+    _fail("invalid-secret-value")
+
+
+def _secret_map(value: Any) -> dict[str, Any]:
+    if type(value) is not dict or not value or len(value) > _MAX_SECRET_KEYS:
+        _fail("invalid-secret-values")
+    result: dict[str, Any] = {}
+    for key, item in value.items():
+        _safe_text(key, _KEY_RE, "invalid-secret-key")
+        _safe_secret_scalar(item)
+        result[key] = item
+    return result
+
+
+def _canonical_bytes(value: Any) -> bytes:
+    try:
+        encoded = (
+            json.dumps(
+                value,
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8", errors="strict")
+    except (TypeError, ValueError, UnicodeError):
+        _fail("invalid-secret-document")
+    if len(encoded) > _MAX_RECORD_BYTES:
+        _fail("secret-document-too-large")
+    return encoded
+
+
+def _duplicate_object_hook(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            _fail("secret-record-integrity")
+        result[key] = value
+    return result
+
+
+def _reject_number(_value: str) -> None:
+    _fail("secret-record-integrity")
+
+
+class AssistantFirstSecretStore:
+    """POSIX dirfd-backed, transaction-bound secret record store."""
+
+    _process_lock = threading.RLock()
+
+    def __init__(self, data_dir: Path | str) -> None:
+        self.data_dir = Path(data_dir)
+
+    @staticmethod
+    def _require_posix() -> None:
+        if (
+            os.name != "posix"
+            or fcntl is None
+            or not hasattr(os, "O_DIRECTORY")
+            or not hasattr(os, "O_NOFOLLOW")
+        ):
+            _fail("secret-store-platform-unqualified")
+
+    @staticmethod
+    def _verify_owned_directory(descriptor: int, *, root: bool) -> None:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISDIR(metadata.st_mode):
+            _fail("secret-store-directory-integrity")
+        if metadata.st_uid != os.geteuid():
+            _fail("secret-store-owner-mismatch")
+        mode = stat.S_IMODE(metadata.st_mode)
+        if root:
+            if mode & 0o022:
+                _fail("secret-store-root-permissions")
+        elif mode != 0o700:
+            _fail("secret-store-directory-permissions")
+
+    @classmethod
+    def _open_child_directory(cls, parent_fd: int, name: str) -> int:
+        try:
+            os.mkdir(name, 0o700, dir_fd=parent_fd)
+        except FileExistsError:
+            pass
+        except OSError:
+            _fail("secret-store-directory-unavailable")
+        try:
+            descriptor = os.open(name, _DIRECTORY_FLAGS, dir_fd=parent_fd)
+        except OSError:
+            _fail("secret-store-directory-integrity")
+        try:
+            cls._verify_owned_directory(descriptor, root=False)
+        except Exception:
+            os.close(descriptor)
+            raise
+        return descriptor
+
+    @contextlib.contextmanager
+    def _store_directory(self) -> Iterator[int]:
+        self._require_posix()
+        try:
+            root_info = self.data_dir.lstat()
+        except OSError:
+            _fail("secret-store-root-unavailable")
+        if stat.S_ISLNK(root_info.st_mode) or not stat.S_ISDIR(root_info.st_mode):
+            _fail("secret-store-root-integrity")
+        try:
+            data_fd = os.open(self.data_dir, _DIRECTORY_FLAGS)
+        except OSError:
+            _fail("secret-store-root-integrity")
+        assistant_fd = -1
+        secrets_fd = -1
+        try:
+            opened = os.fstat(data_fd)
+            if (opened.st_dev, opened.st_ino) != (root_info.st_dev, root_info.st_ino):
+                _fail("secret-store-root-race")
+            self._verify_owned_directory(data_fd, root=True)
+            assistant_fd = self._open_child_directory(data_fd, "assistant-first")
+            secrets_fd = self._open_child_directory(assistant_fd, "secrets")
+            yield secrets_fd
+        finally:
+            if secrets_fd >= 0:
+                os.close(secrets_fd)
+            if assistant_fd >= 0:
+                os.close(assistant_fd)
+            os.close(data_fd)
+
+    @contextlib.contextmanager
+    def _locked_directory(self) -> Iterator[int]:
+        with self._process_lock, self._store_directory() as directory_fd:
+            flags = os.O_RDWR | os.O_CREAT | _FILE_NOFOLLOW | _CLOEXEC
+            try:
+                lock_fd = os.open(".lock", flags, 0o600, dir_fd=directory_fd)
+            except OSError:
+                _fail("secret-store-lock-unavailable")
+            try:
+                metadata = os.fstat(lock_fd)
+                if (
+                    not stat.S_ISREG(metadata.st_mode)
+                    or metadata.st_nlink != 1
+                    or metadata.st_uid != os.geteuid()
+                ):
+                    _fail("secret-store-lock-integrity")
+                os.fchmod(lock_fd, 0o600)
+                fcntl.flock(lock_fd, fcntl.LOCK_EX)
+                self._recover_temporary_files(directory_fd)
+                yield directory_fd
+            except OSError:
+                _fail("secret-store-lock-unavailable")
+            finally:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                os.close(lock_fd)
+
+    @staticmethod
+    def _filename(transaction_id: str) -> str:
+        return f"{transaction_id}.json"
+
+    @staticmethod
+    def _verify_record_file(metadata: os.stat_result) -> None:
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_nlink != 1
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) != 0o600
+            or metadata.st_size > _MAX_RECORD_BYTES
+        ):
+            _fail("secret-record-integrity")
+
+    @staticmethod
+    def _recover_temporary_files(directory_fd: int) -> None:
+        """Remove only owner-only orphan files left by an interrupted swap."""
+        try:
+            names = os.listdir(directory_fd)
+        except OSError:
+            _fail("secret-store-recovery-failed")
+        for name in names:
+            if _TEMPORARY_RE.fullmatch(name) is None:
+                continue
+            try:
+                metadata = os.stat(name, dir_fd=directory_fd, follow_symlinks=False)
+            except OSError:
+                _fail("secret-temporary-integrity")
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_nlink != 1
+                or metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) != 0o600
+            ):
+                _fail("secret-temporary-integrity")
+            try:
+                os.unlink(name, dir_fd=directory_fd)
+                os.fsync(directory_fd)
+            except OSError:
+                _fail("secret-store-recovery-failed")
+
+    def _read_record(
+        self, directory_fd: int, transaction_id: str
+    ) -> dict[str, Any] | None:
+        filename = self._filename(transaction_id)
+        try:
+            before = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            return None
+        except OSError:
+            _fail("secret-record-unavailable")
+        self._verify_record_file(before)
+        try:
+            descriptor = os.open(
+                filename,
+                os.O_RDONLY | _FILE_NOFOLLOW | _CLOEXEC,
+                dir_fd=directory_fd,
+            )
+        except OSError:
+            _fail("secret-record-integrity")
+        try:
+            opened = os.fstat(descriptor)
+            self._verify_record_file(opened)
+            if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
+                _fail("secret-record-race")
+            chunks: list[bytes] = []
+            remaining = opened.st_size
+            while remaining:
+                chunk = os.read(descriptor, min(remaining, 64 * 1024))
+                if not chunk:
+                    _fail("secret-record-integrity")
+                chunks.append(chunk)
+                remaining -= len(chunk)
+        finally:
+            os.close(descriptor)
+        try:
+            record = json.loads(
+                b"".join(chunks).decode("utf-8", errors="strict"),
+                object_pairs_hook=_duplicate_object_hook,
+                parse_float=_reject_number,
+                parse_constant=_reject_number,
+            )
+        except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+            _fail("secret-record-integrity")
+        return self._validated_record(record)
+
+    @staticmethod
+    def _validated_record(value: Any) -> dict[str, Any]:
+        keys = frozenset(
+            {
+                "schema",
+                "transactionId",
+                "planHash",
+                "schemaHash",
+                "idempotencyKey",
+                "reference",
+                "secretValues",
+            }
+        )
+        record = _exact_dict(value, keys, "secret-record-integrity")
+        if record["schema"] != RECORD_SCHEMA:
+            _fail("secret-record-integrity")
+        _safe_text(record["transactionId"], _TRANSACTION_RE, "secret-record-integrity")
+        _safe_text(record["planHash"], _HASH_RE, "secret-record-integrity")
+        _safe_text(record["schemaHash"], _HASH_RE, "secret-record-integrity")
+        _safe_text(record["idempotencyKey"], _HASH_RE, "secret-record-integrity")
+        _safe_text(record["reference"], _REFERENCE_RE, "secret-record-integrity")
+        _secret_map(record["secretValues"])
+        return record
+
+    @staticmethod
+    def _binding(payload: dict[str, Any]) -> tuple[str, str, str]:
+        return (
+            _safe_text(
+                payload["transactionId"], _TRANSACTION_RE, "invalid-transaction-id"
+            ),
+            _safe_text(payload["planHash"], _HASH_RE, "invalid-plan-hash"),
+            _safe_text(payload["schemaHash"], _HASH_RE, "invalid-schema-hash"),
+        )
+
+    @staticmethod
+    def _assert_binding(
+        record: dict[str, Any], transaction_id: str, plan_hash: str, schema_hash: str
+    ) -> None:
+        if (
+            record["transactionId"] != transaction_id
+            or record["planHash"] != plan_hash
+            or record["schemaHash"] != schema_hash
+        ):
+            _fail("secret-binding-mismatch")
+
+    @staticmethod
+    def _status(
+        record: dict[str, Any], *, duplicate: bool | None = None
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {
+            "schema": STATUS_SCHEMA,
+            "transactionId": record["transactionId"],
+            "planHash": record["planHash"],
+            "schemaHash": record["schemaHash"],
+            "reference": record["reference"],
+            "configured": True,
+            "presentSecretKeys": sorted(record["secretValues"]),
+        }
+        if duplicate is not None:
+            result["duplicate"] = duplicate
+        return result
+
+    def _atomic_write(self, directory_fd: int, filename: str, content: bytes) -> None:
+        try:
+            existing = os.stat(filename, dir_fd=directory_fd, follow_symlinks=False)
+        except FileNotFoundError:
+            existing = None
+        except OSError:
+            _fail("secret-record-unavailable")
+        if existing is not None:
+            self._verify_record_file(existing)
+
+        descriptor = -1
+        temporary = ""
+        for _attempt in range(32):
+            temporary = f".{filename}.{secrets.token_hex(12)}.tmp"
+            try:
+                descriptor = os.open(
+                    temporary,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | _FILE_NOFOLLOW | _CLOEXEC,
+                    0o600,
+                    dir_fd=directory_fd,
+                )
+                break
+            except FileExistsError:
+                continue
+            except OSError:
+                _fail("secret-record-write-failed")
+        if descriptor < 0:
+            _fail("secret-record-write-failed")
+        try:
+            os.fchmod(descriptor, 0o600)
+            offset = 0
+            while offset < len(content):
+                written = os.write(descriptor, content[offset:])
+                if written <= 0:
+                    _fail("secret-record-write-failed")
+                offset += written
+            os.fsync(descriptor)
+            os.close(descriptor)
+            descriptor = -1
+            os.replace(
+                temporary,
+                filename,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+            )
+            temporary = ""
+            os.fsync(directory_fd)
+        except OSError:
+            _fail("secret-record-write-failed")
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            if temporary:
+                with contextlib.suppress(OSError):
+                    os.unlink(temporary, dir_fd=directory_fd)
+
+    def stage(self, payload: Any) -> dict[str, Any]:
+        """Atomically stage values and return only an opaque reference."""
+        keys = frozenset(
+            {
+                "schema",
+                "transactionId",
+                "planHash",
+                "schemaHash",
+                "idempotencyKey",
+                "secretValues",
+            }
+        )
+        request = _exact_dict(payload, keys, "invalid-secret-stage-request")
+        if request["schema"] != STAGE_REQUEST_SCHEMA:
+            _fail("invalid-secret-stage-schema")
+        transaction_id, plan_hash, schema_hash = self._binding(request)
+        idempotency_key = _safe_text(
+            request["idempotencyKey"], _HASH_RE, "invalid-idempotency-key"
+        )
+        secret_values = _secret_map(request["secretValues"])
+        with self._locked_directory() as directory_fd:
+            current = self._read_record(directory_fd, transaction_id)
+            if current is not None:
+                self._assert_binding(current, transaction_id, plan_hash, schema_hash)
+                if current["idempotencyKey"] == idempotency_key:
+                    same = hmac.compare_digest(
+                        _canonical_bytes(current["secretValues"]),
+                        _canonical_bytes(secret_values),
+                    )
+                    if not same:
+                        _fail("secret-idempotency-conflict")
+                    return self._status(current, duplicate=True)
+
+            record = {
+                "schema": RECORD_SCHEMA,
+                "transactionId": transaction_id,
+                "planHash": plan_hash,
+                "schemaHash": schema_hash,
+                "idempotencyKey": idempotency_key,
+                "reference": f"secret-v1-{secrets.token_hex(24)}",
+                "secretValues": secret_values,
+            }
+            self._atomic_write(
+                directory_fd, self._filename(transaction_id), _canonical_bytes(record)
+            )
+            return self._status(record, duplicate=False)
+
+    def status(self, payload: Any) -> dict[str, Any]:
+        """Verify one exact reference and return presence metadata only."""
+        keys = frozenset(
+            {"schema", "transactionId", "planHash", "schemaHash", "reference"}
+        )
+        request = _exact_dict(payload, keys, "invalid-secret-status-request")
+        if request["schema"] != STATUS_REQUEST_SCHEMA:
+            _fail("invalid-secret-status-schema")
+        transaction_id, plan_hash, schema_hash = self._binding(request)
+        reference = _safe_text(
+            request["reference"], _REFERENCE_RE, "invalid-secret-reference"
+        )
+        with self._locked_directory() as directory_fd:
+            record = self._read_record(directory_fd, transaction_id)
+            if record is None:
+                _fail("secret-record-not-found")
+            self._assert_binding(record, transaction_id, plan_hash, schema_hash)
+            if not hmac.compare_digest(record["reference"], reference):
+                _fail("secret-reference-mismatch")
+            return self._status(record)
+
+    def delete(self, payload: Any) -> dict[str, Any]:
+        """Delete only the record matching every supplied binding."""
+        keys = frozenset(
+            {"schema", "transactionId", "planHash", "schemaHash", "reference"}
+        )
+        request = _exact_dict(payload, keys, "invalid-secret-delete-request")
+        if request["schema"] != DELETE_REQUEST_SCHEMA:
+            _fail("invalid-secret-delete-schema")
+        transaction_id, plan_hash, schema_hash = self._binding(request)
+        reference = _safe_text(
+            request["reference"], _REFERENCE_RE, "invalid-secret-reference"
+        )
+        with self._locked_directory() as directory_fd:
+            record = self._read_record(directory_fd, transaction_id)
+            if record is None:
+                return {
+                    "schema": STATUS_SCHEMA,
+                    "transactionId": transaction_id,
+                    "planHash": plan_hash,
+                    "schemaHash": schema_hash,
+                    "configured": False,
+                    "deleted": False,
+                    "presentSecretKeys": [],
+                }
+            self._assert_binding(record, transaction_id, plan_hash, schema_hash)
+            if not hmac.compare_digest(record["reference"], reference):
+                _fail("secret-reference-mismatch")
+            try:
+                os.unlink(self._filename(transaction_id), dir_fd=directory_fd)
+                os.fsync(directory_fd)
+            except OSError:
+                _fail("secret-record-delete-failed")
+            return {
+                "schema": STATUS_SCHEMA,
+                "transactionId": transaction_id,
+                "planHash": plan_hash,
+                "schemaHash": schema_hash,
+                "configured": False,
+                "deleted": True,
+                "presentSecretKeys": [],
+            }
+
+
+__all__ = [
+    "DELETE_REQUEST_SCHEMA",
+    "STAGE_REQUEST_SCHEMA",
+    "STATUS_REQUEST_SCHEMA",
+    "STATUS_SCHEMA",
+    "AssistantFirstSecretStore",
+    "SecretStoreError",
+]

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -89,6 +89,15 @@ except Exception:  # pragma: no cover - import environment dependent
     _remote_provider_public_probe_receipt = None
     _remote_provider_ssh_supervisor_plan = None
 
+try:
+    from assistant_first_secret_store import (
+        AssistantFirstSecretStore as _AssistantFirstSecretStore,
+        SecretStoreError as _AssistantFirstSecretStoreError,
+    )
+except Exception:  # pragma: no cover - import environment dependent
+    _AssistantFirstSecretStore = None
+    _AssistantFirstSecretStoreError = RuntimeError
+
 _MODEL_MEMORY_PATH = (
     Path(__file__).resolve().parent.parent
     / "extensions"
@@ -119,6 +128,7 @@ PIXEL_OPS_STATUS_KIND = "ods-pixel-operations-status"
 # never contain a path separator or ".." and escape BACKUP_DIR.
 BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 MAX_BODY = 16384
+_ASSISTANT_SECRET_MAX_BODY = 64 * 1024
 MAX_TELEMETRY_RESPONSE_BYTES = 1024 * 1024
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
@@ -146,6 +156,7 @@ _FALLBACK_CORE_IDS = frozenset({
 INSTALL_DIR: Path = Path()
 DATA_DIR: Path = Path()
 AGENT_API_KEY: str = ""
+ASSISTANT_TRANSACTIONS_ENABLED: bool = False
 GPU_BACKEND: str = "nvidia"
 STARTUP_ODS_MODE: str | None = None
 TIER: str = "1"
@@ -5625,6 +5636,14 @@ def _iso_now() -> str:
 
 
 _BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._\-=+/]+", re.IGNORECASE)
+_HTTP_QUERY_COMPONENT_RE = re.compile(r"\?\S*")
+
+
+def _redact_http_request_target(value):
+    """Remove query data from a BaseHTTPRequestHandler log value."""
+    if not isinstance(value, str):
+        return value
+    return _HTTP_QUERY_COMPONENT_RE.sub("?[REDACTED]", value)
 
 
 def _write_progress(service_id: str, status: str, phase_label: str = "",
@@ -6031,12 +6050,17 @@ def _network_supported(handler) -> bool:
 def check_auth(handler) -> bool:
     auth = handler.headers.get("Authorization", "")
     if not auth.startswith("Bearer "):
-        json_response(handler, 401, {"error": "Authorization header required"})
+        json_response(
+            handler,
+            401,
+            {"error": "Authorization header required"},
+            no_store=True,
+        )
         return False
     # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
     # str, which would turn an unauthenticated request into a 500 not a 403.
     if not secrets.compare_digest(auth[7:].encode("utf-8"), AGENT_API_KEY.encode("utf-8")):
-        json_response(handler, 403, {"error": "Invalid API key"})
+        json_response(handler, 403, {"error": "Invalid API key"}, no_store=True)
         return False
     return True
 
@@ -6091,6 +6115,79 @@ def read_optional_json_body(handler) -> dict | None:
         json_response(handler, 400, {"error": "JSON body must be an object"})
         return None
     return data
+
+
+def _assistant_secret_pairs(pairs: list[tuple[str, object]]) -> dict:
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError("duplicate-key")
+        value[key] = item
+    return value
+
+
+def _reject_assistant_secret_number(_value: str) -> None:
+    raise ValueError("non-integer-number")
+
+
+def _read_assistant_secret_body(handler) -> dict | None:
+    """Read one unambiguous bounded JSON object without echoing its values."""
+    lengths = handler.headers.get_all("Content-Length", [])
+    transfer = handler.headers.get_all("Transfer-Encoding", [])
+    if (
+        len(lengths) != 1
+        or transfer
+        or re.fullmatch(r"[0-9]{1,7}", lengths[0]) is None
+    ):
+        json_response(
+            handler,
+            400,
+            {"error": {"code": "invalid-secret-request-framing"}},
+            no_store=True,
+        )
+        return None
+    length = int(lengths[0])
+    if length <= 0 or length > _ASSISTANT_SECRET_MAX_BODY:
+        json_response(
+            handler,
+            413 if length > _ASSISTANT_SECRET_MAX_BODY else 400,
+            {"error": {"code": "secret-request-size"}},
+            no_store=True,
+        )
+        return None
+    raw = handler.rfile.read(length)
+    if len(raw) != length:
+        json_response(
+            handler,
+            400,
+            {"error": {"code": "incomplete-secret-request"}},
+            no_store=True,
+        )
+        return None
+    try:
+        value = json.loads(
+            raw.decode("utf-8", errors="strict"),
+            object_pairs_hook=_assistant_secret_pairs,
+            parse_float=_reject_assistant_secret_number,
+            parse_constant=_reject_assistant_secret_number,
+        )
+    except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
+        json_response(
+            handler,
+            400,
+            {"error": {"code": "invalid-secret-request"}},
+            no_store=True,
+        )
+        return None
+    if type(value) is not dict:
+        json_response(
+            handler,
+            400,
+            {"error": {"code": "invalid-secret-request"}},
+            no_store=True,
+        )
+        return None
+    return value
 
 
 def validate_service_id(handler, body: dict) -> str | None:
@@ -6421,7 +6518,10 @@ class AgentHandler(BaseHTTPRequestHandler):
     protocol_version = "HTTP/1.1"
 
     def log_message(self, fmt, *args):
-        logger.info(fmt, *args)
+        logger.info(
+            _redact_http_request_target(fmt),
+            *(_redact_http_request_target(value) for value in args),
+        )
 
     def do_GET(self):
         parsed = urlparse(self.path)
@@ -6510,6 +6610,70 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 503, {"error": "access-transition-unavailable"})
         finally:
             _end_model_lifecycle("pixel_access_mode")
+
+    def _handle_assistant_first_secrets(self, action: str) -> None:
+        """Keep configuration secrets inside the authenticated host boundary."""
+        if not check_auth(self):
+            return
+        if not ASSISTANT_TRANSACTIONS_ENABLED:
+            json_response(
+                self,
+                404,
+                {"error": {"code": "not-found"}},
+                no_store=True,
+            )
+            return
+        body = _read_assistant_secret_body(self)
+        if body is None:
+            return
+        if _AssistantFirstSecretStore is None:
+            json_response(
+                self,
+                503,
+                {"error": {"code": "secret-store-unavailable"}},
+                no_store=True,
+            )
+            return
+        try:
+            store = _AssistantFirstSecretStore(DATA_DIR)
+            operation = {
+                "stage": store.stage,
+                "status": store.status,
+                "delete": store.delete,
+            }[action]
+            result = operation(body)
+            json_response(self, 200, result, no_store=True)
+        except _AssistantFirstSecretStoreError as exc:
+            code = getattr(exc, "code", "secret-store-unavailable")
+            if not isinstance(code, str):
+                code = "secret-store-unavailable"
+            if code == "secret-record-not-found":
+                status_code = 404
+            elif code == "secret-store-platform-unqualified":
+                status_code = 501
+            elif code in {
+                "secret-binding-mismatch",
+                "secret-reference-mismatch",
+                "secret-idempotency-conflict",
+            }:
+                status_code = 409
+            elif code.startswith("invalid-") or code == "secret-document-too-large":
+                status_code = 400
+            else:
+                status_code = 503
+            json_response(
+                self,
+                status_code,
+                {"error": {"code": code}},
+                no_store=True,
+            )
+        except (KeyError, OSError, TypeError, ValueError):
+            json_response(
+                self,
+                503,
+                {"error": {"code": "secret-store-unavailable"}},
+                no_store=True,
+            )
 
     def _handle_pixel_ops_status(self, query: dict[str, list[str]]):
         """Return one exact, nonsecret Operations result projection.
@@ -6953,7 +7117,13 @@ class AgentHandler(BaseHTTPRequestHandler):
         # parsed as the next request on an HTTP/1.1 keep-alive connection. GET
         # polling remains reusable, which is where connection churn matters.
         self.close_connection = True
-        if self.path == "/v1/pixel/access-mode":
+        if self.path in {
+            "/v1/assistant-first/secrets/stage",
+            "/v1/assistant-first/secrets/status",
+            "/v1/assistant-first/secrets/delete",
+        }:
+            self._handle_assistant_first_secrets(self.path.rsplit("/", 1)[1])
+        elif self.path == "/v1/pixel/access-mode":
             self._handle_pixel_access_mode(True)
         elif self.path in ("/v1/extension/start", "/v1/extension/stop"):
             action = "start" if self.path.endswith("/start") else "stop"
@@ -15494,7 +15664,8 @@ def _request_server_shutdown(server, signum=None):
 
 
 def main():
-    global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, GPU_BACKEND, STARTUP_ODS_MODE
+    global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, ASSISTANT_TRANSACTIONS_ENABLED
+    global GPU_BACKEND, STARTUP_ODS_MODE
     global TIER, GPU_COUNT, CORE_SERVICE_IDS
     global USER_EXTENSIONS_DIR, EXTENSIONS_DIR, ODS_VERSION
 
@@ -15530,6 +15701,9 @@ def main():
     if not AGENT_API_KEY:
         logger.error("Neither ODS_AGENT_KEY nor DASHBOARD_API_KEY set in .env")
         sys.exit(1)
+    ASSISTANT_TRANSACTIONS_ENABLED = _env_value_is_true(
+        env.get("ODS_ASSISTANT_TRANSACTIONS_ENABLED")
+    )
     GPU_BACKEND = env.get("GPU_BACKEND", "nvidia")
     if _switchboard_state is not None:
         try:

--- a/ods/docs/ADR-ASSISTANT-FIRST-SECRET-CUSTODY.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-SECRET-CUSTODY.md
@@ -1,0 +1,79 @@
+# ADR: Assistant First host-owned secret custody
+
+## Status
+
+Accepted for the opt-in Assistant First source path. The feature remains off
+unless `ODS_ASSISTANT_TRANSACTIONS_ENABLED` is explicitly enabled. Linux is the
+only qualified custody platform in this phase; existing Windows and macOS
+installation paths are unchanged.
+
+## Decision
+
+Assistant First configuration secrets are staged by the native ODS host agent,
+not by the assistant runtime or Dashboard transaction store. The host stores one
+owner-only record per extension transaction under:
+
+```text
+<ODS_DATA_DIR>/assistant-first/secrets/<transaction-id>.json
+```
+
+The record is bound to the exact transaction ID, plan hash, and configuration
+schema hash. Its public handle is a random opaque reference. Secret-derived
+digests are not returned or persisted outside the record because low-entropy
+values could otherwise be guessed offline.
+
+The authenticated host API exposes only three feature-gated POST operations:
+
+- `/v1/assistant-first/secrets/stage`
+- `/v1/assistant-first/secrets/status`
+- `/v1/assistant-first/secrets/delete`
+
+Stage accepts secret values once and returns only the opaque reference, binding
+hashes, and sorted presence keys. Status requires the complete binding and the
+opaque reference. Delete is idempotent when the transaction has no record, but
+an existing record is deleted only when every binding and the reference match.
+No operation returns secret values, byte counts, content hashes, timestamps, or
+submitted values in an error.
+
+## Filesystem contract
+
+The first qualified implementation is POSIX dirfd-based and fails closed unless
+`O_DIRECTORY`, `O_NOFOLLOW`, and advisory file locking are available. It:
+
+- verifies the data root is an owner-controlled directory that is not group or
+  world writable;
+- creates the `assistant-first` and `secrets` directories with mode `0700`;
+- opens every directory and file relative to a verified directory descriptor;
+- rejects symlinks, non-regular files, hard-linked records, unexpected owners,
+  broad file modes, and inode swaps;
+- serializes processes with an owner-only advisory lock;
+- writes same-directory temporary files with mode `0600`, fsyncs the file,
+  atomically replaces the record, and fsyncs the directory;
+- removes only strictly named, owner-only orphan temporary files while holding
+  the lock; and
+- treats a corrupt record as an integrity failure rather than overwriting it.
+
+The on-disk record is the secret store itself and therefore necessarily contains
+the values. Plans, approvals, configuration receipts, transaction journals,
+lockfiles, API responses, logs, browser persistence, and model context may store
+only the opaque reference and presence state.
+
+## Idempotency and replacement
+
+A repeated stage with the same idempotency key and byte-identical canonical
+secret map returns the original reference. Reusing an idempotency key with
+different values fails. A new idempotency key atomically replaces the prior
+record and produces a new reference, invalidating the previous one.
+
+## Deferred integration
+
+This phase intentionally does not wire Dashboard request bodies to the host
+agent. The next stacked change must load the plan envelope and expected plan
+hash from the durable `TransactionStore`, validate configuration with the full
+Manifest v2 schema, send secret values directly to this host endpoint, and
+persist only non-secret values plus the opaque reference. It must revalidate the
+reference and all hashes immediately before approval and apply.
+
+Windows and macOS require separate platform-secret-provider, service-management,
+backup, update, and rollback qualification before these routes can be enabled on
+those systems.

--- a/ods/tests/test_assistant_first_secret_store.py
+++ b/ods/tests/test_assistant_first_secret_store.py
@@ -1,0 +1,441 @@
+"""Linux custody and real host-HTTP tests for Assistant First secrets."""
+
+import http.client
+import importlib.util
+import json
+import os
+import stat
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from http.server import ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.name != "posix", reason="Assistant First secret custody is Linux-first"
+)
+
+BIN_DIR = Path(__file__).resolve().parents[1] / "bin"
+_store_spec = importlib.util.spec_from_file_location(
+    "assistant_first_secret_store", BIN_DIR / "assistant_first_secret_store.py"
+)
+_store_module = importlib.util.module_from_spec(_store_spec)
+sys.modules[_store_spec.name] = _store_module
+_store_spec.loader.exec_module(_store_module)
+AssistantFirstSecretStore = _store_module.AssistantFirstSecretStore
+DELETE_REQUEST_SCHEMA = _store_module.DELETE_REQUEST_SCHEMA
+STAGE_REQUEST_SCHEMA = _store_module.STAGE_REQUEST_SCHEMA
+STATUS_REQUEST_SCHEMA = _store_module.STATUS_REQUEST_SCHEMA
+SecretStoreError = _store_module.SecretStoreError
+
+
+TXN = "txn-" + "1" * 24
+PLAN = "2" * 64
+SCHEMA_HASH = "3" * 64
+IDEMPOTENCY = "4" * 64
+SECRET_VALUE = "do-not-echo-super-secret"
+
+
+def stage_request(**changes):
+    value = {
+        "schema": STAGE_REQUEST_SCHEMA,
+        "transactionId": TXN,
+        "planHash": PLAN,
+        "schemaHash": SCHEMA_HASH,
+        "idempotencyKey": IDEMPOTENCY,
+        "secretValues": {"EXAMPLE_API_KEY": SECRET_VALUE},
+    }
+    value.update(changes)
+    return value
+
+
+def bound_request(schema, reference, **changes):
+    value = {
+        "schema": schema,
+        "transactionId": TXN,
+        "planHash": PLAN,
+        "schemaHash": SCHEMA_HASH,
+        "reference": reference,
+    }
+    value.update(changes)
+    return value
+
+
+def error_code(call):
+    with pytest.raises(SecretStoreError) as raised:
+        call()
+    assert SECRET_VALUE not in str(raised.value)
+    assert SECRET_VALUE not in repr(raised.value)
+    return raised.value.code
+
+
+def test_stage_status_delete_round_trip_is_redacted_and_restrictive(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    staged = store.stage(stage_request())
+    response_text = json.dumps(staged)
+    assert staged["configured"] is True
+    assert staged["presentSecretKeys"] == ["EXAMPLE_API_KEY"]
+    assert staged["duplicate"] is False
+    assert SECRET_VALUE not in response_text
+    assert "secretValues" not in response_text
+
+    secret_dir = tmp_path / "assistant-first" / "secrets"
+    record_path = secret_dir / f"{TXN}.json"
+    assert stat.S_IMODE(secret_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(record_path.stat().st_mode) == 0o600
+    assert record_path.stat().st_nlink == 1
+
+    status = store.status(bound_request(STATUS_REQUEST_SCHEMA, staged["reference"]))
+    assert status == {key: value for key, value in staged.items() if key != "duplicate"}
+    assert SECRET_VALUE not in json.dumps(status)
+
+    deleted = store.delete(bound_request(DELETE_REQUEST_SCHEMA, staged["reference"]))
+    assert deleted["deleted"] is True
+    assert deleted["configured"] is False
+    assert not record_path.exists()
+    repeated = store.delete(bound_request(DELETE_REQUEST_SCHEMA, staged["reference"]))
+    assert repeated["deleted"] is False
+
+
+def test_idempotent_stage_reuses_reference_and_conflict_is_value_free(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    first = store.stage(stage_request())
+    second = store.stage(stage_request())
+    assert second["duplicate"] is True
+    assert second["reference"] == first["reference"]
+    code = error_code(
+        lambda: store.stage(
+            stage_request(secretValues={"EXAMPLE_API_KEY": "different-secret"})
+        )
+    )
+    assert code == "secret-idempotency-conflict"
+
+
+def test_new_idempotency_key_atomically_replaces_reference(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    first = store.stage(stage_request())
+    second = store.stage(
+        stage_request(
+            idempotencyKey="5" * 64,
+            secretValues={"EXAMPLE_API_KEY": "replacement-secret"},
+        )
+    )
+    assert second["reference"] != first["reference"]
+    assert (
+        error_code(
+            lambda: store.status(
+                bound_request(STATUS_REQUEST_SCHEMA, first["reference"])
+            )
+        )
+        == "secret-reference-mismatch"
+    )
+    assert store.status(bound_request(STATUS_REQUEST_SCHEMA, second["reference"]))[
+        "configured"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("transactionId", "txn-" + "a" * 23 + "/", "invalid-transaction-id"),
+        ("planHash", "A" * 64, "invalid-plan-hash"),
+        ("schemaHash", "z" * 64, "invalid-schema-hash"),
+        ("idempotencyKey", True, "invalid-idempotency-key"),
+        ("secretValues", {}, "invalid-secret-values"),
+        ("secretValues", {"bad-key": "secret"}, "invalid-secret-key"),
+        ("secretValues", {"API_KEY": ""}, "invalid-secret-value"),
+        ("secretValues", {"API_KEY": None}, "invalid-secret-value"),
+        ("secretValues", {"API_KEY": 1.25}, "invalid-secret-value"),
+        ("secretValues", {"API_KEY": {"nested": "secret"}}, "invalid-secret-value"),
+    ],
+)
+def test_invalid_stage_is_rejected_before_state_creation(
+    tmp_path, field, value, expected
+):
+    store = AssistantFirstSecretStore(tmp_path)
+    assert error_code(lambda: store.stage(stage_request(**{field: value}))) == expected
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_multiline_secret_is_supported_but_never_projected(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    secret = "-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----\n"
+    result = store.stage(stage_request(secretValues={"SSH_PRIVATE_KEY": secret}))
+    assert result["presentSecretKeys"] == ["SSH_PRIVATE_KEY"]
+    assert secret not in json.dumps(result)
+
+
+def test_binding_and_reference_substitution_cannot_read_or_delete(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    staged = store.stage(stage_request())
+    wrong_plan = bound_request(
+        STATUS_REQUEST_SCHEMA, staged["reference"], planHash="6" * 64
+    )
+    assert error_code(lambda: store.status(wrong_plan)) == "secret-binding-mismatch"
+    wrong_ref = bound_request(DELETE_REQUEST_SCHEMA, "secret-v1-" + "7" * 48)
+    assert error_code(lambda: store.delete(wrong_ref)) == "secret-reference-mismatch"
+    assert store.status(bound_request(STATUS_REQUEST_SCHEMA, staged["reference"]))[
+        "configured"
+    ]
+
+
+def test_symlink_hardlink_and_broad_permissions_fail_closed(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    staged = store.stage(stage_request())
+    record = tmp_path / "assistant-first" / "secrets" / f"{TXN}.json"
+    outside = tmp_path / "outside"
+    outside.write_text("untouched", encoding="utf-8")
+
+    record.unlink()
+    record.symlink_to(outside)
+    assert error_code(lambda: store.stage(stage_request())) == "secret-record-integrity"
+    assert outside.read_text(encoding="utf-8") == "untouched"
+
+    record.unlink()
+    replaced = store.stage(stage_request(idempotencyKey="8" * 64))
+    hardlink = tmp_path / "hardlink"
+    os.link(record, hardlink)
+    assert (
+        error_code(
+            lambda: store.status(
+                bound_request(STATUS_REQUEST_SCHEMA, replaced["reference"])
+            )
+        )
+        == "secret-record-integrity"
+    )
+    hardlink.unlink()
+    record.chmod(0o644)
+    assert (
+        error_code(
+            lambda: store.status(
+                bound_request(STATUS_REQUEST_SCHEMA, replaced["reference"])
+            )
+        )
+        == "secret-record-integrity"
+    )
+    assert staged["reference"] != replaced["reference"]
+
+
+def test_symlinked_data_root_and_writable_root_are_rejected(tmp_path):
+    real = tmp_path / "real"
+    real.mkdir()
+    linked = tmp_path / "linked"
+    linked.symlink_to(real, target_is_directory=True)
+    assert (
+        error_code(lambda: AssistantFirstSecretStore(linked).stage(stage_request()))
+        == "secret-store-root-integrity"
+    )
+
+    real.chmod(0o777)
+    assert (
+        error_code(lambda: AssistantFirstSecretStore(real).stage(stage_request()))
+        == "secret-store-root-permissions"
+    )
+
+
+def test_corrupt_record_is_not_replaced_or_echoed(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    staged = store.stage(stage_request())
+    record = tmp_path / "assistant-first" / "secrets" / f"{TXN}.json"
+    corrupt = b'{"secretValues":{"API_KEY":"do-not-echo-corrupt"}}'
+    record.write_bytes(corrupt)
+    record.chmod(0o600)
+    assert (
+        error_code(
+            lambda: store.status(
+                bound_request(STATUS_REQUEST_SCHEMA, staged["reference"])
+            )
+        )
+        == "secret-record-integrity"
+    )
+    assert record.read_bytes() == corrupt
+
+
+def test_interrupted_temporary_file_is_recovered_under_lock(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    staged = store.stage(stage_request())
+    secret_dir = tmp_path / "assistant-first" / "secrets"
+    orphan = secret_dir / (f".{TXN}.json." + "a" * 24 + ".tmp")
+    orphan.write_text("orphan-secret", encoding="utf-8")
+    orphan.chmod(0o600)
+    assert store.status(bound_request(STATUS_REQUEST_SCHEMA, staged["reference"]))[
+        "configured"
+    ]
+    assert not orphan.exists()
+
+
+def test_unsafe_temporary_entry_blocks_recovery_without_following(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    staged = store.stage(stage_request())
+    secret_dir = tmp_path / "assistant-first" / "secrets"
+    outside = tmp_path / "outside-temporary"
+    outside.write_text("untouched", encoding="utf-8")
+    orphan = secret_dir / (f".{TXN}.json." + "b" * 24 + ".tmp")
+    orphan.symlink_to(outside)
+    assert (
+        error_code(
+            lambda: store.status(
+                bound_request(STATUS_REQUEST_SCHEMA, staged["reference"])
+            )
+        )
+        == "secret-temporary-integrity"
+    )
+    assert outside.read_text(encoding="utf-8") == "untouched"
+
+
+def test_concurrent_same_request_has_one_record_and_one_reference(tmp_path):
+    store = AssistantFirstSecretStore(tmp_path)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _item: store.stage(stage_request()), range(16)))
+    assert len({result["reference"] for result in results}) == 1
+    assert sum(result["duplicate"] is False for result in results) == 1
+    assert sum(result["duplicate"] is True for result in results) == 15
+
+
+@pytest.fixture(scope="module")
+def host_server():
+    path = BIN_DIR / "ods-host-agent.py"
+    spec = importlib.util.spec_from_file_location("_assistant_secret_host_agent", path)
+    agent = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = agent
+    spec.loader.exec_module(agent)
+    agent.AGENT_API_KEY = "synthetic-secret-host-key"
+    agent.ASSISTANT_TRANSACTIONS_ENABLED = True
+    listener = ThreadingHTTPServer(("127.0.0.1", 0), agent.AgentHandler)
+    thread = threading.Thread(target=listener.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield agent, listener
+    finally:
+        listener.shutdown()
+        listener.server_close()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+        sys.modules.pop(spec.name, None)
+
+
+@pytest.fixture
+def host_request(host_server, tmp_path):
+    agent, listener = host_server
+    agent.DATA_DIR = tmp_path
+
+    def call(path, body=None, *, raw=None, token="synthetic-secret-host-key"):
+        connection = http.client.HTTPConnection(*listener.server_address, timeout=5)
+        try:
+            payload = raw if raw is not None else json.dumps(body).encode("utf-8")
+            connection.request(
+                "POST",
+                path,
+                body=payload,
+                headers={"Authorization": "Bearer " + token},
+            )
+            response = connection.getresponse()
+            document = json.loads(response.read())
+            if "?" not in path:
+                assert "no-store" in response.getheader("Cache-Control", "")
+            return response.status, document
+        finally:
+            connection.close()
+
+    return call
+
+
+def test_real_host_http_round_trip_never_echoes_secret(host_request):
+    status, staged = host_request("/v1/assistant-first/secrets/stage", stage_request())
+    assert status == 200
+    assert SECRET_VALUE not in json.dumps(staged)
+    reference = staged["reference"]
+    status, present = host_request(
+        "/v1/assistant-first/secrets/status",
+        bound_request(STATUS_REQUEST_SCHEMA, reference),
+    )
+    assert status == 200 and present["configured"] is True
+    status, deleted = host_request(
+        "/v1/assistant-first/secrets/delete",
+        bound_request(DELETE_REQUEST_SCHEMA, reference),
+    )
+    assert status == 200 and deleted["deleted"] is True
+    assert SECRET_VALUE not in json.dumps([staged, present, deleted])
+
+
+def test_host_auth_and_bad_json_do_not_create_secret_state(host_request, tmp_path):
+    assert (
+        host_request(
+            "/v1/assistant-first/secrets/stage",
+            stage_request(),
+            token="wrong",
+        )[0]
+        == 403
+    )
+    raw = (
+        b'{"schema":"' + STAGE_REQUEST_SCHEMA.encode() + b'",'
+        b'"schema":"duplicate","secretValues":{"API_KEY":"do-not-echo"}}'
+    )
+    status, result = host_request("/v1/assistant-first/secrets/stage", raw=raw)
+    assert status == 400
+    assert "do-not-echo" not in json.dumps(result)
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_host_feature_gate_fails_closed_before_secret_state(
+    host_server, host_request, tmp_path
+):
+    agent, _listener = host_server
+    agent.ASSISTANT_TRANSACTIONS_ENABLED = False
+    try:
+        status, result = host_request(
+            "/v1/assistant-first/secrets/stage", stage_request()
+        )
+    finally:
+        agent.ASSISTANT_TRANSACTIONS_ENABLED = True
+    assert status == 404
+    assert result == {"error": {"code": "not-found"}}
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_host_rejects_float_oversize_and_query_routes(host_request, tmp_path):
+    status, result = host_request(
+        "/v1/assistant-first/secrets/stage", raw=b'{"secretValues":{"API_KEY":1.5}}'
+    )
+    assert status == 400 and "1.5" not in json.dumps(result)
+    assert (
+        host_request("/v1/assistant-first/secrets/stage", raw=b"x" * (64 * 1024 + 1))[0]
+        == 413
+    )
+    assert (
+        host_request(
+            "/v1/assistant-first/secrets/stage?transactionId=" + TXN,
+            stage_request(),
+        )[0]
+        == 404
+    )
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    "request_line",
+    [
+        "POST /v1/assistant-first/secrets/stage?apiKey=do-not-log-me HTTP/1.1",
+        "GET /v1/assistant-first/secrets/stage?apiKey=do-not-log-me",
+        "/v1/assistant-first/secrets/stage?apiKey=do-not-log-me",
+    ],
+)
+def test_host_request_logging_redacts_query_data(host_server, request_line):
+    agent, _listener = host_server
+
+    redacted = agent._redact_http_request_target(request_line)
+
+    assert "?[REDACTED]" in redacted
+    assert "do-not-log-me" not in redacted
+
+
+def test_host_request_logging_redacts_dynamic_format_text(host_server):
+    agent, _listener = host_server
+
+    redacted = agent._redact_http_request_target(
+        "request /path?token=do-not-log-me failed: %s"
+    )
+
+    assert redacted == "request /path?[REDACTED] failed: %s"


### PR DESCRIPTION
## Summary

- add a Linux-first, host-owned secret custody primitive for Assistant First transactions
- bind opaque random secret references to the exact transaction, canonical plan hash, and configuration schema hash
- expose authenticated, POST-only stage/status/delete host endpoints behind the existing opt-in transaction feature flag
- fail closed on unsafe ownership, permissions, symlinks, hard links, inode races, corrupt records, invalid framing, and unsupported platforms
- keep secret values out of API responses, error messages, logs, plans, transaction receipts, and Dashboard state

## Security and recovery properties

- authenticate before feature-gate and body processing
- reject transfer encoding, ambiguous content lengths, oversized bodies, invalid UTF-8, duplicate JSON keys, floats, non-finite values, and unsupported secret types
- use owner-only directories and records, `O_NOFOLLOW`, inode/link checks, cross-process locking, same-directory atomic replacement, and file/directory `fsync`
- recover only strictly named, safely validated orphan temporary files
- make retries deterministic through idempotency-key and canonical-value binding
- redact query data from HTTP request-line logs and reject query-bearing secret routes
- return `Cache-Control: no-store` on authentication and custody responses

## Qualification

- Windows source checks: 14 client tests passed, 26 Linux-only custody tests skipped; 9 host authorization tests passed; focused Ruff and `git diff --check` clean
- Tower1 Linux pre-hardening SHA: 40 custody/client tests passed; 9 host authorization tests passed; focused Ruff and tree checks clean
- Tower3 Linux pre-hardening SHA: 40 custody/client tests passed; 9 host authorization tests passed; focused Ruff and tree checks clean
- Tower2 Linux final exact-SHA: 27 custody tests and 9 host authorization tests passed; the three async client-test failures were a missing sandbox plugin and the same client suite was already green on both Linux workers
- three independent security reviews plus a bounded final-delta review found no blocker at candidate `c66c9fb569bd817ef614184fcffafcf5711484de`

## Scope boundary

This stacked PR adds the host custody primitive only. It does not enable Assistant First by default, wire the Dashboard configuration bridge, install an extension, modify a live service, or claim an installed journey. The configuration API and runtime integration follow in the next phase.

Stacked on `feat/assistant-first-phase-4a-typed-config`.
