### PR TITLE
feat(extensions): add bounded host lease client

### DIFF
--- a/ods/extensions/services/dashboard-api/extension_lease_client.py
+++ b/ods/extensions/services/dashboard-api/extension_lease_client.py
@@ -1,0 +1,480 @@
+"""Value-safe client for host-owned extension-operation leases.
+
+The client is intentionally not wired into transaction execution yet. It keeps
+lease credentials in memory, validates every host echo, and classifies failures
+without performing retries or logging submitted values.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+from extension_transaction_executor import ExecutionBinding
+from host_agent_client import (
+    AgentClientError,
+    AgentHTTPError,
+    AgentProtocolError,
+    AgentTimeout,
+    AgentUnavailable,
+    request_bounded_json,
+)
+
+LEASE_SCHEMA = "ods.extension-operation-lease.v1"
+DEFAULT_TTL_SECONDS = 600
+MAX_TTL_SECONDS = 3600
+MAX_LEASE_SERVICES = 128
+MAX_SERVICE_ID_LENGTH = 128
+MAX_RESPONSE_BYTES = 32 * 1024
+
+_SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+_TRANSACTION_ID_RE = re.compile(r"^txn-[0-9a-f]{24}$")
+_PLAN_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_LEASE_ID_RE = re.compile(r"^lease-[0-9a-f]{32}$")
+_TOKEN_MIN_LENGTH = 32
+_TOKEN_MAX_LENGTH = 256
+
+_ACQUIRE_RESPONSE_KEYS = frozenset(
+    {
+        "schema",
+        "leaseId",
+        "leaseToken",
+        "transactionId",
+        "planHash",
+        "serviceIds",
+        "ttlSeconds",
+    }
+)
+_RENEW_RESPONSE_KEYS = frozenset(
+    {
+        "schema",
+        "leaseId",
+        "transactionId",
+        "planHash",
+        "serviceIds",
+        "active",
+        "ttlSeconds",
+    }
+)
+_STATUS_RESPONSE_KEYS = frozenset(
+    {
+        "schema",
+        "leaseId",
+        "transactionId",
+        "planHash",
+        "serviceIds",
+        "active",
+    }
+)
+_RELEASE_RESPONSE_KEYS = frozenset(
+    {"schema", "leaseId", "transactionId", "planHash", "released"}
+)
+_RETRYABLE_CONFLICT_CODES = frozenset(
+    {"lease-capacity-exhausted", "lease-mutation-active", "service-lock-busy"}
+)
+_AUTHORIZATION_CODES = frozenset(
+    {
+        "invalid-lease-id",
+        "invalid-lease-token",
+        "lease-binding-mismatch",
+        "lease-token-mismatch",
+    }
+)
+_VALIDATION_CODES = frozenset(
+    {
+        "duplicate-lease-token",
+        "incomplete-lease-request",
+        "invalid-lease-request",
+        "invalid-lease-request-framing",
+        "invalid-lease-ttl",
+        "invalid-or-duplicate-lease-id",
+        "invalid-plan-hash",
+        "invalid-service-id",
+        "invalid-service-ids",
+        "invalid-transaction-id",
+        "lease-request-size",
+        "too-many-service-ids",
+    }
+)
+
+
+class ExtensionLeaseError(RuntimeError):
+    """Stable failure with explicit retry and ambiguous-outcome classification."""
+
+    def __init__(
+        self, code: str, *, retryable: bool = False, ambiguous: bool = False
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.retryable = retryable
+        self.ambiguous = ambiguous
+
+    def __repr__(self) -> str:
+        return (
+            f"ExtensionLeaseError({self.code!r}, retryable={self.retryable!r}, "
+            f"ambiguous={self.ambiguous!r})"
+        )
+
+
+class _LeaseToken:
+    __slots__ = ("__value",)
+
+    def __init__(self, value: str) -> None:
+        self.__value = value
+
+    def reveal(self) -> str:
+        return self.__value
+
+    def __repr__(self) -> str:
+        return "<extension lease token: redacted>"
+
+    __str__ = __repr__
+
+
+@dataclass(frozen=True)
+class LeaseGrant:
+    """In-memory lease custody; its credential is excluded from representations."""
+
+    binding: ExecutionBinding
+    lease_id: str
+    service_ids: tuple[str, ...]
+    ttl_seconds: int
+    _token: _LeaseToken = field(repr=False, compare=False)
+
+    def __repr__(self) -> str:
+        return (
+            "LeaseGrant("
+            f"binding={self.binding!r}, lease_id={self.lease_id!r}, "
+            f"service_ids={self.service_ids!r}, ttl_seconds={self.ttl_seconds!r}, "
+            "lease_token=<redacted>)"
+        )
+
+
+@dataclass(frozen=True)
+class LeaseStatus:
+    binding: ExecutionBinding
+    lease_id: str
+    service_ids: tuple[str, ...]
+    active: bool
+
+
+@dataclass(frozen=True)
+class LeaseRelease:
+    binding: ExecutionBinding
+    lease_id: str
+    released: bool
+
+
+def _fail(code: str, *, retryable: bool = False, ambiguous: bool = False) -> None:
+    raise ExtensionLeaseError(code, retryable=retryable, ambiguous=ambiguous)
+
+
+def _validate_binding(binding: ExecutionBinding) -> None:
+    if not isinstance(binding, ExecutionBinding):
+        _fail("lease-invalid-binding")
+    if _TRANSACTION_ID_RE.fullmatch(binding.transaction_id) is None:
+        _fail("lease-invalid-binding")
+    if _PLAN_HASH_RE.fullmatch(binding.plan_hash) is None:
+        _fail("lease-invalid-binding")
+
+
+def _validate_ttl(ttl_seconds: int) -> int:
+    if (
+        isinstance(ttl_seconds, bool)
+        or not isinstance(ttl_seconds, int)
+        or not 1 <= ttl_seconds <= MAX_TTL_SECONDS
+    ):
+        _fail("lease-invalid-ttl")
+    return ttl_seconds
+
+
+def _validate_response_ttl(ttl_seconds: Any) -> int:
+    if (
+        isinstance(ttl_seconds, bool)
+        or not isinstance(ttl_seconds, int)
+        or not 1 <= ttl_seconds <= MAX_TTL_SECONDS
+    ):
+        _fail("lease-invalid-response")
+    return ttl_seconds
+
+
+def _canonical_service_ids(service_ids: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(service_ids, (str, bytes, dict)):
+        _fail("lease-invalid-service-ids")
+    try:
+        values = tuple(service_ids)
+    except TypeError:
+        _fail("lease-invalid-service-ids")
+    if not values or len(values) > MAX_LEASE_SERVICES:
+        _fail("lease-invalid-service-ids")
+    if any(
+        not isinstance(service_id, str)
+        or len(service_id) > MAX_SERVICE_ID_LENGTH
+        or _SERVICE_ID_RE.fullmatch(service_id) is None
+        for service_id in values
+    ):
+        _fail("lease-invalid-service-ids")
+    return tuple(sorted(set(values)))
+
+
+def _validate_lease_id(lease_id: Any) -> str:
+    if not isinstance(lease_id, str) or _LEASE_ID_RE.fullmatch(lease_id) is None:
+        _fail("lease-invalid-response")
+    return lease_id
+
+
+def _validate_token(token: Any) -> str:
+    if (
+        not isinstance(token, str)
+        or not _TOKEN_MIN_LENGTH <= len(token) <= _TOKEN_MAX_LENGTH
+    ):
+        _fail("lease-invalid-response")
+    return token
+
+
+def _validate_response_binding(
+    response: dict[str, Any], binding: ExecutionBinding
+) -> None:
+    if response["schema"] != LEASE_SCHEMA:
+        _fail("lease-invalid-response")
+    if (
+        response["transactionId"] != binding.transaction_id
+        or response["planHash"] != binding.plan_hash
+    ):
+        _fail("lease-binding-mismatch")
+
+
+def _validate_grant(
+    grant: LeaseGrant,
+) -> tuple[ExecutionBinding, str, str, tuple[str, ...]]:
+    if not isinstance(grant, LeaseGrant) or not isinstance(grant._token, _LeaseToken):
+        _fail("lease-invalid-grant")
+    _validate_binding(grant.binding)
+    lease_id = _validate_lease_id(grant.lease_id)
+    service_ids = _canonical_service_ids(grant.service_ids)
+    if service_ids != grant.service_ids:
+        _fail("lease-invalid-grant")
+    _validate_ttl(grant.ttl_seconds)
+    token = _validate_token(grant._token.reveal())
+    return grant.binding, lease_id, token, service_ids
+
+
+def _error_code(error: AgentHTTPError) -> str | None:
+    try:
+        value = json.loads(error.detail)
+    except (TypeError, ValueError):
+        return None
+    if not isinstance(value, dict) or set(value) != {"code"}:
+        return None
+    code = value["code"]
+    return code if isinstance(code, str) else None
+
+
+def _translate_transport_error(error: AgentClientError, *, operation: str) -> None:
+    mutation = operation != "status"
+    if isinstance(error, AgentHTTPError):
+        code = _error_code(error)
+        if error.status_code in {401, 403}:
+            _fail(code if code in _AUTHORIZATION_CODES else "lease-host-auth")
+        if error.status_code == 404:
+            _fail("lease-boundary-disabled")
+        if error.status_code == 409:
+            _fail(
+                code if code in _RETRYABLE_CONFLICT_CODES else "lease-conflict",
+                retryable=True,
+            )
+        if error.status_code == 410:
+            _fail("lease-not-active")
+        if error.status_code == 422:
+            _fail(code if code in _VALIDATION_CODES else "lease-invalid-request")
+        if error.status_code == 503 and code == "extension-lease-manager-unavailable":
+            _fail("lease-unavailable", retryable=True)
+        if error.status_code >= 500:
+            if mutation:
+                _fail("lease-operation-ambiguous", ambiguous=True)
+            _fail("lease-unavailable", retryable=True)
+        _fail("lease-host-rejected")
+
+    if isinstance(error, AgentProtocolError):
+        if mutation:
+            _fail("lease-operation-ambiguous", ambiguous=True)
+        _fail("lease-invalid-response")
+    if isinstance(error, (AgentTimeout, AgentUnavailable)):
+        if mutation:
+            _fail("lease-operation-ambiguous", ambiguous=True)
+        _fail("lease-unavailable", retryable=True)
+    if mutation:
+        _fail("lease-operation-ambiguous", ambiguous=True)
+    _fail("lease-unavailable", retryable=True)
+
+
+def _payload_size(payload: dict[str, Any]) -> None:
+    try:
+        size = len(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    except (TypeError, ValueError):
+        _fail("lease-invalid-request")
+    if size > MAX_RESPONSE_BYTES:
+        _fail("lease-invalid-request")
+
+
+class ExtensionLeaseClient:
+    """Call fixed host lease routes without persisting or logging credentials."""
+
+    def __init__(
+        self, requester: Callable[..., dict[str, Any]] = request_bounded_json
+    ) -> None:
+        self._request = requester
+
+    def _request_host(
+        self,
+        operation: str,
+        payload: dict[str, Any],
+        *,
+        timeout: float,
+    ) -> dict[str, Any]:
+        _payload_size(payload)
+        try:
+            return self._request(
+                "POST",
+                f"/v1/extension/lease/{operation}",
+                payload=payload,
+                timeout=timeout,
+                max_response_bytes=MAX_RESPONSE_BYTES,
+            )
+        except AgentClientError as error:
+            _translate_transport_error(error, operation=operation)
+
+    def acquire(
+        self,
+        binding: ExecutionBinding,
+        service_ids: Iterable[str],
+        *,
+        ttl_seconds: int = DEFAULT_TTL_SECONDS,
+    ) -> LeaseGrant:
+        _validate_binding(binding)
+        canonical_ids = _canonical_service_ids(service_ids)
+        ttl = _validate_ttl(ttl_seconds)
+        response = self._request_host(
+            "acquire",
+            {
+                "schema": LEASE_SCHEMA,
+                "transactionId": binding.transaction_id,
+                "planHash": binding.plan_hash,
+                "serviceIds": list(canonical_ids),
+                "ttlSeconds": ttl,
+            },
+            timeout=10.0,
+        )
+        if not isinstance(response, dict) or set(response) != _ACQUIRE_RESPONSE_KEYS:
+            _fail("lease-invalid-response")
+        _validate_response_binding(response, binding)
+        if response["serviceIds"] != list(canonical_ids):
+            _fail("lease-binding-mismatch")
+        if _validate_response_ttl(response["ttlSeconds"]) != ttl:
+            _fail("lease-binding-mismatch")
+        return LeaseGrant(
+            binding=binding,
+            lease_id=_validate_lease_id(response["leaseId"]),
+            service_ids=canonical_ids,
+            ttl_seconds=ttl,
+            _token=_LeaseToken(_validate_token(response["leaseToken"])),
+        )
+
+    def renew(
+        self, grant: LeaseGrant, *, ttl_seconds: int = DEFAULT_TTL_SECONDS
+    ) -> LeaseGrant:
+        binding, lease_id, token, service_ids = _validate_grant(grant)
+        ttl = _validate_ttl(ttl_seconds)
+        response = self._request_host(
+            "renew",
+            {
+                "schema": LEASE_SCHEMA,
+                "leaseId": lease_id,
+                "leaseToken": token,
+                "transactionId": binding.transaction_id,
+                "planHash": binding.plan_hash,
+                "ttlSeconds": ttl,
+            },
+            timeout=5.0,
+        )
+        if not isinstance(response, dict) or set(response) != _RENEW_RESPONSE_KEYS:
+            _fail("lease-invalid-response")
+        _validate_response_binding(response, binding)
+        if _validate_lease_id(response["leaseId"]) != lease_id:
+            _fail("lease-binding-mismatch")
+        if response["serviceIds"] != list(service_ids):
+            _fail("lease-binding-mismatch")
+        if type(response["active"]) is not bool:
+            _fail("lease-invalid-response")
+        if _validate_response_ttl(response["ttlSeconds"]) != ttl:
+            _fail("lease-binding-mismatch")
+        return LeaseGrant(
+            binding=binding,
+            lease_id=lease_id,
+            service_ids=service_ids,
+            ttl_seconds=ttl,
+            _token=grant._token,
+        )
+
+    def status(self, grant: LeaseGrant) -> LeaseStatus:
+        binding, lease_id, token, service_ids = _validate_grant(grant)
+        response = self._request_host(
+            "status",
+            {
+                "schema": LEASE_SCHEMA,
+                "leaseId": lease_id,
+                "leaseToken": token,
+                "transactionId": binding.transaction_id,
+                "planHash": binding.plan_hash,
+            },
+            timeout=5.0,
+        )
+        if not isinstance(response, dict) or set(response) != _STATUS_RESPONSE_KEYS:
+            _fail("lease-invalid-response")
+        _validate_response_binding(response, binding)
+        if _validate_lease_id(response["leaseId"]) != lease_id:
+            _fail("lease-binding-mismatch")
+        if response["serviceIds"] != list(service_ids):
+            _fail("lease-binding-mismatch")
+        if type(response["active"]) is not bool:
+            _fail("lease-invalid-response")
+        return LeaseStatus(
+            binding=binding,
+            lease_id=lease_id,
+            service_ids=service_ids,
+            active=response["active"],
+        )
+
+    def release(self, grant: LeaseGrant) -> LeaseRelease:
+        binding, lease_id, token, _service_ids = _validate_grant(grant)
+        response = self._request_host(
+            "release",
+            {
+                "schema": LEASE_SCHEMA,
+                "leaseId": lease_id,
+                "leaseToken": token,
+                "transactionId": binding.transaction_id,
+                "planHash": binding.plan_hash,
+            },
+            timeout=5.0,
+        )
+        if not isinstance(response, dict) or set(response) != _RELEASE_RESPONSE_KEYS:
+            _fail("lease-invalid-response")
+        _validate_response_binding(response, binding)
+        if _validate_lease_id(response["leaseId"]) != lease_id:
+            _fail("lease-binding-mismatch")
+        if response["released"] is not True:
+            _fail("lease-invalid-response")
+        return LeaseRelease(binding=binding, lease_id=lease_id, released=True)
+
+
+__all__ = [
+    "ExtensionLeaseClient",
+    "ExtensionLeaseError",
+    "LeaseGrant",
+    "LeaseRelease",
+    "LeaseStatus",
+]

--- a/ods/extensions/services/dashboard-api/extension_lease_client.py
+++ b/ods/extensions/services/dashboard-api/extension_lease_client.py
@@ -142,7 +142,7 @@ class LeaseGrant:
     lease_id: str
     service_ids: tuple[str, ...]
     ttl_seconds: int
-    _token: _LeaseToken = field(repr=False, compare=False)
+    _token: _LeaseToken = field(repr=False)
 
     def __repr__(self) -> str:
         return (
@@ -169,7 +169,7 @@ class LeaseRelease:
 
 
 def _fail(code: str, *, retryable: bool = False, ambiguous: bool = False) -> None:
-    raise ExtensionLeaseError(code, retryable=retryable, ambiguous=ambiguous)
+    raise ExtensionLeaseError(code, retryable=retryable, ambiguous=ambiguous) from None
 
 
 def _validate_binding(binding: ExecutionBinding) -> None:

--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -72,6 +72,7 @@ _TRANSIENT_ROUTE_MESSAGES = (
     "network is unreachable",
     "no route to host",
 )
+_MAX_BOUNDED_RESPONSE_BYTES = 1024 * 1024
 
 
 def _is_transient_route_connect_error(exc: BaseException) -> bool:
@@ -275,6 +276,94 @@ async def _async_request(
             raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
 
 
+def _validate_response_limit(max_response_bytes: int) -> None:
+    if (
+        isinstance(max_response_bytes, bool)
+        or not isinstance(max_response_bytes, int)
+        or not 1 <= max_response_bytes <= _MAX_BOUNDED_RESPONSE_BYTES
+    ):
+        raise ValueError("invalid max_response_bytes")
+
+
+def _bounded_response(
+    response: httpx.Response, *, max_response_bytes: int
+) -> httpx.Response:
+    length = response.headers.get("content-length")
+    if length is not None:
+        try:
+            if int(length) > max_response_bytes:
+                raise AgentProtocolError("Host agent response exceeded the byte limit")
+        except ValueError:
+            pass
+
+    body = bytearray()
+    for chunk in response.iter_bytes():
+        if len(body) + len(chunk) > max_response_bytes:
+            raise AgentProtocolError("Host agent response exceeded the byte limit")
+        body.extend(chunk)
+    # iter_bytes() counts the decoded body, so do not preserve encoding or
+    # framing headers that would make the copied response decode it twice.
+    headers = {
+        key: value
+        for key, value in response.headers.items()
+        if key.casefold()
+        not in {"content-encoding", "content-length", "transfer-encoding"}
+    }
+    return httpx.Response(
+        response.status_code,
+        headers=headers,
+        content=bytes(body),
+        request=response.request,
+    )
+
+
+def _sync_bounded_request(
+    method: str,
+    path: str,
+    *,
+    payload: Any = None,
+    params: dict[str, Any] | None = None,
+    timeout: float,
+    max_response_bytes: int,
+) -> httpx.Response:
+    _validate_response_limit(max_response_bytes)
+    method = method.upper()
+    stale_connection_retries = 1 if method == "GET" else 0
+    connect_retry_index = 0
+    while True:
+        try:
+            with _get_sync_client().stream(
+                method,
+                path,
+                json=payload if payload is not None else None,
+                params=params,
+                timeout=_timeout(timeout),
+            ) as response:
+                return _bounded_response(
+                    response, max_response_bytes=max_response_bytes
+                )
+        except AgentProtocolError:
+            raise
+        except httpx.TimeoutException as exc:
+            raise AgentTimeout(f"Host agent {method} {path} timed out") from exc
+        except httpx.ConnectError as exc:
+            if (
+                _is_transient_route_connect_error(exc)
+                and connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS)
+            ):
+                time.sleep(_CONNECT_RETRY_DELAYS_SECONDS[connect_retry_index])
+                connect_retry_index += 1
+                continue
+            raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
+        except (httpx.NetworkError, httpx.RemoteProtocolError) as exc:
+            if stale_connection_retries:
+                stale_connection_retries -= 1
+                continue
+            raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
+        except httpx.RequestError as exc:
+            raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
+
+
 def request_json(
     method: str,
     path: str,
@@ -284,6 +373,28 @@ def request_json(
     timeout: float = 5.0,
 ) -> dict[str, Any]:
     response = _sync_request(method, path, payload=payload, params=params, timeout=timeout)
+    _raise_for_status(response)
+    return _decode_json(response)
+
+
+def request_bounded_json(
+    method: str,
+    path: str,
+    *,
+    payload: Any = None,
+    params: dict[str, Any] | None = None,
+    timeout: float = 5.0,
+    max_response_bytes: int,
+) -> dict[str, Any]:
+    """Return an object response without buffering more than the caller's limit."""
+    response = _sync_bounded_request(
+        method,
+        path,
+        payload=payload,
+        params=params,
+        timeout=timeout,
+        max_response_bytes=max_response_bytes,
+    )
     _raise_for_status(response)
     return _decode_json(response)
 

