### PR TITLE
fix(token-spy): record cumulative Anthropic usage counters

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -26,6 +26,7 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Streamin
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from filters import apply_filters
 from providers import ProviderRegistry
+from providers.anthropic import cumulative_usage_update
 from routed_telemetry import (
     TelemetryValidationError,
     routed_event_to_usage,
@@ -745,8 +746,10 @@ async def _handle_streaming(client, raw_body, headers, model, sys_analysis,
 
                         elif current_event == "message_delta":
                             delta_usage = data.get("usage", {})
-                            if delta_usage.get("output_tokens") is not None:
-                                usage["output_tokens"] = delta_usage["output_tokens"]
+                            # Anthropic deltas carry cumulative counters, including
+                            # revised input/cache usage. Omitted fields retain
+                            # the last observation; explicit zero is authoritative.
+                            usage.update(cumulative_usage_update(delta_usage))
                             stop = data.get("delta", {}).get("stop_reason")
                             if stop:
                                 usage["stop_reason"] = stop

--- a/ods/extensions/services/token-spy/providers/anthropic.py
+++ b/ods/extensions/services/token-spy/providers/anthropic.py
@@ -13,6 +13,18 @@ from .base import LLMProvider
 from .registry import register_provider
 
 
+def cumulative_usage_update(usage: dict) -> dict:
+    """Normalize present counters without resetting omitted/nullable deltas."""
+    names = {
+        "input_tokens": "input_tokens",
+        "output_tokens": "output_tokens",
+        "cache_read_input_tokens": "cache_read_tokens",
+        "cache_creation_input_tokens": "cache_write_tokens",
+    }
+    return {target: usage[source] for source, target in names.items()
+            if usage.get(source) is not None}
+
+
 @register_provider("anthropic")
 class AnthropicProvider(LLMProvider):
     """Anthropic Messages API provider (Claude models)."""
@@ -240,8 +252,7 @@ class AnthropicProvider(LLMProvider):
             delta_usage = data.get("usage", {})
             delta = data.get("delta", {})
 
-            if delta_usage.get("output_tokens") is not None:
-                result["output_tokens"] = delta_usage["output_tokens"]
+            result.update(cumulative_usage_update(delta_usage))
 
             if delta.get("stop_reason"):
                 result["stop_reason"] = delta["stop_reason"]

--- a/ods/extensions/services/token-spy/tests/test_anthropic_cumulative_usage.py
+++ b/ods/extensions/services/token-spy/tests/test_anthropic_cumulative_usage.py
@@ -1,0 +1,75 @@
+"""Exercise cumulative Anthropic usage at Token Spy's authenticated HTTP route."""
+import asyncio
+import importlib.util
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def proxy(monkeypatch):
+    service = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "usage-regression-key")
+    monkeypatch.setenv("UPSTREAM_API_KEY", "synthetic-provider-key")
+    spec = importlib.util.spec_from_file_location("token_spy_cumulative_usage", service / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    entries = []
+    monkeypatch.setattr(module, "_log_entry", lambda *args, **kwargs: entries.append(dict(args[5])))
+    return module, entries
+
+
+def event(kind, **data):
+    return f"event: {kind}\ndata: {json.dumps(dict(type=kind, **data))}\n\n"
+
+
+@pytest.mark.parametrize("final,expected", [
+    ({"input_tokens": 40, "output_tokens": 12, "cache_read_input_tokens": 80,
+      "cache_creation_input_tokens": 20}, (40, 12, 80, 20)),
+    ({"input_tokens": 0, "output_tokens": 12, "cache_read_input_tokens": 0,
+      "cache_creation_input_tokens": 0}, (0, 12, 0, 0)),
+    ({"input_tokens": None, "output_tokens": 12}, (10, 12, 30, 5)),
+    ({"output_tokens": 12}, (10, 12, 30, 5)),
+])
+def test_final_cumulative_counters_replace_initial_values(proxy, monkeypatch, final, expected):
+    module, entries = proxy
+    payload = (
+        event("message_start", message={"usage": {"input_tokens": 10, "output_tokens": 1,
+              "cache_read_input_tokens": 30, "cache_creation_input_tokens": 5}})
+        + event("message_delta", delta={}, usage={"output_tokens": 4})
+        + event("message_delta", delta={"stop_reason": "end_turn"}, usage=final)
+        + event("message_stop")
+    )
+    upstream = httpx.AsyncClient(base_url="https://upstream.invalid",
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, content=payload)))
+    monkeypatch.setattr(module, "get_http_client", lambda: upstream)
+    client = TestClient(module.app)
+    try:
+        response = client.post("/v1/messages",
+            headers={"Authorization": "Bearer usage-regression-key"},
+            json={"model": "test", "stream": True, "messages": [
+                {"role": "user", "content": "Hello"}]})
+        assert response.status_code == 200
+        assert response.text == payload
+        assert len(entries) == 1
+        assert tuple(entries[0][key] for key in (
+            "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"
+        )) == expected
+        assert entries[0]["stop_reason"] == "end_turn"
+
+        from providers.anthropic import AnthropicProvider
+        adapter = AnthropicProvider()
+        captured = {"input_tokens": 10, "output_tokens": 1,
+                    "cache_read_tokens": 30, "cache_write_tokens": 5}
+        captured.update(adapter.extract_usage_from_stream(
+            "data: " + json.dumps({"usage": final, "delta": {}}), "message_delta") or {})
+        assert tuple(captured[key] for key in (
+            "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens"
+        )) == expected
+    finally:
+        client.close()
+        asyncio.run(upstream.aclose())


