### PR TITLE
feat: add Docker auto-start and auto-recheck feature

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -152,6 +152,33 @@ fn tier_description(tier: u8) -> String {
     }
 }
 
+// ---- Docker Management ----
+
+#[tauri::command]
+pub async fn start_docker() -> InstallPrereqResult {
+    if let Err(msg) = docker::start_docker() {
+        return InstallPrereqResult {
+            success: false,
+            message: msg,
+            reboot_required: false,
+        };
+    }
+
+    if docker::wait_for_docker_running(30).await {
+        InstallPrereqResult {
+            success: true,
+            message: "Docker started successfully.".into(),
+            reboot_required: false,
+        }
+    } else {
+        InstallPrereqResult {
+            success: false,
+            message: "Docker is taking longer than expected to start. Wait a moment and try Re-check, or start it manually.".into(),
+            reboot_required: false,
+        }
+    }
+}
+
 // ---- Installation ----
 
 #[tauri::command]

--- a/installer/src-tauri/src/docker.rs
+++ b/installer/src-tauri/src/docker.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 use serde::Serialize;
+use std::time::Duration;
 
 #[derive(Debug, Serialize)]
 pub struct DockerStatus {
@@ -107,5 +108,58 @@ pub async fn install_docker() -> Result<String, String> {
             "For safety, the desktop installer does not install Docker Desktop automatically.\n\nInstall Docker Desktop manually, then open it once from Applications before rerunning prerequisite checks:\n{}",
             download_url()
         ))
