### PR TITLE
Extract git depth argument constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const GIT_DEPTH_ARG: &str = "--depth";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -195,7 +196,7 @@ fn ensure_checkout(install_dir: &Path) -> Result<(), String> {
     let clone = Command::new("git")
         .args([
             "clone",
-            "--depth",
+            GIT_DEPTH_ARG,
             "1",
             "--branch",
             install_ref(),


### PR DESCRIPTION
Extract --depth git argument to GIT_DEPTH_ARG constant for centralized git clone configuration.