### PR TITLE
Extract INSTALL_SCRIPT_NAME constant 

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -13,6 +13,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
     105, 116,
 ];
+const INSTALL_SCRIPT_NAME: &str = "install.sh";
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)


### PR DESCRIPTION
Extract "install.sh" script name to INSTALL_SCRIPT_NAME constant. References the main installation script executed on Unix-like systems. Named constant prevents hardcoding filenames and makes script references more maintainable across the codebase.