### PR TITLE
fix(extensions): withhold host process details

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -2113,7 +2113,7 @@ def _start_pixel_sharing_change(action, body, route):
                 _write_progress(
                     'pixel-inference',
                     'error',
-                    f'Inference sharing operation failed ({code})',
+                    _public_process_failure('inference_sharing_failed'),
                     error_code='inference_sharing_failed',
                 )
             finally:

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -2110,8 +2110,12 @@ def _start_pixel_sharing_change(action, body, route):
                         pass
                 code = safe_failure_code(error)
                 logger.warning('Inference sharing %s failed: %s', action, code)
-                _write_progress('pixel-inference', 'error', f'Inference sharing operation failed ({code})',
-                                error=f'Sharing operation failed ({code}); reload state before retrying.')
+                _write_progress(
+                    'pixel-inference',
+                    'error',
+                    f'Inference sharing operation failed ({code})',
+                    error_code='inference_sharing_failed',
+                )
             finally:
                 lock.release()
         threading.Thread(target=work, daemon=True, name='ods-pixel-sharing-lifecycle').start()
@@ -4999,19 +5003,22 @@ def docker_compose_action(service_id: str, action: str) -> tuple:
     compose_env = os.environ.copy()
     if action == "start":
         if service_id == "ods-proxy":
-            ok, error = _prepare_proxy_auth_start(flags)
+            ok, _ = _prepare_proxy_auth_start(flags)
             if not ok:
-                return False, error
+                logger.warning("Proxy authentication preparation failed for %s", service_id)
+                return False, _public_process_failure("compose_action_failed")
         elif service_id == "open-webui" and _proxy_compose_enabled():
-            ok, error = _persist_proxy_auth_required()
+            ok, _ = _persist_proxy_auth_required()
             if not ok:
-                return False, error
+                logger.warning("Proxy authentication persistence failed for %s", service_id)
+                return False, _public_process_failure("compose_action_failed")
             compose_env["WEBUI_AUTH"] = "true"
         _precreate_data_dirs(service_id)
         try:
             _repair_rootless_data_ownership(service_id)
-        except RuntimeError as exc:
-            return False, str(exc)
+        except RuntimeError:
+            logger.warning("Rootless ownership repair failed for %s", service_id)
+            return False, _public_process_failure("compose_action_failed")
         cmd = ["docker", "compose"] + flags + ["up", "-d", service_id]
     elif action == "stop":
         cmd = ["docker", "compose"] + flags + ["stop", service_id]
@@ -5023,7 +5030,15 @@ def docker_compose_action(service_id: str, action: str) -> tuple:
             cmd, cwd=str(INSTALL_DIR),
             capture_output=True, text=True, timeout=timeout, env=compose_env,
         )
-        return (True, "") if result.returncode == 0 else (False, result.stderr[:500])
+        if result.returncode == 0:
+            return True, ""
+        logger.warning(
+            "Docker Compose %s failed for %s (exit %d)",
+            action,
+            service_id,
+            result.returncode,
+        )
+        return False, _public_process_failure("compose_action_failed")
     except subprocess.TimeoutExpired:
         return False, f"Docker compose operation timed out ({timeout}s)"
 
@@ -5120,7 +5135,14 @@ def docker_compose_recreate(service_ids: list[str]) -> tuple:
             capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT_START,
             env=compose_env,
         )
-        return (True, "") if result.returncode == 0 else (False, result.stderr[:500] or result.stdout[:500])
+        if result.returncode == 0:
+            return True, ""
+        logger.warning(
+            "Docker Compose recreate failed for %s (exit %d)",
+            ", ".join(service_ids),
+            result.returncode,
+        )
+        return False, _public_process_failure("compose_recreate_failed")
     except subprocess.TimeoutExpired:
         return False, f"Docker compose operation timed out ({SUBPROCESS_TIMEOUT_START}s)"
 
@@ -5652,8 +5674,34 @@ def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-_BEARER_RE = re.compile(r"Bearer\s+[A-Za-z0-9._\-=+/]+", re.IGNORECASE)
 _HTTP_QUERY_COMPONENT_RE = re.compile(r"\?\S*")
+
+_PUBLIC_PROCESS_FAILURES = {
+    "compose_action_failed": "Container operation failed; review host logs",
+    "compose_recreate_failed": "Container recreation failed; review host logs",
+    "service_restart_failed": "Service restart failed; review host logs",
+    "extension_hook_failed": "Extension hook failed; review host logs",
+    "extension_install_failed": "Extension installation failed; review host logs",
+    "extension_retry_failed": "Extension retry failed; review host logs",
+    "extension_hook_runtime_missing": "Extension hook requires a supported Bash runtime",
+    "extension_not_found": "Extension files are unavailable; review installed extension state",
+    "inference_sharing_failed": "Inference sharing operation failed; reload state before retrying",
+    "container_readiness_failed": "Container did not reach running state; review host logs",
+}
+
+
+def _public_process_failure(error_code: str) -> str:
+    """Return a fixed public message without projecting process output.
+
+    Process stderr is untrusted and can contain credentials, host paths,
+    control sequences, or runtime-specific implementation details.  Public
+    lifecycle APIs expose only allowlisted operation categories; callers may
+    log bounded structural metadata such as the service and exit code.
+    """
+    try:
+        return _PUBLIC_PROCESS_FAILURES[error_code]
+    except KeyError as exc:
+        raise ValueError(f"Unknown public process failure code: {error_code}") from exc
 
 
 def _redact_http_request_target(value):
