### PR TITLE
fix(token-spy): preserve fenced prompt sections

### DIFF
--- a/ods/extensions/services/token-spy/filters.py
+++ b/ods/extensions/services/token-spy/filters.py
@@ -185,28 +185,38 @@ def _strip_markdown_sections(text: str, section_headings: list[str]) -> tuple[st
 
     Returns (modified_text, list_of_stripped_heading_names).
     """
+    selected = {heading.rstrip() for heading in section_headings
+                if re.match(r"^#{1,6}[ \t]+", heading)}
     stripped = []
-    for heading in section_headings:
-        # Determine heading level from the heading string
-        m = re.match(r'^(#{1,6})\s+', heading)
-        if not m:
-            continue
-        level = len(m.group(1))
-        # Pattern: match the heading line, then everything until the next heading
-        # at the same or higher level (fewer or equal #), or end of string
-        escaped = re.escape(heading)
-        pattern = re.compile(
-            rf'^{escaped}\s*\n'       # the heading line
-            rf'(.*?)'                  # content (non-greedy)
-            rf'(?=^#{{1,{level}}}\s|\Z)',  # lookahead: next heading at same/higher level or EOF
-            re.MULTILINE | re.DOTALL
-        )
-        new_text, count = pattern.subn('', text)
-        if count > 0:
-            stripped.append(heading)
-            text = new_text
+    kept = []
+    fence = None
+    skip_level = None
+    # A heading inside a fenced example is literal prompt content.
+    for line in re.findall(r"[^\r\n]*(?:\r\n?|\n|$)", text):
+        content = line.rstrip("\r\n")
+        marker = re.match(r"^ {0,3}(`{3,}|~{3,})(.*)$", content)
+        if fence is not None:
+            if (marker and marker[1][0] == fence[0]
+                    and len(marker[1]) >= len(fence) and not marker[2].strip()):
+                fence = None
+        elif marker and (marker[1][0] == "~" or "`" not in marker[2]):
+            fence = marker[1]
+        else:
+            heading = re.match(r"^ {0,3}(#{1,6})(?:[ \t]+|$)", content)
+            if heading:
+                level = len(heading[1])
+                if skip_level is not None and level <= skip_level:
+                    skip_level = None
+                name = content.strip()
+                if name in selected:
+                    if skip_level is None:
+                        skip_level = level
+                    if name not in stripped:
+                        stripped.append(name)
+        if skip_level is None:
+            kept.append(line)
+    return "".join(kept), stripped
 
-    return text, stripped
 
 
 # ── Filter 3: Conversation History ───────────────────────────────────────────

--- a/ods/extensions/services/token-spy/tests/test_prompt_sections.py
+++ b/ods/extensions/services/token-spy/tests/test_prompt_sections.py
@@ -1,0 +1,79 @@
+"""Prompt section filtering must distinguish headings from code examples."""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "prompt_section_filters", Path(__file__).resolve().parents[1] / "filters.py"
+)
+filters = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = filters
+_spec.loader.exec_module(filters)
+
+
+def trim_prompt(text, headings=("## Heartbeats",)):
+    body = {"messages": [{"role": "system", "content": text}]}
+    return filters.apply_filters(body, {
+        "enabled": True,
+        "system_prompt": {
+            "enabled": True, "mode": "strip_sections", "strip_sections": list(headings),
+        },
+    })
+
+
+@pytest.mark.parametrize("fence", ["```", "~~~~", "  ```"])
+def test_keeps_matching_heading_inside_code_example(fence):
+    text = f"Instructions\n{fence}\n## Heartbeats\nexample content\n{fence}\nKeep this.\n"
+    body, result = trim_prompt(text)
+    assert body["messages"][0]["content"] == text
+    assert result.system_sections_stripped == []
+    assert result.chars_saved == 0
+
+
+@pytest.mark.parametrize("fence", ["```python", "~~~python"])
+def test_code_heading_cannot_end_removed_section(fence):
+    closing = fence[:3]
+    text = f"Keep\n## Heartbeats\nDiscard\n{fence}\n# Example\nDiscard too\n{closing}\n## Tools\nKeep tools\n"
+    body, result = trim_prompt(text)
+    assert body["messages"][0]["content"] == "Keep\n## Tools\nKeep tools\n"
+    assert result.system_sections_stripped == ["## Heartbeats"]
+
+
+def test_shorter_or_different_fence_cannot_end_code_example():
+    text = "Before\n````text\n```\n~~~\n## Heartbeats\nExample\n````\nAfter\n"
+    body, _ = trim_prompt(text)
+    assert body["messages"][0]["content"] == text
+
+
+def test_removes_last_heading_without_final_newline():
+    body, result = trim_prompt("Keep\n## Heartbeats")
+    assert body["messages"][0]["content"] == "Keep\n"
+    assert result.system_sections_stripped == ["## Heartbeats"]
+
+
+def test_keeps_crlf_and_unselected_sections_verbatim():
+    text = "# Root\r\nKeep\r\n## Heartbeats\r\nDrop\r\n### Nested\r\nDrop\r\n## Tools\r\nKeep\r\n"
+    body, _ = trim_prompt(text)
+    assert body["messages"][0]["content"] == "# Root\r\nKeep\r\n## Tools\r\nKeep\r\n"
+
+
+def test_removes_repeated_sections_and_reports_each_selected_heading_once():
+    body, result = trim_prompt(
+        "## Heartbeats\nDrop\n## Tools\nKeep\n## Heartbeats\nDrop\n# End\nKeep",
+    )
+    assert body["messages"][0]["content"] == "## Tools\nKeep\n# End\nKeep"
+    assert result.system_sections_stripped == ["## Heartbeats"]
+
+
+def test_unicode_line_separator_does_not_start_a_markdown_heading():
+    text = "Literal separator: \u2028## Heartbeats\nKeep this.\n"
+    body, _ = trim_prompt(text)
+    assert body["messages"][0]["content"] == text
+
+
+def test_empty_heading_ends_removed_section():
+    body, _ = trim_prompt("## Heartbeats\nDrop\n##\nKeep\n")
+    assert body["messages"][0]["content"] == "##\nKeep\n"


### PR DESCRIPTION
## Why this matters

With Token Spy's system-prompt section filter enabled, a literal `## Heartbeats` inside a fenced code example deletes the example and the instructions after it. A heading inside a code block within a removed section can also end removal early. The regex treats code content as document structure.

Track backtick and tilde fences while scanning the prompt once. Only headings outside those fences can begin or end a selected section. Preserve retained text and line endings verbatim; handle a final selected heading without a trailing newline. This uses the fenced-block distinction in [CommonMark 0.31.2](https://spec.commonmark.org/0.31.2/#fenced-code-blocks), without introducing a full Markdown renderer or changing configured heading names.

Production path: authenticated `POST /v1/chat/completions` → `get_filter_settings` → `apply_filters` → forwarded request body. Stored history is not rewritten.

## Overlap check

Searched all 4,124 open/closed PR titles and their changed-file indexes for `filters.py`, Markdown sections, and fences. #3800 covers tool choice, #2689 the retained history tail, #2364/#2023 history size and tool chains, and merged #4082 non-dict entries. None handles fenced prompt sections. The change is confined to the section parser and a separate regression file.

## Risk and validation

- Target: `public-beta`; surface: Token Spy request filtering; risk: high because the opt-in filter changes model input.
- Before: 7 regression failures, 2 passing controls.
- After: `pytest ods/extensions/services/token-spy/tests/test_prompt_sections.py ods/extensions/services/token-spy/tests/test_filters.py -q` — 13 passed (including two additional heading-boundary controls).
- Full Token Spy suite: 33 passed, 1 skipped (the existing PostgreSQL integration lane requires its database).
- Ruff on changed files and `git diff --check` pass.
- Tests exercise the public filter entry point used by the proxy, including backtick/tilde/indented fences, misleading closing fences, section boundaries, repeated sections, EOF, and CRLF.

No live provider request or deployed proxy was exercised. Independent human review and a provider smoke with the operator's actual filter settings remain merge gates; this PR is open for review and remains not merge-ready until those gates pass. Reverting the commit restores the prior filter; no data migration is required.

## AI assistance

Codex investigated the production path, drafted the patch and regression tests, and ran the recorded checks. Human diff review and the live merge gates remain outstanding.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped. Tested filter order: #4550 then #4558; both section preservation and retired-tool regressions pass.
