### PR TITLE
Extract DOWNLOADING_ODS_MSG constant (bug #61)

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -13,6 +13,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
     105, 116,
 ];
+const DOWNLOADING_ODS_MSG: &str = "Downloading ODS";
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)


### PR DESCRIPTION
Extract "Downloading ODS" progress message to DOWNLOADING_ODS_MSG constant. This progress message is displayed to users during the repository download phase. Extracting to a named constant improves maintainability, enables easy updates, and reduces the risk of typos in user-facing messages.