### PR TITLE
feat(extensions): authorize start and stop with leases

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5964,18 +5964,24 @@ def _enable_retry_work(service_id: str) -> None:
                         error=str(exc)[:500])
 
 
-def _start_enable_retry(handler, service_id: str, lock: threading.Lock) -> None:
+def _start_enable_retry(
+    handler,
+    service_id: str,
+    admission: "_ExtensionMutationAdmission",
+) -> bool:
     """Dispatch the enable-retry worker on a daemon thread.
 
-    The caller must hold ``lock``; the thread releases it on exit. Sends
-    the 202 response before spawning the thread so the HTTP request
-    returns promptly (hook + compose start can take minutes).
+    The caller must have entered ``admission``.  Return ``True`` only when
+    a successfully started worker owns its exit; on response or dispatch
+    failure, return ``False`` so ownership remains with the caller.  Sends
+    the 202 response before spawning the thread so the HTTP request returns
+    promptly (hook + compose start can take minutes).
     """
     def _thread_target() -> None:
         try:
             _enable_retry_work(service_id)
         finally:
-            lock.release()
+            admission.__exit__(None, None, None)
 
     try:
         json_response(handler, 202, {"status": "retrying",
@@ -5983,7 +5989,7 @@ def _start_enable_retry(handler, service_id: str, lock: threading.Lock) -> None:
                                      "action": "start"})
         threading.Thread(target=_thread_target, daemon=True).start()
     except Exception:
-        lock.release()
+        logger.exception("Failed to dispatch enable-retry for %s", service_id)
         # If 202 was already sent, the dashboard expects a progress
         # transition. Without this, the stale "error" from the prior
         # failed install stays visible. Best-effort write — if progress
@@ -5993,7 +5999,8 @@ def _start_enable_retry(handler, service_id: str, lock: threading.Lock) -> None:
                             error="Failed to start retry thread")
         except Exception:
             pass
-        raise
+        return False
+    return True
 
 
 def json_response(handler, code: int, body: dict, *, no_store=False):
@@ -8932,35 +8939,48 @@ class AgentHandler(BaseHTTPRequestHandler):
         body = read_json_body(self)
         if body is None:
             return
+        lease_evidence = _parse_extension_mutation_lease(self, body)
+        if lease_evidence is _EXTENSION_MUTATION_LEASE_REJECTED:
+            return
         service_id = validate_service_id(self, body)
         if service_id is None:
             return
         logger.info("%s extension: %s", action, service_id)
-        lock = _service_locks[service_id]
-        if not lock.acquire(blocking=False):
-            json_response(self, 409, {"error": f"Operation already in progress for {service_id}"})
-            return
 
-        # Enable-retry path: if a prior install left progress status=error,
-        # "start" must re-run the post_install hook (if declared) and write
-        # progress updates — otherwise the UI stays stuck on the old error and
-        # env vars populated by the hook never get regenerated. Hook + start
-        # can take minutes, so mirror _handle_install's 202-accept-then-thread
-        # pattern. Non-retry start/stop keeps the existing synchronous path.
-        if action == "start" and _read_progress_status(service_id) == "error":
-            _start_enable_retry(self, service_id, lock)
-            return
-
+        admission = _ExtensionMutationAdmission(
+            self,
+            lease_evidence,
+            (service_id,),
+        )
         try:
-            ok, err = docker_compose_action(service_id, action)
-        except RuntimeError as exc:
-            json_response(self, 500, {"error": str(exc)})
+            admission.__enter__()
+        except _ExtensionMutationAdmissionRejected:
             return
