### PR TITLE
Extract bash voice argument constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const BASH_VOICE_ARG: &str = "--voice";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -49,7 +50,7 @@ pub fn run_install(
     let mut args = vec!["--tier".to_string(), tier.to_string()];
 
     if features.contains(&"voice".to_string()) {
-        args.push("--voice".into());
+        args.push(BASH_VOICE_ARG.into());
     }
     if features.contains(&"workflows".to_string()) {
         args.push("--workflows".into());


### PR DESCRIPTION
Extract --voice bash argument to BASH_VOICE_ARG constant to reduce hardcoded feature strings.