### PR TITLE
perf(token-spy): keep session polling off the HTTP event loop

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -440,7 +440,7 @@ async def _poll_remote_agents():
                 if needs_reset:
                     reason = f"tool loop ({tool_results} calls)" if tool_results >= 480 else f"history {chars:,} >= {limit:,}"
                     log.warning(f"[REMOTE-POLL] {agent}: auto-reset — {reason}")
-                    _kill_session(agent, reason=f"auto-reset ({reason})")
+                    await asyncio.to_thread(_kill_session, agent, reason=f"auto-reset ({reason})")
                     _last_auto_reset[agent] = time.time()
                 elif chars > 0:
                     log.info(f"[REMOTE-POLL] {agent}: {chars:,} / {limit:,} chars ({chars*100//limit}%)")
@@ -448,7 +448,7 @@ async def _poll_remote_agents():
             for agent in AGENT_SESSION_DIRS:
                 if agent == AGENT_NAME or agent in REMOTE_AGENTS:
                     continue  # skip agents that go through this proxy instance
-                status = _get_local_session_status(agent)
+                status = await asyncio.to_thread(_get_local_session_status, agent)
                 if not status:
                     continue
                 chars = status.get("current_history_chars", 0)
@@ -461,7 +461,7 @@ async def _poll_remote_agents():
                 if needs_reset:
                     reason = f"tool loop ({tool_results} calls)" if tool_results >= 480 else f"history {chars:,} >= {limit:,}"
                     log.warning(f"[LOCAL-POLL] {agent}: auto-reset — {reason}")
-                    _kill_session(agent, reason=f"auto-reset ({reason})")
+                    await asyncio.to_thread(_kill_session, agent, reason=f"auto-reset ({reason})")
                     _last_auto_reset[agent] = time.time()
                 elif chars > 0:
                     log.info(f"[LOCAL-POLL] {agent}: {chars:,} / {limit:,} chars ({chars*100//limit}%)")

--- a/ods/extensions/services/token-spy/tests/test_session_poll_responsiveness.py
+++ b/ods/extensions/services/token-spy/tests/test_session_poll_responsiveness.py
@@ -1,0 +1,67 @@
+"""A slow configured local session must not stall the HTTP proxy event loop."""
+import asyncio
+import importlib.util
+from pathlib import Path
+import threading
+
+import httpx
+import pytest
+
+
+@pytest.mark.parametrize("operation", ["status", "reset"])
+def test_health_responds_while_local_session_io_is_pending(monkeypatch, operation):
+    service = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "poll-responsiveness-key")
+    spec = importlib.util.spec_from_file_location("token_spy_poll_io", service / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "AGENT_NAME", "proxy-agent")
+    monkeypatch.setattr(module, "REMOTE_AGENTS", {})
+    monkeypatch.setattr(module, "AGENT_SESSION_DIRS", {"local-agent": "/unused-fixture"})
+    monkeypatch.setattr(module, "get_agent_setting", lambda *_: 100)
+    entered, release, finished = threading.Event(), threading.Event(), threading.Event()
+
+    def blocked_io(*args, **kwargs):
+        entered.set()
+        release.wait()
+        finished.set()
+        return {"current_history_chars": 200, "recommendation": "reset_recommended", "_reset_session_id": "fixture"}
+
+    monkeypatch.setattr(module, "_get_local_session_status", blocked_io if operation == "status"
+                        else lambda *args, **kwargs: {"current_history_chars": 200, "_reset_session_id": "fixture"})
+    monkeypatch.setattr(module, "_kill_session", blocked_io if operation == "reset"
+                        else lambda *args, **kwargs: {"action": "none"})
+    real_sleep = asyncio.sleep
+
+    async def poll_delay(delay):
+        if delay == 10:
+            return
+        if delay == 60:
+            raise asyncio.CancelledError
+        await real_sleep(delay)
+
+    monkeypatch.setattr(module.asyncio, "sleep", poll_delay)
+
+    async def exercise():
+        # Release even the old blocking implementation; failure is based on
+        # operation ordering, not a narrow response-time threshold.
+        watchdog = threading.Timer(6, release.set)
+        watchdog.start()
+        poll = asyncio.create_task(module._poll_remote_agents())
+        try:
+            assert await asyncio.to_thread(entered.wait, 6)
+            async with httpx.AsyncClient(transport=httpx.ASGITransport(app=module.app),
+                                       base_url="http://proxy.test") as client:
+                response = await client.get("/health")
+            assert response.status_code == 200
+            assert not finished.is_set(), "health only responded after the blocked session I/O ended"
+        finally:
+            release.set()
+            watchdog.cancel()
+            try:
+                await poll
+            except asyncio.CancelledError:
+                pass
+
+    asyncio.run(exercise())


### PR DESCRIPTION
**Why this matters:** The background session poller runs local history scans and session resets synchronously on Token Spy's asyncio loop. A slow configured local filesystem or reset command stalls unrelated HTTP requests, including health checks and proxy traffic.

Offload the local scan and both reset I/O calls to worker threads while keeping polling order, decisions and cooldown updates on the event loop.

Validation:
- Run the production poller with deliberately blocked local status/reset I/O and issue a real ASGI GET /health on the same event loop.
- Baseline: **2 failed**; health only responded after the blocked operation ended. Fixed full Token Spy suite: **24 passed, 1 skipped**.
- The regressions assert operation order, not a narrow latency target. A six-second watchdog releases the old implementation so failures finish; every worker is released and joined during cleanup.
- Changed-file Ruff E/F/W and git diff --check pass.

Overlap check: all-state title/file searches. Other event-loop PRs (#3739/#3498/#3350/#2700) affect remote-provider probes. #4569 bounds scanner memory and #4583 binds local reset selection; neither prevents poller I/O from blocking the proxy loop.

AI assistance: implemented and validated with Codex. Review required before merge: independent review of background session operations. Tests simulate stalled I/O; no live agent or remote reset was exercised.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped, including assessed-target deletion and event-loop responsiveness together.

Merge guidance: tested Token Spy main.py order is #4561, #4569, #4583, #4634, #4640. The #4583/#4634 poller conflict must retain await asyncio.to_thread for status and reset, include_session_id=True on assessment, session_id=status["_reset_session_id"] on deletion, and cooldown updates only after action == "killed".
