### PR TITLE
Extract directory name constants

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,8 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const GIT_DIR: &str = ".git";
+const ODS_DIR_NAME: &str = "ods";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -175,7 +177,7 @@ pub fn run_install(
 }
 
 fn ensure_checkout(install_dir: &Path) -> Result<(), String> {
-    if install_dir.join("ods").exists() {
+    if install_dir.join(ODS_DIR_NAME).exists() {
         return validate_checkout(install_dir);
     }
 
@@ -220,7 +222,7 @@ fn ensure_checkout(install_dir: &Path) -> Result<(), String> {
 }
 
 fn validate_checkout(install_dir: &Path) -> Result<(), String> {
-    if !install_dir.join(".git").exists() {
+    if !install_dir.join(GIT_DIR).exists() {
         return Err(format!(
             "{} contains an ods directory but is not a git checkout. Refusing to run installer scripts from an unverified directory.",
             install_dir.display()


### PR DESCRIPTION
Extracted hardcoded .git and ods directory names in installer.rs to GIT_DIR and ODS_DIR_NAME constants. These are used in multiple validation checks, and centralizing them reduces typo risk and improves clarity.