### PR TITLE
feat(extensions): share canonical operation locks

### DIFF
--- a/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
@@ -67,6 +67,21 @@ evidence fails closed and enters the existing reconciliation path. Execution
 receipts return the stored plan hash from the executor result rather than
 independently reflecting request input.
 
+Single-extension Dashboard mutations and the composite executor now share one
+file-lock implementation and namespace under
+`<ODS_DATA_DIR>/.extension-operation-locks`. Service IDs are validated before
+path creation, filenames are SHA-256-derived, symlinked directories and files
+fail closed, and composite lock sets are deduplicated and acquired in lexical
+service-ID order before caller code can run. A bounded composite acquisition
+unwinds every already-held lock if any later lock times out.
+
+This source foundation does not yet make the host agent a second lock owner.
+The current Dashboard routes call host-agent lifecycle endpoints while holding
+their operation lock, so making the callee acquire the same lock would
+self-deadlock. Production execution remains disabled until a host-owned lease
+or equivalent non-reentrant cross-process protocol binds caller and callee to
+the same transaction.
+
 ## Why disabled by default
 
 ODS does not yet have production lifecycle adapters with durable, synchronous
@@ -76,7 +91,7 @@ those adapters and cross-path locks are qualified would create false-success
 and collision risks.
 
 Lifecycle execution therefore remains unavailable by default and in the
-production runtime. The next phase must add the host-owned adapter,
-cross-path locking, backup/restore, strict offline behavior, and real Linux
+production runtime. The next phase must add the host-owned adapter and lease
+protocol, backup/restore, strict offline behavior, and real Linux
 qualification before advertising execution. Existing Full, Core, Custom, and
 single-extension routes remain unchanged.

