### PR TITLE
fix(router): strip connection-nominated request headers

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -630,8 +630,13 @@ def _verify_probe_marker(body_text: str) -> str | None:
 
 def _sanitize_headers(request: Request) -> dict[str, str]:
     headers: dict[str, str] = {}
+    connection_fields = {
+        token.strip().lower()
+        for value in request.headers.getlist("connection")
+        for token in value.split(",")
+    }
     for name, value in request.headers.items():
-        if name.lower() in _HOP_BY_HOP:
+        if name.lower() in _HOP_BY_HOP or name.lower() in connection_fields:
             continue
         headers[name] = value
     headers["content-type"] = "application/json"

--- a/ods/extensions/services/model-router/tests/test_request_connection_headers.py
+++ b/ods/extensions/services/model-router/tests/test_request_connection_headers.py
@@ -1,0 +1,60 @@
+"""Hop-specific request fields must not become end-to-end backend headers."""
+
+import httpx
+import pytest
+
+from test_router import router as router
+
+
+@pytest.mark.parametrize("connection", [
+    [("Connection", "X-Hop-Only, keep-alive")],
+    [("Connection", "x-HoP-OnLy"), ("Connection", "X-Other-Hop")],
+])
+def test_connection_nominated_fields_are_not_forwarded(router, connection):
+    mod, client, write_state, _ = router
+    write_state()
+    seen = []
+
+    def backend(request):
+        seen.append(request.headers)
+        return httpx.Response(200, json={"model": "Concrete.gguf", "choices": []})
+
+    mod.app.state.http = httpx.AsyncClient(transport=httpx.MockTransport(backend))
+    response = client.post("/v1/chat/completions", json={"model": "ods/current", "messages": []},
+                           headers=connection + [
+                               ("X-Hop-Only", "connection-scoped"),
+                               ("X-Other-Hop", "second-connection-field"),
+                               ("X-End-To-End", "retain-me"),
+                           ])
+    assert response.status_code == 200
+    assert "x-hop-only" not in seen[0]
+    if len(connection) > 1:
+        assert "x-other-hop" not in seen[0]
+    else:
+        assert seen[0]["x-other-hop"] == "second-connection-field"
+    assert seen[0]["x-end-to-end"] == "retain-me"
+    assert seen[0]["content-type"] == "application/json"
+    assert mod._inflight == 0
+
+
+def test_backend_owned_credentials_are_applied_after_request_sanitization(router, monkeypatch):
+    mod, client, write_state, _ = router
+    write_state(endpoint="keyed")
+    monkeypatch.setenv("KEYED_API_KEY", "backend-test-key")
+    seen = []
+
+    def backend(request):
+        seen.append(request.headers)
+        return httpx.Response(200, json={"model": "Concrete.gguf", "choices": []})
+
+    mod.app.state.http = httpx.AsyncClient(transport=httpx.MockTransport(backend))
+    response = client.post("/v1/chat/completions", json={"model": "ods/current", "messages": []},
+                           headers={
+                               "Connection": "Authorization, X-Hop-Only, Content-Type",
+                               "Authorization": "Bearer client-test-key",
+                               "X-Hop-Only": "remove-me",
+                           })
+    assert response.status_code == 200
+    assert seen[0]["authorization"] == "Bearer backend-test-key"
+    assert "x-hop-only" not in seen[0]
+    assert seen[0]["content-type"] == "application/json"


### PR DESCRIPTION
## Why this matters
A client can send `Connection: X-Local-State` alongside an `X-Local-State` header. The router removes Connection itself but currently forwards the nominated, hop-specific field to the inference backend. HTTP intermediaries must remove those fields before forwarding ([RFC 9110 §7.6.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-7.6.1)).

Collect options from every Connection field, normalize their names, and remove the nominated request headers alongside the existing fixed list. Backend-owned credentials and JSON content type are applied afterward, so client connection options cannot suppress the router's own backend configuration.

## Overlap check
Searched open and closed PR titles and changed files. #2992 fixes hop-by-hop **response** headers; its patch leaves `_sanitize_headers` unchanged. This addresses the separate client-to-backend boundary and tests it through actual router HTTP requests. No duplicate request-direction fix found.

## Validation
- Regression against public-beta: all 3 new HTTP-boundary tests fail because nominated fields reach the mock backend.
- Full model-router suite: **77 passed** (309 existing deprecation warnings).
- CI-rule Ruff check on changed Python files and `git diff --check` pass.
- Coverage includes mixed case, comma-separated options, repeated Connection fields, retained end-to-end headers, and router-owned credentials.
- Backend transport is mocked; no live GPU/provider deployment was exercised.

## Review / risk
Review required before merge: independent review and the live router release lane required by the high-risk change map. No routing selection, authorization policy, or deployment change.

AI assistance: implemented and validated with Codex; all results above are from executed local checks.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Router: 82 passed. Tested order: #4552 then #4554.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) also includes #2992 and passes all 84 router tests. When combining response-header forwarding with the current router, retain _OwnedStream and cleanup=cleanup_stream.

Exact PR-head CI remains red: Python 3.11 procfs cleanup raises ProcessLookupError (ESRCH), and the sibling Python job was cancelled. See [run 34708352721](https://github.com/Osmantic/ODS/actions/runs/34708352721). #4560 addresses this shared test race; the combined 39-test procfs suite passes. The rerun API denied the contributing account with HTTP 403 (repository admin rights required).
