### PR TITLE
fix(privacy): preserve JSON request parameters during scrubbing

### DIFF
--- a/ods/extensions/services/privacy-shield/PII_COVERAGE.md
+++ b/ods/extensions/services/privacy-shield/PII_COVERAGE.md
@@ -8,6 +8,15 @@ Privacy Shield provides PII (Personally Identifiable Information) detection and 
 
 **Status:** The current implementation uses regex-based pattern matching for PII detection.
 
+### JSON request bodies
+
+For application/json and application/*+json requests, detection runs on quoted
+string values. Object keys, numbers, booleans and null remain protocol data.
+For example, a numeric inference seed stays numeric while a phone number in a
+message string is replaced. Put personal text in string values; numeric JSON
+fields and object keys are outside this text filter's coverage. Non-JSON text
+bodies continue to use whole-text detection.
+
 ### Detected PII Types
 
 | Type | Pattern | Example |

--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -268,6 +268,31 @@ def _build_upstream_headers(request: Request, scrubbed_len: int | None) -> dict:
     return headers
 
 
+# JSON string tokens are disjoint: consume escapes without mistaking an escaped
+# quote for a value boundary. Keep number tokens and object keys as protocol data.
+_JSON_STRING = re.compile(r'"(?:[^"\\]|\\.)*"')
+_JSON_KEY_SUFFIX = re.compile(r"\s*:")
+
+
+def _scrub_request_text(shield: CachedPrivacyShield, text: str, content_type: str):
+    mime, _ = _parse_content_type(content_type)
+    if not (mime == "application/json" or mime.startswith("application/") and mime.endswith("+json")):
+        return shield.process_request(text)
+
+    _, metadata = shield.process_request("")
+
+    def scrub_value(match):
+        nonlocal metadata
+        if _JSON_KEY_SUFFIX.match(text, match.end()):
+            return match.group(0)
+        scrubbed, metadata = shield.process_request(match.group(0))
+        return scrubbed
+
+    scrubbed = _JSON_STRING.sub(scrub_value, text)
+    metadata["scrubbed"] = scrubbed != text
+    return scrubbed, metadata
+
+
 @app.post("/{path:path}", dependencies=[Depends(verify_api_key)])
 @app.get("/{path:path}", dependencies=[Depends(verify_api_key)])
 async def proxy(request: Request, path: str):
@@ -298,7 +323,9 @@ async def proxy(request: Request, path: str):
         outbound = raw_body
         metadata = {"pii_count": 0}
     else:
-        scrubbed_body, metadata = shield.process_request(body_str)
+        scrubbed_body, metadata = _scrub_request_text(
+            shield, body_str, request.headers.get("content-type", "")
+        )
         outbound = scrubbed_body.encode("utf-8")
 
     target_url = f"{TARGET_API_BASE}/{path}"

--- a/ods/extensions/services/privacy-shield/tests/test_json_request_scrubbing.py
+++ b/ods/extensions/services/privacy-shield/tests/test_json_request_scrubbing.py
@@ -1,0 +1,66 @@
+"""PII filtering must not turn JSON inference parameters into invalid JSON."""
+import asyncio
+import json
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from .test_streaming_proxy import AUTH, _resp, proxy
+
+
+@pytest.mark.parametrize("content_type", ["application/json", "application/problem+json"])
+def test_json_numeric_parameters_and_keys_remain_intact(monkeypatch, content_type):
+    phone = "2125550199"
+    body = {"seed": int(phone), "stream": False, "metadata": {phone: None},
+            "messages": [{"role": "user", "content": f'Call "{phone}" or mail seed@example.com.' }]}
+    requests = []
+
+    def upstream_response(request):
+        data = json.loads(request.content)
+        requests.append(data)
+        return _resp(200, {"content-type": "application/json"},
+                     [json.dumps({"reply": data["messages"][0]["content"]}).encode()])
+
+    upstream = httpx.AsyncClient(transport=httpx.MockTransport(upstream_response))
+    monkeypatch.setattr(proxy, "http_client", upstream)
+    monkeypatch.setattr(proxy, "sessions", {})
+    client = TestClient(proxy.app)
+    try:
+        response = client.post("/v1/chat/completions",
+                               headers={**AUTH, "Content-Type": content_type},
+                               content=json.dumps(body).encode())
+        assert response.status_code == 200
+        assert len(requests) == 1
+        sent = requests[0]
+        assert sent["seed"] == body["seed"] and type(sent["seed"]) is int
+        assert sent["stream"] is False
+        assert sent["metadata"] == {phone: None}
+        assert phone not in sent["messages"][0]["content"]
+        assert "seed@example.com" not in sent["messages"][0]["content"]
+        assert response.json() == {"reply": body["messages"][0]["content"]}
+    finally:
+        client.close()
+        asyncio.run(upstream.aclose())
+
+
+def test_plain_text_still_scrubs_number_like_pii(monkeypatch):
+    captured = []
+
+    def upstream_response(request):
+        captured.append(request.content)
+        return _resp(200, {"content-type": "text/plain"}, [request.content])
+
+    upstream = httpx.AsyncClient(transport=httpx.MockTransport(upstream_response))
+    monkeypatch.setattr(proxy, "http_client", upstream)
+    monkeypatch.setattr(proxy, "sessions", {})
+    client = TestClient(proxy.app)
+    try:
+        response = client.post("/echo", headers={**AUTH, "Content-Type": "text/plain"},
+                               content=b"Call 2125550199")
+        assert response.status_code == 200
+        assert b"2125550199" not in captured[0]
+        assert response.text == "Call 2125550199"
+    finally:
+        client.close()
+        asyncio.run(upstream.aclose())


### PR DESCRIPTION
**Why this matters:** A valid inference request with a numeric seed such as 2125550199 is currently scrubbed as one raw text blob. The phone detector replaces that JSON number with an unquoted PII token, making the upstream request invalid. Object keys can also be renamed by detection.

For application/json and application/*+json bodies, apply the existing detector to quoted string values while preserving object keys, number tokens, booleans, null and surrounding syntax. Consume escaped quotes as part of the same string token. Non-JSON text keeps whole-body detection. Document that numeric fields and object keys are outside this text filter's coverage.

Validation:
- Authenticated HTTP proxy + JSON-decoding upstream: preserve numeric seed, a number-like metadata key, false/null, and escaped quotes; redact phone/email in the message and restore the exact reply.
- Baseline **2 failed, 1 plain-text control passed**. Final full Privacy Shield suite **61 passed**.
- Non-JSON text control still scrubs number-like PII and restores it.
- Changed-file Ruff E/F/W and git diff --check pass.

Overlap check: all-state title/file searches found #3671 (request buffering cap), #3054 (unknown response charset), #3101 (response restore cutover), #4559 (exact detected spans), and #4582 (response encoder state). None preserves outbound JSON structure while scrubbing text.

AI assistance: implemented and tested with Codex. Review required before merge: independent privacy-policy review and live provider validation. Tests use synthetic upstream responses. This is a text filter, not schema-aware redaction of numeric personal fields; deployments requiring that need field-aware policy.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Privacy Shield: 74 passed. Tested order: #4559, #4582, #4627.

Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) includes #3054 and #3101 and passes all 77 Privacy Shield tests. Combining #3101 with #4582 requires removing the mid-stream raw cutover while retaining one incremental encoder, its emitted flag, and final flush.
