### PR TITLE
feat(extensions): expose guarded host lease API

### DIFF
--- a/ods/bin/extension_operation_leases.py
+++ b/ods/bin/extension_operation_leases.py
@@ -245,6 +245,21 @@ class ExtensionLeaseManager:
             lease.deadline = now + ttl
             return self._public_record(lease, ttl_seconds=ttl)
 
+    def status(
+        self,
+        lease_id: str,
+        token: str,
+        transaction_id: str,
+        plan_hash: str,
+    ) -> dict[str, Any]:
+        """Return a non-secret record only to the exact lease holder."""
+        _validate_binding(transaction_id, plan_hash)
+        with self._guard:
+            lease = self._authorize_locked(
+                lease_id, token, transaction_id, plan_hash, self._clock()
+            )
+            return self._public_record(lease)
+
     def release(
         self,
         lease_id: str,

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -98,6 +98,11 @@ except Exception:  # pragma: no cover - import environment dependent
     _AssistantFirstSecretStore = None
     _AssistantFirstSecretStoreError = RuntimeError
 
+try:
+    import extension_operation_leases as _extension_leases
+except Exception:  # pragma: no cover - import environment dependent
+    _extension_leases = None
+
 _MODEL_MEMORY_PATH = (
     Path(__file__).resolve().parent.parent
     / "extensions"
@@ -129,6 +134,7 @@ PIXEL_OPS_STATUS_KIND = "ods-pixel-operations-status"
 BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 MAX_BODY = 16384
 _ASSISTANT_SECRET_MAX_BODY = 64 * 1024
+_ASSISTANT_LEASE_MAX_BODY = 32 * 1024
 MAX_TELEMETRY_RESPONSE_BYTES = 1024 * 1024
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
@@ -226,6 +232,8 @@ _MIN_MANAGED_PIXEL_CONTEXT = 4096
 
 # Per-service locks to prevent concurrent start+stop races on the same service
 _service_locks: dict[str, threading.Lock] = collections.defaultdict(threading.Lock)
+_extension_lease_manager = None
+_extension_lease_manager_lock = threading.Lock()
 _ALLOWED_CORE_RECREATE_IDS = frozenset({
     "llama-server", "open-webui", "litellm", "langfuse", "n8n",
     "hermes", "hermes-proxy", "openclaw", "opencode", "perplexica", "searxng", "qdrant",
@@ -6117,7 +6125,7 @@ def read_optional_json_body(handler) -> dict | None:
     return data
 
 
-def _assistant_secret_pairs(pairs: list[tuple[str, object]]) -> dict:
+def _strict_json_pairs(pairs: list[tuple[str, object]]) -> dict:
     value = {}
     for key, item in pairs:
         if key in value:
@@ -6126,11 +6134,19 @@ def _assistant_secret_pairs(pairs: list[tuple[str, object]]) -> dict:
     return value
 
 
-def _reject_assistant_secret_number(_value: str) -> None:
+def _reject_non_integer_json_number(_value: str) -> None:
     raise ValueError("non-integer-number")
 
 
-def _read_assistant_secret_body(handler) -> dict | None:
+def _read_bounded_json_object(
+    handler,
+    *,
+    max_body: int,
+    framing_code: str,
+    size_code: str,
+    incomplete_code: str,
+    invalid_code: str,
+) -> dict | None:
     """Read one unambiguous bounded JSON object without echoing its values."""
     lengths = handler.headers.get_all("Content-Length", [])
     transfer = handler.headers.get_all("Transfer-Encoding", [])
@@ -6142,16 +6158,16 @@ def _read_assistant_secret_body(handler) -> dict | None:
         json_response(
             handler,
             400,
-            {"error": {"code": "invalid-secret-request-framing"}},
+            {"error": {"code": framing_code}},
             no_store=True,
         )
         return None
     length = int(lengths[0])
-    if length <= 0 or length > _ASSISTANT_SECRET_MAX_BODY:
+    if length <= 0 or length > max_body:
         json_response(
             handler,
-            413 if length > _ASSISTANT_SECRET_MAX_BODY else 400,
-            {"error": {"code": "secret-request-size"}},
+            413 if length > max_body else 400,
+            {"error": {"code": size_code}},
             no_store=True,
         )
         return None
@@ -6160,22 +6176,22 @@ def _read_assistant_secret_body(handler) -> dict | None:
         json_response(
             handler,
             400,
-            {"error": {"code": "incomplete-secret-request"}},
+            {"error": {"code": incomplete_code}},
             no_store=True,
         )
         return None
     try:
         value = json.loads(
             raw.decode("utf-8", errors="strict"),
-            object_pairs_hook=_assistant_secret_pairs,
-            parse_float=_reject_assistant_secret_number,
-            parse_constant=_reject_assistant_secret_number,
+            object_pairs_hook=_strict_json_pairs,
+            parse_float=_reject_non_integer_json_number,
+            parse_constant=_reject_non_integer_json_number,
         )
     except (UnicodeError, json.JSONDecodeError, TypeError, ValueError):
         json_response(
             handler,
             400,
-            {"error": {"code": "invalid-secret-request"}},
+            {"error": {"code": invalid_code}},
             no_store=True,
         )
         return None
@@ -6183,11 +6199,33 @@ def _read_assistant_secret_body(handler) -> dict | None:
         json_response(
             handler,
             400,
-            {"error": {"code": "invalid-secret-request"}},
+            {"error": {"code": invalid_code}},
             no_store=True,
         )
         return None
     return value
+
+
+def _read_assistant_secret_body(handler) -> dict | None:
+    return _read_bounded_json_object(
+        handler,
+        max_body=_ASSISTANT_SECRET_MAX_BODY,
+        framing_code="invalid-secret-request-framing",
+        size_code="secret-request-size",
+        incomplete_code="incomplete-secret-request",
+        invalid_code="invalid-secret-request",
+    )
+
+
+def _read_extension_lease_body(handler) -> dict | None:
+    return _read_bounded_json_object(
+        handler,
+        max_body=_ASSISTANT_LEASE_MAX_BODY,
+        framing_code="invalid-lease-request-framing",
+        size_code="lease-request-size",
+        incomplete_code="incomplete-lease-request",
+        invalid_code="invalid-lease-request",
+    )
 
 
 def validate_service_id(handler, body: dict) -> str | None:
@@ -6324,6 +6362,39 @@ def _find_ext_dir(service_id: str) -> Path | None:
     if builtin_dir.is_dir():
         return builtin_dir
     return None
+
+
+def _extension_lease_lock_provider(service_id: str):
+    """Return the existing host lock only for an installed manageable service."""
+    if (
+        _extension_leases is None
+        or not isinstance(service_id, str)
+        or SERVICE_ID_RE.fullmatch(service_id) is None
+    ):
+        raise RuntimeError("extension-lease-manager-unavailable")
+    ext_dir = _find_ext_dir(service_id)
+    has_manifest = ext_dir is not None and any(
+        (ext_dir / name).is_file()
+        for name in ("manifest.yaml", "manifest.yml", "manifest.json")
+    )
+    if service_id in ALWAYS_ON_SERVICES or not has_manifest:
+        raise _extension_leases.LeaseAuthorizationError(
+            "lease-service-not-manageable"
+        )
+    return _service_locks[service_id]
+
+
+def _get_extension_lease_manager():
+    """Create one process-local manager lazily after the feature gate passes."""
+    global _extension_lease_manager
+    if _extension_leases is None:
+        return None
+    with _extension_lease_manager_lock:
+        if _extension_lease_manager is None:
+            _extension_lease_manager = _extension_leases.ExtensionLeaseManager(
+                _extension_lease_lock_provider
+            )
+        return _extension_lease_manager
 
 
 def _service_has_docker_container(service_id: str) -> tuple[bool, str]:
@@ -6610,6 +6681,135 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 503, {"error": "access-transition-unavailable"})
         finally:
             _end_model_lifecycle("pixel_access_mode")
+
+    def _handle_extension_lease(self, action: str) -> None:
+        """Expose lease custody without granting any lifecycle mutation."""
+        if not check_auth(self):
+            return
+        if not ASSISTANT_TRANSACTIONS_ENABLED:
+            json_response(
+                self,
+                404,
+                {"error": {"code": "not-found"}},
+                no_store=True,
+            )
+            return
+        if _extension_leases is None:
+            json_response(
+                self,
+                503,
+                {"error": {"code": "extension-lease-manager-unavailable"}},
+                no_store=True,
+            )
+            return
+        body = _read_extension_lease_body(self)
+        if body is None:
+            return
+        required = {
+            "acquire": {"schema", "transactionId", "planHash", "serviceIds"},
+            "renew": {
+                "schema",
+                "leaseId",
+                "leaseToken",
+                "transactionId",
+                "planHash",
+            },
+            "status": {
+                "schema",
+                "leaseId",
+                "leaseToken",
+                "transactionId",
+                "planHash",
+            },
+            "release": {
+                "schema",
+                "leaseId",
+                "leaseToken",
+                "transactionId",
+                "planHash",
+            },
+        }[action]
+        optional = {"ttlSeconds"} if action in {"acquire", "renew"} else set()
+        if (
+            body.get("schema") != _extension_leases.LEASE_SCHEMA
+            or not required.issubset(body)
+            or not set(body).issubset(required | optional)
+        ):
+            json_response(
+                self,
+                422,
+                {"error": {"code": "invalid-lease-request"}},
+                no_store=True,
+            )
+            return
+        try:
+            manager = _get_extension_lease_manager()
+        except Exception:
+            logger.exception("Extension lease manager initialization failed")
+            manager = None
+        if manager is None:
+            json_response(
+                self,
+                503,
+                {"error": {"code": "extension-lease-manager-unavailable"}},
+                no_store=True,
+            )
+            return
+        try:
+            transaction_id = body["transactionId"]
+            plan_hash = body["planHash"]
+            ttl = (
+                {"ttl_seconds": body["ttlSeconds"]}
+                if "ttlSeconds" in body
+                else {}
+            )
+            if action == "acquire":
+                result = manager.acquire(
+                    transaction_id,
+                    plan_hash,
+                    body["serviceIds"],
+                    **ttl,
+                )
+            else:
+                lease_args = (
+                    body["leaseId"],
+                    body["leaseToken"],
+                    transaction_id,
+                    plan_hash,
+                )
+                if action == "renew":
+                    result = manager.renew(*lease_args, **ttl)
+                elif action == "status":
+                    result = manager.status(*lease_args)
+                else:
+                    result = manager.release(*lease_args)
+        except Exception as exc:
+            if isinstance(exc, _extension_leases.LeaseExpired):
+                status_code = 410
+                code = exc.code
+            elif isinstance(
+                exc, (_extension_leases.LeaseBusy, _extension_leases.LeaseConflict)
+            ):
+                status_code = 409
+                code = exc.code
+            elif isinstance(exc, _extension_leases.LeaseAuthorizationError):
+                status_code = 403
+                code = exc.code
+            elif isinstance(exc, _extension_leases.LeaseError):
+                status_code = 422
+                code = exc.code
+            else:
+                logger.exception("Extension lease request failed")
+                status_code = 503
+                code = "extension-lease-manager-unavailable"
+            json_response(
+                self,
+                status_code,
+                {"error": {"code": code}},
+                no_store=True,
+            )
+            return
+        json_response(self, 200, result, no_store=True)
 
     def _handle_assistant_first_secrets(self, action: str) -> None:
         """Keep configuration secrets inside the authenticated host boundary."""
@@ -7117,7 +7317,24 @@ class AgentHandler(BaseHTTPRequestHandler):
         # parsed as the next request on an HTTP/1.1 keep-alive connection. GET
         # polling remains reusable, which is where connection churn matters.
         self.close_connection = True
-        if self.path in {
+        lease_routes = {
+            "/v1/extension/lease/acquire": "acquire",
+            "/v1/extension/lease/renew": "renew",
+            "/v1/extension/lease/status": "status",
+            "/v1/extension/lease/release": "release",
+        }
+        lease_path = self.path.partition("?")[0]
+        if lease_path in lease_routes:
+            if self.path != lease_path:
+                json_response(
+                    self,
+                    404,
+                    {"error": {"code": "not-found"}},
+                    no_store=True,
+                )
+            else:
+                self._handle_extension_lease(lease_routes[lease_path])
+        elif self.path in {
             "/v1/assistant-first/secrets/stage",
             "/v1/assistant-first/secrets/status",
             "/v1/assistant-first/secrets/delete",
@@ -15635,6 +15852,17 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     # Dashboard model discovery can issue bursts larger than HTTPServer's
     # default backlog of 5; keep action requests from being dropped behind polls.
     request_queue_size = 128
+
+    def service_actions(self):
+        """Release abandoned idle leases during the normal server poll cycle."""
+        super().service_actions()
+        manager = _extension_lease_manager
+        if manager is None:
+            return
+        try:
+            manager.sweep()
+        except Exception:
+            logger.exception("Extension lease sweep failed")
 
 
 def _create_host_agent_server(env: dict, bind_addr: str, port: int):

--- a/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
+++ b/ods/docs/ADR-ASSISTANT-FIRST-TRANSACTION-API.md
@@ -91,17 +91,24 @@ until that mutation exits; expired lease IDs cannot be renewed or replayed.
 Only one mutation may be active under a lease at a time, and it may address
 only services covered by the exact grant.
 
-The lease core is not imported by the host agent, exposed over HTTP, or wired
-into the production runtime in this phase. Those integrations require a
-fail-closed header/body protocol, renewal supervision, legacy direct-caller
-tests, and crash/restart recovery evidence before use.
+The host agent now exposes authenticated, transaction-feature-gated POST
+operations to acquire, renew, inspect, and release this lease. Requests use a
+dedicated bounded strict-JSON parser; reject duplicate keys, floating-point
+values, constants, coercion, unknown fields, and query data; and return only
+`Cache-Control: no-store` responses. Status is token- and binding-protected.
+Service existence and manageability are validated before the host agent's
+`defaultdict` is indexed, so an arbitrary name cannot mint a private lock.
+The server's existing maintenance cycle releases abandoned idle leases after
+expiry, while the lease core continues to pin an active mutation until exit.
 
-This source foundation does not yet make the host agent a second lock owner.
-The current Dashboard routes call host-agent lifecycle endpoints while holding
-their operation lock, so making the callee acquire the same lock would
-self-deadlock. Production execution remains disabled until a host-owned lease
-or equivalent non-reentrant cross-process protocol binds caller and callee to
-the same transaction.
+This is still a custody boundary, not a lifecycle adapter. No existing host
+mutation route accepts a lease token or calls `use`, no Dashboard client or
+renewer is present, and the production runtime still has `executor=None`.
+Legacy direct extension requests contend on the exact same host lock objects,
+but a future lease-bearing mutation call must validate and enter `use` instead
+of trying to re-acquire its already-held lock. Production execution remains
+disabled until that non-reentrant protocol, renewal supervision, and
+crash/restart recovery evidence are implemented and qualified.
 
 ## Why disabled by default
 

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_lease_host_api.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_lease_host_api.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import pytest
 
-
 BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
 TRANSACTION_ID = "txn-" + "1" * 24
 PLAN_HASH = "2" * 64
@@ -200,6 +199,10 @@ def test_host_parser_and_schema_reject_ambiguous_or_oversized_input(
     status, result = host_request("/v1/extension/lease/acquire", raw=duplicate)
     assert status == 400
     assert "do-not-echo" not in json.dumps(result)
+    for raw in (b"[]", b"null"):
+        status, result = host_request("/v1/extension/lease/acquire", raw=raw)
+        assert status == 400
+        assert result == {"error": {"code": "invalid-lease-request"}}
 
     status, result = host_request(
         "/v1/extension/lease/acquire",
@@ -221,6 +224,12 @@ def test_host_parser_and_schema_reject_ambiguous_or_oversized_input(
     )
     assert status == 422
     assert result == {"error": {"code": "invalid-lease-request"}}
+    status, result = host_request(
+        "/v1/extension/lease/acquire",
+        acquire_request(schema, ttlSeconds="60"),
+    )
+    assert status == 422
+    assert result == {"error": {"code": "invalid-lease-ttl"}}
     status, result = host_request(
         "/v1/extension/lease/acquire",
         acquire_request(

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_lease_host_api.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_lease_host_api.py
@@ -1,0 +1,317 @@
+"""Real host-HTTP tests for the dormant extension lease boundary."""
+
+from __future__ import annotations
+
+import collections
+import http.client
+import importlib.util
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+
+BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
+TRANSACTION_ID = "txn-" + "1" * 24
+PLAN_HASH = "2" * 64
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def acquire_request(schema: str, service_ids=None, **changes):
+    value = {
+        "schema": schema,
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "serviceIds": service_ids or ["documents"],
+        "ttlSeconds": 30,
+    }
+    value.update(changes)
+    return value
+
+
+def bound_request(schema: str, grant: dict, **changes):
+    value = {
+        "schema": schema,
+        "leaseId": grant["leaseId"],
+        "leaseToken": grant["leaseToken"],
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+    }
+    value.update(changes)
+    return value
+
+
+@pytest.fixture()
+def host_server(tmp_path):
+    agent_path = BIN_DIR / "ods-host-agent.py"
+    spec = importlib.util.spec_from_file_location(
+        "_extension_lease_host_agent", agent_path
+    )
+    agent = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = agent
+    spec.loader.exec_module(agent)
+
+    builtins = tmp_path / "extensions"
+    users = tmp_path / "user-extensions"
+    users.mkdir()
+    for service_id in ("documents", "voice", "dashboard"):
+        extension = builtins / service_id
+        extension.mkdir(parents=True)
+        (extension / "manifest.yaml").write_text("service: {}\n", encoding="utf-8")
+
+    agent.AGENT_API_KEY = "synthetic-lease-host-key"
+    agent.ASSISTANT_TRANSACTIONS_ENABLED = True
+    agent.EXTENSIONS_DIR = builtins
+    agent.USER_EXTENSIONS_DIR = users
+    agent.ALWAYS_ON_SERVICES = frozenset({"dashboard"})
+    agent._service_locks = collections.defaultdict(threading.Lock)
+    agent._extension_lease_manager = None
+
+    listener = agent.ThreadedHTTPServer(("127.0.0.1", 0), agent.AgentHandler)
+    thread = threading.Thread(target=listener.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield agent, listener
+    finally:
+        listener.shutdown()
+        listener.server_close()
+        thread.join(timeout=3)
+        assert not thread.is_alive()
+        sys.modules.pop(spec.name, None)
+
+
+@pytest.fixture()
+def host_request(host_server):
+    _agent, listener = host_server
+
+    def call(
+        path,
+        body=None,
+        *,
+        raw=None,
+        token="synthetic-lease-host-key",
+        expect_no_store=True,
+    ):
+        connection = http.client.HTTPConnection(*listener.server_address, timeout=5)
+        try:
+            payload = raw if raw is not None else json.dumps(body).encode("utf-8")
+            connection.request(
+                "POST",
+                path,
+                body=payload,
+                headers={"Authorization": "Bearer " + token},
+            )
+            response = connection.getresponse()
+            document = json.loads(response.read())
+            if expect_no_store:
+                assert "no-store" in response.getheader("Cache-Control", "")
+            return response.status, document
+        finally:
+            connection.close()
+
+    return call
+
+
+def test_host_lease_round_trip_is_token_bound_and_no_store(host_server, host_request):
+    agent, _listener = host_server
+    schema = agent._extension_leases.LEASE_SCHEMA
+    status, grant = host_request(
+        "/v1/extension/lease/acquire", acquire_request(schema)
+    )
+    assert status == 200
+    assert grant["serviceIds"] == ["documents"]
+    assert "leaseToken" in grant
+
+    request = bound_request(schema, grant)
+    status, present = host_request("/v1/extension/lease/status", request)
+    assert status == 200
+    assert present["active"] is False
+    assert "leaseToken" not in present
+
+    status, renewed = host_request(
+        "/v1/extension/lease/renew", {**request, "ttlSeconds": 60}
+    )
+    assert status == 200 and renewed["ttlSeconds"] == 60
+    status, released = host_request("/v1/extension/lease/release", request)
+    assert status == 200 and released["released"] is True
+    status, result = host_request("/v1/extension/lease/status", request)
+    assert status == 410
+    assert result == {"error": {"code": "lease-not-active"}}
+
+
+def test_auth_gate_and_missing_manager_fail_closed_before_lock_creation(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    schema = agent._extension_leases.LEASE_SCHEMA
+    request = acquire_request(schema)
+
+    assert host_request(
+        "/v1/extension/lease/acquire", request, token="wrong"
+    )[0] == 403
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+    agent.ASSISTANT_TRANSACTIONS_ENABLED = False
+    try:
+        status, result = host_request("/v1/extension/lease/acquire", request)
+    finally:
+        agent.ASSISTANT_TRANSACTIONS_ENABLED = True
+    assert status == 404
+    assert result == {"error": {"code": "not-found"}}
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+    module = agent._extension_leases
+    agent._extension_leases = None
+    try:
+        status, result = host_request("/v1/extension/lease/acquire", request)
+    finally:
+        agent._extension_leases = module
+    assert status == 503
+    assert result == {
+        "error": {"code": "extension-lease-manager-unavailable"}
+    }
+    assert dict(agent._service_locks) == {}
+
+
+def test_host_parser_and_schema_reject_ambiguous_or_oversized_input(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    schema = agent._extension_leases.LEASE_SCHEMA
+    duplicate = (
+        b'{"schema":"'
+        + schema.encode()
+        + b'","schema":"duplicate","leaseToken":"do-not-echo"}'
+    )
+    status, result = host_request("/v1/extension/lease/acquire", raw=duplicate)
+    assert status == 400
+    assert "do-not-echo" not in json.dumps(result)
+
+    status, result = host_request(
+        "/v1/extension/lease/acquire",
+        raw=json.dumps(acquire_request(schema)).replace("30", "1.5").encode(),
+    )
+    assert status == 400
+    assert "1.5" not in json.dumps(result)
+    assert host_request(
+        "/v1/extension/lease/acquire",
+        raw=b"x" * (agent._ASSISTANT_LEASE_MAX_BODY + 1),
+    )[0] == 413
+    assert host_request(
+        "/v1/extension/lease/acquire?leaseToken=do-not-log", acquire_request(schema)
+    )[0] == 404
+
+    status, result = host_request(
+        "/v1/extension/lease/acquire",
+        acquire_request(schema, unexpected=True),
+    )
+    assert status == 422
+    assert result == {"error": {"code": "invalid-lease-request"}}
+    status, result = host_request(
+        "/v1/extension/lease/acquire",
+        acquire_request(
+            schema,
+            [
+                f"service-{index}"
+                for index in range(agent._extension_leases.MAX_LEASE_SERVICES + 1)
+            ],
+        ),
+    )
+    assert status == 422
+    assert result == {"error": {"code": "too-many-service-ids"}}
+    assert dict(agent._service_locks) == {}
+
+
+@pytest.mark.parametrize("service_id", ["missing", "dashboard"])
+def test_unknown_and_always_on_services_cannot_mint_private_locks(
+    host_server, host_request, service_id
+):
+    agent, _listener = host_server
+    schema = agent._extension_leases.LEASE_SCHEMA
+
+    status, result = host_request(
+        "/v1/extension/lease/acquire", acquire_request(schema, [service_id])
+    )
+
+    assert status == 403
+    assert result == {"error": {"code": "lease-service-not-manageable"}}
+    assert service_id not in agent._service_locks
+
+
+def test_lease_contends_on_the_exact_legacy_extension_lock(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    schema = agent._extension_leases.LEASE_SCHEMA
+    monkeypatch.setattr(agent, "docker_compose_action", lambda *_args: (True, ""))
+    status, grant = host_request(
+        "/v1/extension/lease/acquire", acquire_request(schema)
+    )
+    assert status == 200
+
+    status, _result = host_request(
+        "/v1/extension/start",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+    assert status == 409
+
+    status, released = host_request(
+        "/v1/extension/lease/release", bound_request(schema, grant)
+    )
+    assert status == 200 and released["released"] is True
+    status, result = host_request(
+        "/v1/extension/start",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+    assert status == 200
+    assert result["action"] == "start"
+
+
+def test_server_maintenance_releases_an_abandoned_idle_lease(
+    host_server, host_request, monkeypatch
+):
+    agent, listener = host_server
+    schema = agent._extension_leases.LEASE_SCHEMA
+    clock = FakeClock()
+    agent._extension_lease_manager = agent._extension_leases.ExtensionLeaseManager(
+        agent._extension_lease_lock_provider,
+        clock=clock,
+    )
+    monkeypatch.setattr(agent, "docker_compose_action", lambda *_args: (True, ""))
+    status, grant = host_request(
+        "/v1/extension/lease/acquire",
+        acquire_request(schema, ttlSeconds=1),
+    )
+    assert status == 200
+
+    clock.advance(1)
+    listener.service_actions()
+
+    status, result = host_request(
+        "/v1/extension/start",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+    assert status == 200
+    assert result["action"] == "start"
+    status, result = host_request(
+        "/v1/extension/lease/status", bound_request(schema, grant)
+    )
+    assert status == 410
+    assert result == {"error": {"code": "lease-not-active"}}

--- a/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_operation_leases.py
@@ -233,6 +233,26 @@ def test_token_and_binding_mismatch_cannot_use_or_release_lease():
         manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
 
 
+def test_status_requires_the_exact_token_and_immutable_binding():
+    manager, _lock_map, _events = make_manager()
+    grant = acquire(manager, ("documents",))
+
+    status = manager.status(
+        grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH
+    )
+    assert status["active"] is False
+    assert status["serviceIds"] == ["documents"]
+    assert "leaseToken" not in status
+    with pytest.raises(leases.LeaseAuthorizationError, match="lease-token-mismatch"):
+        manager.status(
+            grant["leaseId"], "wrong-" + "x" * 32, TRANSACTION_ID, PLAN_HASH
+        )
+    with pytest.raises(leases.LeaseAuthorizationError, match="lease-binding-mismatch"):
+        manager.status(grant["leaseId"], TOKEN, TRANSACTION_ID, OTHER_PLAN_HASH)
+
+    manager.release(grant["leaseId"], TOKEN, TRANSACTION_ID, PLAN_HASH)
+
+
 def test_renew_extends_but_never_changes_the_binding_or_services():
     clock = FakeClock()
     manager, lock_map, _events = make_manager(clock=clock)


### PR DESCRIPTION
## Summary

- expose authenticated host-agent POST operations to acquire, renew, inspect, and release an exact extension-operation lease
- reuse the default-off `ODS_ASSISTANT_TRANSACTIONS_ENABLED` gate and return probe-clean 404 responses while disabled
- parse a dedicated 32 KiB strict JSON object with duplicate-key, float, constant, framing, query, unknown-field, and size rejection
- require the exact lease schema, transaction ID, plan hash, token, and action-specific fields; status is token- and binding-protected
- validate installed, manifested, non-always-on services before indexing the host lock `defaultdict`
- share the exact `_service_locks` objects used by legacy extension routes and sweep abandoned idle leases from the server's existing maintenance cycle
- keep the Dashboard production runtime disconnected with `executor=None`

## Why this is separate

The transaction executor cannot safely call existing host lifecycle endpoints while separately re-acquiring the same host locks. This PR adds only the host-side custody protocol and proves that leases contend with legacy requests. No route consumes a lease for mutation yet, so the future non-reentrant `manager.use(...)` boundary can be reviewed independently.

## Safety boundary

- exact lease handlers authenticate before checking the feature gate, parsing input, constructing the manager, or requesting a lock
- acquire is the only response that returns the one-time token; status, renewal, release, and errors never echo it
- every lease response is `Cache-Control: no-store`, and query-bearing lease routes fail closed
- unknown and always-on names cannot create private `defaultdict` lock entries
- expired idle leases are released; an active mutation remains pinned until its context exits
- no host mutation route accepts a lease token or calls `use`
- no Dashboard client, renewer, lifecycle adapter, installation, deployment, or live-service change is included
- production transaction execution remains unavailable (`executor=None`)

## Refreshed stack identity

- refreshed head: `30b8c90e4abe6577e35da5ec00eeffb20048c21f`
- exact tree: `fc6be2f841376fd973cfa2fa17a27ec3a7ce4d3f`
- parents: prior Phase 4J head `9426626949ab23ab76c79b0a44cde58631fee9da`, then refreshed Phase 4I head `73fc87388093ada255086252dc959395cbc4c8cf`
- delta over refreshed Phase 4I: five files, 631 insertions, 25 deletions
- no rebase or force-push was used

## Validation

- Tower3 exact-tree Linux host-agent, lease, lock, transaction, router, and extension suites: `815 passed`
- direct real-HTTP coverage verifies authentication/gate ordering, strict parsing, exact route matching, ambiguous transfer framing rejection, token custody, no-store responses, service validation, legacy-lock contention, and maintenance expiry
- Python compile and focused Ruff checks: passed
- `git diff --check`: passed
- independent Tower1 security and Tower3 concurrency reviews traced the exact handler, parser, lock-provider, manager, expiry, and legacy mutation paths; no remaining blocker
- GitHub exact-head CI: `32 SUCCESS`, `4 SKIPPED`, no failures; PR is `CLEAN` / `MERGEABLE`

## Stack

Base: `feat/assistant-first-phase-4i-host-lease-core` / PR #4486.

The next phase adds the Dashboard-side lease client; this PR still grants no lifecycle mutation through a lease.
