### PR TITLE
fix(preview): publish and verify empty support assets

### DIFF
--- a/ods/extensions/services/dashboard/src/components/PixelEmptyAssets.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/PixelEmptyAssets.test.jsx
@@ -1,0 +1,53 @@
+import { webcrypto, createHash } from 'node:crypto'
+import { Buffer } from 'node:buffer'
+import { render, screen, fireEvent } from '@testing-library/react'
+import PixelTaskFiles from './PixelTaskFiles'
+
+const index = Buffer.from('<h1>Preview</h1>')
+const empty = Buffer.alloc(0)
+const digest = bytes => createHash('sha256').update(bytes).digest('hex')
+const files = [
+  {path:'index.html', bytes:index.length, sha256:digest(index)},
+  {path:'style.css', bytes:0, sha256:digest(empty)},
+]
+const preview = {
+  siteId:'site-'+'a'.repeat(24), sha256:'a'.repeat(64),
+  entrySha256:files[0].sha256, files:2, bytes:index.length,
+}
+const manifestResponse = (receipt = preview, entries = files) => ({
+  ok:true, arrayBuffer:async () => new TextEncoder().encode(JSON.stringify({
+    schemaVersion:1, ...receipt, files:entries,
+  })).buffer,
+})
+
+beforeEach(() => {
+  vi.stubGlobal('crypto', webcrypto)
+  vi.stubGlobal('fetch', vi.fn(async url => url.endsWith('__ods_manifest__.json')
+    ? manifestResponse()
+    : {ok:true, arrayBuffer:async () => empty.buffer}))
+})
+afterEach(() => {vi.restoreAllMocks(); vi.unstubAllGlobals()})
+
+it('lists, verifies and downloads an empty support asset', async () => {
+  const createUrl = vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:empty-asset')
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {})
+  const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+  render(<PixelTaskFiles preview={preview}/>)
+  fireEvent.click(await screen.findByRole('button', {name:/style.css/}))
+  expect(await screen.findByText('Published snapshot · SHA-256 verified')).toBeVisible()
+  expect(screen.getByLabelText('Code for style.css').textContent).toBe('')
+  fireEvent.click(screen.getByRole('button', {name:'Download style.css'}))
+  await screen.findByText('Verified download started')
+  expect(createUrl.mock.calls[0][0].size).toBe(0)
+  expect(click).toHaveBeenCalledOnce()
+})
+
+it('continues to reject an empty entry document', async () => {
+  const receipt = {...preview, bytes:0, entrySha256:digest(empty)}
+  fetch.mockResolvedValue(manifestResponse(receipt, [
+    {...files[0], bytes:0, sha256:digest(empty)}, files[1],
+  ]))
+  render(<PixelTaskFiles preview={receipt}/>)
+  await screen.findByText(/Task files could not be verified/)
+  expect(screen.queryByRole('button', {name:/style.css/})).toBeNull()
+})

--- a/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
+++ b/ods/extensions/services/dashboard/src/lib/pixelArtifacts.js
@@ -50,7 +50,7 @@ export async function loadSnapshotFiles(preview, signal) {
   const seen = new Set()
   for (const file of manifest.files) {
     if (!file || !isArtifactPath(file.path) || seen.has(file.path) || !DIGEST.test(file.sha256)
-      || !Number.isInteger(file.bytes) || file.bytes < 1 || file.bytes > 4 * 1024 * 1024) throw new Error('Invalid file')
+      || !Number.isInteger(file.bytes) || file.bytes < (file.path === 'index.html' ? 1 : 0) || file.bytes > 4 * 1024 * 1024) throw new Error('Invalid file')
     total += file.bytes
     seen.add(file.path)
   }

--- a/ods/extensions/services/pixel-agent/host/workspace_preview.py
+++ b/ods/extensions/services/pixel-agent/host/workspace_preview.py
@@ -226,7 +226,7 @@ def _source_files(
                 or info.st_nlink != 1
                 or info.st_uid != owner_uid
                 or info.st_mode & 0o022
-                or not 1 <= info.st_size <= MAX_FILE_BYTES
+                or not (1 if relative == "index.html" else 0) <= info.st_size <= MAX_FILE_BYTES
                 or any(PATH_COMPONENT.fullmatch(part) is None for part in relative.split("/"))
             ):
                 raise PreviewError("unsafe preview file")

