### PR TITLE
fix(workflows): require declared healthy dependencies

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -82,7 +82,9 @@ async def check_workflow_dependencies(deps: list[str], health_cache: dict[str, b
             health_cache[resolved] = healthy
             results[dep] = healthy
         else:
-            results[dep] = True
+            # An undeclared/uninstalled service has no health evidence.
+            # Keep the catalog and enable prerequisite unavailable.
+            results[dep] = False
     return results
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_workflow_missing_dependencies.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflow_missing_dependencies.py
@@ -1,0 +1,60 @@
+"""Unknown workflow dependencies cannot pass the public enable prerequisite."""
+import json
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+
+@pytest.fixture
+def workflow_catalog(monkeypatch, tmp_path):
+    import routers.workflows as workflows
+    catalog = {"categories": {}, "workflows": [{
+        "id": "example", "name": "Example", "description": "Example workflow",
+        "file": "example.json", "dependencies": ["missing-extension"],
+    }]}
+    (tmp_path / "example.json").write_text(json.dumps({"name": "Example", "nodes": []}))
+    monkeypatch.setattr(workflows, "WORKFLOW_DIR", tmp_path)
+    monkeypatch.setattr(workflows, "load_workflow_catalog", lambda: catalog)
+    monkeypatch.setattr(workflows, "SERVICES", {
+        "llama-server": {"name": "LLM", "port": 8080},
+    })
+    monkeypatch.setattr(workflows, "get_n8n_workflows", AsyncMock(return_value=[]))
+    monkeypatch.setattr(workflows, "check_n8n_available", AsyncMock(return_value=True))
+    return workflows, catalog
+
+
+def test_catalog_does_not_claim_unknown_dependencies_are_ready(test_client, workflow_catalog):
+    response = test_client.get("/api/workflows", headers=test_client.auth_headers)
+    assert response.status_code == 200
+    entry = response.json()["workflows"][0]
+    assert entry["dependencyStatus"] == {"missing-extension": False}
+    assert entry["allDependenciesMet"] is False
+
+
+def test_enable_stops_before_n8n_mutation_for_unknown_dependency(
+    test_client, workflow_catalog, monkeypatch,
+):
+    workflows, _ = workflow_catalog
+    upstream = Mock(side_effect=AssertionError("n8n must not be contacted"))
+    monkeypatch.setattr(workflows.aiohttp, "ClientSession", upstream)
+    response = test_client.post("/api/workflows/example/enable", headers=test_client.auth_headers)
+    assert response.status_code == 400
+    assert "Missing dependencies: missing-extension" in response.json()["detail"]
+    upstream.assert_not_called()
+
+
+@pytest.mark.parametrize("status,expected", [("healthy", True), ("down", False)])
+def test_known_legacy_alias_still_uses_the_real_health_probe(
+    test_client, workflow_catalog, monkeypatch, status, expected,
+):
+    from models import ServiceStatus
+    _, catalog = workflow_catalog
+    catalog["workflows"][0]["dependencies"] = ["ollama", "llama-server"]
+    health = AsyncMock(return_value=ServiceStatus(
+        id="llama-server", name="LLM", port=8080, external_port=8080, status=status))
+    monkeypatch.setattr("helpers.check_service_health", health)
+    response = test_client.get("/api/workflows", headers=test_client.auth_headers)
+    entry = response.json()["workflows"][0]
+    assert entry["dependencyStatus"] == {"ollama": expected, "llama-server": expected}
+    assert entry["allDependenciesMet"] is expected
+    health.assert_awaited_once()

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -224,6 +224,7 @@ def test_check_workflow_dependencies_with_alias(test_client, monkeypatch):
     import routers.workflows as wf_mod
     from models import ServiceStatus
 
+    monkeypatch.setitem(wf_mod.SERVICES, "llama-server", {"name": "LLM Server", "port": 8080})
     healthy_status = ServiceStatus(
         id="llama-server", name="LLM Server", port=8080,
         external_port=8080, status="healthy",
@@ -263,14 +264,14 @@ def test_check_workflow_dependencies_unhealthy(test_client, monkeypatch):
 
 
 def test_check_workflow_dependencies_unknown_dep(test_client, monkeypatch):
-    """check_workflow_dependencies returns True for deps not in SERVICES."""
+    """Unknown dependencies have no health evidence and remain unavailable."""
     import routers.workflows as wf_mod
 
     import asyncio
     result = asyncio.run(
         wf_mod.check_workflow_dependencies(["totally-unknown-service-xyz"])
     )
-    assert result["totally-unknown-service-xyz"] is True
+    assert result["totally-unknown-service-xyz"] is False
 
 
 def test_check_workflow_dependencies_uses_cache(test_client, monkeypatch):


### PR DESCRIPTION
## Why this matters
A workflow naming an extension absent from the active service registry is currently reported as having all prerequisites satisfied, and enable proceeds to contact n8n. There was no health check establishing that the dependency exists or is running.

Treat unresolved dependencies as unavailable. Both the catalog's readiness fields and the existing enable prerequisite now agree; enable returns the existing missing-dependency response before any n8n mutation.

Closes #4192.

## Overlap check
Searched open/closed titles, bodies and changed files. Inspected #2187 and #2495: they resolve additional aliases but deliberately retain the permissive unknown-name branch. This fixes that separate fallback. Declared healthy aliases continue to work and share their health cache; resolving additional manifest aliases remains in those PRs. #3244 concerns extension catalog dependencies.

## Validation
- Public catalog/enable boundary: **2 regressions fail, 2 controls pass** on public-beta.
- **49 workflow tests pass**, including known healthy/down services, legacy alias resolution, cache reuse, and prevention of n8n contact.
- Updated the previous unit expectation that explicitly blessed unknown dependencies, and made its alias control declare the service it expects to probe.
- Changed-file CI-rule Ruff and diff whitespace checks pass.
- Mock health/n8n boundaries; no live workflow was imported. The existing workflow suite emits an unclosed aiohttp-session warning.

## Review / risk
Review required before merge: independent review and live workflow validation. Catalog entries with unresolved names now require repair/installation before enable, as intended by the prerequisite contract.

AI assistance: implemented and validated with Codex.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Full dashboard API: 2,703 passed, 2 skipped.
