### PR TITLE
fix(token-spy): remove empty retired tool-call messages

### DIFF
--- a/ods/extensions/services/token-spy/filters.py
+++ b/ods/extensions/services/token-spy/filters.py
@@ -261,10 +261,17 @@ def _filter_history(body: dict, cfg: dict, result: FilterResult,
                     result.messages_removed += 1
                     continue
                 if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                    # Keep the assistant message but strip tool_calls
                     msg = dict(msg)  # shallow copy
                     del msg["tool_calls"]
                     result.tool_chains_dropped += 1
+                    # Tool-only replies commonly omit content or set it to null.
+                    # Once their calls are retired, they have no payload left.
+                    # Preserve text/parts and non-text assistant payloads.
+                    if msg.get("content") is None and not any(
+                        msg.get(key) for key in ("refusal", "audio", "function_call")
+                    ):
+                        result.messages_removed += 1
+                        continue
                 new_unit.append(msg)
             units[i] = new_unit
 

--- a/ods/extensions/services/token-spy/tests/test_retired_tool_turns.py
+++ b/ods/extensions/services/token-spy/tests/test_retired_tool_turns.py
@@ -1,0 +1,67 @@
+"""Public request-filter regressions for tool-only assistant messages."""
+import copy
+
+import pytest
+
+from test_filters import apply_filters
+
+
+def conversation(assistant_fields):
+    return [
+        {"role": "system", "content": "Keep this policy."},
+        {"role": "user", "content": "Earlier question"},
+        {"role": "assistant", "tool_calls": [
+            {"id": "old-call", "type": "function",
+             "function": {"name": "lookup", "arguments": "{}"}}
+        ], **assistant_fields},
+        {"role": "tool", "tool_call_id": "old-call", "content": "Old result"},
+        {"role": "assistant", "content": "Earlier answer"},
+        {"role": "user", "content": "Current question"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "current-call", "type": "function",
+             "function": {"name": "lookup", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "current-call", "content": "Current result"},
+    ]
+
+
+def filtered(messages, enabled=True):
+    return apply_filters({"model": "test", "messages": copy.deepcopy(messages)}, {
+        "enabled": True,
+        "history": {"enabled": True, "drop_old_tool_calls": enabled,
+                    "drop_old_tool_calls_after_pairs": 1, "always_keep_last_n": 0},
+    })
+
+
+@pytest.mark.parametrize("fields", [{}, {"content": None}])
+def test_retiring_tool_calls_removes_assistant_with_no_remaining_payload(fields):
+    original = conversation(fields)
+    body, metrics = filtered(original)
+    assert body["messages"] == original[:2] + original[4:]
+    assert metrics.messages_removed == 2
+    assert metrics.messages_kept == len(body["messages"])
+    assert metrics.tool_chains_dropped == 2
+    assert original[2]["tool_calls"][0]["id"] == "old-call"
+
+
+@pytest.mark.parametrize("fields", [
+    {"content": "Looking that up."},
+    {"content": ""},
+    {"content": [{"type": "text", "text": "Looking that up."}]},
+    {"content": None, "refusal": "Cannot help with part of that request."},
+    {"content": None, "audio": {"id": "audio-reply"}},
+    {"content": None, "function_call": {"name": "legacy", "arguments": "{}"}},
+])
+def test_retiring_tools_preserves_other_assistant_payloads(fields):
+    original = conversation(fields)
+    body, metrics = filtered(original)
+    assert body["messages"][2] == {"role": "assistant", **fields}
+    assert body["messages"][-3:] == original[-3:]
+    assert metrics.messages_removed == 1
+
+
+def test_disabled_retirement_preserves_tool_only_assistant_and_results():
+    original = conversation({"content": None})
+    body, metrics = filtered(original, enabled=False)
+    assert body["messages"] == original
+    assert metrics.messages_removed == 0


### PR DESCRIPTION
## Why this matters
With old-tool retirement enabled, an ordinary assistant tool call with missing/null content becomes an assistant message without either content or calls. The following request no longer meets the [Chat Completions assistant-message contract](https://developers.openai.com/api/reference/resources/chat). The old tool result is already removed; remove the now-empty assistant entry too.

Only remove entries whose calls were actually retired and that have no remaining content, refusal, audio reference, or legacy function call. Preserve current tool chains and account for removed messages in filter metrics.

## Overlap check
Searched open and closed titles and changed files. #2364/#2023 address size-based trimming of atomic tool chains; #2689 restores a protected raw-message tail; #3800 reconciles forced tool choices with schema filtering. Inspected the relevant patches. None fixes tool-only assistant entries left by the separate, explicitly enabled old-tool-retirement stage. #4550 handles Markdown system-prompt sections.

## Validation
- Public `apply_filters` request boundary: 2 new regressions fail on public-beta for absent/null content; 7 preservation controls pass.
- Full Token Spy suite: **31 passed, 1 skipped** (PostgreSQL integration unavailable).
- CI-rule Ruff and diff whitespace checks pass.
- Tests retain system text, current tool calls/results, normal text/parts, empty text, refusal/audio/function-call payloads, and disabled-filter behavior.
- No live inference provider was called.

## Review / risk
Review required before merge: independent review of opt-in request rewriting. No default filter settings change.

AI assistance: implemented and validated with Codex.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped. Tested filter order: #4550 then #4558.

Exact PR-head CI remains red: Ubuntu dashboard compact-draft assertion in RemoteProvider. See [run 34708563223](https://github.com/Osmantic/ODS/actions/runs/34708563223). #4570 addresses the overwrite; the combined dashboard suite passes all 906 tests. The contributing account lacks repository rerun permission (HTTP 403 on the same workflow).
