### PR TITLE
fix(token-spy): count new turns across partial session cleanup

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -16,6 +16,7 @@ import re
 import secrets
 import shlex
 import tempfile
+import threading
 import time
 from pathlib import Path
 from urllib.parse import urlparse
@@ -1164,7 +1165,16 @@ def _get_local_session_status(agent: str) -> dict:
     }
 
 
+_accumulated_turns_lock = threading.Lock()
+
+
 def _get_local_accumulated_turns(agent: str) -> int:
+    # Summary handlers run in worker threads; serialize checkpoint updates.
+    with _accumulated_turns_lock:
+        return _read_local_accumulated_turns(agent)
+
+
+def _read_local_accumulated_turns(agent: str) -> int:
     """Count total turns across ALL session files for a local-model agent,
     with a persistent accumulator to survive session file cleanup/purge.
     Unlike _get_local_session_status (current session only), this gives the
@@ -1179,9 +1189,11 @@ def _get_local_accumulated_turns(agent: str) -> int:
     # whose OpenClaw gateway doesn't log user messages in the JSONL.
     import glob
     files = glob.glob(os.path.join(sessions_dir, "*.jsonl"))
-    user_turns = 0
-    assistant_turns = 0
+    file_counts = {}
+    scan_failed = False
     for fpath in files:
+        user_turns = 0
+        assistant_turns = 0
         try:
             with open(fpath) as f:
                 for line in f:
@@ -1198,9 +1210,17 @@ def _get_local_accumulated_turns(agent: str) -> int:
                                 assistant_turns += 1
                     except (json.JSONDecodeError, KeyError, TypeError):
                         pass  # skip malformed JSONL lines
-        except Exception:
+        except (OSError, UnicodeError):
             log.warning(f"[SESSION] Failed to read session file: {fpath}")
-    current_file_turns = user_turns if user_turns > 0 else assistant_turns
+            scan_failed = True
+        file_counts[os.path.basename(fpath)] = (user_turns, assistant_turns)
+    use_user_turns = any(counts[0] > 0 for counts in file_counts.values())
+    count_role = "user" if use_user_turns else "assistant"
+    current_counts = {
+        name: counts[0 if use_user_turns else 1]
+        for name, counts in file_counts.items()
+    }
+    current_file_turns = sum(current_counts.values())
 
     # Persistent accumulator — survives session purge (250KB/24h cleanup)
     acc_path = os.path.join(os.path.dirname(__file__), "data", f"{agent}-accumulated-turns.json")
@@ -1213,14 +1233,30 @@ def _get_local_accumulated_turns(agent: str) -> int:
     last_file_turns = acc.get("last_file_turns", 0)
     total = acc.get("total", 0)
 
-    if current_file_turns >= last_file_turns:
-        # Normal growth or no change — add the delta
-        total += (current_file_turns - last_file_turns)
-    else:
-        # Session files were purged (current < last) — add what's on disk now
-        total += current_file_turns
+    if scan_failed:
+        # A temporarily unreadable file is not evidence of cleanup. Keep the
+        # last complete snapshot so its recovery cannot count old turns again.
+        return total
 
-    acc = {"total": total, "last_file_turns": current_file_turns}
+    if "file_turns" in acc:
+        previous_counts = acc["file_turns"]
+        # Keep the existing user/assistant fallback rule. If its source changes,
+        # establish a fresh baseline instead of comparing unlike counters.
+        delta = (
+            sum(max(count - previous_counts.get(name, 0), 0)
+                for name, count in current_counts.items())
+            if not previous_counts or acc["count_role"] == count_role else 0
+        )
+    else:
+        # Migrate the scalar accumulator without recounting surviving history.
+        # Growth can be credited; a smaller snapshot cannot identify new work.
+        delta = max(current_file_turns - last_file_turns, 0)
+    total += delta
+
+    acc = {
+        "total": total, "last_file_turns": current_file_turns,
+        "count_role": count_role, "file_turns": current_counts,
+    }
     try:
         os.makedirs(os.path.dirname(acc_path), exist_ok=True)
         with open(acc_path, "w") as f:

--- a/ods/extensions/services/token-spy/tests/test_accumulated_turn_checkpoints.py
+++ b/ods/extensions/services/token-spy/tests/test_accumulated_turn_checkpoints.py
@@ -1,0 +1,102 @@
+"""Authenticated summary counts retain history without recounting surviving files."""
+import builtins
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def append_turns(path, count, role="user"):
+    with path.open("a") as stream:
+        for _ in range(count):
+            stream.write(json.dumps({"type": "message", "message": {
+                "role": role, "content": "fixture turn"}}) + "\n")
+
+
+@pytest.fixture
+def summary(monkeypatch, tmp_path):
+    service = Path(__file__).resolve().parents[1]
+    monkeypatch.syspath_prepend(str(service))
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "accumulator-fixture-key")
+    spec = importlib.util.spec_from_file_location("token_spy_accumulator", service / "main.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    directory = tmp_path / "sessions"
+    directory.mkdir()
+    monkeypatch.setattr(module, "__file__", str(tmp_path / "main.py"))
+    monkeypatch.setattr(module, "AGENT_SESSION_DIRS", {"local-agent": str(directory)})
+    monkeypatch.setattr(module, "LOCAL_MODEL_AGENTS", {"local-agent"})
+    monkeypatch.setattr(module, "_db_available", False)
+    monkeypatch.setattr(module, "get_agent_setting", lambda *_: 200_000)
+    client = TestClient(module.app)
+
+    def read():
+        response = client.get("/api/summary", headers={"Authorization": "Bearer accumulator-fixture-key"})
+        assert response.status_code == 200
+        rows = response.json()
+        return next(row["turns"] for row in rows if row["agent"] == "local-agent")
+
+    try:
+        yield read, directory, tmp_path / "data" / "local-agent-accumulated-turns.json"
+    finally:
+        client.close()
+
+
+@pytest.mark.parametrize("role", ["user", "assistant"])
+def test_partial_purge_never_recounts_surviving_turns(summary, role):
+    read, directory, _ = summary
+    append_turns(directory / "old.jsonl", 2, role)
+    append_turns(directory / "current.jsonl", 3, role)
+    assert read() == 5
+    (directory / "old.jsonl").unlink()
+    assert read() == 5
+    append_turns(directory / "current.jsonl", 1, role)
+    assert read() == 6
+    append_turns(directory / "new.jsonl", 4, role)
+    assert read() == 10
+    assert read() == 10
+
+
+@pytest.mark.parametrize("new_turns", [1, 2])
+def test_new_file_is_counted_even_when_cleanup_offsets_its_growth(summary, new_turns):
+    read, directory, _ = summary
+    append_turns(directory / "old.jsonl", 2)
+    append_turns(directory / "current.jsonl", 3)
+    assert read() == 5
+    (directory / "old.jsonl").unlink()
+    append_turns(directory / "new.jsonl", new_turns)
+    assert read() == 5 + new_turns
+
+
+def test_legacy_total_is_preserved_when_establishing_file_checkpoints(summary):
+    read, directory, state = summary
+    append_turns(directory / "old.jsonl", 2)
+    append_turns(directory / "current.jsonl", 3)
+    state.parent.mkdir()
+    state.write_text(json.dumps({"total": 100, "last_file_turns": 5}))
+    assert read() == 100
+    (directory / "old.jsonl").unlink()
+    assert read() == 100
+    append_turns(directory / "current.jsonl", 1)
+    assert read() == 101
+
+
+def test_failed_scan_does_not_replace_the_last_complete_checkpoint(summary, monkeypatch):
+    read, directory, _ = summary
+    append_turns(directory / "old.jsonl", 2)
+    append_turns(directory / "current.jsonl", 3)
+    assert read() == 5
+    original_open = builtins.open
+
+    def fail_current(path, *args, **kwargs):
+        if str(path) == str(directory / "current.jsonl"):
+            raise PermissionError("fixture temporarily unreadable")
+        return original_open(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(builtins, "open", fail_current)
+        assert read() == 5
+    append_turns(directory / "current.jsonl", 1)
+    assert read() == 6


### PR DESCRIPTION
**Why this matters:** Local-agent lifetime turns are counted incorrectly after partial session cleanup. If two files contain 2 and 3 turns, deleting the first makes the summary rise from 5 to 8. If cleanup and a new session offset each other, new turns can instead be missed. One aggregate file count cannot distinguish these cases.

Persist a per-file observation checkpoint and add only each retained/new file's growth. Removed history stays in the lifetime total without recounting survivors. Preserve the existing user-turn/assistant fallback rule, migrate the legacy scalar total conservatively, keep the last complete snapshot after an unreadable scan, and serialize in-process summary updates.

Validation:
- Authenticated GET /api/summary with real temporary JSONL histories, deletion, append and persisted legacy state.
- Baseline: **6 failed**. Final full Token Spy suite: **28 passed, 1 skipped**.
- Covers user/assistant histories, cleanup plus new files with equal or smaller aggregate size, legacy migration, and temporary read failures.
- Changed-file Ruff E/F/W and git diff --check pass.

Overlap check: all-state semantic/file search and inspection of #2798 (atomic accumulated-turn state writes) and #2691 (I/O exception narrowing). Neither changes counting after partial cleanup. #4569 addresses current-session memory and #4583 the reset target, not lifetime counting.

AI assistance: implemented and tested with Codex. Review required before merge: independent review of persisted telemetry. Existing totals are retained, not retrospectively repaired. Counts describe observed file growth; work removed between observations cannot be reconstructed. The lock coordinates threads in one process; cross-process/crash-safe persistence remains a separate concern, including #2798.

Combined validation: [c08b6695ff14](https://github.com/0xacee/ODS/tree/c08b6695ff14671054e24fa651715a372c370956) on public-beta base 9fc9f610735ae28b3f401c5de26578856028a7f2. Token Spy: 64 passed, 1 skipped, including partial-cleanup accounting, poll responsiveness, and reset-target regressions.

Merge guidance: tested Token Spy main.py order is #4561, #4569, #4583, #4634, #4640. The #4583/#4634 poller conflict must retain await asyncio.to_thread for status and reset, include_session_id=True on assessment, session_id=status["_reset_session_id"] on deletion, and cooldown updates only after action == "killed". Backlog compatibility: [candidate](https://github.com/0xacee/ODS/tree/81ce0f0d1b1f52325741bb7bab1fac5ac686b936) also includes #2798; all 64 Token Spy tests pass with atomic checkpoint replacement. This PR itself still uses the existing writer.
