### PR TITLE
feat(extensions): add dormant host lease core

### DIFF
--- a/ods/bin/extension_operation_leases.py
+++ b/ods/bin/extension_operation_leases.py
@@ -29,6 +29,9 @@ from typing import Any, Callable, Iterable
 LEASE_SCHEMA = "ods.extension-operation-lease.v1"
 DEFAULT_TTL_SECONDS = 600
 MAX_TTL_SECONDS = 3600
+MAX_LEASE_SERVICES = 128
+MAX_SERVICE_ID_LENGTH = 128
+MAX_ACTIVE_LEASES = 1024
 
 _SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _TRANSACTION_ID_RE = re.compile(r"^txn-[0-9a-f]{24}$")
@@ -84,9 +87,12 @@ def _canonical_service_ids(service_ids: Iterable[str]) -> tuple[str, ...]:
         raise LeaseError("invalid-service-ids") from exc
     if not values:
         raise LeaseError("invalid-service-ids", "empty")
+    if len(values) > MAX_LEASE_SERVICES:
+        raise LeaseError("too-many-service-ids")
     for service_id in values:
         if (
             not isinstance(service_id, str)
+            or len(service_id) > MAX_SERVICE_ID_LENGTH
             or _SERVICE_ID_RE.fullmatch(service_id) is None
         ):
             raise LeaseError("invalid-service-id")
@@ -130,13 +136,22 @@ class ExtensionLeaseManager:
         clock: Callable[[], float] = time.monotonic,
         lease_id_factory: Callable[[], str] | None = None,
         token_factory: Callable[[], str] | None = None,
+        max_active_leases: int = MAX_ACTIVE_LEASES,
     ) -> None:
+        if (
+            isinstance(max_active_leases, bool)
+            or not isinstance(max_active_leases, int)
+            or max_active_leases < 1
+            or max_active_leases > MAX_ACTIVE_LEASES
+        ):
+            raise LeaseError("invalid-lease-capacity")
         self._lock_provider = lock_provider
         self._clock = clock
         self._lease_id_factory = lease_id_factory or (
             lambda: "lease-" + uuid.uuid4().hex
         )
         self._token_factory = token_factory or (lambda: secrets.token_urlsafe(32))
+        self._max_active_leases = max_active_leases
         self._guard = threading.Lock()
         self._leases: dict[str, _Lease] = {}
 
@@ -157,6 +172,8 @@ class ExtensionLeaseManager:
 
         with self._guard:
             self._expire_locked(now)
+            if len(self._leases) >= self._max_active_leases:
+                raise LeaseConflict("lease-capacity-exhausted")
             try:
                 for service_id in canonical_ids:
                     lock = self._lock_provider(service_id)

--- a/ods/bin/extension_operation_leases.py
+++ b/ods/bin/extension_operation_leases.py
@@ -22,8 +22,9 @@ import secrets
 import threading
 import time
 import uuid
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable
+from typing import Any
 
 
 LEASE_SCHEMA = "ods.extension-operation-lease.v1"

--- a/ods/bin/extension_operation_leases.py
+++ b/ods/bin/extension_operation_leases.py
@@ -26,7 +26,6 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
 
-
 LEASE_SCHEMA = "ods.extension-operation-lease.v1"
 DEFAULT_TTL_SECONDS = 600
 MAX_TTL_SECONDS = 3600

