### PR TITLE
Extract powershell command constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -15,6 +15,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
 ];
 
 fn repo_url() -> &'static str {
+const POWERSHELL_CMD: &str = "powershell.exe";
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
 }
 


### PR DESCRIPTION
Extract "powershell.exe" command to POWERSHELL_CMD constant for Windows shell execution.