### PR TITLE
Fix/installer progress and args constants

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -152,6 +152,33 @@ fn tier_description(tier: u8) -> String {
     }
 }
 
+// ---- Docker Management ----
+
+#[tauri::command]
+pub async fn start_docker() -> InstallPrereqResult {
+    if let Err(msg) = docker::start_docker() {
+        return InstallPrereqResult {
+            success: false,
+            message: msg,
+            reboot_required: false,
+        };
+    }
+
+    if docker::wait_for_docker_running(30).await {
+        InstallPrereqResult {
+            success: true,
+            message: "Docker started successfully.".into(),
+            reboot_required: false,
+        }
+    } else {
+        InstallPrereqResult {
+            success: false,
+            message: "Docker is taking longer than expected to start. Wait a moment and try Re-check, or start it manually.".into(),
+            reboot_required: false,
+        }
+    }
+}
+
 // ---- Installation ----
 
 #[tauri::command]

--- a/installer/src-tauri/src/docker.rs
+++ b/installer/src-tauri/src/docker.rs
@@ -1,5 +1,6 @@
 use std::process::Command;
 use serde::Serialize;
+use std::time::Duration;
 
 #[derive(Debug, Serialize)]
 pub struct DockerStatus {
@@ -107,5 +108,58 @@ pub async fn install_docker() -> Result<String, String> {
             "For safety, the desktop installer does not install Docker Desktop automatically.\n\nInstall Docker Desktop manually, then open it once from Applications before rerunning prerequisite checks:\n{}",
             download_url()
         ))