--- a/ods/bin/extension_operation_leases.py
+++ b/ods/bin/extension_operation_leases.py
@@ -1,0 +1,356 @@
+"""Host-owned, transaction-bound leases for extension lifecycle mutations.
+
+This module is deliberately transport-neutral and has no import-time effects.
+The host agent can inject its existing per-service ``threading.Lock`` objects;
+the lease manager then owns those locks until release or expiry. Lease-bearing
+mutation calls use :meth:`ExtensionLeaseManager.use` instead of attempting to
+re-acquire the same locks, preventing caller/callee self-deadlock.
+
+The manager is process-local by design. If the host agent exits, its leases and
+its injected locks disappear together. Production transaction execution stays
+disabled until the HTTP boundary, client renewer, recovery, and real-host
+qualification are implemented and reviewed.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import hmac
+import re
+import secrets
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable, Iterable
+
+
+LEASE_SCHEMA = "ods.extension-operation-lease.v1"
+DEFAULT_TTL_SECONDS = 600
+MAX_TTL_SECONDS = 3600
+
+_SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_TRANSACTION_ID_RE = re.compile(r"^txn-[0-9a-f]{24}$")
+_PLAN_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_LEASE_ID_RE = re.compile(r"^lease-[0-9a-f]{32}$")
+
+
+class LeaseError(RuntimeError):
+    """Base error carrying a stable, non-secret protocol code."""
+
+    def __init__(self, code: str, detail: str | None = None) -> None:
+        self.code = code
+        self.detail = detail
+        super().__init__(code if detail is None else f"{code}:{detail}")
+
+
+class LeaseConflict(LeaseError):
+    """At least one requested service is already locked."""
+
+
+class LeaseAuthorizationError(LeaseError):
+    """The token or immutable transaction binding did not match."""
+
+
+class LeaseExpired(LeaseError):
+    """The lease is unknown, released, or expired and cannot be revived."""
+
+
+class LeaseBusy(LeaseError):
+    """A mutation is already active under the lease."""
+
+
+@dataclass
+class _Lease:
+    lease_id: str
+    token_digest: str
+    transaction_id: str
+    plan_hash: str
+    service_ids: tuple[str, ...]
+    locks: tuple[Any, ...]
+    issued_at: float
+    deadline: float
+    active: bool = False
+    expired: bool = False
+
+
+def _canonical_service_ids(service_ids: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(service_ids, (str, bytes, dict)):
+        raise LeaseError("invalid-service-ids")
+    try:
+        values = tuple(service_ids)
+    except TypeError as exc:
+        raise LeaseError("invalid-service-ids") from exc
+    if not values:
+        raise LeaseError("invalid-service-ids", "empty")
+    for service_id in values:
+        if (
+            not isinstance(service_id, str)
+            or _SERVICE_ID_RE.fullmatch(service_id) is None
+        ):
+            raise LeaseError("invalid-service-id")
+    return tuple(sorted(set(values)))
+
+
+def _validate_binding(transaction_id: str, plan_hash: str) -> None:
+    if (
+        not isinstance(transaction_id, str)
+        or _TRANSACTION_ID_RE.fullmatch(transaction_id) is None
+    ):
+        raise LeaseError("invalid-transaction-id")
+    if not isinstance(plan_hash, str) or _PLAN_HASH_RE.fullmatch(plan_hash) is None:
+        raise LeaseError("invalid-plan-hash")
+
+
+def _validate_ttl(ttl_seconds: int) -> int:
+    if (
+        isinstance(ttl_seconds, bool)
+        or not isinstance(ttl_seconds, int)
+        or ttl_seconds < 1
+        or ttl_seconds > MAX_TTL_SECONDS
+    ):
+        raise LeaseError("invalid-lease-ttl")
+    return ttl_seconds
+
+
+def _token_digest(token: str) -> str:
+    if not isinstance(token, str) or not 32 <= len(token) <= 256:
+        raise LeaseAuthorizationError("invalid-lease-token")
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class ExtensionLeaseManager:
+    """Own exact service locks on behalf of one approved transaction."""
+
+    def __init__(
+        self,
+        lock_provider: Callable[[str], Any],
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        lease_id_factory: Callable[[], str] | None = None,
+        token_factory: Callable[[], str] | None = None,
+    ) -> None:
+        self._lock_provider = lock_provider
+        self._clock = clock
+        self._lease_id_factory = lease_id_factory or (
+            lambda: "lease-" + uuid.uuid4().hex
+        )
+        self._token_factory = token_factory or (lambda: secrets.token_urlsafe(32))
+        self._guard = threading.Lock()
+        self._leases: dict[str, _Lease] = {}
+
+    def acquire(
+        self,
+        transaction_id: str,
+        plan_hash: str,
+        service_ids: Iterable[str],
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> dict[str, Any]:
+        """Acquire a complete canonical lock set or fail without a partial grant."""
+        _validate_binding(transaction_id, plan_hash)
+        canonical_ids = _canonical_service_ids(service_ids)
+        ttl = _validate_ttl(ttl_seconds)
+        now = self._clock()
+        held: list[Any] = []
+
+        with self._guard:
+            self._expire_locked(now)
+            try:
+                for service_id in canonical_ids:
+                    lock = self._lock_provider(service_id)
+                    if lock.acquire(blocking=False) is not True:
+                        raise LeaseConflict("service-lock-busy", service_id)
+                    held.append(lock)
+            except Exception:
+                for lock in reversed(held):
+                    lock.release()
+                raise
+
+            try:
+                lease_id = self._lease_id_factory()
+                token = self._token_factory()
+                if (
+                    not isinstance(lease_id, str)
+                    or _LEASE_ID_RE.fullmatch(lease_id) is None
+                    or lease_id in self._leases
+                ):
+                    raise LeaseError("invalid-or-duplicate-lease-id")
+                digest = _token_digest(token)
+                if any(
+                    hmac.compare_digest(item.token_digest, digest)
+                    for item in self._leases.values()
+                ):
+                    raise LeaseError("duplicate-lease-token")
+            except Exception:
+                for lock in reversed(held):
+                    lock.release()
+                raise
+            lease = _Lease(
+                lease_id=lease_id,
+                token_digest=digest,
+                transaction_id=transaction_id,
+                plan_hash=plan_hash,
+                service_ids=canonical_ids,
+                locks=tuple(held),
+                issued_at=now,
+                deadline=now + ttl,
+            )
+            self._leases[lease_id] = lease
+            return {
+                "schema": LEASE_SCHEMA,
+                "leaseId": lease_id,
+                "leaseToken": token,
+                "transactionId": transaction_id,
+                "planHash": plan_hash,
+                "serviceIds": list(canonical_ids),
+                "ttlSeconds": ttl,
+            }
+
+    def renew(
+        self,
+        lease_id: str,
+        token: str,
+        transaction_id: str,
+        plan_hash: str,
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> dict[str, Any]:
+        """Extend an active lease without changing its binding or service set."""
+        _validate_binding(transaction_id, plan_hash)
+        ttl = _validate_ttl(ttl_seconds)
+        now = self._clock()
+        with self._guard:
+            lease = self._authorize_locked(
+                lease_id, token, transaction_id, plan_hash, now
+            )
+            lease.deadline = now + ttl
+            return self._public_record(lease, ttl_seconds=ttl)
+
+    def release(
+        self,
+        lease_id: str,
+        token: str,
+        transaction_id: str,
+        plan_hash: str,
+    ) -> dict[str, Any]:
+        """Release an inactive exact lease; released IDs cannot be revived."""
+        _validate_binding(transaction_id, plan_hash)
+        now = self._clock()
+        with self._guard:
+            lease = self._authorize_locked(
+                lease_id, token, transaction_id, plan_hash, now
+            )
+            if lease.active:
+                raise LeaseBusy("lease-mutation-active")
+            self._release_locked(lease)
+            return {
+                "schema": LEASE_SCHEMA,
+                "leaseId": lease_id,
+                "transactionId": transaction_id,
+                "planHash": plan_hash,
+                "released": True,
+            }
+
+    @contextlib.contextmanager
+    def use(
+        self,
+        lease_id: str,
+        token: str,
+        transaction_id: str,
+        plan_hash: str,
+        service_ids: Iterable[str],
+    ):
+        """Pin locks around one lease-authorized mutation without re-acquiring."""
+        _validate_binding(transaction_id, plan_hash)
+        requested_ids = _canonical_service_ids(service_ids)
+        with self._guard:
+            lease = self._authorize_locked(
+                lease_id, token, transaction_id, plan_hash, self._clock()
+            )
+            if lease.active:
+                raise LeaseBusy("lease-mutation-active")
+            if not set(requested_ids).issubset(lease.service_ids):
+                raise LeaseAuthorizationError("lease-service-not-covered")
+            lease.active = True
+        try:
+            yield {
+                "schema": LEASE_SCHEMA,
+                "leaseId": lease.lease_id,
+                "transactionId": lease.transaction_id,
+                "planHash": lease.plan_hash,
+                "serviceIds": list(requested_ids),
+            }
+        finally:
+            with self._guard:
+                current = self._leases.get(lease.lease_id)
+                if current is lease:
+                    lease.active = False
+                    self._expire_locked(self._clock())
+
+    def sweep(self) -> list[str]:
+        """Release expired, inactive leases and return their public IDs."""
+        with self._guard:
+            return self._expire_locked(self._clock())
+
+    def describe(self, lease_id: str) -> dict[str, Any]:
+        """Return non-secret status for diagnostics and tests."""
+        with self._guard:
+            self._expire_locked(self._clock())
+            lease = self._leases.get(lease_id)
+            if lease is None or lease.expired:
+                raise LeaseExpired("lease-not-active")
+            return self._public_record(lease)
+
+    def _authorize_locked(
+        self,
+        lease_id: str,
+        token: str,
+        transaction_id: str,
+        plan_hash: str,
+        now: float,
+    ) -> _Lease:
+        if not isinstance(lease_id, str) or _LEASE_ID_RE.fullmatch(lease_id) is None:
+            raise LeaseAuthorizationError("invalid-lease-id")
+        digest = _token_digest(token)
+        self._expire_locked(now)
+        lease = self._leases.get(lease_id)
+        if lease is None or lease.expired:
+            raise LeaseExpired("lease-not-active")
+        if not hmac.compare_digest(lease.token_digest, digest):
+            raise LeaseAuthorizationError("lease-token-mismatch")
+        if lease.transaction_id != transaction_id or lease.plan_hash != plan_hash:
+            raise LeaseAuthorizationError("lease-binding-mismatch")
+        return lease
+
+    def _expire_locked(self, now: float) -> list[str]:
+        released = []
+        for lease in list(self._leases.values()):
+            if now < lease.deadline:
+                continue
+            lease.expired = True
+            if lease.active:
+                continue
+            released.append(lease.lease_id)
+            self._release_locked(lease)
+        return released
+
+    def _release_locked(self, lease: _Lease) -> None:
+        self._leases.pop(lease.lease_id, None)
+        for lock in reversed(lease.locks):
+            lock.release()
+
+    @staticmethod
+    def _public_record(lease: _Lease, *, ttl_seconds: int | None = None) -> dict[str, Any]:
+        record = {
+            "schema": LEASE_SCHEMA,
+            "leaseId": lease.lease_id,
+            "transactionId": lease.transaction_id,
+            "planHash": lease.plan_hash,
+            "serviceIds": list(lease.service_ids),
+            "active": lease.active,
+        }
+        if ttl_seconds is not None:
+            record["ttlSeconds"] = ttl_seconds
+        return record

--- a/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
@@ -81,6 +81,21 @@ accepts but does not need those fields; a future host-owned lease factory must
 bind its grant, renewal, mutation calls, and evidence to both values. A lock
 factory that sees only service IDs is not sufficient for transaction custody.
 
+A dormant, transport-neutral host lease core defines the next boundary without
+activating it. It acquires the host agent's existing per-service locks as one
+canonical set, stores only a SHA-256 digest of a one-time lease token, and
+binds acquire, renew, use, release, and public evidence to the exact
+transaction ID and plan hash. Invalid grants unwind their held lock prefix.
+Expiry releases an idle lease, while an in-flight mutation pins the lock set
+until that mutation exits; expired lease IDs cannot be renewed or replayed.
+Only one mutation may be active under a lease at a time, and it may address
+only services covered by the exact grant.
+
+The lease core is not imported by the host agent, exposed over HTTP, or wired
+into the production runtime in this phase. Those integrations require a
+fail-closed header/body protocol, renewal supervision, legacy direct-caller
+tests, and crash/restart recovery evidence before use.
+
 This source foundation does not yet make the host agent a second lock owner.
 The current Dashboard routes call host-agent lifecycle endpoints while holding
 their operation lock, so making the callee acquire the same lock would

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
@@ -53,7 +53,9 @@ class TrackingLock:
         return self.lock.locked()
 
 
-def make_manager(*, clock=None, token_factory=None, lease_ids=None):
+def make_manager(
+    *, clock=None, token_factory=None, lease_ids=None, max_active_leases=None
+):
     events = []
     lock_map = {}
 
@@ -64,12 +66,14 @@ def make_manager(*, clock=None, token_factory=None, lease_ids=None):
 
     if lease_ids is None:
         lease_ids = iter(["lease-" + "a" * 32, "lease-" + "b" * 32])
-    manager = leases.ExtensionLeaseManager(
-        lock_provider,
-        clock=clock or FakeClock(),
-        lease_id_factory=lambda: next(lease_ids),
-        token_factory=token_factory or (lambda: TOKEN),
-    )
+    manager_args = {
+        "clock": clock or FakeClock(),
+        "lease_id_factory": lambda: next(lease_ids),
+        "token_factory": token_factory or (lambda: TOKEN),
+    }
+    if max_active_leases is not None:
+        manager_args["max_active_leases"] = max_active_leases
+    manager = leases.ExtensionLeaseManager(lock_provider, **manager_args)
     return manager, lock_map, events
 
 
@@ -132,7 +136,22 @@ def test_conflict_unwinds_the_already_acquired_prefix():
         (TRANSACTION_ID, "bad", ["voice"], 10, "invalid-plan-hash"),
         (TRANSACTION_ID, PLAN_HASH, [], 10, "invalid-service-ids"),
         (TRANSACTION_ID, PLAN_HASH, "voice", 10, "invalid-service-ids"),
+        (TRANSACTION_ID, PLAN_HASH, {"voice": True}, 10, "invalid-service-ids"),
         (TRANSACTION_ID, PLAN_HASH, ["../voice"], 10, "invalid-service-id"),
+        (
+            TRANSACTION_ID,
+            PLAN_HASH,
+            ["v" * (leases.MAX_SERVICE_ID_LENGTH + 1)],
+            10,
+            "invalid-service-id",
+        ),
+        (
+            TRANSACTION_ID,
+            PLAN_HASH,
+            [f"service-{index}" for index in range(leases.MAX_LEASE_SERVICES + 1)],
+            10,
+            "too-many-service-ids",
+        ),
         (TRANSACTION_ID, PLAN_HASH, ["voice"], 0, "invalid-lease-ttl"),
         (TRANSACTION_ID, PLAN_HASH, ["voice"], True, "invalid-lease-ttl"),
         (
@@ -168,6 +187,33 @@ def test_invalid_token_factory_unwinds_locks():
 
     assert lock_map["documents"].acquire(blocking=False)
     lock_map["documents"].release()
+
+
+@pytest.mark.parametrize("capacity", [0, True, leases.MAX_ACTIVE_LEASES + 1])
+def test_invalid_capacity_is_rejected_before_any_lock_is_requested(capacity):
+    requested = []
+
+    with pytest.raises(leases.LeaseError, match="invalid-lease-capacity"):
+        leases.ExtensionLeaseManager(requested.append, max_active_leases=capacity)
+
+    assert requested == []
+
+
+def test_capacity_exhaustion_fails_before_requesting_another_service_lock():
+    ids = iter(["lease-" + "a" * 32, "lease-" + "b" * 32])
+    tokens = iter(["first-" + "x" * 32, "second-" + "x" * 32])
+    manager, lock_map, _events = make_manager(
+        lease_ids=ids,
+        token_factory=lambda: next(tokens),
+        max_active_leases=1,
+    )
+    first = acquire(manager, ("documents",))
+
+    with pytest.raises(leases.LeaseConflict, match="lease-capacity-exhausted"):
+        acquire(manager, ("voice",))
+
+    assert "voice" not in lock_map
+    manager.release(first["leaseId"], "first-" + "x" * 32, TRANSACTION_ID, PLAN_HASH)
 
 
 def test_token_and_binding_mismatch_cannot_use_or_release_lease():
@@ -221,6 +267,18 @@ def test_expiry_releases_locks_and_lease_cannot_be_revived():
         manager.renew(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
 
 
+def test_release_after_natural_expiry_fails_closed_and_releases_locks():
+    clock = FakeClock()
+    manager, lock_map, _events = make_manager(clock=clock)
+    grant = acquire(manager, ("documents",), ttl_seconds=1)
+    clock.advance(1)
+
+    with pytest.raises(leases.LeaseExpired, match="lease-not-active"):
+        manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+    assert not lock_map["documents"].locked()
+
+
 def test_use_pins_expired_lease_until_mutation_exits():
     clock = FakeClock()
     manager, lock_map, _events = make_manager(clock=clock)
@@ -263,6 +321,58 @@ def test_use_rejects_a_service_outside_the_exact_grant():
 
     assert lock_map["documents"].locked()
     manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+
+def test_use_body_exception_clears_active_state_without_releasing_live_lease():
+    manager, lock_map, _events = make_manager()
+    grant = acquire(manager, ("documents",))
+
+    with pytest.raises(RuntimeError, match="mutation-failed"):
+        with manager.use(
+            grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["documents"]
+        ):
+            raise RuntimeError("mutation-failed")
+
+    assert manager.describe(grant["leaseId"])["active"] is False
+    assert lock_map["documents"].locked()
+    manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+
+def test_concurrent_acquire_allows_one_exact_winner_without_lock_leak():
+    ids = iter(["lease-" + "a" * 32, "lease-" + "b" * 32])
+    tokens = iter(["first-" + "x" * 32, "second-" + "x" * 32])
+    manager, lock_map, _events = make_manager(
+        lease_ids=ids,
+        token_factory=lambda: next(tokens),
+    )
+    barrier = threading.Barrier(3)
+    outcomes = []
+
+    def contend():
+        barrier.wait()
+        try:
+            outcomes.append(("grant", acquire(manager, ("documents",))))
+        except leases.LeaseConflict as exc:
+            outcomes.append(("conflict", exc.code))
+
+    threads = [threading.Thread(target=contend) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    barrier.wait()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert sorted(item[0] for item in outcomes) == ["conflict", "grant"]
+    grant = next(item[1] for item in outcomes if item[0] == "grant")
+    token = (
+        "first-" + "x" * 32
+        if grant["leaseId"].endswith("a" * 32)
+        else "second-" + "x" * 32
+    )
+    assert lock_map["documents"].locked()
+    manager.release(grant["leaseId"], token, TRANSACTION_ID, PLAN_HASH)
+    assert not lock_map["documents"].locked()
 
 
 def test_second_lease_for_same_service_is_rejected_until_release():

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-
 BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
 if str(BIN_DIR) not in sys.path:
     sys.path.insert(0, str(BIN_DIR))

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import importlib
 import sys
 import threading
 from pathlib import Path
@@ -14,7 +15,7 @@ BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
 if str(BIN_DIR) not in sys.path:
     sys.path.insert(0, str(BIN_DIR))
 
-import extension_operation_leases as leases  # noqa: E402
+leases = importlib.import_module("extension_operation_leases")
 
 
 TRANSACTION_ID = "txn-" + "1" * 24
@@ -289,11 +290,12 @@ def test_use_pins_expired_lease_until_mutation_exits():
     ) as evidence:
         assert evidence["planHash"] == PLAN_HASH
         assert evidence["serviceIds"] == ["documents"]
-        with pytest.raises(leases.LeaseBusy, match="lease-mutation-active"):
-            with manager.use(
-                grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["voice"]
-            ):
-                pass
+        with pytest.raises(
+            leases.LeaseBusy, match="lease-mutation-active"
+        ), manager.use(
+            grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["voice"]
+        ):
+            pass
         with pytest.raises(leases.LeaseBusy, match="lease-mutation-active"):
             manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
         clock.advance(1)
@@ -313,11 +315,10 @@ def test_use_rejects_a_service_outside_the_exact_grant():
 
     with pytest.raises(
         leases.LeaseAuthorizationError, match="lease-service-not-covered"
+    ), manager.use(
+        grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["voice"]
     ):
-        with manager.use(
-            grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["voice"]
-        ):
-            pass
+        pass
 
     assert lock_map["documents"].locked()
     manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
@@ -327,11 +328,10 @@ def test_use_body_exception_clears_active_state_without_releasing_live_lease():
     manager, lock_map, _events = make_manager()
     grant = acquire(manager, ("documents",))
 
-    with pytest.raises(RuntimeError, match="mutation-failed"):
-        with manager.use(
-            grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["documents"]
-        ):
-            raise RuntimeError("mutation-failed")
+    with pytest.raises(RuntimeError, match="mutation-failed"), manager.use(
+        grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["documents"]
+    ):
+        raise RuntimeError("mutation-failed")
 
     assert manager.describe(grant["leaseId"])["active"] is False
     assert lock_map["documents"].locked()

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
@@ -1,0 +1,298 @@
+"""Unit tests for the dormant host-owned extension lease core."""
+
+from __future__ import annotations
+
+import collections
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
+if str(BIN_DIR) not in sys.path:
+    sys.path.insert(0, str(BIN_DIR))
+
+import extension_operation_leases as leases  # noqa: E402
+
+
+TRANSACTION_ID = "txn-" + "1" * 24
+PLAN_HASH = "2" * 64
+OTHER_PLAN_HASH = "3" * 64
+TOKEN = "lease-token-" + "x" * 32
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class TrackingLock:
+    def __init__(self, service_id: str, events: list) -> None:
+        self.service_id = service_id
+        self.events = events
+        self.lock = threading.Lock()
+
+    def acquire(self, *, blocking: bool):
+        acquired = self.lock.acquire(blocking=blocking)
+        self.events.append(("acquire", self.service_id, acquired))
+        return acquired
+
+    def release(self) -> None:
+        self.events.append(("release", self.service_id))
+        self.lock.release()
+
+    def locked(self) -> bool:
+        return self.lock.locked()
+
+
+def make_manager(*, clock=None, token_factory=None, lease_ids=None):
+    events = []
+    lock_map = {}
+
+    def lock_provider(service_id):
+        if service_id not in lock_map:
+            lock_map[service_id] = TrackingLock(service_id, events)
+        return lock_map[service_id]
+
+    if lease_ids is None:
+        lease_ids = iter(["lease-" + "a" * 32, "lease-" + "b" * 32])
+    manager = leases.ExtensionLeaseManager(
+        lock_provider,
+        clock=clock or FakeClock(),
+        lease_id_factory=lambda: next(lease_ids),
+        token_factory=token_factory or (lambda: TOKEN),
+    )
+    return manager, lock_map, events
+
+
+def acquire(manager, service_ids=("voice", "documents"), ttl_seconds=10):
+    return manager.acquire(
+        TRANSACTION_ID,
+        PLAN_HASH,
+        service_ids,
+        ttl_seconds=ttl_seconds,
+    )
+
+
+def test_acquire_is_canonical_deduplicated_and_returns_token_once():
+    manager, _locks, events = make_manager()
+
+    grant = acquire(manager, ("voice", "documents", "voice"))
+
+    assert grant == {
+        "schema": leases.LEASE_SCHEMA,
+        "leaseId": "lease-" + "a" * 32,
+        "leaseToken": TOKEN,
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "serviceIds": ["documents", "voice"],
+        "ttlSeconds": 10,
+    }
+    assert events == [
+        ("acquire", "documents", True),
+        ("acquire", "voice", True),
+    ]
+    status = manager.describe(grant["leaseId"])
+    assert "leaseToken" not in status
+    assert "token" not in str(status).lower()
+
+
+def test_conflict_unwinds_the_already_acquired_prefix():
+    manager, lock_map, events = make_manager()
+    voice = manager._lock_provider("voice")
+    assert voice.acquire(blocking=False)
+    events.clear()
+    try:
+        with pytest.raises(leases.LeaseConflict, match="service-lock-busy:voice"):
+            acquire(manager)
+    finally:
+        voice.release()
+
+    assert events[:3] == [
+        ("acquire", "documents", True),
+        ("acquire", "voice", False),
+        ("release", "documents"),
+    ]
+    assert lock_map["documents"].acquire(blocking=False)
+    lock_map["documents"].release()
+
+
+@pytest.mark.parametrize(
+    ("transaction_id", "plan_hash", "service_ids", "ttl", "code"),
+    [
+        ("bad", PLAN_HASH, ["voice"], 10, "invalid-transaction-id"),
+        (TRANSACTION_ID, "bad", ["voice"], 10, "invalid-plan-hash"),
+        (TRANSACTION_ID, PLAN_HASH, [], 10, "invalid-service-ids"),
+        (TRANSACTION_ID, PLAN_HASH, "voice", 10, "invalid-service-ids"),
+        (TRANSACTION_ID, PLAN_HASH, ["../voice"], 10, "invalid-service-id"),
+        (TRANSACTION_ID, PLAN_HASH, ["voice"], 0, "invalid-lease-ttl"),
+        (TRANSACTION_ID, PLAN_HASH, ["voice"], True, "invalid-lease-ttl"),
+        (
+            TRANSACTION_ID,
+            PLAN_HASH,
+            ["voice"],
+            leases.MAX_TTL_SECONDS + 1,
+            "invalid-lease-ttl",
+        ),
+    ],
+)
+def test_invalid_grant_fails_before_requesting_a_lock(
+    transaction_id, plan_hash, service_ids, ttl, code
+):
+    manager, lock_map, _events = make_manager()
+
+    with pytest.raises(leases.LeaseError, match=code):
+        manager.acquire(
+            transaction_id,
+            plan_hash,
+            service_ids,
+            ttl_seconds=ttl,
+        )
+
+    assert lock_map == {}
+
+
+def test_invalid_token_factory_unwinds_locks():
+    manager, lock_map, _events = make_manager(token_factory=lambda: "short")
+
+    with pytest.raises(leases.LeaseAuthorizationError, match="invalid-lease-token"):
+        acquire(manager, ("documents",))
+
+    assert lock_map["documents"].acquire(blocking=False)
+    lock_map["documents"].release()
+
+
+def test_token_and_binding_mismatch_cannot_use_or_release_lease():
+    manager, lock_map, _events = make_manager()
+    grant = acquire(manager, ("documents",))
+
+    with pytest.raises(leases.LeaseAuthorizationError, match="lease-token-mismatch"):
+        manager.release(grant["leaseId"], "wrong-" + "x" * 32, TRANSACTION_ID, PLAN_HASH)
+    with pytest.raises(leases.LeaseAuthorizationError, match="lease-binding-mismatch"):
+        manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, OTHER_PLAN_HASH)
+    assert lock_map["documents"].locked()
+
+    released = manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+    assert released["released"] is True
+    assert not lock_map["documents"].locked()
+    with pytest.raises(leases.LeaseExpired, match="lease-not-active"):
+        manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+
+def test_renew_extends_but_never_changes_the_binding_or_services():
+    clock = FakeClock()
+    manager, lock_map, _events = make_manager(clock=clock)
+    grant = acquire(manager, ("documents",), ttl_seconds=2)
+    clock.advance(1)
+
+    renewed = manager.renew(
+        grant["leaseId"],
+        TOKEN,
+        TRANSACTION_ID,
+        PLAN_HASH,
+        ttl_seconds=5,
+    )
+    clock.advance(2)
+
+    assert renewed["serviceIds"] == ["documents"]
+    assert renewed["transactionId"] == TRANSACTION_ID
+    assert manager.sweep() == []
+    assert lock_map["documents"].locked()
+
+
+def test_expiry_releases_locks_and_lease_cannot_be_revived():
+    clock = FakeClock()
+    manager, lock_map, _events = make_manager(clock=clock)
+    grant = acquire(manager, ("documents", "voice"), ttl_seconds=1)
+    clock.advance(1)
+
+    assert manager.sweep() == [grant["leaseId"]]
+    assert not lock_map["documents"].locked()
+    assert not lock_map["voice"].locked()
+    with pytest.raises(leases.LeaseExpired, match="lease-not-active"):
+        manager.renew(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+
+def test_use_pins_expired_lease_until_mutation_exits():
+    clock = FakeClock()
+    manager, lock_map, _events = make_manager(clock=clock)
+    grant = acquire(manager, ("documents", "voice"), ttl_seconds=1)
+
+    with manager.use(
+        grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["documents"]
+    ) as evidence:
+        assert evidence["planHash"] == PLAN_HASH
+        assert evidence["serviceIds"] == ["documents"]
+        with pytest.raises(leases.LeaseBusy, match="lease-mutation-active"):
+            with manager.use(
+                grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["voice"]
+            ):
+                pass
+        with pytest.raises(leases.LeaseBusy, match="lease-mutation-active"):
+            manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+        clock.advance(1)
+        assert manager.sweep() == []
+        assert lock_map["documents"].locked()
+        assert lock_map["voice"].locked()
+
+    assert not lock_map["documents"].locked()
+    assert not lock_map["voice"].locked()
+    with pytest.raises(leases.LeaseExpired, match="lease-not-active"):
+        manager.describe(grant["leaseId"])
+
+
+def test_use_rejects_a_service_outside_the_exact_grant():
+    manager, lock_map, _events = make_manager()
+    grant = acquire(manager, ("documents",))
+
+    with pytest.raises(
+        leases.LeaseAuthorizationError, match="lease-service-not-covered"
+    ):
+        with manager.use(
+            grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH, ["voice"]
+        ):
+            pass
+
+    assert lock_map["documents"].locked()
+    manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+
+def test_second_lease_for_same_service_is_rejected_until_release():
+    ids = iter(["lease-" + "a" * 32, "lease-" + "b" * 32])
+    events = []
+    lock_map = collections.defaultdict(lambda: TrackingLock("documents", events))
+    manager = leases.ExtensionLeaseManager(
+        lambda service_id: lock_map[service_id],
+        clock=FakeClock(),
+        lease_id_factory=lambda: next(ids),
+        token_factory=lambda: TOKEN,
+    )
+    first = acquire(manager, ("documents",))
+
+    with pytest.raises(leases.LeaseConflict, match="service-lock-busy"):
+        acquire(manager, ("documents",))
+
+    manager.release(first["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+    second = acquire(manager, ("documents",))
+    assert second["leaseId"] == "lease-" + "b" * 32
+
+
+def test_active_lease_tokens_cannot_be_reused_across_grants():
+    manager, lock_map, _events = make_manager()
+    first = acquire(manager, ("documents",))
+
+    with pytest.raises(leases.LeaseError, match="duplicate-lease-token"):
+        acquire(manager, ("voice",))
+
+    assert lock_map["documents"].locked()
+    assert lock_map["voice"].acquire(blocking=False)
+    lock_map["voice"].release()
+    manager.release(first["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)


### PR DESCRIPTION
## Summary

- add a transport-neutral host-owned lease manager for extension lifecycle mutations
- bind every lease to the exact `(transactionId, planHash)` and canonical service set
- retain only a SHA-256 token digest, reject token or binding replay, and never expose the token through status records
- acquire host locks all-or-nothing, unwind partial failures, pin locks for an active mutation, and release expired inactive leases
- bound TTL, service identifiers, services per grant, and total active leases before the future HTTP boundary exists
- document the dormant lease and recovery boundary in the transaction ADR

## Why this is separate

The host agent already owns its in-process service locks. Having both the Dashboard and host agent independently re-acquire the same operation lock would self-deadlock. This PR establishes the host-owned lease primitive first, without exposing it over HTTP or connecting it to transaction execution, so its authority, expiry, concurrency, and failure behavior can be reviewed in isolation.

## Safety boundary

- the new module is not imported by the host agent and has no import-time effects
- no HTTP endpoint, client, renewer, mutation adapter, installation, deployment, or live service is added or changed
- production transaction execution remains unavailable (`executor=None`)
- an active mutation pins its exact locks even if the TTL expires; they are released when the context exits
- released or expired lease IDs cannot be renewed or revived

## Refreshed stack identity

- refreshed head: `73fc87388093ada255086252dc959395cbc4c8cf`
- exact tree: `9676473b053e6dfd066b2a33a73400e5e4a95369`
- parents: prior Phase 4I head `bf7628d492cdc991d7c28109ed36e6a5578d93d4`, then refreshed Phase 4H head `19656f83d71c79c1e8b60d3aeace573570a0ecd8`
- delta over refreshed Phase 4H: three files, 853 insertions
- no rebase or force-push was used

## Validation

- Tower3 exact-tree Linux lease, lock, transaction, API, configuration, production, runtime, router, and extension suites: `491 passed`
- direct boundary tests cover exact-deadline renewal, capacity reclamation after expiry, disjoint leases, concurrent acquisition, lock unwind, active-expiry pinning, token/binding replay, malformed identifiers, and resource limits
- Python import/compile and `git diff --check`: passed
- independent Tower1 security review and Tower3 reliability review traced authorization, expiry, concurrency, lock release, resource bounds, Python compatibility, and dormancy; no remaining blocker
- GitHub exact-head CI: `32` successful checks, `4` expected skips, `CLEAN` / `MERGEABLE`

## Stack

Base: `feat/assistant-first-phase-4h-bound-leases` / PR #4485.

The next phase exposes this primitive through a narrowly authenticated host API; this PR adds no route.
