### PR TITLE
fix(pixel-edge): honor the 2 MiB chat request limit

### DIFF
--- a/ods/extensions/services/pixel-edge/pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/pixel_edge.py
@@ -769,12 +769,13 @@ async def handle_chat_completions(request: web.Request):
         return web.json_response({"error": "request too large"}, status=413)
 
     try:
-        body = await request.read()
+        # Enforce this route's cap for both Content-Length and chunked bodies.
+        # Request.read() otherwise applies aiohttp's default 1 MiB cap first.
+        body = await _read_bounded(request.content, _MAX_BODY)
+    except ValueError:
+        return web.json_response({"error": "request too large"}, status=413)
     except Exception:
         return web.json_response({"error": "bad request"}, status=400)
-
-    if len(body) > _MAX_BODY:
-        return web.json_response({"error": "request too large"}, status=413)
 
     try:
         data = json.loads(body)

--- a/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
+++ b/ods/extensions/services/pixel-edge/tests/test_pixel_edge.py
@@ -186,7 +186,7 @@ async def _start_upstream():
     fd, path = tempfile.mkstemp(suffix=".sock")
     os.close(fd)
     os.unlink(path)
-    app = web.Application()
+    app = web.Application(client_max_size=2 * 1024 * 1024 + 1)
     app["chat_requests"] = []
     app["cancel_users"] = []
     app["native_runs"] = {}
@@ -1207,6 +1207,50 @@ class TestHeaderStripping(BaseEdgeTest):
 # ---------------------------------------------------------------------------
 
 class TestSizeLimit(BaseEdgeTest):
+
+    async def test_large_valid_body_reaches_upstream(self):
+        for size in (1024 * 1024 + 17, 2 * 1024 * 1024):
+            for chunked in (False, True):
+                with self.subTest(size=size, chunked=chunked):
+                    payload = {"model": "pixel/default", "messages": [
+                        {"role": "user", "content": "x"}]}
+                    raw = json.dumps(payload).encode()
+                    payload["messages"][0]["content"] += "x" * (1024 * 1024 - len(raw))
+                    raw = json.dumps(payload).encode()
+                    raw += b" " * (size - len(raw))
+                    self.assertEqual(len(raw), size)
+
+                    async def chunks():
+                        for offset in range(0, len(raw), 65536):
+                            yield raw[offset:offset + 65536]
+
+                    async with self.client.post(
+                        "http://localhost/v1/chat/completions",
+                        headers={**self.auth(), "Content-Type": "application/json"},
+                        data=chunks() if chunked else raw,
+                    ) as response:
+                        self.assertEqual(response.status, 200, await response.text())
+                    received = self.up_runner.app["chat_requests"][-1]
+                    self.assertTrue(received["messages"][0]["content"].startswith(
+                        payload["messages"][0]["content"]))
+                    self.assertEqual(received["model"], "openclaw/default")
+
+    async def test_chunked_over_limit_returns_413_without_upstream(self):
+        raw = b"x" * (2 * 1024 * 1024 + 1)
+
+        async def chunks():
+            for offset in range(0, len(raw), 65536):
+                yield raw[offset:offset + 65536]
+
+        async with self.client.post(
+            "http://localhost/v1/chat/completions",
+            headers={**self.auth(), "Content-Type": "application/json"},
+            data=chunks(),
+        ) as response:
+            self.assertEqual(response.status, 413)
+            self.assertEqual(await response.json(), {"error": "request too large"})
+        self.assertEqual(self.up_runner.app["chat_requests"], [])
+
     async def test_oversized_body_rejected(self):
         big = json.dumps({"model": "pixel/default",
                           "messages": [{"role": "user", "content": "x" * (2 * 1024 * 1024 + 1)}]})


### PR DESCRIPTION
**Why this matters:** Pixel Edge declares a 2 MiB chat request cap, but aiohttp's default Request.read() cap rejects valid bodies over 1 MiB as HTTP 400. Chunked bodies over the route limit also return 400 instead of 413.

Read the authenticated chat body through the existing bounded stream reader, enforcing the same inclusive 2 MiB limit with and without Content-Length. An oversized body is rejected before admission or any upstream request.

Validation:
- Real edge app and Unix-socket upstream: just over 1 MiB and exactly 2 MiB requests reach upstream, using both fixed-length and chunked transfer. The exact-limit fixture includes JSON whitespace so the rewritten request also fits the host ingress cap.
- A chunked limit+1 request returns 413 and leaves the upstream request list empty. Existing invalid-JSON and declared-length oversize controls remain.
- Final tests rerun against baseline: **2 failed, 2 passed**. Fixed size-limit tests: **4 passed**.
- Synthetic compatibility check with the existing #4330 socket cleanup patch: **111 passed** on Python 3.13, with no merge conflict. This is separate from the PR head.
- Full Pixel Edge suite on Python 3.13: **109 passed, 2 failed** in existing socket-unlink cleanup, already addressed by #4330. These failures are not hidden or counted as passes. Changed-file Ruff E/F/W and git diff --check pass.

Overlap check: searched all-state titles/files. #4403 fixes SSE framing, #4405 bounds response prelude memory, #4329 addresses preview directory links, and #4330 is test cleanup. None changes the chat request body limit.

AI assistance: implemented and tested with Codex. Review required before merge: independent review of the ingress boundary and live release validation. The upstream in local tests is synthetic; no host actions were run.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Pixel Edge body-limit suite: 4 passed. The separate compatibility candidate with #4330 passes all 111 Pixel Edge tests on Python 3.13.

Backlog compatibility candidate: [81ce0f0d1b1f](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936); #4330 retains Python 3.13 socket ownership during fixture cleanup.

Exact PR-head CI remains red in [openSUSE-Tumbleweed Matrix Smoke](https://github.com/Osmantic/ODS/actions/runs/34710584356/job/103598526898): repository metadata/package installation fails and rsync is unavailable, before product smoke tests. This PR changes no installer files. Other 31 checks pass; 4 are skipped. The contributing account cannot request repository workflow reruns (HTTP 403).
