### PR TITLE
Extract CONFIGURING_INSTALLATION_MSG constant 

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -13,6 +13,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
     105, 116,
 ];
+const CONFIGURING_INSTALLATION_MSG: &str = "Configuring installation";
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)


### PR DESCRIPTION
Extract "Configuring installation" progress message to CONFIGURING_INSTALLATION_MSG constant. Used during the configuration setup phase to inform users of current installation progress. Centralizing this string makes it easier to modify messaging without searching through code.