### PR TITLE
feat(extensions): authorize config sync with leases

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -9048,6 +9048,9 @@ class AgentHandler(BaseHTTPRequestHandler):
         body = read_json_body(self)
         if body is None:
             return
+        lease_evidence = _parse_extension_mutation_lease(self, body)
+        if lease_evidence is _EXTENSION_MUTATION_LEASE_REJECTED:
+            return
 
         sid = body.get("service_id", "")
         if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
@@ -9057,6 +9060,20 @@ class AgentHandler(BaseHTTPRequestHandler):
         if not isinstance(preserve_existing, bool):
             json_response(self, 400, {"error": "preserve_existing must be a boolean"})
             return
+
+        admission = _ExtensionMutationAdmission(self, lease_evidence, (sid,))
+        try:
+            with admission:
+                self._handle_extension_sync_config_admitted(sid, preserve_existing)
+        except _ExtensionMutationAdmissionRejected:
+            return
+
+    def _handle_extension_sync_config_admitted(
+        self,
+        sid: str,
+        preserve_existing: bool,
+    ) -> None:
+        """Validate and copy one config tree inside its admission boundary."""
 
         # Only user-installed extensions ship a config/ subdir for sync
         # at install time; built-in configs are pre-created by the
@@ -9177,46 +9194,39 @@ class AgentHandler(BaseHTTPRequestHandler):
                         return
 
         synced: list[str] = []
-        lock = _service_locks[sid]
-        if not lock.acquire(blocking=False):
-            json_response(self, 409, {"error": f"Operation already in progress for {sid}"})
-            return
         try:
-            try:
-                if preserve_existing:
-                    for source_path in sorted(src_svc.rglob("*")):
-                        relative = source_path.relative_to(src_svc)
-                        target_path = target / relative
-                        if source_path.is_dir():
-                            target_path.mkdir(parents=True, exist_ok=True)
-                        elif source_path.is_file() and not target_path.exists():
-                            target_path.parent.mkdir(parents=True, exist_ok=True)
-                            shutil.copy2(source_path, target_path)
-                else:
-                    shutil.copytree(
-                        str(src_svc), str(target),
-                        dirs_exist_ok=True, symlinks=False,
-                    )
-                synced.append(sid)
-            except OSError as exc:
-                json_response(self, 500, {
-                    "error": f"Failed to copy {sid}/config/{sid}: {exc}",
-                })
-                return
-            # Mark .sh files executable in the synced service tree.
-            for root, _dirs, files in os.walk(str(target)):
-                for fname in files:
-                    if fname.endswith(".sh"):
-                        fpath = Path(root) / fname
-                        try:
-                            fpath.chmod(
-                                fpath.stat().st_mode
-                                | stat_mod.S_IXUSR | stat_mod.S_IXGRP | stat_mod.S_IXOTH,
-                            )
-                        except OSError as exc:
-                            logger.warning("chmod +x failed for %s: %s", fpath, exc)
-        finally:
-            lock.release()
+            if preserve_existing:
+                for source_path in sorted(src_svc.rglob("*")):
+                    relative = source_path.relative_to(src_svc)
+                    target_path = target / relative
+                    if source_path.is_dir():
+                        target_path.mkdir(parents=True, exist_ok=True)
+                    elif source_path.is_file() and not target_path.exists():
+                        target_path.parent.mkdir(parents=True, exist_ok=True)
+                        shutil.copy2(source_path, target_path)
+            else:
+                shutil.copytree(
+                    str(src_svc), str(target),
+                    dirs_exist_ok=True, symlinks=False,
+                )
+            synced.append(sid)
+        except OSError as exc:
+            json_response(self, 500, {
+                "error": f"Failed to copy {sid}/config/{sid}: {exc}",
+            })
+            return
+        # Mark .sh files executable in the synced service tree.
+        for root, _dirs, files in os.walk(str(target)):
+            for fname in files:
+                if fname.endswith(".sh"):
+                    fpath = Path(root) / fname
+                    try:
+                        fpath.chmod(
+                            fpath.stat().st_mode
+                            | stat_mod.S_IXUSR | stat_mod.S_IXGRP | stat_mod.S_IXOTH,
+                        )
+                    except OSError as exc:
+                        logger.warning("chmod +x failed for %s: %s", fpath, exc)
 
         logger.info(
             "synced config for extension %s (%d in-scope, %d out-of-scope ignored)",

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -9064,15 +9064,19 @@ class AgentHandler(BaseHTTPRequestHandler):
         admission = _ExtensionMutationAdmission(self, lease_evidence, (sid,))
         try:
             with admission:
-                self._handle_extension_sync_config_admitted(sid, preserve_existing)
+                status, response = self._handle_extension_sync_config_admitted(
+                    sid,
+                    preserve_existing,
+                )
         except _ExtensionMutationAdmissionRejected:
             return
+        json_response(self, status, response)
 
     def _handle_extension_sync_config_admitted(
         self,
         sid: str,
         preserve_existing: bool,
-    ) -> None:
+    ) -> tuple[int, dict]:
         """Validate and copy one config tree inside its admission boundary."""
 
         # Only user-installed extensions ship a config/ subdir for sync
