### PR TITLE
fix(remote-provider): preserve edits made during configuration

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   AlertCircle,
   CheckCircle2,
@@ -320,7 +320,7 @@ export default function RemoteProvider({ compact = false }) {
   const [testResult, setTestResult] = useState(null)
   const [testError, setTestError] = useState(null)
   const [form, setForm] = useState(INITIAL_FORM)
-  const [formDirty, setFormDirty] = useState(false)
+  const formEdit = useRef({ dirty: false, revision: 0 })
   const [planning, setPlanning] = useState(false)
   const [applyingAction, setApplyingAction] = useState(null)
   const [planResult, setPlanResult] = useState(null)
@@ -337,6 +337,17 @@ export default function RemoteProvider({ compact = false }) {
     try {
       const payload = await fetchJson('/api/remote-provider/status')
       setStatusData(payload)
+      const provider = payload?.routeState?.provider
+      if (!formEdit.current.dirty && provider) {
+        setForm(current => ({
+          ...current,
+          baseUrl: provider.baseUrl || '',
+          model: provider.model || '',
+          contextLength: String(provider.contextLength || 32768),
+          maxTokens: String(provider.maxTokens || 4096),
+          reasoning: provider.reasoning === true,
+        }))
+      }
       setError(null)
       return payload
     } catch (err) {
@@ -381,21 +392,10 @@ export default function RemoteProvider({ compact = false }) {
     void loadPeerModels()
   }, [loadPeerModels, statusData?.capabilities?.odsPeerLifecycle, statusData])
 
-  useEffect(() => {
-    const provider = statusData?.routeState?.provider
-    if (formDirty || !provider) return
-    setForm(current => ({
-      ...current,
-      baseUrl: provider.baseUrl || '',
-      model: provider.model || '',
-      contextLength: String(provider.contextLength || 32768),
-      maxTokens: String(provider.maxTokens || 4096),
-      reasoning: provider.reasoning === true,
-    }))
-  }, [formDirty, statusData])
 
   const updateForm = (key, value) => {
-    setFormDirty(true)
+    formEdit.current.dirty = true
+    formEdit.current.revision += 1
     setForm(current => ({ ...current, [key]: value }))
   }
 
@@ -437,12 +437,13 @@ export default function RemoteProvider({ compact = false }) {
     setTestResult(null)
     setTestError(null)
     try {
+      const submittedRevision = formEdit.current.revision
       const payload = action === 'configure' ? configurePayload(form) : { action }
       const result = await fetchJson('/api/remote-provider/apply', jsonOptions(payload), LIFECYCLE_TIMEOUT_MS)
       setLifecycleResult(result)
-      if (action === 'configure') {
+      if (action === 'configure' && formEdit.current.revision === submittedRevision) {
         setForm(current => ({ ...current, apiKey: '' }))
-        setFormDirty(false)
+        formEdit.current.dirty = false
       }
       await loadStatus({ quiet: true })
     } catch (err) {

--- a/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/RemoteProvider.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createElement } from 'react'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import RemoteProvider from './RemoteProvider'
@@ -614,4 +614,37 @@ test('confirms peer model delete before proxying removal', async () => {
   expect(confirmSpy).toHaveBeenCalledWith('Delete Remote Qwen from the remote ODS peer?')
   expect(globalThis.fetch.mock.calls[3][0]).toBe('/api/remote-provider/peer/models/Qwen%2FQwen%203.5%209B')
   expect(globalThis.fetch.mock.calls[3][1].method).toBe('DELETE')
+})
+
+
+test.each(['apply', 'refresh'])('keeps newer edits while configure %s is pending', async pendingStage => {
+  let finishApply
+  let finishRefresh
+  const apply = new Promise(resolve => { finishApply = resolve })
+  const refresh = new Promise(resolve => { finishRefresh = resolve })
+  globalThis.fetch
+    .mockResolvedValueOnce(response(statusPayload))
+    .mockReturnValueOnce(apply)
+    .mockReturnValueOnce(refresh)
+
+  render(createElement(RemoteProvider))
+  await fillConfigureForm()
+  fireEvent.click(screen.getByRole('button', { name: 'Configure', exact: true }))
+  await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2))
+  if (pendingStage === 'refresh') {
+    await act(async () => { finishApply(response(configureApplyPayload)) })
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(3))
+  }
+
+  fireEvent.change(screen.getByLabelText('Base URL'), { target: { value: 'https://next.example/v1' } })
+  fireEvent.change(screen.getByLabelText('API key'), { target: { value: 'next-provider-token' } })
+  await act(async () => {
+    finishApply(response(configureApplyPayload))
+    finishRefresh(response(statusPayload))
+  })
+
+  expect(screen.getByLabelText('Base URL')).toHaveValue('https://next.example/v1')
+  expect(screen.getByLabelText('API key')).toHaveValue('next-provider-token')
+  expect(screen.getByRole('button', { name: 'Configure', exact: true })).toBeEnabled()
+  expect(requestBody(1).provider.baseUrl).toBe('https://gpu.example.test/v1')
 })


### PR DESCRIPTION
**Why this matters:** Editing the Remote GPU connection while a previous Configure request is pending loses the newer URL and API key when that request completes. The completion unconditionally marks the form clean, clears its key, and rehydrates it from server status.

Track the revision actually submitted. Clear a submitted draft only if it has not been edited since. Hydrate clean forms in the status response update itself, so displaying the form does not leave a later passive effect queued to overwrite input.

Validation:
- Deferred-HTTP regression: baseline **1 failed, 13 passed**. Final RemoteProvider suite **14 passed**, covering edits during apply and post-apply refresh, compact view navigation, successful secret clearing, lifecycle actions and peer models.
- Real Chromium component smoke: type a second URL/key while a synthetic configure response is held, release it, refresh status, navigate compact views, then inspect desktop/mobile. New draft survives; exactly one submitted request contains the original URL; no page errors.
- Dashboard lint exits 0 (existing warnings remain); production build and git diff --check pass.
- CI on unrelated Token Spy changes exposed the compact-view draft symptom on Ubuntu (run 34708563223) and Windows (run 34709252447). The new deferred-apply regression establishes the production overwrite independently; those old CI heads are not claimed green.

Overlap check: searched all-state titles and changed files for RemoteProvider/draft preservation. #3039 adds peer-download polling; #3275/#3208 add helper/summary tests; #4207 introduced the compact views. None handles submitted form revision ownership.

AI assistance: implemented and tested with Codex. Review required before merge: independent review of provider lifecycle UI. Browser requests were synthetic; no live provider was configured.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Dashboard: 906 passed; lint exits 0; production build passes. The initial default-worker run timed out in Settings; Settings alone passed all 11 tests, followed by all 906 with four workers.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) includes #3039 and passes the 15-test RemoteProvider suite within 63 affected UI tests. Retain peer-download polling without restoring the removed passive form-hydration effect; hydrate clean forms in loadStatus.
