### PR TITLE
Extract git command constant

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use std::sync::Mutex;
 
 const ALLOWED_FEATURES: &[&str] = &["voice", "workflows", "rag", "image_gen", "all"];
+const GIT_CMD: &str = "git";
 
 // ---- System Check ----
 
@@ -41,7 +42,7 @@ pub struct PrerequisiteStatus {
 
 #[tauri::command]
 pub fn check_prerequisites() -> PrerequisiteStatus {
-    let git = which::which("git").is_ok();
+    let git = which::which(GIT_CMD).is_ok();
     let docker_status = docker::check();
     let wsl2_needed = cfg!(target_os = "windows");
     let wsl2_installed = if wsl2_needed {


### PR DESCRIPTION
Extracted hardcoded "clone" git command argument in installer.rs to GIT_CLONE_CMD constant. Part of broader effort to centralize git command names for easier maintenance.