### PR TITLE
fix(token-spy): include midnight events in SQLite reports

### DIFF
--- a/ods/extensions/services/token-spy/db.py
+++ b/ods/extensions/services/token-spy/db.py
@@ -245,7 +245,10 @@ def query_report(start: str, end: str) -> dict:
         WHERE timestamp >= ? AND timestamp < ?
         ORDER BY timestamp ASC
         """,
-        (f"{start_day.isoformat()}T00:00:00Z", f"{end_exclusive.isoformat()}T00:00:00Z"),
+        # Match the fractional UTC representation written by the column default.
+        # "." sorts before "Z", so a bare 00:00:00Z excludes that day's
+        # first second while admitting the following day's first second.
+        (f"{start_day.isoformat()}T00:00:00.000Z", f"{end_exclusive.isoformat()}T00:00:00.000Z"),
     ).fetchall()
 
     report = _empty_report(start, end)

--- a/ods/extensions/services/token-spy/tests/test_usage_report.py
+++ b/ods/extensions/services/token-spy/tests/test_usage_report.py
@@ -216,3 +216,26 @@ class TestShortSpanAtDateMax:
         db = load_sqlite_db(tmp_path, monkeypatch)
         with pytest.raises(ValueError, match="out of range"):
             db._parse_report_dates("9999-12-01", "9999-12-31")
+
+
+@pytest.mark.parametrize("suffix", [".000Z", ".001Z", ".999Z", "Z"])
+def test_report_partitions_events_at_midnight(tmp_path, monkeypatch, suffix):
+    db = load_sqlite_db(tmp_path, monkeypatch)
+    insert_usage(db, "2026-05-01T00:00:00" + suffix, input_tokens=11)
+    insert_usage(db, "2026-05-01T23:59:59.999Z", input_tokens=13)
+    insert_usage(db, "2026-05-02T00:00:00" + suffix, input_tokens=17)
+
+    first = db.query_report("2026-05-01", "2026-05-01")
+    second = db.query_report("2026-05-02", "2026-05-02")
+    together = db.query_report("2026-05-01", "2026-05-02")
+
+    assert first["summary"]["input_tokens"] == 24
+    assert second["summary"]["input_tokens"] == 17
+    assert together["summary"]["input_tokens"] == 41
+    for report, requests in ((first, 2), (second, 1), (together, 3)):
+        assert report["summary"]["requests"] == requests
+        assert sum(day["requests"] for day in report["daily"]) == requests
+        assert sum(model["requests"] for model in report["models"]) == requests
+        assert sum(service["requests"] for service in report["services"]) == requests
+    assert first["summary"]["spend_usd"] + second["summary"]["spend_usd"] == pytest.approx(together["summary"]["spend_usd"])
+    db._get_conn().close()


### PR DESCRIPTION
## Why this matters

SQLite Usage reports omit events recorded during the first second after midnight. The database writes timestamps such as `2026-05-01T00:00:00.001Z`, while report bounds use `2026-05-01T00:00:00Z`. Lexical comparison places the fractional timestamp before the bound. The same mismatch admits the following day's first second into the SQL result, inflating the request summary even though daily aggregation discards it.

Use millisecond UTC bounds matching the column's stored format. The lower bound remains inclusive and the next day's boundary exclusive; legacy whole-second UTC timestamps still work. The timestamp index remains usable and no stored data is rewritten.

Production path: `GET /api/report` → `query_report` → SQLite usage rows → Dashboard Usage totals.

## Overlap check

Searched 4,124 open/closed PR titles and changed-file indexes for `token-spy/db.py`, midnight and fractional timestamps. Merged #1739 fixes relative-hour queries; #1926 caps report date spans. #2690/#2025 address SSE cursors and #2099 the MEMORY.md column. None fixes the report's midnight bounds. #4343 concerns a different calendar overflow in the dashboard API.

## Risk and validation

Medium risk: read-only SQLite reporting. Target: `public-beta`.

- Regression on base: 3 failed, 12 passed. Fractions .000, .001 and .999 fail; whole-second timestamps pass.
- Full Token Spy suite on this branch: 26 passed, 1 skipped.
- Real temporary SQLite databases exercise persisted rows and the public query boundary. Tests partition adjacent days and check request, token and cost totals, including daily/model/service agreement.
- Ruff with the repository CI rules on both changed files: passed.
- `git diff --check`: passed.

The existing PostgreSQL integration test is skipped without its test database; this PR changes only SQLite. No GPU, provider call or deployed stack is required to reproduce the lexical SQL comparison. Revert this commit to restore previous query behavior; no migration is needed.

## AI assistance

Codex traced the query and storage formats, drafted the patch/tests, and ran the checks above. Human review of the diff remains part of normal PR review.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped, including real SQLite date-boundary fixtures.
