### PR TITLE
feat(extensions): add transactional configuration custody

### DIFF
--- a/ods/extensions/services/dashboard-api/assistant_first_secret_client.py
+++ b/ods/extensions/services/dashboard-api/assistant_first_secret_client.py
@@ -1,0 +1,223 @@
+"""Value-safe Dashboard client for host-owned Assistant First secret custody."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from host_agent_client import AgentClientError, request_json
+
+STAGE_REQUEST_SCHEMA = "ods.assistant-first.secret-stage-request.v1"
+STATUS_REQUEST_SCHEMA = "ods.assistant-first.secret-status-request.v1"
+DELETE_REQUEST_SCHEMA = "ods.assistant-first.secret-delete-request.v1"
+STATUS_SCHEMA = "ods.assistant-first.secret-status.v1"
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_TRANSACTION_RE = re.compile(r"^txn-[0-9a-f]{24}$")
+_REFERENCE_RE = re.compile(r"^secret-v1-[0-9a-f]{48}$")
+_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+_DELETE_RESPONSE_KEYS = frozenset(
+    {
+        "configured",
+        "deleted",
+        "planHash",
+        "presentSecretKeys",
+        "schema",
+        "schemaHash",
+        "transactionId",
+    }
+)
+
+
+class SecretCustodyError(RuntimeError):
+    """Stable custody failure whose text never contains submitted values."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+    def __repr__(self) -> str:
+        return f"SecretCustodyError({self.code!r})"
+
+
+def _fail(code: str) -> None:
+    raise SecretCustodyError(code)
+
+
+def _binding(transaction_id: str, plan_hash: str, schema_hash: str) -> None:
+    if not isinstance(transaction_id, str) or not _TRANSACTION_RE.fullmatch(
+        transaction_id
+    ):
+        _fail("secret-custody-invalid-binding")
+    if not isinstance(plan_hash, str) or not _HASH_RE.fullmatch(plan_hash):
+        _fail("secret-custody-invalid-binding")
+    if not isinstance(schema_hash, str) or not _HASH_RE.fullmatch(schema_hash):
+        _fail("secret-custody-invalid-binding")
+
+
+def _status(
+    response: Any,
+    *,
+    transaction_id: str,
+    plan_hash: str,
+    schema_hash: str,
+    reference: str | None,
+    stage: bool,
+) -> dict[str, Any]:
+    required = {
+        "schema",
+        "transactionId",
+        "planHash",
+        "schemaHash",
+        "configured",
+        "presentSecretKeys",
+    }
+    allowed = required | {"reference", "duplicate"} if stage else required | {
+        "reference"
+    }
+    if not isinstance(response, dict) or not required <= set(response) <= allowed:
+        _fail("secret-custody-invalid-response")
+    if (
+        response["schema"] != STATUS_SCHEMA
+        or response["transactionId"] != transaction_id
+        or response["planHash"] != plan_hash
+        or response["schemaHash"] != schema_hash
+        or response["configured"] is not True
+    ):
+        _fail("secret-custody-binding-mismatch")
+    actual_reference = response.get("reference")
+    if not isinstance(actual_reference, str) or not _REFERENCE_RE.fullmatch(
+        actual_reference
+    ):
+        _fail("secret-custody-invalid-response")
+    if reference is not None and actual_reference != reference:
+        _fail("secret-custody-binding-mismatch")
+    keys = response["presentSecretKeys"]
+    if (
+        not isinstance(keys, list)
+        or keys != sorted(set(keys))
+        or any(not isinstance(key, str) or not _KEY_RE.fullmatch(key) for key in keys)
+    ):
+        _fail("secret-custody-invalid-response")
+    if stage and type(response.get("duplicate")) is not bool:
+        _fail("secret-custody-invalid-response")
+    return dict(response)
+
+
+class HostSecretCustodian:
+    """Stage and verify secrets through fixed POST-only host-agent routes."""
+
+    def __init__(self, requester: Callable[..., dict[str, Any]] = request_json) -> None:
+        self._request = requester
+
+    def stage(
+        self,
+        *,
+        transaction_id: str,
+        plan_hash: str,
+        schema_hash: str,
+        idempotency_key: str,
+        secret_values: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        _binding(transaction_id, plan_hash, schema_hash)
+        payload = {
+            "schema": STAGE_REQUEST_SCHEMA,
+            "transactionId": transaction_id,
+            "planHash": plan_hash,
+            "schemaHash": schema_hash,
+            "idempotencyKey": idempotency_key,
+            "secretValues": dict(secret_values),
+        }
+        try:
+            response = self._request(
+                "POST",
+                "/v1/assistant-first/secrets/stage",
+                payload=payload,
+                timeout=10.0,
+            )
+        except AgentClientError:
+            _fail("secret-custody-unavailable")
+        return _status(
+            response,
+            transaction_id=transaction_id,
+            plan_hash=plan_hash,
+            schema_hash=schema_hash,
+            reference=None,
+            stage=True,
+        )
+
+    def status(
+        self,
+        *,
+        transaction_id: str,
+        plan_hash: str,
+        schema_hash: str,
+        reference: str,
+    ) -> dict[str, Any]:
+        _binding(transaction_id, plan_hash, schema_hash)
+        payload = {
+            "schema": STATUS_REQUEST_SCHEMA,
+            "transactionId": transaction_id,
+            "planHash": plan_hash,
+            "schemaHash": schema_hash,
+            "reference": reference,
+        }
+        try:
+            response = self._request(
+                "POST",
+                "/v1/assistant-first/secrets/status",
+                payload=payload,
+                timeout=5.0,
+            )
+        except AgentClientError:
+            _fail("secret-custody-unavailable")
+        return _status(
+            response,
+            transaction_id=transaction_id,
+            plan_hash=plan_hash,
+            schema_hash=schema_hash,
+            reference=reference,
+            stage=False,
+        )
+
+    def delete(
+        self,
+        *,
+        transaction_id: str,
+        plan_hash: str,
+        schema_hash: str,
+        reference: str,
+    ) -> dict[str, Any]:
+        _binding(transaction_id, plan_hash, schema_hash)
+        payload = {
+            "schema": DELETE_REQUEST_SCHEMA,
+            "transactionId": transaction_id,
+            "planHash": plan_hash,
+            "schemaHash": schema_hash,
+            "reference": reference,
+        }
+        try:
+            response = self._request(
+                "POST",
+                "/v1/assistant-first/secrets/delete",
+                payload=payload,
+                timeout=5.0,
+            )
+        except AgentClientError:
+            _fail("secret-custody-unavailable")
+        if (
+            not isinstance(response, dict)
+            or set(response) != _DELETE_RESPONSE_KEYS
+            or response["schema"] != STATUS_SCHEMA
+            or response["transactionId"] != transaction_id
+            or response["planHash"] != plan_hash
+            or response["schemaHash"] != schema_hash
+            or response["configured"] is not False
+            or type(response["deleted"]) is not bool
+            or response["presentSecretKeys"] != []
+        ):
+            _fail("secret-custody-invalid-response")
+        return dict(response)
+
+
+__all__ = ["HostSecretCustodian", "SecretCustodyError"]

--- a/ods/extensions/services/dashboard-api/extension_configuration.py
+++ b/ods/extensions/services/dashboard-api/extension_configuration.py
@@ -16,7 +16,6 @@ from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlsplit
 
-
 _PLAN_SCHEMA = "ods.assistant-first.plan.v1"
 _SCHEMA = "ods.assistant-first.configuration-schema.v1"
 _RECEIPT_SCHEMA = "ods.assistant-first.configuration-validation.v1"
@@ -440,20 +439,12 @@ def configuration_schema(
     }
 
 
-def validate_configuration_submission(
-    envelope: Any,
-    values: Any,
-    secret_values: Any,
-    *,
-    expected_plan_hash: str,
-) -> dict[str, Any]:
-    """Validate user input and return only redacted presence/default metadata."""
-    plan, plan_hash = _verified_plan(envelope, expected_plan_hash)
-    contracts = _configuration_contracts(plan)
-    value_map = _mapping(values, "values")
-    secret_map = _mapping(secret_values, "secretValues")
+def _validate_configuration_presence(
+    contracts: Mapping[str, Mapping[str, Any]],
+    value_map: Mapping[str, Any],
+    secret_keys: set[str],
+) -> dict[str, list[str]]:
     value_keys = set(value_map)
-    secret_keys = set(secret_map)
     if value_keys & secret_keys:
         _fail("duplicate-submission-key", keys=sorted(value_keys & secret_keys))
     unknown = (value_keys | secret_keys) - set(contracts)
@@ -496,15 +487,7 @@ def validate_configuration_submission(
 
     for key in sorted(value_keys):
         _validate_value(value_map[key], contracts[key], f"values.{key}")
-    for key in sorted(secret_keys):
-        _validate_value(secret_map[key], contracts[key], f"secretValues.{key}")
-
-    schema_document = _configuration_schema_document(contracts)
-    schema_hash = hashlib.sha256(_canonical_json_bytes(schema_document)).hexdigest()
     return {
-        "schema": _RECEIPT_SCHEMA,
-        "planHash": plan_hash,
-        "schemaHash": schema_hash,
         "presentConfigKeys": sorted(value_keys),
         "presentSecretKeys": sorted(secret_keys),
         "appliedDefaultKeys": sorted(
@@ -515,4 +498,62 @@ def validate_configuration_submission(
             and "default" in item
             and key not in value_keys
         ),
+    }
+
+
+def validate_configuration_submission(
+    envelope: Any,
+    values: Any,
+    secret_values: Any,
+    *,
+    expected_plan_hash: str,
+) -> dict[str, Any]:
+    """Validate user input and return only redacted presence/default metadata."""
+    plan, plan_hash = _verified_plan(envelope, expected_plan_hash)
+    contracts = _configuration_contracts(plan)
+    value_map = _mapping(values, "values")
+    secret_map = _mapping(secret_values, "secretValues")
+    presence = _validate_configuration_presence(
+        contracts, value_map, set(secret_map)
+    )
+    for key in sorted(secret_map):
+        _validate_value(secret_map[key], contracts[key], f"secretValues.{key}")
+
+    schema_document = _configuration_schema_document(contracts)
+    schema_hash = hashlib.sha256(_canonical_json_bytes(schema_document)).hexdigest()
+    return {
+        "schema": _RECEIPT_SCHEMA,
+        "planHash": plan_hash,
+        "schemaHash": schema_hash,
+        **presence,
+    }
+
+
+def validate_stored_configuration(
+    envelope: Any,
+    values: Any,
+    present_secret_keys: Any,
+    *,
+    expected_plan_hash: str,
+    expected_schema_hash: str,
+) -> dict[str, Any]:
+    """Revalidate durable non-secret values and secret presence without values."""
+    plan, plan_hash = _verified_plan(envelope, expected_plan_hash)
+    contracts = _configuration_contracts(plan)
+    value_map = _mapping(values, "values")
+    secret_keys = _safe_key_list(present_secret_keys, "presentSecretKeys")
+    if secret_keys != sorted(secret_keys):
+        _fail("invalid-secret-presence-order")
+    schema_document = _configuration_schema_document(contracts)
+    schema_hash = hashlib.sha256(_canonical_json_bytes(schema_document)).hexdigest()
+    if expected_schema_hash != schema_hash:
+        _fail("stored-schema-hash-mismatch")
+    presence = _validate_configuration_presence(
+        contracts, value_map, set(secret_keys)
+    )
+    return {
+        "schema": _RECEIPT_SCHEMA,
+        "planHash": plan_hash,
+        "schemaHash": schema_hash,
+        **presence,
     }

--- a/ods/extensions/services/dashboard-api/extension_configuration.py
+++ b/ods/extensions/services/dashboard-api/extension_configuration.py
@@ -249,7 +249,10 @@ def _validate_value(value: Any, contract: Mapping[str, Any], field: str) -> None
 
     rules = contract.get("validation", {})
     if config_type in {"string", "url"}:
-        if len(value) < rules.get("minLength", 0):
+        minimum_length = rules.get("minLength", 0)
+        if contract["secret"]:
+            minimum_length = max(1, minimum_length)
+        if len(value) < minimum_length:
             _fail("configuration-value-too-short", field=field)
         if len(value) > rules.get("maxLength", _MAX_STRING_LENGTH):
             _fail("configuration-value-too-long", field=field)

--- a/ods/extensions/services/dashboard-api/extension_transaction_configuration.py
+++ b/ods/extensions/services/dashboard-api/extension_transaction_configuration.py
@@ -1,0 +1,217 @@
+"""Transactional bridge from typed configuration to host-owned secret custody."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from assistant_first_secret_client import SecretCustodyError
+from extension_configuration import (
+    ExtensionConfigurationError,
+    configuration_schema,
+    validate_configuration_submission,
+    validate_stored_configuration,
+)
+from extension_transactions import (
+    IntegrityError,
+    TransitionError,
+    ValidationRejected,
+)
+
+
+class TransactionConfigurationManager:
+    """Validate, stage, persist, and reverify one immutable configuration."""
+
+    def __init__(self, store: Any, secret_custodian: Any, clock: Any) -> None:
+        self._store = store
+        self._secret_custodian = secret_custodian
+        self._clock = clock
+
+    def view(self, transaction_id: str) -> dict[str, Any]:
+        loaded = self._store.read(transaction_id)
+        envelope = loaded["envelope"]
+        plan_hash = envelope["planHash"]
+        schema = self._schema(envelope, plan_hash, integrity=True)
+        record = loaded.get("configuration")
+        if record is None:
+            return {
+                "schema": "ods.assistant-first.transaction-configuration-view.v1",
+                "transactionId": transaction_id,
+                "planHash": plan_hash,
+                "schemaHash": schema["schemaHash"],
+                "fields": schema["fields"],
+                "configured": False,
+                "values": {},
+                "presentConfigKeys": [],
+                "presentSecretKeys": [],
+                "appliedDefaultKeys": [],
+            }
+        self._verify_record(loaded, schema)
+        return self._project(record, schema, duplicate=None)
+
+    def submit(
+        self,
+        transaction_id: str,
+        *,
+        plan_hash: str,
+        schema_hash: str,
+        idempotency_key: str,
+        values: dict[str, Any],
+        secret_values: dict[str, Any],
+    ) -> dict[str, Any]:
+        loaded = self._store.read(transaction_id)
+        if loaded["state"] != "awaiting_approval":
+            raise TransitionError("configuration-locked", loaded["state"])
+        envelope = loaded["envelope"]
+        if envelope["planHash"] != plan_hash:
+            raise ValidationRejected("plan-hash-mismatch")
+        schema = self._schema(envelope, plan_hash, integrity=False)
+        if schema["schemaHash"] != schema_hash:
+            raise ValidationRejected("schema-hash-mismatch")
+        try:
+            receipt = validate_configuration_submission(
+                envelope,
+                values,
+                secret_values,
+                expected_plan_hash=plan_hash,
+            )
+        except ExtensionConfigurationError as exc:
+            raise ValidationRejected(exc.code) from None
+        if receipt["presentSecretKeys"] and self._secret_custodian is None:
+            raise IntegrityError("secret-custody-unavailable")
+        timestamp = self._clock()
+        intent = self._store.begin_configuration_exact(
+            transaction_id,
+            plan_hash,
+            schema_hash,
+            idempotency_key,
+            values,
+            receipt["presentSecretKeys"],
+            receipt["appliedDefaultKeys"],
+            timestamp,
+            timestamp,
+        )
+
+        reference = None
+        custody_duplicate = True
+        if receipt["presentSecretKeys"]:
+            try:
+                staged = self._secret_custodian.stage(
+                    transaction_id=transaction_id,
+                    plan_hash=plan_hash,
+                    schema_hash=schema_hash,
+                    idempotency_key=idempotency_key,
+                    secret_values=secret_values,
+                )
+            except SecretCustodyError as exc:
+                raise IntegrityError(exc.code) from None
+            if staged.get("presentSecretKeys") != receipt["presentSecretKeys"]:
+                raise IntegrityError("secret-custody-presence-mismatch")
+            reference = staged.get("reference")
+            custody_duplicate = staged.get("duplicate") is True
+
+        finished = self._store.finish_configuration_exact(
+            transaction_id,
+            plan_hash,
+            idempotency_key,
+            reference,
+        )
+        duplicate = (
+            intent.get("duplicate") is True
+            and custody_duplicate
+            and finished.get("duplicate") is True
+        )
+        return self._project(finished, schema, duplicate=duplicate)
+
+    def require_ready(
+        self, transaction_id: str, plan_hash: str
+    ) -> dict[str, Any]:
+        loaded = self._store.read(transaction_id)
+        envelope = loaded["envelope"]
+        if envelope["planHash"] != plan_hash:
+            raise ValidationRejected("plan-hash-mismatch")
+        schema = self._schema(envelope, plan_hash, integrity=True)
+        record = loaded.get("configuration")
+        if record is None:
+            raise TransitionError("missing-configuration")
+        self._verify_record(loaded, schema)
+        if record["presentSecretKeys"]:
+            if self._secret_custodian is None:
+                raise IntegrityError("secret-custody-unavailable")
+            try:
+                status = self._secret_custodian.status(
+                    transaction_id=transaction_id,
+                    plan_hash=plan_hash,
+                    schema_hash=record["schemaHash"],
+                    reference=record["secretReference"],
+                )
+            except SecretCustodyError as exc:
+                raise IntegrityError(exc.code) from None
+            if status.get("presentSecretKeys") != record["presentSecretKeys"]:
+                raise IntegrityError("secret-custody-presence-mismatch")
+        return self._project(record, schema, duplicate=None)
+
+    @staticmethod
+    def _schema(
+        envelope: dict[str, Any], plan_hash: str, *, integrity: bool
+    ) -> dict[str, Any]:
+        try:
+            return configuration_schema(
+                envelope, expected_plan_hash=plan_hash
+            )
+        except ExtensionConfigurationError as exc:
+            if integrity:
+                raise IntegrityError("configuration-schema-invalid") from None
+            raise ValidationRejected(exc.code) from None
+
+    @staticmethod
+    def _verify_record(
+        loaded: dict[str, Any], schema: dict[str, Any]
+    ) -> None:
+        record = loaded["configuration"]
+        try:
+            receipt = validate_stored_configuration(
+                loaded["envelope"],
+                record["values"],
+                record["presentSecretKeys"],
+                expected_plan_hash=record["planHash"],
+                expected_schema_hash=record["schemaHash"],
+            )
+        except ExtensionConfigurationError:
+            raise IntegrityError("configuration-record-invalid") from None
+        for field in (
+            "planHash",
+            "schemaHash",
+            "presentConfigKeys",
+            "presentSecretKeys",
+            "appliedDefaultKeys",
+        ):
+            if record[field] != receipt[field]:
+                raise IntegrityError("configuration-record-invalid", field)
+        if record["schemaHash"] != schema["schemaHash"]:
+            raise IntegrityError("configuration-schema-mismatch")
+
+    @staticmethod
+    def _project(
+        record: dict[str, Any],
+        schema: dict[str, Any],
+        *,
+        duplicate: bool | None,
+    ) -> dict[str, Any]:
+        result = {
+            "schema": "ods.assistant-first.transaction-configuration-view.v1",
+            "transactionId": record["transactionId"],
+            "planHash": record["planHash"],
+            "schemaHash": record["schemaHash"],
+            "fields": schema["fields"],
+            "configured": True,
+            "values": dict(record["values"]),
+            "presentConfigKeys": list(record["presentConfigKeys"]),
+            "presentSecretKeys": list(record["presentSecretKeys"]),
+            "appliedDefaultKeys": list(record["appliedDefaultKeys"]),
+        }
+        if duplicate is not None:
+            result["duplicate"] = duplicate
+        return result
+
+
+__all__ = ["TransactionConfigurationManager"]

--- a/ods/extensions/services/dashboard-api/extension_transaction_configuration.py
+++ b/ods/extensions/services/dashboard-api/extension_transaction_configuration.py
@@ -33,18 +33,7 @@ class TransactionConfigurationManager:
         schema = self._schema(envelope, plan_hash, integrity=True)
         record = loaded.get("configuration")
         if record is None:
-            return {
-                "schema": "ods.assistant-first.transaction-configuration-view.v1",
-                "transactionId": transaction_id,
-                "planHash": plan_hash,
-                "schemaHash": schema["schemaHash"],
-                "fields": schema["fields"],
-                "configured": False,
-                "values": {},
-                "presentConfigKeys": [],
-                "presentSecretKeys": [],
-                "appliedDefaultKeys": [],
-            }
+            return self._empty_projection(transaction_id, plan_hash, schema)
         self._verify_record(loaded, schema)
         return self._project(record, schema, duplicate=None)
 
@@ -132,7 +121,9 @@ class TransactionConfigurationManager:
         schema = self._schema(envelope, plan_hash, integrity=True)
         record = loaded.get("configuration")
         if record is None:
-            raise TransitionError("missing-configuration")
+            if self._requires_configuration(envelope):
+                raise TransitionError("missing-configuration")
+            return self._empty_projection(transaction_id, plan_hash, schema)
         self._verify_record(loaded, schema)
         if record["presentSecretKeys"]:
             if self._secret_custodian is None:
@@ -149,6 +140,30 @@ class TransactionConfigurationManager:
             if status.get("presentSecretKeys") != record["presentSecretKeys"]:
                 raise IntegrityError("secret-custody-presence-mismatch")
         return self._project(record, schema, duplicate=None)
+
+    @staticmethod
+    def _requires_configuration(envelope: dict[str, Any]) -> bool:
+        plan = envelope["plan"]
+        return bool(plan["requiredConfigKeys"] or plan["requiredSecretKeys"])
+
+    @staticmethod
+    def _empty_projection(
+        transaction_id: str,
+        plan_hash: str,
+        schema: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "schema": "ods.assistant-first.transaction-configuration-view.v1",
+            "transactionId": transaction_id,
+            "planHash": plan_hash,
+            "schemaHash": schema["schemaHash"],
+            "fields": schema["fields"],
+            "configured": False,
+            "values": {},
+            "presentConfigKeys": [],
+            "presentSecretKeys": [],
+            "appliedDefaultKeys": [],
+        }
 
     @staticmethod
     def _schema(

--- a/ods/extensions/services/dashboard-api/extension_transaction_runtime.py
+++ b/ods/extensions/services/dashboard-api/extension_transaction_runtime.py
@@ -19,7 +19,6 @@ from extension_planning_contract import (
     manifest_from_catalog_entry,
 )
 
-
 CatalogProvider = Callable[[], tuple[list[dict[str, Any]], str]]
 ObservedStateProvider = Callable[[], dict[str, Any]]
 PolicyProvider = Callable[[], dict[str, Any]]
@@ -36,6 +35,7 @@ class TransactionRuntime:
     policy: PolicyProvider
     clock: Clock
     executor: Any | None = None
+    configuration: Any | None = None
 
 
 class CurrentInputsProvenanceVerifier:

--- a/ods/extensions/services/dashboard-api/extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/extension_transactions.py
@@ -1,12 +1,12 @@
 """Durable transaction store for assistant-first plans."""
 
-from datetime import datetime
 import hashlib
 import json
 import os
 import re
 import stat
 import threading
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -165,6 +165,29 @@ APPROVAL_KEYS = frozenset(
         "validUntil",
     }
 )
+CONFIGURATION_SCHEMA = "ods.assistant-first.transaction-configuration.v1"
+CONFIGURATION_INTENT_SCHEMA = (
+    "ods.assistant-first.transaction-configuration-intent.v1"
+)
+CONFIGURATION_KEYS = frozenset(
+    {
+        "actor",
+        "appliedDefaultKeys",
+        "configuredAt",
+        "idempotencyKey",
+        "planHash",
+        "presentConfigKeys",
+        "presentSecretKeys",
+        "schema",
+        "schemaHash",
+        "secretReference",
+        "transactionId",
+        "values",
+    }
+)
+CONFIGURATION_INTENT_KEYS = CONFIGURATION_KEYS - {"secretReference"}
+CONFIGURATION_KEY_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,127}$")
+SECRET_REFERENCE_RE = re.compile(r"^secret-v1-[0-9a-f]{48}$")
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -179,7 +202,7 @@ def _json_safe(v, depth=0):
     if v is None or isinstance(v, bool):
         return
     if isinstance(v, int):
-        if v < 0 or v > 2**53:
+        if v < -(2**53 - 1) or v > 2**53 - 1:
             raise ValidationRejected("integer-out-of-range")
         return
     if isinstance(v, float):
@@ -220,6 +243,129 @@ def canonical_json_bytes(value: Any) -> bytes:
         separators=(",", ":"),
     )
     return (text + "\n").encode("utf-8", errors="strict")
+
+
+def _configuration_key_list(value, field):
+    if not isinstance(value, list):
+        raise IntegrityError("configuration-invalid", field)
+    result = []
+    for item in value:
+        if not isinstance(item, str) or not CONFIGURATION_KEY_RE.fullmatch(item):
+            raise IntegrityError("configuration-invalid", field)
+        result.append(item)
+    if result != sorted(set(result)):
+        raise IntegrityError("configuration-invalid", field)
+    return result
+
+
+def _configuration_value(value):
+    if type(value) in {bool, int}:
+        if type(value) is int and not -(2**53 - 1) <= value <= 2**53 - 1:
+            raise IntegrityError("configuration-invalid", "values")
+        return
+    if (
+        isinstance(value, str)
+        and len(value) <= MAX_STRING_LEN
+        and not any(
+            ord(character) < 32
+            or ord(character) == 127
+            or 0xD800 <= ord(character) <= 0xDFFF
+            for character in value
+        )
+    ):
+        return
+    raise IntegrityError("configuration-invalid", "values")
+
+
+def _configuration_submission_values(value):
+    if type(value) is not dict or len(value) > MAX_DICT_KEYS:
+        raise ValidationRejected("invalid-configuration-values")
+    result = {}
+    for key, item in value.items():
+        if not isinstance(key, str) or not CONFIGURATION_KEY_RE.fullmatch(key):
+            raise ValidationRejected("invalid-configuration-values")
+        try:
+            _configuration_value(item)
+        except IntegrityError:
+            raise ValidationRejected("invalid-configuration-values") from None
+        result[key] = item
+    return result
+
+
+def _configuration_submission_keys(value, field):
+    if type(value) is not list:
+        raise ValidationRejected("invalid-configuration-keys", field)
+    try:
+        return _configuration_key_list(value, field)
+    except IntegrityError:
+        raise ValidationRejected("invalid-configuration-keys", field) from None
+
+
+def _validate_configuration_record(
+    record, transaction_id, envelope, binding, *, intent=False
+):
+    expected_keys = CONFIGURATION_INTENT_KEYS if intent else CONFIGURATION_KEYS
+    expected_schema = CONFIGURATION_INTENT_SCHEMA if intent else CONFIGURATION_SCHEMA
+    if not isinstance(record, dict) or set(record) != expected_keys:
+        raise IntegrityError("configuration-invalid", "fields")
+    if record["schema"] != expected_schema:
+        raise IntegrityError("configuration-invalid", "schema")
+    if record["transactionId"] != transaction_id:
+        raise IntegrityError("configuration-binding-mismatch", "transaction")
+    if record["actor"] != binding["actor"]:
+        raise IntegrityError("configuration-binding-mismatch", "actor")
+    if record["planHash"] != envelope["planHash"]:
+        raise IntegrityError("configuration-binding-mismatch", "plan")
+    if not isinstance(record["schemaHash"], str) or not HEX64_RE.fullmatch(
+        record["schemaHash"]
+    ):
+        raise IntegrityError("configuration-invalid", "schemaHash")
+    if not isinstance(record["idempotencyKey"], str) or not HEX64_RE.fullmatch(
+        record["idempotencyKey"]
+    ):
+        raise IntegrityError("configuration-invalid", "idempotencyKey")
+    try:
+        _validate_timestamp(record["configuredAt"])
+    except ValidationRejected as exc:
+        raise IntegrityError("configuration-invalid", "configuredAt") from exc
+
+    values = record["values"]
+    if not isinstance(values, dict) or len(values) > MAX_DICT_KEYS:
+        raise IntegrityError("configuration-invalid", "values")
+    for key, value in values.items():
+        if not isinstance(key, str) or not CONFIGURATION_KEY_RE.fullmatch(key):
+            raise IntegrityError("configuration-invalid", "values")
+        _configuration_value(value)
+    present_config = _configuration_key_list(
+        record["presentConfigKeys"], "presentConfigKeys"
+    )
+    present_secrets = _configuration_key_list(
+        record["presentSecretKeys"], "presentSecretKeys"
+    )
+    applied_defaults = _configuration_key_list(
+        record["appliedDefaultKeys"], "appliedDefaultKeys"
+    )
+    if set(values) != set(present_config):
+        raise IntegrityError("configuration-invalid", "presentConfigKeys")
+    if set(present_config) & set(present_secrets):
+        raise IntegrityError("configuration-invalid", "channel-overlap")
+    if set(applied_defaults) & set(present_config):
+        raise IntegrityError("configuration-invalid", "default-overlap")
+    if not intent:
+        reference = record["secretReference"]
+        if present_secrets:
+            if not isinstance(reference, str) or not SECRET_REFERENCE_RE.fullmatch(
+                reference
+            ):
+                raise IntegrityError("configuration-invalid", "secretReference")
+        elif reference is not None:
+            raise IntegrityError("configuration-invalid", "secretReference")
+    return record
+
+
+def _plan_requires_configuration(envelope):
+    plan = envelope["plan"]
+    return bool(plan["requiredConfigKeys"] or plan["requiredSecretKeys"])
 
 
 def _sha256(b: bytes) -> str:
@@ -1219,6 +1365,30 @@ class TransactionStore:
             raise IntegrityError("approval-time-invalid")
         return approval
 
+    def _load_configuration(self, tx_dir, transaction_id, envelope, binding):
+        path = tx_dir / "configuration.json"
+        if not self._entry_exists(path):
+            return None
+        configuration = _decode_canonical_object(
+            path, CONFIGURATION_KEYS, "configuration"
+        )
+        return _validate_configuration_record(
+            configuration, transaction_id, envelope, binding
+        )
+
+    def _load_configuration_intent(
+        self, tx_dir, transaction_id, envelope, binding
+    ):
+        path = tx_dir / "configuration-intent.json"
+        if not self._entry_exists(path):
+            return None
+        intent = _decode_canonical_object(
+            path, CONFIGURATION_INTENT_KEYS, "configuration-intent"
+        )
+        return _validate_configuration_record(
+            intent, transaction_id, envelope, binding, intent=True
+        )
+
     def _read_transaction(
         self,
         transaction_id,
@@ -1249,6 +1419,28 @@ class TransactionStore:
         if require_index or self._entry_exists(index_path):
             self._load_index(index_path, transaction_id, binding)
         has_approved = any(record["state"] == "approved" for record in records)
+        configuration = self._load_configuration(
+            tx_dir, transaction_id, envelope, binding
+        )
+        configuration_intent = self._load_configuration_intent(
+            tx_dir, transaction_id, envelope, binding
+        )
+        if configuration is not None and configuration_intent is None:
+            raise IntegrityError("missing-configuration-intent")
+        if configuration is not None:
+            expected_configuration = dict(configuration_intent)
+            expected_configuration["schema"] = CONFIGURATION_SCHEMA
+            expected_configuration["secretReference"] = configuration[
+                "secretReference"
+            ]
+            if configuration != expected_configuration:
+                raise IntegrityError("configuration-intent-mismatch")
+        if (
+            has_approved
+            and _plan_requires_configuration(envelope)
+            and configuration is None
+        ):
+            raise IntegrityError("missing-configuration")
         approval_path = tx_dir / "approval.json"
         if has_approved:
             approval = self._load_approval(tx_dir, transaction_id, envelope, binding)
@@ -1266,6 +1458,8 @@ class TransactionStore:
             "txDir": tx_dir,
             "envelope": envelope,
             "binding": binding,
+            "configuration": configuration,
+            "configurationIntent": configuration_intent,
             "journal": records,
             "approval": approval,
             "state": records[-1]["state"],
@@ -1527,6 +1721,148 @@ class TransactionStore:
             "duplicate": True,
         }
 
+    def begin_configuration_exact(
+        self,
+        transaction_id,
+        expected_plan_hash,
+        schema_hash,
+        idempotency_key,
+        values,
+        present_secret_keys,
+        applied_default_keys,
+        configured_at,
+        current_time,
+    ):
+        """Reserve one immutable, value-safe configuration intent."""
+        _validate_timestamp(configured_at)
+        _validate_timestamp(current_time)
+        if configured_at > current_time:
+            raise ValidationRejected("future-configuration")
+        if not isinstance(expected_plan_hash, str) or not HEX64_RE.fullmatch(
+            expected_plan_hash
+        ):
+            raise ValidationRejected("invalid-plan-hash")
+        if not isinstance(schema_hash, str) or not HEX64_RE.fullmatch(schema_hash):
+            raise ValidationRejected("invalid-schema-hash")
+        if not isinstance(idempotency_key, str) or not HEX64_RE.fullmatch(
+            idempotency_key
+        ):
+            raise ValidationRejected("invalid-idempotency-key")
+        safe_values = _configuration_submission_values(values)
+        safe_secret_keys = _configuration_submission_keys(
+            present_secret_keys, "presentSecretKeys"
+        )
+        safe_default_keys = _configuration_submission_keys(
+            applied_default_keys, "appliedDefaultKeys"
+        )
+
+        with self._lock:
+            loaded = self._read_transaction(transaction_id)
+            if loaded["envelope"]["planHash"] != expected_plan_hash:
+                raise ValidationRejected("plan-hash-mismatch")
+            if loaded["state"] != "awaiting_approval":
+                raise TransitionError("configuration-locked", loaded["state"])
+            record = {
+                "actor": loaded["binding"]["actor"],
+                "appliedDefaultKeys": safe_default_keys,
+                "configuredAt": configured_at,
+                "idempotencyKey": idempotency_key,
+                "planHash": expected_plan_hash,
+                "presentConfigKeys": sorted(safe_values),
+                "presentSecretKeys": safe_secret_keys,
+                "schema": CONFIGURATION_INTENT_SCHEMA,
+                "schemaHash": schema_hash,
+                "transactionId": transaction_id,
+                "values": safe_values,
+            }
+            _validate_configuration_record(
+                record,
+                transaction_id,
+                loaded["envelope"],
+                loaded["binding"],
+                intent=True,
+            )
+            path = loaded["txDir"] / "configuration-intent.json"
+            if loaded["configurationIntent"] is not None:
+                existing = loaded["configurationIntent"]
+                record["configuredAt"] = existing["configuredAt"]
+                if existing != record:
+                    raise IdempotencyConflict("configuration-conflict")
+                result = dict(existing)
+                result["duplicate"] = True
+                return result
+            _write_immutable(path, canonical_json_bytes(record), 0o600)
+            written = self._load_configuration_intent(
+                loaded["txDir"],
+                transaction_id,
+                loaded["envelope"],
+                loaded["binding"],
+            )
+            if written != record:
+                raise IntegrityError("configuration-intent-write-verify-failed")
+            result = dict(record)
+            result["duplicate"] = False
+            return result
+
+    def finish_configuration_exact(
+        self,
+        transaction_id,
+        expected_plan_hash,
+        idempotency_key,
+        secret_reference,
+    ):
+        """Commit an exact reserved intent with only an opaque secret reference."""
+        if not isinstance(expected_plan_hash, str) or not HEX64_RE.fullmatch(
+            expected_plan_hash
+        ):
+            raise ValidationRejected("invalid-plan-hash")
+        if not isinstance(idempotency_key, str) or not HEX64_RE.fullmatch(
+            idempotency_key
+        ):
+            raise ValidationRejected("invalid-idempotency-key")
+        with self._lock:
+            loaded = self._read_transaction(transaction_id)
+            if loaded["envelope"]["planHash"] != expected_plan_hash:
+                raise ValidationRejected("plan-hash-mismatch")
+            if loaded["state"] != "awaiting_approval":
+                raise TransitionError("configuration-locked", loaded["state"])
+            intent = loaded["configurationIntent"]
+            if intent is None:
+                raise IntegrityError("missing-configuration-intent")
+            if intent["idempotencyKey"] != idempotency_key:
+                raise IdempotencyConflict("configuration-conflict")
+            record = dict(intent)
+            record["schema"] = CONFIGURATION_SCHEMA
+            record["secretReference"] = secret_reference
+            _validate_configuration_record(
+                record,
+                transaction_id,
+                loaded["envelope"],
+                loaded["binding"],
+            )
+            if loaded["configuration"] is not None:
+                if loaded["configuration"] != record:
+                    raise IdempotencyConflict("configuration-conflict")
+                result = dict(record)
+                result["duplicate"] = True
+                return result
+            _write_immutable(
+                loaded["txDir"] / "configuration.json",
+                canonical_json_bytes(record),
+                0o600,
+            )
+            written = self._load_configuration(
+                loaded["txDir"],
+                transaction_id,
+                loaded["envelope"],
+                loaded["binding"],
+            )
+            if written != record:
+                raise IntegrityError("configuration-write-verify-failed")
+            result = dict(record)
+            result["duplicate"] = False
+            return result
+
     def transition(
         self,
         transaction_id,
@@ -1696,6 +2032,11 @@ class TransactionStore:
                 raise ApprovalError("approval-conflict")
             if current_state != "awaiting_approval":
                 raise ApprovalError("wrong-state", current_state)
+            if (
+                _plan_requires_configuration(envelope)
+                and loaded["configuration"] is None
+            ):
+                raise ApprovalError("missing-configuration")
 
             approval_path = tx_dir / "approval.json"
             if loaded["approval"] is not None:
@@ -1787,6 +2128,11 @@ class TransactionStore:
                 raise ApprovalError("approval-conflict")
             if current_state != "awaiting_approval":
                 raise ApprovalError("wrong-state", current_state)
+            if (
+                _plan_requires_configuration(envelope)
+                and loaded["configuration"] is None
+            ):
+                raise ApprovalError("missing-configuration")
 
             approval_path = tx_dir / "approval.json"
             if loaded["approval"] is not None:
@@ -1856,6 +2202,7 @@ class TransactionStore:
                 "sequence": len(loaded["journal"]),
                 "journal": loaded["journal"],
                 "approval": loaded["approval"],
+                "configuration": loaded["configuration"],
             }
 
     def list_transactions(self):

--- a/ods/extensions/services/dashboard-api/routers/extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/routers/extension_transactions.py
@@ -2,13 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 from typing import Any, TypeVar
-
-from fastapi import APIRouter, Depends, HTTPException, Request
-from fastapi.responses import JSONResponse
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from assistant_first_planner import PlanningError
 from extension_transaction_runtime import TransactionRuntime
@@ -20,10 +17,13 @@ from extension_transactions import (
     TransitionError,
     ValidationRejected,
 )
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse
 from plan_provenance import authorize_plan
-from routers.auth import require_owner_approval_session
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from security import verify_api_key
 
+from routers.auth import require_owner_approval_session
 
 router = APIRouter(prefix="/api/extensions/transactions", tags=["extensions"])
 MAX_REQUEST_BYTES = 64 * 1024
@@ -46,6 +46,19 @@ class ExactHashRequest(BaseModel):
     planHash: str = Field(
         min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"
     )
+
+
+class ConfigurationSubmissionRequest(ExactHashRequest):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schemaHash: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"
+    )
+    idempotencyKey: str = Field(
+        min_length=64, max_length=64, pattern=r"^[0-9a-f]{64}$"
+    )
+    values: dict[str, Any]
+    secretValues: dict[str, Any]
 
 
 def _feature_enabled() -> bool:
@@ -71,6 +84,17 @@ def get_transaction_runtime(request: Request) -> TransactionRuntime:
             headers={"Cache-Control": "no-store"},
         )
     return runtime
+
+
+def _configuration_manager(runtime: TransactionRuntime) -> Any:
+    manager = runtime.configuration
+    if manager is None:
+        raise HTTPException(
+            status_code=503,
+            detail="Extension transaction configuration is unavailable",
+            headers={"Cache-Control": "no-store"},
+        )
+    return manager
 
 
 def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -110,12 +134,12 @@ async def _request_model(request: Request, model_type: type[_Model]) -> _Model:
         TypeError,
         ValueError,
         ValidationError,
-    ) as exc:
+    ):
         raise HTTPException(
             status_code=422,
             detail="Invalid transaction request",
             headers={"Cache-Control": "no-store"},
-        ) from exc
+        ) from None
 
 
 def _error_response(exc: Exception) -> JSONResponse:
@@ -216,8 +240,13 @@ async def approve_transaction(
 ) -> JSONResponse:
     """Bind one owner browser session to one exact stored plan hash."""
     model = await _request_model(request, ExactHashRequest)
-    timestamp = runtime.clock()
     try:
+        await asyncio.to_thread(
+            _configuration_manager(runtime).require_ready,
+            transaction_id,
+            model.planHash,
+        )
+        timestamp = runtime.clock()
         result = runtime.store.approve_exact(
             transaction_id,
             model.planHash,
@@ -228,6 +257,54 @@ async def approve_transaction(
     except TransactionError as exc:
         return _error_response(exc)
     return JSONResponse(content=result, headers={"Cache-Control": "no-store"})
+
+
+@router.get("/{transaction_id}/configuration")
+async def transaction_configuration(
+    transaction_id: str,
+    runtime: TransactionRuntime = Depends(get_transaction_runtime),
+    _api_key: str = Depends(verify_api_key),
+) -> JSONResponse:
+    """Return the stored-plan-derived schema and value-safe configuration."""
+    try:
+        result = await asyncio.to_thread(
+            _configuration_manager(runtime).view, transaction_id
+        )
+    except TransactionError as exc:
+        return _error_response(exc)
+    except Exception:
+        return _error_response(IntegrityError("configuration-unavailable"))
+    return JSONResponse(content=result, headers={"Cache-Control": "no-store"})
+
+
+@router.post("/{transaction_id}/configuration")
+async def configure_transaction(
+    transaction_id: str,
+    request: Request,
+    runtime: TransactionRuntime = Depends(get_transaction_runtime),
+    _api_key: str = Depends(verify_api_key),
+) -> JSONResponse:
+    """Validate configuration and send secret values directly to host custody."""
+    model = await _request_model(request, ConfigurationSubmissionRequest)
+    try:
+        result = await asyncio.to_thread(
+            _configuration_manager(runtime).submit,
+            transaction_id,
+            plan_hash=model.planHash,
+            schema_hash=model.schemaHash,
+            idempotency_key=model.idempotencyKey,
+            values=model.values,
+            secret_values=model.secretValues,
+        )
+    except TransactionError as exc:
+        return _error_response(exc)
+    except Exception:
+        return _error_response(IntegrityError("configuration-unavailable"))
+    return JSONResponse(
+        status_code=200 if result.get("duplicate") is True else 201,
+        content=result,
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @router.get("/{transaction_id}")
@@ -282,6 +359,11 @@ async def execute_transaction(
             headers={"Cache-Control": "no-store"},
         )
     try:
+        await asyncio.to_thread(
+            _configuration_manager(runtime).require_ready,
+            transaction_id,
+            model.planHash,
+        )
         result = runtime.executor.execute(transaction_id, model.planHash)
     except TransactionError as exc:
         return _error_response(exc)

--- a/ods/extensions/services/dashboard-api/tests/test_assistant_first_secret_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_assistant_first_secret_client.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from assistant_first_secret_client import HostSecretCustodian, SecretCustodyError
+from host_agent_client import AgentHTTPError
+
+TRANSACTION_ID = "txn-" + "1" * 24
+PLAN_HASH = "2" * 64
+SCHEMA_HASH = "3" * 64
+IDEMPOTENCY_KEY = "4" * 64
+REFERENCE = "secret-v1-" + "5" * 48
+SENTINEL = "private-do-not-echo"
+
+
+def status(*, duplicate: bool | None = None) -> dict:
+    result = {
+        "schema": "ods.assistant-first.secret-status.v1",
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "schemaHash": SCHEMA_HASH,
+        "reference": REFERENCE,
+        "configured": True,
+        "presentSecretKeys": ["API_KEY"],
+    }
+    if duplicate is not None:
+        result["duplicate"] = duplicate
+    return result
+
+
+def test_stage_uses_fixed_post_and_never_projects_secret() -> None:
+    calls = []
+
+    def request(method, path, **kwargs):
+        calls.append((method, path, kwargs))
+        return status(duplicate=False)
+
+    result = HostSecretCustodian(request).stage(
+        transaction_id=TRANSACTION_ID,
+        plan_hash=PLAN_HASH,
+        schema_hash=SCHEMA_HASH,
+        idempotency_key=IDEMPOTENCY_KEY,
+        secret_values={"API_KEY": SENTINEL},
+    )
+    method, path, kwargs = calls[0]
+    assert (method, path, kwargs["timeout"]) == (
+        "POST",
+        "/v1/assistant-first/secrets/stage",
+        10.0,
+    )
+    assert kwargs["payload"]["secretValues"] == {"API_KEY": SENTINEL}
+    assert SENTINEL not in json.dumps(result)
+
+
+def test_status_uses_fixed_post_and_exact_reference_binding() -> None:
+    calls = []
+
+    def request(method, path, **kwargs):
+        calls.append((method, path, kwargs))
+        return status()
+
+    result = HostSecretCustodian(request).status(
+        transaction_id=TRANSACTION_ID,
+        plan_hash=PLAN_HASH,
+        schema_hash=SCHEMA_HASH,
+        reference=REFERENCE,
+    )
+    assert calls[0][0:2] == (
+        "POST",
+        "/v1/assistant-first/secrets/status",
+    )
+    assert calls[0][2]["payload"]["reference"] == REFERENCE
+    assert result["reference"] == REFERENCE
+
+
+def test_transport_error_text_cannot_escape_custody_boundary() -> None:
+    def request(*_args, **_kwargs):
+        raise AgentHTTPError(500, SENTINEL, SENTINEL)
+
+    with pytest.raises(SecretCustodyError) as caught:
+        HostSecretCustodian(request).stage(
+            transaction_id=TRANSACTION_ID,
+            plan_hash=PLAN_HASH,
+            schema_hash=SCHEMA_HASH,
+            idempotency_key=IDEMPOTENCY_KEY,
+            secret_values={"API_KEY": SENTINEL},
+        )
+    assert caught.value.code == "secret-custody-unavailable"
+    assert SENTINEL not in str(caught.value)
+    assert SENTINEL not in repr(caught.value)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda value: value.update(extra=True),
+        lambda value: value.update(planHash="0" * 64),
+        lambda value: value.update(reference="wrong"),
+        lambda value: value.update(presentSecretKeys=["TOKEN", "API_KEY"]),
+        lambda value: value.update(duplicate="false"),
+    ],
+)
+def test_stage_rejects_non_exact_or_misbound_response(mutation) -> None:
+    response = status(duplicate=False)
+    mutation(response)
+    custodian = HostSecretCustodian(lambda *_args, **_kwargs: response)
+    with pytest.raises(SecretCustodyError):
+        custodian.stage(
+            transaction_id=TRANSACTION_ID,
+            plan_hash=PLAN_HASH,
+            schema_hash=SCHEMA_HASH,
+            idempotency_key=IDEMPOTENCY_KEY,
+            secret_values={"API_KEY": SENTINEL},
+        )
+
+
+def test_delete_requires_exact_value_safe_response() -> None:
+    response = {
+        "schema": "ods.assistant-first.secret-status.v1",
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "schemaHash": SCHEMA_HASH,
+        "configured": False,
+        "deleted": True,
+        "presentSecretKeys": [],
+    }
+    custodian = HostSecretCustodian(lambda *_args, **_kwargs: response)
+    assert custodian.delete(
+        transaction_id=TRANSACTION_ID,
+        plan_hash=PLAN_HASH,
+        schema_hash=SCHEMA_HASH,
+        reference=REFERENCE,
+    )["deleted"] is True
+
+    response["reference"] = REFERENCE
+    with pytest.raises(SecretCustodyError):
+        custodian.delete(
+            transaction_id=TRANSACTION_ID,
+            plan_hash=PLAN_HASH,
+            schema_hash=SCHEMA_HASH,
+            reference=REFERENCE,
+        )

--- a/ods/extensions/services/dashboard-api/tests/test_extension_configuration.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_configuration.py
@@ -4,9 +4,8 @@ import copy
 import hashlib
 import json
 
-import pytest
-
 import extension_configuration as configuration
+import pytest
 
 
 def contract(
@@ -548,4 +547,110 @@ def test_unknown_and_duplicate_submission_keys_fail_closed() -> None:
     error(
         "duplicate-submission-key",
         lambda: submit(stored, {"PATH": "one"}, {"PATH": "two"}),
+    )
+
+
+def test_stored_configuration_revalidates_values_and_secret_presence() -> None:
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract("ENDPOINT", config_type="url"),
+                contract("TOKEN", secret=True),
+            ],
+        )
+    )
+    schema_hash = schema(stored)["schemaHash"]
+    receipt = configuration.validate_stored_configuration(
+        stored,
+        {"ENDPOINT": "https://example.invalid/v1"},
+        ["TOKEN"],
+        expected_plan_hash=stored["planHash"],
+        expected_schema_hash=schema_hash,
+    )
+    assert receipt["presentConfigKeys"] == ["ENDPOINT"]
+    assert receipt["presentSecretKeys"] == ["TOKEN"]
+
+
+def test_stored_configuration_rejects_stale_schema_or_missing_secret() -> None:
+    stored = envelope(
+        (
+            "provider",
+            [contract("ENDPOINT"), contract("TOKEN", secret=True)],
+        )
+    )
+    values = {"ENDPOINT": "configured"}
+    error(
+        "stored-schema-hash-mismatch",
+        lambda: configuration.validate_stored_configuration(
+            stored,
+            values,
+            ["TOKEN"],
+            expected_plan_hash=stored["planHash"],
+            expected_schema_hash="0" * 64,
+        ),
+    )
+    error(
+        "missing-required-configuration",
+        lambda: configuration.validate_stored_configuration(
+            stored,
+            values,
+            [],
+            expected_plan_hash=stored["planHash"],
+            expected_schema_hash=schema(stored)["schemaHash"],
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("present_keys", "code"),
+    [
+        (["TOKEN", "API_KEY"], "invalid-secret-presence-order"),
+        (["TOKEN", "TOKEN"], "duplicate-configuration-key"),
+    ],
+)
+def test_stored_secret_presence_is_canonical(present_keys, code: str) -> None:
+    stored = envelope(
+        (
+            "provider",
+            [
+                contract("API_KEY", secret=True, required=False),
+                contract("TOKEN", secret=True),
+            ],
+        )
+    )
+    error(
+        code,
+        lambda: configuration.validate_stored_configuration(
+            stored,
+            {},
+            present_keys,
+            expected_plan_hash=stored["planHash"],
+            expected_schema_hash=schema(stored)["schemaHash"],
+        ),
+    )
+
+
+def test_stored_configuration_rejects_invalid_persisted_value() -> None:
+    stored = envelope(
+        (
+            "notes",
+            [
+                contract(
+                    "WORKERS",
+                    config_type="integer",
+                    validation={"minimum": 1, "maximum": 8},
+                )
+            ],
+        )
+    )
+    error(
+        "configuration-value-too-large",
+        lambda: configuration.validate_stored_configuration(
+            stored,
+            {"WORKERS": 9},
+            [],
+            expected_plan_hash=stored["planHash"],
+            expected_schema_hash=schema(stored)["schemaHash"],
+        ),
     )

--- a/ods/extensions/services/dashboard-api/tests/test_extension_configuration.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_configuration.py
@@ -446,6 +446,14 @@ def test_secret_value_is_validated_but_absent_from_receipt_and_errors() -> None:
     assert sentinel not in json.dumps(caught.as_dict())
 
 
+def test_empty_secret_is_rejected_before_host_custody() -> None:
+    stored = envelope(("provider", [contract("TOKEN", secret=True)]))
+    error(
+        "configuration-value-too-short",
+        lambda: submit(stored, {}, {"TOKEN": ""}),
+    )
+
+
 def test_valid_submission_receipt_contains_presence_only() -> None:
     sentinel = "private-value-1234567890"
     stored = envelope(

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_api.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_api.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
-
 import routers.extension_transactions as transaction_api
 import security
 import session_signer
 from extension_transaction_runtime import TransactionRuntime
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 from plan_provenance import validate_request_intent
-
 
 API_KEY = "transaction-test-key"
 NOW = "2026-09-11T12:00:00Z"
@@ -108,6 +106,42 @@ class FakeExecutor:
         )
 
 
+class FakeConfiguration:
+    def __init__(self) -> None:
+        self.ready_calls = []
+        self.submit_calls = []
+
+    def require_ready(self, transaction_id, plan_hash):
+        self.ready_calls.append((transaction_id, plan_hash))
+        return {"configured": True}
+
+    def view(self, transaction_id):
+        return {
+            "schema": "ods.assistant-first.transaction-configuration-view.v1",
+            "transactionId": transaction_id,
+            "planHash": PLAN_HASH,
+            "schemaHash": "9" * 64,
+            "fields": [],
+            "configured": False,
+            "values": {},
+            "presentConfigKeys": [],
+            "presentSecretKeys": [],
+            "appliedDefaultKeys": [],
+        }
+
+    def submit(self, transaction_id, **submission):
+        self.submit_calls.append((transaction_id, submission))
+        return {
+            **self.view(transaction_id),
+            "schemaHash": submission["schema_hash"],
+            "configured": True,
+            "values": dict(submission["values"]),
+            "presentConfigKeys": sorted(submission["values"]),
+            "presentSecretKeys": sorted(submission["secret_values"]),
+            "duplicate": False,
+        }
+
+
 def create_body(**intent_changes) -> dict:
     intent = {
         "requestedServices": ["notes"],
@@ -128,6 +162,7 @@ def api(monkeypatch):
     session_signer._set_secret_for_tests("phase3c-session-secret")
     store = FakeStore()
     executor = FakeExecutor()
+    configuration = FakeConfiguration()
     calls = []
 
     def catalog():
@@ -161,12 +196,14 @@ def api(monkeypatch):
         policy=policy,
         clock=lambda: NOW,
         executor=executor,
+        configuration=configuration,
     )
     with TestClient(app) as client:
         yield SimpleNamespace(
             client=client,
             store=store,
             executor=executor,
+            configuration=configuration,
             authorize_calls=calls,
             headers={"Authorization": f"Bearer {API_KEY}"},
         )
@@ -326,6 +363,7 @@ def test_owner_approval_passes_only_exact_hash_and_hashed_identity(api):
     )
     assert response.status_code == 200
     assert api.store.approved == [(TX_ID, PLAN_HASH, approved_by, NOW, NOW)]
+    assert api.configuration.ready_calls == [(TX_ID, PLAN_HASH)]
     assert "approval" not in response.request.content.decode("utf-8")
 
 
@@ -363,6 +401,97 @@ def test_status_is_no_store_and_redacts_approval_binding(api):
     assert response.json()["plan"]["requiredSecretKeys"] == ["NOTES_API_KEY"]
 
 
+def test_configuration_routes_are_authenticated_bounded_and_value_safe(api):
+    path = f"/api/extensions/transactions/{TX_ID}/configuration"
+    assert api.client.get(path).status_code == 401
+    viewed = api.client.get(path, headers=api.headers)
+    assert viewed.status_code == 200
+    assert viewed.headers["cache-control"] == "no-store"
+
+    secret = "do-not-echo-configuration-secret"
+    body = {
+        "planHash": PLAN_HASH,
+        "schemaHash": "9" * 64,
+        "idempotencyKey": "8" * 64,
+        "values": {"NOTES_PATH": "/notes"},
+        "secretValues": {"NOTES_API_KEY": secret},
+    }
+    assert api.client.post(path, json=body).status_code == 401
+    response = api.client.post(path, json=body, headers=api.headers)
+    assert response.status_code == 201
+    assert response.headers["cache-control"] == "no-store"
+    assert secret not in response.text
+    assert response.json()["presentSecretKeys"] == ["NOTES_API_KEY"]
+    assert api.configuration.submit_calls == [
+        (
+            TX_ID,
+            {
+                "plan_hash": PLAN_HASH,
+                "schema_hash": "9" * 64,
+                "idempotency_key": "8" * 64,
+                "values": {"NOTES_PATH": "/notes"},
+                "secret_values": {"NOTES_API_KEY": secret},
+            },
+        )
+    ]
+
+
+def test_configuration_submission_rejects_extra_authority(api):
+    response = api.client.post(
+        f"/api/extensions/transactions/{TX_ID}/configuration",
+        json={
+            "planHash": PLAN_HASH,
+            "schemaHash": "9" * 64,
+            "idempotencyKey": "8" * 64,
+            "values": {},
+            "secretValues": {},
+            "envelope": envelope(),
+        },
+        headers=api.headers,
+    )
+    assert response.status_code == 422
+    assert api.configuration.submit_calls == []
+
+
+def test_configuration_parser_and_internal_failures_never_echo_secret(api):
+    path = f"/api/extensions/transactions/{TX_ID}/configuration"
+    secret = "do-not-echo-parser-secret"
+    schema_hash = "9" * 64
+    idempotency_key = "8" * 64
+    duplicate = (
+        f'{{"planHash":"{PLAN_HASH}","schemaHash":"{schema_hash}",'
+        f'"idempotencyKey":"{idempotency_key}","values":{{}},'
+        f'"secretValues":{{"NOTES_API_KEY":"{secret}",'
+        f'"NOTES_API_KEY":"{secret}"}}}}'
+    )
+    rejected = api.client.post(
+        path,
+        content=duplicate,
+        headers={**api.headers, "Content-Type": "application/json"},
+    )
+    assert rejected.status_code == 422
+    assert secret not in rejected.text
+
+    def fail_with_secret(*_args, **_kwargs):
+        raise RuntimeError(secret)
+
+    api.configuration.submit = fail_with_secret
+    failed = api.client.post(
+        path,
+        json={
+            "planHash": PLAN_HASH,
+            "schemaHash": "9" * 64,
+            "idempotencyKey": "8" * 64,
+            "values": {},
+            "secretValues": {"NOTES_API_KEY": secret},
+        },
+        headers=api.headers,
+    )
+    assert failed.status_code == 503
+    assert failed.json() == {"error": {"code": "configuration-unavailable"}}
+    assert secret not in failed.text
+
+
 def test_execute_requires_api_key_and_passes_only_id_and_hash(api):
     path = f"/api/extensions/transactions/{TX_ID}/execute"
     assert api.client.post(path, json={"planHash": PLAN_HASH}).status_code == 401
@@ -371,6 +500,7 @@ def test_execute_requires_api_key_and_passes_only_id_and_hash(api):
     )
     assert response.status_code == 200
     assert api.executor.calls == [(TX_ID, PLAN_HASH)]
+    assert api.configuration.ready_calls == [(TX_ID, PLAN_HASH)]
     assert response.json()["finalState"] == "committed"
 
     rejected = api.client.post(
@@ -391,6 +521,7 @@ def test_execute_is_unavailable_without_injected_executor(api):
         policy=runtime.policy,
         clock=runtime.clock,
         executor=None,
+        configuration=runtime.configuration,
     )
     response = api.client.post(
         f"/api/extensions/transactions/{TX_ID}/execute",
@@ -407,6 +538,7 @@ def test_main_registers_transaction_routes():
     paths = {route.path for route in app.routes}
     assert "/api/extensions/transactions" in paths
     assert "/api/extensions/transactions/{transaction_id}/approval" in paths
+    assert "/api/extensions/transactions/{transaction_id}/configuration" in paths
     assert "/api/extensions/transactions/{transaction_id}" in paths
     assert "/api/extensions/transactions/{transaction_id}/execute" in paths
 

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_configuration.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_configuration.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+
+import pytest
+from assistant_first_secret_client import SecretCustodyError
+from extension_configuration import configuration_schema
+from extension_transaction_configuration import TransactionConfigurationManager
+from extension_transactions import IntegrityError, TransitionError, ValidationRejected
+
+TRANSACTION_ID = "txn-" + "1" * 24
+IDEMPOTENCY_KEY = "2" * 64
+REFERENCE = "secret-v1-" + "3" * 48
+SENTINEL = "private-do-not-echo"
+NOW = "2026-09-12T07:00:00Z"
+_DEFAULT_CUSTODY = object()
+
+
+def contract(key: str, *, secret: bool = False) -> dict:
+    return {
+        "key": key,
+        "type": "string",
+        "required": True,
+        "secret": secret,
+        "source": "user",
+        "restartBehavior": "service",
+    }
+
+
+def envelope() -> dict:
+    plan = {
+        "schema": "ods.assistant-first.plan.v1",
+        "selectedServices": ["provider"],
+        "definitions": [
+            {
+                "id": "provider",
+                "configuration": [
+                    contract("ENDPOINT"),
+                    contract("TOKEN", secret=True),
+                ],
+            }
+        ],
+        "requiredConfigKeys": ["ENDPOINT"],
+        "requiredSecretKeys": ["TOKEN"],
+    }
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":")) + "\n"
+    return {"plan": plan, "planHash": hashlib.sha256(canonical.encode()).hexdigest()}
+
+
+class FakeStore:
+    def __init__(self) -> None:
+        self.loaded = {
+            "transactionId": TRANSACTION_ID,
+            "state": "awaiting_approval",
+            "envelope": envelope(),
+            "configuration": None,
+        }
+        self.intent = None
+        self.events = []
+
+    def read(self, transaction_id):
+        assert transaction_id == TRANSACTION_ID
+        return copy.deepcopy(self.loaded)
+
+    def begin_configuration_exact(
+        self,
+        transaction_id,
+        plan_hash,
+        schema_hash,
+        idempotency_key,
+        values,
+        present_secret_keys,
+        applied_default_keys,
+        configured_at,
+        _current_time,
+    ):
+        self.events.append("intent")
+        candidate = {
+            "schema": "ods.assistant-first.transaction-configuration-intent.v1",
+            "transactionId": transaction_id,
+            "actor": "assistant-manager",
+            "planHash": plan_hash,
+            "schemaHash": schema_hash,
+            "idempotencyKey": idempotency_key,
+            "configuredAt": configured_at,
+            "values": copy.deepcopy(values),
+            "presentConfigKeys": sorted(values),
+            "presentSecretKeys": list(present_secret_keys),
+            "appliedDefaultKeys": list(applied_default_keys),
+        }
+        duplicate = self.intent is not None
+        if duplicate:
+            candidate["configuredAt"] = self.intent["configuredAt"]
+            assert candidate == self.intent
+        else:
+            self.intent = candidate
+        return {**copy.deepcopy(self.intent), "duplicate": duplicate}
+
+    def finish_configuration_exact(
+        self, transaction_id, plan_hash, idempotency_key, reference
+    ):
+        self.events.append("finish")
+        assert self.intent is not None
+        assert (transaction_id, plan_hash, idempotency_key) == (
+            TRANSACTION_ID,
+            self.intent["planHash"],
+            self.intent["idempotencyKey"],
+        )
+        candidate = {
+            **copy.deepcopy(self.intent),
+            "schema": "ods.assistant-first.transaction-configuration.v1",
+            "secretReference": reference,
+        }
+        duplicate = self.loaded["configuration"] is not None
+        if duplicate:
+            assert candidate == self.loaded["configuration"]
+        else:
+            self.loaded["configuration"] = candidate
+        return {**copy.deepcopy(candidate), "duplicate": duplicate}
+
+
+class FakeCustodian:
+    def __init__(self) -> None:
+        self.events = []
+        self.fail = False
+        self.store = None
+
+    def stage(self, **submission):
+        assert self.store is not None
+        assert self.store.intent is not None
+        if not self.events:
+            assert self.store.loaded["configuration"] is None
+        self.events.append(("stage", copy.deepcopy(submission)))
+        if self.fail:
+            raise SecretCustodyError("secret-custody-unavailable")
+        return {
+            "reference": REFERENCE,
+            "duplicate": len(self.events) > 1,
+            "presentSecretKeys": sorted(submission["secret_values"]),
+        }
+
+    def status(self, **binding):
+        self.events.append(("status", copy.deepcopy(binding)))
+        return {"presentSecretKeys": ["TOKEN"]}
+
+
+def manager(store=None, custody=_DEFAULT_CUSTODY):
+    store = store or FakeStore()
+    if custody is _DEFAULT_CUSTODY:
+        custody = FakeCustodian()
+    if isinstance(custody, FakeCustodian):
+        custody.store = store
+    return TransactionConfigurationManager(store, custody, lambda: NOW), store, custody
+
+
+def submission(store) -> dict:
+    stored = store.loaded["envelope"]
+    return {
+        "plan_hash": stored["planHash"],
+        "schema_hash": configuration_schema(
+            stored, expected_plan_hash=stored["planHash"]
+        )["schemaHash"],
+        "idempotency_key": IDEMPOTENCY_KEY,
+        "values": {"ENDPOINT": "https://example.invalid/v1"},
+        "secret_values": {"TOKEN": SENTINEL},
+    }
+
+
+def test_view_derives_schema_from_stored_plan_without_secret_reference() -> None:
+    service, _store, _custody = manager()
+    result = service.view(TRANSACTION_ID)
+    assert result["configured"] is False
+    assert [field["key"] for field in result["fields"]] == ["ENDPOINT", "TOKEN"]
+    assert "secretReference" not in result
+
+
+def test_submit_reserves_before_custody_and_projects_no_secret_or_reference() -> None:
+    service, store, custody = manager()
+    result = service.submit(TRANSACTION_ID, **submission(store))
+    assert store.events == ["intent", "finish"]
+    assert custody.events[0][0] == "stage"
+    assert custody.events[0][1]["secret_values"] == {"TOKEN": SENTINEL}
+    assert store.intent["presentSecretKeys"] == ["TOKEN"]
+    assert SENTINEL not in json.dumps(store.intent)
+    assert SENTINEL not in json.dumps(result)
+    assert REFERENCE not in json.dumps(result)
+    assert result["configured"] is True
+    assert result["duplicate"] is False
+
+
+def test_exact_retry_is_idempotent_across_intent_custody_and_final_record() -> None:
+    service, store, _custody = manager()
+    first = service.submit(TRANSACTION_ID, **submission(store))
+    second = service.submit(TRANSACTION_ID, **submission(store))
+    assert first["duplicate"] is False
+    assert second["duplicate"] is True
+    assert store.events == ["intent", "finish", "intent", "finish"]
+
+
+def test_custody_unavailable_is_rejected_before_writing_intent() -> None:
+    service, store, _custody = manager(custody=None)
+    with pytest.raises(IntegrityError) as caught:
+        service.submit(TRANSACTION_ID, **submission(store))
+    assert caught.value.code == "secret-custody-unavailable"
+    assert store.intent is None
+
+
+def test_custody_failure_leaves_value_safe_retriable_intent() -> None:
+    custody = FakeCustodian()
+    custody.fail = True
+    service, store, _custody = manager(custody=custody)
+    with pytest.raises(IntegrityError) as caught:
+        service.submit(TRANSACTION_ID, **submission(store))
+    assert caught.value.code == "secret-custody-unavailable"
+    assert store.intent is not None
+    assert store.loaded["configuration"] is None
+    assert SENTINEL not in str(caught.value)
+    assert SENTINEL not in json.dumps(store.intent)
+
+
+def test_wrong_binding_or_locked_state_fails_before_custody() -> None:
+    service, store, custody = manager()
+    invalid = submission(store)
+    invalid["plan_hash"] = "0" * 64
+    with pytest.raises(ValidationRejected) as caught:
+        service.submit(TRANSACTION_ID, **invalid)
+    assert caught.value.code == "plan-hash-mismatch"
+    store.loaded["state"] = "approved"
+    with pytest.raises(TransitionError) as caught:
+        service.submit(TRANSACTION_ID, **submission(store))
+    assert caught.value.code == "configuration-locked"
+    assert custody.events == []
+
+
+def test_require_ready_revalidates_record_and_host_presence() -> None:
+    service, store, custody = manager()
+    service.submit(TRANSACTION_ID, **submission(store))
+    result = service.require_ready(TRANSACTION_ID, store.loaded["envelope"]["planHash"])
+    assert result["configured"] is True
+    assert custody.events[-1][0] == "status"
+    assert custody.events[-1][1]["reference"] == REFERENCE
+
+    original_status = custody.status
+    custody.status = lambda **_binding: {"presentSecretKeys": []}
+    with pytest.raises(IntegrityError) as caught:
+        service.require_ready(TRANSACTION_ID, store.loaded["envelope"]["planHash"])
+    assert caught.value.code == "secret-custody-presence-mismatch"
+    custody.status = original_status
+
+
+def test_require_ready_rejects_missing_or_stale_configuration() -> None:
+    service, store, _custody = manager()
+    with pytest.raises(TransitionError) as caught:
+        service.require_ready(TRANSACTION_ID, store.loaded["envelope"]["planHash"])
+    assert caught.value.code == "missing-configuration"
+
+    service.submit(TRANSACTION_ID, **submission(store))
+    store.loaded["configuration"]["schemaHash"] = "0" * 64
+    with pytest.raises(IntegrityError) as caught:
+        service.require_ready(TRANSACTION_ID, store.loaded["envelope"]["planHash"])
+    assert caught.value.code == "configuration-record-invalid"

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_configuration.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_configuration.py
@@ -49,6 +49,28 @@ def envelope() -> dict:
     return {"plan": plan, "planHash": hashlib.sha256(canonical.encode()).hexdigest()}
 
 
+def optional_envelope() -> dict:
+    plan = {
+        "schema": "ods.assistant-first.plan.v1",
+        "selectedServices": ["notes"],
+        "definitions": [
+            {
+                "id": "notes",
+                "configuration": [
+                    {
+                        **contract("LABEL"),
+                        "required": False,
+                    }
+                ],
+            }
+        ],
+        "requiredConfigKeys": [],
+        "requiredSecretKeys": [],
+    }
+    canonical = json.dumps(plan, sort_keys=True, separators=(",", ":")) + "\n"
+    return {"plan": plan, "planHash": hashlib.sha256(canonical.encode()).hexdigest()}
+
+
 class FakeStore:
     def __init__(self) -> None:
         self.loaded = {
@@ -261,3 +283,14 @@ def test_require_ready_rejects_missing_or_stale_configuration() -> None:
     with pytest.raises(IntegrityError) as caught:
         service.require_ready(TRANSACTION_ID, store.loaded["envelope"]["planHash"])
     assert caught.value.code == "configuration-record-invalid"
+
+
+def test_require_ready_allows_unset_optional_configuration() -> None:
+    service, store, custody = manager()
+    store.loaded["envelope"] = optional_envelope()
+    result = service.require_ready(
+        TRANSACTION_ID, store.loaded["envelope"]["planHash"]
+    )
+    assert result["configured"] is False
+    assert [field["key"] for field in result["fields"]] == ["LABEL"]
+    assert custody.events == []

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transactions.py
@@ -5,11 +5,10 @@ import json
 import os
 import threading
 
-import pytest
-
 import assistant_first_planner as planner
+import extension_configuration as configuration
 import extension_transactions as transactions
-
+import pytest
 
 pytestmark = pytest.mark.skipif(
     os.name != "posix", reason="the durable transaction store is Linux-qualified"
@@ -135,6 +134,52 @@ def build_envelope(service_id: str = "notes") -> dict:
         provider_preferences={},
         missing_config_keys=[],
         missing_secret_keys=[],
+        catalog_revision=CATALOG_REVISION,
+        observed_state_revision=STATE_REVISION,
+        observed_state=HOST_STATE,
+        policy_revision=POLICY_REVISION,
+        policy=POLICY,
+        valid_until=VALID_UNTIL,
+    )
+
+
+def build_configured_envelope() -> dict:
+    entry = catalog_entry("provider")
+    entry["service"]["planning"]["configuration"] = [
+        {
+            "key": "ENDPOINT",
+            "type": "url",
+            "required": True,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+        },
+        {
+            "key": "OFFSET",
+            "type": "integer",
+            "required": True,
+            "secret": False,
+            "source": "user",
+            "restart_behavior": "service",
+            "validation": {"minimum": -5, "maximum": 5},
+        },
+        {
+            "key": "TOKEN",
+            "type": "string",
+            "required": True,
+            "secret": True,
+            "source": "user",
+            "restart_behavior": "service",
+        },
+    ]
+    return planner.build_plan(
+        [entry],
+        requested_action="ensure",
+        requested_services=["provider"],
+        requested_capabilities=[],
+        provider_preferences={},
+        missing_config_keys=["ENDPOINT", "OFFSET"],
+        missing_secret_keys=["TOKEN"],
         catalog_revision=CATALOG_REVISION,
         observed_state_revision=STATE_REVISION,
         observed_state=HOST_STATE,
@@ -882,3 +927,219 @@ def test_exact_owner_approval_serializes_concurrent_calls(tmp_path):
 
     assert all(not thread.is_alive() for thread in threads)
     assert sorted(result["noop"] for result in results) == [False, True]
+
+
+def test_configuration_intent_and_record_are_immutable_value_safe_and_required(
+    tmp_path,
+):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_configured_envelope()
+    descriptor = create(store, envelope)
+    transaction_id = descriptor["transactionId"]
+    schema_hash = configuration.configuration_schema(
+        envelope, expected_plan_hash=envelope["planHash"]
+    )["schemaHash"]
+
+    with pytest.raises(transactions.ApprovalError) as caught:
+        store.approve_exact(
+            transaction_id,
+            envelope["planHash"],
+            "owner-" + "a" * 16,
+            APPROVED_AT,
+            NOW,
+        )
+    assert caught.value.code == "missing-configuration"
+
+    values = {"ENDPOINT": "https://example.invalid/v1", "OFFSET": -1}
+    intent = store.begin_configuration_exact(
+        transaction_id,
+        envelope["planHash"],
+        schema_hash,
+        "2" * 64,
+        values,
+        ["TOKEN"],
+        [],
+        CREATED_AT,
+        NOW,
+    )
+    transaction_dir = store._tx_dir / transaction_id
+    intent_path = transaction_dir / "configuration-intent.json"
+    intent_bytes = intent_path.read_bytes()
+    assert intent["duplicate"] is False
+    assert intent["values"]["OFFSET"] == -1
+    assert b"secretReference" not in intent_bytes
+    assert b"secretValues" not in intent_bytes
+    assert "private-do-not-write" not in intent_bytes.decode()
+    assert (intent_path.stat().st_mode & 0o777) == 0o600
+
+    reference = "secret-v1-" + "3" * 48
+    record = store.finish_configuration_exact(
+        transaction_id,
+        envelope["planHash"],
+        "2" * 64,
+        reference,
+    )
+    record_path = transaction_dir / "configuration.json"
+    record_bytes = record_path.read_bytes()
+    assert record["duplicate"] is False
+    assert record["secretReference"] == reference
+    assert b"secretValues" not in record_bytes
+    assert (record_path.stat().st_mode & 0o777) == 0o600
+    assert store.read(transaction_id)["configuration"]["values"] == values
+
+    approved = store.approve_exact(
+        transaction_id,
+        envelope["planHash"],
+        "owner-" + "a" * 16,
+        APPROVED_AT,
+        NOW,
+    )
+    assert approved["state"] == "approved"
+
+
+def test_configuration_exact_retry_and_conflict_do_not_replace_intent(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_configured_envelope()
+    descriptor = create(store, envelope)
+    transaction_id = descriptor["transactionId"]
+    schema_hash = configuration.configuration_schema(
+        envelope, expected_plan_hash=envelope["planHash"]
+    )["schemaHash"]
+    arguments = (
+        transaction_id,
+        envelope["planHash"],
+        schema_hash,
+        "4" * 64,
+        {"ENDPOINT": "https://example.invalid/v1", "OFFSET": -1},
+        ["TOKEN"],
+        [],
+        CREATED_AT,
+        NOW,
+    )
+    first = store.begin_configuration_exact(*arguments)
+    replay = store.begin_configuration_exact(*arguments)
+    assert first["duplicate"] is False
+    assert replay["duplicate"] is True
+
+    changed = list(arguments)
+    changed[4] = {"ENDPOINT": "https://other.invalid/v1", "OFFSET": -1}
+    with pytest.raises(transactions.IdempotencyConflict) as caught:
+        store.begin_configuration_exact(*changed)
+    assert caught.value.code == "configuration-conflict"
+    assert store.read(transaction_id)["configuration"] is None
+
+
+def test_configuration_intent_serializes_competing_store_instances(tmp_path):
+    root = tmp_path / "transactions"
+    first_store = transactions.TransactionStore(root)
+    second_store = transactions.TransactionStore(root)
+    envelope = build_configured_envelope()
+    descriptor = create(first_store, envelope)
+    transaction_id = descriptor["transactionId"]
+    schema_hash = configuration.configuration_schema(
+        envelope, expected_plan_hash=envelope["planHash"]
+    )["schemaHash"]
+    results = []
+    errors = []
+
+    def reserve(store, suffix: str) -> None:
+        try:
+            results.append(
+                store.begin_configuration_exact(
+                    transaction_id,
+                    envelope["planHash"],
+                    schema_hash,
+                    suffix * 64,
+                    {
+                        "ENDPOINT": f"https://{suffix}.example.invalid/v1",
+                        "OFFSET": -1,
+                    },
+                    ["TOKEN"],
+                    [],
+                    CREATED_AT,
+                    NOW,
+                )
+            )
+        except transactions.TransactionError as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=reserve, args=(first_store, "5")),
+        threading.Thread(target=reserve, args=(second_store, "6")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert len(results) == 1
+    assert len(errors) == 1
+    assert errors[0].code == "configuration-conflict"
+
+
+def test_configuration_record_must_match_its_durable_intent(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_configured_envelope()
+    descriptor = create(store, envelope)
+    transaction_id = descriptor["transactionId"]
+    schema_hash = configuration.configuration_schema(
+        envelope, expected_plan_hash=envelope["planHash"]
+    )["schemaHash"]
+    store.begin_configuration_exact(
+        transaction_id,
+        envelope["planHash"],
+        schema_hash,
+        "7" * 64,
+        {"ENDPOINT": "https://example.invalid/v1", "OFFSET": -1},
+        ["TOKEN"],
+        [],
+        CREATED_AT,
+        NOW,
+    )
+    store.finish_configuration_exact(
+        transaction_id,
+        envelope["planHash"],
+        "7" * 64,
+        "secret-v1-" + "8" * 48,
+    )
+    record_path = store._tx_dir / transaction_id / "configuration.json"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    record["values"]["OFFSET"] = -2
+    record_path.write_bytes(transactions.canonical_json_bytes(record))
+
+    with pytest.raises(transactions.IntegrityError) as caught:
+        store.read(transaction_id)
+    assert caught.value.code == "configuration-intent-mismatch"
+
+
+@pytest.mark.parametrize(
+    ("values", "secret_keys", "default_keys", "code"),
+    [
+        ([], ["TOKEN"], [], "invalid-configuration-values"),
+        ({"OFFSET": -1}, "TOKEN", [], "invalid-configuration-keys"),
+        ({"OFFSET": -1}, ["TOKEN", "TOKEN"], [], "invalid-configuration-keys"),
+    ],
+)
+def test_configuration_reservation_rejects_malformed_direct_inputs(
+    tmp_path, values, secret_keys, default_keys, code
+):
+    store = transactions.TransactionStore(tmp_path / "transactions")
+    envelope = build_configured_envelope()
+    descriptor = create(store, envelope)
+    schema_hash = configuration.configuration_schema(
+        envelope, expected_plan_hash=envelope["planHash"]
+    )["schemaHash"]
+    with pytest.raises(transactions.ValidationRejected) as caught:
+        store.begin_configuration_exact(
+            descriptor["transactionId"],
+            envelope["planHash"],
+            schema_hash,
+            "9" * 64,
+            values,
+            secret_keys,
+            default_keys,
+            CREATED_AT,
+            NOW,
+        )
+    assert caught.value.code == code


### PR DESCRIPTION
## Summary

Phase 4C of the Assistant First stack bridges Manifest v2 typed configuration to the Phase 4B host-owned secret custodian.

- derive the configuration form from the server-stored canonical plan; callers cannot submit or replace the envelope
- accept non-secret values and secret values through separate bounded channels
- reserve an immutable, value-safe configuration intent before contacting the host, then persist only non-secret values, presence metadata, and the opaque host reference
- make exact retries crash-recoverable and reject competing submissions under the cross-process transaction lock
- revalidate plan, schema, stored values, secret presence, and host custody immediately before approval and execution
- expose authenticated, no-store GET/POST configuration routes without returning secret values or references
- preserve the existing default-off feature gate and injected runtime boundary

This PR is stacked on `feat/assistant-first-phase-4b-secret-custody` / #4466 and must land after it.

## Security properties

- secret values are sent only in the fixed-body POST to the host custodian
- transaction intent, final record, API responses, receipts, and stable errors contain no secret values
- caller-supplied plan envelopes, authority fields, floats, duplicate JSON keys, malformed UTF-8, and oversized requests fail closed
- configuration becomes immutable outside `awaiting_approval`
- approval time is sampled after custody readiness verification
- host stage, status, and delete responses require exact binding and shape
- configuration files use the existing `0700` directory / `0600` immutable-file discipline with no-follow and hardlink defenses

## Verification

- Windows focused matrix: `120 passed, 99 skipped`
- Windows full Dashboard API regression: `2935 passed, 120 skipped`; one unrelated environment failure because the host lacks Windows symlink privilege in `test_user_extensions.py::TestScanUserExtensions::test_scan_symlink_skipped`
- Tower1 exact-SHA Linux matrix: `219 passed, 0 skipped, 0 failed`
- changed-file Ruff `F,I`: clean
- strict Ruff on new files: clean
- `git diff --check`: clean

Initial Linux review found and the delta fixes approval for plans with no required configuration and rejects empty secrets before host custody. Final exact candidate: `1d49f0a07d371e0eca2f1ce815bf50744ca7855a`.

## Scope boundary

This phase provides deterministic configuration validation, host custody, durable recovery, and approval/execution readiness. Applying non-secret values and secret references to extension adapters remains a later execution integration phase. No install, deployment, live-service mutation, or destructive data purge is included.
