### PR TITLE
fix(privacy): replace exactly the detected PII spans

### DIFF
--- a/ods/extensions/services/privacy-shield/pii_scrubber.py
+++ b/ods/extensions/services/privacy-shield/pii_scrubber.py
@@ -80,29 +80,24 @@ class PIIDetector:
         scrubbed = text
 
         for pii_type, pattern in self.PATTERNS.items():
-            matches = pattern.findall(scrubbed)
-            for match in matches:
-                if isinstance(match, tuple):
-                    match = match[0]  # Handle groups
+            def replace_match(found):
+                match = found.group(0)
 
-                # Credit card: validate with Luhn to reduce false positives
+                # Credit card: validate with Luhn to reduce false positives.
                 if pii_type == 'credit_card' and not self._luhn_check(match):
-                    continue
+                    return match
 
-                # Check if we've seen this PII before
-                existing_token = None
                 for token, original in self.pii_map.items():
                     if original == match:
-                        existing_token = token
-                        break
+                        return token
 
-                if existing_token:
-                    scrubbed = scrubbed.replace(match, existing_token, 1)
-                else:
-                    # New PII - create token
-                    token = self._generate_token(pii_type, match)
-                    self.pii_map[token] = match
-                    scrubbed = scrubbed.replace(match, token, 1)
+                token = self._generate_token(pii_type, match)
+                self.pii_map[token] = match
+                return token
+
+            # Replace exactly the regex match. A same-valued substring earlier
+            # in the text may not satisfy the pattern's boundary conditions.
+            scrubbed = pattern.sub(replace_match, scrubbed)
 
         return scrubbed
 

--- a/ods/extensions/services/privacy-shield/tests/test_detected_spans.py
+++ b/ods/extensions/services/privacy-shield/tests/test_detected_spans.py
@@ -1,0 +1,44 @@
+"""Scrub detected spans without substituting earlier non-matching substrings."""
+from .test_pii_scrubber import PrivacyShield
+
+import pytest
+
+
+@pytest.mark.parametrize("value,nonmatch", [
+    ("2125550199", "9992125550199888"),
+    ("123-45-6789", "x123-45-6789y"),
+    ("192.168.1.1", "x192.168.1.1y"),
+])
+def test_request_scrubs_the_detected_occurrence_not_an_earlier_substring(value, nonmatch):
+    shield = PrivacyShield()
+    text = f"Reference: {nonmatch}; contact: {value}."
+    scrubbed, metadata = shield.process_request(text)
+    assert scrubbed.startswith(f"Reference: {nonmatch}; contact: <PII_")
+    assert not scrubbed.endswith(f"contact: {value}.")
+    assert metadata["scrubbed"] is True
+    assert metadata["pii_count"] == 1
+    assert shield.process_response(scrubbed) == text
+
+    # Reusing a session mapping must use the same span-aware replacement.
+    again, repeated_metadata = shield.process_request(text)
+    assert again == scrubbed
+    assert repeated_metadata["pii_count"] == 1
+
+
+def test_repeated_real_matches_share_one_token_and_restore_exactly():
+    shield = PrivacyShield()
+    text = "Call 2125550199 or 2125550199."
+    scrubbed, metadata = shield.process_request(text)
+    token = next(iter(shield.detector.pii_map))
+    assert scrubbed == f"Call {token} or {token}."
+    assert metadata["pii_count"] == 1
+    assert shield.process_response(scrubbed) == text
+
+
+def test_invalid_luhn_candidates_stay_unchanged_alongside_valid_cards():
+    shield = PrivacyShield()
+    text = "Invalid 4111 1111 1111 1112; valid 4111 1111 1111 1111."
+    scrubbed, metadata = shield.process_request(text)
+    assert scrubbed.startswith("Invalid 4111 1111 1111 1112; valid <PII_credit_card_")
+    assert metadata["pii_count"] == 1
+    assert shield.process_response(scrubbed) == text


### PR DESCRIPTION
## Why this matters
For `Reference: 9992125550199888; contact: 2125550199.`, the phone regex correctly detects the standalone contact number. The replacement loop nevertheless replaces its first textual occurrence inside the unrelated reference and leaves the actual detected phone number intact. The same mismatch affects SSN/IP boundary matches and previously stored session mappings.

Use a regex substitution callback so replacement occurs at the detected span. Keep the existing patterns, Luhn check, session-token reuse, and reversible mapping unchanged.

## Overlap check
Searched open and closed titles and changed files. #2085 improves IPv6 matching; #2195 broadens valid card lengths; #2363 changes API-key syntax; #2528 validates IP candidates. Those concern candidate detection. This fixes the independent replacement-location error after a candidate has already been detected. No equivalent span-substitution fix found.

## Validation
- Public PrivacyShield request/response round trip: **3 regressions fail, 2 controls pass** on public-beta.
- Full Privacy Shield suite: **63 passed** (one dependency deprecation warning).
- CI-rule Ruff on changed files and `git diff --check` pass.
- Regression covers phone, SSN, IP, existing mappings, repeated true matches, and invalid/valid Luhn candidates.
- Tests use synthetic values. No live external provider or private user data was used.

## Review / risk
Review required before merge: independent review of the privacy transformation and required live proxy validation. The regex-only detector's coverage is unchanged.

AI assistance: implemented and validated with Codex.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Privacy Shield: 74 passed. Tested order: #4559, #4582, #4627; detected-span replacement, response encoding, and JSON request structure compose.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) includes #3054 and #3101 and passes all 77 Privacy Shield tests. Combining #3101 with #4582 requires removing the mid-stream raw cutover while retaining one incremental encoder, its emitted flag, and final flush.