--- a/ods/extensions/services/dashboard-api/tests/test_extension_lease_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_lease_client.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from extension_lease_client import (
+    MAX_RESPONSE_BYTES,
+    ExtensionLeaseClient,
+    ExtensionLeaseError,
+    LeaseGrant,
+)
+from extension_transaction_executor import ExecutionBinding
+from host_agent_client import (
+    AgentHTTPError,
+    AgentProtocolError,
+    AgentTimeout,
+    AgentUnavailable,
+)
+
+TRANSACTION_ID = "txn-" + "1" * 24
+PLAN_HASH = "2" * 64
+LEASE_ID = "lease-" + "3" * 32
+LEASE_TOKEN = "private-lease-token-" + "4" * 32
+BINDING = ExecutionBinding(TRANSACTION_ID, PLAN_HASH)
+SERVICE_IDS = ("aider", "ollama")
+
+
+def acquire_response(**changes) -> dict:
+    response = {
+        "schema": "ods.extension-operation-lease.v1",
+        "leaseId": LEASE_ID,
+        "leaseToken": LEASE_TOKEN,
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "serviceIds": list(SERVICE_IDS),
+        "ttlSeconds": 600,
+    }
+    response.update(changes)
+    return response
+
+
+def public_response(*, ttl: bool = False, **changes) -> dict:
+    response = {
+        "schema": "ods.extension-operation-lease.v1",
+        "leaseId": LEASE_ID,
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "serviceIds": list(SERVICE_IDS),
+        "active": False,
+    }
+    if ttl:
+        response["ttlSeconds"] = 600
+    response.update(changes)
+    return response
+
+
+def grant() -> LeaseGrant:
+    return ExtensionLeaseClient(lambda *_args, **_kwargs: acquire_response()).acquire(
+        BINDING, reversed(SERVICE_IDS)
+    )
+
+
+def test_acquire_uses_exact_bounded_post_and_returns_redacted_grant() -> None:
+    calls = []
+
+    def request(method, path, **kwargs):
+        calls.append((method, path, kwargs))
+        return acquire_response()
+
+    result = ExtensionLeaseClient(request).acquire(
+        BINDING, ["ollama", "aider", "ollama"]
+    )
+
+    method, path, kwargs = calls[0]
+    assert (method, path) == ("POST", "/v1/extension/lease/acquire")
+    assert kwargs["timeout"] == 10.0
+    assert kwargs["max_response_bytes"] == MAX_RESPONSE_BYTES
+    assert kwargs["payload"] == {
+        "schema": "ods.extension-operation-lease.v1",
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+        "serviceIds": list(SERVICE_IDS),
+        "ttlSeconds": 600,
+    }
+    assert result.binding is BINDING
+    assert result.service_ids == SERVICE_IDS
+    assert LEASE_TOKEN not in str(result)
+    assert LEASE_TOKEN not in repr(result)
+    assert LEASE_TOKEN not in repr(asdict(result))
+
+
+def test_renew_status_and_release_keep_token_in_body_only() -> None:
+    current = grant()
+    calls = []
+
+    def request(method, path, **kwargs):
+        calls.append((method, path, kwargs))
+        operation = path.rsplit("/", 1)[-1]
+        if operation == "renew":
+            return public_response(ttl=True)
+        if operation == "status":
+            return public_response(active=True)
+        return {
+            "schema": "ods.extension-operation-lease.v1",
+            "leaseId": LEASE_ID,
+            "transactionId": TRANSACTION_ID,
+            "planHash": PLAN_HASH,
+            "released": True,
+        }
+
+    client = ExtensionLeaseClient(request)
+    renewed = client.renew(current)
+    status = client.status(renewed)
+    released = client.release(renewed)
+
+    assert renewed.binding is BINDING
+    assert status.active is True
+    assert released.released is True
+    assert [call[1].rsplit("/", 1)[-1] for call in calls] == [
+        "renew",
+        "status",
+        "release",
+    ]
+    for _method, path, kwargs in calls:
+        assert LEASE_TOKEN not in path
+        assert kwargs["payload"]["leaseToken"] == LEASE_TOKEN
+        assert kwargs["max_response_bytes"] == MAX_RESPONSE_BYTES
+
+
+@pytest.mark.parametrize(
+    "changes, code",
+    [
+        ({"extra": True}, "lease-invalid-response"),
+        ({"schema": "wrong"}, "lease-invalid-response"),
+        ({"transactionId": "txn-" + "9" * 24}, "lease-binding-mismatch"),
+        ({"planHash": "9" * 64}, "lease-binding-mismatch"),
+        ({"serviceIds": ["aider"]}, "lease-binding-mismatch"),
+        ({"leaseId": "bad"}, "lease-invalid-response"),
+        ({"leaseToken": "short"}, "lease-invalid-response"),
+        ({"ttlSeconds": True}, "lease-invalid-response"),
+        ({"ttlSeconds": 601}, "lease-binding-mismatch"),
+    ],
+)
+def test_acquire_rejects_non_exact_or_misbound_response(changes, code) -> None:
+    response = acquire_response(**changes)
+    with pytest.raises(ExtensionLeaseError) as caught:
+        ExtensionLeaseClient(lambda *_args, **_kwargs: response).acquire(
+            BINDING, SERVICE_IDS
+        )
+    assert caught.value.code == code
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        ExecutionBinding("not-canonical", PLAN_HASH),
+        object(),
+    ],
+)
+def test_invalid_binding_is_rejected_before_request(value) -> None:
+    called = False
+
+    def request(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return acquire_response()
+
+    with pytest.raises(ExtensionLeaseError, match="lease-invalid-binding"):
+        ExtensionLeaseClient(request).acquire(value, SERVICE_IDS)
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    "service_ids, ttl",
+    [
+        ([], 600),
+        ("aider", 600),
+        (["Bad ID"], 600),
+        (["a" * 129], 600),
+        ([f"service-{index}" for index in range(129)], 600),
+        (SERVICE_IDS, True),
+        (SERVICE_IDS, 0),
+        (SERVICE_IDS, 3601),
+    ],
+)
+def test_invalid_acquire_values_are_rejected_before_request(service_ids, ttl) -> None:
+    called = False
+
+    def request(*_args, **_kwargs):
+        nonlocal called
+        called = True
+        return acquire_response()
+
+    with pytest.raises(ExtensionLeaseError):
+        ExtensionLeaseClient(request).acquire(BINDING, service_ids, ttl_seconds=ttl)
+    assert called is False
+
+
+@pytest.mark.parametrize(
+    "status_code, host_code, expected, retryable, ambiguous",
+    [
+        (401, None, "lease-host-auth", False, False),
+        (403, "lease-token-mismatch", "lease-token-mismatch", False, False),
+        (404, None, "lease-boundary-disabled", False, False),
+        (409, "service-lock-busy", "service-lock-busy", True, False),
+        (410, "lease-not-active", "lease-not-active", False, False),
+        (422, "invalid-lease-ttl", "invalid-lease-ttl", False, False),
+        (
+            503,
+            "extension-lease-manager-unavailable",
+            "lease-unavailable",
+            True,
+            False,
+        ),
+        (500, None, "lease-operation-ambiguous", False, True),
+    ],
+)
+def test_http_failures_have_stable_classification(
+    status_code, host_code, expected, retryable, ambiguous
+) -> None:
+    detail = json.dumps({"code": host_code}) if host_code else "private-host-detail"
+
+    def request(*_args, **_kwargs):
+        raise AgentHTTPError(status_code, detail, LEASE_TOKEN)
+
+    with pytest.raises(ExtensionLeaseError) as caught:
+        ExtensionLeaseClient(request).acquire(BINDING, SERVICE_IDS)
+    assert caught.value.code == expected
+    assert caught.value.retryable is retryable
+    assert caught.value.ambiguous is ambiguous
+    assert LEASE_TOKEN not in str(caught.value)
+    assert LEASE_TOKEN not in repr(caught.value)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        AgentTimeout(LEASE_TOKEN),
+        AgentUnavailable(LEASE_TOKEN),
+        AgentProtocolError(LEASE_TOKEN),
+    ],
+)
+def test_mutation_transport_failures_are_ambiguous_and_never_retryable(error) -> None:
+    def request(*_args, **_kwargs):
+        raise error
+
+    with pytest.raises(ExtensionLeaseError) as caught:
+        ExtensionLeaseClient(request).acquire(BINDING, SERVICE_IDS)
+    assert caught.value.code == "lease-operation-ambiguous"
+    assert caught.value.ambiguous is True
+    assert caught.value.retryable is False
+    assert LEASE_TOKEN not in str(caught.value)
+
+
+def test_status_transport_failure_is_retryable() -> None:
+    def request(*_args, **_kwargs):
+        raise AgentTimeout(LEASE_TOKEN)
+
+    with pytest.raises(ExtensionLeaseError) as caught:
+        ExtensionLeaseClient(request).status(grant())
+    assert caught.value.code == "lease-unavailable"
+    assert caught.value.retryable is True
+    assert caught.value.ambiguous is False
+
+
+def test_client_has_no_logging_persistence_or_production_wiring() -> None:
+    source_root = Path(__file__).resolve().parents[1]
+    module = source_root / "extension_lease_client.py"
+    text = module.read_text(encoding="utf-8")
+    for forbidden in (
+        "import logging",
+        "logging.",
+        "logger =",
+        "print(",
+        "open(",
+        "AGENT_URL",
+    ):
+        assert forbidden not in text
+
+    importers = {
+        path.relative_to(source_root).as_posix()
+        for path in source_root.rglob("*.py")
+        if "tests" not in path.parts
+        and path != module
+        and "extension_lease_client" in path.read_text(encoding="utf-8")
+    }
+    assert importers == set()

