### PR TITLE
Extract git remote command constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -17,6 +17,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
 }
+const GIT_REMOTE_CMD: &str = "remote";
 
 fn install_ref() -> &'static str {
     option_env!("ODS_INSTALL_REF").unwrap_or(DEFAULT_INSTALL_REF)


### PR DESCRIPTION
Extract "remote" git subcommand to GIT_REMOTE_CMD constant for remote operations.