### PR DESCRIPTION
## Why this matters
Anthropic message deltas can carry cumulative input and cache counters, in addition to output tokens. Token Spy currently retains the initial input/cache values and only updates output, under-reporting a response whose final counters differ.

Normalize the present cumulative counters in one helper used by the deployed Messages proxy and provider adapter. Replace previous values rather than adding them; retain prior observations for omitted/null fields and honor explicit zero values. Stream content and event framing are unchanged.

Contract references: [Anthropic streaming usage is cumulative](https://platform.claude.com/docs/en/build-with-claude/streaming) and [MessageDeltaUsage fields](https://platform.claude.com/docs/en/api/typescript/messages).

## Overlap check
Searched open/closed titles and changed files. #2511 changes Claude model pricing; #2519 fixes OpenAI cached-token accounting; #3595 prices routed telemetry. Inspected #3806: it handles nullable usage containers but does not record cumulative input/cache deltas. This changes counter extraction, not rates or nullable-container policy.

## Validation
- Authenticated `POST /v1/messages` regressions on public-beta: **2 fail, 2 controls pass**.
- Full Token Spy suite: **26 passed, 1 skipped** (PostgreSQL integration unavailable).
- Same scenarios exercise the provider adapter after the HTTP assertions.
- Multiple deltas, revised input/cache totals, explicit zeros, omitted/null individual fields, exact passthrough text, one logged entry, and stop reason are checked.
- Changed-file Ruff with CI rules and diff whitespace checks pass.
- Mock upstream transport; no live provider calls or billing charges.

## Review / risk
Review required before merge: independent review of proxy telemetry behavior and the live proxy validation lane. Pricing tables and requests are unchanged.

AI assistance: implemented and validated with Codex.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped.

Merge guidance: tested Token Spy main.py order is #4561, #4569, #4583, #4634, #4640. The #4583/#4634 poller conflict must retain await asyncio.to_thread for status and reset, include_session_id=True on assessment, session_id=status["_reset_session_id"] on deletion, and cooldown updates only after action == "killed".

Exact PR-head CI remains red: Windows dashboard compact-draft assertion in RemoteProvider. See [run 34709252447](https://github.com/Osmantic/ODS/actions/runs/34709252447). #4570 addresses the overwrite; the combined dashboard suite passes all 906 tests. The contributing account lacks repository rerun permission (HTTP 403 on the same workflow).
