### PR TITLE
Extract git clone command constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const GIT_CLONE_CMD: &str = "clone";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -194,7 +195,7 @@ fn ensure_checkout(install_dir: &Path) -> Result<(), String> {
 
     let clone = Command::new("git")
         .args([
-            "clone",
+            GIT_CLONE_CMD,
             "--depth",
             "1",
             "--branch",


### PR DESCRIPTION
Extract "clone" git command to GIT_CLONE_CMD constant for centralized git clone configuration.