### PR TITLE
fix(token-spy): reset the assessed local session

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -448,7 +448,7 @@ async def _poll_remote_agents():
             for agent in AGENT_SESSION_DIRS:
                 if agent == AGENT_NAME or agent in REMOTE_AGENTS:
                     continue  # skip agents that go through this proxy instance
-                status = _get_local_session_status(agent)
+                status = _get_local_session_status(agent, include_session_id=True)
                 if not status:
                     continue
                 chars = status.get("current_history_chars", 0)
@@ -461,8 +461,12 @@ async def _poll_remote_agents():
                 if needs_reset:
                     reason = f"tool loop ({tool_results} calls)" if tool_results >= 480 else f"history {chars:,} >= {limit:,}"
                     log.warning(f"[LOCAL-POLL] {agent}: auto-reset — {reason}")
-                    _kill_session(agent, reason=f"auto-reset ({reason})")
-                    _last_auto_reset[agent] = time.time()
+                    result = _kill_session(
+                        agent, reason=f"auto-reset ({reason})",
+                        session_id=status["_reset_session_id"],
+                    )
+                    if result.get("action") == "killed":
+                        _last_auto_reset[agent] = time.time()
                 elif chars > 0:
                     log.info(f"[LOCAL-POLL] {agent}: {chars:,} / {limit:,} chars ({chars*100//limit}%)")
         except Exception as e:
@@ -1083,7 +1087,7 @@ _last_auto_reset: dict[str, float] = {}
 
 
 
-def _get_local_session_status(agent: str) -> dict:
+def _get_local_session_status(agent: str, *, include_session_id: bool = False) -> dict:
     """Get session status for a local agent by reading JSONL files directly.
     Used for agents whose traffic doesn't pass through the token monitor proxy
     (e.g. agents using a local model via vLLM/Ollama)."""
@@ -1146,7 +1150,7 @@ def _get_local_session_status(agent: str) -> dict:
     # agents whose OpenClaw gateway doesn't log user messages in the JSONL.
     turns = user_turns if user_turns > 0 else assistant_turns
 
