### PR TITLE
feat(extensions): authorize core recreation with leases

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -6497,7 +6497,7 @@ def _find_ext_dir(service_id: str) -> Path | None:
 
 
 def _extension_lease_lock_provider(service_id: str):
-    """Return the existing host lock only for an installed manageable service."""
+    """Return the existing host lock only for a lease-manageable service."""
     if (
         _extension_leases is None
         or not isinstance(service_id, str)
@@ -6509,7 +6509,13 @@ def _extension_lease_lock_provider(service_id: str):
         (ext_dir / name).is_file()
         for name in ("manifest.yaml", "manifest.yml", "manifest.json")
     )
-    if service_id in ALWAYS_ON_SERVICES or not has_manifest:
+    is_recreatable_core_service = (
+        service_id in CORE_SERVICE_IDS
+        and service_id in _ALLOWED_CORE_RECREATE_IDS
+    )
+    if service_id in ALWAYS_ON_SERVICES or (
+        not has_manifest and not is_recreatable_core_service
+    ):
         raise _extension_leases.LeaseAuthorizationError(
             "lease-service-not-manageable"
         )
@@ -9014,52 +9020,56 @@ class AgentHandler(BaseHTTPRequestHandler):
         body = read_json_body(self)
         if body is None:
             return
+        lease_evidence = _parse_extension_mutation_lease(self, body)
+        if lease_evidence is _EXTENSION_MUTATION_LEASE_REJECTED:
+            return
 
         requested = body.get("service_ids", [])
-        unique_service_ids = sorted(set(requested)) if isinstance(requested, list) else requested
-        ok, error = validate_core_recreate_ids(unique_service_ids)
+        ok, error = validate_core_recreate_ids(requested)
         if not ok:
             json_response(self, 400, {"error": error})
             return
+        unique_service_ids = sorted(set(requested))
 
-        locks = []
         try:
-            for service_id in unique_service_ids:
-                lock = _service_locks[service_id]
-                if not lock.acquire(blocking=False):
-                    json_response(self, 409, {"error": f"Operation already in progress for {service_id}"})
-                    return
-                locks.append(lock)
-
-            logger.info("Recreating core services: %s", ", ".join(unique_service_ids))
-            ok, err = docker_compose_recreate(unique_service_ids)
-            if ok:
-                json_response(self, 200, {
-                    "status": "ok",
-                    "action": "recreate",
-                    "service_ids": unique_service_ids,
-                })
-            else:
-                json_response(
-                    self,
-                    503 if "timed out" in err else 500,
-                    {
+            with _ExtensionMutationAdmission(
+                self, lease_evidence, unique_service_ids
+            ):
+                logger.info(
+                    "Recreating core services: %s",
+                    ", ".join(unique_service_ids),
+                )
+                try:
+                    ok, err = docker_compose_recreate(unique_service_ids)
+                    if ok:
+                        response_status = 200
+                        response_body = {
+                            "status": "ok",
+                            "action": "recreate",
+                            "service_ids": unique_service_ids,
+                        }
+                    else:
+                        response_status = 503 if "timed out" in err else 500
+                        response_body = {
+                            "error": _public_process_failure(
+                                "compose_recreate_failed"
+                            ),
+                            "error_code": "compose_recreate_failed",
+                        }
+                except (RuntimeError, subprocess.CalledProcessError) as exc:
+                    logger.warning(
+                        "Core recreation failed before completion (%s)",
+                        type(exc).__name__,
+                    )
+                    response_status = 500
+                    response_body = {
                         "error": _public_process_failure("compose_recreate_failed"),
                         "error_code": "compose_recreate_failed",
-                    },
-                )
-        except (RuntimeError, subprocess.CalledProcessError) as exc:
-            logger.warning(
-                "Core recreation failed before completion (%s)",
-                type(exc).__name__,
-            )
-            json_response(self, 500, {
-                "error": _public_process_failure("compose_recreate_failed"),
-                "error_code": "compose_recreate_failed",
-            })
-        finally:
-            for lock in reversed(locks):
-                lock.release()
+                    }
+        except _ExtensionMutationAdmissionRejected:
+            return
+
+        json_response(self, response_status, response_body)
 
     def _handle_extension(self, action: str):
         if not check_auth(self):

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_lease_routes.py
@@ -211,6 +211,255 @@ class CountingLock:
         return self._lock.locked()
 
 
