### PR TITLE
perf(token-spy): bound memory for local session status polls

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -1097,38 +1097,39 @@ def _get_local_session_status(agent: str) -> dict:
         return None
 
     largest = files[0]
-    try:
-        with open(largest) as f:
-            lines = f.readlines()
-    except Exception:
-        log.warning(f"[SESSION] Failed to read session file: {largest}")
-        return None
-
     user_turns = 0
     assistant_turns = 0
     history_chars = 0
     tool_results = 0
-    for line in lines:
-        try:
-            d = json.loads(line)
-            if d.get("type") == "message":
-                msg = d.get("message", {})
-                if isinstance(msg, str):
-                    msg = json.loads(msg)
-                role = msg.get("role", "")
-                if role == "user":
-                    user_turns += 1
-                elif role == "assistant":
-                    assistant_turns += 1
-                if role in ("toolResult", "tool") or msg.get("tool_call_id"):
-                    tool_results += 1
-                c = msg.get("content", "")
-                if isinstance(c, list):
-                    history_chars += sum(len(str(x)) for x in c)
-                elif isinstance(c, str):
-                    history_chars += len(c)
-        except (json.JSONDecodeError, KeyError, TypeError):
-            pass  # skip malformed JSONL lines
+    total_lines = 0
+    try:
+        with open(largest) as session_file:
+            for line in session_file:
+                total_lines += 1
+                try:
+                    d = json.loads(line)
+                    if d.get("type") == "message":
+                        msg = d.get("message", {})
+                        if isinstance(msg, str):
+                            msg = json.loads(msg)
+                        role = msg.get("role", "")
+                        if role == "user":
+                            user_turns += 1
+                        elif role == "assistant":
+                            assistant_turns += 1
+                        if role in ("toolResult", "tool") or msg.get("tool_call_id"):
+                            tool_results += 1
+                        c = msg.get("content", "")
+                        if isinstance(c, list):
+                            history_chars += sum(len(str(x)) for x in c)
+                        elif isinstance(c, str):
+                            history_chars += len(c)
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    pass  # skip malformed JSONL lines
+
+    except (OSError, UnicodeError):
+        log.warning(f"[SESSION] Failed to read session file: {largest}")
+        return None
 
     limit = get_agent_setting(agent, "session_char_limit") or AUTO_RESET_HISTORY_CHARS
     if tool_results >= 480:
@@ -1159,7 +1160,7 @@ def _get_local_session_status(agent: str) -> dict:
         "is_local_model": agent in LOCAL_MODEL_AGENTS,
         "tool_results": tool_results,
         "file_bytes": os.path.getsize(largest),
-        "total_lines": len(lines),
+        "total_lines": total_lines,
         "session_files": len(files),
     }
 

--- a/ods/extensions/services/token-spy/tests/test_local_session_memory.py
+++ b/ods/extensions/services/token-spy/tests/test_local_session_memory.py
@@ -1,0 +1,77 @@
+"""Session-status HTTP fallback stays bounded for long local-model histories."""
+import importlib.util
+import json
+import tracemalloc
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def local_status(monkeypatch, tmp_path):
+    service = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "local-history-test-key")
+    spec = importlib.util.spec_from_file_location("token_spy_local_history", service / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "AGENT_SESSION_DIRS", {"local-test": str(tmp_path)})
+    monkeypatch.setattr(module, "_db_available", False)
+    monkeypatch.setattr(module, "get_agent_setting", lambda *_: 200_000)
+    client = TestClient(module.app)
+    try:
+        yield client, tmp_path
+    finally:
+        client.close()
+
+
+def read_status(client):
+    response = client.get("/api/session-status?agent=local-test",
+                          headers={"Authorization": "Bearer local-history-test-key"})
+    assert response.status_code == 200
+    return response.json()
+
+
+def test_large_local_history_has_bounded_peak_memory(local_status):
+    client, directory = local_status
+    path = directory / "current.jsonl"
+    content = "x" * 1024
+    row = json.dumps({"type": "message", "message": {"role": "user", "content": content}}) + "\n"
+    with path.open("w") as stream:
+        for _ in range(12_000):
+            stream.write(row)
+    read_status(client)  # Warm HTTP/import machinery outside the memory measurement.
+    tracemalloc.start()
+    try:
+        result = read_status(client)
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+    assert result["current_session_turns"] == 12_000
+    assert result["current_history_chars"] == 12_288_000
+    assert result["total_lines"] == 12_000
+    assert result["file_bytes"] == path.stat().st_size
+    assert result["recommendation"] == "reset_recommended"
+    # The ~13 MB history must not be retained in memory for a status poll.
+    assert peak < 3_000_000, f"session-status allocated {peak:,} bytes"
+
+
+def test_streamed_counts_include_blank_and_malformed_lines(local_status):
+    client, directory = local_status
+    rows = [
+        {"type": "message", "message": {"role": "assistant", "content": "hello"}},
+        {"type": "message", "message": json.dumps({"role": "tool", "content": "done"})},
+        {"type": "message", "message": {"role": "user", "content": ["one", "two"]}},
+        {"type": "metadata"},
+    ]
+    path = directory / "current.jsonl"
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\ninvalid\n\n")
+    result = read_status(client)
+    assert result["current_session_turns"] == 1
+    assert result["current_history_chars"] == 15
+    assert result["tool_results"] == 1
+    assert result["total_lines"] == 6
+    assert result["session_files"] == 1
+    assert result["file_bytes"] == path.stat().st_size
+    assert result["recommendation"] == "healthy"


### PR DESCRIPTION
**Why this matters:** A local-model agent with a long JSONL conversation causes every authenticated session-status poll to load the entire history into memory. A 12,000-turn fixture (~13 MB) allocated 13,724,595 bytes in the existing HTTP fallback. Read the file incrementally while preserving turn counts, tool counts, history characters, malformed-line handling, file size and recommendations.

Evidence and validation:
- Regression exercises GET /api/session-status with database fallback and a real local history, including a measured peak-memory budget of 3 MB after warming HTTP machinery.
- Before: 1 regression failed, 1 counting control passed. After: full Token Spy suite **24 passed, 1 skipped**. Changed-file Ruff E/F/W checks and git diff --check pass.
- Separate mixed-record fixture verifies blank/malformed lines and string-encoded messages.
- Overlap check: open/closed title and changed-file searches found #2691 (narrow exception handling in these helpers); its patch does not stream the history. This uses its intended I/O exception boundary for the stream. No remote SSH behavior or reset selection is changed.

AI assistance: implemented and validated with Codex. Local HTTP tests use synthetic session files and no live agent. Review required before merge: independent review of session monitoring, which feeds automatic reset decisions.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped, including the public HTTP memory-budget regression.

Merge guidance: tested Token Spy main.py order is #4561, #4569, #4583, #4634, #4640. The #4583/#4634 poller conflict must retain await asyncio.to_thread for status and reset, include_session_id=True on assessment, session_id=status["_reset_session_id"] on deletion, and cooldown updates only after action == "killed".
