### PR TITLE
Extract git origin remote constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -11,6 +11,7 @@ const DEFAULT_INSTALL_REF: &str = "main";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
+const GIT_REMOTE_ORIGIN: &str = "origin";
     105, 116,
 ];
 


### PR DESCRIPTION
Extract "origin" remote name to GIT_REMOTE_ORIGIN constant for remote URL retrieval.