### PR TITLE
feat: add network pre-flight connectivity checks

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -152,6 +152,19 @@ fn tier_description(tier: u8) -> String {
     }
 }
 
+// ---- Network ----
+
+#[tauri::command]
+pub async fn check_network() -> network::NetworkStatus {
+    tokio::task::spawn_blocking(network::check)
+        .await
+        .unwrap_or(network::NetworkStatus {
+            github_reachable: false,
+            docker_registry_reachable: false,
+            all_reachable: false,
+        })
+}
+
 // ---- Installation ----
 
 #[tauri::command]

--- a/installer/src-tauri/src/main.rs
+++ b/installer/src-tauri/src/main.rs
@@ -5,6 +5,7 @@ mod commands;
 mod docker;
 mod gpu;
 mod installer;
+mod network;
 mod platform;
 mod state;
 
@@ -14,6 +15,7 @@ fn main() {
             commands::check_system,
             commands::check_prerequisites,
             commands::install_prerequisites,
+            commands::check_network,
             commands::detect_gpu,
             commands::start_install,
             commands::get_install_progress,

--- a/installer/src-tauri/src/network.rs
+++ b/installer/src-tauri/src/network.rs
@@ -1,0 +1,34 @@
+use serde::Serialize;
+use std::net::{TcpStream, ToSocketAddrs};
+use std::time::Duration;
+
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const GITHUB_HOST: &str = "github.com:443";
+const DOCKER_REGISTRY_HOST: &str = "registry-1.docker.io:443";
+
+#[derive(Debug, Serialize)]
+pub struct NetworkStatus {
+    pub github_reachable: bool,
+    pub docker_registry_reachable: bool,
+    pub all_reachable: bool,
+}
+
+pub fn check() -> NetworkStatus {
+    let github_reachable = is_reachable(GITHUB_HOST);
+    let docker_registry_reachable = is_reachable(DOCKER_REGISTRY_HOST);
+    NetworkStatus {
+        github_reachable,
+        docker_registry_reachable,
+        all_reachable: github_reachable && docker_registry_reachable,
+    }
+}
+
+fn is_reachable(host: &str) -> bool {
+    match host.to_socket_addrs() {
+        Ok(mut addrs) => addrs
+            .next()
+            .map(|addr| TcpStream::connect_timeout(&addr, CONNECT_TIMEOUT).is_ok())
+            .unwrap_or(false),
+        Err(_) => false,
+    }
+}

--- a/installer/src/hooks/useTauri.ts
+++ b/installer/src/hooks/useTauri.ts
@@ -63,6 +63,12 @@ export interface GpuResult {
   tier_description: string;
 }
 
+export interface NetworkStatus {
+  github_reachable: boolean;
+  docker_registry_reachable: boolean;
+  all_reachable: boolean;
+}
+
 export interface ProgressInfo {
   phase: string;
   percent: number;
@@ -93,6 +99,8 @@ export const installPrerequisite = (component: string) =>
   invoke<InstallPrereqResult>("install_prerequisites", { component });
 
 export const detectGpu = () => invoke<GpuResult>("detect_gpu");
+
+export const checkNetwork = () => invoke<NetworkStatus>("check_network");
 
 export const startInstall = (
   tier: number,

--- a/installer/src/pages/Installing.tsx
+++ b/installer/src/pages/Installing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { startInstall, getInstallProgress, type ProgressInfo } from "../hooks/useTauri";
+import { startInstall, getInstallProgress, checkNetwork, type ProgressInfo } from "../hooks/useTauri";
 
 interface Props {
   tier: number;
@@ -10,6 +10,7 @@ interface Props {
 }
 
 const PHASE_LABELS: Record<string, string> = {
+  network: "Checking network connectivity",
   preflight: "Running preflight checks",
   detection: "Detecting hardware",
   docker: "Setting up Docker",
@@ -38,12 +39,36 @@ export default function Installing({
     if (started.current) return;
     started.current = true;
 
-    // Start the install
-    startInstall(tier, features, installDir).then(() => {
-      onComplete();
-    }).catch((e) => {
-      onError(String(e));
-    });
+    (async () => {
+      // Check network connectivity first
+      setProgress((p) => ({
+        ...p,
+        phase: "network",
+        message: "Checking network connectivity...",
+        percent: 1,
+      }));
+
+      try {
+        const networkStatus = await checkNetwork();
+        if (!networkStatus.all_reachable) {
+          let errorMsg = "Network connectivity check failed:";
+          if (!networkStatus.github_reachable) {
+            errorMsg += " GitHub is not reachable.";
+          }
+          if (!networkStatus.docker_registry_reachable) {
+            errorMsg += " Docker registry is not reachable.";
+          }
+          onError(errorMsg);
+          return;
+        }
+
+        // Network is OK, proceed with installation
+        await startInstall(tier, features, installDir);
+        onComplete();
+      } catch (e) {
+        onError(String(e));
+      }
+    })();
 
     // Poll for progress
     const interval = setInterval(async () => {


### PR DESCRIPTION
### Network Pre-flight Checks — Summary
Problem: Users with blocked GitHub/Docker registry connectivity hang for minutes in git clone or image pulls with no feedback.

Solution: TCP-based connectivity validation before installation starts. Checks github.com:443 and registry-1.docker.io:443 with 5-second timeouts, fails fast within ~10 seconds with clear error messages naming which host(s) are unreachable.

Implementation:

Backend: New network.rs module using TcpStream::connect_timeout (stdlib, no new dependencies)
Frontend: Installing.tsx runs checkNetwork() before startInstall(), shows "Checking network connectivity" phase
Error feedback: "Network connectivity check failed: GitHub is not reachable." or similar per host
Impact: Fail-fast UX for blocked networks (10s feedback vs minutes of hanging). No new dependencies, pure Rust + tokio async wrapper.

