### PR TITLE
feat(extensions): authorize compose toggles with leases

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -135,6 +135,15 @@ BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 MAX_BODY = 16384
 _ASSISTANT_SECRET_MAX_BODY = 64 * 1024
 _ASSISTANT_LEASE_MAX_BODY = 32 * 1024
+_EXTENSION_MUTATION_LEASE_SCHEMA = "ods.extension-operation-lease.v1"
+_EXTENSION_MUTATION_LEASE_KEYS = frozenset({
+    "schema", "leaseId", "leaseToken", "transactionId", "planHash",
+})
+_EXTENSION_MUTATION_LEASE_ID_RE = re.compile(r"^lease-[0-9a-f]{32}$")
+_EXTENSION_MUTATION_TRANSACTION_ID_RE = re.compile(r"^txn-[0-9a-f]{24}$")
+_EXTENSION_MUTATION_PLAN_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_EXTENSION_MUTATION_LEASE_ABSENT = object()
+_EXTENSION_MUTATION_LEASE_REJECTED = object()
 MAX_TELEMETRY_RESPONSE_BYTES = 1024 * 1024
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
@@ -6397,6 +6406,200 @@ def _get_extension_lease_manager():
         return _extension_lease_manager
 
 
+class _ExtensionMutationLeaseEvidence:
+    """Validated request-scoped lease evidence with a redacted credential."""
+
+    __slots__ = (
+        "lease_id", "__lease_token", "transaction_id", "plan_hash",
+    )
+
+    def __init__(
+        self,
+        lease_id: str,
+        lease_token: str,
+        transaction_id: str,
+        plan_hash: str,
+    ) -> None:
+        self.lease_id = lease_id
+        self.__lease_token = lease_token
+        self.transaction_id = transaction_id
+        self.plan_hash = plan_hash
+
+    def reveal_token(self) -> str:
+        return self.__lease_token
+
+    def __repr__(self) -> str:
+        return (
+            "_ExtensionMutationLeaseEvidence("
+            f"lease_id={self.lease_id!r}, lease_token=<redacted>, "
+            f"transaction_id={self.transaction_id!r}, "
+            f"plan_hash={self.plan_hash!r})"
+        )
+
+    __str__ = __repr__
+
+
+class _ExtensionMutationAdmissionRejected(Exception):
+    """Internal control flow after the admission boundary wrote a response."""
+
+
+def _parse_extension_mutation_lease(handler, body: dict):
+    """Return exact lease evidence, absence, or a responded rejection marker."""
+
+    if "lease" not in body:
+        return _EXTENSION_MUTATION_LEASE_ABSENT
+    if not ASSISTANT_TRANSACTIONS_ENABLED:
+        json_response(
+            handler,
+            404,
+            {"error": {"code": "not-found"}},
+            no_store=True,
+        )
+        return _EXTENSION_MUTATION_LEASE_REJECTED
+
+    value = body.get("lease")
+    valid = (
+        isinstance(value, dict)
+        and set(value) == _EXTENSION_MUTATION_LEASE_KEYS
+        and all(isinstance(value.get(key), str) for key in value)
+    )
+    if valid:
+        valid = (
+            value["schema"] == _EXTENSION_MUTATION_LEASE_SCHEMA
+            and _EXTENSION_MUTATION_LEASE_ID_RE.fullmatch(value["leaseId"])
+            is not None
+            and 32 <= len(value["leaseToken"]) <= 256
+            and _EXTENSION_MUTATION_TRANSACTION_ID_RE.fullmatch(
+                value["transactionId"]
+            )
+            is not None
+            and _EXTENSION_MUTATION_PLAN_HASH_RE.fullmatch(value["planHash"])
+            is not None
+        )
+    if not valid:
+        json_response(
+            handler,
+            422,
+            {"error": {"code": "invalid-lease-request"}},
+            no_store=True,
+        )
+        return _EXTENSION_MUTATION_LEASE_REJECTED
+    return _ExtensionMutationLeaseEvidence(
+        value["leaseId"],
+        value["leaseToken"],
+        value["transactionId"],
+        value["planHash"],
+    )
+
+
+def _extension_mutation_lease_error(handler, exc: Exception) -> None:
+    """Write the stable lease error taxonomy without emitting details."""
+
+    module = _extension_leases
+    if module is not None and isinstance(exc, module.LeaseExpired):
+        status = 410
+    elif module is not None and isinstance(
+        exc, (module.LeaseBusy, module.LeaseConflict)
+    ):
+        status = 409
+    elif module is not None and isinstance(exc, module.LeaseAuthorizationError):
+        status = 403
+    elif module is not None and isinstance(exc, module.LeaseError):
+        status = 422
+    else:
+        logger.error(
+            "Extension mutation lease admission failed (%s)",
+            type(exc).__name__,
+        )
+        json_response(
+            handler,
+            503,
+            {"error": {"code": "extension-lease-manager-unavailable"}},
+            no_store=True,
+        )
+        return
+    json_response(
+        handler,
+        status,
+        {"error": {"code": exc.code}},
+        no_store=True,
+    )
+
+
+class _ExtensionMutationAdmission:
+    """Enter either the unchanged legacy locks or one exact lease window."""
+
+    __slots__ = (
+        "_handler", "_evidence", "_service_ids", "_legacy_locks",
+        "_lease_context",
+    )
+
+    def __init__(self, handler, evidence, service_ids) -> None:
+        self._handler = handler
+        self._evidence = evidence
+        self._service_ids = tuple(service_ids)
+        self._legacy_locks = []
+        self._lease_context = None
+
+    def __repr__(self) -> str:
+        mode = (
+            "legacy"
+            if self._evidence is _EXTENSION_MUTATION_LEASE_ABSENT
+            else "lease"
+        )
+        return f"_ExtensionMutationAdmission(mode={mode!r})"
+
+    def __enter__(self):
+        if self._evidence is _EXTENSION_MUTATION_LEASE_ABSENT:
+            for service_id in self._service_ids:
+                lock = _service_locks[service_id]
+                if lock.acquire(blocking=False) is not True:
+                    for held_lock in reversed(self._legacy_locks):
+                        held_lock.release()
+                    self._legacy_locks.clear()
+                    json_response(
+                        self._handler,
+                        409,
+                        {
+                            "error": (
+                                "Operation already in progress for "
+                                f"{service_id}"
+                            )
+                        },
+                    )
+                    raise _ExtensionMutationAdmissionRejected from None
+                self._legacy_locks.append(lock)
+            return None
+
+        try:
+            manager = _get_extension_lease_manager()
+            if manager is None:
+                raise RuntimeError("extension-lease-manager-unavailable")
+            context = manager.use(
+                self._evidence.lease_id,
+                self._evidence.reveal_token(),
+                self._evidence.transaction_id,
+                self._evidence.plan_hash,
+                self._service_ids,
+            )
+            result = context.__enter__()
+        except Exception as exc:
+            _extension_mutation_lease_error(self._handler, exc)
+            raise _ExtensionMutationAdmissionRejected from None
+        self._lease_context = context
+        return result
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        if self._lease_context is not None:
+            context = self._lease_context
+            self._lease_context = None
+            return bool(context.__exit__(exc_type, exc_value, traceback))
+        for lock in reversed(self._legacy_locks):
+            lock.release()
+        self._legacy_locks.clear()
+        return False
+
+
 def _service_has_docker_container(service_id: str) -> tuple[bool, str]:
     """Return whether service_id maps to a Docker container restart target."""
     ext_dir = _find_ext_dir(service_id)