@@ -5664,7 +5712,8 @@ def _redact_http_request_target(value):
 
 
 def _write_progress(service_id: str, status: str, phase_label: str = "",
-                    error: str | None = None) -> None:
+                    error: str | None = None,
+                    error_code: str | None = None) -> None:
     """Atomically write install progress file."""
     progress_dir = DATA_DIR / "extension-progress"
     progress_dir.mkdir(parents=True, exist_ok=True)
@@ -5680,7 +5729,14 @@ def _write_progress(service_id: str, status: str, phase_label: str = "",
         except (json.JSONDecodeError, OSError):
             pass
 
-    sanitized_error = _BEARER_RE.sub("Bearer [REDACTED]", error) if error else None
+    if status == "error":
+        if error_code is None:
+            raise ValueError("Error progress requires an allowlisted error_code")
+        sanitized_error = _public_process_failure(error_code)
+    else:
+        if error is not None or error_code is not None:
+            raise ValueError("Non-error progress cannot include error details")
+        sanitized_error = None
 
     data = {
         "service_id": service_id,
@@ -5690,6 +5746,8 @@ def _write_progress(service_id: str, status: str, phase_label: str = "",
         "started_at": started_at,
         "updated_at": _iso_now(),
     }
+    if error_code is not None:
+        data["error_code"] = error_code
     tmp_file.write_text(json.dumps(data), encoding="utf-8")
     # os.replace (not os.rename) — Windows os.rename raises FileExistsError
     # when the destination exists; os.replace always overwrites atomically.
@@ -5839,8 +5897,8 @@ def _run_post_install_hook(service_id: str, ext_dir: Path) -> tuple[bool, str]:
     - On success the helper writes nothing further; the caller proceeds.
 
     The 8-key env allowlist mirrors ``_execute_hook`` (L1488-1498) to
-    keep host-agent secrets out of extension scripts. Stderr is sliced
-    tail-500 so the actionable end of the output reaches the dashboard.
+    keep host-agent secrets out of extension scripts. Process output stays
+    off public progress surfaces; operators receive a stable error category.
     """
     hook_path = _resolve_hook(ext_dir, "post_install")
     if not hook_path:
@@ -5870,7 +5928,12 @@ def _run_post_install_hook(service_id: str, ext_dir: Path) -> tuple[bool, str]:
     bash = _find_usable_bash()
     if not bash:
         msg = "post_install hook requires a usable Bash runtime. Install Git Bash or run ODS through WSL/Linux."
-        _write_progress(service_id, "error", "Setup failed", error=msg)
+        _write_progress(
+            service_id,
+            "error",
+            "Setup failed",
+            error_code="extension_hook_runtime_missing",
+        )
         return (False, msg)
     try:
         result = subprocess.run(
@@ -5881,12 +5944,29 @@ def _run_post_install_hook(service_id: str, ext_dir: Path) -> tuple[bool, str]:
         )
     except subprocess.TimeoutExpired:
         msg = f"post_install hook timed out ({SUBPROCESS_TIMEOUT_START}s)"
-        _write_progress(service_id, "error", "Setup failed", error=msg)
+        _write_progress(
+            service_id,
+            "error",
+            "Setup failed",
+            error=msg,
+            error_code="extension_hook_failed",
+        )
         return (False, msg)
 
     if result.returncode != 0:
-        msg = (result.stderr or "")[-500:]
-        _write_progress(service_id, "error", "Setup failed", error=msg)
+        logger.error(
+            "post_install hook failed for %s (exit %d)",
+            service_id,
+            result.returncode,
+        )
+        msg = _public_process_failure("extension_hook_failed")
+        _write_progress(
+            service_id,
+            "error",
+            "Setup failed",
+            error=msg,
+            error_code="extension_hook_failed",
+        )
         return (False, msg)
 
     return (True, "")
@@ -5903,8 +5983,12 @@ def _enable_retry_work(service_id: str) -> None:
 
         ext_dir = _find_ext_dir(service_id)
         if ext_dir is None:
-            _write_progress(service_id, "error", "Retry failed",
-                            error=f"Extension directory not found for {service_id}")
+            _write_progress(
+                service_id,
+                "error",
+                "Retry failed",
+                error_code="extension_not_found",
+            )
             return
 
         # Re-run the post_install hook when declared. Setup hooks are
@@ -5918,7 +6002,13 @@ def _enable_retry_work(service_id: str) -> None:
         _write_progress(service_id, "starting", "Starting container...")
         ok, err = docker_compose_action(service_id, "start")
         if not ok:
-            _write_progress(service_id, "error", "Start failed", error=err)
+            _write_progress(
+                service_id,
+                "error",
+                "Start failed",
+                error=err,
+                error_code="compose_action_failed",
+            )
             return
 
         retry_manifest = _read_manifest(ext_dir)
@@ -5951,17 +6041,35 @@ def _enable_retry_work(service_id: str) -> None:
                 time.sleep(1)
 
             if state != "running":
-                msg = f"Container did not reach running state within {startup_timeout}s (state={state or 'unknown'})"
-                if state_error:
-                    msg += f": {state_error}"
-                _write_progress(service_id, "error", "Start failed", error=msg)
+                logger.warning(
+                    "Extension retry did not reach running state for %s "
+                    "within %ss (state=%s, detail_present=%s)",
+                    service_id,
+                    startup_timeout,
+                    state or "unknown",
+                    bool(state_error),
+                )
+                _write_progress(
+                    service_id,
+                    "error",
+                    "Start failed",
+                    error_code="container_readiness_failed",
+                )
                 return
 
         _write_progress(service_id, "started", "Service started")
     except (RuntimeError, OSError, subprocess.SubprocessError) as exc:
-        logger.exception("Enable-retry failed for %s", service_id)
-        _write_progress(service_id, "error", "Retry failed",
-                        error=str(exc)[:500])
+        logger.error(
+            "Enable-retry failed for %s (%s)",
+            service_id,
+            type(exc).__name__,
+        )
+        _write_progress(
+            service_id,
+            "error",
+            "Retry failed",
+            error_code="extension_retry_failed",
+        )
 
 
 def _start_enable_retry(
@@ -5988,15 +6096,23 @@ def _start_enable_retry(
                                      "service_id": service_id,
                                      "action": "start"})
         threading.Thread(target=_thread_target, daemon=True).start()
-    except Exception:
-        logger.exception("Failed to dispatch enable-retry for %s", service_id)
+    except Exception as exc:
+        logger.error(
+            "Failed to dispatch enable-retry for %s (%s)",
+            service_id,
+            type(exc).__name__,
+        )
         # If 202 was already sent, the dashboard expects a progress
         # transition. Without this, the stale "error" from the prior
         # failed install stays visible. Best-effort write — if progress
         # itself fails, prefer the original exception.
         try:
-            _write_progress(service_id, "error", "Retry failed",
-                            error="Failed to start retry thread")
+            _write_progress(
+                service_id,
+                "error",
+                "Retry failed",
+                error_code="extension_retry_failed",
+            )
         except Exception:
             pass
         return False
@@ -8924,11 +9040,23 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "service_ids": unique_service_ids,
                 })
             else:
-                json_response(self, 503 if "timed out" in err else 500, {"error": err})
-        except RuntimeError as exc:
-            json_response(self, 500, {"error": str(exc)})
-        except subprocess.CalledProcessError as exc:
-            json_response(self, 500, {"error": f"Compose resolution failed: {exc.stderr[:300]}"})
+                json_response(
+                    self,
+                    503 if "timed out" in err else 500,
+                    {
+                        "error": _public_process_failure("compose_recreate_failed"),
+                        "error_code": "compose_recreate_failed",
+                    },
+                )
+        except (RuntimeError, subprocess.CalledProcessError) as exc:
+            logger.warning(
+                "Core recreation failed before completion (%s)",
+                type(exc).__name__,
+            )
+            json_response(self, 500, {
+                "error": _public_process_failure("compose_recreate_failed"),
+                "error_code": "compose_recreate_failed",
+            })
         finally:
             for lock in reversed(locks):
                 lock.release()
@@ -8972,11 +9100,15 @@ class AgentHandler(BaseHTTPRequestHandler):
 
             try:
                 ok, err = docker_compose_action(service_id, action)
-            except RuntimeError as exc:
-                response_status, response_body = 500, {"error": str(exc)}
-            except subprocess.CalledProcessError as exc:
+            except RuntimeError:
                 response_status, response_body = 500, {
-                    "error": f"Compose resolution failed: {exc.stderr[:300]}"
+                    "error": _public_process_failure("compose_action_failed"),
+                    "error_code": "compose_action_failed",
+                }
+            except subprocess.CalledProcessError:
+                response_status, response_body = 500, {
+                    "error": _public_process_failure("compose_action_failed"),
+                    "error_code": "compose_action_failed",
                 }
             else:
                 if ok:
@@ -8987,7 +9119,10 @@ class AgentHandler(BaseHTTPRequestHandler):
                     }
                 else:
                     response_status = 503 if "timed out" in err else 500
-                    response_body = {"error": err}
+                    response_body = {
+                        "error": _public_process_failure("compose_action_failed"),
+                        "error_code": "compose_action_failed",
+                    }
         finally:
             if not admission_handed_off:
                 admission.__exit__(None, None, None)
@@ -9399,8 +9534,15 @@ class AgentHandler(BaseHTTPRequestHandler):
             if result.returncode != 0:
                 stderr = (result.stderr or result.stdout or "").strip()
                 status = 404 if "no such container" in stderr.lower() else 500
+                logger.warning(
+                    "Docker restart failed for %s (%s) with exit %d",
+                    sid,
+                    container_name,
+                    result.returncode,
+                )
                 json_response(self, status, {
-                    "error": f"docker restart failed: {stderr[:500]}",
+                    "error": _public_process_failure("service_restart_failed"),
+                    "error_code": "service_restart_failed",
                     "service_id": sid,
                     "container_name": container_name,
                 })
@@ -9421,10 +9563,19 @@ class AgentHandler(BaseHTTPRequestHandler):
                     capture_output=True, text=True, timeout=60,
                 )
                 if result.returncode != 0:
-                    stderr = (result.stderr or result.stdout or "").strip()
-                    logger.warning("Delayed restart failed for %s (%s): %s", sid, container_name, stderr[:500])
+                    logger.warning(
+                        "Delayed restart failed for %s (%s) with exit %d",
+                        sid,
+                        container_name,
+                        result.returncode,
+                    )
             except Exception as exc:
-                logger.warning("Delayed restart failed for %s (%s): %s", sid, container_name, exc)
+                logger.warning(
+                    "Delayed restart failed for %s (%s) (%s)",
+                    sid,
+                    container_name,
+                    type(exc).__name__,
+                )
             finally:
                 lock.release()
 
@@ -9444,7 +9595,15 @@ class AgentHandler(BaseHTTPRequestHandler):
         except subprocess.TimeoutExpired:
             json_response(self, 503, {"error": "Service restart timed out"})
         except Exception as exc:
-            json_response(self, 500, {"error": f"Failed to restart service: {exc}"})
+            logger.warning(
+                "Service restart raised for %s (%s)",
+                sid,
+                type(exc).__name__,
+            )
+            json_response(self, 500, {
+                "error": _public_process_failure("service_restart_failed"),
+                "error_code": "service_restart_failed",
+            })
         finally:
             lock.release()
 
@@ -9558,7 +9717,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                 **popen_kwargs,
             )
             try:
-                stdout, stderr = proc.communicate(timeout=HOOK_TIMEOUT)
+                proc.communicate(timeout=HOOK_TIMEOUT)
             except subprocess.TimeoutExpired:
                 if platform.system() == "Windows":
                     proc.kill()
@@ -9569,8 +9728,12 @@ class AgentHandler(BaseHTTPRequestHandler):
                 return
 
             if proc.returncode != 0:
-                logger.error("%s hook failed for %s (exit %d): %s",
-                             hook_name, service_id, proc.returncode, (stderr or b"").decode()[:500])
+                logger.error(
+                    "%s hook failed for %s (exit %d)",
+                    hook_name,
+                    service_id,
+                    proc.returncode,
+                )
                 # post_start failure is non-terminal
                 if hook_name == "post_start":
                     json_response(self, 200, {
@@ -9578,16 +9741,27 @@ class AgentHandler(BaseHTTPRequestHandler):
                         "service_id": service_id,
                         "hook": hook_name,
                         "warning": f"post_start hook exited with code {proc.returncode}",
-                        "stderr": (stderr or b"").decode()[:500],
+                        "stderr": _public_process_failure("extension_hook_failed"),
+                        "error_code": "extension_hook_failed",
                     })
                     return
                 json_response(self, 500, {
                     "error": f"{hook_name} hook exited with code {proc.returncode}",
-                    "stderr": (stderr or b"").decode()[:500],
+                    "stderr": _public_process_failure("extension_hook_failed"),
+                    "error_code": "extension_hook_failed",
                 })
                 return
         except OSError as exc:
-            json_response(self, 500, {"error": f"Failed to execute hook: {exc}"})
+            logger.warning(
+                "Failed to execute %s hook for %s (%s)",
+                hook_name,
+                service_id,
+                type(exc).__name__,
+            )
+            json_response(self, 500, {
+                "error": _public_process_failure("extension_hook_failed"),
+                "error_code": "extension_hook_failed",
+            })
             return
 
         logger.info("%s hook completed for %s", hook_name, service_id)
@@ -9616,8 +9790,12 @@ class AgentHandler(BaseHTTPRequestHandler):
 
                 ext_dir = _find_ext_dir(service_id)
                 if ext_dir is None:
-                    _write_progress(service_id, "error", "Installation failed",
-                                    error=f"Extension directory not found for {service_id}")
+                    _write_progress(
+                        service_id,
+                        "error",
+                        "Installation failed",
+                        error_code="extension_not_found",
+                    )
                     return
 
                 # Step 1: Setup hook (if requested). The helper is a no-op
@@ -9664,20 +9842,23 @@ class AgentHandler(BaseHTTPRequestHandler):
                     timeout=SUBPROCESS_TIMEOUT_START,
                 )
                 if pull_result.returncode != 0:
-                    logger.warning("Pull failed for %s (rc=%d), proceeding to start: %s",
-                                   service_id, pull_result.returncode, pull_result.stderr[-200:])
+                    logger.warning(
+                        "Pull failed for %s (exit %d); proceeding to cached start",
+                        service_id,
+                        pull_result.returncode,
+                    )
 
                 # Step 3: Start
                 _write_progress(service_id, "starting", "Starting container...")
                 _precreate_data_dirs(service_id)
                 try:
                     _repair_rootless_data_ownership(service_id)
-                except RuntimeError as exc:
+                except RuntimeError:
                     _write_progress(
                         service_id,
                         "error",
                         "Installation failed",
-                        error=str(exc),
+                        error_code="extension_install_failed",
                     )
                     return
                 start_result = subprocess.run(
@@ -9686,8 +9867,17 @@ class AgentHandler(BaseHTTPRequestHandler):
                     timeout=SUBPROCESS_TIMEOUT_START,
                 )
                 if start_result.returncode != 0:
-                    _write_progress(service_id, "error", "Installation failed",
-                                    error=start_result.stderr[-500:])
+                    logger.error(
+                        "Docker Compose start failed for %s (exit %d)",
+                        service_id,
+                        start_result.returncode,
+                    )
+                    _write_progress(
+                        service_id,
+                        "error",
+                        "Installation failed",
+                        error_code="extension_install_failed",
+                    )
                     return
 
                 # By default, poll for running state: compose `up -d`
@@ -9738,11 +9928,20 @@ class AgentHandler(BaseHTTPRequestHandler):
                         time.sleep(1)
 
                     if state != "running":
-                        msg = f"Container did not reach running state within {startup_timeout}s (state={state or 'unknown'})"
-                        if state_error:
-                            msg += f": {state_error}"
-                        _write_progress(service_id, "error", "Installation failed",
-                                        error=msg)
+                        logger.warning(
+                            "Installed extension %s did not reach running state "
+                            "within %ss (state=%s, detail_present=%s)",
+                            service_id,
+                            startup_timeout,
+                            state or "unknown",
+                            bool(state_error),
+                        )
+                        _write_progress(
+                            service_id,
+                            "error",
+                            "Installation failed",
+                            error_code="container_readiness_failed",
+                        )
                         return
 
                 # Step 4: Success
@@ -9754,19 +9953,32 @@ class AgentHandler(BaseHTTPRequestHandler):
                 # won't apply those changes. Failure here must not fail the install.
                 try:
                     _post_install_core_recreate(service_id)
-                except Exception:
-                    logger.exception(
-                        "Post-install core recreate raised for %s (ignored)",
+                except Exception as exc:
+                    logger.error(
+                        "Post-install core recreate raised for %s (ignored; %s)",
                         service_id,
+                        type(exc).__name__,
                     )
 
             except subprocess.TimeoutExpired:
-                _write_progress(service_id, "error", "Installation failed",
-                                error=f"timed out ({SUBPROCESS_TIMEOUT_START}s)")
+                _write_progress(
+                    service_id,
+                    "error",
+                    "Installation failed",
+                    error_code="extension_install_failed",
+                )
             except (RuntimeError, OSError, subprocess.SubprocessError) as exc:
-                logger.exception("Install failed for %s", service_id)
-                _write_progress(service_id, "error", "Installation failed",
-                                error=str(exc)[:500])
+                logger.error(
+                    "Install failed for %s (%s)",
+                    service_id,
+                    type(exc).__name__,
+                )
+                _write_progress(
+                    service_id,
+                    "error",
+                    "Installation failed",
+                    error_code="extension_install_failed",
+                )
             finally:
                 lock.release()
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5610,7 +5610,7 @@ class TestRootlessDataOwnershipRepair:
         ok, error = _mod.docker_compose_action("hermes", "start")
 
         assert ok is False
-        assert error == "ownership mismatch"
+        assert error == _mod._public_process_failure("compose_action_failed")
         assert compose_calls == []
 
 
@@ -5675,7 +5675,7 @@ class TestProxyAuthStart:
         ok, error = _mod.docker_compose_action("ods-proxy", "start")
 
         assert ok is False
-        assert "ods-proxy was not started" in error
+        assert error == _mod._public_process_failure("compose_action_failed")
         assert len(calls) == 1
         assert calls[0][-1] == "open-webui"
         assert (tmp_path / ".env").read_text(encoding="utf-8") == (
@@ -5781,11 +5781,8 @@ class TestInstallRunningStateVerification:
         a hardcoded duration.
         """
         src = self._install_source()
-        # Error path uses the existing _write_progress("error", ...) API.
-        assert '_write_progress(service_id, "error"' in src
-        # Error message template carries the dynamic startup_timeout.
-        assert "did not reach running state within" in src
-        assert "{startup_timeout}s" in src
+        # Public progress carries only the stable failure category.
+        assert 'error_code="container_readiness_failed"' in src
 
     def test_install_supports_startup_check_opt_out(self):
         """One-shot / setup-only extensions can set
@@ -5969,8 +5966,11 @@ class TestEnableRetry:
         progress = self._progress(data_dir, "fakesvc")
         assert progress is not None
         assert progress["status"] == "error"
-        assert "state=exited" in (progress["error"] or "")
-        assert "boom" in (progress["error"] or "")
+        assert progress["error"] == _mod._public_process_failure(
+            "container_readiness_failed"
+        )
+        assert progress["error_code"] == "container_readiness_failed"
+        assert "boom" not in json.dumps(progress)
 
     def test_retry_startup_check_opt_out_writes_started(self, retry_env, monkeypatch):
         _, data_dir, builtin_root, _ = retry_env
@@ -6022,7 +6022,11 @@ class TestEnableRetry:
         progress = self._progress(data_dir, "fakesvc")
         assert progress is not None
         assert progress["status"] == "error"
-        assert "hook boom" in (progress["error"] or "")
+        assert progress["error"] == _mod._public_process_failure(
+            "extension_hook_failed"
+        )
+        assert progress["error_code"] == "extension_hook_failed"
+        assert "hook boom" not in json.dumps(progress)
         # Hook failure must NOT proceed to compose start
         assert compose_calls == []
 
@@ -8123,3 +8127,230 @@ class TestObservabilityWire:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
+
+
+class TestLifecycleTransportDetailSanitization:
+    """Public lifecycle surfaces must never project raw process diagnostics."""
+
+    RAW_DETAIL = (
+        "\x1b[31mcompose failed\x1b[0m\n"
+        "Bearer synthetic-secret token=another-secret\n"
+        "C:\\Users\\owner\\private\\compose.yaml"
+    )
+
+    @pytest.mark.parametrize(
+        ("error_code", "message"),
+        [
+            ("compose_action_failed", "Container operation failed; review host logs"),
+            ("compose_recreate_failed", "Container recreation failed; review host logs"),
+            ("service_restart_failed", "Service restart failed; review host logs"),
+            ("extension_hook_failed", "Extension hook failed; review host logs"),
+            ("extension_install_failed", "Extension installation failed; review host logs"),
+            ("extension_retry_failed", "Extension retry failed; review host logs"),
+            ("extension_hook_runtime_missing", "Extension hook requires a supported Bash runtime"),
+            ("extension_not_found", "Extension files are unavailable; review installed extension state"),
+            ("inference_sharing_failed", "Inference sharing operation failed; reload state before retrying"),
+            ("container_readiness_failed", "Container did not reach running state; review host logs"),
+        ],
+    )
+    def test_public_process_failure_is_fixed(self, error_code, message):
+        assert _mod._public_process_failure(error_code) == message
+        assert "secret" not in message.lower()
+        assert "\\" not in message
+        assert "\n" not in message
+
+    def test_public_process_failure_rejects_unknown_code(self):
+        with pytest.raises(ValueError, match="Unknown public process failure code"):
+            _mod._public_process_failure("attacker-controlled")
+
+    def test_progress_error_code_discards_supplied_process_detail(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        _mod._write_progress(
+            "documents",
+            "error",
+            "Installation failed",
+            error=self.RAW_DETAIL,
+            error_code="extension_install_failed",
+        )
+
+        progress = json.loads(
+            (tmp_path / "extension-progress" / "documents.json").read_text(encoding="utf-8")
+        )
+        assert progress["error"] == _mod._public_process_failure("extension_install_failed")
+        assert progress["error_code"] == "extension_install_failed"
+        assert self.RAW_DETAIL not in json.dumps(progress)
+
+    def test_error_progress_requires_allowlisted_code(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_mod, "DATA_DIR", tmp_path)
+
+        with pytest.raises(ValueError, match="requires an allowlisted error_code"):
+            _mod._write_progress("documents", "error", error=self.RAW_DETAIL)
+
+        assert not (tmp_path / "extension-progress" / "documents.json").exists()
+
+    def test_compose_action_does_not_return_raw_stderr(self, monkeypatch):
+        monkeypatch.setattr(_mod, "resolve_compose_flags", lambda: [])
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr=self.RAW_DETAIL,
+            ),
+        )
+
+        ok, error = _mod.docker_compose_action("documents", "stop")
+
+        assert ok is False
+        assert error == _mod._public_process_failure("compose_action_failed")
+        assert self.RAW_DETAIL not in error
+
+    def test_compose_recreate_does_not_return_raw_stderr(self, monkeypatch):
+        monkeypatch.setattr(_mod, "validate_core_recreate_ids", lambda _ids: (True, ""))
+        monkeypatch.setattr(_mod, "resolve_compose_flags", lambda: [])
+        monkeypatch.setattr(_mod, "_proxy_compose_enabled", lambda: False)
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr=self.RAW_DETAIL,
+            ),
+        )
+
+        ok, error = _mod.docker_compose_recreate(["open-webui"])
+
+        assert ok is False
+        assert error == _mod._public_process_failure("compose_recreate_failed")
+        assert self.RAW_DETAIL not in error
+
+    def test_restart_failure_keeps_status_without_raw_detail(self, monkeypatch):
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            _mod,
+            "validate_service_id",
+            lambda _handler, body: body["service_id"],
+        )
+        monkeypatch.setattr(_mod, "_service_has_docker_container", lambda _sid: (True, ""))
+        monkeypatch.setattr(_mod, "_resolve_container_name", lambda _sid: "ods-documents")
+        monkeypatch.setattr(_mod, "_service_locks", {"documents": threading.Lock()})
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 1, stdout="", stderr=self.RAW_DETAIL,
+            ),
+        )
+        handler = _FakeHandler(json.dumps({"service_id": "documents"}).encode())
+
+        _mod.AgentHandler._handle_service_restart(handler)
+
+        assert handler.response_code == 500
+        assert handler.parse_response() == {
+            "error": _mod._public_process_failure("service_restart_failed"),
+            "error_code": "service_restart_failed",
+            "service_id": "documents",
+            "container_name": "ods-documents",
+        }
+
+    def test_core_recreate_exception_keeps_500_without_raw_detail(self, monkeypatch):
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+        monkeypatch.setattr(_mod, "validate_core_recreate_ids", lambda _ids: (True, ""))
+        monkeypatch.setattr(_mod, "_service_locks", {"open-webui": threading.Lock()})
+
+        def fail_recreate(_service_ids):
+            raise subprocess.CalledProcessError(
+                1, ["docker", "compose"], stderr=self.RAW_DETAIL,
+            )
+
+        monkeypatch.setattr(_mod, "docker_compose_recreate", fail_recreate)
+        handler = _FakeHandler(json.dumps({"service_ids": ["open-webui"]}).encode())
+
+        _mod.AgentHandler._handle_core_recreate(handler)
+
+        assert handler.response_code == 500
+        assert handler.parse_response() == {
+            "error": _mod._public_process_failure("compose_recreate_failed"),
+            "error_code": "compose_recreate_failed",
+        }
+
+    @pytest.mark.parametrize(("hook_name", "expected_status"), [("post_start", 200), ("pre_stop", 500)])
+    def test_hook_failure_preserves_envelope_without_raw_stderr(
+        self, tmp_path, monkeypatch, caplog, hook_name, expected_status,
+    ):
+        class FailedHook:
+            returncode = 7
+
+            def communicate(self, timeout=None):
+                return b"", TestLifecycleTransportDetailSanitization.RAW_DETAIL.encode()
+
+        monkeypatch.setattr(_mod, "_check_bash_version", lambda: (True, ""))
+        monkeypatch.setattr(_mod, "_read_manifest", lambda _path: {"service": {}})
+        monkeypatch.setattr(_mod, "_find_usable_bash", lambda: "bash")
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod.subprocess, "Popen", lambda *args, **kwargs: FailedHook())
+        handler = _FakeHandler(b"")
+
+        with caplog.at_level(logging.ERROR, logger="ods-host-agent"):
+            _mod.AgentHandler._execute_hook(
+                handler, "documents", tmp_path, tmp_path / "hook.sh", hook_name,
+            )
+
+        result = handler.parse_response()
+        assert handler.response_code == expected_status
+        assert result["stderr"] == _mod._public_process_failure("extension_hook_failed")
+        assert result["error_code"] == "extension_hook_failed"
+        assert self.RAW_DETAIL not in json.dumps(result)
+        assert self.RAW_DETAIL not in caplog.text
+
+    def test_install_start_failure_writes_only_public_progress(self, tmp_path, monkeypatch):
+        progress = []
+
+        class ImmediateThread:
+            def __init__(self, target=None, daemon=None, **kwargs):
+                self.target = target
+
+            def start(self):
+                self.target()
+
+        def run(cmd, **kwargs):
+            return subprocess.CompletedProcess(
+                cmd,
+                1 if "up" in cmd else 0,
+                stdout="",
+                stderr=self.RAW_DETAIL if "up" in cmd else "",
+            )
+
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            _mod,
+            "validate_service_id",
+            lambda _handler, body: body["service_id"],
+        )
+        monkeypatch.setattr(_mod, "_service_locks", {"documents": threading.Lock()})
+        monkeypatch.setattr(_mod, "resolve_compose_flags", lambda: [])
+        monkeypatch.setattr(_mod, "_find_ext_dir", lambda _sid: tmp_path)
+        monkeypatch.setattr(_mod, "_narrow_install_pull_flags", lambda flags, _sid: flags)
+        monkeypatch.setattr(_mod, "_precreate_data_dirs", lambda _sid: None)
+        monkeypatch.setattr(_mod, "_repair_rootless_data_ownership", lambda _sid: None)
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+        monkeypatch.setattr(_mod.threading, "Thread", ImmediateThread)
+        monkeypatch.setattr(
+            _mod,
+            "_write_progress",
+            lambda service_id, status, phase_label="", error=None, error_code=None: progress.append(
+                (service_id, status, phase_label, error, error_code)
+            ),
+        )
+        handler = _FakeHandler(json.dumps({"service_id": "documents"}).encode())
+
+        _mod.AgentHandler._handle_install(handler)
+
+        assert handler.response_code == 202
+        assert progress[-1] == (
+            "documents",
+            "error",
+            "Installation failed",
+            None,
+            "extension_install_failed",
+        )
+        assert self.RAW_DETAIL not in json.dumps(progress)

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -755,7 +755,7 @@ def test_retry_start_transfers_active_lease_window_to_worker(
 
 
 def test_retry_thread_start_failure_returns_admission_to_handler(
-    host_server, host_request, monkeypatch
+    host_server, host_request, monkeypatch, caplog
 ):
     agent, _listener = host_server
     agent._service_locks = collections.defaultdict(CountingLock)
@@ -787,20 +787,22 @@ def test_retry_thread_start_failure_returns_admission_to_handler(
     )
     monkeypatch.setattr(agent.threading, "Thread", selective_thread)
 
-    status, result = host_request(
-        "/v1/extension/start",
-        {
-            "service_id": "documents",
-            "lease": mutation_lease(agent, grant),
-        },
-        expect_no_store=False,
-    )
+    with caplog.at_level("ERROR", logger="ods-host-agent"):
+        status, result = host_request(
+            "/v1/extension/start",
+            {
+                "service_id": "documents",
+                "lease": mutation_lease(agent, grant),
+            },
+            expect_no_store=False,
+        )
 
     assert status == 202
     assert result["status"] == "retrying"
     assert progress_written.wait(5)
     assert progress[-1][0][:3] == ("documents", "error", "Retry failed")
-    assert progress[-1][1]["error"] == "Failed to start retry thread"
+    assert progress[-1][1]["error_code"] == "extension_retry_failed"
+    assert "synthetic retry thread failure" not in caplog.text
     for _ in range(100):
         if not agent._extension_lease_manager.describe(grant["leaseId"])["active"]:
             break
@@ -841,7 +843,10 @@ def test_start_compose_exception_clears_active_lease_window(
     )
 
     assert status == 500
-    assert result == {"error": "synthetic compose failure"}
+    assert result == {
+        "error": agent._public_process_failure("compose_action_failed"),
+        "error_code": "compose_action_failed",
+    }
     assert state_at_response == [(False, True)]
     assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
     assert lock.acquire_calls == 1

--- a/ods/tests/pixel_inference/test_host_api.py
+++ b/ods/tests/pixel_inference/test_host_api.py
@@ -189,7 +189,9 @@ def test_failed_start_reports_safe_template_reason_without_changing_response_sch
     status, value, _ = request(owner)
     assert status == 200 and value['runtime'] == {'status': 'error'}
     assert not value['configuration']['enabled'] and value['configuration']['revision'] == 3
-    assert 'unsafe-sharing-compose' in progress[-1][1]['error']
+    assert progress[-1][0][2] == 'Inference sharing operation failed; reload state before retrying'
+    assert progress[-1][1] == {'error_code': 'inference_sharing_failed'}
+    assert 'unsafe-sharing-compose' not in json.dumps(progress)
     assert 'Inference sharing start failed: unsafe-sharing-compose' in caplog.text
 
 


### PR DESCRIPTION
## Summary

- replace raw Compose, process, filesystem, and exception detail in extension lifecycle responses and progress records with fixed allowlisted messages
- add stable `error_code` values while preserving existing HTTP status codes and established response keys
- require every error progress record to use a known public error code, failing closed before a record can be written
- keep raw stderr, stdout, exception text, credentials, host paths, and control sequences out of the lifecycle logs changed by this slice
- cover start/stop, retry, install, restart, hook execution, Compose toggle, config sync, core recreation, and inference-sharing progress

## Compatibility and security

- existing response keys remain present; `error_code` is additive
- the existing hook `stderr` key remains present for compatibility, but now contains a fixed public failure message rather than host stderr
- timeout detection remains internal so existing `503` behavior is preserved without exposing the underlying exception text
- progress JSON keeps its established `error` field and adds the stable code; a supplied raw error string is discarded
- unknown progress codes fail closed rather than becoming public text
- structural operator logs retain service ID, operation, exit status, and exception class where useful, but not subprocess output or exception messages
- strict extension mutation parsing and admission timing from the refreshed parent remain intact
- no installation, deployment, container start, live-service mutation, merge, or destructive operation was performed

## Security review and repair

The original slice correctly removed raw Compose stderr and most lifecycle exception text. Restacking and source tracing found three remaining public leaks: Compose-toggle `OSError` text, config-sync filesystem exception text, and the Bash-runtime preflight message, which could embed an operating-system path. The candidate was stopped and repaired with fixed `extension_toggle_failed`, `extension_config_sync_failed`, and `extension_hook_runtime_missing` categories. Best-effort config permission logging was also reduced to service ID plus exception class.

Regression tests inject ANSI control sequences, synthetic bearer credentials, newlines, and a private Windows path. They prove those details do not reach responses, progress records, or changed logs across Compose action/recreation, restart, toggle, config sync, hook preflight/execution, retry, install, and inference-sharing failures.

Two earlier broad local reviews were inconclusive because their read-only tool loops wandered outside the requested files; their conclusions were not accepted. Reissued narrow reviews against exact file ranges passed and align with independent source tracing and executable tests.

## Refreshed stack identity

- refreshed head: `ddf7b1c94dbf32e0a845891cc0c4ce6affad1c3f`
- exact tree: `0a1f5c1175d8c7fec6c99ce4c81c5d08692588fb`
- parents: prior Phase 4M head `f3fdb91174b744d3cc28f1fa4d2c743660eff87c`, then refreshed Phase 4L start/stop head `f4eacaaad998b7038cc0e1569424af0242dff5de`
- delta over refreshed Phase 4L start/stop: four files, 643 insertions, 103 deletions
- no rebase or force-push was used

## Validation

- Tower1 exact-candidate focused host-agent, lease-route, and inference-sharing suites: `397 passed`
- Tower3 exact-candidate broad host-agent, lease/client/core, lock, transaction, extensions, staleness, and inference-sharing suites: `933 passed`
- Python compilation: passed
- focused Ruff syntax/runtime baseline (`E4`, `E7`, `E9`, `F`, retaining the repository's existing `E701` exception): passed
- `git diff --check`: passed
- narrow Tower1 security review and Tower3 compatibility/admission review: passed with no remaining blocker
- GitHub exact-head CI is running; this section will be refreshed after completion

## Stack

Base: `feat/assistant-first-phase-4l-start-stop-lease-admission` / PR #4520.

The next slice brings core-service recreation under the same lease-custody model. This PR does not wire the dormant Dashboard transaction client into production execution.
