### PR TITLE
Extract chmod executable permission constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const CHMOD_EXECUTABLE: &str = "+x";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -74,7 +75,7 @@ pub fn run_install(
     #[cfg(not(target_os = "windows"))]
     {
         let _ = Command::new("chmod")
-            .args(["+x", &install_script.to_string_lossy()])
+            .args([CHMOD_EXECUTABLE, &install_script.to_string_lossy()])
             .output();
     }
 


### PR DESCRIPTION
Extracted hardcoded "+x" chmod permission string in installer.rs to CHMOD_EXECUTABLE constant. Makes the Unix file permission value explicit and easier to find if needed for adjustments.