### PR TITLE
fix(models): confirm activation with the current inventory

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModelsActivationSnapshot.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModelsActivationSnapshot.test.js
@@ -1,0 +1,73 @@
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useModels } from '../useModels'
+
+const snapshot = active => ({
+  ok:true,
+  json:async () => ({
+    models:[
+      {id:'target',status:active === 'target' ? 'loaded' : 'downloaded'},
+      {id:'other',status:active === 'other' ? 'loaded' : 'downloaded'},
+    ],
+    currentModel:active, activationReadyModel:active,
+    odsMode:'local', configuredMode:'local', llmBackend:'llama-server',
+  }),
+})
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn())
+})
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  delete document.hidden
+})
+
+it('keeps activation pending when its poll is superseded by a newer inventory', async () => {
+  let finishOld
+  const old = new Promise(resolve => {finishOld = resolve})
+  let reads = 0
+  let active = 'other'
+  fetch.mockImplementation((url, options) => {
+    if (options?.method === 'POST') return Promise.resolve({ok:true})
+    reads++
+    return reads === 2 ? old : Promise.resolve(snapshot(active))
+  })
+  const {result} = renderHook(() => useModels())
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  Object.defineProperty(document, 'hidden', {configurable:true, value:true})
+  vi.useFakeTimers()
+  let activation
+  act(() => {activation = result.current.loadModel('target')})
+  await act(async () => {await vi.advanceTimersByTimeAsync(5000)})
+  expect(reads).toBe(2)
+  await act(async () => {await result.current.refresh()})
+  await act(async () => {finishOld(snapshot('target'))})
+  expect(result.current.currentModel).toBe('other')
+  expect(result.current.activationLoading).toBe('target')
+  expect(result.current.error).toBeNull()
+
+  active = 'target'
+  await act(async () => {await vi.advanceTimersByTimeAsync(5000); await activation})
+  expect(result.current.activationLoading).toBeNull()
+  expect(result.current.currentModel).toBe('target')
+  expect(result.current.error).toBeNull()
+})
+
+it('reports an unconfirmed activation when the final snapshot no longer matches', async () => {
+  let reads = 0
+  fetch.mockImplementation((url, options) => {
+    if (options?.method === 'POST') return Promise.resolve({ok:true})
+    reads++
+    return Promise.resolve(snapshot(reads === 2 ? 'target' : 'other'))
+  })
+  const {result} = renderHook(() => useModels())
+  await waitFor(() => expect(result.current.loading).toBe(false))
+  Object.defineProperty(document, 'hidden', {configurable:true, value:true})
+  vi.useFakeTimers()
+  let activation
+  act(() => {activation = result.current.loadModel('target')})
+  await act(async () => {await vi.advanceTimersByTimeAsync(5000); await activation})
+  expect(result.current.currentModel).toBe('other')
+  expect(result.current.activationLoading).toBeNull()
+  expect(result.current.error).toMatch(/Could not confirm activation of target/)
+})

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -240,7 +240,7 @@ export function useModels() {
       const data = await response.json()
 
       // A slower, older request must not overwrite a newer snapshot.
-      if (requestId < latestSettledModelsRequestRef.current) return data
+      if (requestId < latestSettledModelsRequestRef.current) return null
       latestSettledModelsRequestRef.current = requestId
 
       setModels(data.models)
@@ -432,11 +432,12 @@ export function useModels() {
       // Take one final authoritative snapshot at the deadline or after a POST
       // failure. This cannot turn an unverified 409 into same-target success.
       const finalData = await fetchModels()
-      if (!activationError && activationMatches(finalData)) targetLoaded = true
+      const confirmed = !activationError && activationMatches(finalData)
 
-      if (!targetLoaded) {
-        setMutationError(activationError ||
-          `Timed out after 10 minutes waiting for ${modelId} to activate. The server may still be finishing; refresh before retrying.`)
+      if (!confirmed) {
+        setMutationError(activationError || (targetLoaded
+          ? `Could not confirm activation of ${modelId} against the latest model status. Refresh before retrying.`
+          : `Timed out after 10 minutes waiting for ${modelId} to activate. The server may still be finishing; refresh before retrying.`))
       }
     } finally {
       controller.abort()


### PR DESCRIPTION
## Why this matters
A model activation can be reported as finished using an inventory response the hook has already rejected as stale. An activation poll and manual refresh may settle out of order; the old poll returns its payload even though it cannot update the displayed inventory. The activation loop then consumes that stale payload as success.

Return no snapshot to consumers when a request is superseded. Also require the final refresh to confirm the target: observing the target once is insufficient when the final inventory reports another model. That case now produces actionable confirmation guidance.

## Overlap check
Searched open/closed PR titles and changed files. Inspected #3376 (inventory timeout guidance) and #3027 (payload shape validation); neither changes stale return values or final activation confirmation. The existing out-of-order test checks rendered inventory only. This regression exercises the activation consumer as well.

## Validation
- Both new hook regressions fail on public-beta after correcting the test's initial document visibility setup.
- **81 tests pass** across the activation regression, existing useModels suite, and Models page suite.
- Dashboard lint: zero errors (existing warnings); production build passes.
- Hook tests use controlled HTTP responses and timers, including a successful follow-up activation. No real model was activated and no GPU installation lane was run.

## Review / risk
Review required before merge: independent review of activation UI behavior. Backend activation requests and runtime selection are unchanged.

AI assistance: implemented and validated with Codex.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Dashboard: 906 passed; lint exits 0; production build passes. The first default-worker run timed out in Settings; Settings alone passed all 11 tests and the complete run with four workers passed all 906.
