### PR TITLE
test(pixel): handle processes exiting during procfs reads

### DIFF
--- a/ods/tests/pixel_inference/test_advice_setup_process.py
+++ b/ods/tests/pixel_inference/test_advice_setup_process.py
@@ -19,7 +19,9 @@ pytestmark=pytest.mark.skipif(sys.platform!='linux',reason='Linux process-state 
 
 def live(pid):
     try: return Path(f'/proc/{pid}/stat').read_text().split(') ',1)[1].split()[0]!='Z'
-    except FileNotFoundError: return False
+    # Linux may return ESRCH after open succeeds but the task exits during
+    # read. Both missing-task outcomes mean the process is no longer live.
+    except (FileNotFoundError, ProcessLookupError): return False
 
 
 def until(check,seconds=5):

--- a/ods/tests/pixel_inference/test_procfs_exit_race.py
+++ b/ods/tests/pixel_inference/test_procfs_exit_race.py
@@ -1,0 +1,39 @@
+"""Deterministic coverage for the observed CI exit-during-procfs-read race."""
+import errno
+from pathlib import Path
+
+import pytest
+
+from test_advice_setup_process import live
+from test_route_worker import process_live
+
+pytestmark = pytest.mark.skipif(__import__("sys").platform != "linux", reason="Linux procfs")
+
+
+@pytest.mark.parametrize("probe", [live, process_live])
+@pytest.mark.parametrize("error", [
+    FileNotFoundError(errno.ENOENT, "No such file"),
+    ProcessLookupError(errno.ESRCH, "No such process"),
+])
+def test_process_disappearing_during_stat_read_is_not_live(monkeypatch, probe, error):
+    def disappeared(path, *args, **kwargs):
+        assert path == Path("/proc/123456/stat")
+        raise error
+    monkeypatch.setattr(Path, "read_text", disappeared)
+    assert probe(123456) is False
+
+
+@pytest.mark.parametrize("probe", [live, process_live])
+def test_unexpected_procfs_access_error_still_fails_the_test(monkeypatch, probe):
+    def denied(*args, **kwargs):
+        raise PermissionError(errno.EACCES, "Permission denied")
+    monkeypatch.setattr(Path, "read_text", denied)
+    with pytest.raises(PermissionError):
+        probe(123456)
+
+
+@pytest.mark.parametrize("probe", [live, process_live])
+@pytest.mark.parametrize("state,expected", [("S", True), ("R", True), ("Z", False)])
+def test_live_and_zombie_classification_is_unchanged(monkeypatch, probe, state, expected):
+    monkeypatch.setattr(Path, "read_text", lambda *_: f"123456 (python) {state} 1 2 3")
+    assert probe(123456) is expected

--- a/ods/tests/pixel_inference/test_route_worker.py
+++ b/ods/tests/pixel_inference/test_route_worker.py
@@ -66,7 +66,9 @@ def port_closed(lease):
 
 def process_live(pid):
     try: return Path(f'/proc/{pid}/stat').read_text().split(') ',1)[1].split()[0]!='Z'
-    except FileNotFoundError: return False
+    # Linux may return ESRCH after open succeeds but the task exits during
+    # read. Both missing-task outcomes mean the process is no longer live.
+    except (FileNotFoundError, ProcessLookupError): return False
 
 
 def test_claim_consumed_and_live_slot_released(saved):


### PR DESCRIPTION
## Why this matters
[This public-beta CI run](https://github.com/Osmantic/ODS/actions/runs/34708352721/job/103592424453) failed in `test_supervisor_sigkill_closes_orphan_listener` after the worker had already disappeared: reading its open `/proc/<pid>/stat` raised `ProcessLookupError: ESRCH`. The helper handles ENOENT but not the kernel's exit-during-read outcome. This turns successful process cleanup into intermittent CI failure.

Recognize ESRCH alongside ENOENT in both Linux process-state helpers used by the route-worker and advice-setup lifecycle tests. Other access failures still fail visibly; timeouts, listener-closure assertions, lock ownership checks, and actual process cleanup remain intact.

## Overlap check
Searched open and closed PR titles and changed files. Inspected #4427, which reformats these test files for public-beta lint but leaves both process-state helpers unchanged. No existing ESRCH race fix found.

## Validation
- Deterministic fault injection: 2 ESRCH cases fail on public-beta, 10 existing-outcome controls pass.
- **39 tests pass** across the new regression and both real process-lifecycle suites, including supervisor SIGKILL, descendant teardown, EOF and listener/lock checks.
- New regression module passes CI-rule Ruff; diff whitespace check passes. Existing semicolon/style lint debt in the two old test modules is handled by #4427.
- Linux/WSL only; no production process-control code is changed.

AI assistance: implemented and validated with Codex.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Procfs/route-worker/advice-process suites: 39 passed, including deterministic ESRCH and real process cleanup. Dashboard: 906 passed.