-        except subprocess.CalledProcessError as exc:
-            json_response(self, 500, {"error": f"Compose resolution failed: {exc.stderr[:300]}"})
-            return
+
+        admission_handed_off = False
+        try:
+            # Enable-retry path: if a prior install left progress status=error,
+            # "start" must re-run the post_install hook (if declared) and write
+            # progress updates — otherwise the UI stays stuck on the old error and
+            # env vars populated by the hook never get regenerated. Hook + start
+            # can take minutes, so mirror _handle_install's 202-accept-then-thread
+            # pattern. Non-retry start/stop keeps the existing synchronous path.
+            if action == "start" and _read_progress_status(service_id) == "error":
+                if _start_enable_retry(self, service_id, admission):
+                    admission_handed_off = True
+                return
+
+            try:
+                ok, err = docker_compose_action(service_id, action)
+            except RuntimeError as exc:
+                json_response(self, 500, {"error": str(exc)})
+                return
+            except subprocess.CalledProcessError as exc:
+                json_response(self, 500, {"error": f"Compose resolution failed: {exc.stderr[:300]}"})
+                return
         finally:
-            lock.release()
+            if not admission_handed_off:
+                admission.__exit__(None, None, None)
         if ok:
             json_response(self, 200, {"status": "ok", "service_id": service_id, "action": action})
         else:

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -8973,18 +8973,25 @@ class AgentHandler(BaseHTTPRequestHandler):
             try:
                 ok, err = docker_compose_action(service_id, action)
             except RuntimeError as exc:
-                json_response(self, 500, {"error": str(exc)})
-                return
+                response_status, response_body = 500, {"error": str(exc)}
             except subprocess.CalledProcessError as exc:
-                json_response(self, 500, {"error": f"Compose resolution failed: {exc.stderr[:300]}"})
-                return
+                response_status, response_body = 500, {
+                    "error": f"Compose resolution failed: {exc.stderr[:300]}"
+                }
+            else:
+                if ok:
+                    response_status, response_body = 200, {
+                        "status": "ok",
+                        "service_id": service_id,
+                        "action": action,
+                    }
+                else:
+                    response_status = 503 if "timed out" in err else 500
+                    response_body = {"error": err}
         finally:
             if not admission_handed_off:
                 admission.__exit__(None, None, None)