--- a/ods/extensions/services/dashboard-api/extension_operation_locks.py
+++ b/ods/extensions/services/dashboard-api/extension_operation_locks.py
@@ -1,0 +1,229 @@
+"""Cross-process locks for extension lifecycle operations.
+
+Single-extension routes and composite transactions must use the same lock
+namespace.  The lock files live beside the durable ODS data root rather than
+inside an extension directory, so reinstalling an extension cannot replace a
+held lock inode.  Composite acquisitions are sorted and completed before the
+caller is allowed to mutate anything.
+
+These locks are advisory.  Every process that mutates extension lifecycle
+state must participate in this protocol and must see the same underlying data
+directory.  Kernel locks are released automatically when a process exits.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import math
+import os
+import re
+import stat
+import time
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Callable, Iterable
+
+if os.name == "nt":  # pragma: no cover - branch covered on Windows CI
+    fcntl = None
+    import msvcrt
+else:  # pragma: no cover - branch covered on POSIX CI
+    import fcntl
+
+    msvcrt = None
+
+
+_SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_LOCK_DIRECTORY = ".extension-operation-locks"
+_POLL_SECONDS = 0.05
+
+
+class ServiceLockError(RuntimeError):
+    """The requested extension lock could not be acquired safely."""
+
+
+class ServiceLockTimeout(ServiceLockError):
+    """A bounded extension lock acquisition exceeded its deadline."""
+
+
+def validate_service_id(service_id: str) -> str:
+    """Return a canonical service ID or fail before creating any path."""
+    if not isinstance(service_id, str) or _SERVICE_ID_RE.fullmatch(service_id) is None:
+        raise ServiceLockError("invalid-service-id")
+    return service_id
+
+
+def operation_lock_directory(lock_parent: Path) -> Path:
+    """Create and validate the stable operation-lock directory."""
+    parent = Path(lock_parent).resolve()
+    lock_dir = parent / _LOCK_DIRECTORY
+    if lock_dir.is_symlink():
+        raise ServiceLockError("operation-lock-directory-is-symlink")
+    try:
+        lock_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise ServiceLockError("operation-lock-directory-unavailable") from exc
+    if lock_dir.is_symlink():
+        raise ServiceLockError("operation-lock-directory-is-symlink")
+    try:
+        resolved = lock_dir.resolve(strict=True)
+    except OSError as exc:
+        raise ServiceLockError("operation-lock-directory-unavailable") from exc
+    if not resolved.is_relative_to(parent):
+        raise ServiceLockError("operation-lock-directory-escaped-parent")
+    if not resolved.is_dir():
+        raise ServiceLockError("operation-lock-directory-not-directory")
+    return resolved
+
+
+def operation_lock_path(lock_parent: Path, service_id: str) -> Path:
+    """Return the non-user-controlled filename for one service lock."""
+    import hashlib
+
+    service_id = validate_service_id(service_id)
+    lock_dir = operation_lock_directory(lock_parent)
+    lock_name = hashlib.sha256(service_id.encode("utf-8")).hexdigest() + ".lock"
+    return lock_dir / lock_name
+
+
+def _open_lock_file(lock_path: Path):
+    if lock_path.is_symlink():
+        raise ServiceLockError("operation-lock-file-is-symlink")
+
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_BINARY"):
+        flags |= os.O_BINARY
+    if hasattr(os, "O_NOINHERIT"):
+        flags |= os.O_NOINHERIT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise ServiceLockError("operation-lock-file-unavailable") from exc
+
+    try:
+        descriptor_stat = os.fstat(descriptor)
+        if not stat.S_ISREG(descriptor_stat.st_mode) or descriptor_stat.st_nlink != 1:
+            raise ServiceLockError("operation-lock-file-unsafe")
+        if lock_path.is_symlink():
+            raise ServiceLockError("operation-lock-file-is-symlink")
+        path_stat = lock_path.stat()
+        if (
+            os.name == "posix"
+            and (descriptor_stat.st_dev, descriptor_stat.st_ino)
+            != (path_stat.st_dev, path_stat.st_ino)
+        ):
+            raise ServiceLockError("operation-lock-file-replaced")
+        return os.fdopen(descriptor, "r+b", buffering=0)
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _acquire_lock(lockfile, lock_path: Path, timeout: float | None) -> None:
+    if timeout is not None and timeout < 0:
+        raise ServiceLockError("invalid-lock-timeout")
+
+    if timeout is None:
+        if fcntl is not None:
+            fcntl.flock(lockfile, fcntl.LOCK_EX)
+            return
+        lockfile.seek(0, os.SEEK_END)
+        if lockfile.tell() == 0:
+            lockfile.write(b"\0")
+        lockfile.seek(0)
+        msvcrt.locking(lockfile.fileno(), msvcrt.LK_LOCK, 1)
+        return
+
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            if fcntl is not None:
+                fcntl.flock(lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            else:
+                lockfile.seek(0, os.SEEK_END)
+                if lockfile.tell() == 0:
+                    lockfile.write(b"\0")
+                lockfile.seek(0)
+                msvcrt.locking(lockfile.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+        except (BlockingIOError, OSError):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise ServiceLockTimeout(f"service-lock-timeout:{lock_path.name}")
+            time.sleep(min(_POLL_SECONDS, remaining))
+
+
+def _release_lock(lockfile) -> None:
+    if fcntl is not None:
+        fcntl.flock(lockfile, fcntl.LOCK_UN)
+    else:
+        lockfile.seek(0)
+        msvcrt.locking(lockfile.fileno(), msvcrt.LK_UNLCK, 1)
+
+
+@contextlib.contextmanager
+def exclusive_file_lock(lock_path: Path, *, timeout: float | None = None):
+    """Acquire one symlink-safe cross-process lock file."""
+    lockfile = _open_lock_file(Path(lock_path))
+    acquired = False
+    try:
+        _acquire_lock(lockfile, Path(lock_path), timeout)
+        acquired = True
+        yield
+    finally:
+        try:
+            if acquired:
+                _release_lock(lockfile)
+        finally:
+            lockfile.close()
+
+
+@contextlib.contextmanager
+def lock_services(
+    lock_parent: Path,
+    service_ids: Iterable[str],
+    *,
+    timeout: float | None = None,
+):
+    """Acquire every requested service lock in canonical order.
+
+    No caller code runs until all locks are held.  If any acquisition fails,
+    ``ExitStack`` releases the already-held prefix in reverse order.
+    """
+    if timeout is not None and (
+        isinstance(timeout, bool)
+        or not isinstance(timeout, (int, float))
+        or not math.isfinite(timeout)
+        or timeout < 0
+    ):
+        raise ServiceLockError("invalid-lock-timeout")
+    canonical_ids = tuple(sorted({validate_service_id(item) for item in service_ids}))
+    lock_dir = operation_lock_directory(lock_parent)
+    deadline = None if timeout is None else time.monotonic() + timeout
+    with ExitStack() as stack:
+        for service_id in canonical_ids:
+            remaining = None
+            if deadline is not None:
+                remaining = max(0.0, deadline - time.monotonic())
+            lock_path = operation_lock_path(lock_dir.parent, service_id)
+            stack.enter_context(exclusive_file_lock(lock_path, timeout=remaining))
+        yield canonical_ids
+
+
+class FileServiceLockFactory:
+    """TransactionExecutor lock factory backed by the shared file namespace."""
+
+    def __init__(
+        self,
+        lock_parent: Path | Callable[[], Path],
+        *,
+        timeout: float | None = None,
+    ) -> None:
+        self._lock_parent = lock_parent
+        self._timeout = timeout
+
+    def lock_services(self, service_ids: list[str]):
+        parent = self._lock_parent() if callable(self._lock_parent) else self._lock_parent
+        return lock_services(parent, service_ids, timeout=self._timeout)

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -36,14 +36,7 @@ from host_agent_client import (
     request_text as request_agent_text,
 )
 from security import verify_api_key
-
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - only hit on Windows hosts
-    fcntl = None
-    import msvcrt
-else:  # pragma: no cover - platform branch
-    msvcrt = None
+from extension_operation_locks import exclusive_file_lock, lock_services
 
 logger = logging.getLogger(__name__)
 
@@ -1003,27 +996,8 @@ def _check_agent_health() -> bool:
 @contextlib.contextmanager
 def _exclusive_file_lock(lock_path: Path):
     """Acquire a cross-process exclusive lock for one lock file."""
-    lockfile = open(lock_path, "a+b")
-    try:
-        if fcntl is not None:
-            fcntl.flock(lockfile, fcntl.LOCK_EX)
-        elif msvcrt is not None:
-            lockfile.seek(0, os.SEEK_END)
-            if lockfile.tell() == 0:
-                lockfile.write(b"\0")
-                lockfile.flush()
-            lockfile.seek(0)
-            msvcrt.locking(lockfile.fileno(), msvcrt.LK_LOCK, 1)
+    with exclusive_file_lock(lock_path):
         yield
-    finally:
-        try:
-            if fcntl is not None:
-                fcntl.flock(lockfile, fcntl.LOCK_UN)
-            elif msvcrt is not None:
-                lockfile.seek(0)
-                msvcrt.locking(lockfile.fileno(), msvcrt.LK_UNLCK, 1)
-        finally:
-            lockfile.close()
 
 
 @contextlib.contextmanager
@@ -1037,14 +1011,7 @@ def _extensions_lock():
 def _extension_operation_lock(service_id: str):
     """Serialize the complete lifecycle transaction for one extension."""
     lock_parent = _extensions_lock_path().parent.resolve()
-    lock_dir = lock_parent / ".extension-operation-locks"
-    if lock_dir.is_symlink():
-        raise OSError("Extension operation lock directory is a symlink")
-    lock_dir.mkdir(parents=True, exist_ok=True)
-    if not lock_dir.resolve().is_relative_to(lock_parent):
-        raise OSError("Invalid extension operation lock directory")
-    lock_name = hashlib.sha256(service_id.encode("utf-8")).hexdigest() + ".lock"
-    with _exclusive_file_lock(lock_dir / lock_name):
+    with lock_services(lock_parent, [service_id]):
         yield
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_locks.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_locks.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import multiprocessing
 import sys
 import threading
+import time
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,14 @@ if str(DASHBOARD_API_DIR) not in sys.path:
     sys.path.insert(0, str(DASHBOARD_API_DIR))
 
 import extension_operation_locks as locks  # noqa: E402
+
+
+def _hold_lock_until_terminated(lock_path: str, ready_path: str) -> None:
+    """Child-process target used to prove kernel-owned crash release."""
+    with locks.exclusive_file_lock(Path(lock_path)):
+        Path(ready_path).write_text("ready", encoding="utf-8")
+        while True:
+            time.sleep(1)
 
 
 def test_composite_locks_are_deduplicated_and_acquired_in_canonical_order(
@@ -112,6 +122,33 @@ def test_competing_lock_times_out_then_succeeds_after_release(tmp_path):
 
     assert outcome == ["timed-out"]
     with locks.exclusive_file_lock(lock_path, timeout=0.1):
+        pass
+
+
+def test_cross_process_timeout_and_crash_release(tmp_path):
+    lock_path = locks.operation_lock_path(tmp_path, "documents")
+    ready_path = tmp_path / "child-ready"
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(
+        target=_hold_lock_until_terminated,
+        args=(str(lock_path), str(ready_path)),
+    )
+    process.start()
+    try:
+        deadline = time.monotonic() + 5
+        while not ready_path.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready_path.exists(), "child did not acquire the operation lock"
+
+        with pytest.raises(locks.ServiceLockTimeout):
+            with locks.exclusive_file_lock(lock_path, timeout=0.05):
+                pass
+    finally:
+        process.terminate()
+        process.join(timeout=5)
+
+    assert not process.is_alive()
+    with locks.exclusive_file_lock(lock_path, timeout=1):
         pass
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_locks.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_locks.py
@@ -1,0 +1,148 @@
+"""Tests for the shared single/composite extension operation locks."""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+DASHBOARD_API_DIR = Path(__file__).resolve().parent.parent
+if str(DASHBOARD_API_DIR) not in sys.path:
+    sys.path.insert(0, str(DASHBOARD_API_DIR))
+
+import extension_operation_locks as locks  # noqa: E402
+
+
+def test_composite_locks_are_deduplicated_and_acquired_in_canonical_order(
+    tmp_path, monkeypatch
+):
+    entered = []
+    exited = []
+
+    @contextlib.contextmanager
+    def recording_lock(lock_path, *, timeout=None):
+        entered.append((lock_path.name, timeout))
+        try:
+            yield
+        finally:
+            exited.append(lock_path.name)
+
+    monkeypatch.setattr(locks, "exclusive_file_lock", recording_lock)
+
+    with locks.lock_services(tmp_path, ["voice", "documents", "voice"], timeout=5):
+        assert [name for name, _ in entered] == [
+            locks.operation_lock_path(tmp_path, service_id).name
+            for service_id in ("documents", "voice")
+        ]
+
+    assert exited == [name for name, _ in reversed(entered)]
+
+
+@pytest.mark.parametrize(
+    "service_id",
+    ["", "../voice", "voice/search", "Voice", ".voice", "voice search"],
+)
+def test_invalid_service_id_fails_before_lock_directory_creation(tmp_path, service_id):
+    with pytest.raises(locks.ServiceLockError, match="invalid-service-id"):
+        with locks.lock_services(tmp_path, [service_id]):
+            pass
+
+    assert not (tmp_path / ".extension-operation-locks").exists()
+
+
+def test_factory_resolves_parent_once_per_acquisition(tmp_path):
+    calls = []
+
+    def parent_provider():
+        calls.append(True)
+        return tmp_path
+
+    factory = locks.FileServiceLockFactory(parent_provider, timeout=1)
+    with factory.lock_services(["documents"]):
+        pass
+
+    assert calls == [True]
+
+
+@pytest.mark.parametrize("timeout", [-1, float("inf"), float("nan"), True, "1"])
+def test_invalid_timeout_fails_before_lock_directory_creation(tmp_path, timeout):
+    with pytest.raises(locks.ServiceLockError, match="invalid-lock-timeout"):
+        with locks.lock_services(tmp_path, ["documents"], timeout=timeout):
+            pass
+
+    assert not (tmp_path / ".extension-operation-locks").exists()
+
+
+def test_timeout_releases_already_acquired_composite_prefix(tmp_path):
+    factory = locks.FileServiceLockFactory(tmp_path, timeout=0.1)
+    blocked_path = locks.operation_lock_path(tmp_path, "voice")
+
+    with locks.exclusive_file_lock(blocked_path):
+        with pytest.raises(locks.ServiceLockTimeout):
+            with factory.lock_services(["voice", "documents"]):
+                pytest.fail("caller must not run without the complete lock set")
+
+    # "documents" sorts first and was acquired before "voice" timed out.  It
+    # must have been unwound, not leaked by the failed composite acquisition.
+    documents_path = locks.operation_lock_path(tmp_path, "documents")
+    with locks.exclusive_file_lock(documents_path, timeout=0.1):
+        pass
+
+
+def test_competing_lock_times_out_then_succeeds_after_release(tmp_path):
+    lock_path = locks.operation_lock_path(tmp_path, "documents")
+    outcome = []
+
+    def compete():
+        try:
+            with locks.exclusive_file_lock(lock_path, timeout=0.05):
+                outcome.append("acquired")
+        except locks.ServiceLockTimeout:
+            outcome.append("timed-out")
+
+    with locks.exclusive_file_lock(lock_path):
+        thread = threading.Thread(target=compete)
+        thread.start()
+        thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    assert outcome == ["timed-out"]
+    with locks.exclusive_file_lock(lock_path, timeout=0.1):
+        pass
+
+
+@pytest.mark.skipif(not hasattr(Path, "symlink_to"), reason="symlinks unavailable")
+def test_symlinked_lock_file_is_rejected(tmp_path):
+    lock_path = locks.operation_lock_path(tmp_path, "documents")
+    target = tmp_path / "unrelated"
+    target.write_text("unchanged", encoding="utf-8")
+    try:
+        lock_path.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("current account cannot create symlinks")
+
+    with pytest.raises(locks.ServiceLockError, match="operation-lock-file-is-symlink"):
+        with locks.exclusive_file_lock(lock_path):
+            pass
+
+    assert target.read_text(encoding="utf-8") == "unchanged"
+
+
+def test_symlinked_lock_directory_is_rejected(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    lock_dir = tmp_path / ".extension-operation-locks"
+    try:
+        lock_dir.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("current account cannot create directory symlinks")
+
+    with pytest.raises(
+        locks.ServiceLockError, match="operation-lock-directory-is-symlink"
+    ):
+        with locks.lock_services(tmp_path, ["documents"]):
+            pass

--- a/ods/extensions/services/dashboard-api/tests/test_extension_transaction_executor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_transaction_executor.py
@@ -20,6 +20,7 @@ if str(DASHBOARD_API_DIR) not in sys.path:
     sys.path.insert(0, str(DASHBOARD_API_DIR))
 
 import assistant_first_planner as planner  # noqa: E402
+import extension_operation_locks as operation_locks  # noqa: E402
 import extension_transaction_executor as executor_mod  # noqa: E402
 import extension_transactions as transactions  # noqa: E402
 
@@ -309,7 +310,9 @@ def create_and_approve(store, envelope: dict):
     return descriptor
 
 
-def make_executor(store, adapter=None, observer=None, verifier=None):
+def make_executor(
+    store, adapter=None, observer=None, verifier=None, lock_factory=None
+):
     if observer is None:
         observer = RecordingObserver()
     if adapter is None:
@@ -318,10 +321,12 @@ def make_executor(store, adapter=None, observer=None, verifier=None):
         adapter.observer = observer
     if verifier is None:
         verifier = AlwaysTrueVerifier()
+    if lock_factory is None:
+        lock_factory = NoOpLockFactory()
     return executor_mod.TransactionExecutor(
         store=store,
         verifier=verifier,
-        lock_factory=NoOpLockFactory(),
+        lock_factory=lock_factory,
         adapter=adapter,
         observer=observer,
         actor=ACTOR,
@@ -367,6 +372,24 @@ def test_approved_only_execution(tmp_path):
     # Verify terminal state in store
     loaded = store.read(txn_id)
     assert loaded["state"] == "committed"
+
+
+def test_executor_accepts_the_shared_canonical_file_lock_factory(tmp_path):
+    store = transactions.TransactionStore(tmp_path / "store")
+    envelope = build_envelope(service_ids=["voice", "documents"])
+    descriptor = create_and_approve(store, envelope)
+    lock_root = tmp_path / "locks"
+    lock_factory = operation_locks.FileServiceLockFactory(lock_root, timeout=1)
+
+    result = make_executor(store, lock_factory=lock_factory).execute(
+        descriptor["transactionId"], envelope["planHash"]
+    )
+
+    assert result.final_state == "committed"
+    assert [
+        operation_locks.operation_lock_path(lock_root, service_id).is_file()
+        for service_id in ("documents", "voice")
+    ] == [True, True]
 
 
 def test_every_host_call_carries_the_exact_immutable_binding(tmp_path):


### PR DESCRIPTION
## Summary

- extract the Dashboard's existing extension lock into a reusable, stdlib-only cross-process lock module
- give `TransactionExecutor` a production-shaped `FileServiceLockFactory` using the same per-service namespace as single-extension routes
- acquire composite service locks in deduplicated lexical order before caller code runs and unwind partial acquisition on timeout
- reject invalid service IDs, invalid deadlines, symlinked lock directories/files, hard-linked lock files, and replaced lock inodes before mutation
- document why host-agent lock acquisition remains deferred until a host-owned lease/token protocol prevents caller/callee self-deadlock

## Safety boundary

- production transaction execution remains unavailable (`executor=None`)
- this PR does not install, start, stop, remove, update, or deploy an extension
- existing single-extension Dashboard routes retain their blocking behavior and existing lock filenames
- the shared collision boundary is the per-service operation lock; the legacy global `.extensions-lock` remains an additional filesystem mutex
- no host-agent or CLI mutation path is changed in this slice

## Refreshed stack identity

- refreshed head: `37f5d8fabda34be90ac4ce4f0794bc03e3e8c7c6`
- exact tree: `ee5b7d6c9d2e3f077e047a9d27c321fde7b5339d`
- parents: prior Phase 4G head `3e4dcd3b463e48a9d2a3c538ba3d318303333095`, then refreshed Phase 4F head `71a403c3aa24b2ce5163c17d9311927a62237d16`
- delta over refreshed Phase 4F: six files, 513 insertions, 40 deletions
- no rebase or force-push was used

## Validation

- Tower3 exact-tree Linux lock, transaction, API, store, and extension-router suites: `428 passed`
- the cross-process child-termination test proves contention timeout and kernel-owned crash release
- added a real cross-path test proving the transaction factory and existing single-extension route contend on the same lock inode
- added hard-link rejection and owner-only new-file mode tests
- Python compile checks: passed
- `git diff --check`: passed
- independent Tower1/Tower3 read-only reviews traced namespace selection, canonical ordering, partial-acquisition unwind, crash release, legacy route coverage, disabled production execution, and Full/Core/Custom preservation; no remaining blocker
- GitHub exact-head CI: 32 successful checks and four intentionally skipped Claude-review jobs; no failures
- GitHub reports the PR `CLEAN` and `MERGEABLE`

## Stack

Base: `feat/assistant-first-phase-4f-host-execution` / PR #4483.

The next phase adds a host-owned lease protocol so caller and callee can share collision authority without reentrant self-deadlock.
