### PR TITLE
Extract cmd start argument constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -14,6 +14,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 116,
 ];
 
+const CMD_START_ARG: &str = "start";
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
 }


### PR DESCRIPTION
Extract "start" cmd argument to CMD_START_ARG constant for URL launching on Windows.