@@ -9081,13 +9085,11 @@ class AgentHandler(BaseHTTPRequestHandler):
         ext_dir = USER_EXTENSIONS_DIR / sid
         if not ext_dir.is_dir():
             # Not a user extension — no-op (built-ins handled by installer).
-            json_response(self, 200, {"status": "ok", "service_id": sid, "synced": []})
-            return
+            return 200, {"status": "ok", "service_id": sid, "synced": []}
 
         ext_config = ext_dir / "config"
         if not ext_config.is_dir():
-            json_response(self, 200, {"status": "ok", "service_id": sid, "synced": []})
-            return
+            return 200, {"status": "ok", "service_id": sid, "synced": []}
 
         # Reject ANY symlink in the config/ tree (or if config/ itself is a
         # symlink). _copytree_safe (the install-time copier) strips symlinks
@@ -9102,23 +9104,21 @@ class AgentHandler(BaseHTTPRequestHandler):
         # siblings) — a symlink anywhere is treated as tampering, even if the
         # contract restriction below means we wouldn't have copied it anyway.
         if ext_config.is_symlink():
-            json_response(self, 400, {
+            return 400, {
                 "error": (
                     f"config sync refused: {sid}/config is a symlink "
                     f"(symlinks are not permitted in extension configs)"
                 ),
-            })
-            return
+            }
         for root, dirs, files in os.walk(str(ext_config), followlinks=False):
             for name in dirs + files:
                 if (Path(root) / name).is_symlink():
-                    json_response(self, 400, {
+                    return 400, {
                         "error": (
                             f"config sync refused: symlink {name} in "
                             f"{sid}/config (symlinks are not permitted)"
                         ),
-                    })
-                    return
+                    }
 
         # Default copy contract: an extension may only write to its OWN
         # config tree — `<ext>/config/<service_id>/` → `INSTALL_DIR/config/<service_id>/`.
@@ -9143,55 +9143,49 @@ class AgentHandler(BaseHTTPRequestHandler):
 
         # If the extension ships no `config/<sid>/` at all, no-op.
         if not src_svc.exists():
-            json_response(self, 200, {
+            return 200, {
                 "status": "ok",
                 "service_id": sid,
                 "synced": [],
                 "skipped": out_of_scope,
-            })
-            return
+            }
         if not src_svc.is_dir():
-            json_response(self, 400, {
+            return 400, {
                 "error": (
                     f"config sync refused: {sid}/config/{sid} must be a directory"
                 ),
-            })
-            return
+            }
 
         install_config = (INSTALL_DIR / "config").resolve()
         try:
             install_config.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
-            json_response(self, 500, {"error": f"Failed to prepare config dir: {exc}"})
-            return
+            return 500, {"error": f"Failed to prepare config dir: {exc}"}
 
         target_candidate = install_config / sid
         if target_candidate.is_symlink():
-            json_response(self, 400, {
+            return 400, {
                 "error": f"config sync refused: target is a symlink for {sid}",
-            })
-            return
+            }
         target = target_candidate.resolve()
         # Path-traversal guard: target must stay under install_config. Always true
         # because sid is validated against SERVICE_ID_RE above (no slashes / dots),
         # but kept as defense-in-depth in case the regex ever loosens.
         if not target.is_relative_to(install_config):
-            json_response(self, 400, {
+            return 400, {
                 "error": f"config sync refused: target outside install dir for {sid}",
-            })
-            return
+            }
 
         if target.is_dir():
             for root, dirs, files in os.walk(str(target), followlinks=False):
                 for name in dirs + files:
                     if (Path(root) / name).is_symlink():
-                        json_response(self, 400, {
+                        return 400, {
                             "error": (
                                 f"config sync refused: existing target symlink {name} "
                                 f"for {sid}"
                             ),
-                        })
-                        return
+                        }
 
         synced: list[str] = []
         try:
@@ -9211,10 +9205,9 @@ class AgentHandler(BaseHTTPRequestHandler):
                 )
             synced.append(sid)
         except OSError as exc:
