### PR TITLE
Extract PowerShell execution policy constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const PS_EXECUTION_POLICY: &str = "Bypass";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -82,7 +83,7 @@ pub fn run_install(
         let mut ps_args = vec![
             "-NoProfile".to_string(),
             "-ExecutionPolicy".to_string(),
-            "Bypass".to_string(),
+            PS_EXECUTION_POLICY.to_string(),
             "-File".to_string(),
             install_ps1.to_string_lossy().to_string(),
             "-NonInteractive".to_string(),


### PR DESCRIPTION
xtract PowerShell execution policy constant - Replaced hardcoded "Bypass" execution policy string with PS_EXECUTION_POLICY constant in the Windows installer PowerShell arguments for easier configuration and maintenance.