### PR TITLE
Extract git is-inside-work-tree argument constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -8,6 +8,7 @@ use std::thread;
 
 const DEFAULT_REPO_URL: &str = "https://github.com/Osmantic/ODS.git";
 const DEFAULT_INSTALL_REF: &str = "main";
+const GIT_IS_WORKTREE_ARG: &str = "is-inside-work-tree";
 const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     104, 116, 116, 112, 115, 58, 47, 47, 103, 105, 116, 104, 117, 98, 46, 99, 111, 109, 47, 76,
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
@@ -227,7 +228,7 @@ fn validate_checkout(install_dir: &Path) -> Result<(), String> {
         ));
     }
 
-    let is_work_tree = run_git(install_dir, &["rev-parse", "--is-inside-work-tree"])?;
+    let is_work_tree = run_git(install_dir, &["rev-parse", GIT_IS_WORKTREE_ARG])?;
     if is_work_tree.trim() != "true" {
         return Err(format!(
             "{} is not a valid git worktree.",


### PR DESCRIPTION
Extract "is-inside-work-tree" git argument to GIT_IS_WORKTREE_ARG constant for git worktree validation.