--- a/ods/extensions/services/pixel-agent/tests/test_preview_empty_assets.py
+++ b/ods/extensions/services/pixel-agent/tests/test_preview_empty_assets.py
@@ -1,0 +1,90 @@
+"""Empty support assets must survive publication, verification and HTTP reads."""
+
+import sys
+if sys.platform == "win32":
+    from unittest import SkipTest
+    raise SkipTest("Requires POSIX ownership; run under Linux/WSL")
+
+from contextlib import closing
+import hashlib
+import http.client
+import json
+import os
+import threading
+
+import pytest
+
+from test_workspace_preview import MODULE
+
+
+def make_site(tmp_path):
+    workspace, previews = tmp_path / "workspace", tmp_path / "previews"
+    workspace.mkdir(mode=0o700)
+    previews.mkdir(mode=0o700)
+    site = workspace / "demo"
+    site.mkdir(mode=0o700)
+    for name, data in {
+        "index.html": b'<link rel="stylesheet" href="style.css"><script src="app.js"></script>',
+        "style.css": b"", "app.js": b"",
+    }.items():
+        (site / name).write_bytes(data)
+        (site / name).chmod(0o600)
+    return workspace, previews, site
+
+
+def test_empty_assets_survive_publish_manifest_http_and_comparison(tmp_path):
+    workspace, previews, site = make_site(tmp_path)
+    receipt = MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+    assert receipt["files"] == 3
+    assert MODULE.publish_snapshot(workspace, previews, "demo", os.getuid()) == receipt
+    manifest = json.loads(MODULE.snapshot_manifest(previews, receipt["siteId"]))
+    empty_digest = hashlib.sha256(b"").hexdigest()
+    for name in ("app.js", "style.css"):
+        assert next(row for row in manifest["files"] if row["path"] == name) == {
+            "path": name, "bytes": 0, "sha256": empty_digest,
+        }
+
+    with MODULE.PreviewHTTPServer(("127.0.0.1", 0), previews) as server:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            for method in ("GET", "HEAD"):
+                with closing(http.client.HTTPConnection("127.0.0.1", server.server_port, timeout=5)) as conn:
+                    conn.request(method, f"/{receipt['siteId']}/style.css", headers={
+                        "Host": f"{receipt['siteId']}.localhost:{server.server_port}",
+                    })
+                    response = conn.getresponse()
+                    assert response.status == 200
+                    assert response.getheader("Content-Length") == "0"
+                    assert response.getheader("X-Preview-SHA256") == empty_digest
+                    assert response.read() == b""
+        finally:
+            server.shutdown()
+            thread.join(timeout=5)
+
+    (site / "style.css").write_text("body { color: red; }\n")
+    next_receipt = MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+    changes = json.loads(MODULE.snapshot_changes(
+        previews, next_receipt["siteId"], receipt["siteId"],
+    ))["changes"]
+    assert [(row["path"], row["change"], row["additions"], row["deletions"]) for row in changes] == [
+        ("style.css", "modified", 1, 0),
+    ]
+    # Earlier snapshots remain immutable after the support asset gains content.
+    assert (previews / receipt["siteId"] / "style.css").read_bytes() == b""
+
+
+def test_empty_entry_is_still_rejected(tmp_path):
+    workspace, previews, site = make_site(tmp_path)
+    (site / "index.html").write_bytes(b"")
+    with pytest.raises(MODULE.PreviewError):
+        MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+    assert list(previews.iterdir()) == []
+
+
+def test_empty_assets_do_not_bypass_file_count_limit(tmp_path, monkeypatch):
+    workspace, previews, _ = make_site(tmp_path)
+    monkeypatch.setattr(MODULE, "MAX_FILES", 2)
+    with pytest.raises(MODULE.PreviewError):
+        MODULE.publish_snapshot(workspace, previews, "demo", os.getuid())
+    assert list(previews.iterdir()) == []


### PR DESCRIPTION
## Why this matters

Publishing a valid site with a nonempty `index.html` and an empty stylesheet or script currently fails with “unsafe preview file.” Empty CSS and JS are valid support assets, and removing a placeholder merely to publish also changes the site's file inventory.

Allow zero-byte support assets while keeping the root entry document nonempty. Carry that rule through host publication/reverification and the browser manifest validator. Size/count/ownership/symlink constraints and SHA-256 checks still apply to every asset.

Production contract: workspace file → immutable published bytes and receipt → rehashed manifest → Task files → source verification → download. Empty files keep their path, zero length and SHA-256 identity. Later edits produce a distinct snapshot, preserving the original.

## Overlap check

Searched all 4,124 open/closed PR titles/file indexes for `workspace_preview.py`, `pixelArtifacts.js` and empty assets/publications. #4226 adds supported project text filenames, #4338 deep paths, #4321 HTTP-LAN hashing and #4357 query suffixes. None permits empty support assets. Inspected #4226's patch; its file-type extension is independent. #4453 builds ZIP downloads using the existing file loader.

## Risk and validation

High risk: host publication and preview HTTP serving. Target: `public-beta`.

- Before: the publication regression fails at `_source_files`; two negative controls pass.
- After: workspace preview suite plus new publication tests — 14 passed.
- Five affected frontend test files — 19 passed.
- Dashboard lint — 0 errors; existing warnings remain. Production build passed.
- Ruff with the repository CI rules on changed Python files and `git diff --check` passed.
- Real loopback HTTP GET/HEAD confirms zero Content-Length, empty body and the expected digest. Publication is repeatable; manifest and snapshot comparison handle the asset, and empty entry/file-count violations still fail.
- Headless Chromium rendered the real Task files component, verified empty CSS with browser WebCrypto and downloaded a 0-byte file. Controls worked at desktop/mobile viewport sizes with no page errors. This was a component smoke with a fixture manifest, not a full installed-dashboard or visual-layout qualification.

POSIX ownership/publication was tested on Linux/WSL. No installed preview daemon, fresh install, macOS host or Windows host was exercised. Independent human review and the installed preview lane remain merge gates; this PR is open for review and remains not merge-ready until those gates pass. Revert the commit to roll back acceptance; existing nonempty snapshots need no migration. Empty-asset snapshots would again be rejected by the old manifest verifier.

## AI assistance

Codex traced both producer and browser consumers, drafted the patch/tests, and ran the recorded checks. Human diff review and installed-host validation remain outstanding.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Dashboard API: 2,703 passed, 2 skipped; preview scripts: 32 passed; dashboard: 906 passed, lint exits 0, production build passes.
