### PR TITLE
feat(extensions): bind lifecycle effects to approved plans

### DIFF
--- a/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
@@ -59,6 +59,13 @@ profiles remain disabled unless an operator explicitly enables it.
 Execution provenance is rechecked inside the executor's service locks against
 the current catalog revision, policy revision, normalized observed-state
 revision, canonical stored plan hash, and selected definition digests.
+After the exact stored hash is validated, the executor creates one immutable
+binding from the transaction ID and SHA-256 plan hash. Every lifecycle adapter
+call receives that binding, and every synchronous completion result and durable
+host observation must echo both values exactly. Missing or mismatched binding
+evidence fails closed and enters the existing reconciliation path. Execution
+receipts return the stored plan hash from the executor result rather than
+independently reflecting request input.
 
 ## Why disabled by default
 

--- a/ods/extensions/services/dashboard-api/extension_transaction_executor.py
+++ b/ods/extensions/services/dashboard-api/extension_transaction_executor.py
@@ -10,6 +10,7 @@ deliberately absent from this module.
 from __future__ import annotations
 
 import datetime
+import re
 import threading
 from dataclasses import dataclass, field
 from typing import Any, Callable, Protocol
@@ -33,6 +34,21 @@ EXECUTION_STEPS = (
 )
 ACTIVE_STATES = frozenset(EXECUTION_STEPS[:-1])
 RECOVERY_STATES = frozenset({"failed", "reconciling"})
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+@dataclass(frozen=True)
+class ExecutionBinding:
+    """Immutable identity that every host effect and observation must echo."""
+
+    transaction_id: str
+    plan_hash: str
+
+    def __post_init__(self) -> None:
+        if not self.transaction_id:
+            raise ValidationRejected("invalid-transaction-id")
+        if _SHA256_RE.fullmatch(self.plan_hash) is None:
+            raise ValidationRejected("invalid-plan-hash")
 
 
 class ProvenanceVerifier(Protocol):
@@ -58,44 +74,64 @@ class LifecycleAdapter(Protocol):
 
     Every method returns a mapping containing both ``ok: true`` and
     ``completed: true`` only after the requested work has completed. A queued
-    job or HTTP 202 acknowledgement is never completion. ``backup_all`` must
+    job or HTTP 202 acknowledgement is never completion. The mapping must echo
+    the binding as ``transactionId`` and ``planHash``. ``backup_all`` must
     preserve the first pre-transaction backup when replayed after a crash.
     """
 
-    def reserve(self, operation: dict[str, str]) -> dict[str, Any]: ...
-
-    def download_and_verify_all(
-        self, operations: list[dict[str, str]]
+    def reserve(
+        self, binding: ExecutionBinding, operation: dict[str, str]
     ) -> dict[str, Any]: ...
 
-    def stage_all(self, operations: list[dict[str, str]]) -> dict[str, Any]: ...
+    def download_and_verify_all(
+        self, binding: ExecutionBinding, operations: list[dict[str, str]]
+    ) -> dict[str, Any]: ...
 
-    def backup_all(self, service_ids: list[str]) -> dict[str, Any]: ...
+    def stage_all(
+        self, binding: ExecutionBinding, operations: list[dict[str, str]]
+    ) -> dict[str, Any]: ...
 
-    def configure_all(self, service_ids: list[str]) -> dict[str, Any]: ...
+    def backup_all(
+        self, binding: ExecutionBinding, service_ids: list[str]
+    ) -> dict[str, Any]: ...
 
-    def apply_one(self, operation: dict[str, str]) -> dict[str, Any]: ...
+    def configure_all(
+        self, binding: ExecutionBinding, service_ids: list[str]
+    ) -> dict[str, Any]: ...
 
-    def verify_all(self, service_ids: list[str]) -> dict[str, Any]: ...
+    def apply_one(
+        self, binding: ExecutionBinding, operation: dict[str, str]
+    ) -> dict[str, Any]: ...
 
-    def compensate_one(self, operation: dict[str, str]) -> dict[str, Any]: ...
+    def verify_all(
+        self, binding: ExecutionBinding, service_ids: list[str]
+    ) -> dict[str, Any]: ...
 
-    def restore_all(self, service_ids: list[str]) -> dict[str, Any]: ...
+    def compensate_one(
+        self, binding: ExecutionBinding, operation: dict[str, str]
+    ) -> dict[str, Any]: ...
 
-    def release(self, service_ids: list[str]) -> dict[str, Any]: ...
+    def restore_all(
+        self, binding: ExecutionBinding, service_ids: list[str]
+    ) -> dict[str, Any]: ...
+
+    def release(
+        self, binding: ExecutionBinding, service_ids: list[str]
+    ) -> dict[str, Any]: ...
 
 
 class ObservationAdapter(Protocol):
-    """Read durable host evidence, never transient progress UI state."""
+    """Read durable host evidence bound to the exact stored plan."""
 
-    def observe(self, transaction_id: str) -> dict[str, Any]:
-        """Return exactly ``{"appliedServices": [IDs in plan order]}``."""
+    def observe(self, binding: ExecutionBinding) -> dict[str, Any]:
+        """Return the binding plus ``appliedServices`` in plan order."""
         ...
 
 
 @dataclass(frozen=True)
 class ExecuteResult:
     transaction_id: str
+    plan_hash: str
     final_state: str
     sequence: int
     applied_services: list[str] = field(default_factory=list)
@@ -131,6 +167,7 @@ class TransactionExecutor:
         secrets, shell commands, or purge intent.
         """
         with self._process_lock:
