### PR TITLE
fix(models): recover from invalid Hub detail responses

### DIFF
--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceDetailsRecovery.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceDetailsRecovery.test.jsx
@@ -1,0 +1,44 @@
+import { Component, createElement } from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import HuggingFaceModelBrowser from './HuggingFaceModelBrowser'
+
+class BrowserBoundary extends Component {
+  state = { failed: false }
+  static getDerivedStateFromError() { return { failed: true } }
+  render() { return this.state.failed ? createElement('p', null, 'Model browser crashed') : this.props.children }
+}
+const repo = { id: 'fixture/model', author: 'fixture' }
+const details = { id: repo.id, artifacts: [], sha: 'a'.repeat(40) }
+const response = body => ({ ok: true, status: 200, json: async () => body })
+
+beforeEach(() => { vi.useFakeTimers() })
+afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.restoreAllMocks() })
+
+test.each([
+  ['HTML response', { ok: true, status: 200, json: async () => { throw new SyntaxError('Unexpected token <') } }],
+  ['error envelope', response({ error: 'Repository metadata unavailable' })],
+  ['missing artifact list', response({ ...details, artifacts: null })],
+  ['wrong repository', response({ ...details, id: 'another/model' })],
+])('keeps malformed %s recoverable in the artifact dialog', async (_name, badResponse) => {
+  const fetch = vi.fn()
+    .mockResolvedValueOnce(response({ models: [repo] }))
+    .mockResolvedValueOnce(badResponse)
+    .mockResolvedValueOnce(response(details))
+  vi.stubGlobal('fetch', fetch)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  render(createElement(BrowserBoundary, null, createElement(HuggingFaceModelBrowser)))
+
+  await act(async () => { await vi.advanceTimersByTimeAsync(350) })
+  await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Choose file' })) })
+  expect(screen.queryByText('Model browser crashed')).toBeNull()
+  expect(screen.getByRole('alert')).toHaveTextContent('Could not read repository metadata. Retry details.')
+  expect(screen.queryByRole('button', { name: 'Import', exact: true })).toBeNull()
+
+  await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'Retry details' })) })
+  expect(screen.queryByRole('alert')).toBeNull()
+  expect(screen.getByText(/no complete GGUF artifact/i)).toBeVisible()
+  expect(fetch.mock.calls.filter(([url]) => url.includes('/repositories/')).map(([url]) => url))
+    .toEqual(['/api/models/huggingface/repositories/fixture/model', '/api/models/huggingface/repositories/fixture/model'])
+  expect(fetch.mock.calls.some(([, options]) => options?.method === 'POST')).toBe(false)
+})

--- a/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
+++ b/ods/extensions/services/dashboard/src/components/model-library/HuggingFaceModelBrowser.jsx
@@ -73,6 +73,9 @@ export default function HuggingFaceModelBrowser({ gpu, downloadBusy, onImportSta
       const body = await responseJson(response)
       if (!response.ok) throw new Error(errorMessage(body, 'Could not inspect this repository'))
       if (detailsRequestRef.current !== requestId) return
+      if (body?.id !== model.id || !Array.isArray(body.artifacts)) {
+        throw new Error('Could not read repository metadata. Retry details.')
+      }
       setDetails(body)
     } catch (requestError) {
       if (detailsRequestRef.current === requestId) setDetailsError(requestError.message)


### PR DESCRIPTION
**Why this matters:** A successful HTTP response containing HTML, an error envelope, or a missing artifacts array can crash the Hugging Face artifact dialog instead of offering its existing Retry details action. The response helper converts unreadable JSON to an empty object, which then reaches rendering.

Require the requested repository ID and an artifacts array before accepting detail data. Invalid metadata stays in the dialog's error path; retry requests the same repository and cannot start an import.

Validation:
- Four UI regressions fail on the base: HTTP-200 HTML, error envelope, null artifacts, and another repository's response. Each verifies recovery through a valid retry.
- Final component + Models suites: **47 passed**. Dashboard lint exits 0 (existing warnings remain), production build and git diff --check pass.
- Real Chromium component smoke: HTTP-200 HTML shows a recoverable error, retry succeeds in a mobile viewport, no page errors or import requests. Desktop/mobile screenshots saved locally.

Overlap check: all-state title/file searches; inspected #3050 (cancels obsolete detail requests). #4339 handles obsolete search results and #4356 gives the dialog native modal behavior. None rejects an unusable detail envelope before rendering.

AI assistance: implemented and validated with Codex. Review required before merge: independent review of the model-import UI. Browser API responses were synthetic; no model was downloaded.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Dashboard: 906 passed; lint exits 0; production build passes.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) includes #3050 and passes 63 affected UI tests. Retain request cancellation and ownership checks before validating the repository envelope. #4356 native-dialog compatibility was not exercised on this candidate.