--- a/ods/extensions/services/dashboard-api/tests/test_extension_lease_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_lease_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import traceback
 from dataclasses import asdict
 from pathlib import Path
 
@@ -233,6 +234,7 @@ def test_http_failures_have_stable_classification(
     assert caught.value.ambiguous is ambiguous
     assert LEASE_TOKEN not in str(caught.value)
     assert LEASE_TOKEN not in repr(caught.value)
+    assert LEASE_TOKEN not in "".join(traceback.format_exception(caught.value))
 
 
 @pytest.mark.parametrize(

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import gzip
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -244,6 +245,82 @@ def test_timeout_is_distinct_from_unavailable(monkeypatch):
     try:
         with pytest.raises(agent_client.AgentTimeout):
             agent_client.request_json("GET", "/health")
+    finally:
+        client.close()
+
+
+def test_bounded_json_rejects_response_before_unbounded_buffering(monkeypatch):
+    body = b'{"value":"' + b"x" * 128 + b'"}'
+    client = httpx.Client(
+        base_url="http://agent",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, content=body)
+        ),
+    )
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    try:
+        with pytest.raises(agent_client.AgentProtocolError):
+            agent_client.request_bounded_json("GET", "/health", max_response_bytes=64)
+    finally:
+        client.close()
+
+
+def test_bounded_json_preserves_status_mapping(monkeypatch):
+    client = httpx.Client(
+        base_url="http://agent",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(409, json={"error": {"code": "busy"}})
+        ),
+    )
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    try:
+        with pytest.raises(agent_client.AgentHTTPError) as caught:
+            agent_client.request_bounded_json(
+                "POST", "/v1/test", max_response_bytes=1024
+            )
+        assert caught.value.status_code == 409
+        assert caught.value.detail == '{"code":"busy"}'
+    finally:
+        client.close()
+
+
+def test_bounded_json_counts_decoded_body_without_double_decoding(monkeypatch):
+    compressed = gzip.compress(b'{"status":"ok"}')
+    client = httpx.Client(
+        base_url="http://agent",
+        transport=httpx.MockTransport(
+            lambda _request: httpx.Response(
+                200,
+                headers={"content-encoding": "gzip"},
+                content=compressed,
+            )
+        ),
+    )
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    try:
+        assert agent_client.request_bounded_json(
+            "GET", "/health", max_response_bytes=64
+        ) == {"status": "ok"}
+    finally:
+        client.close()
+
+
+def test_bounded_json_rejects_invalid_limit_before_request(monkeypatch):
+    calls = 0
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = httpx.Client(
+        base_url="http://agent", transport=httpx.MockTransport(handler)
+    )
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    try:
+        with pytest.raises(ValueError, match="invalid max_response_bytes"):
+            agent_client.request_bounded_json("GET", "/health", max_response_bytes=0)
+        assert calls == 0
     finally:
         client.close()
 


