### PR TITLE
Extract IMAGE_GEN_ARG constant 

### DIFF
--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -13,6 +13,7 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
     105, 116,
 ];
+const IMAGE_GEN_ARG: &str = "--image-gen";
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)


### PR DESCRIPTION
Extract "--image-gen" feature flag to IMAGE_GEN_ARG constant. Used to enable image generation capabilities during installation. Named constant improves code clarity and makes feature management more maintainable.