### PR TITLE
fix(privacy): preserve text encoding across streamed chunks

### DIFF
--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -4,6 +4,7 @@ M3: API Privacy Shield - HTTP Proxy (ODS Integration)
 FastAPI-based proxy with connection pooling and PII caching.
 """
 
+import codecs
 import logging
 import os
 import re
@@ -356,7 +357,7 @@ async def proxy(request: Request, path: str):
             "X-Privacy-Shield": "active",
             "X-PII-Scrubbed": str(metadata.get("pii_count", 0)),
             "X-Processing-Time-Ms": f"{overhead_ms:.2f}",
-            "Content-Type": content_type,
+            "content-type": content_type,
         }
     )
 
@@ -391,6 +392,8 @@ async def proxy(request: Request, path: str):
                 # do_restore is only true when the body is uncompressed text,
                 # so raw bytes == decoded bytes here and stay byte-exact.
                 restorer = StreamRestorer(shield.detector, charset)
+                encoder = codecs.getincrementalencoder(charset)(errors="replace")
+                emitted = False
                 seen = 0
                 async for chunk in chunks:
                     seen += len(chunk)
@@ -400,18 +403,19 @@ async def proxy(request: Request, path: str):
                         # Continue draining the SAME iterator — do NOT
                         # re-iterate the upstream response.
                         tail = restorer.finalize()
-                        if tail:
-                            yield tail.encode(charset, "replace")
+                        if tail or emitted:
+                            yield encoder.encode(tail, final=True)
                         yield chunk
                         async for rest in chunks:
                             yield rest
                         return
                     out = restorer.feed(chunk)
                     if out:
-                        yield out.encode(charset, "replace")
+                        yield encoder.encode(out)
+                        emitted = True
                 tail = restorer.finalize()
-                if tail:
-                    yield tail.encode(charset, "replace")
+                if tail or emitted:
+                    yield encoder.encode(tail, final=True)
             else:
                 # Transparent byte-for-byte passthrough (compressed/binary):
                 # raw bytes preserve the original transport encoding.

--- a/ods/extensions/services/privacy-shield/tests/test_stream_encoding.py
+++ b/ods/extensions/services/privacy-shield/tests/test_stream_encoding.py
@@ -1,0 +1,42 @@
+"""Text restoration must emit one encoded document across transport chunks."""
+import asyncio
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from .test_streaming_proxy import AUTH, _resp, proxy
+
+
+@pytest.mark.parametrize("encoding", ["utf-8-sig", "utf-16", "utf-32", "utf-8"])
+@pytest.mark.parametrize("chunk_size", [7, 31])
+def test_restored_json_retains_one_encoding_stream(monkeypatch, encoding, chunk_size):
+    email = "encoding.fixture@example.com"
+    expected = {"reply": f"Hello 日本語 — {email}, goodbye."}
+
+    def upstream_response(request):
+        scrubbed = json.loads(request.content)["messages"][0]["content"]
+        assert email not in scrubbed
+        body = json.dumps({"reply": f"Hello 日本語 — {scrubbed}, goodbye."},
+                          ensure_ascii=False).encode(encoding)
+        return _resp(200, {"content-type": f"application/json; charset={encoding}"},
+                     [body[offset:offset + chunk_size]
+                      for offset in range(0, len(body), chunk_size)])
+
+    upstream = httpx.AsyncClient(transport=httpx.MockTransport(upstream_response))
+    monkeypatch.setattr(proxy, "http_client", upstream)
+    monkeypatch.setattr(proxy, "sessions", {})
+    client = TestClient(proxy.app)
+    try:
+        response = client.post("/v1/chat/completions", headers=AUTH,
+                               json={"messages": [{"role": "user", "content": email}]})
+        assert response.status_code == 200
+        restored = response.content.decode(encoding)
+        assert restored == json.dumps(expected, ensure_ascii=False)
+        assert json.loads(restored) == expected
+        assert response.headers["content-type"] == f"application/json; charset={encoding}"
+        assert "content-length" not in response.headers
+    finally:
+        client.close()
+        asyncio.run(upstream.aclose())


### PR DESCRIPTION
**Why this matters:** Privacy Shield incrementally decodes upstream text but independently re-encodes every emitted chunk. UTF-8-with-signature, UTF-16 and UTF-32 encoders therefore insert a fresh byte-order mark in the middle of the response. Even JSON keys can be split by U+FEFF and the restored response no longer matches the provider's document.

Keep one incremental encoder per response and flush it at completion. Emit one Content-Type field describing that stream; the existing case-mismatched header update duplicated this field.

Validation:
- Authenticated HTTP proxy regressions restore a real scrubbed email in Unicode JSON split at 7-byte and 31-byte boundaries.
- UTF-8-sig/UTF-16/UTF-32 each reproduce interior BOM corruption on the base; UTF-8 controls expose the duplicate Content-Type field. Baseline: **8 failed**. Fixed full Privacy Shield suite: **66 passed**.
- Tests verify exact decoded JSON, restored PII, retained charset and removed stale Content-Length. Changed-file Ruff E/F/W and git diff --check pass.

Overlap check: all-state titles/files searched. Inspected #3054: unknown charset passthrough, not stateful encoding. #3101 removes the restore-cap cutover for unknown-length streams; that separate issue and the existing cutover policy are not changed here. #4559 corrects detected PII spans, not response encoding.

AI assistance: implemented and validated with Codex. Review required before merge: independent proxy review. HTTP tests use a mock upstream transport; live provider streaming has not been validated.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Privacy Shield: 74 passed. Tested order: #4559, #4582, #4627.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) includes #3054 and #3101 and passes all 77 Privacy Shield tests. Combining #3101 with #4582 requires removing the mid-stream raw cutover while retaining one incremental encoder, its emitted flag, and final flush.
