### PR TITLE
Extract WORKFLOWS_ARG constant

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -13,6 +13,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
     105, 116,
 ];
+const WORKFLOWS_ARG: &str = "--workflows";
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)


### PR DESCRIPTION
Extract "--workflows" feature flag to WORKFLOWS_ARG constant. Used to enable workflow automation features during installation. Named constant reduces code duplication and improves readability of feature selection logic.