### PR DESCRIPTION
## Summary

- add a dormant Dashboard-side client for the host agent's acquire, renew, inspect, and release lease API
- require an exact `ExecutionBinding` and validate echoed transaction, plan, service, and lease identities on every successful response
- keep the raw lease token inside a redacted credential object and suppress transport exception chains so credentials and transport details cannot escape through `str`, `repr`, dataclass rendering, or formatted tracebacks
- add a streamed, bounded synchronous JSON transport with a 32 KiB lease-response limit and correct handling for gzip-decoded response objects
- classify failures explicitly as terminal, retryable, or ambiguous; mutating requests never retry automatically after a request may have been sent
- reject unknown response keys, invalid status/action combinations, oversized or malformed bodies, redirects, and invalid identifiers

## Why this is separate

Phase 4J established the host-side lease protocol but intentionally left the Dashboard disconnected. This PR adds only the bounded client and its security semantics. Keeping it unused lets the wire contract, credential custody, and ambiguity model be reviewed before any executor or runtime path can invoke it.

## Safety boundary

- callers pass a `LeaseGrant`, not a reusable raw token string
- the token is sent only in authenticated JSON request bodies and is never persisted, logged, included in exception messages, or exposed by object rendering
- every successful response must match the request's exact execution binding
- transport, protocol, size-limit, and unknown server failures on acquire, renew, and release are ambiguous and non-retryable
- status transport failures and known 409 contention/conflict responses are retryable; 403, 410, 422, and gate-disabled 404 responses are terminal
- the client contains no retry loop, renewal supervisor, executor integration, lifecycle adapter, router wiring, installation, deployment, or live-service change
- production transaction execution remains default-off and disconnected