-            json_response(self, 500, {
+            return 500, {
                 "error": f"Failed to copy {sid}/config/{sid}: {exc}",
-            })
-            return
+            }
         # Mark .sh files executable in the synced service tree.
         for root, _dirs, files in os.walk(str(target)):
             for fname in files:
@@ -9232,7 +9225,7 @@ class AgentHandler(BaseHTTPRequestHandler):
             "synced config for extension %s (%d in-scope, %d out-of-scope ignored)",
             sid, len(synced), len(out_of_scope),
         )
-        json_response(self, 200, {
+        return 200, {
             "status": "ok",
             "service_id": sid,
             "synced": synced,
@@ -9241,7 +9234,7 @@ class AgentHandler(BaseHTTPRequestHandler):
             # predates preserve_existing instead of silently full-copying
             # over user config during update/rollback.
             "preserve_existing": bool(preserve_existing),
-        })
+        }
 
     def _handle_logs(self):
         if not check_auth(self):

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -378,11 +378,21 @@ def test_malformed_sync_config_lease_fails_before_manager_lock_or_copy(
 
 
 def test_sync_config_without_lease_preserves_legacy_behavior(
-    host_server, host_request
+    host_server, host_request, monkeypatch
 ):
     agent, _listener = host_server
     agent._service_locks = collections.defaultdict(CountingLock)
     _source, target = write_user_config(agent, "documents")
+    lock = agent._service_locks["documents"]
+    original_json_response = agent.json_response
+    locked_at_response = []
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if code == 200 and body.get("service_id") == "documents":
+            locked_at_response.append(lock.locked())
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
 
     status, result = host_request(
         "/v1/extension/sync_config",
@@ -399,8 +409,9 @@ def test_sync_config_without_lease_preserves_legacy_behavior(
         "preserve_existing": False,
     }
     assert agent._extension_lease_manager is None
-    assert agent._service_locks["documents"].acquire_calls == 1
-    assert not agent._service_locks["documents"].locked()
+    assert lock.acquire_calls == 1
+    assert locked_at_response == [False]
+    assert not lock.locked()
     assert (target / "settings.yaml").read_text(encoding="utf-8") == "enabled: true\n"
 
 
@@ -413,13 +424,22 @@ def test_valid_sync_config_lease_covers_copy_without_reacquiring(
     grant = acquire_lease(agent, host_request)
     lock = agent._service_locks["documents"]
     original_copytree = shutil.copytree
+    original_json_response = agent.json_response
+    state_at_response = []
 
     def observed_copytree(*args, **kwargs):
         state = agent._extension_lease_manager.describe(grant["leaseId"])
         assert state["active"] is True
         return original_copytree(*args, **kwargs)
 
+    def observed_json_response(handler, code, body, **kwargs):
+        if code == 200 and body.get("service_id") == "documents":
+            state = agent._extension_lease_manager.describe(grant["leaseId"])
+            state_at_response.append((state["active"], lock.locked()))
+        return original_json_response(handler, code, body, **kwargs)
+
     monkeypatch.setattr(agent.shutil, "copytree", observed_copytree)
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
     status, result = host_request(
         "/v1/extension/sync_config",
         {
@@ -439,7 +459,79 @@ def test_valid_sync_config_lease_covers_copy_without_reacquiring(
     }
     assert (target / "settings.yaml").read_text(encoding="utf-8") == "enabled: true\n"
     assert lock.acquire_calls == 1
+    assert state_at_response == [(False, True)]
     assert lock.locked()
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+
+
+def test_sync_config_noop_response_is_written_after_lease_window_closes(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    directory = agent.USER_EXTENSIONS_DIR / "documents"
+    directory.mkdir()
+    (directory / "manifest.yaml").write_text("service: {}\n", encoding="utf-8")
+    grant = acquire_lease(agent, host_request)
+    original_json_response = agent.json_response
+    active_at_response = []
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if code == 200 and body.get("service_id") == "documents":
+            state = agent._extension_lease_manager.describe(grant["leaseId"])
+            active_at_response.append(state["active"])
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {"status": "ok", "service_id": "documents", "synced": []}
+    assert active_at_response == [False]
+
+
+def test_sync_config_error_response_is_written_after_lease_window_closes(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    write_user_config(agent, "documents")
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+    original_json_response = agent.json_response
+    state_at_response = []
+
+    def fail_copytree(*_args, **_kwargs):
+        raise OSError("synthetic copy failure")
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if code == 500:
+            state = agent._extension_lease_manager.describe(grant["leaseId"])
+            state_at_response.append((state["active"], lock.locked()))
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(agent.shutil, "copytree", fail_copytree)
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 500
+    assert result == {
+        "error": "Failed to copy documents/config/documents: synthetic copy failure"
+    }
+    assert state_at_response == [(False, True)]
     assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import collections
 import json
+import shutil
 import threading
 import traceback
 
@@ -45,6 +46,18 @@ def write_compose(agent, service_id: str, *, active: bool) -> None:
     directory = agent.EXTENSIONS_DIR / service_id
     name = "compose.yaml" if active else "compose.yaml.disabled"
     (directory / name).write_text("services: {}\n", encoding="utf-8")
+
+
+def write_user_config(agent, service_id: str) -> tuple:
+    directory = agent.USER_EXTENSIONS_DIR / service_id
+    source = directory / "config" / service_id
+    source.mkdir(parents=True)
+    (directory / "manifest.yaml").write_text("service: {}\n", encoding="utf-8")
+    (source / "settings.yaml").write_text("enabled: true\n", encoding="utf-8")
+    install_dir = agent.USER_EXTENSIONS_DIR.parent / "install"
+    install_dir.mkdir()
+    agent.INSTALL_DIR = install_dir
+    return source, install_dir / "config" / service_id
 
 
 def test_compose_toggle_without_lease_preserves_legacy_behavior(
@@ -344,3 +357,131 @@ def test_toggle_mutation_error_clears_active_window_and_redacts_evidence(
             None,
         )
     )
+
+
+def test_malformed_sync_config_lease_fails_before_manager_lock_or_copy(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    _source, target = write_user_config(agent, "documents")
+
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {"service_id": "documents", "lease": {"schema": "wrong"}},
+    )
+
+    assert status == 422
+    assert result == {"error": {"code": "invalid-lease-request"}}
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+    assert not target.exists()
+
+
+def test_sync_config_without_lease_preserves_legacy_behavior(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    _source, target = write_user_config(agent, "documents")
+
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "service_id": "documents",
+        "synced": ["documents"],
+        "skipped": [],
+        "preserve_existing": False,
+    }
+    assert agent._extension_lease_manager is None
+    assert agent._service_locks["documents"].acquire_calls == 1
+    assert not agent._service_locks["documents"].locked()
+    assert (target / "settings.yaml").read_text(encoding="utf-8") == "enabled: true\n"
+
+
+def test_valid_sync_config_lease_covers_copy_without_reacquiring(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    _source, target = write_user_config(agent, "documents")
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+    original_copytree = shutil.copytree
+
+    def observed_copytree(*args, **kwargs):
+        state = agent._extension_lease_manager.describe(grant["leaseId"])
+        assert state["active"] is True
+        return original_copytree(*args, **kwargs)
+
+    monkeypatch.setattr(agent.shutil, "copytree", observed_copytree)
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "service_id": "documents",
+        "synced": ["documents"],
+        "skipped": [],
+        "preserve_existing": False,
+    }
+    assert (target / "settings.yaml").read_text(encoding="utf-8") == "enabled: true\n"
+    assert lock.acquire_calls == 1
+    assert lock.locked()
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+
+
+def test_sync_config_lease_scope_failure_cannot_prepare_target(
+    host_server, host_request
+):
+    agent, _listener = host_server
+    _source, target = write_user_config(agent, "voice")
+    grant = acquire_lease(agent, host_request, ["documents"])
+
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {
+            "service_id": "voice",
+            "lease": mutation_lease(agent, grant),
+        },
+    )
+
+    assert status == 403
+    assert result == {"error": {"code": "lease-service-not-covered"}}
+    assert not target.exists()
+    assert "voice" not in agent._service_locks
+
+
+def test_sync_config_authenticates_lease_before_noop(host_server, host_request):
+    agent, _listener = host_server
+    directory = agent.USER_EXTENSIONS_DIR / "documents"
+    directory.mkdir()
+    (directory / "manifest.yaml").write_text("service: {}\n", encoding="utf-8")
+    grant = acquire_lease(agent, host_request)
+    submitted = mutation_lease(
+        agent,
+        grant,
+        leaseToken="wrong-token-value" * 3,
+    )
+
+    status, result = host_request(
+        "/v1/extension/sync_config",
+        {"service_id": "documents", "lease": submitted},
+    )
+
+    assert status == 403
+    assert result == {"error": {"code": "lease-token-mismatch"}}
+    assert not (directory / "config").exists()
+    assert submitted["leaseToken"] not in json.dumps(result)


### PR DESCRIPTION
## Summary

- apply the existing dual-mode extension mutation admission boundary to `/v1/extension/sync_config`
- authenticate any present lease before no-op decisions, source inspection, target preparation, copy, or permission changes
- use the shared bounded, duplicate-rejecting mutation-envelope reader before lease parsing
- keep the admission window active across all config filesystem validation and mutation
- release the admission window before writing any admitted success or error response
- preserve the legacy non-blocking per-service lock path when lease evidence is absent
- remove the route-local second lock acquisition so a lease-authorized request cannot deadlock or falsely conflict with its own non-reentrant lock

## Why this is separate

Phase 4L-A introduced the shared admission boundary and proved it on synchronous Compose-file toggles. Config sync has a wider filesystem surface: source and target symlink rejection, path containment, optional preserve-existing copies, target directory creation, and script permission changes. This slice places the entire decision-and-copy path inside the same admission window without mixing in background worker lifetime or container execution.

## Compatibility and safety boundary

- no `lease` member preserves the existing response bodies and non-blocking service-lock behavior
- a present `lease` member never silently falls back to the legacy path
- strict request parsing rejects duplicate top-level or nested keys, ambiguous framing, oversized or incomplete bodies, malformed UTF-8, non-object JSON, floats, constants, and trailing JSON before lease parsing
- malformed lease evidence fails before constructing a manager, creating a service lock, or copying config
- lease scope, token, transaction, and plan bindings are checked before even a no-op result
- the feature gate remains default-off and lease-bearing requests retain the not-found boundary while disabled
- lease mode enters `manager.use(...)` and does not reacquire the service lock already held for the lease lifetime
- source inspection, target preparation, copy, and `.sh` permission updates all occur inside the admission boundary
- admitted helpers return the existing status/body contract so the outer handler can close admission before making the result client-visible
- admission rejection writes its stable HTTP error before raising the empty internal control-flow exception
- existing symlink, path-containment, own-service-only, preserve-existing, error, and response behavior remains intact
- start/stop, install, retry workers, restart, hooks, core recreation, production executor wiring, renewal supervision, and live enablement remain deferred because their mutation lifetime is materially different
- no installation, deployment, container start, live-service mutation, merge, or destructive operation was performed

## Security review and repair

Restacking exposed that the original sync-config slice still used the legacy JSON reader even though the parent toggle route had adopted strict bounded parsing. The candidate was stopped and changed to the shared mutation reader. New real-HTTP tests reject duplicate top-level lease evidence, duplicate nested lease-token keys, and `Content-Length` plus `Transfer-Encoding` ambiguity before manager construction, lock creation, or filesystem copy.

An initial local review then incorrectly claimed that admission rejection omitted its HTTP response. Direct source tracing and the real-HTTP suite disproved that claim: `_ExtensionMutationAdmission.__enter__` calls `_extension_mutation_lease_error(...)`, which writes the stable response, before raising `_ExtensionMutationAdmissionRejected` solely for handler control flow. Narrow correction reviews on both physical workers confirmed this path.

## Refreshed stack identity

- refreshed head: `8ea5411bc36bdc5a605a8bf02ab8e298544b68b6`
- exact tree: `809120c9f891cec7bede565c7d46f35ca60e07df`
- parents: prior Phase 4L sync-config head `5f81ce612035cf8de527baa63f5a4604913f7d83`, then refreshed Phase 4L toggle head `45ee73db7dc1bbe7d33cc9576e06142f9d254af3`
- delta over refreshed Phase 4L toggle: two files, 352 insertions, 69 deletions
- no rebase or force-push was used

## Validation

- Tower3 exact-candidate Linux host-agent, route, lease-client, lease API/core, lock, transaction, router, extension, and staleness suites: `887 passed`
- existing host-agent coverage verifies preserve-existing copies, source and target symlink rejection, service-ID validation, cross-service isolation, and script permission handling
- new real-HTTP coverage verifies strict-envelope rejection, no manager/lock/copy on invalid input, legacy lock parity, lease non-reacquisition, scope/token failures, no-op ordering, copy/error cleanup, and response-after-admission timing
- Python compilation: passed
- focused Ruff syntax/runtime baseline (`E4`, `E7`, `E9`, `F`, retaining the repository's existing `E701` exception): passed
- `git diff --check`: passed
- Tower1 corrected security review and Tower3 narrow correctness review: passed with no remaining blocker
- GitHub exact-head CI: `32` successful checks, `4` intentionally skipped checks, no failures
- GitHub merge state: `CLEAN` / `MERGEABLE`

## Stack

Base: `feat/assistant-first-phase-4l-toggle-lease-admission` / PR #4516.

The next slice extends lease custody across the background start/stop worker lifetime. This PR does not wire the dormant Dashboard client into production execution.