-    return {
+    result = {
         "agent": agent,
         "current_session_turns": turns,
         "current_history_chars": history_chars,
@@ -1162,6 +1166,10 @@ def _get_local_session_status(agent: str) -> dict:
         "total_lines": len(lines),
         "session_files": len(files),
     }
+    if include_session_id:
+        # Poller-only selection: public status responses keep their existing shape.
+        result["_reset_session_id"] = os.path.basename(largest)[:-len(".jsonl")]
+    return result
 
 
 def _get_local_accumulated_turns(agent: str) -> int:
@@ -1375,8 +1383,8 @@ def _kill_remote_session(agent: str, reason: str = "dashboard") -> dict:
         log.error(f"Remote session check failed for {agent}: {e}")
         return {"agent": agent, "action": "none", "reason": "Remote check failed"}
 
-def _kill_session(agent: str, reason: str = "manual") -> dict:
-    """Kill the largest active session for an agent. Returns result dict."""
+def _kill_session(agent: str, reason: str = "manual", *, session_id: str | None = None) -> dict:
+    """Reset the selected local session, or the largest for manual/proxy calls."""
     import subprocess
     if agent in REMOTE_AGENTS:
         return _kill_remote_session(agent, reason)
@@ -1385,16 +1393,20 @@ def _kill_session(agent: str, reason: str = "manual") -> dict:
     if not sessions_dir:
         return {"agent": agent, "action": "none", "reason": f"unknown agent: {agent}"}
 
-    result = subprocess.run(
-        ["ls", "-S", f"{sessions_dir}/"],
-        capture_output=True, text=True,
-    )
-    largest = None
-    for line in result.stdout.strip().split("\n"):
-        line = line.strip()
-        if line.endswith(".jsonl"):
-            largest = line.replace(".jsonl", "")
-            break
+    largest = session_id
+    if session_id is not None:
+        if not session_id or os.path.basename(session_id) != session_id or "\0" in session_id:
+            return {"agent": agent, "action": "none", "reason": "invalid session selection"}
+    else:
+        result = subprocess.run(
+            ["ls", "-S", f"{sessions_dir}/"],
+            capture_output=True, text=True,
+        )
+        for line in result.stdout.strip().split("\n"):
+            line = line.strip()
+            if line.endswith(".jsonl"):
+                largest = line.replace(".jsonl", "")
+                break
 
     if not largest:
         return {"agent": agent, "action": "none", "reason": "no active sessions found"}

--- a/ods/extensions/services/token-spy/tests/test_local_reset_target.py
+++ b/ods/extensions/services/token-spy/tests/test_local_reset_target.py
@@ -1,0 +1,88 @@
+"""The production poller must reset the local history it actually assessed."""
+import asyncio
+import importlib.util
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def local_agent(monkeypatch, tmp_path):
+    service = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "local-reset-fixture-key")
+    spec = importlib.util.spec_from_file_location("token_spy_reset_target", service / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "AGENT_NAME", "proxy-agent")
+    monkeypatch.setattr(module, "REMOTE_AGENTS", {})
+    monkeypatch.setattr(module, "AGENT_SESSION_DIRS", {"local-agent": str(tmp_path)})
+    monkeypatch.setattr(module, "get_agent_setting", lambda *_: 100)
+    monkeypatch.setattr(module, "_last_auto_reset", {})
+    for name, chars, timestamp in [("older-large", 1000, 100), ("current", 200, 200)]:
+        path = tmp_path / f"{name}.jsonl"
+        path.write_text(json.dumps({"type": "message", "message": {
+            "role": "user", "content": "x" * chars}}) + "\n")
+        os.utime(path, (timestamp, timestamp))
+    (tmp_path / "sessions.json").write_text(json.dumps({
+        "old": {"sessionId": "older-large"}, "new": {"sessionId": "current"}}))
+    return module, tmp_path
+
+
+def one_poll(module, monkeypatch):
+    calls = 0
+
+    async def pause(_delay):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(module.asyncio, "sleep", pause)
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(module._poll_remote_agents())
+
+
+def test_local_poll_resets_newest_assessed_history(local_agent, monkeypatch):
+    module, directory = local_agent
+    one_poll(module, monkeypatch)
+    assert (directory / "older-large.jsonl").exists()
+    assert not (directory / "current.jsonl").exists()
+    assert json.loads((directory / "sessions.json").read_text()) == {
+        "old": {"sessionId": "older-large"}}
+    assert "local-agent" in module._last_auto_reset
+
+
+def test_disappearing_assessed_history_never_retargets_another_file(local_agent, monkeypatch):
+    module, directory = local_agent
+    read_status = module._get_local_session_status
+
+    def disappear(*args, **kwargs):
+        status = read_status(*args, **kwargs)
+        (directory / "current.jsonl").unlink()
+        return status
+
+    monkeypatch.setattr(module, "_get_local_session_status", disappear)
+    one_poll(module, monkeypatch)
+    assert (directory / "older-large.jsonl").exists()
+    assert "local-agent" not in module._last_auto_reset
+
+
+def test_public_status_does_not_add_internal_reset_selection(local_agent):
+    module, _ = local_agent
+    assert not any(key.startswith("_") for key in module._get_local_session_status("local-agent"))
+
+
+def test_manual_reset_keeps_largest_session_behavior(local_agent, monkeypatch):
+    import subprocess
+    from types import SimpleNamespace
+
+    module, directory = local_agent
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: SimpleNamespace(
+        stdout="older-large.jsonl\ncurrent.jsonl\nsessions.json\n"))
+    result = module._kill_session("local-agent", reason="dashboard")
+    assert result["session_id"] == "older-large"
+    assert (directory / "current.jsonl").exists()
+    assert not (directory / "older-large.jsonl").exists()


### PR DESCRIPTION
**Why this matters:** The local-agent poller assesses the newest JSONL history by modification time, then calls a reset helper that independently selects the largest file. With an older large conversation and a newer over-limit one, it deletes the older conversation and leaves the assessed problem running.

Carry the assessed session ID into the local poller's reset operation. If that file has disappeared, stop without selecting another history. Record the cooldown only after an actual reset. Manual/proxy reset selection keeps its existing largest-session behavior; the public session-status response gains no internal selection metadata.

Validation:
- Exercise the real production polling loop against two temporary histories and their sessions.json index.
- Before: **2 failed, 2 controls passed**. After: **4 focused tests passed**; full Token Spy suite **26 passed, 1 skipped**.
- Verify only the newest assessed file/index entry is removed; disappearance never retargets the older file or records a successful reset; manual selection and public status shape remain covered.
- Changed-file Ruff E/F/W and git diff --check pass.

Overlap check: searched live/all-state titles and changed files. Inspected #1923 (shell session-manager active-ID extraction), #2803 (atomic index writes) and #2691 (I/O exception types). #4569 bounds local scanner memory. None binds the poller's reset target to the history it assessed.

AI assistance: implemented and tested with Codex. Review required before merge: independent review of destructive session operations and live validation. Deletion tests touch synthetic temporary files only. This binds selection by session ID; it does not add filesystem locking or replace the separate atomic index-write proposals.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped, including assessed-target deletion and event-loop responsiveness together.

Merge guidance: tested Token Spy main.py order is #4561, #4569, #4583, #4634, #4640. The #4583/#4634 poller conflict must retain await asyncio.to_thread for status and reset, include_session_id=True on assessment, session_id=status["_reset_session_id"] on deletion, and cooldown updates only after action == "killed".