+    }
+}
+
+/// Launch the already-installed Docker daemon/app. Does NOT install Docker.
+pub fn start_docker() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open")
+            .args(["-a", "Docker"])
+            .spawn()
+            .map_err(|e| format!("Failed to launch Docker Desktop: {}", e))?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let docker_path = format!("{}\\Docker\\Docker\\Docker Desktop.exe",
+            std::env::var("ProgramFiles").unwrap_or_else(|_| "C:\\Program Files".to_string()));
+        if std::path::Path::new(&docker_path).exists() {
+            Command::new(&docker_path)
+                .spawn()
+                .map_err(|e| format!("Failed to launch Docker Desktop: {}", e))?;
+            Ok(())
+        } else {
+            Err("Docker Desktop not found at standard location. Please start it manually from the Start menu.".to_string())
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        Command::new("systemctl")
+            .args(["start", "docker"])
+            .output()
+            .map_err(|e| format!("Failed to start Docker daemon: {}", e))?;
+        Ok(())
+    }
+}
+
+/// Poll `is_docker_running()` until true or timeout elapses.
+pub async fn wait_for_docker_running(timeout_secs: u64) -> bool {
+    let start = std::time::Instant::now();
+    let timeout = Duration::from_secs(timeout_secs);
+
+    loop {
+        if is_docker_running() {
+            return true;
+        }
+
+        if start.elapsed() >= timeout {
+            return false;
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }

--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -13,6 +13,16 @@ const TRANSFERRED_REPO_URL_BYTES: &[u8] = &[
     105, 103, 104, 116, 45, 72, 101, 97, 114, 116, 45, 76, 97, 98, 115, 47, 79, 68, 83, 46, 103,
     105, 116,
 ];
+const DOWNLOADING_ODS_MSG: &str = "Downloading ODS";
+const CONFIGURING_INSTALLATION_MSG: &str = "Configuring installation";
+const TIER_ARG: &str = "--tier";
+const VOICE_ARG: &str = "--voice";
+const WORKFLOWS_ARG: &str = "--workflows";
+const RAG_ARG: &str = "--rag";
+const IMAGE_GEN_ARG: &str = "--image-gen";
+const ALL_ARG: &str = "--all";
+const RUNNING_INSTALLER_MSG: &str = "Running installer";
+const INSTALL_SCRIPT_NAME: &str = "install.sh";
 
 fn repo_url() -> &'static str {
     option_env!("ODS_REPO_URL").unwrap_or(DEFAULT_REPO_URL)
@@ -38,36 +48,36 @@ pub fn run_install(
     features: Vec<String>,
 ) -> Result<(), String> {
     // Phase 1: Clone the repo
-    update_progress(&state, "Downloading ODS", 5);
+    update_progress(&state, DOWNLOADING_ODS_MSG, 5);
 
     ensure_checkout(&install_dir)?;
 
-    update_progress(&state, "Configuring installation", 15);
+    update_progress(&state, CONFIGURING_INSTALLATION_MSG, 15);
 
     // Phase 2: Build installer arguments
     let ods_dir = install_dir.join("ods");
-    let mut args = vec!["--tier".to_string(), tier.to_string()];
+    let mut args = vec![TIER_ARG.to_string(), tier.to_string()];
 
     if features.contains(&"voice".to_string()) {
-        args.push("--voice".into());
+        args.push(VOICE_ARG.into());
     }
     if features.contains(&"workflows".to_string()) {
-        args.push("--workflows".into());
+        args.push(WORKFLOWS_ARG.into());
     }
     if features.contains(&"rag".to_string()) {
-        args.push("--rag".into());
+        args.push(RAG_ARG.into());
     }
     if features.contains(&"image_gen".to_string()) {
-        args.push("--image-gen".into());
+        args.push(IMAGE_GEN_ARG.into());
     }
     if features.contains(&"all".to_string()) {
-        args.push("--all".into());
+        args.push(ALL_ARG.into());
     }
 
     // Phase 3: Run the installer with progress parsing
-    update_progress(&state, "Running installer", 20);
+    update_progress(&state, RUNNING_INSTALLER_MSG, 20);
 
-    let install_script = ods_dir.join("install.sh");
+    let install_script = ods_dir.join(INSTALL_SCRIPT_NAME);
     let install_ps1 = install_dir.join("install.ps1");
 
     // Make sure the script is executable

--- a/installer/src-tauri/src/main.rs
+++ b/installer/src-tauri/src/main.rs
@@ -14,6 +14,7 @@ fn main() {
             commands::check_system,
             commands::check_prerequisites,
             commands::install_prerequisites,
+            commands::start_docker,
             commands::detect_gpu,
             commands::start_install,
             commands::get_install_progress,

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -92,6 +92,9 @@ export const checkPrerequisites = () =>
 export const installPrerequisite = (component: string) =>
   invoke<InstallPrereqResult>("install_prerequisites", { component });
 
+export const startDocker = () =>
+  invoke<InstallPrereqResult>("start_docker");
+
 export const detectGpu = () => invoke<GpuResult>("detect_gpu");
 
 export const startInstall = (

--- a/installer/src/pages/Prerequisites.tsx
+++ b/installer/src/pages/Prerequisites.tsx
@@ -4,6 +4,7 @@ import StatusIcon from "../components/StatusIcon";
 import {
   checkPrerequisites,
   installPrerequisite,
+  startDocker,
   type PrerequisiteStatus,
 } from "../hooks/useTauri";
 
@@ -17,6 +18,7 @@ type InstallStatus = "idle" | "installing" | "done" | "failed";
 export default function Prerequisites({ onNext, onError }: Props) {
   const [prereqs, setPrereqs] = useState<PrerequisiteStatus | null>(null);
   const [dockerStatus, setDockerStatus] = useState<InstallStatus>("idle");
+  const [dockerStartStatus, setDockerStartStatus] = useState<InstallStatus>("idle");
   const [wslStatus, setWslStatus] = useState<InstallStatus>("idle");
   const [message, setMessage] = useState("");
   const [rebootNeeded, setRebootNeeded] = useState(false);
@@ -106,6 +108,28 @@ export default function Prerequisites({ onNext, onError }: Props) {
     setPrereqs(updated);
   };
 
+  const handleStartDocker = async () => {
+    setDockerStartStatus("installing");
+    setMessage("Starting Docker... this can take up to 30 seconds.");
+    try {
+      const result = await startDocker();
+      if (result.success) {
+        setDockerStartStatus("done");
+        setMessage(result.message);
+        // Auto-recheck prerequisites after Docker starts
+        const updated = await checkPrerequisites();
+        setPrereqs(updated);
+        setDockerStartStatus("idle");
+      } else {
+        setDockerStartStatus("failed");
+        setMessage(result.message);
+      }
+    } catch (e) {
+      setDockerStartStatus("failed");
+      setMessage(String(e));
+    }
+  };
+
   return (
     <div className="flex flex-col items-center justify-center h-full px-8">
       <h2 className="text-2xl font-bold mb-2">Prerequisites Needed</h2>
@@ -157,9 +181,11 @@ export default function Prerequisites({ onNext, onError }: Props) {
               status={
                 prereqs.docker_installed && prereqs.docker_running
                   ? "pass"
-                  : dockerStatus === "installing"
+                  : dockerStartStatus === "installing"
                     ? "loading"
-                    : "fail"
+                    : dockerStatus === "installing"
+                      ? "loading"
+                      : "fail"
               }
             />
             <div>
@@ -176,6 +202,17 @@ export default function Prerequisites({ onNext, onError }: Props) {
               Install
             </Button>
           )}
+          {prereqs.docker_installed &&
+            !prereqs.docker_running &&
+            dockerStartStatus === "idle" && (
+              <Button
+                variant="secondary"
+                onClick={handleStartDocker}
+                disabled={dockerStartStatus === "installing"}
+              >
+                Start Docker
+              </Button>
+            )}
         </div>
       </div>
 
@@ -197,12 +234,17 @@ export default function Prerequisites({ onNext, onError }: Props) {
         </div>
       ) : (
         <div className="flex gap-3">
-          <Button variant="ghost" onClick={handleRecheck}>
+          <Button
+            variant="ghost"
+            onClick={handleRecheck}
+            disabled={dockerStartStatus === "installing"}
+          >
             Re-check
           </Button>
           <Button
             onClick={onNext}
             disabled={
+              dockerStartStatus === "installing" ||
               !prereqs.git_installed ||
               !prereqs.docker_installed ||
               !prereqs.docker_running


### PR DESCRIPTION
## Summary

<!-- What changed, and why? -->

## AI Assistance

<!-- If AI tools helped draft code, docs, tests, reviews, or triage, say what they did. Use "None" when not applicable. The human author remains accountable for reading the diff, choosing the validation, and responding to review. -->

## Release Lane

<!-- Pick the lane before review. See ods/docs/RELEASE_CHANNELS.md. -->

- [ ] Stable hotfix targeting `release/2.6.x`
- [ ] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
<!-- If this targets release/2.6.x, explain the current-stable user problem it fixes. -->
```

## Changed Surface

<!-- Check every surface this PR can affect. -->

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

<!-- Use ods/docs/HIGH_RISK_CHANGE_MAP.md to pick the right level. -->

- Risk level: <!-- Low / Medium / High -->
- Validation run:
  - [ ] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [ ] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.6.x`
  - [ ] Not required because: <!-- explain -->

Commands/results:

```text
<!-- paste the important commands and results -->
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

<!-- Call out skipped/deferred lanes, known limitations, or rollback notes. -->
