### PR TITLE
Extract xdg-open command constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -15,6 +15,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
 ];
 
 fn repo_url() -> &'static str {
+const XDG_OPEN_CMD: &str = "xdg-open";
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
 }
 


### PR DESCRIPTION
Extract "xdg-open" command to XDG_OPEN_CMD constant for Linux desktop integration.