+            binding = ExecutionBinding(transaction_id, plan_hash)
             initial = self._load_exact(transaction_id, plan_hash)
             if initial["state"] in TERMINAL_STATES:
                 return self._result(initial)
@@ -148,7 +185,7 @@ class TransactionExecutor:
                 if state in TERMINAL_STATES:
                     return self._result(loaded)
                 if state in RECOVERY_STATES:
-                    return self._reconcile(transaction_id, operations, service_ids)
+                    return self._reconcile(binding, operations, service_ids)
                 if state != "approved" and state not in ACTIVE_STATES:
                     raise TransitionError("invalid-start-state", state)
 
@@ -160,7 +197,7 @@ class TransactionExecutor:
                     if state == "approved":
                         raise TransitionError("provenance-check-failed") from exc
                     return self._fail_and_reconcile(
-                        transaction_id,
+                        binding,
                         operations,
                         service_ids,
                         "provenance-check-failed",
@@ -169,7 +206,7 @@ class TransactionExecutor:
                     if state == "approved":
                         raise TransitionError("provenance-mismatch")
                     return self._fail_and_reconcile(
-                        transaction_id,
+                        binding,
                         operations,
                         service_ids,
                         "provenance-mismatch",
@@ -184,7 +221,7 @@ class TransactionExecutor:
                     )
                     state = "reserved"
 
-                return self._drive(transaction_id, state, operations, service_ids)
+                return self._drive(binding, state, operations, service_ids)
 
     def _load_exact(self, transaction_id: str, plan_hash: str) -> dict[str, Any]:
         loaded = self._store.read(transaction_id)
@@ -197,7 +234,7 @@ class TransactionExecutor:
 
     def _drive(
         self,
-        transaction_id: str,
+        binding: ExecutionBinding,
         state: str,
         operations: list[dict[str, str]],
         service_ids: list[str],
@@ -205,10 +242,10 @@ class TransactionExecutor:
         while state != "committed":
             try:
                 next_state = self._complete_phase(
-                    transaction_id, state, operations, service_ids
+                    binding, state, operations, service_ids
                 )
                 self._transition(
-                    transaction_id,
+                    binding.transaction_id,
                     next_state,
                     step=state,
                     status="completed",
@@ -216,13 +253,13 @@ class TransactionExecutor:
                 state = next_state
             except Exception as exc:
                 return self._fail_and_reconcile(
-                    transaction_id,
+                    binding,
                     operations,
                     service_ids,
                     _safe_failure_code(state, exc),
                 )
 
-        loaded = self._store.read(transaction_id)
+        loaded = self._store.read(binding.transaction_id)
         mutable_ops = [op for op in operations if op["action"] != "noop"]
         return self._result(
             loaded,
@@ -231,7 +268,7 @@ class TransactionExecutor:
 
     def _complete_phase(
         self,
-        transaction_id: str,
+        binding: ExecutionBinding,
         state: str,
         operations: list[dict[str, str]],
         service_ids: list[str],
@@ -242,44 +279,55 @@ class TransactionExecutor:
         if state == "reserved":
             for operation in mutable_ops:
                 self._require_completed(
-                    self._adapter.reserve(dict(operation)), "reserve"
+                    self._adapter.reserve(binding, dict(operation)),
+                    "reserve",
+                    binding,
                 )
             return "downloading"
 
         if state == "downloading":
             self._require_completed(
                 self._adapter.download_and_verify_all(
-                    [dict(op) for op in mutable_ops]
+                    binding, [dict(op) for op in mutable_ops]
                 ),
                 "download-and-verify",
+                binding,
             )
             return "staged"
 
         if state == "staged":
             self._require_completed(
-                self._adapter.stage_all([dict(op) for op in mutable_ops]), "stage"
+                self._adapter.stage_all(binding, [dict(op) for op in mutable_ops]),
+                "stage",
+                binding,
             )
             return "configuring"
 
         if state == "configuring":
             self._require_completed(
-                self._adapter.backup_all(list(mutable_service_ids)), "backup"
+                self._adapter.backup_all(binding, list(mutable_service_ids)),
+                "backup",
+                binding,
             )
             self._require_completed(
-                self._adapter.configure_all(list(mutable_service_ids)), "configure"
+                self._adapter.configure_all(binding, list(mutable_service_ids)),
+                "configure",
+                binding,
             )
             return "applying"
 
         if state == "applying":
-            applied = self._observed_applied(transaction_id, mutable_ops)
+            applied = self._observed_applied(binding, mutable_ops)
             for index, operation in enumerate(mutable_ops):
                 service_id = operation["serviceId"]
                 if index < len(applied):
                     continue
                 self._require_completed(
-                    self._adapter.apply_one(dict(operation)), "apply"
+                    self._adapter.apply_one(binding, dict(operation)),
+                    "apply",
+                    binding,
                 )
-                applied = self._observed_applied(transaction_id, mutable_ops)
+                applied = self._observed_applied(binding, mutable_ops)
                 expected = [op["serviceId"] for op in mutable_ops[: index + 1]]
                 if applied != expected:
                     raise IntegrityError(
@@ -288,15 +336,19 @@ class TransactionExecutor:
             return "verifying"
 
         if state == "verifying":
-            applied = self._observed_applied(transaction_id, mutable_ops)
+            applied = self._observed_applied(binding, mutable_ops)
             expected = [op["serviceId"] for op in mutable_ops]
             if applied != expected:
                 raise IntegrityError("incomplete-apply-before-verify")
             self._require_completed(
-                self._adapter.verify_all(list(service_ids)), "verify"
+                self._adapter.verify_all(binding, list(service_ids)),
+                "verify",
+                binding,
             )
             self._require_completed(
-                self._adapter.release(list(mutable_service_ids)), "release"
+                self._adapter.release(binding, list(mutable_service_ids)),
+                "release",
+                binding,
             )
             return "committed"
 
@@ -304,25 +356,25 @@ class TransactionExecutor:
 
     def _fail_and_reconcile(
         self,
-        transaction_id: str,
+        binding: ExecutionBinding,
         operations: list[dict[str, str]],
         service_ids: list[str],
         failure_code: str,
     ) -> ExecuteResult:
-        loaded = self._store.read(transaction_id)
+        loaded = self._store.read(binding.transaction_id)
         state = loaded["state"]
         if state in TERMINAL_STATES:
             return self._result(loaded)
         if state not in RECOVERY_STATES:
             self._transition(
-                transaction_id,
+                binding.transaction_id,
                 "failed",
                 step="execute",
                 status="failed",
                 detail=failure_code,
             )
         return self._reconcile(
-            transaction_id,
+            binding,
             operations,
             service_ids,
             failure_code=failure_code,
@@ -330,15 +382,15 @@ class TransactionExecutor:
 
     def _reconcile(
         self,
-        transaction_id: str,
+        binding: ExecutionBinding,
         operations: list[dict[str, str]],
         service_ids: list[str],
         failure_code: str = "interrupted-execution",
     ) -> ExecuteResult:
-        loaded = self._store.read(transaction_id)
+        loaded = self._store.read(binding.transaction_id)
         if loaded["state"] == "failed":
             self._transition(
-                transaction_id,
+                binding.transaction_id,
                 "reconciling",
                 step="reconcile",
                 status="started",
@@ -350,7 +402,7 @@ class TransactionExecutor:
         mutable_service_ids = [op["serviceId"] for op in mutable_ops]
         recovery_ok = True
         try:
-            applied = self._observed_applied(transaction_id, mutable_ops)
+            applied = self._observed_applied(binding, mutable_ops)
         except Exception:
             applied = []
             recovery_ok = False
@@ -359,10 +411,13 @@ class TransactionExecutor:
         for service_id in reversed(applied):
             try:
                 self._require_completed(
-                    self._adapter.compensate_one(dict(by_service[service_id])),
+                    self._adapter.compensate_one(
+                        binding, dict(by_service[service_id])
+                    ),
                     "compensate",
+                    binding,
                 )
-                remaining = self._observed_applied(transaction_id, mutable_ops)
+                remaining = self._observed_applied(binding, mutable_ops)
                 if service_id in remaining:
                     raise IntegrityError(
                         "missing-durable-compensation-evidence", service_id
@@ -373,31 +428,41 @@ class TransactionExecutor:
         for operation_name, call in (
             (
                 "restore",
-                lambda: self._adapter.restore_all(list(mutable_service_ids)),
+                lambda: self._adapter.restore_all(
+                    binding, list(mutable_service_ids)
+                ),
             ),
-            ("release", lambda: self._adapter.release(list(mutable_service_ids))),
+            (
+                "release",
+                lambda: self._adapter.release(binding, list(mutable_service_ids)),
+            ),
         ):
             try:
-                self._require_completed(call(), operation_name)
+                self._require_completed(call(), operation_name, binding)
             except Exception:
                 recovery_ok = False
 
         final_state = "rolled_back" if recovery_ok else "manual_recovery_required"
         self._transition(
-            transaction_id,
+            binding.transaction_id,
             final_state,
             step="reconcile",
             status="completed" if recovery_ok else "manual-required",
         )
-        loaded = self._store.read(transaction_id)
+        loaded = self._store.read(binding.transaction_id)
         return self._result(loaded, applied_services=applied, error=failure_code)
 
     def _observed_applied(
-        self, transaction_id: str, operations: list[dict[str, str]]
+        self, binding: ExecutionBinding, operations: list[dict[str, str]]
     ) -> list[str]:
-        evidence = self._observer.observe(transaction_id)
-        if not isinstance(evidence, dict) or set(evidence) != {"appliedServices"}:
+        evidence = self._observer.observe(binding)
+        if not isinstance(evidence, dict) or set(evidence) != {
+            "appliedServices",
+            "planHash",
+            "transactionId",
+        }:
             raise IntegrityError("invalid-observation-shape")
+        self._require_binding(evidence, "observation", binding)
         applied = evidence["appliedServices"]
         if not isinstance(applied, list) or any(
             not isinstance(service_id, str) for service_id in applied
@@ -410,14 +475,29 @@ class TransactionExecutor:
             raise IntegrityError("non-prefix-applied-services")
         return list(applied)
 
-    @staticmethod
-    def _require_completed(result: dict[str, Any], operation: str) -> None:
+    @classmethod
+    def _require_completed(
+        cls,
+        result: dict[str, Any],
+        operation: str,
+        binding: ExecutionBinding,
+    ) -> None:
         if not isinstance(result, dict):
             raise TransitionError("adapter-incomplete", operation)
         if result.get("statusCode") in {202, "202"} or result.get("accepted") is True:
             raise TransitionError("adapter-background-ack", operation)
         if result.get("ok") is not True or result.get("completed") is not True:
             raise TransitionError("adapter-incomplete", operation)
+        cls._require_binding(result, operation, binding)
+
+    @staticmethod
+    def _require_binding(
+        evidence: dict[str, Any], operation: str, binding: ExecutionBinding
+    ) -> None:
+        if evidence.get("transactionId") != binding.transaction_id:
+            raise IntegrityError("adapter-transaction-mismatch", operation)
+        if evidence.get("planHash") != binding.plan_hash:
+            raise IntegrityError("adapter-plan-hash-mismatch", operation)
 
     def _transition(
         self,
@@ -450,6 +530,7 @@ class TransactionExecutor:
     ) -> ExecuteResult:
         return ExecuteResult(
             transaction_id=loaded["transactionId"],
+            plan_hash=loaded["envelope"]["planHash"],
             final_state=loaded["state"],
             sequence=loaded["sequence"],
             applied_services=list(applied_services or []),

--- a/ods/extensions/services/dashboard-api/routers/extension_transactions.py
+++ b/ods/extensions/services/dashboard-api/routers/extension_transactions.py
@@ -561,7 +561,7 @@ async def execute_transaction(
     return JSONResponse(
         content={
             "transactionId": result.transaction_id,
-            "planHash": model.planHash,
+            "planHash": result.plan_hash,
             "finalState": result.final_state,
             "sequence": result.sequence,
             "appliedServices": result.applied_services,

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_api.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_api.py
@@ -156,6 +156,7 @@ class FakeExecutor:
         self.calls.append((transaction_id, plan_hash))
         return SimpleNamespace(
             transaction_id=transaction_id,
+            plan_hash=plan_hash,
             final_state="committed",
             sequence=10,
             applied_services=["notes"],

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_executor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_executor.py
@@ -202,12 +202,18 @@ class RecordingAdapter:
     def fail_at(self, method: str, call_number: int) -> None:
         self._fail_at.setdefault(method, []).append(call_number)
 
-    def _record(self, method: str, kwargs: dict) -> dict:
+    def _record(self, method: str, binding, kwargs: dict) -> dict:
         count = len([c for c in self.calls if c[0] == method])
+        kwargs = {"binding": binding, **kwargs}
         self.calls.append((method, kwargs))
         if self._fail_at.get(method, []) and count in self._fail_at[method]:
             return {"ok": False, "error": "injected-failure"}
-        result = {"ok": True, "completed": True}
+        result = {
+            "ok": True,
+            "completed": True,
+            "transactionId": binding.transaction_id,
+            "planHash": binding.plan_hash,
+        }
         if method == "apply_one" and self.observer is not None:
             service_id = kwargs["operation"]["serviceId"]
             if service_id not in self.observer.applied_services:
@@ -218,35 +224,39 @@ class RecordingAdapter:
                 self.observer.applied_services.remove(service_id)
         return result
 
-    def reserve(self, operation: dict[str, str]) -> dict:
-        return self._record("reserve", {"operation": operation})
+    def reserve(self, binding, operation: dict[str, str]) -> dict:
+        return self._record("reserve", binding, {"operation": operation})
 
-    def download_and_verify_all(self, operations: list[dict[str, str]]) -> dict:
-        return self._record("download_and_verify_all", {"operations": operations})
+    def download_and_verify_all(
+        self, binding, operations: list[dict[str, str]]
+    ) -> dict:
+        return self._record(
+            "download_and_verify_all", binding, {"operations": operations}
+        )
 
-    def stage_all(self, operations: list[dict[str, str]]) -> dict:
-        return self._record("stage_all", {"operations": operations})
+    def stage_all(self, binding, operations: list[dict[str, str]]) -> dict:
+        return self._record("stage_all", binding, {"operations": operations})
 
-    def backup_all(self, service_ids: list[str]) -> dict:
-        return self._record("backup_all", {"service_ids": service_ids})
+    def backup_all(self, binding, service_ids: list[str]) -> dict:
+        return self._record("backup_all", binding, {"service_ids": service_ids})
 
-    def configure_all(self, service_ids: list[str]) -> dict:
-        return self._record("configure_all", {"service_ids": service_ids})
+    def configure_all(self, binding, service_ids: list[str]) -> dict:
+        return self._record("configure_all", binding, {"service_ids": service_ids})
 
-    def apply_one(self, operation: dict[str, str]) -> dict:
-        return self._record("apply_one", {"operation": operation})
+    def apply_one(self, binding, operation: dict[str, str]) -> dict:
+        return self._record("apply_one", binding, {"operation": operation})
 
-    def verify_all(self, service_ids: list[str]) -> dict:
-        return self._record("verify_all", {"service_ids": service_ids})
+    def verify_all(self, binding, service_ids: list[str]) -> dict:
+        return self._record("verify_all", binding, {"service_ids": service_ids})
 
-    def release(self, service_ids: list[str]) -> dict:
-        return self._record("release", {"service_ids": service_ids})
+    def release(self, binding, service_ids: list[str]) -> dict:
+        return self._record("release", binding, {"service_ids": service_ids})
 
-    def compensate_one(self, operation: dict[str, str]) -> dict:
-        return self._record("compensate_one", {"operation": operation})
+    def compensate_one(self, binding, operation: dict[str, str]) -> dict:
+        return self._record("compensate_one", binding, {"operation": operation})
 
-    def restore_all(self, service_ids: list[str]) -> dict:
-        return self._record("restore_all", {"service_ids": service_ids})
+    def restore_all(self, binding, service_ids: list[str]) -> dict:
+        return self._record("restore_all", binding, {"service_ids": service_ids})
 
 
 class RecordingObserver:
@@ -254,9 +264,15 @@ class RecordingObserver:
 
     def __init__(self) -> None:
         self.applied_services: list[str] = []
+        self.bindings = []
 
-    def observe(self, transaction_id: str) -> dict:
-        return {"appliedServices": list(self.applied_services)}
+    def observe(self, binding) -> dict:
+        self.bindings.append(binding)
+        return {
+            "transactionId": binding.transaction_id,
+            "planHash": binding.plan_hash,
+            "appliedServices": list(self.applied_services),
+        }
 
 
 class NoOpLockFactory:
@@ -333,6 +349,7 @@ def test_approved_only_execution(tmp_path):
     result = executor.execute(txn_id, envelope["planHash"])
 
     assert result.final_state == "committed"
+    assert result.plan_hash == envelope["planHash"]
     assert result.applied_services == ["notes"]
     assert result.error is None
 
@@ -350,6 +367,77 @@ def test_approved_only_execution(tmp_path):
     # Verify terminal state in store
     loaded = store.read(txn_id)
     assert loaded["state"] == "committed"
+
+
+def test_every_host_call_carries_the_exact_immutable_binding(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "store")
+    envelope = build_envelope(service_ids=["notes"])
+    descriptor = create_and_approve(store, envelope)
+    observer = RecordingObserver()
+    adapter = RecordingAdapter(observer)
+
+    result = make_executor(
+        store, adapter=adapter, observer=observer
+    ).execute(descriptor["transactionId"], envelope["planHash"])
+
+    assert result.final_state == "committed"
+    bindings = [payload["binding"] for _, payload in adapter.calls]
+    bindings.extend(observer.bindings)
+    assert bindings
+    assert all(
+        binding == executor_mod.ExecutionBinding(
+            descriptor["transactionId"], envelope["planHash"]
+        )
+        for binding in bindings
+    )
+    with pytest.raises(AttributeError):
+        bindings[0].plan_hash = "0" * 64
+
+
+@pytest.mark.parametrize("field", ["transactionId", "planHash"])
+def test_adapter_completion_with_wrong_binding_fails_closed(tmp_path, field):
+    store = transactions.TransactionStore(tmp_path / "store")
+    envelope = build_envelope(service_ids=["notes"])
+    descriptor = create_and_approve(store, envelope)
+    adapter = RecordingAdapter()
+
+    def wrong_bound_reserve(binding, operation):
+        result = adapter._record("reserve", binding, {"operation": operation})
+        result[field] = "0" * 64
+        return result
+
+    adapter.reserve = wrong_bound_reserve
+    result = make_executor(store, adapter=adapter).execute(
+        descriptor["transactionId"], envelope["planHash"]
+    )
+
+    assert result.final_state == "rolled_back"
+    expected = (
+        "adapter-transaction-mismatch"
+        if field == "transactionId"
+        else "adapter-plan-hash-mismatch"
+    )
+    assert expected in result.error
+
+
+def test_observation_with_wrong_binding_requires_manual_recovery(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "store")
+    envelope = build_envelope(service_ids=["notes"])
+    descriptor = create_and_approve(store, envelope)
+
+    class WrongBoundObserver(RecordingObserver):
+        def observe(self, binding):
+            evidence = super().observe(binding)
+            evidence["planHash"] = "0" * 64
+            return evidence
+
+    observer = WrongBoundObserver()
+    result = make_executor(store, observer=observer).execute(
+        descriptor["transactionId"], envelope["planHash"]
+    )
+
+    assert result.final_state == "manual_recovery_required"
+    assert "adapter-plan-hash-mismatch" in result.error
 
 
 def test_noop_services_are_observed_but_never_mutated(tmp_path):
@@ -552,19 +640,27 @@ def test_adapter_incomplete_rejection(tmp_path):
     class IncompleteAdapter:
         """Returns partial results without ok=True on reserve."""
         calls = []
-        def reserve(self, operation):
+        @staticmethod
+        def _complete(binding):
+            return {
+                "ok": True,
+                "completed": True,
+                "transactionId": binding.transaction_id,
+                "planHash": binding.plan_hash,
+            }
+        def reserve(self, binding, operation):
             self.calls.append(("reserve", operation))
             return {"status": "accepted"}  # No ok field → adapter-incomplete
-        def download_and_verify_all(self, operations):
-            return {"ok": True, "completed": True}
-        def stage_all(self, operations): return {"ok": True, "completed": True}
-        def backup_all(self, service_ids): return {"ok": True, "completed": True}
-        def configure_all(self, service_ids): return {"ok": True, "completed": True}
-        def apply_one(self, operation): return {"ok": True, "completed": True}
-        def verify_all(self, service_ids): return {"ok": True, "completed": True}
-        def release(self, service_ids): return {"ok": True, "completed": True}
-        def compensate_one(self, operation): return {"ok": True, "completed": True}
-        def restore_all(self, service_ids): return {"ok": True, "completed": True}
+        def download_and_verify_all(self, binding, operations):
+            return self._complete(binding)
+        def stage_all(self, binding, operations): return self._complete(binding)
+        def backup_all(self, binding, service_ids): return self._complete(binding)
+        def configure_all(self, binding, service_ids): return self._complete(binding)
+        def apply_one(self, binding, operation): return self._complete(binding)
+        def verify_all(self, binding, service_ids): return self._complete(binding)
+        def release(self, binding, service_ids): return self._complete(binding)
+        def compensate_one(self, binding, operation): return self._complete(binding)
+        def restore_all(self, binding, service_ids): return self._complete(binding)
 
     adapter = IncompleteAdapter()
     executor = make_executor(store, adapter=adapter)
@@ -804,8 +900,10 @@ def test_background_ack_is_not_completion(tmp_path):
 
     adapter = RecordingAdapter()
 
-    def queued_reserve(operation):
-        adapter.calls.append(("reserve", {"operation": operation}))
+    def queued_reserve(binding, operation):
+        adapter.calls.append(
+            ("reserve", {"binding": binding, "operation": operation})
+        )
         return {"ok": True, "completed": False, "statusCode": 202}
 
     adapter.reserve = queued_reserve
@@ -874,8 +972,8 @@ def test_crash_after_apply_resumes_from_durable_observation(tmp_path):
         pass
 
     class CrashAfterFirstApply(RecordingAdapter):
-        def apply_one(self, operation):
-            result = super().apply_one(operation)
+        def apply_one(self, binding, operation):
+            result = super().apply_one(binding, operation)
             if len([call for call in self.calls if call[0] == "apply_one"]) == 1:
                 raise InjectedCrash("simulated process death")
             return result
@@ -1025,8 +1123,8 @@ def test_crash_at_each_phase_converges_without_duplicate_effect(
             self.effects: set[tuple[str, str]] = set()
             self.effect_counts: dict[tuple[str, str], int] = {}
 
-        def _record(self, method, kwargs):
-            result = super()._record(method, kwargs)
+        def _record(self, method, binding, kwargs):
+            result = super()._record(method, binding, kwargs)
             operation = kwargs.get("operation")
             subject = operation["serviceId"] if operation else "all"
             key = (method, subject)
@@ -1070,8 +1168,8 @@ def test_crash_during_compensation_resumes_without_duplicate_compensation(tmp_pa
             self.crashed = False
             self.compensation_effects = 0
 
-        def compensate_one(self, operation):
-            result = super().compensate_one(operation)
+        def compensate_one(self, binding, operation):
+            result = super().compensate_one(binding, operation)
             self.compensation_effects += 1
             if not self.crashed:
                 self.crashed = True


### PR DESCRIPTION
## Summary

- add an immutable `ExecutionBinding` containing the durable transaction ID and exact SHA-256 plan hash
- pass that binding to every lifecycle adapter and durable observation call
- require synchronous completion receipts and observations to echo both binding values exactly
- return the stored plan hash from `ExecuteResult` and the execute API response
- fail mismatched, missing, or shape-broadened evidence into the existing reconciliation path

## Safety boundary

This is a source-only execution-contract foundation. The production runtime still has `executor=None`, capability discovery still reports `execution: false`, and the execute route still returns 503. It does not add a host adapter, enable mutation, install or start containers, expose secrets, approve plans, or merge any branch.

The adapter protocol change is intentionally breaking while no production adapter exists. This prevents a future adapter from inheriting an unbound lifecycle interface.

## Refreshed stack identity

- refreshed head: `71a403c3aa24b2ce5163c17d9311927a62237d16`
- exact tree: `a166b5359b624f087793215a1023465fe2bd6666`
- parents: prior Phase 4F head `c119c018e8d7c8f7527be32dbdb97b71fbeba99b`, then refreshed Phase 4E head `71224021629fbeee956f41c5f354e7d16b76cfa5`
- delta over refreshed Phase 4E: five files, 327 insertions, 99 deletions
- no rebase or force-push was used

## Verification

- exact-tree Linux transaction/executor/API/production/runtime suites: `162 passed`
- added regression coverage proving unexpected observation fields fail closed
- added regression coverage proving a stored envelope missing `planHash` is rejected by store integrity validation before result construction
- Python compile checks: passed
- `git diff --check`: passed
- two read-only adversarial reviews traced binding propagation, completion evidence, noop handling, compensation order, and stored-envelope validation; no remaining blocker
- GitHub exact-head CI: 32 successful checks and four intentionally skipped Claude-review jobs; no failures
- GitHub reports the PR `CLEAN` and `MERGEABLE`

## Follow-up

Later PRs implement cross-process locks and a host-owned synchronous adapter against this binding. Production execution must remain unadvertised until that adapter, backup/restore, crash replay, strict offline behavior, and real Linux qualification are complete.

