### PR TITLE
Extract chmod command constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -16,6 +16,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
+const CHMOD_CMD: &str = "chmod";
 }
 
 fn install_ref() -> &'static str {


### PR DESCRIPTION
Extract "chmod" command to CHMOD_CMD constant for Unix script permissions.