+def test_core_recreate_malformed_lease_fails_before_lock_or_compose(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset({"open-webui"}))
+    compose_calls = []
+    monkeypatch.setattr(
+        agent,
+        "docker_compose_recreate",
+        lambda service_ids: (compose_calls.append(service_ids) or (True, "")),
+    )
+
+    status, result = host_request(
+        "/v1/core/recreate",
+        {"service_ids": ["open-webui"], "lease": {"schema": "wrong"}},
+    )
+
+    assert status == 422
+    assert result == {"error": {"code": "invalid-lease-request"}}
+    assert compose_calls == []
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+
+def test_core_recreate_without_lease_preserves_legacy_lock_lifetime(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset({"litellm"}))
+    agent._service_locks = collections.defaultdict(CountingLock)
+    lock = agent._service_locks["litellm"]
+    original_json_response = agent.json_response
+    locked_at_response = []
+
+    def observed_recreate(service_ids):
+        assert service_ids == ["litellm"]
+        assert lock.locked()
+        return True, ""
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if body.get("action") == "recreate":
+            locked_at_response.append(lock.locked())
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(agent, "docker_compose_recreate", observed_recreate)
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
+    status, result = host_request(
+        "/v1/core/recreate",
+        {"service_ids": ["litellm"]},
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "action": "recreate",
+        "service_ids": ["litellm"],
+    }
+    assert lock.acquire_calls == 1
+    assert locked_at_response == [False]
+    assert not lock.locked()
+
+
+def test_core_recreate_without_lease_preserves_legacy_busy_response(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset({"litellm"}))
+    lock = threading.Lock()
+    lock.acquire()
+    agent._service_locks = {"litellm": lock}
+    try:
+        status, result = host_request(
+            "/v1/core/recreate",
+            {"service_ids": ["litellm"]},
+            expect_no_store=False,
+        )
+    finally:
+        lock.release()
+
+    assert status == 409
+    assert result == {"error": "Operation already in progress for litellm"}
+
+
+def test_core_recreate_timeout_releases_legacy_lock_before_response(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset({"litellm"}))
+    lock = threading.Lock()
+    agent._service_locks = {"litellm": lock}
+    original_json_response = agent.json_response
+    locked_at_response = []
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if body.get("error_code") == "compose_recreate_failed":
+            locked_at_response.append(lock.locked())
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(
+        agent,
+        "docker_compose_recreate",
+        lambda _service_ids: (False, "Docker compose operation timed out"),
+    )
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
+    status, result = host_request(
+        "/v1/core/recreate",
+        {"service_ids": ["litellm"]},
+        expect_no_store=False,
+    )
+
+    assert status == 503
+    assert result == {
+        "error": agent._public_process_failure("compose_recreate_failed"),
+        "error_code": "compose_recreate_failed",
+    }
+    assert locked_at_response == [False]
+    assert not lock.locked()
+
+
+def test_core_recreate_valid_lease_covers_compose_without_reacquiring(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    service_ids = ["hermes", "litellm"]
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset(service_ids))
+    agent._service_locks = collections.defaultdict(CountingLock)
+    grant = acquire_lease(agent, host_request, service_ids)
+    locks = [agent._service_locks[service_id] for service_id in service_ids]
+    original_json_response = agent.json_response
+    state_at_response = []
+
+    def observed_recreate(observed_service_ids):
+        state = agent._extension_lease_manager.describe(grant["leaseId"])
+        assert state["active"] is True
+        assert observed_service_ids == service_ids
+        assert all(lock.locked() for lock in locks)
+        return True, ""
+
+    def observed_json_response(handler, code, body, **kwargs):
+        if body.get("action") == "recreate":
+            state = agent._extension_lease_manager.describe(grant["leaseId"])
+            state_at_response.append(
+                (state["active"], [lock.locked() for lock in locks])
+            )
+        return original_json_response(handler, code, body, **kwargs)
+
+    monkeypatch.setattr(agent, "docker_compose_recreate", observed_recreate)
+    monkeypatch.setattr(agent, "json_response", observed_json_response)
+    status, result = host_request(
+        "/v1/core/recreate",
+        {
+            "service_ids": list(reversed(service_ids)),
+            "lease": mutation_lease(agent, grant),
+        },
+        expect_no_store=False,
+    )
+
+    assert status == 200
+    assert result == {
+        "status": "ok",
+        "action": "recreate",
+        "service_ids": service_ids,
+    }
+    assert all(lock.acquire_calls == 1 for lock in locks)
+    assert state_at_response == [(False, [True, True])]
+    assert agent._extension_lease_manager.describe(grant["leaseId"])["active"] is False
+
+
+def test_core_recreate_lease_must_cover_every_requested_service(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(
+        agent,
+        "CORE_SERVICE_IDS",
+        frozenset({"hermes", "litellm"}),
+    )
+    compose_calls = []
+    grant = acquire_lease(agent, host_request, ["hermes"])
+    monkeypatch.setattr(
+        agent,
+        "docker_compose_recreate",
+        lambda service_ids: (compose_calls.append(service_ids) or (True, "")),
+    )
+
+    status, result = host_request(
+        "/v1/core/recreate",
+        {
+            "service_ids": ["litellm"],
+            "lease": mutation_lease(agent, grant),
+        },
+    )
+
+    assert status == 403
+    assert result == {"error": {"code": "lease-service-not-covered"}}
+    assert compose_calls == []
+    assert "litellm" not in agent._service_locks
+
+
+@pytest.mark.parametrize(
+    ("service_id", "always_on"),
+    [
+        ("not-eligible-core", frozenset()),
+        ("open-webui", frozenset({"open-webui"})),
+    ],
+)
+def test_core_recreate_lease_rejects_unmanageable_core_service(
+    host_server, host_request, monkeypatch, service_id, always_on
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset({service_id}))
+    monkeypatch.setattr(agent, "ALWAYS_ON_SERVICES", always_on)
+
+    status, result = host_request(
+        "/v1/extension/lease/acquire",
+        acquire_request(agent._extension_leases.LEASE_SCHEMA, [service_id]),
+    )
+
+    assert status == 403
+    assert result == {"error": {"code": "lease-service-not-manageable"}}
+    assert service_id not in agent._service_locks
+
+
+def test_core_recreate_unhashable_service_id_returns_bounded_400(
+    host_server, host_request, monkeypatch
+):
+    agent, _listener = host_server
+    monkeypatch.setattr(agent, "CORE_SERVICE_IDS", frozenset({"litellm"}))
+    compose_calls = []
+    monkeypatch.setattr(
+        agent,
+        "docker_compose_recreate",
+        lambda service_ids: (compose_calls.append(service_ids) or (True, "")),
+    )
+
+    status, result = host_request(
+        "/v1/core/recreate",
+        {"service_ids": [{"service": "litellm"}]},
+        expect_no_store=False,
+    )
+
+    assert status == 400
+    assert result == {"error": "Invalid service_id: {'service': 'litellm'}"}
+    assert compose_calls == []
+    assert agent._extension_lease_manager is None
+    assert dict(agent._service_locks) == {}
+
+
 def test_valid_toggle_lease_uses_existing_custody_without_reacquiring(
     host_server, host_request
 ):


### PR DESCRIPTION
## Summary

- make `POST /v1/core/recreate` participate in the existing optional extension-mutation lease admission boundary
- preserve legacy requests and response envelopes while releasing their service locks before writing the response
- allow leases for manifestless core services only when the service is both known core and explicitly eligible for Dashboard-triggered recreation
- validate the strict duplicate-rejecting request envelope before lease parsing, lock creation, or Compose execution
- validate raw `service_ids` before deduplication so unhashable JSON values receive a bounded `400` response

## Compatibility and security

- requests without a `lease` retain the existing `200`, `409`, `500`, and `503` behavior and response bodies for structurally valid requests
- a present `lease` never silently falls back to legacy locking
- malformed lease evidence fails before lease-manager creation, service-lock creation, or Compose execution
- duplicate top-level or nested keys and ambiguous `Content-Length` plus `Transfer-Encoding` framing fail before any stateful work
- a valid lease must cover every requested core service and reuses the locks already held by that lease without reacquiring them
- the mutation window is inactive before the response is sent; lease custody remains held until explicit release
- always-on services, non-core IDs, non-eligible core IDs, and manifestless non-core services remain unmanageable through the lease API
- direct internal `docker_compose_recreate` callers are unchanged
- timeout classification and fixed public failure messages remain unchanged; no process output or lease token is projected
- no installation, deployment, container start, live-service mutation, merge, or destructive operation was performed

## Restack repair

The original slice used the legacy JSON reader before parsing optional lease evidence. That would have allowed duplicate keys and ambiguous transfer framing at this newly authorized mutation endpoint. The candidate was stopped and switched to the shared strict mutation reader. New real-HTTP tests cover duplicate top-level lease evidence, duplicate nested lease-token keys, and `Content-Length` plus `Transfer-Encoding` ambiguity, proving no manager, lock, or Compose work occurs.

Raw `service_ids` are still validated before `sorted(set(...))`, so unhashable JSON values remain a bounded validation error rather than an internal exception. Lease acquisition was independently traced to ensure its manifestless-core allowance is limited to the intersection of known core and explicitly recreatable IDs, with always-on services still rejected.

## Refreshed stack identity

- refreshed head: `9766a0c4d527d2659944b0b3d75625cf9d09a5ad`
- exact tree: `40a6f215f12f5eeba9ce64cf0cc10bd4663f90a4`
- parents: prior Phase 4N head `fcd8d7c42d4432c0d379f9ca3512e091fe87bb94`, then refreshed Phase 4M head `ddf7b1c94dbf32e0a845891cc0c4ce6affad1c3f`
- delta over refreshed Phase 4M: two files, 346 insertions, 40 deletions
- no rebase or force-push was used

## Validation

- Tower1 exact-candidate focused host-agent, lease-route, and inference-sharing suites: `407 passed`
- Tower3 exact-candidate broad host-agent, lease/client/core, lock, transaction, extensions, staleness, and inference-sharing suites: `943 passed`
- focused core-recreate coverage proves legacy success/busy/timeout cleanup, lease success without reacquisition, complete-scope enforcement, unmanageable-service rejection, unhashable input handling, and response-after-admission timing
- Python compilation: passed
- focused Ruff syntax/runtime baseline (`E4`, `E7`, `E9`, `F`, retaining the repository's existing `E701` exception): passed
- `git diff --check`: passed
- narrow Tower1 strict-envelope/scope review and Tower3 concurrency/cleanup review: passed with no remaining blocker
- GitHub exact-head CI is running; this section will be refreshed after completion

## Stack

Base: `feat/assistant-first-phase-4m-transport-sanitization` / PR #4524.

The next phase begins production transaction execution and recovery integration. This PR does not activate the dormant Dashboard transaction executor.