+    }
+}
+
+/// Launch the already-installed Docker daemon/app. Does NOT install Docker.
+pub fn start_docker() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open")
+            .args(["-a", "Docker"])
+            .spawn()
+            .map_err(|e| format!("Failed to launch Docker Desktop: {}", e))?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let docker_path = format!("{}\\Docker\\Docker\\Docker Desktop.exe",
+            std::env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".to_string()));
+        if std::path::Path::new(&docker_path).exists() {
+            Command::new(&docker_path)
+                .spawn()
+                .map_err(|e| format!("Failed to launch Docker Desktop: {}", e))?;
+            Ok(())
+        } else {
+            Err("Docker Desktop not found at standard location. Please start it manually from the Start menu.".to_string())
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Command::new("systemctl")
+            .args(["start", "docker"])
+            .output()
+            .map_err(|e| format!("Failed to start Docker daemon: {}", e))?;
+        Ok(())
+    }
+}
+
+/// Poll `is_docker_running()` until true or timeout elapses.
+pub async fn wait_for_docker_running(timeout_secs: u64) -> bool {
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(timeout_secs);
+
+    loop {
+        if is_docker_running() {
+            return true;
+        }
+
+        if start.elapsed() >= timeout {
+            return false;
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }

--- a/installer/src-tauri/src/main.rs
+++ b/installer/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
             commands::check_system,
             commands::check_prerequisites,
             commands::install_prerequisites,
+            commands::start_docker,
             commands::detect_gpu,
             commands::start_install,
             commands::get_install_progress,

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -92,6 +92,9 @@ export const checkPrerequisites = () =>
 export const installPrerequisite = (component: string) =>
   invoke<InstallPrereqResult>("install_prerequisites", { component });
 
+export const startDocker = () =>
+  invoke<InstallPrereqResult>("start_docker");
+
 export const detectGpu = () => invoke<GpuResult>("detect_gpu");
 
 export const startInstall = (

--- a/installer/src/pages/Prerequisites.tsx
+++ b/installer/src/pages/Prerequisites.tsx
@@ -4,6 +4,7 @@ import StatusIcon from "../components/StatusIcon";
 import {
   checkPrerequisites,
   installPrerequisite,
+  startDocker,
   type PrerequisiteStatus,
 } from "../hooks/useTauri";
 
@@ -17,6 +18,7 @@ type InstallStatus = "idle" | "installing" | "done" | "failed";
 export default function Prerequisites({ onNext, onError }: Props) {
   const [prereqs, setPrereqs] = useState<PrerequisiteStatus | null>(null);
   const [dockerStatus, setDockerStatus] = useState<InstallStatus>("idle");
+  const [dockerStartStatus, setDockerStartStatus] = useState<InstallStatus>("idle");
   const [wslStatus, setWslStatus] = useState<InstallStatus>("idle");
   const [message, setMessage] = useState("");
   const [rebootNeeded, setRebootNeeded] = useState(false);
@@ -106,6 +108,28 @@ export default function Prerequisites({ onNext, onError }: Props) {
     setPrereqs(updated);
   };
 
+  const handleStartDocker = async () => {
+    setDockerStartStatus("installing");
+    setMessage("Starting Docker... this can take up to 30 seconds.");
+    try {
+      const result = await startDocker();
+      if (result.success) {
+        setDockerStartStatus("done");
+        setMessage(result.message);
+        // Auto-recheck prerequisites after Docker starts
+        const updated = await checkPrerequisites();
+        setPrereqs(updated);
+        setDockerStartStatus("idle");
+      } else {
+        setDockerStartStatus("failed");
+        setMessage(result.message);
+      }
+    } catch (e) {
+      setDockerStartStatus("failed");
+      setMessage(String(e));
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center h-full px-8">
       <h2 className="text-2xl font-bold mb-2">Prerequisites Needed</h2>
@@ -157,9 +181,11 @@ export default function Prerequisites({ onNext, onError }: Props) {
               status={
                 prereqs.docker_installed && prereqs.docker_running
                   ? "pass"
-                  : dockerStatus === "installing"
+                  : dockerStartStatus === "installing"
                     ? "loading"
-                    : "fail"
+                    : dockerStatus === "installing"
+                      ? "loading"
+                      : "fail"
               }
             />
             <div>
@@ -176,6 +202,17 @@ export default function Prerequisites({ onNext, onError }: Props) {
               Install
             </Button>
           )}
+          {prereqs.docker_installed &&
+            !prereqs.docker_running &&
+            dockerStartStatus === "idle" && (
+              <Button
+                variant="secondary"
+                onClick={handleStartDocker}
+                disabled={dockerStartStatus === "installing"}
+              >
+                Start Docker
+              </Button>
+            )}
         </div>
       </div>
 
@@ -197,12 +234,17 @@ export default function Prerequisites({ onNext, onError }: Props) {
         </div>
       ) : (
         <div className="flex gap-3">
-          <Button variant="ghost" onClick={handleRecheck}>
+          <Button
+            variant="ghost"
+            onClick={handleRecheck}
+            disabled={dockerStartStatus === "installing"}
+          >
             Re-check
           </Button>
           <Button
             onClick={onNext}
             disabled={
+              dockerStartStatus === "installing" ||
               !prereqs.git_installed ||
               !prereqs.docker_installed ||
               !prereqs.docker_running


### PR DESCRIPTION
https://github.com/Osmantic/ODS/issues/4519

Add one-click Docker startup from Prerequisites page with automatic re-check once daemon is running. Eliminates friction of manually starting Docker Desktop then clicking Re-check.

Backend (Rust):
- docker.rs: Added start_docker() to launch Docker per-platform (macOS: 'open -a Docker', Windows: %ProgramFiles%\Docker\Docker\Docker Desktop.exe, Linux: systemctl start docker)
- docker.rs: Added wait_for_docker_running(timeout_secs) async function that polls is_docker_running() every 500ms until success or 30s timeout
- commands.rs: Added start_docker command that calls start_docker() then waits for daemon startup, returns InstallPrereqResult
- main.rs: Registered start_docker command in tauri::generate_handler!

Frontend (React/TypeScript):
- useTauri.ts: Added startDocker() invoke wrapper
- Prerequisites.tsx: Added dockerStartStatus state for tracking startup progress. When docker_installed && !docker_running, show 'Start Docker' button. On success, auto-call checkPrerequisites() to refresh page without user clicking Re-check. On failure, show error message and keep Re-check button available as fallback. Disable Continue/Re-check buttons while starting.