### PR TITLE
Extract stderr label constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -16,6 +16,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
+const STDERR_LABEL: &str = "stderr";
 }
 
 fn install_ref() -> &'static str {


### PR DESCRIPTION
Extract "stderr" label to STDERR_LABEL constant for process stream handling.