### PR TITLE
fix(router): verify nested Responses stream identities

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -707,10 +707,19 @@ def _rewrite_sse_event(
                     obj = None
                 if isinstance(obj, dict):
                     payloads.append(obj)
-                    if isinstance(obj.get("model"), str):
-                        if obj["model"]:
-                            models.append(obj["model"])
-                        obj["model"] = alias
+                    model_objects = [obj]
+                    # Responses lifecycle events wrap their response object.
+                    # Observe the concrete identity before restoring the alias,
+                    # just as for top-level Chat/Completions model fields.
+                    if (isinstance(obj.get("type"), str)
+                            and obj["type"].startswith("response.")
+                            and isinstance(obj.get("response"), dict)):
+                        model_objects.append(obj["response"])
+                    for model_object in model_objects:
+                        if isinstance(model_object.get("model"), str):
+                            if model_object["model"]:
+                                models.append(model_object["model"])
+                            model_object["model"] = alias
                     _sanitize_choice_content(obj)
                     content = (
                         b"data: "

--- a/ods/extensions/services/model-router/tests/test_responses_stream_identity.py
+++ b/ods/extensions/services/model-router/tests/test_responses_stream_identity.py
@@ -1,0 +1,73 @@
+"""Responses lifecycle events carry model identity inside response objects."""
+
+import json
+import uuid
+
+import pytest
+
+from test_router import router as router, _set_stream_upstream, _signed_marker
+
+
+def event(model, kind="response.completed"):
+    return (f"event: {kind}\n" + "data: " + json.dumps({
+        "type": kind,
+        "response": {
+            "model": model, "status": "completed",
+            "output": [{"content": [{"type": "output_text", "text": "Concrete.gguf is literal text"}]}],
+            "usage": {"input_tokens": 9, "output_tokens": 4},
+        },
+    }) + "\n\n").encode()
+
+
+@pytest.mark.parametrize("alias", ["ods/current", "default"])
+def test_rewrites_nested_response_identity_and_records_concrete_model(router, alias):
+    mod, client, write_state, _ = router
+    write_state()
+    probe = str(uuid.uuid4())
+    raw = event("Concrete.gguf", "response.created") + event("Concrete.gguf")
+    _set_stream_upstream(mod, [raw[:63], raw[63:117], raw[117:]])
+    response = client.post("/v1/responses", json={
+        "model": alias, "stream": True, "input": _signed_marker(probe),
+    })
+    assert response.status_code == 200
+    values = [json.loads(line[6:]) for line in response.text.splitlines() if line.startswith("data: ")]
+    assert [value["response"]["model"] for value in values] == [alias, alias]
+    assert values[-1]["response"]["output"][0]["content"][0]["text"] == "Concrete.gguf is literal text"
+    evidence = client.get(f"/internal/route-evidence/{probe}", headers={
+        "Authorization": "Bearer internal-secret",
+    })
+    assert evidence.status_code == 200
+    assert evidence.json()["responseModel"] == "Concrete.gguf"
+    assert mod._inflight == 0
+
+
+@pytest.mark.parametrize("models", [("Wrong.gguf",), ("Wrong.gguf", "Concrete.gguf")])
+def test_nested_mismatched_identity_cannot_produce_success_evidence(router, models):
+    mod, client, write_state, _ = router
+    write_state()
+    probe = str(uuid.uuid4())
+    _set_stream_upstream(mod, [event(model) for model in models])
+    response = client.post("/v1/responses", json={
+        "model": "ods/current", "stream": True, "input": _signed_marker(probe),
+    })
+    assert response.status_code == 200
+    evidence = client.get(f"/internal/route-evidence/{probe}", headers={
+        "Authorization": "Bearer internal-secret",
+    })
+    assert evidence.status_code == 404
+    assert mod._inflight == 0
+
+
+def test_pinned_responses_stream_rejects_nested_identity_change(router):
+    mod, client, write_state, _ = router
+    write_state()
+    _set_stream_upstream(mod, [event("Wrong.gguf")])
+    with pytest.raises(mod.RouterError, match="Backend response identity changed"):
+        client.post("/v1/responses", json={
+            "model": "ods/current", "stream": True, "input": "hi",
+        }, headers={
+            "X-ODS-Expected-Catalog": "concrete",
+            "X-ODS-Expected-Model": "Concrete.gguf",
+            "X-ODS-Expected-Route": "7",
+        })
+    assert mod._inflight == 0


### PR DESCRIPTION
## Why this matters

A `/v1/responses` stream reports its model inside `response.model` on lifecycle events. The router only examined top-level `model`, so it returned the concrete model instead of the requested alias and could record successful route evidence even when the backend reported a different model. Pinned inference requests also missed this mismatch.

Inspect the nested response object on Responses events, collect its concrete identity before rewriting, and use the existing evidence/pinning checks. Ordinary generated output text is unchanged. Both `ods/current` and `default` continue to be public aliases.

Production contract: requested alias → selected persisted route → upstream runtime model → nested SSE identity → pinned-route check / evidence → public alias. The fix keeps that contract identical to the existing Chat Completions path.

## Overlap check

Searched 4,124 open/closed PR titles and file indexes for `model-router/app/main.py`, Responses and nested model identity. Merged #1914 frames SSE; #1966 permits completed streams without explicit identity; #2035 captures Responses usage. #1933 bounds buffered data, #2097 covers non-streaming evidence, and #3743 admission deadlines. None inspects the nested model identity in Responses lifecycle events.

## Risk and validation

High risk: inference routing and route evidence. Target: `public-beta`.

- New HTTP-boundary regressions on base: 5 failed.
- Full model-router suite: 79 passed.
- Tests stream lifecycle events across transport chunk boundaries through FastAPI, exercise both public aliases, reject wrong nested identities for pinned requests, withhold probe evidence after any mismatching event, preserve literal generated text, and verify admission is released.
- Existing Chat Completions, telemetry, shared-route pinning, cancellation and state-publication tests pass.
- Ruff with the repository CI rules on changed files and `git diff --check` pass.

317 warnings from existing FastAPI lifecycle/deprecation/resource behavior were emitted and remain visible in the log. No live model runtime or sharing peer was exercised. Independent human review and a Responses-capable runtime smoke remain merge gates; this PR is open for review and remains not merge-ready until those gates pass. Revert the commit to roll back; state schema and persisted data are unchanged.

## AI assistance

Codex traced the route contract, drafted the patch/tests, and ran the recorded checks. Human diff review and live runtime validation remain outstanding.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Router: 82 passed. Tested order: #4552 then #4554.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) also includes #2992 and passes all 84 router tests. When combining response-header forwarding with the current router, retain _OwnedStream and cleanup=cleanup_stream.