@@ -8774,6 +8977,9 @@ class AgentHandler(BaseHTTPRequestHandler):
         body = read_json_body(self)
         if body is None:
             return
+        lease_evidence = _parse_extension_mutation_lease(self, body)
+        if lease_evidence is _EXTENSION_MUTATION_LEASE_REJECTED:
+            return
 
         # Validate service_id format and existence
         sid = body.get("service_id", "")
@@ -8797,25 +9003,28 @@ class AgentHandler(BaseHTTPRequestHandler):
             src = ext_dir / "compose.yaml"
             dst = ext_dir / "compose.yaml.disabled"
 
-        lock = _service_locks[sid]
-        if not lock.acquire(blocking=False):
-            json_response(self, 409, {"error": f"Operation already in progress for {sid}"})
-            return
+        admission = _ExtensionMutationAdmission(self, lease_evidence, (sid,))
         try:
-            # Check existence inside the lock to prevent TOCTOU races
-            if not src.exists():
-                state = "enabled" if activate else "disabled"
-                json_response(self, 409, {"error": f"Extension already {state}: {sid}"})
-                return
-            # os.replace (not os.rename) — Windows os.rename raises
-            # FileExistsError when destination exists; os.replace always
-            # overwrites atomically.
-            os.replace(str(src), str(dst))
+            with admission:
+                # Check existence inside the admission boundary to prevent
+                # TOCTOU races across legacy and lease-authorized callers.
+                if not src.exists():
+                    state = "enabled" if activate else "disabled"
+                    json_response(
+                        self,
+                        409,
+                        {"error": f"Extension already {state}: {sid}"},
+                    )
+                    return
+                # os.replace (not os.rename) — Windows os.rename raises
+                # FileExistsError when destination exists; os.replace always
+                # overwrites atomically.
+                os.replace(str(src), str(dst))
+        except _ExtensionMutationAdmissionRejected:
+            return
         except OSError as exc:
             json_response(self, 500, {"error": f"Failed to {action} extension: {exc}"})
             return
