### PR TITLE
fix(dashboard-api): add dict rename keys bounds guard

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1372,3 +1372,18 @@ def numeric_exponential_moving_average_safe(values: list, alpha: float = 0.2) ->
         current = alpha * v + (1 - alpha) * current
         ema.append(current)
     return ema
+
+
+def dict_rename_keys_safe(d: dict | None, mapping: dict | None) -> dict:
+    """Safely rename dictionary keys according to a mapping dict {old_key: new_key}.
+    Returns {} on None or non-dict inputs.
+    """
+    if not isinstance(d, dict) or d is None:
+        return {}
+    if not isinstance(mapping, dict) or not mapping:
+        return dict(d)
+    result = {}
+    for k, v in d.items():
+        new_k = mapping.get(k, k)
+        result[new_k] = v
+    return result

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1740,3 +1740,15 @@ def test_flatten_bounds_cycles_and_large_depth_without_losing_empty_leaves():
         nested = {"child": nested}
     result = dict_flatten_nested_safe(nested, max_depth=100000)
     assert len(next(iter(result)).split(".")) == 128
+
+
+class TestDictRenameKeysSafe:
+    def test_valid_renaming(self):
+        from helpers import dict_rename_keys_safe
+        d = {"old_a": 1, "b": 2}
+        assert dict_rename_keys_safe(d, {"old_a": "new_a"}) == {"new_a": 1, "b": 2}
+
+    def test_invalid_inputs(self):
+        from helpers import dict_rename_keys_safe
+        assert dict_rename_keys_safe(None, {"a": "b"}) == {}
+        assert dict_rename_keys_safe({"a": 1}, None) == {"a": 1}


### PR DESCRIPTION
### Error
Missing dict rename keys check

### Root Cause
Unsafe execution

### Fix
Added dict rename keys guard

### Proof of Resolution