## Refreshed stack identity

- refreshed head: `8890eaa2235aef1ae208cb2cf81c721ad199a22e`
- exact tree: `ea83df02137ae9f1b75ae4e10da21504951173df`
- parents: prior Phase 4K head `d5cae9b9995929d2e5620cd6666b581992580509`, then refreshed Phase 4J head `30b8c90e4abe6577e35da5ec00eeffb20048c21f`
- delta over refreshed Phase 4J: four files, 963 insertions
- no rebase or force-push was used

## Validation

- Tower3 exact-tree Linux lease-client, host-client, host-agent, lease, lock, transaction, router, and extension suites: `870 passed`
- additional acceptance checks cover generic 503 ambiguity, bytes/dict service-list rejection, and opaque token-object preservation across renewal
- Python compile checks: passed
- Ruff: new lease client and test are clean; the changed host-client paths are clean when excluding pre-existing unchanged `I001` / `B010` findings
- `git diff --check`: passed
- independent Tower1 credential-custody and Tower3 protocol reviews traced redaction, exception chains, exact response identity, decoded-byte limits, redirect behavior, mutation retry ambiguity, and dormancy; no remaining blocker
- GitHub exact-head CI: `32 SUCCESS`, `4 SKIPPED`, no failures; PR is `CLEAN` / `MERGEABLE`

## Stack

Base: `feat/assistant-first-phase-4j-host-lease-api` / PR #4487.

The next phases admit individual lifecycle endpoints under exact lease custody; this PR remains unused by production code.