-        finally:
-            lock.release()
 
         logger.info("%sd extension compose: %s", action, sid)
         json_response(self, 200, {"status": "ok", "service_id": sid, "action": action})

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -1,0 +1,346 @@
+"""Lease-bound HTTP tests for synchronous host extension mutations."""
+
+# Imported pytest fixtures are intentionally discovered by their original
+# names and then injected as test parameters.
+# ruff: noqa: F401, F811
+
+from __future__ import annotations
+
+import collections
+import json
+import threading
+import traceback
+
+import pytest
+
+from test_extension_operation_lease_host_api import (
+    PLAN_HASH,
+    TRANSACTION_ID,
+    FakeClock,
+    acquire_request,
+    bound_request,
+    host_request,
+    host_server,
+)
+
+
+def mutation_lease(agent, grant: dict, **changes) -> dict:
+    return bound_request(agent._extension_leases.LEASE_SCHEMA, grant, **changes)
+
+
+def acquire_lease(agent, request, service_ids=None, **changes) -> dict:
+    status, grant = request(
+        "/v1/extension/lease/acquire",
+        acquire_request(
+            agent._extension_leases.LEASE_SCHEMA,
+            service_ids,
+            **changes,
+        ),
+    )
+    assert status == 200
+    return grant
+
+
+def write_compose(agent, service_id: str, *, active: bool) -> None:
+    directory = agent.EXTENSIONS_DIR / service_id
+    name = "compose.yaml" if active else "compose.yaml.disabled"
+    (directory / name).write_text("services: {}\n", encoding="utf-8")
+
+
+def test_compose_toggle_without_lease_preserves_legacy_behavior(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "service_id": "documents",
+        "action": "activate",
+    }
+    assert agent._extension_lease_manager is None
+    assert (agent.EXTENSIONS_DIR / "documents" / "compose.yaml").is_file()
+
+    status, result = host_request(
+        "/v1/extension/deactivate",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+    assert status == 200
+    assert result["action"] == "deactivate"
+    assert not agent._service_locks["documents"].locked()
+
+
+def valid_evidence() -> dict:
+    return {
+        "schema": "ods.extension-operation-lease.v1",
+        "leaseId": "lease-" + "a" * 32,
+        "leaseToken": "b" * 32,
+        "transactionId": TRANSACTION_ID,
+        "planHash": PLAN_HASH,
+    }
+
+
+@pytest.mark.parametrize(
+    "lease",
+    [
+        None,
+        [],
+        True,
+        {},
+        {"schema": "ods.extension-operation-lease.v1"},
+        {**valid_evidence(), "note": "not-allowed"},
+        {**valid_evidence(), "schema": "ods.extension-operation-lease.v2"},
+        {**valid_evidence(), "leaseId": "lease-not-hex"},
+        {**valid_evidence(), "leaseToken": "x" * 31},
+        {**valid_evidence(), "leaseToken": "x" * 257},
+        {**valid_evidence(), "transactionId": "txn-not-hex"},
+        {**valid_evidence(), "planHash": "0" * 63},
+        {**valid_evidence(), "planHash": None},
+    ],
+)
+def test_malformed_toggle_lease_fails_before_manager_or_lock_creation(
+    host_server, host_request, lease
+):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents", "lease": lease},
+    )
+
+    assert status == 422
+    assert result == {"error": {"code": "invalid-lease-request"}}
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+    assert (agent.EXTENSIONS_DIR / "documents" / "compose.yaml.disabled").is_file()
+
+
+def test_disabled_toggle_lease_gate_does_not_construct_manager_or_lock(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+    agent.ASSISTANT_TRANSACTIONS_ENABLED = False
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents", "lease": valid_evidence()},
+    )
+
+    assert status == 404
+    assert result == {"error": {"code": "not-found"}}
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+
+@pytest.mark.parametrize("token_length", [32, 256])
+def test_toggle_lease_parser_accepts_exact_token_boundaries(
+    host_server, token_length
+):
+    agent, _listener = host_server
+    evidence = valid_evidence()
+    evidence["leaseToken"] = "boundary-secret".ljust(token_length, "x")
+
+    parsed = agent._parse_extension_mutation_lease(None, {"lease": evidence})
+
+    assert parsed is not agent._EXTENSION_MUTATION_LEASE_REJECTED
+    assert evidence["leaseToken"] not in repr(parsed)
+
+
+def test_toggle_lease_manager_unavailable_is_fixed_and_redacted(
+    host_server, host_request, caplog
+):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+    evidence = valid_evidence()
+    module = agent._extension_leases
+    caplog.set_level("ERROR", logger="ods-host-agent")
+    agent._extension_leases = None
+    try:
+        status, result = host_request(
+            "/v1/extension/activate",
+            {"service_id": "documents", "lease": evidence},
+        )
+    finally:
+        agent._extension_leases = module
+
+    rendered = json.dumps(result) + caplog.text
+    assert status == 503
+    assert result == {
+        "error": {"code": "extension-lease-manager-unavailable"}
+    }
+    assert evidence["leaseToken"] not in rendered
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+
+class CountingLock:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.acquire_calls = 0
+
+    def acquire(self, *args, **kwargs):
+        self.acquire_calls += 1
+        return self._lock.acquire(*args, **kwargs)
+
+    def release(self) -> None:
+        self._lock.release()
+
+    def locked(self) -> bool:
+        return self._lock.locked()
+
+
+def test_valid_toggle_lease_uses_existing_custody_without_reacquiring(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    write_compose(agent, "documents", active=False)
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+    assert lock.acquire_calls == 1
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+    assert status == 200
+    assert result["action"] == "activate"
+    assert lock.acquire_calls == 1
+
+    status, result = host_request(
+        "/v1/extension/deactivate",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+    assert status == 200
+    assert result["action"] == "deactivate"
+    assert lock.acquire_calls == 1
+    assert lock.locked()
+
+
+@pytest.mark.parametrize(
+    ("changes", "code"),
+    [
+        ({"leaseToken": "wrong-token-value" * 3}, "lease-token-mismatch"),
+        (
+            {"transactionId": "txn-" + "3" * 24},
+            "lease-binding-mismatch",
+        ),
+        ({"planHash": "4" * 64}, "lease-binding-mismatch"),
+    ],
+)
+def test_toggle_lease_rejects_wrong_token_or_binding_without_leaking_it(
+    host_server, host_request, changes, code
+):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+    grant = acquire_lease(agent, host_request)
+    submitted = mutation_lease(agent, grant, **changes)
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents", "lease": submitted},
+    )
+
+    rendered = json.dumps(result)
+    assert status == 403
+    assert result == {"error": {"code": code}}
+    assert submitted["leaseToken"] not in rendered
+    assert "documents" not in rendered
+    assert (agent.EXTENSIONS_DIR / "documents" / "compose.yaml.disabled").is_file()
+
+
+def test_toggle_lease_scope_and_expiry_fail_closed(host_server, host_request):
+    agent, _listener = host_server
+    clock = FakeClock()
+    agent._extension_lease_manager = agent._extension_leases.ExtensionLeaseManager(
+        agent._extension_lease_lock_provider,
+        clock=clock,
+    )
+    write_compose(agent, "voice", active=False)
+    grant = acquire_lease(agent, host_request, ["documents"], ttlSeconds=1)
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "voice", "lease": mutation_lease(agent, grant)},
+    )
+    assert status == 403
+    assert result == {"error": {"code": "lease-service-not-covered"}}
+    assert "voice" not in agent._service_locks
+
+    clock.advance(1)
+    write_compose(agent, "documents", active=False)
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents", "lease": mutation_lease(agent, grant)},
+    )
+    assert status == 410
+    assert result == {"error": {"code": "lease-not-active"}}
+
+
+def test_legacy_toggle_contends_with_held_lease(host_server, host_request):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+    acquire_lease(agent, host_request)
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+
+    assert status == 409
+    assert result == {"error": "Operation already in progress for documents"}
+
+
+def test_toggle_mutation_error_clears_active_window_and_redacts_evidence(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    write_compose(agent, "documents", active=False)
+    grant = acquire_lease(agent, host_request)
+    evidence = mutation_lease(agent, grant)
+    monkeypatch.setattr(agent.os, "replace", lambda *_args: (_ for _ in ()).throw(
+        OSError("synthetic replace failure")
+    ))
+
+    status, result = host_request(
+        "/v1/extension/activate",
+        {"service_id": "documents", "lease": evidence},
+        expect_no_store=False,
+    )
+    assert status == 500
+    assert evidence["leaseToken"] not in json.dumps(result)
+
+    status, present = host_request(
+        "/v1/extension/lease/status",
+        bound_request(agent._extension_leases.LEASE_SCHEMA, grant),
+    )
+    assert status == 200
+    assert present["active"] is False
+    assert evidence["leaseToken"] not in repr(
+        agent._parse_extension_mutation_lease(None, {"lease": evidence})
+    )
+    assert evidence["leaseToken"] not in "".join(
+        traceback.format_exception(
+            agent._ExtensionMutationAdmissionRejected,
+            agent._ExtensionMutationAdmissionRejected(),
+            None,
+        )
+    )


### PR DESCRIPTION
## Summary

- add one dual-mode mutation admission boundary for extension host routes
- preserve the existing non-blocking per-service lock behavior when lease evidence is absent
- require exact, all-or-none lease evidence when it is present and fail closed on disabled, malformed, expired, unauthorized, conflicting, or unavailable lease state
- wire only synchronous extension activate/deactivate Compose toggles through the lease window in this slice
- move the extension existence check and Compose file swap into the same admission window to remove the route-local time-of-check/time-of-use gap
- parse the mutation envelope with the same bounded, duplicate-rejecting JSON discipline as the lease API
- redact lease tokens, service identifiers, manager details, and unexpected exception text from responses, logs, and object rendering

## Why this is separate

Phase 4K added a bounded Dashboard-side lease client but deliberately left it dormant. This PR establishes the first host mutation consumer and proves the shared admission semantics on the smallest synchronous route shape before applying them to configuration, restart, install, or background workers.

Deferred work needs a different lifetime: the worker must enter the already-acquired lease with `manager.use(...)` around the actual mutation window. Keeping that work out of this PR prevents request-handler lifetime from being mistaken for worker lifetime.

## Compatibility and safety boundary

- no `lease` member preserves the legacy response and lock path
- a present `lease` member never silently falls back to the legacy path
- the lease object requires the exact schema, key set, identifier formats, binding fields, and a 32-256 character token
- duplicate top-level or nested keys, ambiguous HTTP framing, oversized or incomplete bodies, malformed UTF-8, non-object JSON, floats, constants, and trailing JSON are rejected before manager or lock construction
- malformed evidence is rejected before constructing the manager or creating a service lock
- the transaction feature gate remains default-off; lease-bearing requests receive the existing not-found boundary while disabled
- lease mode enters `manager.use(...)` and does not reacquire the non-reentrant service locks already held by the lease
- context-entry failures are classified and returned without suppressing mutation-body exceptions or leaking exception details
- the always-on/core rejection remains owned by the lease manager
- start/stop, configuration sync, restart, install, core recreation, Dashboard client wiring, renewal supervision, and live enablement are intentionally not included
- no installation, deployment, container start, live-service mutation, or merge was performed

## Security review and repair

The first exact-tree review found that the legacy outer-body reader silently accepted duplicate JSON keys and ambiguous request framing. That could replace an otherwise exact `lease` object before lease-evidence validation. The candidate was stopped, changed to a reusable strict bounded mutation reader, and expanded with duplicate top-level lease, duplicate nested token, transfer-framing, and oversize tests. Tower1 then traced every rejection path and confirmed it returns before lease parsing, manager construction, or lock acquisition while the valid no-lease path remains compatible.

## Refreshed stack identity

- refreshed head: `45ee73db7dc1bbe7d33cc9576e06142f9d254af3`
- exact tree: `abaed6ea34dd5a498999ffbec4959aab246275bc`
- parents: prior Phase 4L toggle head `a47f2ed2ce60433479cd3beb94b879884cdf494f`, then refreshed Phase 4K head `8890eaa2235aef1ae208cb2cf81c721ad199a22e`
- delta over refreshed Phase 4K: two files, 640 insertions, 16 deletions
- no rebase or force-push was used

## Validation

- Tower3 exact-tree Linux host-agent, toggle-route, lease-client, lease API/core, lock, transaction, router, and extension suites: `897 passed`
- direct route coverage proves legacy admission, exact lease custody, no non-reentrant reacquisition, scope/binding/token/expiry failures, mutation-window cleanup, shared-lock contention, and redaction
- strict-envelope coverage proves duplicate-key, framing, size, and parse failures happen before manager or lock creation
- Python compilation: passed
- focused Ruff syntax/runtime baseline (`E4`, `E7`, `E9`, `F`, retaining the repository's existing `E701` exception): passed
- `git diff --check`: passed
- Tower1 security review found the outer-envelope blocker; the independent post-fix review confirms it is closed
- Tower3 lock-ordering and custody review traced partial-acquire rollback, admission lifetime, expiry, active pinning, cleanup, and exception behavior; no lock/deadlock blocker
- GitHub exact-head CI is running; this section will be refreshed after completion

## Stack

Base: `feat/assistant-first-phase-4k-host-lease-client` / PR #4490.

The next slices extend the same admission contract to configuration sync and background start/stop lifetimes. This PR still does not wire the dormant Dashboard client into production execution.
