### PR TITLE
Extract bash tier argument constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const BASH_TIER_ARG: &str = "--tier";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -46,7 +47,7 @@ pub fn run_install(
 
     // Phase 2: Build installer arguments
     let ods_dir = install_dir.join("ods");
-    let mut args = vec!["--tier".to_string(), tier.to_string()];
+    let mut args = vec![BASH_TIER_ARG.to_string(), tier.to_string()];
 
     if features.contains(&"voice".to_string()) {
         args.push("--voice".into());


### PR DESCRIPTION
Extract --tier bash argument to BASH_TIER_ARG constant for consistent tier handling across platforms.