-        if ok:
-            json_response(self, 200, {"status": "ok", "service_id": service_id, "action": action})
-        else:
-            json_response(self, 503 if "timed out" in err else 500, {"error": err})
+        json_response(self, response_status, response_body)
 
     def _handle_extension_compose_toggle(self, activate: bool):
         """Rename compose.yaml.disabled <-> compose.yaml for an extension.

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -604,6 +604,41 @@ def test_malformed_start_stop_lease_fails_before_lock_or_compose(
 
 
 @pytest.mark.parametrize("action", ["start", "stop"])
+def test_start_stop_without_lease_releases_lock_before_response(
+    host_server, host_request, monkeypatch, action
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    lock = agent._service_locks["documents"]
+    original_json_response = agent.json_response
+    locked_at_response = []
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if body.get("service_id") == "documents":
+            locked_at_response.append(lock.locked())
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(agent, "_read_progress_status", lambda _sid: "complete")
+    monkeypatch.setattr(agent, "docker_compose_action", lambda *_args: (True, ""))
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
+    status, result = host_request(
+        f"/v1/extension/{action}",
+        {"service_id": "documents"},
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "service_id": "documents",
+        "action": action,
+    }
+    assert lock.acquire_calls == 1
+    assert locked_at_response == [False]
+    assert not lock.locked()
+
+
+@pytest.mark.parametrize("action", ["start", "stop"])
 def test_valid_start_stop_lease_covers_compose_without_reacquiring(
     host_server, host_request, monkeypatch, action
 ):
@@ -611,6 +646,8 @@ def test_valid_start_stop_lease_covers_compose_without_reacquiring(
     agent._service_locks = collections.defaultdict(CountingLock)
     grant = acquire_lease(agent, host_request)
     lock = agent._service_locks["documents"]
+    original_json_response = agent.json_response
+    state_at_response = []
 
     def observed_compose(service_id, observed_action):
         state = agent._extension_lease_manager.describe(grant["leaseId"])
@@ -619,7 +656,14 @@ def test_valid_start_stop_lease_covers_compose_without_reacquiring(
         assert observed_action == action
         return True, ""
 
+    def observed_json_response(handler, code, body, **kwargs):
+        if body.get("service_id") == "documents":
+            state = agent._extension_lease_manager.describe(grant["leaseId"])
+            state_at_response.append((state["active"], lock.locked()))
+        return original_json_response(handler, code, body, **kwargs)
+
     monkeypatch.setattr(agent, "docker_compose_action", observed_compose)
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
     status, result = host_request(
         f"/v1/extension/{action}",
         {
@@ -636,6 +680,7 @@ def test_valid_start_stop_lease_covers_compose_without_reacquiring(
         "action": action,
     }
     assert lock.acquire_calls == 1
+    assert state_at_response == [(False, True)]
     assert lock.locked()
     assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
 
@@ -772,11 +817,20 @@ def test_start_compose_exception_clears_active_lease_window(
     agent._service_locks = collections.defaultdict(CountingLock)
     grant = acquire_lease(agent, host_request)
     lock = agent._service_locks["documents"]
+    original_json_response = agent.json_response
+    state_at_response = []
 
     def fail_compose(*_args):
         raise RuntimeError("synthetic compose failure")
 
+    def observed_json_response(handler, code, body, **kwargs):
+        if code == 500:
+            state = agent._extension_lease_manager.describe(grant["leaseId"])
+            state_at_response.append((state["active"], lock.locked()))
+        return original_json_response(handler, code, body, **kwargs)
+
     monkeypatch.setattr(agent, "docker_compose_action", fail_compose)
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
     status, result = host_request(
         "/v1/extension/start",
         {
@@ -788,6 +842,7 @@ def test_start_compose_exception_clears_active_lease_window(
 
     assert status == 500
     assert result == {"error": "synthetic compose failure"}
+    assert state_at_response == [(False, True)]
     assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
     assert lock.acquire_calls == 1
     assert lock.locked()

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -577,3 +577,217 @@ def test_sync_config_authenticates_lease_before_noop(host_server, host_request):
     assert result == {"error": {"code": "lease-token-mismatch"}}
     assert not (directory / "config").exists()
     assert submitted["leaseToken"] not in json.dumps(result)
+
+
+@pytest.mark.parametrize("action", ["start", "stop"])
+def test_malformed_start_stop_lease_fails_before_lock_or_compose(
+    host_server, host_request, monkeypatch, action
+):
+    agent, _listener = host_server
+    compose_calls = []
+    monkeypatch.setattr(
+        agent,
+        "docker_compose_action",
+        lambda *args: (compose_calls.append(args) or (True, "")),
+    )
+
+    status, result = host_request(
+        f"/v1/extension/{action}",
+        {"service_id": "documents", "lease": {"schema": "wrong"}},
+    )
+
+    assert status == 422
+    assert result == {"error": {"code": "invalid-lease-request"}}
+    assert compose_calls == []
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+
+@pytest.mark.parametrize("action", ["start", "stop"])
+def test_valid_start_stop_lease_covers_compose_without_reacquiring(
+    host_server, host_request, monkeypatch, action
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+
+    def observed_compose(service_id, observed_action):
+        state = agent._extension_lease_manager.describe(grant["leaseId"])
+        assert state["active"] is True
+        assert service_id == "documents"
+        assert observed_action == action
+        return True, ""
+
+    monkeypatch.setattr(agent, "docker_compose_action", observed_compose)
+    status, result = host_request(
+        f"/v1/extension/{action}",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "service_id": "documents",
+        "action": action,
+    }
+    assert lock.acquire_calls == 1
+    assert lock.locked()
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+
+
+def test_retry_start_transfers_active_lease_window_to_worker(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+    worker_started = threading.Event()
+    allow_worker_exit = threading.Event()
+    spawned = []
+    original_thread = threading.Thread
+
+    def observed_work(service_id):
+        assert service_id == "documents"
+        state = agent._extension_lease_manager.describe(grant["leaseId"])
+        assert state["active"] is True
+        worker_started.set()
+        assert allow_worker_exit.wait(5)
+
+    def recording_thread(*args, **kwargs):
+        thread = original_thread(*args, **kwargs)
+        target = kwargs.get("target")
+        if getattr(target, "__name__", "") == "_thread_target":
+            spawned.append(thread)
+        return thread
+
+    monkeypatch.setattr(agent, "_read_progress_status", lambda _sid: "error")
+    monkeypatch.setattr(agent, "_enable_retry_work", observed_work)
+    monkeypatch.setattr(agent.threading, "Thread", recording_thread)
+
+    status, result = host_request(
+        "/v1/extension/start",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 202
+    assert result == {
+        "status": "retrying",
+        "service_id": "documents",
+        "action": "start",
+    }
+    assert worker_started.wait(5)
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is True
+    assert len(spawned) == 1
+    status, busy = host_request(
+        "/v1/extension/lease/release",
+        bound_request(agent._extension_leases.LEASE_SCHEMA, grant),
+    )
+    assert status == 409
+    assert busy == {"error": {"code": "lease-mutation-active"}}
+    allow_worker_exit.set()
+    spawned[0].join(timeout=5)
+    assert not spawned[0].is_alive()
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+    assert lock.acquire_calls == 1
+    assert lock.locked()
+    status, released = host_request(
+        "/v1/extension/lease/release",
+        bound_request(agent._extension_leases.LEASE_SCHEMA, grant),
+    )
+    assert status == 200
+    assert released["released"] is True
+    assert not lock.locked()
+
+
+def test_retry_thread_start_failure_returns_admission_to_handler(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+    original_thread = threading.Thread
+    progress = []
+    progress_written = threading.Event()
+
+    class FailingRetryThread:
+        def start(self):
+            raise RuntimeError("synthetic retry thread failure")
+
+    def selective_thread(*args, **kwargs):
+        target = kwargs.get("target")
+        if getattr(target, "__name__", "") == "_thread_target":
+            return FailingRetryThread()
+        return original_thread(*args, **kwargs)
+
+    def record_progress(*args, **kwargs):
+        progress.append((args, kwargs))
+        progress_written.set()
+
+    monkeypatch.setattr(agent, "_read_progress_status", lambda _sid: "error")
+    monkeypatch.setattr(
+        agent,
+        "_write_progress",
+        record_progress,
+    )
+    monkeypatch.setattr(agent.threading, "Thread", selective_thread)
+
+    status, result = host_request(
+        "/v1/extension/start",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 202
+    assert result["status"] == "retrying"
+    assert progress_written.wait(5)
+    assert progress[-1][0][:3] == ("documents", "error", "Retry failed")
+    assert progress[-1][1]["error"] == "Failed to start retry thread"
+    for _ in range(100):
+        if not agent._extension_lease_manager.describe(grant["leaseId"])["active"]:
+            break
+        threading.Event().wait(0.01)
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+    assert lock.acquire_calls == 1
+    assert lock.locked()
+
+
+def test_start_compose_exception_clears_active_lease_window(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    agent._service_locks = collections.defaultdict(CountingLock)
+    grant = acquire_lease(agent, host_request)
+    lock = agent._service_locks["documents"]
+
+    def fail_compose(*_args):
+        raise RuntimeError("synthetic compose failure")
+
+    monkeypatch.setattr(agent, "docker_compose_action", fail_compose)
+    status, result = host_request(
+        "/v1/extension/start",
+        {
+            "service_id": "documents",
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 500
+    assert result == {"error": "synthetic compose failure"}
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+    assert lock.acquire_calls == 1
+    assert lock.locked()


### PR DESCRIPTION
## Summary

- apply the shared dual-mode extension mutation admission boundary to `/v1/extension/start` and `/v1/extension/stop`
- preserve the legacy non-blocking per-service lock path when lease evidence is absent
- use the shared bounded, duplicate-rejecting mutation-envelope reader before lease parsing
- keep synchronous Compose work inside the active mutation window, then close admission before writing success or error responses
- transfer admission ownership to the asynchronous enable-retry worker and close it in the worker's `finally` block
- return admission ownership to the request handler when retry dispatch fails, record a progress error, and avoid a second synchronous mutation

## Why this is separate

Phase 4L-B admits synchronous config filesystem work. Start/stop adds a materially different lifetime: ordinary Compose actions are synchronous, while an enable retry acknowledges with `202` and continues through hook and Compose work on a daemon thread. This slice makes ownership transfer explicit and tests handler, worker, and dispatch-failure cleanup independently.

## Compatibility and safety boundary

- no `lease` member preserves the existing start/stop API and non-blocking service-lock behavior
- a present `lease` member never silently falls back to the legacy path
- strict request parsing rejects duplicate top-level or nested keys and ambiguous transfer framing before lease parsing, manager construction, lock creation, or Compose execution
- lease authorization binds the exact lease, token, transaction, plan, and service scope before mutation
- lease mode enters `manager.use(...)` and does not reacquire the service lock held for the lease lifetime
- synchronous `200`, `500`, and `503` status/body contracts remain unchanged and are written only after the active mutation window closes
- enable retry retains the established `202`-before-worker-start contract; `202` means accepted/in progress, never completed
- if retry thread creation fails after acknowledgement, the durable progress surface records an error and the handler clears admission without falling through to a second start attempt
- the worker clears admission on success, handled failure, or unexpected exit
- the existing bounded Compose-resolution error body is preserved here; broader transport-detail sanitization remains a dedicated follow-on hardening slice
- install, restart, hooks, core recreation, production executor wiring, renewal supervision, and live enablement remain deferred because their mutation lifetimes require separate evidence
- no installation, deployment, container start, live-service mutation, merge, or destructive operation was performed

## Security review and repair

Restacking exposed that the original start/stop slice still used the legacy JSON reader even though the parent mutation routes had adopted strict bounded parsing. The candidate was stopped and changed to the shared mutation reader. New real-HTTP tests reject duplicate top-level lease evidence, duplicate nested lease-token keys, and `Content-Length` plus `Transfer-Encoding` ambiguity before manager construction, lock creation, or Compose execution.

The stricter parser also exposed a legacy unit-test fixture that modeled headers as a plain dictionary rather than the `HTTPMessage` interface used in production. The fixture now supplies single-value `get_all(...)` behavior while retaining its existing mutable mapping surface. Production duplicate-header rejection was not weakened.

Independent source review confirmed that retry ownership transfers only after `Thread.start()` succeeds. Dispatch failure leaves cleanup with the request handler; a running worker clears admission in `finally`; synchronous responses are written after admission closes. A secondary review included imagined implementation details and was treated only as a no-blocker signal, not as acceptance evidence.

## Refreshed stack identity

- refreshed head: `f4eacaaad998b7038cc0e1569424af0242dff5de`
- exact tree: `c4c47043444515a26d4d25a4562f61ce02f440f4`
- parents: prior Phase 4L start/stop head `9ce250186b73b60c877f478c3c5d8a7c31c74fe8`, then refreshed Phase 4L sync-config head `8ea5411bc36bdc5a605a8bf02ab8e298544b68b6`
- delta over refreshed Phase 4L sync-config: three files, 386 insertions, 33 deletions
- no rebase or force-push was used

## Validation

- Tower1/Tower3 exact-candidate Linux host-agent, route, lease-client, lease API/core, lock, transaction, router, extension, and staleness suites: `898 passed`
- new real-HTTP coverage verifies strict-envelope rejection and no manager, lock, or Compose work on invalid input
- deterministic response-time assertions cover legacy start/stop success, leased start/stop success, and leased synchronous failure
- retry tests prove the active window remains pinned while the worker runs, release is rejected during that window, worker completion clears the window, and dispatch failure returns cleanup to the handler without a second Compose attempt
- Python compilation: passed
- focused Ruff syntax/runtime baseline (`E4`, `E7`, `E9`, `F`, retaining the repository's existing `E701` exception): passed
- `git diff --check`: passed
- Tower1 security review and independent Codex source tracing: passed with no remaining blocker
- GitHub exact-head CI: `32` successful checks, `4` intentionally skipped checks, no failures
- GitHub merge state: `CLEAN` / `MERGEABLE`

## Stack

Base: `feat/assistant-first-phase-4l-sync-config-lease-admission` / PR #4517.

The next slice sanitizes transport-level extension mutation failures. This PR does not wire the dormant Dashboard client into production execution.
